### PR TITLE
fix(ci): replace archived trilom/file-changes-action

### DIFF
--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -28,16 +28,16 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Find modified files
-        id: file_changes
-        uses: trilom/file-changes-action@v1.2.4
+      - name: Find changed files
+        id: changed_files
+        uses: tj-actions/changed-files@v45
         with:
-          output: " "
+          separator: " "
 
-      - name: List modified files
-        run: echo '${{ steps.file_changes.outputs.files}}'
+      - name: List changed files
+        run: echo '${{ steps.changed_files.outputs.all_changed_files }}'
 
       - name: Run pre-commits
         uses: pre-commit/action@v3.0.1
         with:
-          extra_args: --files ${{ steps.file_changes.outputs.files}}
+          extra_args: --files ${{ steps.changed_files.outputs.all_changed_files }}


### PR DESCRIPTION
## Summary

- Replace `trilom/file-changes-action@v1.2.4` with `tj-actions/changed-files@v45` in the Code Quality PR workflow
- The `trilom` action is archived/unmaintained and now returns 403 "Resource not accessible by integration" errors after the repo was transferred to the `tinaudio` org
- Output names are mapped accordingly: `files` -> `all_changed_files`, step id `file_changes` -> `changed_files`, with space separator preserved

## Test plan

- [ ] Open a test PR and verify the Code Quality PR workflow runs successfully
- [ ] Confirm changed files are correctly detected and passed to pre-commit

Refs #25