### PR TITLE
docs(design): add storage v1.0.0 milestone to taxonomy

### DIFF
--- a/docs/design/github-taxonomy.md
+++ b/docs/design/github-taxonomy.md
@@ -141,6 +141,7 @@ Workflow labels (`duplicate`, `invalid`, `wontfix`, `good first issue`, `help wa
 | training v1.0.0      | Training        |
 | ci-automation v1.0.0 | CI & Automation |
 | code-health v1.0.0   | Code Health     |
+| storage v1.0.0       | Storage         |
 
 Every work stream has a milestone. Set the milestone on each issue individually — GitHub does not auto-inherit milestones from parent issues.
 


### PR DESCRIPTION
## Summary
- Adds `storage v1.0.0` milestone to the milestones table in `docs/design/github-taxonomy.md`, reflecting the milestone that now exists on GitHub

Refs #129

## Test plan
- [ ] Verify the markdown table renders correctly
- [ ] Confirm `storage v1.0.0` milestone exists on GitHub