### PR TITLE
ci(review): enable full claude review output logging, relax metadata gate

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -35,20 +35,20 @@ jobs:
           prompt: |
             Review this PR. Follow the Code Review section in CLAUDE.md — invoke all seven
             review skills and evaluate every checklist item against the changed code.
-            Prefix each comment with BLOCK: or WARN:.
+            Prefix each finding comment with BLOCK: or WARN:.
 
-            After reviewing, if there are NO BLOCK-level issues, add a final comment that
-            starts with exactly "VERDICT: APPROVE". If there ARE BLOCK-level issues,
-            add a final comment starting with "VERDICT: CHANGES_REQUESTED".
+            After reviewing, post one final summary comment. Do NOT prefix it with
+            BLOCK: or WARN:. Start it with exactly "VERDICT: APPROVE" if there are no
+            BLOCK-level issues, or "VERDICT: CHANGES_REQUESTED" if there are.
             Still leave all individual WARN comments regardless.
 
       - name: Auto-approve if no blocking issues
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LAST_COMMENT=$(gh pr view ${{ github.event.pull_request.number }} \
-            --json comments --jq '.comments[-1].body')
-          if echo "$LAST_COMMENT" | grep -q "^VERDICT: APPROVE"; then
+          VERDICT=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("VERDICT:"))] | last | .body // ""')
+          if echo "$VERDICT" | grep -q "^VERDICT: APPROVE"; then
             gh pr review ${{ github.event.pull_request.number }} --approve \
               --body "No BLOCK-level issues found. Auto-approved by Claude review."
           fi

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -35,55 +35,8 @@ jobs:
           prompt: |
             Review this PR. Follow the Code Review section in CLAUDE.md — invoke all seven
             review skills and evaluate every checklist item against the changed code.
-            Prefix each finding comment with BLOCK: or WARN:.
-
-            After reviewing, post one final summary comment. Do NOT prefix it with
-            BLOCK: or WARN:. Start it with exactly "VERDICT: APPROVE" if there are no
-            BLOCK-level issues, or "VERDICT: CHANGES_REQUESTED" if there are.
-            Still leave all individual WARN comments regardless.
-
-      - name: Check for unresolved Copilot comments
-        id: copilot-check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          UNRESOLVED=$(gh api graphql -f query='
-            query($owner: String!, $repo: String!, $pr: Int!) {
-              repository(owner: $owner, name: $repo) {
-                pullRequest(number: $pr) {
-                  reviewThreads(first: 100) {
-                    nodes {
-                      isResolved
-                      comments(first: 1) {
-                        nodes { author { login } }
-                      }
-                    }
-                  }
-                }
-              }
-            }' -f owner="${{ github.repository_owner }}" \
-               -f repo="${{ github.event.repository.name }}" \
-               -F pr=${{ github.event.pull_request.number }} \
-            --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
-              | select(.isResolved == false)
-              | select(.comments.nodes[0].author.login == "copilot-pull-request-reviewer")
-            ] | length')
-          echo "unresolved=$UNRESOLVED" >> "$GITHUB_OUTPUT"
-          if [ "$UNRESOLVED" -gt 0 ]; then
-            echo "::warning::$UNRESOLVED unresolved Copilot review thread(s) — skipping auto-approve"
-          fi
-
-      - name: Auto-approve if no blocking issues
-        if: steps.copilot-check.outputs.unresolved == '0'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERDICT=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("VERDICT:"))] | last | .body // ""')
-          if echo "$VERDICT" | grep -q "^VERDICT: APPROVE"; then
-            gh pr review ${{ github.event.pull_request.number }} --approve \
-              --body "No BLOCK-level issues found. Auto-approved by Claude review."
-          fi
+            Prefix each comment with BLOCK: or WARN:.
+          show_full_output: true
 
   skip-notice:
     if: github.event.pull_request.head.repo.fork == true

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -37,6 +37,22 @@ jobs:
             review skills and evaluate every checklist item against the changed code.
             Prefix each comment with BLOCK: or WARN:.
 
+            After reviewing, if there are NO BLOCK-level issues, add a final comment that
+            starts with exactly "VERDICT: APPROVE". If there ARE BLOCK-level issues,
+            add a final comment starting with "VERDICT: CHANGES_REQUESTED".
+            Still leave all individual WARN comments regardless.
+
+      - name: Auto-approve if no blocking issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LAST_COMMENT=$(gh pr view ${{ github.event.pull_request.number }} \
+            --json comments --jq '.comments[-1].body')
+          if echo "$LAST_COMMENT" | grep -q "^VERDICT: APPROVE"; then
+            gh pr review ${{ github.event.pull_request.number }} --approve \
+              --body "No BLOCK-level issues found. Auto-approved by Claude review."
+          fi
+
   skip-notice:
     if: github.event.pull_request.head.repo.fork == true
     runs-on: ubuntu-latest

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -42,7 +42,39 @@ jobs:
             BLOCK-level issues, or "VERDICT: CHANGES_REQUESTED" if there are.
             Still leave all individual WARN comments regardless.
 
