### PR TITLE
fix(ci): skip no-commit-to-branch hook in main branch CI

### DIFF
--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -27,3 +27,5 @@ jobs:
 
       - name: Run pre-commits
         uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: no-commit-to-branch


### PR DESCRIPTION
## Summary
- The `no-commit-to-branch` hook in `.pre-commit-config.yaml` prevents direct commits to `main` (useful locally)
- The `Code Quality Main` workflow runs `pre-commit --all-files` on push to `main`, where the checkout is always on `main` — so the hook always fails
- Add `SKIP: no-commit-to-branch` env var to bypass the hook in CI

## Test plan
- [ ] Merge this PR and verify the next `Code Quality Main` run passes without the `no-commit-to-branch` failure
- [ ] Verify the hook still works locally: `git checkout main && pre-commit run no-commit-to-branch` should fail