### PR TITLE
ci: improve CI workflow efficiency, auto-approve visibility, and Claude review UX

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
-      checks: read
+      checks: write
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -46,8 +46,10 @@ jobs:
             PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" \
               --jq '.[0].number // empty')
             if [ -z "$PR_NUMBER" ]; then
-              echo "::notice::No PR found for this workflow run"
-              exit 78
+              echo "::notice::No PR found for this workflow run (e.g. push to main)"
+              echo "result=skip" >> "$GITHUB_OUTPUT"
+              echo "reason=No PR found for this workflow run" >> "$GITHUB_OUTPUT"
+              exit 0
             fi
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_NUMBER="${{ github.event.inputs.pr_number }}"
@@ -55,8 +57,10 @@ jobs:
             PR_NUMBER="${{ github.event.pull_request.number }}"
           fi
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "result=" >> "$GITHUB_OUTPUT"
 
       - name: Check all conditions
+        if: steps.pr.outputs.result != 'skip'
         id: conditions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -71,21 +75,25 @@ jobs:
           IS_FORK=$(echo "$PR_DATA" | jq -r '.fork')
           BASE_REF=$(echo "$PR_DATA" | jq -r '.base')
           HEAD_SHA=$(echo "$PR_DATA" | jq -r '.sha')
+          echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
           # --- Condition 0: Only approve PRs targeting main ---
           if [ "$BASE_REF" != "main" ]; then
-            echo "::error::PR targets ${BASE_REF}, not main — not eligible"
-            exit 1
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+            echo "reason=PR targets ${BASE_REF}, not main" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           # --- Condition 1: PR is not a draft or fork ---
           if [ "$IS_DRAFT" = "true" ]; then
-            echo "::error::PR is a draft — not eligible"
-            exit 1
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+            echo "reason=PR is a draft" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
           if [ "$IS_FORK" = "true" ]; then
-            echo "::error::PR is from a fork — not eligible"
-            exit 1
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+            echo "reason=PR is from a fork" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           # --- Condition 2: All CI checks pass ---
@@ -93,12 +101,13 @@ jobs:
           PENDING=$(echo "$CHECK_DATA" | grep -c "^queued\|^in_progress" || true)
           FAILED=$(echo "$CHECK_DATA" | grep -v "^completed success\|^completed skipped\|^completed neutral\|^queued\|^in_progress" | grep -c . || true)
           if [ "$PENDING" -gt 0 ]; then
-            echo "::notice::${PENDING} check(s) still running — waiting"
-            exit 78
+            echo "result=neutral" >> "$GITHUB_OUTPUT"
+            echo "reason=${PENDING} check(s) still running" >> "$GITHUB_OUTPUT"
+            exit 0
           elif [ "$FAILED" -gt 0 ]; then
