### PR TITLE
chore: enforce pre-commit + lint compliance and add new linting hooks

### DIFF
--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -20,5 +20,10 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
       - name: Run pre-commits
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -23,6 +23,11 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
       - name: Find modified files
         id: file_changes
         uses: trilom/file-changes-action@v1.2.4

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,7 @@ checkpoints/
 
 # VST3
 plugins/
+
+# Claude Code (keep skills only)
+.claude/
+!.claude/skills/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,17 +25,45 @@ repos:
 
   # ruff: linting (E/F/I/S/T/UP/W rules) and formatting for Python & Jupyter.
   # Config lives in pyproject.toml under [tool.ruff]. Legacy src/ files are
-  # excluded via extend-exclude there (see issue #25).
+  # excluded via per-file-ignores there (see issue #25).
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.5
     hooks:
       # ruff-pre-commit already passes --force-exclude in its entry point,
-      # so ruff respects extend-exclude in pyproject.toml automatically.
+      # so ruff respects per-file-ignores in pyproject.toml automatically.
       - id: ruff
         args: [--fix]
         types_or: [python, jupyter]
       - id: ruff-format
         types_or: [python, jupyter]
+
+  # pyright: static type checker for Python (local hook)
+  - repo: local
+    hooks:
+      - id: pyright
+        name: pyright
+        entry: pyright
+        language: python
+        types: [python]
+        additional_dependencies: ["pyright"]
+        exclude: >-
+          (?x)^(
+            notebooks/|
+            scripts/.*\.py|
+            src/data/.*\.py|
+            src/eval\.py|
+            src/metrics\.py|
+            src/models/.*\.py|
+            src/train\.py|
+            src/utils/callbacks\.py|
+            src/utils/instantiators\.py|
+            src/utils/logging_utils\.py|
+            src/utils/math\.py|
+            src/utils/pylogger\.py|
+            src/utils/rich_utils\.py|
+            src/utils/utils\.py|
+            tests/.*\.py
+          )$
 
   # docformatter: auto-wraps and normalises docstrings (sphinx style).
   # Config lives in pyproject.toml under [tool.docformatter].

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,24 +50,6 @@ repos:
         types: [python]
         additional_dependencies: ["docformatter[tomli]==1.7.4"]
         args: [--in-place]
-        exclude: >-
-          (?x)^(
-            scripts/add_music2latent\.py|
-            scripts/compute_audio_metrics\.py|
-            scripts/rewrite_dataset_to_latest\.py|
-            scripts/subdir_funtime\.py|
-            src/data/audio_datamodule\.py|
-            src/data/fm_datamodule\.py|
-            src/data/kosc_datamodule\.py|
-            src/data/ksin_datamodule\.py|
-            src/data/vst/core\.py|
-            src/data/vst/generate_vst_dataset\.py|
-            src/data/vst/param_spec\.py|
-            src/models/components/loss\.py|
-            src/models/components/sinkhorn\.py|
-            src/models/components/transformer\.py|
-            src/utils/callbacks\.py
-          )$
 
   # interrogate: enforces docstring coverage (fail-under=80%).
   # Config lives in pyproject.toml under [tool.interrogate].

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,16 +12,14 @@ repos:
       - id: check-yaml
       - id: detect-private-key
       - id: check-executables-have-shebangs
-        exclude: >-
-          (?x)^(
-            jobs/predict/get-ckpt-from-wandb\.sh|
-            renderscript\.sh|
-            scripts/aggregate_samples\.sh|
-            scripts/get-ckpt-from-wandb\.sh
-          )$
+      # prevent accidental commits to main branch
+      - id: no-commit-to-branch
+        args: [--branch, main]
       - id: check-toml
       - id: check-case-conflict
       - id: check-added-large-files
+      - id: check-json
+      - id: debug-statements
 
   # ruff: linting (E/F/I/S/T/UP/W rules) and formatting for Python & Jupyter.
   # Config lives in pyproject.toml under [tool.ruff]. Legacy src/ files are
@@ -65,12 +63,23 @@ repos:
             tests/.*\.py
           )$
 
-  # check-jsonschema: validates JSON/YAML against JSON schemas
+  # check-jsonschema: validates GitHub workflow files against schema
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.29.4
     hooks:
-      - id: check-jsonschema
-        types: [json, yaml]
+      - id: check-github-workflows
+
+  # validate-pyproject: validates pyproject.toml against PEP 517/518
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.18
+    hooks:
+      - id: validate-pyproject
+
+  # gitlint: lints commit messages for conventional commits compliance
+  - repo: https://github.com/jorisroovers/gitlint
+    rev: v0.19.1
+    hooks:
+      - id: gitlint
 
   # docformatter: auto-wraps and normalises docstrings (sphinx style).
   # Config lives in pyproject.toml under [tool.docformatter].
@@ -224,3 +233,17 @@ repos:
     hooks:
       - id: nbstripout
         exclude: "^notebooks/inpsect-models\\.ipynb$"
+
+  # C++ formatting and linting (no-op until .cpp/.h files are added)
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v17.0.6
+    hooks:
+      - id: clang-format
+        args: [--style=Google]
+        types_or: [c, c++]
+
+  - repo: https://github.com/cpplint/cpplint
+    rev: 1.6.1
+    hooks:
+      - id: cpplint
+        args: [--filter=-legal/copyright]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -134,45 +134,32 @@ repos:
             scripts/plot_param2tok\.py|
             scripts/predict_vst_audio\.py|
             scripts/reshard_data\.py|
-            scripts/rewrite_dataset_to_latest\.py|
-            scripts/subdir_funtime\.py|
             src/data/audio_datamodule\.py|
             src/data/fm_datamodule\.py|
             src/data/kosc_datamodule\.py|
             src/data/ksin_datamodule\.py|
-            src/data/mnist_datamodule\.py|
             src/data/ot\.py|
             src/data/surge_datamodule\.py|
             src/data/vst/core\.py|
             src/data/vst/generate_vst_dataset\.py|
             src/data/vst/param_spec\.py|
             src/data/vst/surge_xt_param_spec\.py|
-            src/eval\.py|
             src/metrics\.py|
             src/models/components/cnn\.py|
             src/models/components/embed_pool\.py|
             src/models/components/loss\.py|
             src/models/components/residual_mlp\.py|
-            src/models/components/simple_dense_net\.py|
             src/models/components/sinkhorn\.py|
             src/models/components/transformer\.py|
             src/models/components/vae\.py|
             src/models/components/vector_field\.py|
             src/models/ksin_ff_module\.py|
             src/models/ksin_flow_matching_module\.py|
-            src/models/mnist_module\.py|
             src/models/surge_ff_module\.py|
             src/models/surge_flow_matching_module\.py|
             src/models/surge_flowvae_module\.py|
-            src/train\.py|
             src/utils/callbacks\.py|
-            src/utils/instantiators\.py|
-            src/utils/logging_utils\.py|
-            src/utils/math\.py|
-            src/utils/pylogger\.py|
-            src/utils/rich_utils\.py|
-            src/utils/utils\.py|
-            tests/conftest\.py
+            src/utils/math\.py
           )$
 
   # yaml formatting

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,15 +8,6 @@ repos:
       # general file hygiene: whitespace, encoding, secrets, file size
       - id: trailing-whitespace
       - id: end-of-file-fixer
-        exclude: >-
-          (?x)^(
-            configs/experiment/fm/ffn_asym\.yaml|
-            configs/experiment/kosc/flow_fixed\.yaml|
-            configs/experiment/kosc/flow_fixed_asym\.yaml|
-            configs/experiment/ksin/flow_fixed\.yaml|
-            configs/experiment/ksin/flow_fixed_asym\.yaml|
-            configs/model/encoder/cnn\.yaml
-          )$
       - id: check-docstring-first
       - id: check-yaml
       - id: detect-private-key

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,13 @@ repos:
             tests/.*\.py
           )$
 
+  # check-jsonschema: validates JSON/YAML against JSON schemas
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.29.4
+    hooks:
+      - id: check-jsonschema
+        types: [json, yaml]
+
   # docformatter: auto-wraps and normalises docstrings (sphinx style).
   # Config lives in pyproject.toml under [tool.docformatter].
   # Local hook because v1.7.4's upstream manifest uses language: python_venv,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,26 +41,45 @@ repos:
       - id: pyright
         name: pyright
         entry: pyright
-        language: python
+        language: system
         types: [python]
-        additional_dependencies: ["pyright"]
         exclude: >-
           (?x)^(
             notebooks/|
-            scripts/.*\.py|
-            src/data/.*\.py|
-            src/eval\.py|
+            scripts/add_music2latent\.py|
+            scripts/compute_audio_metrics\.py|
+            scripts/get_dataset_stats\.py|
+            scripts/model_from_wandb_repl\.py|
+            scripts/plot_param2tok\.py|
+            scripts/predict_vst_audio\.py|
+            scripts/reshard_data\.py|
+            scripts/rewrite_dataset_to_latest\.py|
+            src/data/fm_datamodule\.py|
+            src/data/kosc_datamodule\.py|
+            src/data/mnist_datamodule\.py|
+            src/data/ot\.py|
+            src/data/surge_datamodule\.py|
+            src/data/vst/core\.py|
+            src/data/vst/generate_vst_dataset\.py|
+            src/data/vst/param_spec\.py|
             src/metrics\.py|
-            src/models/.*\.py|
+            src/models/components/cnn\.py|
+            src/models/components/residual_mlp\.py|
+            src/models/components/transformer\.py|
+            src/models/components/vae\.py|
+            src/models/components/vector_field\.py|
+            src/models/ksin_ff_module\.py|
+            src/models/ksin_flow_matching_module\.py|
+            src/models/mnist_module\.py|
+            src/models/surge_ff_module\.py|
+            src/models/surge_flow_matching_module\.py|
+            src/models/surge_flowvae_module\.py|
             src/train\.py|
             src/utils/callbacks\.py|
-            src/utils/instantiators\.py|
             src/utils/logging_utils\.py|
-            src/utils/math\.py|
-            src/utils/pylogger\.py|
-            src/utils/rich_utils\.py|
-            src/utils/utils\.py|
-            tests/.*\.py
+            tests/conftest\.py|
+            tests/helpers/package_available\.py|
+            tests/helpers/run_sh_command\.py
           )$
 
   # check-jsonschema: validates GitHub workflow files against schema

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,22 +118,6 @@ repos:
     hooks:
       - id: prettier
         types: [yaml]
-        exclude: >-
-          (?x)^(
-            configs/callbacks/default\.yaml|
-            configs/experiment/fm/ffn_asym\.yaml|
-            configs/experiment/kosc/flow_fixed\.yaml|
-            configs/experiment/kosc/flow_fixed_asym\.yaml|
-            configs/experiment/ksin/flow_fixed\.yaml|
-            configs/experiment/ksin/flow_fixed_asym\.yaml|
-            configs/experiment/surge/flow_simple_nofinalffn\.yaml|
-            configs/hparams_search/ksin_optuna\.yaml|
-            configs/model/encoder/cnn\.yaml|
-            configs/model/surge_flow\.yaml|
-            configs/model/surge_flowmlp\.yaml|
-            environment\.yaml|
-            sweeps/fm\.yaml
-          )$
 
   # shell scripts linter
   - repo: https://github.com/shellcheck-py/shellcheck-py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,31 +7,6 @@ repos:
     hooks:
       # general file hygiene: whitespace, encoding, secrets, file size
       - id: trailing-whitespace
