### PR TITLE
fix: stabilize test suite and fix source issues

### DIFF
--- a/configs/train.yaml
+++ b/configs/train.yaml
@@ -5,7 +5,7 @@
 defaults:
   - _self_
   - data: ksin
-  - model: ksin_ff
+  - model: ffn
   - callbacks: default
   - logger: many_loggers # set logger here or use command line (e.g. `python train.py logger=tensorboard`)
   - trainer: gpu

--- a/src/data/ksin_datamodule.py
+++ b/src/data/ksin_datamodule.py
@@ -40,8 +40,9 @@ def _sample_freqs_shifted(
     device: Union[str, torch.device],
     generator: Optional[torch.Generator] = None,
 ) -> torch.Tensor:
-    """Sample frequencies with different train and test distributions. These are
-    slightly overlapping truncated normal distributions.
+    """Sample frequencies with different train and test distributions.
+
+    These are slightly overlapping truncated normal distributions.
     """
     freqs = torch.empty(num_samples, k, device=device)
     mean = -1.0 / 3.0 if not is_test else 1.0 / 3.0
@@ -150,11 +151,11 @@ class KSinDataset(torch.utils.data.Dataset):
 
 
 class KSinDataModule(LightningDataModule):
-    """k-Sin is a simple synthetic synthesiser parameter estimation task designed to
-    elicit problematic behaviour in response to permutation invariant labels.
+    """K-Sin is a simple synthetic synthesiser parameter estimation task designed to elicit
+    problematic behaviour in response to permutation invariant labels.
 
-    Each item consists of a signal containing a mixture of sinusoids, and the amplitude
-    and frequency parameters used to generate the sinusoids.
+    Each item consists of a signal containing a mixture of sinusoids, and the amplitude and
+    frequency parameters used to generate the sinusoids.
     """
 
     def __init__(
@@ -169,6 +170,7 @@ class KSinDataModule(LightningDataModule):
         batch_size: int = 1024,
         ot: bool = False,
         num_workers: int = 0,
+        pin_memory: bool = False,
     ):
         super().__init__()
 
@@ -185,6 +187,7 @@ class KSinDataModule(LightningDataModule):
 
         # dataloader
         self.batch_size = batch_size
+        self.pin_memory = pin_memory
 
         self.device = None
         self.num_workers = num_workers
@@ -222,6 +225,7 @@ class KSinDataModule(LightningDataModule):
                 shuffle=True,
                 collate_fn=ot_collate_fn if self.ot else regular_collate_fn,
                 num_workers=self.num_workers,
+                pin_memory=self.pin_memory,
             )
             self.val = torch.utils.data.DataLoader(
                 val_ds,
@@ -229,6 +233,7 @@ class KSinDataModule(LightningDataModule):
                 shuffle=False,
                 collate_fn=regular_collate_fn,
                 num_workers=self.num_workers,
+                pin_memory=self.pin_memory,
             )
         else:
             test_ds = KSinDataset(
@@ -247,6 +252,7 @@ class KSinDataModule(LightningDataModule):
                 shuffle=False,
                 collate_fn=regular_collate_fn,
                 num_workers=self.num_workers,
+                pin_memory=self.pin_memory,
             )
 
     def train_dataloader(self):

--- a/src/data/surge_datamodule.py
+++ b/src/data/surge_datamodule.py
@@ -244,6 +244,7 @@ class SurgeDataModule(LightningDataModule):
         repeat_first_batch: bool = False,
         predict_file: Optional[str] = None,
         conditioning: Literal["mel", "m2l"] = "mel",
+        pin_memory: bool = True,
     ):
         super().__init__()
 
@@ -256,6 +257,7 @@ class SurgeDataModule(LightningDataModule):
         self.repeat_first_batch = repeat_first_batch
         self.predict_file = predict_file
         self.conditioning = conditioning
+        self.pin_memory = pin_memory
 
     def setup(self, stage: Optional[str] = None):
         self.train_dataset = SurgeXTDataset(
@@ -307,7 +309,7 @@ class SurgeDataModule(LightningDataModule):
             self.train_dataset,
             batch_size=None,
             num_workers=self.num_workers,
-            pin_memory=True,
+            pin_memory=self.pin_memory,
             # sampler=WithinChunkShuffledSampler(
             #     self.batch_size, len(self.train_dataset), 4
             # ),
@@ -322,7 +324,7 @@ class SurgeDataModule(LightningDataModule):
             batch_size=None,
             shuffle=False,
             num_workers=self.num_workers,
-            pin_memory=True,
+            pin_memory=self.pin_memory,
         )
 
     def test_dataloader(self):
