### PR TITLE
fix(ci): switch auto-approve trigger to workflow_run

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,16 +1,24 @@
 name: Auto-approve PR
 
 # Re-evaluates whenever a condition might change:
-# - CI checks finish (check_suite)
-# - A review is submitted (Copilot, Claude, human)
+# - CI workflows finish (workflow_run — check_suite doesn't trigger across workflows)
+# - A review is submitted by a human (bot reviews don't trigger workflows)
 # - PR is marked ready for review (leaves draft)
+# - Manual trigger via workflow_dispatch
 on:
-  check_suite:
+  workflow_run:
+    workflows: ["Tests", "Code Quality PR", "Claude Code Review"]
     types: [completed]
   pull_request_review:
     types: [submitted]
   pull_request:
     types: [ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to evaluate"
+        required: true
+        type: number
 
 jobs:
   auto-approve:
@@ -33,14 +41,17 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "${{ github.event_name }}" = "check_suite" ]; then
-            PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.check_suite.head_sha }}/pulls" \
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            # workflow_run: look up PR from the head SHA of the triggering workflow
+            PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" \
               --jq '.[0].number // empty')
             if [ -z "$PR_NUMBER" ]; then
-              echo "No PR found for this check suite — skipping"
+              echo "No PR found for this workflow run — skipping"
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            PR_NUMBER="${{ github.event.inputs.pr_number }}"
           else
             PR_NUMBER="${{ github.event.pull_request.number }}"
           fi


### PR DESCRIPTION
## Summary
- Replace `check_suite` trigger with `workflow_run` (fires when Tests, Code Quality PR, or Claude Code Review complete)
- Add `workflow_dispatch` for manual runs with a PR number input

## Context
`check_suite` events created by GitHub Actions don't trigger other workflows (GitHub prevents cascading). This is why auto-approve never fired on PR #63. `workflow_run` is the correct trigger for cross-workflow dependencies.

`workflow_dispatch` allows manual evaluation via **Actions → Auto-approve PR → Run workflow → enter PR number**.

## Test plan
- [ ] After merging, verify auto-approve triggers when Tests workflow completes on a PR
- [ ] Test manual trigger via workflow_dispatch with a PR number

Closes #62