### PR TITLE
ci: add GitHub App auto-approve bot

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,14 +14,12 @@ on:
 
 jobs:
   auto-approve:
-    # Only run on non-fork, non-draft PRs targeting main
-    if: >-
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
+      issues: read
+      checks: read
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -35,7 +33,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # check_suite doesn't include PR number directly — look it up
           if [ "${{ github.event_name }}" = "check_suite" ]; then
             PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.check_suite.head_sha }}/pulls" \
               --jq '.[0].number // empty')
@@ -61,18 +58,34 @@ jobs:
           REPO="${{ github.repository }}"
           PASS=true
 
-          # --- Condition 1: PR is not a draft ---
-          IS_DRAFT=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.draft')
-          if [ "$IS_DRAFT" = "true" ]; then
+          # Fetch PR metadata once
+          PR_DATA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '{draft: .draft, fork: (.head.repo.fork // false), base: .base.ref, sha: .head.sha}')
+          IS_DRAFT=$(echo "$PR_DATA" | jq -r '.draft')
+          IS_FORK=$(echo "$PR_DATA" | jq -r '.fork')
+          BASE_REF=$(echo "$PR_DATA" | jq -r '.base')
+          HEAD_SHA=$(echo "$PR_DATA" | jq -r '.sha')
+
+          # --- Condition 0: Only approve PRs targeting main ---
+          if [ "$BASE_REF" != "main" ]; then
+            echo "::notice::PR targets ${BASE_REF}, not main — skipping"
+            PASS=false
+          fi
+
+          # --- Condition 1: PR is not a draft or fork ---
+          if [ "$PASS" = "true" ] && [ "$IS_DRAFT" = "true" ]; then
             echo "::notice::PR is a draft — skipping"
+            PASS=false
+          fi
+          if [ "$PASS" = "true" ] && [ "$IS_FORK" = "true" ]; then
+            echo "::notice::PR is from a fork — skipping"
             PASS=false
           fi
 
           # --- Condition 2: All CI checks pass ---
           if [ "$PASS" = "true" ]; then
-            FAILED=$(gh api "repos/${REPO}/commits/$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha')/check-runs" \
+            FAILED=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
               --jq '[.check_runs[] | select(.name != "auto-approve") | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral" and .status != "queued" and .status != "in_progress")] | length')
-            PENDING=$(gh api "repos/${REPO}/commits/$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha')/check-runs" \
+            PENDING=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
               --jq '[.check_runs[] | select(.name != "auto-approve") | select(.status == "queued" or .status == "in_progress")] | length')
             if [ "$PENDING" -gt 0 ]; then
               echo "::notice::${PENDING} check(s) still running — will re-evaluate when they complete"
@@ -83,15 +96,16 @@ jobs:
             fi
           fi
 
-          # --- Condition 3: Claude review has no BLOCK issues ---
+          # --- Condition 3: Claude review explicitly approves ---
+          # Requires PR #56 which adds VERDICT: output to claude-review.yml
           if [ "$PASS" = "true" ]; then
             VERDICT=$(gh api "repos/${REPO}/issues/${PR}/comments" \
               --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("VERDICT:"))] | last | .body // ""')
-            if echo "$VERDICT" | grep -q "^VERDICT: CHANGES_REQUESTED"; then
-              echo "::notice::Claude review found BLOCK-level issues — skipping"
-              PASS=false
-            elif [ -z "$VERDICT" ]; then
+            if [ -z "$VERDICT" ]; then
               echo "::notice::No Claude review verdict yet — skipping"
+              PASS=false
+            elif ! echo "$VERDICT" | grep -q "^VERDICT: APPROVE"; then
+              echo "::notice::Claude review verdict is not APPROVE — skipping"
               PASS=false
             fi
           fi