-        exclude: >-
-          (?x)^(
-            README\.md|
-            jobs/predict/ffn-fsd50k\.sh|
-            jobs/predict/ffn-full\.sh|
-            jobs/predict/ffn-nsynth\.sh|
-            jobs/predict/ffn-simple\.sh|
-            jobs/predict/flow-fsd50k\.sh|
-            jobs/predict/flow-full-1\.0\.sh|
-            jobs/predict/flow-full-4\.0\.sh|
-            jobs/predict/flow-full\.sh|
-            jobs/predict/flow-nsynth\.sh|
-            jobs/predict/flow-simple\.sh|
-            jobs/predict/flowmlp-fsd50k\.sh|
-            jobs/predict/flowmlp-full\.sh|
-            jobs/predict/flowmlp-nsynth\.sh|
-            jobs/predict/flowmlp-simple\.sh|
-            jobs/predict/vae-fsd50k\.sh|
-            jobs/predict/vae-full\.sh|
-            jobs/predict/vae-nsynth\.sh|
-            jobs/predict/vae-simple\.sh|
-            scripts/get_dataset_stats\.py|
-            scripts/paramspec_to_table\.py|
-            scripts/subdir_funtime\.py
-          )$
       - id: end-of-file-fixer
         exclude: >-
           (?x)^(

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Audio synthesizer inversion in symmetric parameter spaces with approximately equivariant flow matching
 
-This repository accompanies a submission to ISMIR 2025. A full README explaining how to use this code will be provided before the conference. In the meantime, audio examples are available at the [online supplement](https://benhayes.net/synth-perm/). 
+This repository accompanies a submission to ISMIR 2025. A full README explaining how to use this code will be provided before the conference. In the meantime, audio examples are available at the [online supplement](https://benhayes.net/synth-perm/).
 
 If you would like to explore the source code, you may find the below helpful:
 

--- a/configs/callbacks/default.yaml
+++ b/configs/callbacks/default.yaml
@@ -17,7 +17,6 @@ model_checkpoint:
   mode: "min"
   save_last: True
   auto_insert_metric_name: False
-
 # early_stopping:
 #   monitor: "val/chamfer"
 #   patience: 50

--- a/configs/experiment/fm/ffn_asym.yaml
+++ b/configs/experiment/fm/ffn_asym.yaml
@@ -13,4 +13,3 @@ model:
 
 data:
   break_symmetry: true
-

--- a/configs/experiment/kosc/flow_fixed.yaml
+++ b/configs/experiment/kosc/flow_fixed.yaml
@@ -13,4 +13,3 @@ model:
 
 data:
   ot: true
-

--- a/configs/experiment/kosc/flow_fixed_asym.yaml
+++ b/configs/experiment/kosc/flow_fixed_asym.yaml
@@ -14,4 +14,3 @@ model:
 data:
   break_symmetry: true
   ot: true
-

--- a/configs/experiment/ksin/flow_fixed.yaml
+++ b/configs/experiment/ksin/flow_fixed.yaml
@@ -9,4 +9,3 @@ run_name: flow_fixed
 
 data:
   ot: true
-

--- a/configs/experiment/ksin/flow_fixed_asym.yaml
+++ b/configs/experiment/ksin/flow_fixed_asym.yaml
@@ -10,4 +10,3 @@ run_name: flow_fixed_asym
 data:
   break_symmetry: true
   ot: true
-

--- a/configs/experiment/surge/flow_simple_nofinalffn.yaml
+++ b/configs/experiment/surge/flow_simple_nofinalffn.yaml
@@ -11,6 +11,5 @@ model:
     projection:
       final_ffn: false
 
-
 experiment_name: surge-simple-onehot
 run_name: flow-nofinalffn

--- a/configs/hparams_search/ksin_optuna.yaml
+++ b/configs/hparams_search/ksin_optuna.yaml
@@ -11,7 +11,7 @@ defaults:
 
 # choose metric which will be optimized by Optuna
 # make sure this is the correct name of some metric logged in lightning module!
-optimized_metric: 'val/lsd'
+optimized_metric: "val/lsd"
 
 trainer:
   devices: 1
@@ -34,7 +34,7 @@ logger:
 num_gpus: 3
 n_jobs: 3
 hydra:
-  mode: 'MULTIRUN' # set hydra to multirun by default if this config is attached
+  mode: "MULTIRUN" # set hydra to multirun by default if this config is attached
 
   launcher:
     ray:

--- a/configs/model/encoder/cnn.yaml
+++ b/configs/model/encoder/cnn.yaml
@@ -4,4 +4,3 @@ hidden_dim: 24
 out_dim: 128
 num_blocks: 4
 kernel_size: 7
-

--- a/configs/model/surge_flow.yaml
+++ b/configs/model/surge_flow.yaml
@@ -50,7 +50,6 @@ num_params: 90
 # training
 cfg_dropout_rate: 0.1
 
-
 rectified_sigma_min: 0.0
 
 # sampling

--- a/configs/model/surge_flowmlp.yaml
+++ b/configs/model/surge_flowmlp.yaml
@@ -25,7 +25,6 @@ vector_field:
   conditioning_dim: ${model.encoder.d_model}
   num_layers: 9
 
-
 # training
 cfg_dropout_rate: 0.1
 

--- a/jobs/predict/ffn-fsd50k.sh
+++ b/jobs/predict/ffn-fsd50k.sh
@@ -33,4 +33,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/ffn-full.sh
+++ b/jobs/predict/ffn-full.sh
@@ -33,4 +33,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/ffn-nsynth.sh
+++ b/jobs/predict/ffn-nsynth.sh
@@ -33,4 +33,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/ffn-simple.sh
+++ b/jobs/predict/ffn-simple.sh
@@ -33,4 +33,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/flow-fsd50k.sh
+++ b/jobs/predict/flow-fsd50k.sh
@@ -35,4 +35,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/flow-full-1.0.sh
+++ b/jobs/predict/flow-full-1.0.sh
@@ -35,4 +35,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/flow-full-4.0.sh
+++ b/jobs/predict/flow-full-4.0.sh
@@ -35,4 +35,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/flow-full.sh
+++ b/jobs/predict/flow-full.sh
@@ -35,4 +35,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/flow-nsynth.sh
+++ b/jobs/predict/flow-nsynth.sh
@@ -35,4 +35,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/flow-simple.sh
+++ b/jobs/predict/flow-simple.sh
@@ -35,4 +35,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/flowmlp-fsd50k.sh
+++ b/jobs/predict/flowmlp-fsd50k.sh
@@ -35,4 +35,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/flowmlp-full.sh
+++ b/jobs/predict/flowmlp-full.sh
@@ -35,4 +35,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/flowmlp-nsynth.sh
+++ b/jobs/predict/flowmlp-nsynth.sh
@@ -35,4 +35,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/flowmlp-simple.sh
+++ b/jobs/predict/flowmlp-simple.sh
@@ -35,4 +35,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/get-ckpt-from-wandb.sh
+++ b/jobs/predict/get-ckpt-from-wandb.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 wandbid=$1
 CANDIDATES=$(
   find logs/train -type d -wholename "*wandb/*$wandbid" -print0 \

--- a/jobs/predict/vae-fsd50k.sh
+++ b/jobs/predict/vae-fsd50k.sh
@@ -33,4 +33,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/vae-full.sh
+++ b/jobs/predict/vae-full.sh
@@ -33,4 +33,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/vae-nsynth.sh
+++ b/jobs/predict/vae-nsynth.sh
@@ -33,4 +33,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/jobs/predict/vae-simple.sh
+++ b/jobs/predict/vae-simple.sh
@@ -33,4 +33,4 @@ python src/eval.py \
     mode=predict \
     data.batch_size=1024 \
     data.num_workers=11 \
-    ckpt_path=$CKPT_PATH 
+    ckpt_path=$CKPT_PATH

--- a/notebooks/inpsect-models.ipynb
+++ b/notebooks/inpsect-models.ipynb
@@ -36,17 +36,14 @@
     "import datetime\n",
     "import os\n",
     "import time\n",
-    "from glob import glob\n",
     "from pathlib import Path\n",
     "from types import SimpleNamespace\n",
     "\n",
     "import hydra\n",
-    "from omegaconf import OmegaConf, DictConfig\n",
     "import matplotlib.pyplot as plt\n",
     "import pandas as pd\n",
     "import torch\n",
-    "\n",
-    "from src.utils import register_resolvers"
+    "from omegaconf import OmegaConf"
    ]
   },
   {
@@ -95,10 +92,12 @@
     "    version = int(version)\n",
     "    return version\n",
     "\n",
+    "\n",
     "def get_ctime(file):\n",
     "    timestamp = file.stat().st_ctime\n",
     "    dt = datetime.datetime.fromtimestamp(timestamp)\n",
     "    return dt\n",
+    "\n",
     "\n",
     "def get_nearest_ctime(hparam_path, checkpoints):\n",
     "    hparam_ctime = get_ctime(hparam_path)\n",
@@ -106,15 +105,17 @@
     "    return opts[0]\n",
     "    # return min(opts, key=lambda c: abs((get_ctime(c) - hparam_ctime).total_seconds()))\n",
     "\n",
+    "\n",
     "def get_latest(checkpoints):\n",
     "    opts = [c for c in checkpoints if \"last\" in c.name]\n",
     "    if len(opts) > 1:\n",
     "        print(opts)\n",
     "    return max(opts, key=lambda c: get_ctime(c))\n",
     "\n",
+    "\n",
     "def get_checkpoint(hparam_path):\n",
     "    version = get_version(hparam_path)\n",
-    "    \n",
+    "\n",
     "    ckpt_dir = hparam_path.parent.parent.parent / \"checkpoints\"\n",
     "    if not ckpt_dir.exists():\n",
     "        return None\n",
@@ -133,14 +134,15 @@
     "    #         checkpoints = [c for c in checkpoints if c.name == f\"last.ckpt\"]\n",
     "    #         if len(checkpoints) == 0:\n",
     "    #             return None\n",
-    "    \n",
+    "\n",
     "    # return checkpoints[-1]\n",
+    "\n",
     "\n",
     "def get_max_epoch(hparam_path):\n",
     "    try:\n",
     "        return len(pd.read_csv(hparam_path.parent / \"metrics.csv\"))\n",
     "    except:\n",
-    "        return 0\n"
+    "        return 0"
    ]
   },
   {
@@ -164,7 +166,7 @@
     "hparam_files = [h for h in hparam_files if get_max_epoch(h) >= 900]\n",
     "ckpt_files = [get_checkpoint(h) for h in hparam_files]\n",
     "\n",
-    "hparam_files = [h for h,c in zip(hparam_files, ckpt_files) if c is not None]\n",
+    "hparam_files = [h for h, c in zip(hparam_files, ckpt_files) if c is not None]\n",
     "ckpt_files = [c for c in ckpt_files if c is not None]\n",
     "\n",
     "print(len(hparam_files))"
@@ -179,22 +181,25 @@
    "source": [
     "def get_model_cls(model_idx):\n",
     "    from importlib import import_module\n",
+    "\n",
     "    target = OmegaConf.load(hparam_files[model_idx]).model._target_\n",
     "    mod, cls = target.rsplit(\".\", 1)\n",
     "    mod = import_module(mod)\n",
     "    return getattr(mod, cls)\n",
+    "\n",
     "\n",
     "def load_model(model_idx, device):\n",
     "    cls = get_model_cls(model_idx)\n",
     "    model = cls.load_from_checkpoint(ckpt_files[model_idx], device=device)\n",
     "    return model\n",
     "\n",
+    "\n",
     "def load_dataset(model_idx, device):\n",
     "    target = OmegaConf.load(hparam_files[model_idx]).data\n",
     "    dm = hydra.utils.instantiate(target)\n",
     "    dm.device = device\n",
     "    dm.setup(\"test\")\n",
-    "    return dm.test_dataloader()\n"
+    "    return dm.test_dataloader()"
    ]
   },
   {
@@ -229,7 +234,7 @@
     "    md.date = get_ctime(hparam_file)\n",
     "\n",
     "    return md.__dict__\n",
-    "    \n",
+    "\n",
     "\n",
     "rows = [extract_metadata(h) for h in hparam_files]"
    ]
@@ -522,8 +527,8 @@
     "sps = steps / dur\n",
     "print(f\"Done. {steps} steps in {dur:.2f} seconds ({sps} steps/sec)\")\n",
     "if old_data:\n",
-    "    sample[..., :sample.shape[-1] // 2] = 2 * sample[..., :sample.shape[-1] // 2] / torch.pi - 1\n",
-    "    sample[..., sample.shape[-1] // 2:] = 2 * sample[..., sample.shape[-1] // 2:] - 1\n",
+    "    sample[..., : sample.shape[-1] // 2] = 2 * sample[..., : sample.shape[-1] // 2] / torch.pi - 1\n",
+    "    sample[..., sample.shape[-1] // 2 :] = 2 * sample[..., sample.shape[-1] // 2 :] - 1\n",
     "\n",
     "yc = y.cpu()\n",
     "sc = sample.cpu()\n",
@@ -531,15 +536,16 @@
     "    for j in range(y.shape[-1] // 2):\n",
     "        if i == j:\n",
     "            continue\n",
-    "        \n",
+    "\n",
     "        plt.scatter(yc[:, i], yc[:, j], color=\"black\")\n",
     "for i in range(y.shape[-1] // 2):\n",
     "    for j in range(y.shape[-1] // 2):\n",
     "        if i == j:\n",
-    "            continue    \n",
+    "            continue\n",
     "        plt.scatter(sc[:, i], sc[:, j], marker=\"+\", color=\"red\", alpha=0.05)\n",
-    "    \n",
-    "plt.xlim(-1, 1); plt.ylim(-1, 1)"
+    "\n",
+    "plt.xlim(-1, 1)\n",
+    "plt.ylim(-1, 1)"
    ]
   },
   {
@@ -566,7 +572,7 @@
     "X_ = torch.fft.rfft(x_).abs().log10()\n",
     "\n",
     "plt.plot(X[0].cpu())\n",
-    "plt.plot(X_.T.cpu(), alpha = 0.01, color=\"red\")\n",
+    "plt.plot(X_.T.cpu(), alpha=0.01, color=\"red\")\n",
     "plt.show()"
    ]
   },
@@ -597,7 +603,9 @@
     "    b = pot.unif(x1.shape[0], type_as=x1)\n",
     "    costs = torch.cdist(x0, x1).sqrt()\n",
     "\n",
-    "    ot_map = pot.sinkhorn(a, b, costs, 0.1, method=\"sinkhorn\", numItermax=1000, verbose=True, stopThr=1e-6)\n",
+    "    ot_map = pot.sinkhorn(\n",
+    "        a, b, costs, 0.1, method=\"sinkhorn\", numItermax=1000, verbose=True, stopThr=1e-6\n",
+    "    )\n",
     "    # ot_map = pot.emd(a, b, costs, numThreads=4)\n",
     "    pi = ot_map.flatten().square()\n",
     "    samples = torch.multinomial(pi, batch_size, replacement=True)\n",
@@ -608,7 +616,7 @@
     "    x1 = x1[j]\n",
     "    z = z[j]\n",
     "\n",
-    "    return x0, x1, z\n"
+    "    return x0, x1, z"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,48 +29,7 @@ target-version = "py310"
 line-length = 99
 exclude = ["logs", "data"]
 # Legacy files excluded until per-file lint cleanup is done (see issue #25).
-extend-exclude = [
-    "notebooks/",
-    "scripts/",
-    "src/utils/__init__.py",
-    "src/data/audio_datamodule.py",
-    "src/data/fm_datamodule.py",
-    "src/data/kosc_datamodule.py",
-    "src/data/ksin_datamodule.py",
-    "src/data/mnist_datamodule.py",
-    "src/data/ot.py",
-    "src/data/surge_datamodule.py",
-    "src/data/vst/core.py",
-    "src/data/vst/generate_vst_dataset.py",
-    "src/data/vst/param_spec.py",
-    "src/data/vst/surge_xt_param_spec.py",
-    "src/eval.py",
-    "src/metrics.py",
-    "src/models/components/cnn.py",
-    "src/models/components/embed_pool.py",
-    "src/models/components/loss.py",
-    "src/models/components/residual_mlp.py",
-    "src/models/components/simple_dense_net.py",
-    "src/models/components/sinkhorn.py",
-    "src/models/components/transformer.py",
-    "src/models/components/vae.py",
-    "src/models/components/vector_field.py",
-    "src/models/ksin_ff_module.py",
-    "src/models/ksin_flow_matching_module.py",
-    "src/models/mnist_module.py",
-    "src/models/surge_ff_module.py",
-    "src/models/surge_flow_matching_module.py",
-    "src/models/surge_flowvae_module.py",
-    "src/train.py",
-    "src/utils/callbacks.py",
-    "src/utils/instantiators.py",
-    "src/utils/logging_utils.py",
-    "src/utils/math.py",
-    "src/utils/pylogger.py",
-    "src/utils/rich_utils.py",
-    "src/utils/utils.py",
-    "tests/conftest.py",
-]
+extend-exclude = []
 
 [tool.ruff.lint]
 # E=pycodestyle errors, F=pyflakes, I=isort, S=bandit security,