+      - name: Check for unresolved Copilot comments
+        id: copilot-check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          UNRESOLVED=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  reviewThreads(first: 100) {
+                    nodes {
+                      isResolved
+                      comments(first: 1) {
+                        nodes { author { login } }
+                      }
+                    }
+                  }
+                }
+              }
+            }' -f owner="${{ github.repository_owner }}" \
+               -f repo="${{ github.event.repository.name }}" \
+               -F pr=${{ github.event.pull_request.number }} \
+            --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+              | select(.isResolved == false)
+              | select(.comments.nodes[0].author.login == "copilot-pull-request-reviewer")
+            ] | length')
+          echo "unresolved=$UNRESOLVED" >> "$GITHUB_OUTPUT"
+          if [ "$UNRESOLVED" -gt 0 ]; then
+            echo "::warning::$UNRESOLVED unresolved Copilot review thread(s) — skipping auto-approve"
+          fi
+
       - name: Auto-approve if no blocking issues
+        if: steps.copilot-check.outputs.unresolved == '0'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/pr-metadata-gate.yaml
+++ b/.github/workflows/pr-metadata-gate.yaml
@@ -49,8 +49,8 @@ jobs:
           fi
           LINKED_ISSUES=$(( CONNECTED - DISCONNECTED ))
 
-          # Also check body for closing keywords
-          BODY_REFS=$(echo "$PR_BODY" | grep -ciE '(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+') || {
+          # Check body for any issue/PR references (#N)
+          BODY_REFS=$(echo "$PR_BODY" | grep -coE '#[0-9]+') || {
             rc=$?
             if [ "$rc" -eq 1 ]; then
               BODY_REFS=0  # No matches found — expected case
@@ -61,7 +61,7 @@ jobs:
           }
 
           if [ "${LINKED_ISSUES}" -le 0 ] && [ "${BODY_REFS}" -eq 0 ]; then
-            echo "::error::PR #${PR_NUMBER} has no linked GitHub issue. Add 'closes #N' to the PR body or link an issue via the sidebar."
+            echo "::error::PR #${PR_NUMBER} has no linked GitHub issue. Add 'Closes #N', 'Part of #N', or 'Related to #N' to the PR body."
             exit 1
           fi
 

--- a/.github/workflows/pr-metadata-gate.yaml
+++ b/.github/workflows/pr-metadata-gate.yaml
@@ -61,7 +61,7 @@ jobs:
           }
 
           if [ "${LINKED_ISSUES}" -le 0 ] && [ "${BODY_REFS}" -eq 0 ]; then
-            echo "::error::PR #${PR_NUMBER} has no linked GitHub issue. Add 'Closes #N', 'Part of #N', or 'Related to #N' to the PR body."
+            echo "::error::PR #${PR_NUMBER} has no linked GitHub issue. Add an issue reference (e.g., 'Closes #N', 'Part of #N', or just '#N') to the PR body."
             exit 1
           fi
 


### PR DESCRIPTION
## Summary
- Enable `show_full_output: true` on Claude review action for debugging
- Simplify PR metadata gate to accept any `#N` issue reference (not just closing keywords)

## Context
**Full output logging:** The Claude review action ran on PR #57 (21 turns, $0.51) but posted nothing — 1 permission denial, "No buffered inline comments". Enabling `show_full_output` will surface the full conversation in the Actions log so we can diagnose why.

**Auto-approve removed:** Approval logic was moved to a dedicated `auto-approve.yml` workflow (PR #57 / branch `ci/approval-bot`). This PR no longer touches approval.

**Metadata gate fix:** The gate previously only matched closing keywords (`Closes`, `Fixes`, `Resolves`), so PRs using `Part of #N` or `Related to #N` failed the linked-issue check. Now it matches any `#N` reference in the PR body.

## Test plan
- [x] Verify workflow YAML is valid (pre-commit passed)
- [ ] After merging, open a test PR and confirm Claude review logs are visible in Actions
- [ ] Verify `Part of #N` passes the metadata gate after this lands on main

Part of #16