### PR TITLE
feat(pipeline): add pipeline deps and split requirements files

### DIFF
--- a/checkmake.ini
+++ b/checkmake.ini
@@ -1,0 +1,5 @@
+[maxbodylength]
+maxBodyLength = 10
+
+[minphony]
+disabled = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ filterwarnings = [
 log_cli = "True"
 markers = [
   "slow: slow tests",
+  "pipeline: pipeline integration tests",
 ]
 minversion = "6.0"
 testpaths = "tests/"

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -1,0 +1,37 @@
+# --------- hydra --------- #
+hydra-colorlog==1.2.0
+hydra-core==1.3.2
+hydra-optuna-sweeper==1.2.0
+
+# --------- loggers --------- #
+wandb
+
+# --------- pipeline --------- #
+click
+numpy
+pydantic
+pyyaml
+structlog
+tenacity
+webdataset
+
+# --------- others --------- #
+dask[distributed]
+einops
+h5py
+hdf5plugin
+librosa
+loguru
+matplotlib
+mido
+pedalboard
+POT
+pre-commit
+pyloudnorm
+pyright
+pytest
+rich
+rootutils
+runpod==1.8.1
+scipy==1.14.1
+threadpoolctl

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,0 +1,6 @@
+# --------- torch stack --------- #
+# Install with an explicit index in Docker when targeting CUDA wheels.
+torch>=2.0.0
+torchvision>=0.15.0
+lightning>=2.0.0
+torchmetrics>=0.11.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,40 +1,6 @@
-# --------- pytorch --------- #
-torch>=2.0.0
-torchvision>=0.15.0
-lightning>=2.0.0
-torchmetrics>=0.11.4
-
-# --------- hydra --------- #
-hydra-core==1.3.2
-hydra-colorlog==1.2.0
-hydra-optuna-sweeper==1.2.0
-
-# --------- loggers --------- #
-wandb
-# neptune-client
-# mlflow
-# comet-ml
-# aim>=3.16.2  # no lower than 3.16.2, see https://github.com/aimhubio/aim/issues/2550
-
-# --------- others --------- #
-rootutils       # standardizing the project root setup
-pre-commit      # hooks for applying linters on commit
-pyright         # linter dep (static type checker)
-rich            # beautiful text formatting in terminal
-pytest          # tests
-scipy==1.14.1
-# sh            # for running bash commands in some tests (linux/macos only)
-
-POT
-einops
-threadpoolctl
-matplotlib
-
-mido
-pedalboard
-librosa
-loguru
-pyloudnorm
-h5py
-hdf5plugin
-dask[distributed]
+# Backward-compatible umbrella requirements file.
+# Docker/CI can install these files separately for tighter control and better caching:
+#   pip install -r requirements-torch.txt
+#   pip install -r requirements-app.txt
+-r requirements-torch.txt
+-r requirements-app.txt


### PR DESCRIPTION
## Summary

- Split flat `requirements.txt` into `requirements-torch.txt` (torch stack) and `requirements-app.txt` (all other deps) for better Docker layer caching
- Add pipeline dependencies: click, numpy, pydantic, pyyaml, structlog, tenacity, webdataset, runpod
- Add `checkmake.ini` config for the existing checkmake pre-commit hook
- Add `pipeline` pytest marker for future `tests/pipeline/` tests

## Context

First building block of the distributed data pipeline ([design doc](https://github.com/ktinubu/synth-permutations/blob/main/docs/design/data-pipeline.md)). Issue #68 Phase 1: Dependencies & Tooling.

## Verification

- `pip install -r requirements.txt` succeeds
- `pip install -r requirements-torch.txt` and `pip install -r requirements-app.txt` work independently
- All new pipeline deps importable: `import click, pydantic, structlog, tenacity, webdataset, yaml, numpy`
- `ruff check .` passes (no config changes)
- `pytest tests/ -x -m "not slow"` — 5 passed, 1 skipped, 12 deselected
- CI workflows reference `requirements.txt` which now includes both sub-files via `-r` — no CI changes needed

## Test plan

- [x] CI passes (pytest + ruff)

Refs #68