@@ -78,6 +37,27 @@ extend-exclude = [
 select = ["E", "F", "I", "S", "T", "UP", "W"]
 # E501: line length handled by ruff-format, S101: allow assert in tests
 ignore = ["E501", "S101"]
+
+[tool.ruff.lint.per-file-ignores]
+"notebooks/**" = ["E702", "E722", "F841", "T201"]
+"scripts/add_music2latent.py" = ["S605"]
+"scripts/compute_audio_metrics.py" = ["T201"]
+"scripts/get_dataset_stats.py" = ["E402", "T201"]
+"scripts/make_sig_perf.py" = ["E402", "T201"]
+"scripts/model_from_wandb_repl.py" = ["E402"]
+"scripts/paramspec_to_table.py" = ["E402", "T201"]
+"scripts/plot_param2tok.py" = ["E402", "E741", "F841", "T201"]
+"scripts/predict_vst_audio.py" = ["E402", "F841"]
+"scripts/reshard_data.py" = ["T201"]
+"scripts/subdir_funtime.py" = ["F841"]
+"src/eval.py" = ["E402", "F841"]
+"src/models/components/transformer.py" = ["F841"]
+"src/models/components/vae.py" = ["E402", "T201"]
+"src/models/ksin_ff_module.py" = ["F821"]
+"src/models/surge_ff_module.py" = ["F821"]
+"src/train.py" = ["E402"]
+"src/utils/__init__.py" = ["F401"]
+"src/utils/callbacks.py" = ["F821", "T201"]
 
 [tool.interrogate]
 verbose = 2

--- a/renderscript.sh
+++ b/renderscript.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 tempfile=$(mktemp)
 Xvfb -displayfd 3 -screen 0 1280x720x24 -ac 3>"$tempfile" &
 XVFB_PID=$!

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ wandb
 # --------- others --------- #
 rootutils       # standardizing the project root setup
 pre-commit      # hooks for applying linters on commit
+pyright         # linter dep (static type checker)
 rich            # beautiful text formatting in terminal
 pytest          # tests
 scipy==1.14.1

--- a/scripts/add_music2latent.py
+++ b/scripts/add_music2latent.py
@@ -22,9 +22,9 @@ def get_shard_id(shard_path: Path) -> int:
 def reader_process(
     shard_path: Path, batch_size: int, read_queue: Queue, batch_indices: List[int]
 ):
-    """
-    Opens the HDF5 file in read-only SWMR mode and reads only the batches whose
-    indices are in `batch_indices` from the "audio" dataset.
+    """Opens the HDF5 file in read-only SWMR mode and reads only the batches whose indices are in
+    `batch_indices` from the "audio" dataset.
+
     Each read batch is put on the read_queue as a tuple: (start_index, end_index, audio_data).
     When finished, a None is put on the queue as a sentinel.
     """
@@ -40,9 +40,10 @@ def reader_process(
 
 
 def writer_process(shard_path: Path, write_queue: Queue):
-    """
-    Opens the HDF5 file in read/write SWMR mode and writes processed batches into the
-    "music2latent" dataset. Each item in the write_queue is expected to be a tuple:
+    """Opens the HDF5 file in read/write SWMR mode and writes processed batches into the
+    "music2latent" dataset.
+
+    Each item in the write_queue is expected to be a tuple:
     (start_index, end_index, processed_data). When finished (i.e. when receiving None),
     the process exits.
     """
@@ -63,11 +64,10 @@ def writer_process(shard_path: Path, write_queue: Queue):
 def process_shard(
     shard_path: Path, batch_size: int, m2l: EncoderDecoder, num_readers: int
 ):
-    """
-    For a given shard, first pre-create the output dataset if needed.
-    Then spawn multiple reader processes and one writer process.
-    The main (GPU) process pulls batches from the read_queue, processes them,
-    and pushes the results onto the write_queue.
+    """For a given shard, first pre-create the output dataset if needed.
+
+    Then spawn multiple reader processes and one writer process. The main (GPU) process pulls
+    batches from the read_queue, processes them, and pushes the results onto the write_queue.
     """
     # First, create (or verify) the output dataset.
     # first we run `h5clear -s file`

--- a/scripts/add_music2latent.py
+++ b/scripts/add_music2latent.py
@@ -1,10 +1,9 @@
 #!/usr/bin/env python
-import time
 import multiprocessing
 import os
+import time
 from multiprocessing import Process, Queue
 from pathlib import Path
-from typing import List, Optional, Tuple
 
 import click
 import h5py
@@ -19,9 +18,7 @@ def get_shard_id(shard_path: Path) -> int:
     return int(shard_path.stem.split("-")[1])
 
 
-def reader_process(
-    shard_path: Path, batch_size: int, read_queue: Queue, batch_indices: List[int]
-):
+def reader_process(shard_path: Path, batch_size: int, read_queue: Queue, batch_indices: list[int]):
     """Opens the HDF5 file in read-only SWMR mode and reads only the batches whose indices are in
     `batch_indices` from the "audio" dataset.
 
@@ -61,9 +58,7 @@ def writer_process(shard_path: Path, write_queue: Queue):
             f.flush()  # Flush so changes are visible in SWMR mode.
 
 
-def process_shard(
-    shard_path: Path, batch_size: int, m2l: EncoderDecoder, num_readers: int
-):
+def process_shard(shard_path: Path, batch_size: int, m2l: EncoderDecoder, num_readers: int):
     """For a given shard, first pre-create the output dataset if needed.
 
     Then spawn multiple reader processes and one writer process. The main (GPU) process pulls
@@ -77,9 +72,7 @@ def process_shard(
         num_samples = f["audio"].shape[0]
         if "music2latent" not in f:
             # Adjust the shape and dtype as needed.
-            f.create_dataset(
-                "music2latent", shape=(num_samples, 128, 42), dtype=np.float32
-            )
+            f.create_dataset("music2latent", shape=(num_samples, 128, 42), dtype=np.float32)
         f.flush()
 
     f.close()
@@ -151,12 +144,8 @@ def process_shard(
 
 @click.command()
 @click.argument("data_dir", type=str)
-@click.option(
-    "--batch-size", "-c", type=int, default=1024, help="Batch size for processing."
-)
-@click.option(
-    "--shard-range", "-r", type=int, nargs=2, default=None, help="Optional shard range."
-)
+@click.option("--batch-size", "-c", type=int, default=1024, help="Batch size for processing.")
+@click.option("--shard-range", "-r", type=int, nargs=2, default=None, help="Optional shard range.")
 @click.option("--shard", "-s", type=int, default=None, help="Optional shard index.")
 @click.option(
     "--num-readers",
@@ -168,8 +157,8 @@ def process_shard(
 def main(
     data_dir: str,
     batch_size: int,
-    shard_range: Optional[Tuple[int, int]],
-    shard: Optional[int],
+    shard_range: tuple[int, int] | None,
+    shard: int | None,
     num_readers: int,
 ):
     data_dir = Path(data_dir)
@@ -179,9 +168,7 @@ def main(
         raise ValueError("Cannot specify both --shard-range and --shard.")
 
     if shard_range is not None:
-        data_shards = [
-            ds for ds in data_shards if get_shard_id(ds) in range(*shard_range)
-        ]
+        data_shards = [ds for ds in data_shards if get_shard_id(ds) in range(*shard_range)]
     if shard is not None:
         data_shards = [ds for ds in data_shards if get_shard_id(ds) == shard]
 

--- a/scripts/aggregate_samples.sh
+++ b/scripts/aggregate_samples.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 ## declare an array variable
 declare -a datasets=("full" "simple" "nsynth" "fsd")
 

--- a/scripts/compute_audio_metrics.py
+++ b/scripts/compute_audio_metrics.py
@@ -41,7 +41,7 @@ from pedalboard.io import AudioFile
 
 
 def subdir_matches_pattern(dir: Path) -> bool:
-    """Returns true if subdir contains pred.wav and target.wav"""
+    """Returns true if subdir contains pred.wav and target.wav."""
     return (dir / "target.wav").exists() and (dir / "pred.wav").exists()
 
 

--- a/scripts/compute_audio_metrics.py
+++ b/scripts/compute_audio_metrics.py
@@ -26,7 +26,6 @@ import multiprocessing
 import os
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from pathlib import Path
-from typing import List
 
 import click
 import librosa
@@ -45,7 +44,7 @@ def subdir_matches_pattern(dir: Path) -> bool:
     return (dir / "target.wav").exists() and (dir / "pred.wav").exists()
 
 
-def find_possible_subdirs(audio_dir: Path) -> List[Path]:
+def find_possible_subdirs(audio_dir: Path) -> list[Path]:
     all_subdirectories = [d for d in audio_dir.glob("*") if d.is_dir()]
     matching_dirs = [d for d in all_subdirectories if subdir_matches_pattern(d)]
     return matching_dirs
@@ -102,9 +101,7 @@ def compute_jtfs(y: np.ndarray, J: int = 10, Q: int = 12):
     return scatter(y)
 
 
-def compute_jtfs_distance(
-    target: np.ndarray, pred: np.ndarray, J: int = 10, Q: int = 12
-) -> float:
+def compute_jtfs_distance(target: np.ndarray, pred: np.ndarray, J: int = 10, Q: int = 12) -> float:
     logger.info("Computing JTFS...")
 
     target_jtfs = compute_jtfs(target, J, Q)
@@ -205,9 +202,7 @@ def compute_sot(target: np.ndarray, pred: np.ndarray) -> float:
     target_stft = get_stft(target)
     pred_stft = get_stft(pred)
 
-    target_stft = target_stft / np.clip(
-        target_stft.sum(axis=-1, keepdims=True), 1e-6, None
-    )
+    target_stft = target_stft / np.clip(target_stft.sum(axis=-1, keepdims=True), 1e-6, None)
     pred_stft = pred_stft / np.clip(pred_stft.sum(axis=-1, keepdims=True), 1e-6, None)
 
     dists = batched_wasserstein_distance_np(target_stft, pred_stft)
@@ -252,7 +247,7 @@ def compute_metrics_on_dir(audio_dir: Path) -> dict[str, float]:
     return dict(mss=mss, wmfcc=wmfcc, sot=sot, rms=rms)
 
 
-def compute_metrics(audio_dirs: List[Path], output_dir: Path):
+def compute_metrics(audio_dirs: list[Path], output_dir: Path):
     idxs = []
     rows = []
     for dir in audio_dirs:
@@ -289,16 +284,12 @@ def main(audio_dir: str, output_dir: str, num_workers: int):
 
     sublist_length = len(audio_dirs) // num_workers
     sublists = [
-        audio_dirs[i * sublist_length : (i + 1) * sublist_length]
-        for i in range(num_workers)
+        audio_dirs[i * sublist_length : (i + 1) * sublist_length] for i in range(num_workers)
     ]
 
     metric_dfs = []
     with ProcessPoolExecutor(max_workers=num_workers) as executor:
-        futures = [
-            executor.submit(compute_metrics, sublist, output_dir)
-            for sublist in sublists
-        ]
+        futures = [executor.submit(compute_metrics, sublist, output_dir) for sublist in sublists]
 
         for future in as_completed(futures):
             metric_file = future.result()

--- a/scripts/generate_surge_xt_data.py
+++ b/scripts/generate_surge_xt_data.py
@@ -1,9 +1,11 @@
 import click
 
+
 @click.command()
 @click.option("--surge-path", default="vsts/Surge XT.vst3")
 def main(surge_path: str):
     pass
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/get-ckpt-from-wandb.sh
+++ b/scripts/get-ckpt-from-wandb.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 wandbid=$1
 CANDIDATES=$(
   find logs/train -type d -wholename "*wandb/*$wandbid" -print0 \

--- a/scripts/get_dataset_stats.py
+++ b/scripts/get_dataset_stats.py
@@ -82,7 +82,7 @@ def get_stats_directory(directory):
             logger.info(f"Processed {i + 1} files...")
 
     mean, std = finalize(existing)
-    
+
 
     logger.info(f"Saving to {str(out_file)}")
 

--- a/scripts/get_dataset_stats.py
+++ b/scripts/get_dataset_stats.py
@@ -3,7 +3,6 @@ import sys
 
 import dask.array as da
 import h5py
-import hdf5plugin
 import numpy as np
 import rootutils
 from dask.distributed import Client, progress
@@ -83,14 +82,12 @@ def get_stats_directory(directory):
 
     mean, std = finalize(existing)
 
-
     logger.info(f"Saving to {str(out_file)}")
 
     np.savez(out_file, mean=mean, std=std)
 
 
 if __name__ == "__main__":
-
     # filename = "/data/scratch/acw585/surge/train.hdf5"
     filename = sys.argv[1]
 

--- a/scripts/make_sig_perf.py
+++ b/scripts/make_sig_perf.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import Callable
+from collections.abc import Callable
 
 import psutil
 import rootutils

--- a/scripts/model_from_wandb_repl.py
+++ b/scripts/model_from_wandb_repl.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Literal, Tuple
+from typing import Literal
 
 import click
 import hydra
@@ -16,7 +16,7 @@ from src.utils import register_resolvers
 
 def wandb_dir_to_ckpt_and_hparams(
     wandb_dir: Path, ckpt_type: Literal["best", "last"]
-) -> Tuple[Path, Path]:
+) -> tuple[Path, Path]:
     log_dir = wandb_dir.parent.parent
     ckpt_dir = log_dir / "checkpoints"
 
@@ -97,9 +97,7 @@ def main(
 
     if len(ckpts_and_hparams) > 1:
         # take the one with the most recently updated hparam file
-        ckpt_file, hparam_file = max(
-            ckpts_and_hparams, key=lambda x: x[1].stat().st_mtime
-        )
+        ckpt_file, hparam_file = max(ckpts_and_hparams, key=lambda x: x[1].stat().st_mtime)
     elif len(ckpts_and_hparams) == 1:
         ckpt_file, hparam_file = ckpts_and_hparams[0]
     else:

--- a/scripts/paramspec_to_table.py
+++ b/scripts/paramspec_to_table.py
@@ -51,8 +51,8 @@ def main():
 
     params = list(set(simple_params + full_params))
     params = sorted(params)
-    params = [(p, True) if p in simple_params else (p, False) for p in params ]
-    params = [(p, s, True) if p in full_params else (p, s, False) for p, s in params ]
+    params = [(p, True) if p in simple_params else (p, False) for p in params]
+    params = [(p, s, True) if p in full_params else (p, s, False) for p, s in params]
     params = [(clean_param(p), s, f) for p, s, f in params]
 
     params = {p: {"simple": s, "full": f} for p, s, f in params}
@@ -65,9 +65,7 @@ def main():
 
     print(TABLE_PREAMBLE)
     for k, v in params.items():
-        print(
-            f" &\n{k} &\n{YES if v['simple'] else NO} & {YES if v['full'] else NO} &\n \\\\"
-        )
+        print(f" &\n{k} &\n{YES if v['simple'] else NO} & {YES if v['full'] else NO} &\n \\\\")
 
     print(TABLE_POSTAMBLE)
 

--- a/scripts/paramspec_to_table.py
+++ b/scripts/paramspec_to_table.py
@@ -6,7 +6,7 @@ from src.data.vst import param_specs
 
 TABLE_PREAMBLE = """
 \\begin{longtable}{rlccl}
- \\addlinespace[-\\aboverulesep] 
+ \\addlinespace[-\\aboverulesep]
  \\cmidrule[\\heavyrulewidth]{2-5}
     &
      Parameter &
@@ -16,7 +16,7 @@ TABLE_PREAMBLE = """
 
 TABLE_POSTAMBLE = """
  \\cmidrule[\\heavyrulewidth]{2-5}
- \\addlinespace[-\\belowrulesep] 
+ \\addlinespace[-\\belowrulesep]
 \\rule{0pt}{0ex}\\\\
 \\caption{}
 \\label{tab:}

--- a/scripts/plot_param2tok.py
+++ b/scripts/plot_param2tok.py
@@ -1,7 +1,6 @@
-import math
 import os
 from pathlib import Path
-from typing import Literal, Tuple
+from typing import Literal
 
 import click
 import hydra
@@ -9,7 +8,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 import rootutils
 import torch
-from IPython import embed
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
@@ -22,7 +20,7 @@ from src.utils import register_resolvers
 
 def wandb_dir_to_ckpt_and_hparams(
     wandb_dir: Path, ckpt_type: Literal["best", "last"]
-) -> Tuple[Path, Path]:
+) -> tuple[Path, Path]:
     log_dir = wandb_dir.parent.parent
     ckpt_dir = log_dir / "checkpoints"
 
