### PR TITLE
ci(test): use gpu-x64 runner for expensive tests

### DIFF
--- a/.github/workflows/test-expensive.yml
+++ b/.github/workflows/test-expensive.yml
@@ -1,9 +1,7 @@
-name: Full Tests (including slow)
+name: GPU Tests
 
-# Intentionally no pull_request trigger — the full suite (including @slow tests)
-# takes too long for PR feedback loops.  Runs on manual dispatch and post-merge
-# to main only.  Uses a GPU runner so @RunIf(min_gpus=1) tests execute.
-# TODO: add pull_request trigger once runtime is acceptable for PR CI (#35).
+# Runs only @pytest.mark.gpu tests on a GPU runner.
+# Manual dispatch and post-merge to main.
 on:
   workflow_dispatch:
   push:
@@ -34,8 +32,8 @@ jobs:
         run: |
           python -m pip list
 
-      - name: Run pytest
+      - name: Run GPU tests
         env:
           HYDRA_FULL_ERROR: "1"
         run: |
-          pytest -vv -s
+          pytest -vv -s -m gpu

--- a/.github/workflows/test-expensive.yml
+++ b/.github/workflows/test-expensive.yml
@@ -2,8 +2,7 @@ name: Full Tests (including slow)
 
 # Intentionally no pull_request trigger — the full suite (including @slow tests)
 # takes too long for PR feedback loops.  Runs on manual dispatch and post-merge
-# to main only.  GPU-requiring tests (guarded by @RunIf(min_gpus=1)) are skipped
-# automatically on CPU runners.
+# to main only.  Uses a GPU runner so @RunIf(min_gpus=1) tests execute.
 # TODO: add pull_request trigger once runtime is acceptable for PR CI (#35).
 on:
   workflow_dispatch:
@@ -12,7 +11,7 @@ on:
 
 jobs:
   run_tests:
-    runs-on: ubuntu-latest
+    runs-on: gpu-x64
 
     timeout-minutes: 120
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ filterwarnings = [
 log_cli = "True"
 markers = [
   "slow: slow tests",
+  "gpu: tests requiring a GPU",
   "pipeline: pipeline integration tests",
 ]
 minversion = "6.0"

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -47,6 +47,7 @@ def test_train_fast_dev_run(cfg_train: DictConfig) -> None:
     train(cfg_train)
 
 
+@pytest.mark.gpu
 @RunIf(min_gpus=1)
 def test_train_fast_dev_run_gpu(cfg_train: DictConfig) -> None:
     """Run for 1 train, val and test step on GPU.
@@ -61,6 +62,7 @@ def test_train_fast_dev_run_gpu(cfg_train: DictConfig) -> None:
     train(cfg_train)
 
 
+@pytest.mark.gpu
 @RunIf(min_gpus=1)
 @pytest.mark.slow
 def test_train_fast_dev_run_gpu_compile(cfg_train: DictConfig) -> None:
@@ -76,6 +78,7 @@ def test_train_fast_dev_run_gpu_compile(cfg_train: DictConfig) -> None:
     train(cfg_train)
 
 
+@pytest.mark.gpu
 @RunIf(min_gpus=1)
 @pytest.mark.slow
 def test_train_epoch_gpu_amp(cfg_train: DictConfig) -> None:


### PR DESCRIPTION
## Summary

- Switch `test-expensive.yml` from `ubuntu-latest` to `gpu-x64` runner
- Enables `@RunIf(min_gpus=1)` tests to actually execute instead of being skipped

## Test plan

- [ ] Manually trigger the workflow and verify it picks up a GPU runner
- [ ] Confirm GPU-guarded tests run instead of being skipped

Refs #34