-            echo "::error::${FAILED} check(s) failed"
-            echo "$CHECK_DATA" | grep -v "^completed success\|^completed skipped\|^completed neutral\|^queued\|^in_progress" >&2
-            exit 1
+            echo "result=failure" >> "$GITHUB_OUTPUT"
+            echo "reason=${FAILED} check(s) failed" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           # --- Condition 3: Copilot has reviewed and all threads are resolved ---
@@ -108,8 +117,9 @@ jobs:
           COPILOT_REVIEWS=$(gh api "repos/${REPO}/pulls/${PR}/reviews" \
             --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length')
           if [ "$COPILOT_REVIEWS" -eq 0 ]; then
-            echo "::notice::Copilot has not reviewed yet — waiting"
-            exit 78
+            echo "result=neutral" >> "$GITHUB_OUTPUT"
+            echo "reason=Copilot has not reviewed yet" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           UNRESOLVED=$(gh api graphql -f query='
@@ -132,19 +142,20 @@ jobs:
               | select(.comments.nodes[0].author.login == "copilot-pull-request-reviewer")
             ] | length')
           if [ "$UNRESOLVED" -gt 0 ]; then
-            echo "::notice::${UNRESOLVED} unresolved Copilot thread(s) — waiting"
-            exit 78
+            echo "result=neutral" >> "$GITHUB_OUTPUT"
+            echo "reason=${UNRESOLVED} unresolved Copilot thread(s)" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
-          echo "All conditions met"
+          echo "result=approve" >> "$GITHUB_OUTPUT"
+          echo "reason=All conditions met" >> "$GITHUB_OUTPUT"
 
       - name: Approve PR
-        if: success()
+        if: steps.conditions.outputs.result == 'approve'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           # Check if this app already approved (avoid duplicate approvals)
-          # App slug is derived from the app name; check for any approval from our bot
           APP_LOGIN="${{ steps.app-token.outputs.app-slug }}[bot]"
           ALREADY=$(gh api "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/reviews" \
             --jq "[.[] | select(.state == \"APPROVED\") | select(.user.login == \"${APP_LOGIN}\")] | length")
@@ -154,3 +165,48 @@ jobs:
           fi
           gh pr review ${{ steps.pr.outputs.number }} --repo "${{ github.repository }}" --approve \
             --body "All conditions met: CI passing, no unresolved Copilot threads. Auto-approved."
+
+      # GitHub Actions doesn't support neutral exit codes from shell steps
+      # (exit 78 was removed in the v1→v2 migration; actions/runner#662).
+      # To show an honest status — green for approved, grey for waiting,
+      # red for ineligible — we create a check run via the Checks API,
+      # which is the only mechanism that supports conclusion: "neutral".
+      - name: Report status
+        if: always() && steps.pr.outputs.result != 'skip'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const result = '${{ steps.conditions.outputs.result }}';
+            const reason = '${{ steps.conditions.outputs.reason }}';
+            const headSha = '${{ steps.conditions.outputs.head_sha }}';
+
+            // Map result to Checks API conclusion
+            // - approve  → success  (green tick)
+            // - neutral  → neutral  (grey, not ready yet)
+            // - failure  → failure  (red, ineligible)
+            const conclusionMap = {
+              approve: 'success',
+              neutral: 'neutral',
+              failure: 'failure',
+            };
+            const conclusion = conclusionMap[result] || 'failure';
+
+            const titleMap = {
+              approve: 'Approved',
+              neutral: 'Waiting',
+              failure: 'Not eligible',
+            };
+            const title = titleMap[result] || 'Unknown';
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: headSha,
+              name: 'Auto-approve status',
+              status: 'completed',
+              conclusion,
+              output: {
+                title,
+                summary: reason,
+              },
+            });

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -97,7 +97,7 @@ jobs:
           fi
 
           # --- Condition 2: All CI checks pass ---
-          CHECK_DATA=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --jq '.check_runs[] | select(.name != "auto-approve" and .name != "claude-review") | "\(.status) \(.conclusion // "none") \(.name)"')
+          CHECK_DATA=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --jq '.check_runs[] | select(.name != "auto-approve" and .name != "Auto-approve status" and .name != "claude-review") | "\(.status) \(.conclusion // "none") \(.name)"')
           PENDING=$(echo "$CHECK_DATA" | grep -c "^queued\|^in_progress" || true)
           FAILED=$(echo "$CHECK_DATA" | grep -v "^completed success\|^completed skipped\|^completed neutral\|^queued\|^in_progress" | grep -c . || true)
           if [ "$PENDING" -gt 0 ]; then

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -70,9 +70,8 @@ jobs:
           REPO="${{ github.repository }}"
 
           # Fetch PR metadata once
-          PR_DATA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '{draft: .draft, fork: (.head.repo.fork // false), base: .base.ref, sha: .head.sha}')
+          PR_DATA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '{draft: .draft, base: .base.ref, sha: .head.sha}')
           IS_DRAFT=$(echo "$PR_DATA" | jq -r '.draft')
-          IS_FORK=$(echo "$PR_DATA" | jq -r '.fork')
           BASE_REF=$(echo "$PR_DATA" | jq -r '.base')
           HEAD_SHA=$(echo "$PR_DATA" | jq -r '.sha')
           echo "head_sha=$HEAD_SHA" >> "$GITHUB_OUTPUT"