@@ -132,9 +146,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          # Check if bot already approved (avoid duplicate approvals)
+          # Check if this app already approved (avoid duplicate approvals)
+          # App slug is derived from the app name; check for any approval from our bot
+          APP_LOGIN="${{ steps.app-token.outputs.app-slug }}[bot]"
           ALREADY=$(gh api "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/reviews" \
-            --jq '[.[] | select(.state == "APPROVED") | select(.user.login | endswith("[bot]"))] | length')
+            --jq "[.[] | select(.state == \"APPROVED\") | select(.user.login == \"${APP_LOGIN}\")] | length")
           if [ "$ALREADY" -gt 0 ]; then
             echo "::notice::Bot already approved — skipping duplicate"
             exit 0

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -96,32 +96,44 @@ jobs:
             fi
           fi
 
-          # --- Condition 3: No unresolved Copilot review threads ---
+          # --- Condition 3: Copilot has reviewed and all threads are resolved ---
           if [ "$PASS" = "true" ]; then
             OWNER="${{ github.repository_owner }}"
             REPO_NAME=$(echo "$REPO" | cut -d/ -f2)
-            UNRESOLVED=$(gh api graphql -f query='
-              query($owner: String!, $repo: String!, $pr: Int!) {
-                repository(owner: $owner, name: $repo) {
-                  pullRequest(number: $pr) {
-                    reviewThreads(first: 100) {
-                      nodes {
-                        isResolved
-                        comments(first: 1) {
-                          nodes { author { login } }
+
+            # Check that Copilot has submitted at least one review
+            COPILOT_REVIEWS=$(gh api "repos/${REPO}/pulls/${PR}/reviews" \
+              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length')
+            if [ "$COPILOT_REVIEWS" -eq 0 ]; then
+              echo "::notice::Copilot has not reviewed yet — skipping"
+              PASS=false
+            fi
+
+            # Check for unresolved Copilot threads
+            if [ "$PASS" = "true" ]; then
+              UNRESOLVED=$(gh api graphql -f query='
+                query($owner: String!, $repo: String!, $pr: Int!) {
+                  repository(owner: $owner, name: $repo) {
+                    pullRequest(number: $pr) {
+                      reviewThreads(first: 100) {
+                        nodes {
+                          isResolved
+                          comments(first: 1) {
+                            nodes { author { login } }
+                          }
                         }
                       }
                     }
                   }
-                }
-              }' -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR" \
-              --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
-                | select(.isResolved == false)
-                | select(.comments.nodes[0].author.login == "copilot-pull-request-reviewer")
-              ] | length')
-            if [ "$UNRESOLVED" -gt 0 ]; then
-              echo "::notice::${UNRESOLVED} unresolved Copilot thread(s) — skipping"
-              PASS=false
+                }' -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR" \
+                --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+                  | select(.isResolved == false)
+                  | select(.comments.nodes[0].author.login == "copilot-pull-request-reviewer")
+                ] | length')
+              if [ "$UNRESOLVED" -gt 0 ]; then
+                echo "::notice::${UNRESOLVED} unresolved Copilot thread(s) — skipping"
+                PASS=false
+              fi
             fi
           fi
 

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -83,16 +83,16 @@ jobs:
 
           # --- Condition 2: All CI checks pass ---
           if [ "$PASS" = "true" ]; then
-            FAILED=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-              --jq '[.check_runs[] | select(.name != "auto-approve") | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral" and .status != "queued" and .status != "in_progress")] | length')
-            PENDING=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-              --jq '[.check_runs[] | select(.name != "auto-approve") | select(.status == "queued" or .status == "in_progress")] | length')
+            CHECK_DATA=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --jq '.check_runs[] | select(.name != "auto-approve") | "\(.status) \(.conclusion // "none") \(.name)"')
+            PENDING=$(echo "$CHECK_DATA" | grep -c "^queued\|^in_progress" || true)
+            FAILED=$(echo "$CHECK_DATA" | grep -v "^completed success\|^completed skipped\|^completed neutral\|^queued\|^in_progress" | grep -c . || true)
             if [ "$PENDING" -gt 0 ]; then
-              echo "::notice::${PENDING} check(s) still running — will re-evaluate when they complete"
+              echo "::notice::${PENDING} check(s) still running — skipping"
               PASS=false
             elif [ "$FAILED" -gt 0 ]; then
-              echo "::notice::${FAILED} check(s) failed — skipping"
-              PASS=false
+              echo "::error::${FAILED} check(s) failed"
+              echo "$CHECK_DATA" | grep -v "^completed success\|^completed skipped\|^completed neutral\|^queued\|^in_progress" >&2
+              exit 1
             fi
           fi
 

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -153,5 +153,5 @@ jobs:
             echo "::notice::Bot already approved — skipping duplicate"
             exit 0
           fi
-          gh pr review ${{ steps.pr.outputs.number }} --approve \
-            --body "All conditions met: CI passing, Claude review clean, no unresolved Copilot threads. Auto-approved."
+          gh pr review ${{ steps.pr.outputs.number }} --repo "${{ github.repository }}" --approve \
+            --body "All conditions met: CI passing, no unresolved Copilot threads. Auto-approved."

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,143 @@
+name: Auto-approve PR
+
+# Re-evaluates whenever a condition might change:
+# - CI checks finish (check_suite)
+# - A review is submitted (Copilot, Claude, human)
+# - PR is marked ready for review (leaves draft)
+on:
+  check_suite:
+    types: [completed]
+  pull_request_review:
+    types: [submitted]
+  pull_request:
+    types: [ready_for_review]
+
+jobs:
+  auto-approve:
+    # Only run on non-fork, non-draft PRs targeting main
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APPROVAL_BOT_APP_ID }}
+          private-key: ${{ secrets.APPROVAL_BOT_PRIVATE_KEY }}
+
+      - name: Resolve PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # check_suite doesn't include PR number directly — look it up
+          if [ "${{ github.event_name }}" = "check_suite" ]; then
+            PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.check_suite.head_sha }}/pulls" \
+              --jq '.[0].number // empty')
+            if [ -z "$PR_NUMBER" ]; then
+              echo "No PR found for this check suite — skipping"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          else
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+          fi
+          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
+      - name: Check all conditions
+        if: steps.pr.outputs.skip != 'true'
+        id: conditions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          PR=${{ steps.pr.outputs.number }}
+          REPO="${{ github.repository }}"
+          PASS=true
+
+          # --- Condition 1: PR is not a draft ---
+          IS_DRAFT=$(gh api "repos/${REPO}/pulls/${PR}" --jq '.draft')
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "::notice::PR is a draft — skipping"
+            PASS=false
+          fi
+
+          # --- Condition 2: All CI checks pass ---
+          if [ "$PASS" = "true" ]; then
+            FAILED=$(gh api "repos/${REPO}/commits/$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha')/check-runs" \
+              --jq '[.check_runs[] | select(.name != "auto-approve") | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral" and .status != "queued" and .status != "in_progress")] | length')
+            PENDING=$(gh api "repos/${REPO}/commits/$(gh api "repos/${REPO}/pulls/${PR}" --jq '.head.sha')/check-runs" \
+              --jq '[.check_runs[] | select(.name != "auto-approve") | select(.status == "queued" or .status == "in_progress")] | length')
+            if [ "$PENDING" -gt 0 ]; then
+              echo "::notice::${PENDING} check(s) still running — will re-evaluate when they complete"
+              PASS=false
+            elif [ "$FAILED" -gt 0 ]; then
+              echo "::notice::${FAILED} check(s) failed — skipping"
+              PASS=false
+            fi
+          fi
+
+          # --- Condition 3: Claude review has no BLOCK issues ---
+          if [ "$PASS" = "true" ]; then
+            VERDICT=$(gh api "repos/${REPO}/issues/${PR}/comments" \
+              --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("VERDICT:"))] | last | .body // ""')
+            if echo "$VERDICT" | grep -q "^VERDICT: CHANGES_REQUESTED"; then
+              echo "::notice::Claude review found BLOCK-level issues — skipping"
+              PASS=false
+            elif [ -z "$VERDICT" ]; then
+              echo "::notice::No Claude review verdict yet — skipping"
+              PASS=false
+            fi
+          fi
+
+          # --- Condition 4: No unresolved Copilot review threads ---
+          if [ "$PASS" = "true" ]; then
+            OWNER="${{ github.repository_owner }}"
+            REPO_NAME=$(echo "$REPO" | cut -d/ -f2)
+            UNRESOLVED=$(gh api graphql -f query='
+              query($owner: String!, $repo: String!, $pr: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $pr) {
+                    reviewThreads(first: 100) {
+                      nodes {
+                        isResolved
+                        comments(first: 1) {
+                          nodes { author { login } }
+                        }
+                      }
+                    }
+                  }
+                }
+              }' -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR" \
+              --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+                | select(.isResolved == false)
+                | select(.comments.nodes[0].author.login == "copilot-pull-request-reviewer")
+              ] | length')
+            if [ "$UNRESOLVED" -gt 0 ]; then
+              echo "::notice::${UNRESOLVED} unresolved Copilot thread(s) — skipping"
+              PASS=false
+            fi
+          fi
+
+          echo "approve=$PASS" >> "$GITHUB_OUTPUT"
+
+      - name: Approve PR
+        if: steps.pr.outputs.skip != 'true' && steps.conditions.outputs.approve == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Check if bot already approved (avoid duplicate approvals)
+          ALREADY=$(gh api "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/reviews" \
+            --jq '[.[] | select(.state == "APPROVED") | select(.user.login | endswith("[bot]"))] | length')
+          if [ "$ALREADY" -gt 0 ]; then
+            echo "::notice::Bot already approved — skipping duplicate"
+            exit 0
+          fi
+          gh pr review ${{ steps.pr.outputs.number }} --approve \
+            --body "All conditions met: CI passing, Claude review clean, no unresolved Copilot threads. Auto-approved."

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -96,21 +96,7 @@ jobs:
             fi
           fi
 
