### PR TITLE
chore: add missing deps and gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ vst_data/
 .DS_Store
 audio/
 checkpoints/
+
+# VST3
+plugins/

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,6 @@ pedalboard
 librosa
 loguru
 pyloudnorm
+h5py
+hdf5plugin
+dask[distributed]


### PR DESCRIPTION
## Summary
- Add h5py, hdf5plugin, dask[distributed] to requirements.txt
- Add `plugins/` to .gitignore (VST3 build artifacts, OS/architecture dependent)

## PR Chain
- PR 1/4: `ci/github-actions-setup` → `main` (#42)
- PR 2/4: `chore/lint-config` → `ci/github-actions-setup` (#43)
- **PR 3/4** (this PR) → `chore/lint-config`
- PR 4/4: `fix/src-test-config` → `chore/misc-housekeeping`

## Test plan
- [ ] `pip install -r requirements.txt` installs without errors
- [ ] `plugins/` directory is ignored by git