@@ -90,12 +89,6 @@ jobs:
             echo "reason=PR is a draft" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [ "$IS_FORK" = "true" ]; then
-            echo "result=failure" >> "$GITHUB_OUTPUT"
-            echo "reason=PR is from a fork" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           # --- Condition 2: All CI checks pass ---
           CHECK_DATA=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --jq '.check_runs[] | select(.name != "auto-approve" and .name != "Auto-approve status" and .name != "claude-review") | "\(.status) \(.conclusion // "none") \(.name)"')
           PENDING=$(echo "$CHECK_DATA" | grep -c "^queued\|^in_progress" || true)

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -139,7 +139,7 @@ jobs:
             }' -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR" \
             --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
               | select(.isResolved == false)
-              | select(.comments.nodes[0].author.login == "copilot-pull-request-reviewer")
+              | select(.comments.nodes[0].author.login | startswith("copilot-pull-request-reviewer"))
             ] | length')
           if [ "$UNRESOLVED" -gt 0 ]; then
             echo "result=neutral" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -47,7 +47,7 @@ jobs:
               --jq '.[0].number // empty')
             if [ -z "$PR_NUMBER" ]; then
               echo "::notice::No PR found for this workflow run"
-              exit 1
+              exit 78
             fi
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_NUMBER="${{ github.event.inputs.pr_number }}"
@@ -93,8 +93,8 @@ jobs:
           PENDING=$(echo "$CHECK_DATA" | grep -c "^queued\|^in_progress" || true)
           FAILED=$(echo "$CHECK_DATA" | grep -v "^completed success\|^completed skipped\|^completed neutral\|^queued\|^in_progress" | grep -c . || true)
           if [ "$PENDING" -gt 0 ]; then
-            echo "::error::${PENDING} check(s) still running — waiting"
-            exit 1
+            echo "::notice::${PENDING} check(s) still running — waiting"
+            exit 78
           elif [ "$FAILED" -gt 0 ]; then
             echo "::error::${FAILED} check(s) failed"
             echo "$CHECK_DATA" | grep -v "^completed success\|^completed skipped\|^completed neutral\|^queued\|^in_progress" >&2