@@ -223,9 +221,7 @@ def get_labels(spec: str):
 
         true_intervals.append((cur_name, cur_len))
 
-    true_intervals = [
-        (RENAMES.get(name, name), length) for name, length in true_intervals
-    ]
+    true_intervals = [(RENAMES.get(name, name), length) for name, length in true_intervals]
 
     return true_intervals
 
@@ -441,9 +437,7 @@ def main(
 
     if len(ckpts_and_hparams) > 1:
         # take the one with the most recently updated hparam file
-        ckpt_file, hparam_file = max(
-            ckpts_and_hparams, key=lambda x: x[1].stat().st_mtime
-        )
+        ckpt_file, hparam_file = max(ckpts_and_hparams, key=lambda x: x[1].stat().st_mtime)
     elif len(ckpts_and_hparams) == 1:
         ckpt_file, hparam_file = ckpts_and_hparams[0]
     else:

--- a/scripts/predict_vst_audio.py
+++ b/scripts/predict_vst_audio.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-from typing import List, Optional
 
 import click
 import librosa
@@ -60,7 +59,7 @@ def write_spectrograms(
             ax=axs[i],
             cmap="magma",
         )
-        axs[i].set_title(f"Pred (Chan {i+1})")
+        axs[i].set_title(f"Pred (Chan {i + 1})")
 
     for i, spec in enumerate(target_specs):
         spec = librosa.amplitude_to_db(spec, ref=np.max)
@@ -73,7 +72,7 @@ def write_spectrograms(
             ax=axs[i + len(pred_specs)],
             cmap="magma",
         )
-        axs[i + len(pred_specs)].set_title(f"Target (Chan {i+1})")
+        axs[i + len(pred_specs)].set_title(f"Target (Chan {i + 1})")
 
     plt.tight_layout()
     plt.savefig(save_path)
@@ -185,9 +184,7 @@ def main(
                 target_params_ = target_params[j].numpy()
                 target_params_ = (target_params_ + 1) / 2
                 target_params_ = np.clip(target_params_, 0, 1)
-                target_synth_params, target_note_params = param_spec.decode(
-                    target_params_
-                )
+                target_synth_params, target_note_params = param_spec.decode(target_params_)
 
                 load_preset(plugin, preset_path)
                 new_target = render_params(

--- a/scripts/rewrite_dataset_to_latest.py
+++ b/scripts/rewrite_dataset_to_latest.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
+import concurrent.futures
 import os
 from pathlib import Path
+
 import click
 import h5py
-import concurrent.futures
 
 
 def rewrite_shard(shard: Path, output_dir: Path) -> (Path, bool, str):
@@ -21,8 +22,7 @@ def rewrite_shard(shard: Path, output_dir: Path) -> (Path, bool, str):
     temp_file = output_dir / f"{shard.stem}.temp.h5"
 
     try:
-        with h5py.File(shard, "r") as f_in, \
-             h5py.File(temp_file, "w", libver="latest") as f_out:
+        with h5py.File(shard, "r") as f_in, h5py.File(temp_file, "w", libver="latest") as f_out:
             # Copy every top-level item (dataset or group) from the input file.
             for key in f_in:
                 f_in.copy(key, f_out)
@@ -38,10 +38,16 @@ def rewrite_shard(shard: Path, output_dir: Path) -> (Path, bool, str):
 @click.command()
 @click.argument("input_dir", type=str)
 @click.argument("output_dir", type=str)
-@click.option("--pattern", "-p", type=str, default="shard-*.h5",
-              help="Glob pattern to find shard files in the input directory.")
-@click.option("--workers", "-w", type=int, default=4,
-              help="Number of worker processes to run in parallel.")
+@click.option(
+    "--pattern",
+    "-p",
+    type=str,
+    default="shard-*.h5",
+    help="Glob pattern to find shard files in the input directory.",
+)
+@click.option(
+    "--workers", "-w", type=int, default=4, help="Number of worker processes to run in parallel."
+)
 def main(input_dir, output_dir, pattern, workers):
     """Rewrite each HDF5 file matching the given pattern in INPUT_DIR so that it is created with
     libver="latest" (i.e. with a superblock version >= 3) and write the new files to OUTPUT_DIR."""
@@ -54,7 +60,9 @@ def main(input_dir, output_dir, pattern, workers):
         click.echo(f"No files found matching pattern '{pattern}' in {input_dir}.")
         return
 
-    click.echo(f"Found {len(shard_files)} file(s). Rewriting with libver='latest' using {workers} workers...")
+    click.echo(
+        f"Found {len(shard_files)} file(s). Rewriting with libver='latest' using {workers} workers..."
+    )
 
     # Process the shards in parallel.
     with concurrent.futures.ProcessPoolExecutor(max_workers=workers) as executor:

--- a/scripts/rewrite_dataset_to_latest.py
+++ b/scripts/rewrite_dataset_to_latest.py
@@ -7,9 +7,8 @@ import concurrent.futures
 
 
 def rewrite_shard(shard: Path, output_dir: Path) -> (Path, bool, str):
-    """
-    Rewrites a given HDF5 shard file so that it is created with libver="latest"
-    and writes the new file to output_dir.
+    """Rewrites a given HDF5 shard file so that it is created with libver="latest" and writes the
+    new file to output_dir.
 
     Parameters:
         shard (Path): Path to the input HDF5 shard file.
@@ -44,10 +43,8 @@ def rewrite_shard(shard: Path, output_dir: Path) -> (Path, bool, str):
 @click.option("--workers", "-w", type=int, default=4,
               help="Number of worker processes to run in parallel.")
 def main(input_dir, output_dir, pattern, workers):
-    """
-    Rewrite each HDF5 file matching the given pattern in INPUT_DIR so that it is created
-    with libver="latest" (i.e. with a superblock version >= 3) and write the new files to OUTPUT_DIR.
-    """
+    """Rewrite each HDF5 file matching the given pattern in INPUT_DIR so that it is created with
+    libver="latest" (i.e. with a superblock version >= 3) and write the new files to OUTPUT_DIR."""
     input_dir = Path(input_dir)
     output_dir = Path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)

--- a/scripts/subdir_funtime.py
+++ b/scripts/subdir_funtime.py
@@ -30,7 +30,7 @@ def compute_mel_specs(y: np.ndarray, sample_rate: float = 44100.0):
         hop = int(hop_size * sample_rate / 1000.0)
 
         spec = librosa.feature.melspectrogram(
-            y=y, 
+            y=y,
             sr=sample_rate,
             n_mels=n_mels,
             n_fft=win,
@@ -84,7 +84,7 @@ def main(root_dir, n_subdirs, output_txt):
     """
     # Grab all potential subdirectories in root_dir
     all_subdirs = sorted(
-        d for d in os.listdir(root_dir) 
+        d for d in os.listdir(root_dir)
         if os.path.isdir(os.path.join(root_dir, d))
     )
 

--- a/scripts/subdir_funtime.py
+++ b/scripts/subdir_funtime.py
@@ -15,9 +15,10 @@ MEL_PARAMS = [
 ]
 
 def compute_mel_specs(y: np.ndarray, sample_rate: float = 44100.0):
-    """
-    Given an audio signal 'y' of shape (channels, samples), compute three mel-spectrograms
-    using different window/hop/mel parameters. Return them as a list of dB-scaled numpy arrays.
+    """Given an audio signal 'y' of shape (channels, samples), compute three mel-spectrograms using
+    different window/hop/mel parameters.
+
+    Return them as a list of dB-scaled numpy arrays.
     """
     # If the input audio has more than 1 channel, we can average down to mono
     # or otherwise choose a specific channel. Here we simply sum across channels:
@@ -43,10 +44,8 @@ def compute_mel_specs(y: np.ndarray, sample_rate: float = 44100.0):
     return mel_specs
 
 def compute_mss(target: np.ndarray, pred: np.ndarray) -> float:
-    """
-    Compute the mean spectral (mel) distance (MSS) between 'target' and 'pred' audio,
-    both of which must be numpy arrays of shape (channels, samples).
-    """
+    """Compute the mean spectral (mel) distance (MSS) between 'target' and 'pred' audio, both of
+    which must be numpy arrays of shape (channels, samples)."""
     logger.info("Computing MSS...")
     target_specs = compute_mel_specs(target)
     pred_specs = compute_mel_specs(pred)
@@ -77,11 +76,9 @@ def compute_mss(target: np.ndarray, pred: np.ndarray) -> float:
     help="Output file name for storing sorted results."
 )
 def main(root_dir, n_subdirs, output_txt):
-    """
-    Script that computes the MSS metric for up to N subdirectories (each containing
-    'pred.wav' and 'target.wav') and writes a text file containing the subdir names
-    sorted by ascending MSS value.
-    """
+    """Script that computes the MSS metric for up to N subdirectories (each containing 'pred.wav'
+    and 'target.wav') and writes a text file containing the subdir names sorted by ascending MSS
+    value."""
     # Grab all potential subdirectories in root_dir
     all_subdirs = sorted(
         d for d in os.listdir(root_dir)

--- a/scripts/subdir_funtime.py
+++ b/scripts/subdir_funtime.py
@@ -1,9 +1,10 @@
-import os
-import click
-import numpy as np
-import librosa
-from pedalboard.io import AudioFile
 import logging
+import os
+
+import click
+import librosa
+import numpy as np
+from pedalboard.io import AudioFile
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -13,6 +14,7 @@ MEL_PARAMS = [
     (25, 10, 64),
     (100, 50, 128),
 ]
+
 
 def compute_mel_specs(y: np.ndarray, sample_rate: float = 44100.0):
     """Given an audio signal 'y' of shape (channels, samples), compute three mel-spectrograms using
@@ -43,6 +45,7 @@ def compute_mel_specs(y: np.ndarray, sample_rate: float = 44100.0):
 
     return mel_specs
 
+
 def compute_mss(target: np.ndarray, pred: np.ndarray) -> float:
     """Compute the mean spectral (mel) distance (MSS) between 'target' and 'pred' audio, both of
     which must be numpy arrays of shape (channels, samples)."""
@@ -57,23 +60,19 @@ def compute_mss(target: np.ndarray, pred: np.ndarray) -> float:
     dist /= len(target_specs)
     return dist
 
+
 @click.command()
 @click.option(
-    "--root_dir",
-    required=True,
-    help="Path to the folder containing sample_1, sample_2, etc."
+    "--root_dir", required=True, help="Path to the folder containing sample_1, sample_2, etc."
 )
 @click.option(
-    "--n_subdirs",
-    default=10,
-    show_default=True,
-    help="Number of subdirectories to process."
+    "--n_subdirs", default=10, show_default=True, help="Number of subdirectories to process."
 )
 @click.option(
     "--output_txt",
     default="mss_results.txt",
     show_default=True,
-    help="Output file name for storing sorted results."
+    help="Output file name for storing sorted results.",
 )
 def main(root_dir, n_subdirs, output_txt):
     """Script that computes the MSS metric for up to N subdirectories (each containing 'pred.wav'
@@ -81,8 +80,7 @@ def main(root_dir, n_subdirs, output_txt):
     value."""
     # Grab all potential subdirectories in root_dir
     all_subdirs = sorted(
-        d for d in os.listdir(root_dir)
-        if os.path.isdir(os.path.join(root_dir, d))
+        d for d in os.listdir(root_dir) if os.path.isdir(os.path.join(root_dir, d))
     )
 
     # If you only want sample_<number> style subdirs, you could filter here. E.g.:
@@ -125,6 +123,7 @@ def main(root_dir, n_subdirs, output_txt):
             f_out.write(f"{subdir_name}\t{mss_val:.6f}\n")
 
     logger.info(f"Done. Results written to {output_txt}")
+
 
 if __name__ == "__main__":
     main()

--- a/src/data/audio_datamodule.py
+++ b/src/data/audio_datamodule.py
@@ -9,9 +9,10 @@ from pedalboard.io import AudioFile
 
 
 def make_spectrogram(audio: np.ndarray, sample_rate: float) -> np.ndarray:
-    """Values hardcoded to be roughly like those used by the audio spectrogram
-    transformer. i.e. 100 frames per second, 128 mels, ~25ms window, hamming
-    window."""
+    """Values hardcoded to be roughly like those used by the audio spectrogram transformer.
+
+    i.e. 100 frames per second, 128 mels, ~25ms window, hamming window.
+    """
 
     n_fft = int(0.025 * sample_rate)
     hop_length = int(sample_rate / 100.0)

--- a/src/data/fm_datamodule.py
+++ b/src/data/fm_datamodule.py
@@ -42,9 +42,8 @@ def _sample_freqs_symmetry_broken(
     device: Union[str, torch.device],
     generator: Optional[torch.Generator] = None,
 ) -> torch.Tensor:
-    """Sample frequencies such that each sinusoidal component has frequency drawn from
-    disjoint intervals.
-    """
+    """Sample frequencies such that each sinusoidal component has frequency drawn from disjoint
+    intervals."""
     freqs = _sample_freqs(k, num_samples, device, generator) / k
     shift = 2.0 * torch.arange(k, device=device) / k
     return freqs + shift[None, :]
@@ -54,6 +53,7 @@ def fm_conditional_symmetry(
     params: torch.Tensor, length: int, break_symmetry: bool = False
 ):
     """An FM synthesiser with algorithm (M1->C1) + C2.
+
     param layout: [m1, c2, c1]
     """
     freqs, amps = params.chunk(2, dim=-1)
@@ -244,9 +244,8 @@ class FMDataset(torch.utils.data.Dataset):
 
 
 class FMDataModule(LightningDataModule):
-    """The FM task is designed to probe conditional symmetry by constructing signals
-    from simple frequency modulation synthesisers.
-    """
+    """The FM task is designed to probe conditional symmetry by constructing signals from simple
+    frequency modulation synthesisers."""
 
     def __init__(
         self,

--- a/src/data/kosc_datamodule.py
+++ b/src/data/kosc_datamodule.py
@@ -168,11 +168,11 @@ class KOscDataset(torch.utils.data.Dataset):
 
 
 class KOscDataModule(LightningDataModule):
-    """k-Osc is a simple synthetic synthesiser parameter estimation task designed to
-    elicit problematic behaviour in response to permutation invariant labels.
+    """K-Osc is a simple synthetic synthesiser parameter estimation task designed to elicit
+    problematic behaviour in response to permutation invariant labels.
 
-    Each item consists of a signal containing a mixture of sinusoids, and the amplitude
-    and frequency parameters used to generate the sinusoids.
+    Each item consists of a signal containing a mixture of sinusoids, and the amplitude and
+    frequency parameters used to generate the sinusoids.
     """
 
     def __init__(

--- a/src/data/vst/core.py
+++ b/src/data/vst/core.py
@@ -11,10 +11,8 @@ from pedalboard.io import AudioFile
 
 
 def _call_with_interrupt(fn: Callable, sleep_time: float = 2.0):
-    """
-    Calls the function fn on the main thread, while another thread
-    sends a KeyboardInterrupt (SIGINT) to the main thread.
-    """
+    """Calls the function fn on the main thread, while another thread sends a KeyboardInterrupt
+    (SIGINT) to the main thread."""
 
     def send_interrupt():
         # Brief sleep so that fn starts before we send the interrupt

--- a/src/data/vst/generate_vst_dataset.py
+++ b/src/data/vst/generate_vst_dataset.py
@@ -38,9 +38,10 @@ class VSTDataSample:
 
 
 def make_spectrogram(audio: np.ndarray, sample_rate: float) -> np.ndarray:
-    """Values hardcoded to be roughly like those used by the audio spectrogram
-    transformer. i.e. 100 frames per second, 128 mels, ~25ms window, hamming
-    window."""
+    """Values hardcoded to be roughly like those used by the audio spectrogram transformer.
+
+    i.e. 100 frames per second, 128 mels, ~25ms window, hamming window.
+    """
 
     n_fft = int(0.025 * sample_rate)
     hop_length = int(sample_rate / 100.0)

--- a/src/data/vst/param_spec.py
+++ b/src/data/vst/param_spec.py
@@ -199,7 +199,7 @@ class ContinuousParameter(Parameter):
 
 
 class NoteDurationParameter(Parameter):
-    """A special parameter for sampling note durations"""
+    """A special parameter for sampling note durations."""
 
     def __init__(self, name: str, max_note_duration_seconds: float):
         super().__init__(name)

--- a/src/eval.py
+++ b/src/eval.py
@@ -1,8 +1,7 @@
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import hydra
 import rootutils
-import torch
 from lightning import Callback, LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.loggers import Logger
 from omegaconf import DictConfig
@@ -41,7 +40,7 @@ log = RankedLogger(__name__, rank_zero_only=True)
 
 
 @task_wrapper
-def evaluate(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+def evaluate(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     """Evaluates given checkpoint on a datamodule testset.
 
     This method is wrapped in optional @task_wrapper decorator, that controls the behavior during
@@ -59,15 +58,13 @@ def evaluate(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     model: LightningModule = hydra.utils.instantiate(cfg.model)
 
     log.info("Instantiating callbacks...")
-    callbacks: List[Callback] = instantiate_callbacks(cfg.get("callbacks"))
+    callbacks: list[Callback] = instantiate_callbacks(cfg.get("callbacks"))
 
     log.info("Instantiating loggers...")
-    logger: List[Logger] = instantiate_loggers(cfg.get("logger"))
+    logger: list[Logger] = instantiate_loggers(cfg.get("logger"))
 
     log.info(f"Instantiating trainer <{cfg.trainer._target_}>")
-    trainer: Trainer = hydra.utils.instantiate(
-        cfg.trainer, logger=logger, callbacks=callbacks
-    )
+    trainer: Trainer = hydra.utils.instantiate(cfg.trainer, logger=logger, callbacks=callbacks)
 
     object_dict = {
         "cfg": cfg,

--- a/src/metrics.py
+++ b/src/metrics.py
@@ -1,10 +1,9 @@
-from typing import Callable
+from collections.abc import Callable
 
 import torch
 from scipy.optimize import linear_sum_assignment
 from torchmetrics import Metric
 
-from src.data.ksin_datamodule import make_sin
 from src.models.components.loss import chamfer_loss, params_to_tokens
 
 
@@ -74,9 +73,7 @@ class SpectralDistance(Metric):
 class ChamferDistance(Metric):
     def __init__(self, params_per_token: int, **kwargs):
         super().__init__(**kwargs)
-        self.add_state(
-            "chamfer_distance", default=torch.tensor(0.0), dist_reduce_fx="sum"
-        )
+        self.add_state("chamfer_distance", default=torch.tensor(0.0), dist_reduce_fx="sum")
         self.add_state("count", default=torch.tensor(0), dist_reduce_fx="sum")
         self.params_per_token = params_per_token
 

--- a/src/models/components/cnn.py
+++ b/src/models/components/cnn.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional
+from typing import Literal
 
 import torch
 import torch.nn as nn
@@ -8,8 +8,8 @@ class ResidualMLPBlock(nn.Module):
     def __init__(
         self,
         in_dim: int,
-        hidden_dim: Optional[int] = None,
-        out_dim: Optional[int] = None,
+        hidden_dim: int | None = None,
+        out_dim: int | None = None,
     ) -> None:
         super().__init__()
         if hidden_dim is None:
@@ -28,9 +28,7 @@ class ResidualMLPBlock(nn.Module):
         )
 
         self.residual = (
-            nn.Identity()
-            if in_dim == out_dim
-            else nn.Linear(in_dim, out_dim, bias=False)
+            nn.Identity() if in_dim == out_dim else nn.Linear(in_dim, out_dim, bias=False)
         )
 
     def forward(self, x):
@@ -49,8 +47,8 @@ class ResidualBlock(nn.Module):
     def __init__(
         self,
         in_dim: int,
-        hidden_dim: Optional[int] = None,
-        out_dim: Optional[int] = None,
+        hidden_dim: int | None = None,
+        out_dim: int | None = None,
         kernel_size: int = 7,
         norm: Literal["bn", "ln"] = "bn",
     ):
@@ -72,11 +70,7 @@ class ResidualBlock(nn.Module):
                 padding=kernel_size // 2,
             ),
             nn.GELU(),
-            (
-                nn.BatchNorm1d(hidden_dim)
-                if norm == "bn"
-                else LayerNormConv1dFriendly(hidden_dim)
-            ),
+            (nn.BatchNorm1d(hidden_dim) if norm == "bn" else LayerNormConv1dFriendly(hidden_dim)),
             nn.Conv1d(
                 in_channels=hidden_dim,
                 out_channels=out_dim,
@@ -103,9 +97,7 @@ class ResidualBlock(nn.Module):
 
 
 class ConvDownsampler(nn.Module):
-    def __init__(
-        self, in_dim: int, out_dim: int, stride: int, norm: Literal["bn", "ln"] = "bn"
-    ):
+    def __init__(self, in_dim: int, out_dim: int, stride: int, norm: Literal["bn", "ln"] = "bn"):
         super().__init__()
         self.net = nn.Sequential(
             nn.BatchNorm1d(in_dim) if norm == "bn" else LayerNormConv1dFriendly(in_dim),

--- a/src/models/components/loss.py
+++ b/src/models/components/loss.py
@@ -9,9 +9,7 @@ def params_to_tokens(params: torch.Tensor, params_per_token: int = 2):
     return torch.stack(units, dim=-1)
 
 
-def chamfer_loss(
-    predicted: torch.Tensor, target: torch.Tensor, params_per_token: int = 2
-):
+def chamfer_loss(predicted: torch.Tensor, target: torch.Tensor, params_per_token: int = 2):
     predicted_tokens = params_to_tokens(predicted, params_per_token)
     target_tokens = params_to_tokens(target, params_per_token)
 

--- a/src/models/components/loss.py
+++ b/src/models/components/loss.py
@@ -3,9 +3,8 @@ import torch.nn as nn
 
 
 def params_to_tokens(params: torch.Tensor, params_per_token: int = 2):
-    """Assuming our model outputs a tensor of shape (batch, 2k), we stack it into a
-    tensor of shape (batch, k, 2) to allow for metric computation.
-    """
+    """Assuming our model outputs a tensor of shape (batch, 2k), we stack it into a tensor of shape
+    (batch, k, 2) to allow for metric computation."""
     units = params.chunk(params_per_token, dim=-1)
     return torch.stack(units, dim=-1)
 

--- a/src/models/components/residual_mlp.py
+++ b/src/models/components/residual_mlp.py
@@ -1,4 +1,4 @@
-from typing import Literal, Optional
+from typing import Literal
 
 import torch
 import torch.nn as nn
@@ -11,8 +11,8 @@ class ResidualMLPBlock(nn.Module):
     def __init__(
         self,
         in_dim: int,
-        hidden_dim: Optional[int] = None,
-        out_dim: Optional[int] = None,
+        hidden_dim: int | None = None,
+        out_dim: int | None = None,
     ) -> None:
         super().__init__()
         if hidden_dim is None:
@@ -31,9 +31,7 @@ class ResidualMLPBlock(nn.Module):
         )
 
         self.residual = (
-            nn.Identity()
-            if in_dim == out_dim
-            else nn.Linear(in_dim, out_dim, bias=False)
+            nn.Identity() if in_dim == out_dim else nn.Linear(in_dim, out_dim, bias=False)
         )
 
     def forward(self, x):
@@ -135,12 +133,9 @@ class ConditionalResidualMLP(nn.Module):
         else:
             raise ValueError("unexpected z shape")
 
-
         return torch.where(dropout_mask, z, dropout_token)
 
-    def forward(
-        self, x: torch.Tensor, t: torch.Tensor, c: Optional[torch.Tensor]
-    ) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, t: torch.Tensor, c: torch.Tensor | None) -> torch.Tensor:
         if c is None:
             c = self.cfg_dropout_token[0].expand(x.shape[0], -1)
 

--- a/src/models/components/sinkhorn.py
+++ b/src/models/components/sinkhorn.py
@@ -68,8 +68,9 @@ def sinkhorn(
 
 class SinkhornAttention(nn.Module):
     """Applies attention using a fixed number of Sinkhorn iterations in lieu of softmax.
-    This allows our attention matrix to approximate a doubly stochastic matrix, or a
-    transportation polytope in the case of cross-attention.
+
+    This allows our attention matrix to approximate a doubly stochastic matrix, or a transportation
+    polytope in the case of cross-attention.
     """
 
     def __init__(

--- a/src/models/components/transformer.py
+++ b/src/models/components/transformer.py
@@ -289,22 +289,17 @@ class SinusoidalConditioning(nn.Module):
 
 
 class MutualAttentionProjection(nn.Module):
-    """
-    p (b, n) parameters
-    sinusoidal embed -> MLP
-    +
-    pos embed
+    """P (b, n) parameters sinusoidal embed -> MLP + pos embed.
 
     to get (b, n, d) tokens
 
-    then concat with k learnt tokens for (b, n + k, d)
-    apply self attn and take last k for (b, k, d)
+    then concat with k learnt tokens for (b, n + k, d) apply self attn and take last k for (b, k,
+    d)
 
     pass through transformer
 
-    at output concat with n learnt tokens for (b, n + k, d)
-    apply self attn and take first n
-    final ffn to 1d
+    at output concat with n learnt tokens for (b, n + k, d) apply self attn and take first n final
+    ffn to 1d
     """
 
     def __init__(self, d_model: int, num_params: int, num_tokens: int):
@@ -511,6 +506,7 @@ class ApproxEquivTransformer(nn.Module):
 
 class PatchEmbed(nn.Module):
     """Convolutional patch encoder like in ViT, with overlap from AST.
+
     Difference is we zero pad up to next whole patch.
     """
 

--- a/src/models/components/transformer.py
+++ b/src/models/components/transformer.py
@@ -1,6 +1,5 @@
 import math
-from functools import cached_property
-from typing import Literal, Optional, Tuple
+from typing import Literal
 
 import torch
 import torch.nn as nn
@@ -8,9 +7,7 @@ from einops import rearrange
 
 
 class PositionalEncoding(nn.Module):
-    def __init__(
-        self, size: int, num_pos: int, init: Literal["zeros", "norm0.02"] = "zeros"
-    ):
+    def __init__(self, size: int, num_pos: int, init: Literal["zeros", "norm0.02"] = "zeros"):
         super().__init__()
 
         if init == "zeros":
@@ -65,9 +62,7 @@ class LearntProjection(nn.Module):
     ):
         super().__init__()
 
-        assignment = torch.full(
-            (num_tokens, num_params), 1.0 / math.sqrt(num_tokens * num_params)
-        )
+        assignment = torch.full((num_tokens, num_params), 1.0 / math.sqrt(num_tokens * num_params))
         assignment = assignment + 1e-4 * torch.randn_like(assignment)
         self._assignment = nn.Parameter(assignment)
 
@@ -77,7 +72,6 @@ class LearntProjection(nn.Module):
 
         self._in_projection = nn.Parameter(proj.clone())
         self._out_projection = nn.Parameter(proj.T.clone())
-
 
         if initial_ffn:
             self.initial_ffn = nn.Sequential(
@@ -136,9 +130,6 @@ class LearntProjection(nn.Module):
         return penalty
 
 
-
-
-
 class AdaptiveLayerNorm(nn.LayerNorm):
     def __init__(self, dim: int, conditioning_dim: int, *args, **kwargs):
         super().__init__(dim, *args, **kwargs)
@@ -166,9 +157,7 @@ class DiTransformerBlock(nn.Module):
     ):
         super().__init__()
         if first_norm:
-            self.norm1 = (
-                nn.LayerNorm(d_model) if norm == "layer" else nn.RMSNorm(d_model)
-            )
+            self.norm1 = nn.LayerNorm(d_model) if norm == "layer" else nn.RMSNorm(d_model)
         else:
             self.norm1 = nn.Identity()
         self.norm2 = nn.LayerNorm(d_model) if norm == "layer" else nn.RMSNorm(d_model)
@@ -239,7 +228,6 @@ class DiTransformerBlock(nn.Module):
             x = a2 * x + res
 
         return x
-
 
 
 class SinusoidalEncoding(nn.Module):
@@ -371,9 +359,7 @@ class ApproxEquivTransformer(nn.Module):
         self.cfg_dropout_token = nn.Parameter(torch.randn(1, conditioning_dim))
 
         conditioning_dim = (
-            conditioning_dim + 1
-            if time_encoding == "scalar"
-            else conditioning_dim + d_enc
+            conditioning_dim + 1 if time_encoding == "scalar" else conditioning_dim + d_enc
         )
 
         self.conditioning_ffn = nn.Sequential(
@@ -463,7 +449,7 @@ class ApproxEquivTransformer(nn.Module):
         self,
         x: torch.Tensor,
         t: torch.Tensor,
-        conditioning: Optional[torch.Tensor] = None,
+        conditioning: torch.Tensor | None = None,
     ) -> torch.Tensor:
         if conditioning is None:
             conditioning = self.cfg_dropout_token.expand(x.shape[0], -1)
@@ -516,7 +502,7 @@ class PatchEmbed(nn.Module):
         stride: int,
         in_channels: int,
         d_model: int,
-        spec_shape: Tuple[int] = (128, 401),
+        spec_shape: tuple[int] = (128, 401),
     ):
         super().__init__()
         assert stride < patch_size, "Overlap must be less than patch size"
@@ -537,9 +523,7 @@ class PatchEmbed(nn.Module):
         self.num_tokens = self._get_num_tokens(in_channels, spec_shape)
 
     def _get_num_tokens(self, in_channels, spec_shape):
-        x = torch.randn(
-            1, in_channels, *spec_shape, device=self.projection.weight.device
-        )
+        x = torch.randn(1, in_channels, *spec_shape, device=self.projection.weight.device)
         out_shape = self.projection(self.pad(x)).shape
         return math.prod(out_shape[-2:])
 
@@ -571,7 +555,7 @@ class AudioSpectrogramTransformer(nn.Module):
         patch_size: int = 16,
         patch_stride: int = 10,
         input_channels: int = 2,
-        spec_shape: Tuple[int] = (128, 401),
+        spec_shape: tuple[int] = (128, 401),
     ):
         super().__init__()
 
@@ -649,7 +633,7 @@ class ASTWithProjectionHead(AudioSpectrogramTransformer):
         patch_size: int = 16,
         patch_stride: int = 10,
         input_channels: int = 2,
-        spec_shape: Tuple[int] = (128, 401),
+        spec_shape: tuple[int] = (128, 401),
     ):
         super().__init__(
             d_model=d_model,

--- a/src/models/components/vae.py
+++ b/src/models/components/vae.py
@@ -1,6 +1,5 @@
 import math
 from dataclasses import dataclass
-from typing import Optional, Tuple
 
 import rootutils
 import torch
@@ -48,7 +47,9 @@ class CustomRealNVP(CompositeTransform):
         mask = torch.ones(features)
         mask[::2] = -1
 
-        use_dropout = True  # Quick and dirty: 'global' variable, as seen by the create_resnet function
+        use_dropout = (
+            True  # Quick and dirty: 'global' variable, as seen by the create_resnet function
+        )
 
         def create_resnet(in_features, out_features):
             return nets.ResidualNet(
@@ -64,9 +65,7 @@ class CustomRealNVP(CompositeTransform):
         layers = []
         for layer in range(num_layers):
             use_dropout = layer < (num_layers - 2)  # No dropout on the 2 last layers
-            transform = coupling_constructor(
-                mask=mask, transform_net_create_fn=create_resnet
-            )
+            transform = coupling_constructor(mask=mask, transform_net_create_fn=create_resnet)
             layers.append(transform)
             mask *= -1  # Checkerboard masking inverse
             if batch_norm_between_layers and layer < (
@@ -85,8 +84,8 @@ class EncoderBlock(nn.Module):
         self,
         in_channels: int,
         out_channels: int,
-        kernel_size: Tuple[int],
-        stride: Tuple[int],
+        kernel_size: tuple[int],
+        stride: tuple[int],
         padding: int,
     ):
         super().__init__()
@@ -114,7 +113,7 @@ class EncoderBlock(nn.Module):
 
 
 class Encoder(nn.Module):
-    def __init__(self, latent_dim: int, spec_dim: Tuple[int] = (128, 401)):
+    def __init__(self, latent_dim: int, spec_dim: tuple[int] = (128, 401)):
         super().__init__()
 
         self.cnn = nn.Sequential(
@@ -153,10 +152,10 @@ class DecoderBlock(nn.Module):
         self,
         in_channels: int,
         out_channels: int,
-        kernel_size: Tuple[int],
-        stride: Tuple[int],
+        kernel_size: tuple[int],
+        stride: tuple[int],
         padding: int,
-        output_padding: Optional[Tuple[int]] = None,
+        output_padding: tuple[int] | None = None,
     ):
         super().__init__()
         self.conv1 = nn.ConvTranspose2d(
@@ -190,9 +189,7 @@ class DecoderBlock(nn.Module):
 
 
 class Decoder(nn.Module):
-    def __init__(
-        self, latent_dim: int, num_channels: int, spec_dim: Tuple[int] = (128, 401)
-    ):
+    def __init__(self, latent_dim: int, num_channels: int, spec_dim: tuple[int] = (128, 401)):
         super().__init__()
 
         self.in_proj = nn.Linear(latent_dim, 2048)
@@ -302,9 +299,7 @@ def reconstruction_loss(y_hat: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
     return nn.functional.mse_loss(y_hat, y)
 
 
-def gaussian_log_prob(
-    x: torch.Tensor, mu: torch.Tensor, log_var: torch.Tensor
-) -> torch.Tensor:
+def gaussian_log_prob(x: torch.Tensor, mu: torch.Tensor, log_var: torch.Tensor) -> torch.Tensor:
     return -0.5 * (
         x.shape[1] * math.log(2 * math.pi)
         + torch.sum(log_var + (x - mu).pow(2) / log_var.exp(), dim=1)

--- a/src/models/components/vector_field.py
+++ b/src/models/components/vector_field.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import torch
 import torch.nn as nn
 
@@ -21,9 +19,9 @@ class VectorFieldBlock(nn.Module):
     def __init__(
         self,
         in_dim: int,
-        conditioning_dim: Optional[int] = None,
-        hidden_dim: Optional[int] = None,
-        out_dim: Optional[int] = None,
+        conditioning_dim: int | None = None,
+        hidden_dim: int | None = None,
+        out_dim: int | None = None,
     ) -> None:
         super().__init__()
         if hidden_dim is None:
@@ -46,18 +44,12 @@ class VectorFieldBlock(nn.Module):
         )
 
         self.residual = (
-            nn.Identity()
-            if in_dim == out_dim
-            else nn.Linear(in_dim, out_dim, bias=False)
+            nn.Identity() if in_dim == out_dim else nn.Linear(in_dim, out_dim, bias=False)
         )
 
-    def forward(
-        self, x: torch.Tensor, z: Optional[torch.Tensor] = None
-    ) -> torch.Tensor:
+    def forward(self, x: torch.Tensor, z: torch.Tensor | None = None) -> torch.Tensor:
         if self.conditioning:
-            assert (
-                z is not None
-            ), "z must be provided for conditional vector field block."
+            assert z is not None, "z must be provided for conditional vector field block."
             y = self.norm(x, z)
         else:
             y = self.norm(x)
@@ -69,9 +61,7 @@ class VectorFieldBlock(nn.Module):
 
 
 class VectorField(nn.Module):
-    def __init__(
-        self, field_dim: int, hidden_dim: int, conditioning_dim: int, num_blocks: int
-    ):
+    def __init__(self, field_dim: int, hidden_dim: int, conditioning_dim: int, num_blocks: int):
         super().__init__()
 
         self.field_dim = field_dim
@@ -101,7 +91,7 @@ class VectorField(nn.Module):
         self,
         x: torch.Tensor,
         t: torch.Tensor,
-        conditioning: Optional[torch.Tensor] = None,
+        conditioning: torch.Tensor | None = None,
     ):
         if conditioning is None:
             conditioning = self.cfg_dropout_token.expand(x.shape[0], -1)

--- a/src/models/ksin_ff_module.py
+++ b/src/models/ksin_ff_module.py
@@ -1,10 +1,9 @@
-from typing import Any, Callable, Dict, Tuple
+from typing import Any
 
 import torch
 from lightning import LightningModule
 
-from src.metrics import (ChamferDistance, LinearAssignmentDistance,
-                         LogSpectralDistance, SpectralDistance)
+from src.metrics import ChamferDistance, LinearAssignmentDistance, LogSpectralDistance
 from src.models.components.loss import ChamferLoss
 
 
@@ -49,13 +48,13 @@ class KSinFeedForwardModule(LightningModule):
         self.val_lsd.reset()
         self.val_chamfer.reset()
 
-    def model_step(self, batch: Tuple[torch.Tensor, torch.Tensor]):
+    def model_step(self, batch: tuple[torch.Tensor, torch.Tensor]):
         x, y, *_ = batch
         preds = self.forward(x)
         loss = self.criterion(preds, y)
         return loss, preds, y, x
 
-    def training_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         loss, preds, targets, inputs = self.model_step(batch)
 
         *_, synth_fn = batch
@@ -67,7 +66,7 @@ class KSinFeedForwardModule(LightningModule):
     def on_train_epoch_end(self) -> None:
         pass
 
-    def validation_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def validation_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         loss, preds, targets, inputs = self.model_step(batch)
 
         # update and log metrics
@@ -76,15 +75,13 @@ class KSinFeedForwardModule(LightningModule):
         self.val_chamfer(preds, targets)
 
         self.log("val/lsd", self.val_lsd, on_step=False, on_epoch=True, prog_bar=True)
-        self.log(
-            "val/chamfer", self.val_chamfer, on_step=False, on_epoch=True, prog_bar=True
-        )
+        self.log("val/chamfer", self.val_chamfer, on_step=False, on_epoch=True, prog_bar=True)
         self.log("val/loss", loss, on_step=False, on_epoch=True, prog_bar=True)
 
     def on_validation_epoch_end(self):
         pass
 
-    def test_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def test_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         loss, preds, targets, inputs = self.model_step(batch)
 
         *_, synth_fn = batch
@@ -116,7 +113,7 @@ class KSinFeedForwardModule(LightningModule):
         if self.hparams.compile and stage == "fit":
             self.net = torch.compile(self.net)
 
-    def configure_optimizers(self) -> Dict[str, Any]:
+    def configure_optimizers(self) -> dict[str, Any]:
         optimizer = self.hparams.optimizer(params=self.trainer.model.parameters())
 
         if self.hparams.scheduler is not None:

--- a/src/models/ksin_flow_matching_module.py
+++ b/src/models/ksin_flow_matching_module.py
@@ -1,16 +1,19 @@
 import math
+from collections.abc import Callable
 from functools import partial
-from typing import Any, Callable, Dict, Literal, Tuple
-from warnings import warn
+from typing import Any, Literal
 
 import ot as pot
 import torch
 from lightning import LightningModule
-from scipy.optimize import linear_sum_assignment
 from lightning.pytorch.utilities import grad_norm
+from scipy.optimize import linear_sum_assignment
 
-from src.metrics import (ChamferDistance, LinearAssignmentDistance,
-                         LogSpectralDistance, SpectralDistance)
+from src.metrics import (
+    ChamferDistance,
+    LinearAssignmentDistance,
+    LogSpectralDistance,
+)
 from src.utils.math import divmod
 
 
@@ -250,16 +253,12 @@ class KSinFlowMatchingModule(LightningModule):
         else:
             raise NotImplementedError(f"Unknown coupling {self.hparams.coupling}")
 
-    def _rectified_probability_path(
-        self, x0: torch.Tensor, x1: torch.Tensor, t: torch.Tensor
-    ):
+    def _rectified_probability_path(self, x0: torch.Tensor, x1: torch.Tensor, t: torch.Tensor):
         x_t = x0 * (1 - t) * (1 - self.hparams.rectified_sigma_min) + x1 * t
 
         return x_t
 
-    def _cfm_probability_path(
-        self, x0: torch.Tensor, x1: torch.Tensor, t: torch.Tensor
-    ):
+    def _cfm_probability_path(self, x0: torch.Tensor, x1: torch.Tensor, t: torch.Tensor):
         mu_t = x0 * (1 - t) + x1 * t
         sigma_t = self.hparams.cfm_sigma * torch.randn_like(mu_t)
         x_t = mu_t + sigma_t
@@ -274,9 +273,7 @@ class KSinFlowMatchingModule(LightningModule):
 
         return x_t
 
-    def _sample_probability_path(
-        self, x0: torch.Tensor, x1: torch.Tensor, t: torch.Tensor
-    ):
+    def _sample_probability_path(self, x0: torch.Tensor, x1: torch.Tensor, t: torch.Tensor):
         if self.hparams.probability_path == "rectified":
             x_t = self._rectified_probability_path(x0, x1, t)
         elif self.hparams.probability_path == "cfm":
@@ -284,9 +281,7 @@ class KSinFlowMatchingModule(LightningModule):
         elif self.hparams.probability_path == "fm":
             x_t = self._fm_probability_path(x0, x1, t)
         else:
-            raise NotImplementedError(
-                f"Unknown probability path {self.hparams.probability_path}"
-            )
+            raise NotImplementedError(f"Unknown probability path {self.hparams.probability_path}")
 
         return x_t
 
@@ -312,13 +307,11 @@ class KSinFlowMatchingModule(LightningModule):
         elif self.hparams.probability_path == "fm":
             target = self._fm_vector_field(x1, x_t, t)
         else:
-            raise NotImplementedError(
-                f"Unknown probability path {self.hparams.probability_path}"
-            )
+            raise NotImplementedError(f"Unknown probability path {self.hparams.probability_path}")
 
         return target
 
-    def _train_step(self, batch: Tuple[torch.Tensor, torch.Tensor]):
+    def _train_step(self, batch: tuple[torch.Tensor, torch.Tensor]):
         signal, params, noise, _ = batch
 
         # Get conditioning vector
@@ -351,7 +344,7 @@ class KSinFlowMatchingModule(LightningModule):
 
         return loss, penalty
 
-    def training_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         if self.global_step < self.hparams.freeze_for_first_n_steps:
             # freeze vector_field and encoder, leaving only projection active
             for param in self.vector_field.parameters():
@@ -373,9 +366,7 @@ class KSinFlowMatchingModule(LightningModule):
         self.log("train/loss", loss, on_step=True, on_epoch=True, prog_bar=True)
 
         if penalty is not None:
-            self.log(
-                "train/penalty", penalty, on_step=True, on_epoch=True, prog_bar=True
-            )
+            self.log("train/penalty", penalty, on_step=True, on_epoch=True, prog_bar=True)
 
         return loss + penalty
 
@@ -394,7 +385,7 @@ class KSinFlowMatchingModule(LightningModule):
 
     def _sample(
         self,
-        batch: Tuple[torch.Tensor, torch.Tensor],
+        batch: tuple[torch.Tensor, torch.Tensor],
         steps: int,
         cfg_strength: float,
     ):
@@ -422,7 +413,7 @@ class KSinFlowMatchingModule(LightningModule):
 
         return sample, y, x
 
-    def validation_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def validation_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         preds, targets, inputs = self._sample(
             batch,
             self.hparams.validation_sample_steps,
@@ -436,15 +427,13 @@ class KSinFlowMatchingModule(LightningModule):
         # self.val_lad(preds, targets)
 
         self.log("val/lsd", self.val_lsd, on_step=False, on_epoch=True, prog_bar=True)
-        self.log(
-            "val/chamfer", self.val_chamfer, on_step=False, on_epoch=True, prog_bar=True
-        )
+        self.log("val/chamfer", self.val_chamfer, on_step=False, on_epoch=True, prog_bar=True)
         # self.log("val/lad", self.val_lad, on_step=False, on_epoch=True, prog_bar=True)
 
     def on_validation_epoch_end(self):
         pass
 
-    def test_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def test_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         preds, targets, inputs = self._sample(
             batch, self.hparams.test_sample_steps, self.hparams.test_cfg_strength
         )
@@ -486,7 +475,7 @@ class KSinFlowMatchingModule(LightningModule):
         self.log_dict(encoder_norms, on_step=True, on_epoch=True)
         self.log_dict(vf_norms, on_step=True, on_epoch=True)
 
-    def configure_optimizers(self) -> Dict[str, Any]:
+    def configure_optimizers(self) -> dict[str, Any]:
         optimizer = self.hparams.optimizer(params=self.trainer.model.parameters())
 
         if self.hparams.scheduler is not None:

--- a/src/models/mnist_module.py
+++ b/src/models/mnist_module.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple
+from typing import Any
 
 import torch
 from lightning import LightningModule
@@ -93,8 +93,8 @@ class MNISTLitModule(LightningModule):
         self.val_acc_best.reset()
 
     def model_step(
-        self, batch: Tuple[torch.Tensor, torch.Tensor]
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        self, batch: tuple[torch.Tensor, torch.Tensor]
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """Perform a single model step on a batch of data.
 
         :param batch: A batch of data (a tuple) containing the input tensor of images and target labels.
@@ -111,7 +111,7 @@ class MNISTLitModule(LightningModule):
         return loss, preds, y
 
     def training_step(
-        self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int
+        self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int
     ) -> torch.Tensor:
         """Perform a single training step on a batch of data from the training set.
 
@@ -135,7 +135,7 @@ class MNISTLitModule(LightningModule):
         "Lightning hook that is called when a training epoch ends."
         pass
 
-    def validation_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> None:
+    def validation_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> None:
         """Perform a single validation step on a batch of data from the validation set.
 
         :param batch: A batch of data (a tuple) containing the input tensor of images and target
@@ -158,7 +158,7 @@ class MNISTLitModule(LightningModule):
         # otherwise metric would be reset by lightning after each epoch
         self.log("val/acc_best", self.val_acc_best.compute(), sync_dist=True, prog_bar=True)
 
-    def test_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> None:
+    def test_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int) -> None:
         """Perform a single test step on a batch of data from the test set.
 
         :param batch: A batch of data (a tuple) containing the input tensor of images and target
@@ -189,7 +189,7 @@ class MNISTLitModule(LightningModule):
         if self.hparams.compile and stage == "fit":
             self.net = torch.compile(self.net)
 
-    def configure_optimizers(self) -> Dict[str, Any]:
+    def configure_optimizers(self) -> dict[str, Any]:
         """Choose what optimizers and learning-rate schedulers to use in your optimization.
         Normally you'd need one. But in the case of GANs or similar you might have multiple.
 

--- a/src/models/surge_ff_module.py
+++ b/src/models/surge_ff_module.py
@@ -1,6 +1,4 @@
-import math
-from functools import partial
-from typing import Any, Callable, Dict, Literal, Optional, Tuple
+from typing import Any
 
 import torch
 from lightning import LightningModule
@@ -27,7 +25,7 @@ class SurgeFeedForwardModule(LightningModule):
         # so it's worth to make sure validation metrics don't store results from these checks
         pass
 
-    def model_step(self, batch: Dict[str, torch.Tensor]):
+    def model_step(self, batch: dict[str, torch.Tensor]):
         target_params = batch["params"]
         mel_spec = batch["mel_spec"]
 
@@ -35,7 +33,7 @@ class SurgeFeedForwardModule(LightningModule):
         loss = torch.nn.functional.mse_loss(pred_params, target_params)
         return loss, pred_params, target_params, mel_spec
 
-    def training_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         loss, *_ = self.model_step(batch)
         self.log("train/loss", loss, on_step=True, on_epoch=True, prog_bar=True)
 
@@ -44,33 +42,29 @@ class SurgeFeedForwardModule(LightningModule):
     def on_train_epoch_end(self) -> None:
         pass
 
-    def validation_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def validation_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         loss, preds, targets, *_ = self.model_step(batch)
         per_param_mse = (preds - targets).square().mean(dim=0)
         param_mse = per_param_mse.mean()
-        self.log(
-            "val/param_mse", param_mse, on_step=False, on_epoch=True, prog_bar=True
-        )
+        self.log("val/param_mse", param_mse, on_step=False, on_epoch=True, prog_bar=True)
 
         return {"param_mse": param_mse, "per_param_mse": per_param_mse}
 
     def on_validation_epoch_end(self):
         pass
 
-    def test_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def test_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         loss, preds, targets, *_ = self.model_step(batch)
         per_param_mse = (preds - targets).square().mean(dim=0)
         param_mse = per_param_mse.mean()
-        self.log(
-            "test/param_mse", param_mse, on_step=False, on_epoch=True, prog_bar=True
-        )
+        self.log("test/param_mse", param_mse, on_step=False, on_epoch=True, prog_bar=True)
 
         return {"param_mse": param_mse, "per_param_mse": per_param_mse}
 
     def on_test_epoch_end(self) -> None:
         pass
 
-    def predict_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def predict_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         mel_spec = batch["mel_spec"]
         preds = self.net(mel_spec)
         return (
@@ -89,7 +83,7 @@ class SurgeFeedForwardModule(LightningModule):
         norms = {f"net/{k}": v for k, v in norms.items()}
         self.log_dict(norms, on_step=True, on_epoch=False)
 
-    def configure_optimizers(self) -> Dict[str, Any]:
+    def configure_optimizers(self) -> dict[str, Any]:
         optimizer = self.hparams.optimizer(params=self.trainer.model.parameters())
 
         if self.hparams.warmup_steps > 0:

--- a/src/models/surge_flow_matching_module.py
+++ b/src/models/surge_flow_matching_module.py
@@ -1,6 +1,6 @@
-import math
+from collections.abc import Callable
 from functools import partial
-from typing import Any, Callable, Dict, Literal, Optional, Tuple
+from typing import Any, Literal
 
 import torch
 from lightning import LightningModule
@@ -85,16 +85,12 @@ class SurgeFlowMatchingModule(LightningModule):
 
         return x0, x1
 
-    def _rectified_probability_path(
-        self, x0: torch.Tensor, x1: torch.Tensor, t: torch.Tensor
-    ):
+    def _rectified_probability_path(self, x0: torch.Tensor, x1: torch.Tensor, t: torch.Tensor):
         x_t = x0 * (1 - t) * (1 - self.hparams.rectified_sigma_min) + x1 * t
 
         return x_t
 
-    def _sample_probability_path(
-        self, x0: torch.Tensor, x1: torch.Tensor, t: torch.Tensor
-    ):
+    def _sample_probability_path(self, x0: torch.Tensor, x1: torch.Tensor, t: torch.Tensor):
         x_t = self._rectified_probability_path(x0, x1, t)
         return x_t
 
@@ -107,9 +103,7 @@ class SurgeFlowMatchingModule(LightningModule):
         target = self._rectified_vector_field(x0, x1)
         return target
 
-    def _get_conditioning_from_batch(
-        self, batch: dict[str, torch.Tensor]
-    ) -> torch.Tensor:
+    def _get_conditioning_from_batch(self, batch: dict[str, torch.Tensor]) -> torch.Tensor:
         if self.hparams.conditioning == "mel":
             return batch["mel_spec"]
         elif self.hparams.conditioning == "m2l":
@@ -117,7 +111,7 @@ class SurgeFlowMatchingModule(LightningModule):
         else:
             raise ValueError(f"Unknown conditioning {self.hparams.conditioning}")
 
-    def _train_step(self, batch: Tuple[torch.Tensor, torch.Tensor]):
+    def _train_step(self, batch: tuple[torch.Tensor, torch.Tensor]):
         conditioning = self._get_conditioning_from_batch(batch)
         params = batch["params"]
         noise = batch["noise"]
@@ -151,14 +145,12 @@ class SurgeFlowMatchingModule(LightningModule):
 
         return loss, penalty
 
-    def training_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         loss, penalty = self._train_step(batch)
         self.log("train/loss", loss, on_step=True, on_epoch=True, prog_bar=True)
 
         if penalty is not None:
-            self.log(
-                "train/penalty", penalty, on_step=True, on_epoch=True, prog_bar=True
-            )
+            self.log("train/penalty", penalty, on_step=True, on_epoch=True, prog_bar=True)
 
         return loss + penalty
 
@@ -170,7 +162,7 @@ class SurgeFlowMatchingModule(LightningModule):
 
     def _sample(
         self,
-        conditioning: Optional[torch.Tensor],
+        conditioning: torch.Tensor | None,
         noise: torch.Tensor,
         steps: int,
         cfg_strength: float,
@@ -200,7 +192,7 @@ class SurgeFlowMatchingModule(LightningModule):
 
         return sample
 
-    def validation_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def validation_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         conditioning = self._get_conditioning_from_batch(batch)
         pred_params = self._sample(
             conditioning,
@@ -211,16 +203,14 @@ class SurgeFlowMatchingModule(LightningModule):
 
         per_param_mse = (pred_params - batch["params"]).square().mean(dim=0)
         param_mse = per_param_mse.mean()
-        self.log(
-            "val/param_mse", param_mse, on_step=False, on_epoch=True, prog_bar=True
-        )
+        self.log("val/param_mse", param_mse, on_step=False, on_epoch=True, prog_bar=True)
 
         return {"param_mse": param_mse, "per_param_mse": per_param_mse}
 
     def on_validation_epoch_end(self):
         pass
 
-    def test_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def test_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         conditioning = self._get_conditioning_from_batch(batch)
         pred_params = self._sample(
             conditioning,
@@ -230,9 +220,7 @@ class SurgeFlowMatchingModule(LightningModule):
         )
 
         param_mse = (pred_params - batch["params"]).square().mean()
-        self.log(
-            "test/param_mse", param_mse, on_step=False, on_epoch=True, prog_bar=True
-        )
+        self.log("test/param_mse", param_mse, on_step=False, on_epoch=True, prog_bar=True)
 
         return param_mse
 
@@ -272,7 +260,7 @@ class SurgeFlowMatchingModule(LightningModule):
         self.log_dict(vf_norms, on_step=True, on_epoch=False)
         self.log_dict(encoder_norms, on_step=True, on_epoch=False)
 
-    def configure_optimizers(self) -> Dict[str, Any]:
+    def configure_optimizers(self) -> dict[str, Any]:
         optimizer = self.hparams.optimizer(params=self.trainer.model.parameters())
 
         if self.hparams.warmup_steps > 0:

--- a/src/models/surge_flowvae_module.py
+++ b/src/models/surge_flowvae_module.py
@@ -1,6 +1,4 @@
-import math
-from functools import partial
-from typing import Any, Callable, Dict, Literal, Optional, Tuple
+from typing import Any
 
 import torch
 from lightning import LightningModule
@@ -33,15 +31,13 @@ class SurgeFlowVAEModule(LightningModule):
         # so it's worth to make sure validation metrics don't store results from these checks
         pass
 
-    def model_step(self, batch: Dict[str, torch.Tensor]):
+    def model_step(self, batch: dict[str, torch.Tensor]):
         target_params = batch["params"]
 
         mel_spec = batch["mel_spec"]
 
         vae_out = self.net(mel_spec)
-        losses = compute_flowvae_loss(
-            vae_out, mel_spec, target_params, self.hparams.param_spec
-        )
+        losses = compute_flowvae_loss(vae_out, mel_spec, target_params, self.hparams.param_spec)
 
         return losses, mel_spec, target_params, vae_out
 
@@ -50,11 +46,11 @@ class SurgeFlowVAEModule(LightningModule):
         if step > self.hparams.beta_warmup_steps:
             return self.hparams.beta_max
 
-        return self.hparams.beta_start + (
-            self.global_step / self.hparams.beta_warmup_steps
-        ) * (self.hparams.beta_max - self.hparams.beta_start)
+        return self.hparams.beta_start + (self.global_step / self.hparams.beta_warmup_steps) * (
+            self.hparams.beta_max - self.hparams.beta_start
+        )
 
-    def training_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         losses, *_, vae_out = self.model_step(batch)
         x_hat = vae_out.x_hat
 
@@ -62,11 +58,7 @@ class SurgeFlowVAEModule(LightningModule):
         self.log("train/param_std", x_hat.std(), on_step=True, on_epoch=True)
 
         beta = self.get_beta()
-        loss = (
-            losses["reconstruction_loss"]
-            + beta * losses["latent_loss"]
-            + losses["param_loss"]
-        )
+        loss = losses["reconstruction_loss"] + beta * losses["latent_loss"] + losses["param_loss"]
 
         losses_to_log = {f"train/{k}": v for k, v in losses.items()}
         self.log("train/loss", loss, on_step=True, on_epoch=True, prog_bar=True)
@@ -78,7 +70,7 @@ class SurgeFlowVAEModule(LightningModule):
     def on_train_epoch_end(self) -> None:
         pass
 
-    def validation_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def validation_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         losses, *_, vae_out = self.model_step(batch)
         x_hat = vae_out.x_hat
 
@@ -91,7 +83,7 @@ class SurgeFlowVAEModule(LightningModule):
     def on_validation_epoch_end(self):
         pass
 
-    def test_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def test_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         losses, *_ = self.model_step(batch)
         losses = {f"test/{k}": v for k, v in losses.items()}
         self.log_dict(losses, on_step=False, on_epoch=True, prog_bar=True)
@@ -99,7 +91,7 @@ class SurgeFlowVAEModule(LightningModule):
     def on_test_epoch_end(self) -> None:
         pass
 
-    def predict_step(self, batch: Tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def predict_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         mel_spec = batch["mel_spec"]
         out = self.net(mel_spec)
 
@@ -119,7 +111,7 @@ class SurgeFlowVAEModule(LightningModule):
         norms = {f"net/{k}": v for k, v in norms.items()}
         self.log_dict(norms, on_step=True, on_epoch=False)
 
-    def configure_optimizers(self) -> Dict[str, Any]:
+    def configure_optimizers(self) -> dict[str, Any]:
         optimizer = self.hparams.optimizer(params=self.trainer.model.parameters())
 
         if self.hparams.warmup_steps > 0:

--- a/src/train.py
+++ b/src/train.py
@@ -1,10 +1,9 @@
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import hydra
 import lightning as L
 import rootutils
 import torch
-import torch.multiprocessing as mp
 from lightning import Callback, LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.loggers import Logger
 from omegaconf import DictConfig
@@ -45,7 +44,7 @@ log = RankedLogger(__name__, rank_zero_only=True)
 
 
 @task_wrapper
-def train(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+def train(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     """Trains the model. Can additionally evaluate on a testset, using best weights obtained during
     training.
 
@@ -66,15 +65,13 @@ def train(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     model: LightningModule = hydra.utils.instantiate(cfg.model)
 
     log.info("Instantiating callbacks...")
-    callbacks: List[Callback] = instantiate_callbacks(cfg.get("callbacks"))
+    callbacks: list[Callback] = instantiate_callbacks(cfg.get("callbacks"))
 
     log.info("Instantiating loggers...")
-    logger: List[Logger] = instantiate_loggers(cfg.get("logger"))
+    logger: list[Logger] = instantiate_loggers(cfg.get("logger"))
 
     log.info(f"Instantiating trainer <{cfg.trainer._target_}>")
-    trainer: Trainer = hydra.utils.instantiate(
-        cfg.trainer, callbacks=callbacks, logger=logger
-    )
+    trainer: Trainer = hydra.utils.instantiate(cfg.trainer, callbacks=callbacks, logger=logger)
 
     object_dict = {
         "cfg": cfg,
@@ -117,7 +114,7 @@ def train(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
 
 
 @hydra.main(version_base="1.3", config_path="../configs", config_name="train.yaml")
-def main(cfg: DictConfig) -> Optional[float]:
+def main(cfg: DictConfig) -> float | None:
     """Main entry point for training.
 
     :param cfg: DictConfig configuration composed by Hydra.

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -2,4 +2,10 @@ from src.utils.instantiators import instantiate_callbacks, instantiate_loggers
 from src.utils.logging_utils import log_hyperparameters
 from src.utils.pylogger import RankedLogger
 from src.utils.rich_utils import enforce_tags, print_config_tree
-from src.utils.utils import extras, get_metric_value, task_wrapper, register_resolvers, watch_gradients
+from src.utils.utils import (
+    extras,
+    get_metric_value,
+    register_resolvers,
+    task_wrapper,
+    watch_gradients,
+)

--- a/src/utils/callbacks.py
+++ b/src/utils/callbacks.py
@@ -1,18 +1,15 @@
 import os
-from typing import Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
 import wandb
-from einops import rearrange
 from lightning.pytorch.callbacks import BasePredictionWriter, Callback
 
 from src.data.vst import param_specs
 from src.models.components.transformer import (
     ApproxEquivTransformer,
     LearntProjection,
-    PositionalEncoding,
 )
 from src.models.ksin_flow_matching_module import KSinFlowMatchingModule
 from src.models.surge_flow_matching_module import SurgeFlowMatchingModule
@@ -39,9 +36,7 @@ class PlotLossPerTimestep(Callback):
 
         # Get conditioning vector
         conditioning = pl_module.encoder(signal)
-        z = pl_module.vector_field.apply_dropout(
-            conditioning, pl_module.hparams.cfg_dropout_rate
-        )
+        z = pl_module.vector_field.apply_dropout(conditioning, pl_module.hparams.cfg_dropout_rate)
 
         x0, x1, z = pl_module._sample_x0_and_x1(params, z)
 
@@ -118,12 +113,8 @@ class PlotPositionalEncodingSimilarity(Callback):
         fig, ax = plt.subplots(n_rows, n_cols, figsize=(2 * n_cols, 2 * n_rows))
 
         for i, sim in enumerate(sims):
-            ax[i // n_cols, i % n_cols].imshow(
-                sim.cpu().numpy(), vmin=-1, vmax=1, aspect="equal"
-            )
-            ax[i // n_cols, i % n_cols].set_title(
-                f"PE {i // n_cols}-{i % n_cols}", fontsize=8
-            )
+            ax[i // n_cols, i % n_cols].imshow(sim.cpu().numpy(), vmin=-1, vmax=1, aspect="equal")
+            ax[i // n_cols, i % n_cols].set_title(f"PE {i // n_cols}-{i % n_cols}", fontsize=8)
 
         for i in range(n_pe, n_rows * n_cols):
             ax[i // n_cols, i % n_cols].axis("off")
@@ -163,7 +154,7 @@ class PlotLearntProjection(Callback):
     def __init__(
         self,
         after_val: bool = True,
-        every_n_steps: Optional[int] = None,
+        every_n_steps: int | None = None,
         sort_assignments: bool = True,
     ):
         super().__init__()
@@ -177,9 +168,7 @@ class PlotLearntProjection(Callback):
     def _sort_assignments(self, assignment):
         assignment = assignment.abs()
         k = torch.arange(assignment.shape[-1], device=assignment.device)[None]
-        positional_average = torch.sum(assignment * k, dim=-1) / torch.sum(
-            assignment, dim=-1
-        )
+        positional_average = torch.sum(assignment * k, dim=-1) / torch.sum(assignment, dim=-1)
         sorted_idxs = torch.argsort(positional_average)
         assignment = assignment[sorted_idxs]
         return assignment
@@ -212,24 +201,16 @@ class PlotLearntProjection(Callback):
         return fig
 
     def _get_value_similarity(self, pl_module):
-        proj = (
-            pl_module.vector_field.projection.in_projection
-        )  # num_params x d_embed x d_model
+        proj = pl_module.vector_field.projection.in_projection  # num_params x d_embed x d_model
 
-        sim_proj = torch.nn.functional.cosine_similarity(
-            proj[None], proj[:, None], dim=-1
-        )
+        sim_proj = torch.nn.functional.cosine_similarity(proj[None], proj[:, None], dim=-1)
 
         return sim_proj
 
     def _get_output_similarity(self, pl_module):
-        proj = (
-            pl_module.vector_field.projection.out_projection.T
-        )  # num_params x d_embed x d_model
+        proj = pl_module.vector_field.projection.out_projection.T  # num_params x d_embed x d_model
 
-        sim_proj = torch.nn.functional.cosine_similarity(
-            proj[None], proj[:, None], dim=-1
-        )
+        sim_proj = torch.nn.functional.cosine_similarity(proj[None], proj[:, None], dim=-1)
 
         return sim_proj
 
@@ -275,9 +256,7 @@ class PlotLearntProjection(Callback):
     def _log_plots(self, fig_ass, fig_value, trainer):
         plot_ass = wandb.Image(fig_ass)
         plot_value = wandb.Image(fig_value)
-        wandb.log(
-            {"assignment": plot_ass, "value": plot_value}, step=trainer.global_step
-        )
+        wandb.log({"assignment": plot_ass, "value": plot_value}, step=trainer.global_step)
 
         plt.close(fig_ass)
         plt.close(fig_value)
@@ -360,9 +339,7 @@ class PredictionWriter(BasePredictionWriter):
         torch.save(batch["audio"], os.path.join(self.output_dir, "target-audio.pt"))
 
         if "params" in batch:
-            torch.save(
-                batch["params"], os.path.join(self.output_dir, "target-params.pt")
-            )
+            torch.save(batch["params"], os.path.join(self.output_dir, "target-params.pt"))
 
 
 class LogPerParamMSE(Callback):

--- a/src/utils/callbacks.py
+++ b/src/utils/callbacks.py
@@ -19,8 +19,10 @@ from src.models.surge_flow_matching_module import SurgeFlowMatchingModule
 
 
 class PlotLossPerTimestep(Callback):
-    """Takes a batch from the validation dataloader, and runs it through the model at
-    a number of different values for t. Plots the loss as a function of t.
+    """Takes a batch from the validation dataloader, and runs it through the model at a number of
+    different values for t.
+
+    Plots the loss as a function of t.
     """
 
     def __init__(self, num_timesteps: int = 100):

--- a/src/utils/instantiators.py
+++ b/src/utils/instantiators.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import hydra
 from lightning import Callback
 from lightning.pytorch.loggers import Logger
@@ -10,13 +8,13 @@ from src.utils import pylogger
 log = pylogger.RankedLogger(__name__, rank_zero_only=True)
 
 
-def instantiate_callbacks(callbacks_cfg: DictConfig) -> List[Callback]:
+def instantiate_callbacks(callbacks_cfg: DictConfig) -> list[Callback]:
     """Instantiates callbacks from config.
 
     :param callbacks_cfg: A DictConfig object containing callback configurations.
     :return: A list of instantiated callbacks.
     """
-    callbacks: List[Callback] = []
+    callbacks: list[Callback] = []
 
     if not callbacks_cfg:
         log.warning("No callback configs found! Skipping..")
@@ -33,13 +31,13 @@ def instantiate_callbacks(callbacks_cfg: DictConfig) -> List[Callback]:
     return callbacks
 
 
-def instantiate_loggers(logger_cfg: DictConfig) -> List[Logger]:
+def instantiate_loggers(logger_cfg: DictConfig) -> list[Logger]:
     """Instantiates loggers from config.
 
     :param logger_cfg: A DictConfig object containing logger configurations.
     :return: A list of instantiated loggers.
     """
-    logger: List[Logger] = []
+    logger: list[Logger] = []
 
     if not logger_cfg:
         log.warning("No logger configs found! Skipping...")

--- a/src/utils/logging_utils.py
+++ b/src/utils/logging_utils.py
@@ -1,6 +1,5 @@
-from typing import Any, Dict
+from typing import Any
 
-from lightning.pytorch.loggers import Logger, WandbLogger
 from lightning_utilities.core.rank_zero import rank_zero_only
 from omegaconf import OmegaConf
 
@@ -10,7 +9,7 @@ log = pylogger.RankedLogger(__name__, rank_zero_only=True)
 
 
 @rank_zero_only
-def log_hyperparameters(object_dict: Dict[str, Any]) -> None:
+def log_hyperparameters(object_dict: dict[str, Any]) -> None:
     """Controls which config parts are saved by Lightning loggers.
 
     Additionally saves:

--- a/src/utils/pylogger.py
+++ b/src/utils/pylogger.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Mapping, Optional
+from collections.abc import Mapping
 
 from lightning_utilities.core.rank_zero import rank_prefixed_message, rank_zero_only
 
@@ -11,7 +11,7 @@ class RankedLogger(logging.LoggerAdapter):
         self,
         name: str = __name__,
         rank_zero_only: bool = False,
-        extra: Optional[Mapping[str, object]] = None,
+        extra: Mapping[str, object] | None = None,
     ) -> None:
         """Initializes a multi-GPU-friendly python command line logger that logs on all processes
         with their rank prefixed in the log message.
@@ -24,7 +24,7 @@ class RankedLogger(logging.LoggerAdapter):
         super().__init__(logger=logger, extra=extra)
         self.rank_zero_only = rank_zero_only
 
-    def log(self, level: int, msg: str, rank: Optional[int] = None, *args, **kwargs) -> None:
+    def log(self, level: int, msg: str, rank: int | None = None, *args, **kwargs) -> None:
         """Delegate a log call to the underlying logger, after prefixing its message with the rank
         of the process it's being logged from. If `'rank'` is provided, then the log will only
         occur on that rank/process.

--- a/src/utils/rich_utils.py
+++ b/src/utils/rich_utils.py
@@ -1,5 +1,5 @@
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Sequence
 
 import rich
 import rich.syntax

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -1,6 +1,7 @@
 import warnings
+from collections.abc import Callable
 from importlib.util import find_spec
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any
 
 import torch
 from lightning import LightningModule
@@ -51,9 +52,7 @@ def extras(cfg: DictConfig) -> None:
         rich_utils.print_config_tree(cfg, resolve=True, save_to_file=True)
 
     if precision := cfg.extras.get("float32_matmul_precision", False):
-        log.info(
-            "Enabling float32 matmul precision! <cfg.extras.float32_matmul_precision=True>"
-        )
+        log.info("Enabling float32 matmul precision! <cfg.extras.float32_matmul_precision=True>")
         torch.set_float32_matmul_precision(precision)
 
 
@@ -79,7 +78,7 @@ def task_wrapper(task_func: Callable) -> Callable:
     :return: The wrapped task function.
     """
 
-    def wrap(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    def wrap(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
         # execute the task
         try:
             metric_dict, object_dict = task_func(cfg=cfg)
@@ -112,9 +111,7 @@ def task_wrapper(task_func: Callable) -> Callable:
     return wrap
 
 
-def get_metric_value(
-    metric_dict: Dict[str, Any], metric_name: Optional[str]
-) -> Optional[float]:
+def get_metric_value(metric_dict: dict[str, Any], metric_name: str | None) -> float | None:
     """Safely retrieves value of the metric logged in LightningModule.
 
     :param metric_dict: A dict containing metric values.
@@ -138,7 +135,7 @@ def get_metric_value(
     return metric_value
 
 
-def watch_gradients(model: LightningModule, loggers: List[Logger]) -> None:
+def watch_gradients(model: LightningModule, loggers: list[Logger]) -> None:
     """Watches gradients during training.
 
     :param model: The model to watch gradients for.

--- a/sweeps/fm.yaml
+++ b/sweeps/fm.yaml
@@ -19,7 +19,7 @@ parameters:
       # - fm/flow_asym
       - fm/flow_fixed
       - fm/flow_fixed_asym
-  'experiment/fm/algorithm':
+  "experiment/fm/algorithm":
     values:
       - conditional
       - mixed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ from src.utils.utils import register_resolvers
 # isolating resolver registration into a lighter module.
 register_resolvers()
 
+
 @pytest.fixture(scope="package")
 def cfg_train_global() -> DictConfig:
     """A pytest fixture for setting up a default Hydra DictConfig for training.

--- a/tests/helpers/run_if.py
+++ b/tests/helpers/run_if.py
@@ -4,7 +4,7 @@ https://github.com/PyTorchLightning/pytorch-lightning/blob/master/tests/helpers/
 """
 
 import sys
-from typing import Any, Dict, Optional
+from typing import Any
 
 import pytest
 import torch
@@ -43,9 +43,9 @@ class RunIf:
     def __new__(
         cls,
         min_gpus: int = 0,
-        min_torch: Optional[str] = None,
-        max_torch: Optional[str] = None,
-        min_python: Optional[str] = None,
+        min_torch: str | None = None,
+        max_torch: str | None = None,
+        min_python: str | None = None,
         skip_windows: bool = False,
         sh: bool = False,
         tpu: bool = False,
@@ -55,7 +55,7 @@ class RunIf:
         neptune: bool = False,
         comet: bool = False,
         mlflow: bool = False,
-        **kwargs: Dict[Any, Any],
+        **kwargs: dict[Any, Any],
     ) -> MarkDecorator:
         """Creates a new `@RunIf` `MarkDecorator` decorator.
 

--- a/tests/helpers/run_sh_command.py
+++ b/tests/helpers/run_sh_command.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 
 from tests.helpers.package_available import _SH_AVAILABLE
@@ -8,7 +6,7 @@ if _SH_AVAILABLE:
     import sh
 
 
-def run_sh_command(command: List[str]) -> None:
+def run_sh_command(command: list[str]) -> None:
     """Default method for executing shell commands with `pytest` and `sh` package.
 
     :param command: A list of shell commands as strings.


### PR DESCRIPTION
## Summary

- Fix trailing whitespace, trailing newlines, docstrings, and prettier formatting across legacy files, removing pre-commit exclusions as files become compliant
- Reformat source files to pass ruff and docformatter; consolidate ruff config to use `per-file-ignores` instead of `extend-exclude`
- Modernize type hints to PEP 604/585 builtins in test helpers
- Add new pre-commit hooks: pyright, check-jsonschema, validate-pyproject, check-json, check-github-workflows, gitlint, no-commit-to-branch, debug-statements, clang-format (Google style), cpplint
- Switch pyright hook to `language: system` so it uses project deps instead of an isolated venv; narrow exclusions from broad directory patterns to 34 specific files with real type errors
- Narrow interrogate exclusions from 48 to 27 files — removed 21 files that already meet 80% docstring coverage
- Gitignore `.claude/` except `.claude/skills/`

Closes #26
Related: #25

## Test plan

- [x] `pre-commit run --all-files` passes with no failures