-          # --- Condition 3: Claude review explicitly approves ---
-          # Requires PR #56 which adds VERDICT: output to claude-review.yml
-          if [ "$PASS" = "true" ]; then
-            VERDICT=$(gh api "repos/${REPO}/issues/${PR}/comments" \
-              --jq '[.[] | select(.user.login == "github-actions[bot]") | select(.body | startswith("VERDICT:"))] | last | .body // ""')
-            if [ -z "$VERDICT" ]; then
-              echo "::notice::No Claude review verdict yet — skipping"
-              PASS=false
-            elif ! echo "$VERDICT" | grep -q "^VERDICT: APPROVE"; then
-              echo "::notice::Claude review verdict is not APPROVE — skipping"
-              PASS=false
-            fi
-          fi
-
-          # --- Condition 4: No unresolved Copilot review threads ---
+          # --- Condition 3: No unresolved Copilot review threads ---
           if [ "$PASS" = "true" ]; then
             OWNER="${{ github.repository_owner }}"
             REPO_NAME=$(echo "$REPO" | cut -d/ -f2)


### PR DESCRIPTION
## Summary
Add a workflow that auto-approves PRs via a GitHub App token when all conditions are met.

## Conditions for approval
1. PR is not a draft or fork, and targets `main`
2. All CI checks pass (tests, code-quality, coverage)
3. Copilot has submitted a review and all threads are resolved

## Setup required
1. [Create a GitHub App](https://github.com/settings/apps/new) with **Pull requests: Read & write** permission
2. Install it on this repo
3. Add repo secrets:
   - `APPROVAL_BOT_APP_ID` — the App ID from the app's settings page
   - `APPROVAL_BOT_PRIVATE_KEY` — a generated private key (PEM)

## How it works
The workflow triggers on `check_suite` completion, `pull_request_review` submission, and `pull_request` ready-for-review events. Each trigger re-evaluates all conditions. The GitHub App token is used for the approval so it counts toward branch protection review requirements (unlike `GITHUB_TOKEN`).

Claude review is independent — it leaves comments but does not gate approval. Duplicate approvals are prevented.

## Test plan
- [ x] Verify this PRs is approved

Closes #59