@@ -108,8 +108,8 @@ jobs:
           COPILOT_REVIEWS=$(gh api "repos/${REPO}/pulls/${PR}/reviews" \
             --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length')
           if [ "$COPILOT_REVIEWS" -eq 0 ]; then
-            echo "::error::Copilot has not reviewed yet — waiting"
-            exit 1
+            echo "::notice::Copilot has not reviewed yet — waiting"
+            exit 78
           fi
 
           UNRESOLVED=$(gh api graphql -f query='
@@ -132,8 +132,8 @@ jobs:
               | select(.comments.nodes[0].author.login == "copilot-pull-request-reviewer")
             ] | length')
           if [ "$UNRESOLVED" -gt 0 ]; then
-            echo "::error::${UNRESOLVED} unresolved Copilot thread(s) — not eligible"
-            exit 1
+            echo "::notice::${UNRESOLVED} unresolved Copilot thread(s) — waiting"
+            exit 78
           fi
 
           echo "All conditions met"

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -46,9 +46,8 @@ jobs:
             PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" \
               --jq '.[0].number // empty')
             if [ -z "$PR_NUMBER" ]; then
-              echo "No PR found for this workflow run — skipping"
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              exit 0
+              echo "::notice::No PR found for this workflow run"
+              exit 1
             fi
           elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             PR_NUMBER="${{ github.event.inputs.pr_number }}"
@@ -56,10 +55,8 @@ jobs:
             PR_NUMBER="${{ github.event.pull_request.number }}"
           fi
           echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - name: Check all conditions
-        if: steps.pr.outputs.skip != 'true'
         id: conditions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -67,7 +64,6 @@ jobs:
           set -euo pipefail
           PR=${{ steps.pr.outputs.number }}
           REPO="${{ github.repository }}"
-          PASS=true
 
           # Fetch PR metadata once
           PR_DATA=$(gh api "repos/${REPO}/pulls/${PR}" --jq '{draft: .draft, fork: (.head.repo.fork // false), base: .base.ref, sha: .head.sha}')
@@ -78,80 +74,72 @@ jobs:
 
           # --- Condition 0: Only approve PRs targeting main ---
           if [ "$BASE_REF" != "main" ]; then
-            echo "::notice::PR targets ${BASE_REF}, not main — skipping"
-            PASS=false
+            echo "::error::PR targets ${BASE_REF}, not main — not eligible"
+            exit 1
           fi
 
           # --- Condition 1: PR is not a draft or fork ---
-          if [ "$PASS" = "true" ] && [ "$IS_DRAFT" = "true" ]; then
-            echo "::notice::PR is a draft — skipping"
-            PASS=false
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "::error::PR is a draft — not eligible"
+            exit 1
           fi
-          if [ "$PASS" = "true" ] && [ "$IS_FORK" = "true" ]; then
-            echo "::notice::PR is from a fork — skipping"
-            PASS=false
+          if [ "$IS_FORK" = "true" ]; then
+            echo "::error::PR is from a fork — not eligible"
+            exit 1
           fi
 
           # --- Condition 2: All CI checks pass ---
-          if [ "$PASS" = "true" ]; then
-            CHECK_DATA=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --jq '.check_runs[] | select(.name != "auto-approve" and .name != "claude-review") | "\(.status) \(.conclusion // "none") \(.name)"')
-            PENDING=$(echo "$CHECK_DATA" | grep -c "^queued\|^in_progress" || true)
-            FAILED=$(echo "$CHECK_DATA" | grep -v "^completed success\|^completed skipped\|^completed neutral\|^queued\|^in_progress" | grep -c . || true)
-            if [ "$PENDING" -gt 0 ]; then
-              echo "::notice::${PENDING} check(s) still running — skipping"
-              PASS=false
-            elif [ "$FAILED" -gt 0 ]; then
-              echo "::error::${FAILED} check(s) failed"
-              echo "$CHECK_DATA" | grep -v "^completed success\|^completed skipped\|^completed neutral\|^queued\|^in_progress" >&2
-              exit 1
-            fi
+          CHECK_DATA=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --jq '.check_runs[] | select(.name != "auto-approve" and .name != "claude-review") | "\(.status) \(.conclusion // "none") \(.name)"')
+          PENDING=$(echo "$CHECK_DATA" | grep -c "^queued\|^in_progress" || true)
+          FAILED=$(echo "$CHECK_DATA" | grep -v "^completed success\|^completed skipped\|^completed neutral\|^queued\|^in_progress" | grep -c . || true)
+          if [ "$PENDING" -gt 0 ]; then
+            echo "::error::${PENDING} check(s) still running — waiting"
+            exit 1
+          elif [ "$FAILED" -gt 0 ]; then
+            echo "::error::${FAILED} check(s) failed"
+            echo "$CHECK_DATA" | grep -v "^completed success\|^completed skipped\|^completed neutral\|^queued\|^in_progress" >&2
+            exit 1
           fi
 
           # --- Condition 3: Copilot has reviewed and all threads are resolved ---
-          if [ "$PASS" = "true" ]; then
-            OWNER="${{ github.repository_owner }}"
-            REPO_NAME=$(echo "$REPO" | cut -d/ -f2)
+          OWNER="${{ github.repository_owner }}"
+          REPO_NAME=$(echo "$REPO" | cut -d/ -f2)
 
