### PR TITLE
chore(docs): align doc work items with GitHub issue metadata

### DIFF
--- a/.claude/skills/github-taxonomy/SKILL.md
+++ b/.claude/skills/github-taxonomy/SKILL.md
@@ -25,7 +25,7 @@ This is a rigid process skill. Follow every step — do not skip steps or improv
 Follow the full lifecycle (taxonomy doc §11):
 
 1. **Set Issue Type** — one of: Epic, Phase, Task, Bug, Feature
-2. **Add domain label** — exactly one of: `data-pipeline`, `ci-automation`, `code-health`, `evaluation`, `testing`, `training`
+2. **Add domain label** — one of: `data-pipeline`, `ci-automation`, `code-health`, `evaluation`, `storage`, `testing`, `training`. Cross-cutting infrastructure may carry multiple domain labels (see taxonomy doc §6).
 3. **Assign milestone** — use the work stream's milestone (e.g., `data-pipeline v1.0.0`)
 4. **Add to the project** — set Status to `Todo`
 5. **Set Priority** via the project field:

--- a/docs/design/data-pipeline-implementation-plan.md
+++ b/docs/design/data-pipeline-implementation-plan.md
@@ -9,21 +9,21 @@ ______________________________________________________________________
 
 ### Index
 
-| §   | Section                                                       | GitHub issue |
-| --- | ------------------------------------------------------------- | ------------ |
-| 1   | [Priorities & Conventions](#1-priorities--conventions)        | —            |
-| 2   | [Merge Path](#2-merge-path)                                   | #74          |
-| 3   | [Codebase Inventory](#3-codebase-inventory)                   | —            |
-| 4   | [Pipeline Config Schema](#4-pipeline-config-schema)           | —            |
-| 5   | [Phase 1 — Foundation](#5-phase-1--foundation-68)             | #68          |
-| 6   | [Phase 2 — Pipeline Core](#6-phase-2--pipeline-core-69)       | #69          |
-| 7   | [Phase 3 — Docker](#7-phase-3--docker-infrastructure-70)      | #70          |
-| 8   | [Phase 4 — Pipeline Engine](#8-phase-4--pipeline-engine-71)   | #71          |
-| 9   | [Phase 5 — Pipeline CLI](#9-phase-5--pipeline-cli-72)         | #72          |
-| 10  | [Phase 6 — Production & E2E](#10-phase-6--production--e2e-73) | #73          |
-| 11  | [Cross-cutting work](#11-cross-cutting-work)                  | #76, #77     |
-| 12  | [Verification Strategy](#12-verification-strategy)            | —            |
-| 13  | [Assumptions](#13-assumptions)                                | —            |
+| §   | Section                                                       | GitHub issue               |
+| --- | ------------------------------------------------------------- | -------------------------- |
+| 1   | [Priorities & Conventions](#1-priorities--conventions)        | —                          |
+| 2   | [Merge Path](#2-merge-path)                                   | #74                        |
+| 3   | [Codebase Inventory](#3-codebase-inventory)                   | —                          |
+| 4   | [Pipeline Config Schema](#4-pipeline-config-schema)           | —                          |
+| 5   | [Phase 1 — Foundation](#5-phase-1--foundation-68)             | #68                        |
+| 6   | [Phase 2 — Pipeline Core](#6-phase-2--pipeline-core-69)       | #69                        |
+| 7   | [Phase 3 — Docker](#7-phase-3--docker-infrastructure-70)      | #70                        |
+| 8   | [Phase 4 — Pipeline Engine](#8-phase-4--pipeline-engine-71)   | #71                        |
+| 9   | [Phase 5 — Pipeline CLI](#9-phase-5--pipeline-cli-72)         | #72                        |
+| 10  | [Phase 6 — Production & E2E](#10-phase-6--production--e2e-73) | #73                        |
+| 11  | [Cross-cutting work](#11-cross-cutting-work)                  | #76, #77, #120, #121, #122 |
+| 12  | [Verification Strategy](#12-verification-strategy)            | —                          |
+| 13  | [Assumptions](#13-assumptions)                                | —                          |
 
 ______________________________________________________________________
 
@@ -865,6 +865,18 @@ These tests are written incrementally as each PR lands.
 - RunPod `auto-stop` configuration in `RunPodBackend.submit()`
 - `--timeout` flag on `generate` command
 - BATS test: worker killed via SIGTERM after timeout still uploads debug log
+
+### Dataset ID & Run ID Conventions ([#120](https://github.com/tinaudio/synth-setter/issues/120))
+
+Define `dataset_id`, `run_id` naming conventions and W&B artifact provenance chain.
+
+### Align R2 Root Datapaths ([#121](https://github.com/tinaudio/synth-setter/issues/121))
+
+Ensure R2 root datapaths are consistent across data pipeline, eval pipeline, and training pipeline design docs.
+
+### Centralized Provenance & Storage Design Doc ([#122](https://github.com/tinaudio/synth-setter/issues/122))
+
+Write a design doc that unifies provenance and storage conventions across all pipelines.
 
 ______________________________________________________________________
 

--- a/docs/design/eval-pipeline.md
+++ b/docs/design/eval-pipeline.md
@@ -641,29 +641,6 @@ This section consolidates every configuration and environment behavior change in
 
 ## 8. Dependency Graph & Parallelism
 
-### Issue Dependencies
-
-```
-                    EVAL PIPELINE                              R2 INTEGRATION
-                    ─────────────                              ──────────────
-
-                ┌─── #86 Render ─────┐
-                │    (P1, no blocker) │
-                │                    │
- #94 Paths ──→ #85 Predict ─────────┼──→ #88 Docker ──→ #89 E2E CI
- (P1)       (P1)                    │    (P2)            (P2)
-                │                    │
-                ├─── #87 Metrics ────┤                     #90 rclone ──→ #91 R2 Dataset
-                │    (P1, no blocker)│                     (P1)       │    (P1)
-                │         │          │                                │
-                │         │                                          │
-                │         └──→ #93 R2 Artifacts ◄────────────────────┘
-                │              (P2)
-                │
-                └──→ #97 Runbook (P2)
-
-```
-
 ### Blocking Matrix
 
 | Issue | Title               | Blocked by    | Blocks                  |
@@ -677,7 +654,7 @@ This section consolidates every configuration and environment behavior change in
 | #89   | E2E CI              | #85–88        | —                       |
 | #91   | R2 dataset download | #90, #94      | —                       |
 | #93   | R2 artifact upload  | #90, #87      | —                       |
-| #92   | R2 checkpoint sync  | —             | —                       |
+| #92   | R2 checkpoint sync  | #90           | —                       |
 | #95   | Consolidate SGE     | —             | —                       |
 | #96   | W&B metrics logging | #87           | —                       |
 | #97   | Eval runbook        | #85, #86, #87 | —                       |

--- a/docs/design/eval-pipeline.md
+++ b/docs/design/eval-pipeline.md
@@ -677,7 +677,11 @@ This section consolidates every configuration and environment behavior change in
 | #89   | E2E CI              | #85–88        | —                       |
 | #91   | R2 dataset download | #90, #94      | —                       |
 | #93   | R2 artifact upload  | #90, #87      | —                       |
+| #92   | R2 checkpoint sync  | —             | —                       |
+| #95   | Consolidate SGE     | —             | —                       |
+| #96   | W&B metrics logging | #87           | —                       |
 | #97   | Eval runbook        | #85, #86, #87 | —                       |
+| #128  | W&B resolver        | #94           | #88                     |
 
 ### Parallel Execution Windows
 
@@ -818,12 +822,12 @@ main ──●──────────────────●───
        PR#1               PR#2               PR#3               PR#4
 ```
 
-| PR                              | Issues             | Contents                                                                                          | Integration test                                                                     |
-| ------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| **#1: Portable Eval**           | #94, #85, #86, #87 | Config cleanup, portable predict/render/metrics, Makefile targets                                 | `make predict`, `make render`, `make metrics` on local fixture                       |
-| **#2: R2 + W&B**                | #90, #91, #96      | rclone wrapper, R2 dataset download, `log_model="all"`, `${wandb:...}` resolver, W&B eval metrics | `make predict` with `data.r2_path=...` auto-downloads; W&B checkpoint download works |
-| **#3: Docker + CI + Artifacts** | #88, #93, #89      | Docker eval, R2 eval artifact upload, E2E CI                                                      | `make docker-eval` runs full pipeline; GH Actions passes                             |
-| **#4: Documentation**           | #97                | Eval runbook                                                                                      | Follow runbook from scratch                                                          |
+| PR                              | Issues              | Contents                                                                                          | Integration test                                                                     |
+| ------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **#1: Portable Eval**           | #94, #85, #86, #87  | Config cleanup, portable predict/render/metrics, Makefile targets                                 | `make predict`, `make render`, `make metrics` on local fixture                       |
+| **#2: R2 + W&B**                | #90, #91, #96, #128 | rclone wrapper, R2 dataset download, `log_model="all"`, `${wandb:...}` resolver, W&B eval metrics | `make predict` with `data.r2_path=...` auto-downloads; W&B checkpoint download works |
+| **#3: Docker + CI + Artifacts** | #88, #93, #89       | Docker eval, R2 eval artifact upload, E2E CI                                                      | `make docker-eval` runs full pipeline; GH Actions passes                             |
+| **#4: Documentation**           | #97                 | Eval runbook                                                                                      | Follow runbook from scratch                                                          |
 
 ### Estimated change size
 
@@ -922,7 +926,7 @@ main ──●──────────────────●───
 - `ProcessPoolExecutor` parallelism preserved
 - JTFS and f0 code stays as-is — track reactivation as a separate issue (out of scope)
 
-### PR #2: R2 + W&B (#90, #91, #96)
+### PR #2: R2 + W&B (#90, #91, #96, #128)
 
 #### Phase 5: rclone Wrapper (#90)
 
@@ -961,7 +965,7 @@ main ──●──────────────────●───
 - Logs download progress via structlog
 - **No default value** — R2 download is always an explicit opt-in
 
-#### Phase 7: W&B Checkpoint Config + Resolver
+#### Phase 7: W&B Checkpoint Config + Resolver (#128)
 
 **Goal:** Enable crash-resilient checkpoint upload via W&B and lazy resolution via OmegaConf.
 

--- a/docs/design/github-taxonomy.md
+++ b/docs/design/github-taxonomy.md
@@ -116,7 +116,7 @@ Priority is tracked via a **Priority** single-select field on the project:
 
 ## 6. Labels
 
-Labels classify issues by **domain** only. Type and blocking are handled by native features; priority is a project field.
+Labels classify issues by **domain**. Type and blocking are handled by native features; priority is a project field.
 
 | Label           | Color   | Description                                   |
 | --------------- | ------- | --------------------------------------------- |
@@ -124,8 +124,11 @@ Labels classify issues by **domain** only. Type and blocking are handled by nati
 | `ci-automation` | #1d76db | CI & automation work stream                   |
 | `code-health`   | #fbca04 | Code quality and tech debt                    |
 | `evaluation`    | #C5DEF5 | Evaluation pipeline, metrics, and inference   |
+| `storage`       | #D4C5F9 | Storage infrastructure (R2, rclone)           |
 | `testing`       | #0E8A16 | Test infrastructure, fixtures, CI test config |
 | `training`      | #8B5CF6 | Training pipeline, ops, and infrastructure    |
+
+**Multi-label policy:** Most issues carry a single domain label. Cross-cutting infrastructure (e.g., R2/rclone work that serves both data pipeline and eval pipeline) may carry multiple domain labels to appear in all relevant filtered views. Use multiple labels only when the work genuinely spans work streams — not as a default.
 
 Workflow labels (`duplicate`, `invalid`, `wontfix`, `good first issue`, `help wanted`, `question`) are retained for their standard GitHub purposes.
 
@@ -162,6 +165,7 @@ Use saved views with domain label filters to switch between work streams:
 | All Work        | Hierarchy | (none)                |
 | Data Pipeline   | Hierarchy | `label:data-pipeline` |
 | Evaluation      | Hierarchy | `label:evaluation`    |
+| Storage         | Hierarchy | `label:storage`       |
 | CI & Automation | Board     | `label:ci-automation` |
 | Code Health     | Table     | `label:code-health`   |
 | Training        | Hierarchy | `label:training`      |


### PR DESCRIPTION
## Summary

- Audit data pipeline and eval pipeline implementation docs against GitHub issues
- Fix metadata gaps: priorities, labels, blocking relationships, missing references
- Create `storage` domain label for cross-cutting R2/rclone work
- Create #128 (W&B checkpoint resolver) to close a tracking gap in the eval doc

### GitHub metadata changes
- Set priorities on 22 issues across both pipelines
- Add 13 missing blocking relationships from eval doc §8 matrix
- Fix 4 issue titles to conventional commit format
- Fix labels: remove non-domain labels from #76, #89, #97; add `storage` to #90–93, #99

### Doc changes
- `data-pipeline-implementation-plan.md`: add #120, #121, #122 to §11 cross-cutting
- `eval-pipeline.md`: add #92, #95, #96, #128 to §8 blocking matrix; #128 to §12 PR#2/Phase 7
- `github-taxonomy.md`: add `storage` label, multi-label policy for cross-cutting work, Storage view
- `github-taxonomy SKILL.md`: add `storage` to domain label list

## Test plan

- [x] Verify all data-pipeline milestone issues have priorities set
- [x] Verify all evaluation milestone issues have priorities set
- [x] Verify #128 is sub-issue of #98 with correct blocking (#94 blocks it, it blocks #88)
- [x] Verify labels: #76 has single label, #89/#97 have non-domain labels removed, #90–93/#99 have `storage` added
- [x] Verify blocking relationships match eval doc §8 matrix
- [x] Pre-commit hooks pass (mdformat, codespell, etc.)

Refs #74, #98, #99