@@ -331,7 +333,7 @@ class SurgeDataModule(LightningDataModule):
             batch_size=None,
             shuffle=False,
             num_workers=self.num_workers,
-            pin_memory=True,
+            pin_memory=self.pin_memory,
         )
 
     def predict_dataloader(self):
@@ -340,7 +342,7 @@ class SurgeDataModule(LightningDataModule):
             batch_size=None,
             shuffle=False,
             num_workers=self.num_workers,
-            pin_memory=True,
+            pin_memory=self.pin_memory,
         )
 
     def teardown(self, stage: Optional[str] = None):

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -13,8 +13,11 @@ log = pylogger.RankedLogger(__name__, rank_zero_only=True)
 
 
 def register_resolvers() -> None:
-    OmegaConf.register_new_resolver("mul", lambda x, y: x * y)
-    OmegaConf.register_new_resolver("div", lambda x, y: int(x) // int(y))
+    # Avoid double-registration when modules are imported multiple times in tests
+    if not OmegaConf.has_resolver("mul"):
+        OmegaConf.register_new_resolver("mul", lambda x, y: x * y)
+    if not OmegaConf.has_resolver("div"):
+        OmegaConf.register_new_resolver("div", lambda x, y: int(x) // int(y))
 
 
 def extras(cfg: DictConfig) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,13 @@ from hydra import compose, initialize
 from hydra.core.global_hydra import GlobalHydra
 from omegaconf import DictConfig, open_dict
 
+from src.utils.utils import register_resolvers
+
+# Register custom OmegaConf resolvers (mul, div) needed to parse Hydra configs.
+# This import pulls in torch/lightning transitively via src.utils.utils, but every
+# test in this suite already requires those dependencies, so there is no benefit to
+# isolating resolver registration into a lighter module.
+register_resolvers()
 
 @pytest.fixture(scope="package")
 def cfg_train_global() -> DictConfig:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ def cfg_train_global() -> DictConfig:
             cfg.data.pin_memory = False
             cfg.extras.print_config = False
             cfg.extras.enforce_tags = False
+            cfg.model.compile = False
             cfg.logger = None
 
     return cfg

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,9 @@ def cfg_train_global() -> DictConfig:
             cfg.extras.enforce_tags = False
             cfg.model.compile = False
             cfg.logger = None
+            callbacks = cfg.get("callbacks")
+            if callbacks is not None and "lr_monitor" in callbacks:
+                del callbacks.lr_monitor
 
     return cfg
 
@@ -65,6 +68,9 @@ def cfg_eval_global() -> DictConfig:
             cfg.extras.print_config = False
             cfg.extras.enforce_tags = False
             cfg.logger = None
+            callbacks = cfg.get("callbacks")
+            if callbacks is not None and "lr_monitor" in callbacks:
+                del callbacks.lr_monitor
 
     return cfg
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -30,8 +30,9 @@ def test_train_fast_dev_run_tiny_model_tiny_data(cfg_train: DictConfig) -> None:
     train(cfg_train)
 
 
+@pytest.mark.slow
 def test_train_fast_dev_run(cfg_train: DictConfig) -> None:
-    """Run for 1 train, val and test step.
+    """Run for 1 train, val and test step with torch.compile enabled.
 
     :param cfg_train: A DictConfig containing a valid training configuration.
     """
@@ -39,6 +40,7 @@ def test_train_fast_dev_run(cfg_train: DictConfig) -> None:
     with open_dict(cfg_train):
         cfg_train.trainer.fast_dev_run = True
         cfg_train.trainer.accelerator = "cpu"
+        cfg_train.model.compile = True
     train(cfg_train)
 
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -54,6 +54,7 @@ def test_train_fast_dev_run_gpu(cfg_train: DictConfig) -> None:
     with open_dict(cfg_train):
         cfg_train.trainer.fast_dev_run = True
         cfg_train.trainer.accelerator = "gpu"
+        cfg_train.data.batch_size = 32
     train(cfg_train)
 
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -8,6 +8,9 @@ from omegaconf import DictConfig, open_dict
 from src.train import train
 from tests.helpers.run_if import RunIf
 
+# TODO(#39): replace hardcoded accelerator overrides with --accelerator pytest flag
+# TODO(#40): add @pytest.mark.ram gate for memory-intensive CPU tests test_train_fast_dev_run
+
 
 def test_train_fast_dev_run_tiny_model_tiny_data(cfg_train: DictConfig) -> None:
     """Run for 1 train, val and test step with small batch size, no compile.
@@ -88,6 +91,7 @@ def test_train_epoch_gpu_amp(cfg_train: DictConfig) -> None:
     train(cfg_train)
 
 
+# TODO: fix val_check_interval incompatibility with check_val_every_n_epoch=None (#47)
 @pytest.mark.slow
 def test_train_epoch_double_val_loop(cfg_train: DictConfig) -> None:
     """Train 1 epoch with validation loop twice per epoch.

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -60,6 +60,21 @@ def test_train_fast_dev_run_gpu(cfg_train: DictConfig) -> None:
 
 @RunIf(min_gpus=1)
 @pytest.mark.slow
+def test_train_fast_dev_run_gpu_compile(cfg_train: DictConfig) -> None:
+    """Run for 1 train, val and test step on GPU with torch.compile enabled.
+
+    :param cfg_train: A DictConfig containing a valid training configuration.
+    """
+    HydraConfig().set_config(cfg_train)
+    with open_dict(cfg_train):
+        cfg_train.trainer.fast_dev_run = True
+        cfg_train.trainer.accelerator = "gpu"
+        cfg_train.model.compile = True
+    train(cfg_train)
+
+
+@RunIf(min_gpus=1)
+@pytest.mark.slow
 def test_train_epoch_gpu_amp(cfg_train: DictConfig) -> None:
     """Train 1 epoch on GPU with mixed-precision.
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -9,6 +9,27 @@ from src.train import train
 from tests.helpers.run_if import RunIf
 
 
+def test_train_fast_dev_run_tiny_model_tiny_data(cfg_train: DictConfig) -> None:
+    """Run for 1 train, val and test step with small batch size, no compile.
+
+    :param cfg_train: A DictConfig containing a valid training configuration.
+    """
+    HydraConfig().set_config(cfg_train)
+    with open_dict(cfg_train):
+        # Prevent CPU unittest OOM by shrinking model,
+        # batch, training example, dataset size.
+        cfg_train.trainer.fast_dev_run = True
+        cfg_train.trainer.accelerator = "cpu"
+        cfg_train.data.batch_size = 32
+        cfg_train.model.net.channels = 4
+        cfg_train.model.net.encoder_blocks = 1
+        cfg_train.model.net.trunk_blocks = 1
+        cfg_train.model.net.hidden_dim = 32
+        cfg_train.data.signal_length = 64
+        cfg_train.data.train_val_test_sizes = [4, 4, 4]
+    train(cfg_train)
+
+
 def test_train_fast_dev_run(cfg_train: DictConfig) -> None:
     """Run for 1 train, val and test step.
 


### PR DESCRIPTION
## Summary
- Fix default model config: `ksin_ff` → `ffn` (ksin_ff.yaml was deleted)
- Guard OmegaConf resolver registration against double-registration in tests
- Add configurable `pin_memory` to KSinDataModule and SurgeDataModule
- Register resolvers at conftest module level, disable torch.compile in test fixtures
- Remove lr_monitor callback from test fixtures (not available in test env)
- Add lightweight tiny-model test variant for fast CI runs
- Mark original fast_dev_run test as `@slow` with torch.compile enabled
- Add GPU compile test variant
- Reduce batch size in GPU test to prevent OOM

Each logical fix is in its own commit for clean review.

## PR Chain
- PR 1/4: `ci/github-actions-setup` → `main` (#42)
- PR 2/4: `chore/lint-config` → `ci/github-actions-setup` (#43)
- PR 3/4: `chore/misc-housekeeping` → `chore/lint-config` (#44)
- **PR 4/4** (this PR) → `chore/misc-housekeeping`

## Test plan
- [ ] `pytest -k "not slow" -vv -s` passes (tiny model test runs, slow tests skipped)
- [ ] `pytest -vv -s` passes (all tests including slow/compile variants)
- [ ] Final state matches cumulative diff of PR #24
- [ ] Close PR #24 after this chain merges