-            # Check that Copilot has submitted at least one review
-            COPILOT_REVIEWS=$(gh api "repos/${REPO}/pulls/${PR}/reviews" \
-              --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length')
-            if [ "$COPILOT_REVIEWS" -eq 0 ]; then
-              echo "::notice::Copilot has not reviewed yet — skipping"
-              PASS=false
-            fi
+          COPILOT_REVIEWS=$(gh api "repos/${REPO}/pulls/${PR}/reviews" \
+            --jq '[.[] | select(.user.login == "copilot-pull-request-reviewer[bot]")] | length')
+          if [ "$COPILOT_REVIEWS" -eq 0 ]; then
+            echo "::error::Copilot has not reviewed yet — waiting"
+            exit 1
+          fi
 
-            # Check for unresolved Copilot threads
-            if [ "$PASS" = "true" ]; then
-              UNRESOLVED=$(gh api graphql -f query='
-                query($owner: String!, $repo: String!, $pr: Int!) {
-                  repository(owner: $owner, name: $repo) {
-                    pullRequest(number: $pr) {
-                      reviewThreads(first: 100) {
-                        nodes {
-                          isResolved
-                          comments(first: 1) {
-                            nodes { author { login } }
-                          }
-                        }
+          UNRESOLVED=$(gh api graphql -f query='
+            query($owner: String!, $repo: String!, $pr: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pr) {
+                  reviewThreads(first: 100) {
+                    nodes {
+                      isResolved
+                      comments(first: 1) {
+                        nodes { author { login } }
                       }
                     }
                   }
-                }' -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR" \
-                --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
-                  | select(.isResolved == false)
-                  | select(.comments.nodes[0].author.login == "copilot-pull-request-reviewer")
-                ] | length')
-              if [ "$UNRESOLVED" -gt 0 ]; then
-                echo "::notice::${UNRESOLVED} unresolved Copilot thread(s) — skipping"
-                PASS=false
-              fi
-            fi
+                }
+              }
+            }' -f owner="$OWNER" -f repo="$REPO_NAME" -F pr="$PR" \
+            --jq '[.data.repository.pullRequest.reviewThreads.nodes[]
+              | select(.isResolved == false)
+              | select(.comments.nodes[0].author.login == "copilot-pull-request-reviewer")
+            ] | length')
+          if [ "$UNRESOLVED" -gt 0 ]; then
+            echo "::error::${UNRESOLVED} unresolved Copilot thread(s) — not eligible"
+            exit 1
           fi
 
-          echo "approve=$PASS" >> "$GITHUB_OUTPUT"
+          echo "All conditions met"
 
       - name: Approve PR
-        if: steps.pr.outputs.skip != 'true' && steps.conditions.outputs.approve == 'true'
+        if: success()
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,11 +19,22 @@ jobs:
     env:
       GH_PR_NUMBER: ${{ inputs.pr_number }}
     steps:
+      - name: Reject fork PRs
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          is_fork=$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr_number }} --jq '.head.repo.fork')
+          if [ "$is_fork" = "true" ]; then
+            echo "::error::Refusing to run on fork PR (secrets would be exposed)."
+            exit 1
+          fi
+
       - name: Checkout PR head
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: refs/pull/${{ inputs.pr_number }}/head
+          persist-credentials: false
 
       - name: Validate API key is configured
         run: |

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,18 +19,8 @@ jobs:
     env:
       GH_PR_NUMBER: ${{ inputs.pr_number }}
     steps:
-      - name: Reject fork PRs
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          is_fork=$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr_number }} --jq '.head.repo.fork')
-          if [ "$is_fork" = "true" ]; then
-            echo "::error::Refusing to run on fork PR (secrets would be exposed)."
-            exit 1
-          fi
-
       - name: Checkout PR head
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: refs/pull/${{ inputs.pr_number }}/head

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,29 +1,38 @@
 name: Claude Code Review
 
+# Runs automatically when a PR is opened, and on-demand via the
+# "needs-claude-review" label. Inline comments require pull_request
+# context — workflow_dispatch can't post them (actions/runner#662,
+# claude-code-action#635).
 on:
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "PR number to review"
-        required: true
-        type: number
+  pull_request:
+    types: [opened, labeled]
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
 
 jobs:
   claude-review:
+    # Run on open, or when the "needs-claude-review" label is added.
+    # The label guard prevents reviews firing on unrelated labels.
+    if: >
+      github.event.pull_request.head.repo.fork == false &&
+      (
+        github.event.action == 'opened' ||
+        (github.event.action == 'labeled' && github.event.label.name == 'needs-claude-review')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       id-token: write
     timeout-minutes: 15
-    env:
-      GH_PR_NUMBER: ${{ inputs.pr_number }}
     steps:
-      - name: Checkout PR head
+      - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: refs/pull/${{ inputs.pr_number }}/head
           persist-credentials: false
 
       - name: Validate API key is configured
@@ -57,4 +66,3 @@ jobs:
             Review this PR. Follow the Code Review section in CLAUDE.md — invoke all seven
             review skills and evaluate every checklist item against the changed code.
             Prefix each comment with BLOCK: or WARN:.
-          show_full_output: true

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,23 +1,29 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-    branches: [main]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review"
+        required: true
+        type: number
 
 jobs:
   claude-review:
-    if: github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
       id-token: write
     timeout-minutes: 15
+    env:
+      GH_PR_NUMBER: ${{ inputs.pr_number }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout PR head
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: refs/pull/${{ inputs.pr_number }}/head
 
       - name: Validate API key is configured
         run: |
@@ -51,10 +57,3 @@ jobs:
             review skills and evaluate every checklist item against the changed code.
             Prefix each comment with BLOCK: or WARN:.
           show_full_output: true
-
-  skip-notice:
-    if: github.event.pull_request.head.repo.fork == true
-    runs-on: ubuntu-latest
-    steps:
-      - name: Post fork PR notice
-        run: echo "::notice::Claude review is skipped for fork PRs (secrets are unavailable)."

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,9 +8,6 @@ on:
   pull_request:
     types: [opened, labeled]
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
 
 jobs:
   claude-review:

--- a/.github/workflows/test-expensive.yml
+++ b/.github/workflows/test-expensive.yml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
 
 jobs:
   run_tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,14 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
   pull_request:
     branches: [main, "release/*", "dev"]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
 
 jobs:
   run_tests_ubuntu:


### PR DESCRIPTION
## Summary

### Test suite
- **Skip tests for docs-only PRs**: Add `paths-ignore` for `**/*.md` and `docs/**` to `test.yml` and `test-expensive.yml` so docs-only changes don't waste CI minutes

### Claude Code Review
- **Auto on open, on-demand after**: Runs automatically when a PR is opened against main, then on-demand via `needs-claude-review` label for subsequent reviews
- **Inline comments restored**: Switched back to `pull_request` trigger — `workflow_dispatch` can't post inline PR comments because the MCP server requires PR context (`claude-code-action#635`)
- **Docs-only PRs skipped** via `paths-ignore`
- **Aligned to `actions/checkout@v6`** to match other workflows
- Removed `show_full_output` (debugging flag, not needed in prod)

### Auto-approve
- **Honest status via Checks API**: GitHub Actions doesn't support neutral exit codes from shell steps (`actions/runner#662`). Creates a separate "Auto-approve status" check run with three-tier conclusions:
  - **Green**: PR was actually approved
  - **Grey/neutral**: Not ready yet — checks pending, Copilot hasn't reviewed, unresolved threads
  - **Red**: Ineligible — draft, wrong base branch, or failed checks
- **Fixed self-referential check bug**: Excluded "Auto-approve status" from the CI check query to prevent previous failure conclusions from blocking future approvals
- **Fixed Copilot login match bug**: GraphQL filter now uses `startswith("copilot-pull-request-reviewer")` to match both with and without `[bot]` suffix
- **Removed redundant fork check**: Fork PRs can't pass CI or Copilot review conditions anyway

Part of #110

## Test plan
- [ ] Push a docs-only commit to a PR → verify Tests and Claude Review are **not** triggered
- [ ] Push a code commit to a PR → verify Tests **are** triggered
- [ ] Open a new code PR → verify Claude Review runs automatically and posts inline comments
- [ ] Add `needs-claude-review` label to existing PR → verify Claude Review runs
- [ ] Trigger auto-approve on a PR with pending checks → verify "Auto-approve status" shows grey/neutral
- [ ] Trigger auto-approve on a PR with failed checks → verify check shows red
- [ ] Trigger auto-approve on a fully-passing PR → verify it approves and check shows green
- [ ] Merge to main → verify auto-approve shows neutral (no PR found), not red