### PR TITLE
docs(pipeline): align data pipeline docs with storage-provenance-spec

### DIFF
--- a/docs/design/data-pipeline-implementation-plan.md
+++ b/docs/design/data-pipeline-implementation-plan.md
@@ -1,7 +1,7 @@
 # Implementation Plan: Distributed Data Pipeline
 
 > **Canonical design:** [data-pipeline.md](data-pipeline.md)
-> **Tracking:** [#74](https://github.com/tinaudio/synth-setter/issues/74)
+> **Tracking:** #74
 > **Issue tracking:** [github-taxonomy.md](github-taxonomy.md)
 > **Storage conventions:** [storage-provenance-spec.md](storage-provenance-spec.md)
 > **Builds on:** Generation infrastructure by benhayes@ (see design doc §1)
@@ -89,7 +89,7 @@ ______________________________________________________________________
 ## 4. Pipeline Config Schema
 
 Matches design doc §14.5. Config filenames encode runtime parameters — the filename
-stem is the `dataset_config_id` (see [storage-provenance-spec.md §1](storage-provenance-spec.md)):
+stem is the `dataset_config_id` (see [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids)):
 
 ```yaml
 # configs/dataset/surge-simple-480k-10k.yaml
@@ -249,7 +249,7 @@ Sub-issues: [#18](https://github.com/tinaudio/synth-setter/issues/18) (config-dr
   `param_spec`, `renderer_version`, `output_format` (`"hdf5"` or `"wds"`), `sample_rate`,
   `shard_size`, `num_shards`, `base_seed`, `splits` (`{"train": N, "val": N, "test": N}`),
   `shards` (list of `ShardSpec`), plus generation params.
-  ID conventions follow [storage-provenance-spec.md §1](storage-provenance-spec.md).
+  ID conventions follow [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids).
   Splits use explicit `{train: N, val: N, test: N}` matching design doc §14.4.
   Validation: `train + val + test == num_shards`.
 - `ShardSpec`: `shard_id: int`, `filename: str` (`"shard-000042.h5"`), `seed` (= `base_seed + shard_id`),
@@ -267,7 +267,7 @@ Sub-issues: [#18](https://github.com/tinaudio/synth-setter/issues/18) (config-dr
   `splits` (sample counts, not shard counts), `stats`, `validation_summary`,
   `worker_architectures` (list of unique CPU archs), `shard_manifest: list[dict]`
   (per-shard `{shard_id, filename, content_hash}`), `input_spec_sha256`, `input_spec_path`.
-- Run ID format: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}` (see [storage-provenance-spec.md §1](storage-provenance-spec.md)).
+- Run ID format: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}` (see [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids)).
   `dataset_config_id` is the config filename stem, which encodes runtime params for readability.
 - `materialize_spec(config: RunConfig, timestamp=None, renderer_version=None) -> PipelineSpec`.
   Optional `renderer_version` override for testing; test fixtures pass `"test-1.0"` explicitly.
@@ -327,7 +327,7 @@ ______________________________________________________________________
 
 **Key behaviors:**
 
-- Path computation matching [storage-provenance-spec.md §2–§3](storage-provenance-spec.md) R2 layout.
+- Path computation matching [storage-provenance-spec.md §2](storage-provenance-spec.md#2-r2-bucket-layout)–[§3](storage-provenance-spec.md#3-r2-contents-per-workflow) R2 layout.
   Root: `data/{dataset_config_id}/{dataset_wandb_run_id}/`. Helpers for:
   - Shard lifecycle: `write_rendering_marker`, `write_valid_marker`, `write_invalid_marker`
   - Quarantine: `upload_to_quarantine(dataset_wandb_run_id, shard_id, worker_id, attempt, local_path)`
@@ -722,7 +722,7 @@ ______________________________________________________________________
   logs 7 metrics to `wandb.summary` (`pipeline/shards_total`, `pipeline/shards_valid`,
   `pipeline/shards_quarantined`, `pipeline/total_samples`, `pipeline/generation_time_seconds`,
   `pipeline/finalize_time_seconds`, `pipeline/errors_total`) + registers dataset artifact
-  as `data-{dataset_config_id}` (naming per [storage-provenance-spec.md §4](storage-provenance-spec.md))
+  as `data-{dataset_config_id}` (naming per [storage-provenance-spec.md §4](storage-provenance-spec.md#4-wb-artifact-types))
 
 **Unit tests:** Promotes, rejects missing/corrupt, idempotent, stale marker recovery,
 lexicographic shard selection with multiple attempts, `.promoted` markers written,

--- a/docs/design/data-pipeline-implementation-plan.md
+++ b/docs/design/data-pipeline-implementation-plan.md
@@ -3,6 +3,7 @@
 > **Canonical design:** [data-pipeline.md](data-pipeline.md)
 > **Tracking:** [#74](https://github.com/tinaudio/synth-setter/issues/74)
 > **Issue tracking:** [github-taxonomy.md](github-taxonomy.md)
+> **Storage conventions:** [storage-provenance-spec.md](storage-provenance-spec.md)
 > **Builds on:** Generation infrastructure by benhayes@ (see design doc §1)
 > **Last Updated:** 2026-03-20
 
@@ -39,6 +40,7 @@ ______________________________________________________________________
 
 - `pipeline/` at project root (not `src/`) — invoked via `python -m pipeline`
 - Tests in `tests/pipeline/` with own `conftest.py`
+- Storage layout, IDs, and W&B conventions follow [storage-provenance-spec.md](storage-provenance-spec.md)
 
 ______________________________________________________________________
 
@@ -86,11 +88,12 @@ ______________________________________________________________________
 
 ## 4. Pipeline Config Schema
 
-Matches design doc §14.5:
+Matches design doc §14.5. Config filenames encode runtime parameters — the filename
+stem is the `dataset_config_id` (see [storage-provenance-spec.md §1](storage-provenance-spec.md)):
 
 ```yaml
-# configs/pipeline/surge_simple_480k.yaml
-experiment_name: surge_simple
+# configs/dataset/surge-simple-480k-10k.yaml
+# → dataset_config_id = surge-simple-480k-10k
 param_spec: surge_simple
 plugin_path: plugins/Surge XT.vst3    # renderer_version auto-extracted from bundle
 output_format: hdf5                   # "hdf5" (local training) or "wds" (multi-GPU streaming)
@@ -113,11 +116,13 @@ min_loudness: -55.0
 sample_batch_size: 32
 ```
 
+**Run ID derivation:** `dataset_wandb_run_id = {dataset_config_id}-{YYYYMMDDTHHMMSSZ}` (e.g., `surge-simple-480k-10k-20260313T100000Z`). Maps to `run_id` in pipeline code.
+
 CLI (compute/storage are not in config):
 
 ```bash
 python -m pipeline generate \
-  --config configs/pipeline/surge_simple_480k.yaml \
+  --config configs/dataset/surge-simple-480k-10k.yaml \
   --workers 10 --backend runpod --image tinaudio/perm:dev-snapshot-abc1234
 ```
 
@@ -231,7 +236,7 @@ Sub-issues: [#18](https://github.com/tinaudio/synth-setter/issues/18) (config-dr
 
 - `pipeline/__init__.py`
 - `pipeline/schemas.py` — `RunConfig`, `PipelineSpec`, `ShardSpec`, `WorkerReport`, `ShardResult`, `DatasetCard`, `ValidationSummary`, `Sample`
-- `configs/pipeline/surge_simple_480k.yaml` — sample config
+- `configs/dataset/surge-simple-480k-10k.yaml` — sample config (filename = `dataset_config_id`)
 - `tests/pipeline/__init__.py`
 - `tests/pipeline/test_schemas.py`
 
@@ -239,10 +244,12 @@ Sub-issues: [#18](https://github.com/tinaudio/synth-setter/issues/18) (config-dr
 
 - `RunConfig` (Pydantic strict): validates raw YAML input. Fields match config schema (§4).
   `output_format` defaults to `"hdf5"` if missing from config.
-- `PipelineSpec` (frozen, strict): `run_id`, `created_at`, `code_version`, `is_repo_dirty`,
+- `PipelineSpec` (frozen, strict): `dataset_config_id`, `dataset_wandb_run_id` (maps to
+  `run_id` in code), `created_at`, `code_version`, `is_repo_dirty`,
   `param_spec`, `renderer_version`, `output_format` (`"hdf5"` or `"wds"`), `sample_rate`,
   `shard_size`, `num_shards`, `base_seed`, `splits` (`{"train": N, "val": N, "test": N}`),
   `shards` (list of `ShardSpec`), plus generation params.
+  ID conventions follow [storage-provenance-spec.md §1](storage-provenance-spec.md).
   Splits use explicit `{train: N, val: N, test: N}` matching design doc §14.4.
   Validation: `train + val + test == num_shards`.
 - `ShardSpec`: `shard_id: int`, `filename: str` (`"shard-000042.h5"`), `seed` (= `base_seed + shard_id`),
@@ -255,13 +262,13 @@ Sub-issues: [#18](https://github.com/tinaudio/synth-setter/issues/18) (config-dr
   `success: bool`, `content_hash: str | None` (SHA-256), `render_time_sec: float`, `error: str | None`.
 - `WorkerReport`: includes `cpu_arch`, `os_info`, `attempt_uuid`, `results: list[ShardResult]`.
 - `ValidationSummary`: `valid: int`, `quarantined: int`, `quarantined_shards: list[str]`.
-- `DatasetCard`: `schema_version`, `run_id`, `finalized_at`, `code_version`, `is_repo_dirty`,
+- `DatasetCard`: `schema_version`, `dataset_config_id`, `dataset_wandb_run_id`, `finalized_at`, `code_version`, `is_repo_dirty`,
   `param_spec`, `renderer_version`, `output_format`, `sample_rate`, `total_samples`,
   `splits` (sample counts, not shard counts), `stats`, `validation_summary`,
   `worker_architectures` (list of unique CPU archs), `shard_manifest: list[dict]`
   (per-shard `{shard_id, filename, content_hash}`), `input_spec_sha256`, `input_spec_path`.
-- Run ID format: `{experiment_name}-{total_samples}-{shard_size}-{YYYYMMDD-HHMMSS}` (human-friendly k/M).
-  Uses `total_samples` not `total_train_samples` — design doc §14.6 text is a bug (example is correct).
+- Run ID format: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}` (see [storage-provenance-spec.md §1](storage-provenance-spec.md)).
+  `dataset_config_id` is the config filename stem, which encodes runtime params for readability.
 - `materialize_spec(config: RunConfig, timestamp=None, renderer_version=None) -> PipelineSpec`.
   Optional `renderer_version` override for testing; test fixtures pass `"test-1.0"` explicitly.
 
@@ -284,7 +291,7 @@ Sub-issues: [#18](https://github.com/tinaudio/synth-setter/issues/18) (config-dr
 def test_spec_materialization_end_to_end(tmp_path):
     """Config dict -> materialize -> serialize -> deserialize -> verify integrity."""
     config = {
-        "experiment_name": "test_run", "base_seed": 42,
+        "base_seed": 42,
         "num_shards": 10, "shard_size": 1000,
         "splits": {"train": 8, "val": 1, "test": 1},
         "param_spec": "surge_simple", "plugin_path": "plugins/Surge XT.vst3",
@@ -320,12 +327,13 @@ ______________________________________________________________________
 
 **Key behaviors:**
 
-- Path computation matching design doc §6 R2 layout, including helpers for:
+- Path computation matching [storage-provenance-spec.md §2–§3](storage-provenance-spec.md) R2 layout.
+  Root: `data/{dataset_config_id}/{dataset_wandb_run_id}/`. Helpers for:
   - Shard lifecycle: `write_rendering_marker`, `write_valid_marker`, `write_invalid_marker`
-  - Quarantine: `upload_to_quarantine(run_id, shard_id, worker_id, attempt, local_path)`
-  - Worker attempts: `upload_report(run_id, worker_id, attempt, report)`,
-    `upload_debug_log(run_id, worker_id, attempt, log_path)`
-  - Finalize outputs: paths for `data/shards/`, `data/train.h5`, `data/stats.npz`,
+  - Quarantine: `upload_to_quarantine(dataset_wandb_run_id, shard_id, worker_id, attempt, local_path)`
+  - Worker attempts: `upload_report(dataset_wandb_run_id, worker_id, attempt, report)`,
+    `upload_debug_log(dataset_wandb_run_id, worker_id, attempt, log_path)`
+  - Finalize outputs: paths for `shards/`, `train.h5`, `stats.npz`,
     `metadata/dataset.json`, `metadata/dataset.complete`
 - `StorageBackend` protocol: `list_shard_markers`, `write_marker`, `upload_file`,
   `download_file`, `list_prefix`, `exists`
@@ -336,7 +344,7 @@ ______________________________________________________________________
 
 **Unit tests (write first):**
 
-- Path generation matches design doc for all artifact types
+- Path generation matches storage-provenance-spec.md for all artifact types
 - Local: write → exists → list round-trip
 - R2: rclone command construction (mock subprocess) — verify `--checksum` in every command
 - R2: delegates to `RcloneUploader.upload()` for directory uploads
@@ -709,10 +717,12 @@ ______________________________________________________________________
 - Dataset card includes `output_format`, `worker_architectures` (logs warning if
   heterogeneous), content hashes, shard manifest
 - Upload finalized outputs to R2 storage
-- `dataset.complete` contains `run_id` + timestamp (written last)
-- W&B integration: logs 7 metrics (`pipeline/shards_total`, `pipeline/shards_valid`,
+- `dataset.complete` contains `dataset_wandb_run_id` + timestamp (written last)
+- W&B integration (`project="synth-setter"`, `job_type="data-generation"`):
+  logs 7 metrics to `wandb.summary` (`pipeline/shards_total`, `pipeline/shards_valid`,
   `pipeline/shards_quarantined`, `pipeline/total_samples`, `pipeline/generation_time_seconds`,
   `pipeline/finalize_time_seconds`, `pipeline/errors_total`) + registers dataset artifact
+  as `data-{dataset_config_id}` (naming per [storage-provenance-spec.md §4](storage-provenance-spec.md))
 
 **Unit tests:** Promotes, rejects missing/corrupt, idempotent, stale marker recovery,
 lexicographic shard selection with multiple attempts, `.promoted` markers written,
@@ -883,7 +893,7 @@ ______________________________________________________________________
 
 1. **Per-PR:** CI runs `pytest` + `ruff` on every push
 2. **After all tasks:** `pytest tests/pipeline/ -v`, `pytest tests/pipeline/test_e2e.py -v`
-3. **Local dry run:** `python -m pipeline generate --config configs/pipeline/surge_simple_480k.yaml --backend local --workers 2`
+3. **Local dry run:** `python -m pipeline generate --config configs/dataset/surge-simple-480k-10k.yaml --backend local --workers 2`
 4. **Docker fidelity:** `bash scripts/test_local_docker.sh`
 5. **Mutation testing:** `mutmut run --paths-to-mutate=pipeline/`
 

--- a/docs/design/data-pipeline-implementation-plan.md
+++ b/docs/design/data-pipeline-implementation-plan.md
@@ -921,8 +921,7 @@ ______________________________________________________________________
     `reshard_data.py` — it hardcodes 10k shard size)
 11. `R2StorageBackend` wraps `src/data/uploader.RcloneUploader` (already has `--checksum`)
 12. `shard_id` is `int` in schema, formatted to string for paths/filenames
-13. Run ID uses `total_samples` not `total_train_samples` — design doc §14.6 text to be fixed
-14. Config splits use `{train: N, val: N, test: N}` matching design doc §14.4
+13. Config splits use `{train: N, val: N, test: N}` matching design doc §14.4
 
 ______________________________________________________________________
 

--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -1540,8 +1540,8 @@ artifact = wandb.Artifact(
 artifact.add_file(input_spec_path)        # input_spec.json
 artifact.add_file(card_path)        # dataset.json
 artifact.add_reference(
-    f"r2://{bucket}/data/{spec.dataset_config_id}/{spec.dataset_wandb_run_id}/"
-)  # pointer to R2 data
+    f"s3://synth-data/data/{spec.dataset_config_id}/{spec.dataset_wandb_run_id}/"
+)  # R2 is S3-compatible; W&B resolves via S3 API (requires AWS_ENDPOINT_URL)
 run.log_artifact(artifact)
 run.finish()
 ```

--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -3,7 +3,7 @@
 > **Status**: Draft
 > **Author**: ktinubu@
 > **Last Updated**: 2026-03-20
-> **Tracking**: [#74](https://github.com/tinaudio/synth-setter/issues/74)
+> **Tracking**: #74
 > **Storage conventions**: [storage-provenance-spec.md](storage-provenance-spec.md)
 
 ______________________________________________________________________
@@ -264,7 +264,7 @@ Finalize output depends on `output_format` in the spec:
 
 ### R2 File Structure
 
-> R2 root path follows [storage-provenance-spec.md §2](storage-provenance-spec.md). Pipeline-specific internal structure (workers/, lifecycle markers) is additive detail.
+> R2 root path follows [storage-provenance-spec.md §2](storage-provenance-spec.md#2-r2-bucket-layout). Pipeline-specific internal structure (workers/, lifecycle markers) is additive detail.
 
 ```
 data/{dataset_config_id}/{dataset_wandb_run_id}/   # e.g. data/surge-simple-480k-10k/surge-simple-480k-10k-20260312T143022Z/
@@ -878,7 +878,7 @@ Shard count is tuned for GPU worker count — one shard per GPU worker per epoch
 
 ## 8. Experiment Tracking (Weights & Biases)
 
-> Authoritative W&B conventions (artifact naming, metadata placement, lineage DAG, job_type values) are defined in [storage-provenance-spec.md](storage-provenance-spec.md). Repeated here for data-generation context.
+> Authoritative W&B conventions (artifact naming, metadata placement, lineage DAG, `job_type` values) are defined in [storage-provenance-spec.md §4–§7](storage-provenance-spec.md#4-wb-artifact-types). Repeated here for data-generation context.
 
 W&B serves as a lightweight observability layer for the pipeline — a few key metrics and the dataset as a first-class artifact. It is not a monitoring dashboard or a log aggregator. W&B is an index and lineage tracker, not the authoritative dataset store. R2 holds the data; `dataset.json` holds the metadata; W&B points to both.
 
@@ -1345,7 +1345,7 @@ On first `generate`:
 
 ### 14.6 Run ID Format
 
-> ID conventions follow [storage-provenance-spec.md §1](storage-provenance-spec.md).
+> ID conventions follow [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids).
 
 | Pipeline concept          | Storage spec concept                               | Example                                                              |
 | ------------------------- | -------------------------------------------------- | -------------------------------------------------------------------- |
@@ -1403,8 +1403,8 @@ configs/
 | **W&B (Weights & Biases)** | [Weights & Biases](https://wandb.ai/), an experiment tracking platform. Used here as a lightweight observability layer: pipeline metrics, dataset artifact registry, and lineage tracking from dataset → training run.                                                                                             |
 | **Virtual dataset**        | HDF5 feature that creates a logical view over multiple files without copying data. Used by finalize to compose train/val/test splits from individual shards.                                                                                                                                                       |
 | **Input spec**             | JSON file (`input_spec.json`) defining the frozen input specification for a run — shard specs, seeds, shapes, splits, renderer version. Written once on first `generate`, never modified.                                                                                                                          |
-| **dataset_config_id**      | Stable identifier for a dataset configuration, derived from the config filename (without extension). Format: `{name}-{total_train_samples}-{shard_size}`. Example: `surge-simple-480k-10k`. See [storage-provenance-spec.md §1](storage-provenance-spec.md).                                                       |
-| **dataset_wandb_run_id**   | Unique identifier for a pipeline execution. Format: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}`. Example: `surge-simple-480k-10k-20260312T143022Z`. See [storage-provenance-spec.md §1](storage-provenance-spec.md).                                                                                                  |
+| **dataset_config_id**      | Stable identifier for a dataset configuration, derived from the config filename (without extension). Format: `{name}-{total_train_samples}-{shard_size}`. Example: `surge-simple-480k-10k`. See [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids).                                                 |
+| **dataset_wandb_run_id**   | Unique identifier for a pipeline execution. Format: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}`. Example: `surge-simple-480k-10k-20260312T143022Z`. See [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids).                                                                                            |
 | **Shard ID**               | Logical index for a shard (`shard-000042`). Deterministic, defined at run creation, independent of which worker computes it.                                                                                                                                                                                       |
 | **worker_id**              | Infrastructure identifier (e.g., RunPod's `RUNPOD_POD_ID`). Appears only in metadata, not in shard paths.                                                                                                                                                                                                          |
 | **Reconciliation**         | Comparing desired state (spec) against actual state (validated shards in R2) to determine what work remains.                                                                                                                                                                                                       |

--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -73,21 +73,21 @@ cat configs/dataset/surge-simple-480k-10k.yaml
 # → num_shards: 48, shard_size: 10000, ...
 
 # 2. Launch generation — creates spec, launches workers, exits
-python -m pipeline.cli generate --config configs/dataset/surge-simple-480k-10k.yaml --workers 10
+python -m pipeline generate --config configs/dataset/surge-simple-480k-10k.yaml --workers 10
 # → Created run surge-simple-480k-10k-20260313T100000Z
 # → Launched 10 workers for 48 shards
 # → Exiting. Run 'status' to check progress.
 
 # 3. Check progress (can run from any machine, any time)
-python -m pipeline.cli status --run-id surge-simple-480k-10k-20260313T100000Z
+python -m pipeline status --run-id surge-simple-480k-10k-20260313T100000Z
 # → Valid: 44/48  Missing: 2  Quarantined: 2
 
 # 4. Re-run generation for missing shards only
-python -m pipeline.cli generate --run-id surge-simple-480k-10k-20260313T100000Z
+python -m pipeline generate --run-id surge-simple-480k-10k-20260313T100000Z
 # → 4 shards missing, launching 1 worker
 
 # 5. Finalize — download, reshard, compute stats, register in W&B
-python -m pipeline.cli finalize --run-id surge-simple-480k-10k-20260313T100000Z
+python -m pipeline finalize --run-id surge-simple-480k-10k-20260313T100000Z
 # → 48/48 valid. output_format: hdf5
 # → Resharding → train.h5, val.h5, test.h5  (or .tar shards if wds)
 # → Stats computed. Dataset registered in W&B as data-surge-simple-480k-10k.
@@ -228,9 +228,9 @@ Finalize output depends on `output_format` in the spec:
 │                                │        ┌──────────────────┐
 │  1. Validate auth (R2+RunPod)  │        │  Cloudflare R2   │
 │  2. Read/create spec     ◄─────┼───────►│                  │
-│  3. List staged shards   ◄─────┼────────┤  {run_id}/       │
-│  4. Validate staged shards     │        │   metadata/      │
-│  5. Compute missing set        │        │   workers/       │
+│  3. List staged shards   ◄─────┼────────┤  data/{cfg}/{id}/ │
+│  4. Validate staged shards     │        │   metadata/       │
+│  5. Compute missing set        │        │   workers/        │
 │  6. Partition across N workers │        │                  │
 │  7. Submit N tasks             │        │                  │
 │  8. Exit                       │        │                  │
@@ -557,7 +557,7 @@ Instead of tracking worker state or polling provider APIs, the pipeline determin
 `make status` runs the same reconciliation logic as `generate` but only prints the result. It checks for `.h5` + `.valid` marker existence — no data loading or re-validation. It does not query RunPod, check worker health, or monitor live tasks. The output is fully determined by storage contents — running it from any machine, at any time, produces the same result.
 
 ```
-$ python -m pipeline.cli status --run-id surge-simple-480k-10k-20260313T100000Z
+$ python -m pipeline status --run-id surge-simple-480k-10k-20260313T100000Z
 
 Run: surge-simple-480k-10k-20260313T100000Z
 Spec shards: 48
@@ -1541,7 +1541,7 @@ artifact.add_file(input_spec_path)        # input_spec.json
 artifact.add_file(card_path)        # dataset.json
 artifact.add_reference(
     f"s3://synth-data/data/{spec.dataset_config_id}/{spec.dataset_wandb_run_id}/"
-)  # R2 is S3-compatible; W&B resolves via S3 API (requires AWS_ENDPOINT_URL)
+)  # R2 is S3-compatible; W&B resolves via S3 API (uses AWS_ENDPOINT_URL or WANDB_S3_ENDPOINT_URL; see storage-provenance-spec.md §11)
 run.log_artifact(artifact)
 run.finish()
 ```

--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -4,6 +4,7 @@
 > **Author**: ktinubu@
 > **Last Updated**: 2026-03-20
 > **Tracking**: [#74](https://github.com/tinaudio/synth-setter/issues/74)
+> **Storage conventions**: [storage-provenance-spec.md](storage-provenance-spec.md)
 
 ______________________________________________________________________
 
@@ -67,38 +68,38 @@ RunPod is used because it's the platform where GPUs are already available and co
 ## 2. Typical Workflow
 
 ```bash
-# 1. Create a dataset config
-cat configs/pipeline/surge_simple_480k.yaml
-# → experiment_name: surge_simple, num_shards: 48, shard_size: 10000, ...
+# 1. Create a dataset config (filename = dataset_config_id)
+cat configs/dataset/surge-simple-480k-10k.yaml
+# → num_shards: 48, shard_size: 10000, ...
 
 # 2. Launch generation — creates spec, launches workers, exits
-python -m pipeline.cli generate --config configs/pipeline/surge_simple_480k.yaml --workers 10
-# → Created run surge_simple-480k-10k-20260313-100000
+python -m pipeline.cli generate --config configs/dataset/surge-simple-480k-10k.yaml --workers 10
+# → Created run surge-simple-480k-10k-20260313T100000Z
 # → Launched 10 workers for 48 shards
 # → Exiting. Run 'status' to check progress.
 
 # 3. Check progress (can run from any machine, any time)
-python -m pipeline.cli status --run-id surge_simple-480k-10k-20260313-100000
+python -m pipeline.cli status --run-id surge-simple-480k-10k-20260313T100000Z
 # → Valid: 44/48  Missing: 2  Quarantined: 2
 
 # 4. Re-run generation for missing shards only
-python -m pipeline.cli generate --run-id surge_simple-480k-10k-20260313-100000
+python -m pipeline.cli generate --run-id surge-simple-480k-10k-20260313T100000Z
 # → 4 shards missing, launching 1 worker
 
 # 5. Finalize — download, reshard, compute stats, register in W&B
-python -m pipeline.cli finalize --run-id surge_simple-480k-10k-20260313-100000
+python -m pipeline.cli finalize --run-id surge-simple-480k-10k-20260313T100000Z
 # → 48/48 valid. output_format: hdf5
 # → Resharding → train.h5, val.h5, test.h5  (or .tar shards if wds)
-# → Stats computed. Dataset registered in W&B.
+# → Stats computed. Dataset registered in W&B as data-surge-simple-480k-10k.
 # → dataset.complete written.
 ```
 
 Make targets are thin aliases for convenience:
 
 ```bash
-make generate ARGS="--config configs/pipeline/surge_simple_480k.yaml --workers 10"
-make status ARGS="--run-id surge_simple-480k-10k-20260313-100000"
-make finalize ARGS="--run-id surge_simple-480k-10k-20260313-100000"
+make generate ARGS="--config configs/dataset/surge-simple-480k-10k.yaml --workers 10"
+make status ARGS="--run-id surge-simple-480k-10k-20260313T100000Z"
+make finalize ARGS="--run-id surge-simple-480k-10k-20260313T100000Z"
 ```
 
 ## 3. Goals, Non-Goals & Design Principles
@@ -263,31 +264,32 @@ Finalize output depends on `output_format` in the spec:
 
 ### R2 File Structure
 
+> R2 root path follows [storage-provenance-spec.md §2](storage-provenance-spec.md). Pipeline-specific internal structure (workers/, lifecycle markers) is additive detail.
+
 ```
-{run_id}/                              # e.g. surge_simple-480k-10k-20260312-143022
-  data/
-    shards/                              # Written ONLY by finalize (promoted from staging)
-      shard-000000.h5                    # Canonical finalized shards
-      shard-000001.h5
-      ...
-      shard-000479.h5
-    # output_format: hdf5
-    train.h5                             # Virtual dataset (written by finalize)
-    val.h5
-    test.h5
-    # output_format: wds
-    train-000000.tar                     # WebDataset archives (written by finalize)
-    train-000001.tar
+data/{dataset_config_id}/{dataset_wandb_run_id}/   # e.g. data/surge-simple-480k-10k/surge-simple-480k-10k-20260312T143022Z/
+  shards/                              # Written ONLY by finalize (promoted from staging)
+    shard-000000.h5                    # Canonical finalized shards
+    shard-000001.h5
     ...
-    val-000000.tar
-    test-000000.tar
-    stats.npz                            # Normalization statistics
+    shard-000479.h5
+  # output_format: hdf5
+  train.h5                             # Virtual dataset (written by finalize)
+  val.h5
+  test.h5
+  # output_format: wds
+  train-000000.tar                     # WebDataset archives (written by finalize)
+  train-000001.tar
+  ...
+  val-000000.tar
+  test-000000.tar
+  stats.npz                            # Normalization statistics
   metadata/
     config.yaml                          # User recipe (provenance copy, not authoritative)
     input_spec.json                      # Frozen input specification (authoritative)
     dataset.json                         # Self-describing dataset card (written by finalize)
     dataset.complete                     # Completion marker (written by finalize)
-    workers/                             # Everything workers produce goes here
+    workers/                             # Workers may only write under metadata/workers/
       shards/                            # Per-shard staging area + lifecycle markers
         shard-000000/
           {worker_id}-{attempt_uuid}.h5          # Worker's validated shard output
@@ -303,6 +305,8 @@ Finalize output depends on `output_format` in the spec:
           report.json                    # Worker summary — per-shard results, content_hash, timing
           debug.log                      # Debug log (JSONL), uploaded by EXIT trap
 ```
+
+Datasets are immutable once metadata/dataset.complete exists. Creating a new dataset version requires a new dataset_wandb_run_id.
 
 ### Artifact Taxonomy
 
@@ -553,9 +557,9 @@ Instead of tracking worker state or polling provider APIs, the pipeline determin
 `make status` runs the same reconciliation logic as `generate` but only prints the result. It checks for `.h5` + `.valid` marker existence — no data loading or re-validation. It does not query RunPod, check worker health, or monitor live tasks. The output is fully determined by storage contents — running it from any machine, at any time, produces the same result.
 
 ```
-$ python -m pipeline.cli status --run-id surge_simple-480k-10k-20260313-100000
+$ python -m pipeline.cli status --run-id surge-simple-480k-10k-20260313T100000Z
 
-Run: surge_simple-480k-10k-20260313-100000
+Run: surge-simple-480k-10k-20260313T100000Z
 Spec shards: 48
 Staged (valid):   44
 Missing:           2
@@ -874,11 +878,21 @@ Shard count is tuned for GPU worker count — one shard per GPU worker per epoch
 
 ## 8. Experiment Tracking (Weights & Biases)
 
+> Authoritative W&B conventions (artifact naming, metadata placement, lineage DAG, job_type values) are defined in [storage-provenance-spec.md](storage-provenance-spec.md). Repeated here for data-generation context.
+
 W&B serves as a lightweight observability layer for the pipeline — a few key metrics and the dataset as a first-class artifact. It is not a monitoring dashboard or a log aggregator. W&B is an index and lineage tracker, not the authoritative dataset store. R2 holds the data; `dataset.json` holds the metadata; W&B points to both.
 
-### What Goes in W&B
+The finalize stage initializes W&B with `wandb.init(project="synth-setter", job_type="data-generation")`.
 
-**Pipeline metrics** (logged by `finalize`):
+### Metadata Placement
+
+| Where             | What goes there                                                        | Why                                                  |
+| ----------------- | ---------------------------------------------------------------------- | ---------------------------------------------------- |
+| `wandb.summary`   | Pipeline metrics (see table below)                                     | Final values, not time-series — summary is correct   |
+| Artifact metadata | `dataset_config_id`, `dataset_wandb_run_id`, `shard_count`, provenance | Travels with the artifact through the lineage DAG    |
+| `dataset.json`    | Full dataset card (structure, stats, validation)                       | Self-describing record in R2, referenced by artifact |
+
+**Pipeline metrics** (written to `wandb.summary` by `finalize`):
 
 | Metric                             | Type  | Description                                           |
 | ---------------------------------- | ----- | ----------------------------------------------------- |
@@ -892,13 +906,16 @@ W&B serves as a lightweight observability layer for the pipeline — a few key m
 
 **Dataset artifact** (logged by `finalize`):
 
-The finalized dataset is registered as a W&B Artifact of type `"dataset"`:
+The finalized dataset is registered as a W&B Artifact named `data-{dataset_config_id}` of type `"dataset"`:
 
 - **Files included:** `input_spec.json`, `dataset.json` (the card)
-- **Metadata:** run_id, param_spec, code_version, is_repo_dirty, total_samples, split sizes
+- **Metadata:** `dataset_config_id`, `dataset_wandb_run_id`, `shard_count`, `param_spec`, `code_version`, `is_repo_dirty`, `total_samples`, split sizes
 - **References:** R2 path to the actual HDF5 data (not uploaded to W&B — too large)
+- **Versioning:** W&B auto-versions artifacts: `data-{dataset_config_id}:v0`, `:v1`, etc. `:latest` always points to the most recent finalize.
 
-This creates a dataset entry in the W&B artifact registry that can be referenced by training runs, establishing **artifact lineage**: code version → dataset artifact → training run → model checkpoint. Training runs close the lineage loop by declaring the dataset as an input: `artifact = run.use_artifact(f"dataset-{run_id}:latest")`. See [Appendix E.3](#e3-wb-integration) for the full implementation.
+This creates a dataset entry in the W&B artifact registry that can be referenced by training runs, establishing **artifact lineage**: code version → dataset artifact → training run → model checkpoint. Training runs close the lineage loop by declaring the dataset as an input: `artifact = run.use_artifact(f"data-{dataset_config_id}:latest")`. See [Appendix E.3](#e3-wb-integration) for the full implementation.
+
+After finalize, datasets enter the training → evaluation → promotion pipeline. See [promotion-pipeline-reference.md](../reference/promotion-pipeline-reference.md).
 
 ## 9. Alternatives Considered
 
@@ -1300,8 +1317,7 @@ Pydantic is for trust boundaries — where data enters the system from an extern
 A run starts from a typed YAML config file:
 
 ```yaml
-# configs/pipeline/surge_simple_480k.yaml
-experiment_name: surge_simple
+# configs/dataset/surge-simple-480k-10k.yaml (filename = dataset_config_id)
 param_spec: surge_simple
 plugin_path: plugins/Surge XT.vst3
 output_format: hdf5       # "hdf5" (local training) or "wds" (multi-GPU streaming)
@@ -1318,7 +1334,7 @@ On first `generate`:
 
 1. Load YAML, validate against Pydantic `RunConfig` (strict mode)
 2. Extract `renderer_version` from the plugin bundle (`CFBundleShortVersionString` from `Info.plist` on macOS, `Version` from `moduleinfo.json` on Linux)
-3. Derive `run_id`: `{experiment_name}-{train_size}-{shard_size}-{YYYYMMDD-HHMMSS}`
+3. Derive `dataset_wandb_run_id`: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}`
 4. Materialize `PipelineSpec` — expand config into shard-level spec (seeds, shapes, row ranges)
 5. Upload spec + source config to R2
 6. Proceed with reconciliation
@@ -1329,10 +1345,15 @@ On first `generate`:
 
 ### 14.6 Run ID Format
 
-```
-{experiment_name}-{total_train_samples}-{shard_size}-{YYYYMMDD-HHMMSS}
-Example: surge_simple-480k-10k-20260312-143022
-```
+> ID conventions follow [storage-provenance-spec.md §1](storage-provenance-spec.md).
+
+| Pipeline concept          | Storage spec concept                               | Example                                                              |
+| ------------------------- | -------------------------------------------------- | -------------------------------------------------------------------- |
+| Config filename (no ext)  | `dataset_config_id`                                | `surge-simple-480k-10k`                                              |
+| Config ID + ISO timestamp | `dataset_wandb_run_id`                             | `surge-simple-480k-10k-20260312T143022Z`                             |
+| R2 root path              | `data/{dataset_config_id}/{dataset_wandb_run_id}/` | `data/surge-simple-480k-10k/surge-simple-480k-10k-20260312T143022Z/` |
+
+Config filenames live in `configs/dataset/` and use the pattern `{name}-{total_train_samples}-{shard_size}.yaml`. The filename without extension is the `dataset_config_id`.
 
 ### 14.7 CLI & Directory Structure
 
@@ -1357,13 +1378,13 @@ pipeline/
   logging_config.py     # structlog configuration
 ```
 
-Pipeline configs live in `configs/pipeline/` to distinguish them from training configs in `configs/data/` and `configs/trainer/`:
+Pipeline configs live in `configs/dataset/` (filename = `dataset_config_id`) to distinguish them from training configs in `configs/data/` and `configs/trainer/`:
 
 ```
 configs/
-  pipeline/            # Dataset generation recipes (YAML)
-    surge_simple_480k.yaml
-    surge_xt_1m.yaml
+  dataset/             # Dataset generation recipes (YAML); filename = dataset_config_id
+    surge-simple-480k-10k.yaml
+    surge-xt-1m-10k.yaml
   data/                # Training data module configs (Hydra)
     surge_simple.yaml
     surge.yaml
@@ -1382,7 +1403,8 @@ configs/
 | **W&B (Weights & Biases)** | [Weights & Biases](https://wandb.ai/), an experiment tracking platform. Used here as a lightweight observability layer: pipeline metrics, dataset artifact registry, and lineage tracking from dataset → training run.                                                                                             |
 | **Virtual dataset**        | HDF5 feature that creates a logical view over multiple files without copying data. Used by finalize to compose train/val/test splits from individual shards.                                                                                                                                                       |
 | **Input spec**             | JSON file (`input_spec.json`) defining the frozen input specification for a run — shard specs, seeds, shapes, splits, renderer version. Written once on first `generate`, never modified.                                                                                                                          |
-| **run_id**                 | Unique identifier for a pipeline execution. Format: `{experiment}-{size}-{shard_size}-{timestamp}`. Example: `surge_simple-480k-10k-20260312-143022`.                                                                                                                                                              |
+| **dataset_config_id**      | Stable identifier for a dataset configuration, derived from the config filename (without extension). Format: `{name}-{total_train_samples}-{shard_size}`. Example: `surge-simple-480k-10k`. See [storage-provenance-spec.md §1](storage-provenance-spec.md).                                                       |
+| **dataset_wandb_run_id**   | Unique identifier for a pipeline execution. Format: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}`. Example: `surge-simple-480k-10k-20260312T143022Z`. See [storage-provenance-spec.md §1](storage-provenance-spec.md).                                                                                                  |
 | **Shard ID**               | Logical index for a shard (`shard-000042`). Deterministic, defined at run creation, independent of which worker computes it.                                                                                                                                                                                       |
 | **worker_id**              | Infrastructure identifier (e.g., RunPod's `RUNPOD_POD_ID`). Appears only in metadata, not in shard paths.                                                                                                                                                                                                          |
 | **Reconciliation**         | Comparing desired state (spec) against actual state (validated shards in R2) to determine what work remains.                                                                                                                                                                                                       |
@@ -1488,23 +1510,27 @@ Implementation of experiment tracking ([§8](#8-experiment-tracking-weights--bia
 # In finalize, after resharding and stats:
 import wandb
 
-run = wandb.init(project="surge-data-pipeline", job_type="data-pipeline")
+run = wandb.init(
+    project="synth-setter",
+    job_type="data-generation",
+    id=spec.dataset_wandb_run_id,
+)
 
-# Log pipeline metrics
-run.log({
-    "pipeline/shards_total": spec.num_shards,
-    "pipeline/shards_valid": validation_summary.valid,
-    "pipeline/shards_quarantined": validation_summary.quarantined,
-    "pipeline/total_samples": total_samples,
-    "pipeline/errors_total": total_errors,
-})
+# Log pipeline metrics to summary (final values, not time-series)
+run.summary["pipeline/shards_total"] = spec.num_shards
+run.summary["pipeline/shards_valid"] = validation_summary.valid
+run.summary["pipeline/shards_quarantined"] = validation_summary.quarantined
+run.summary["pipeline/total_samples"] = total_samples
+run.summary["pipeline/errors_total"] = total_errors
 
 # Register dataset as artifact
 artifact = wandb.Artifact(
-    name=f"dataset-{spec.run_id}",
+    name=f"data-{spec.dataset_config_id}",  # name follows storage-provenance-spec.md §4
     type="dataset",
     metadata={
-        "run_id": spec.run_id,
+        "dataset_config_id": spec.dataset_config_id,
+        "dataset_wandb_run_id": spec.dataset_wandb_run_id,
+        "shard_count": spec.num_shards,
         "param_spec": spec.param_spec,
         "code_version": spec.code_version,
         "total_samples": total_samples,
@@ -1513,7 +1539,9 @@ artifact = wandb.Artifact(
 )
 artifact.add_file(input_spec_path)        # input_spec.json
 artifact.add_file(card_path)        # dataset.json
-artifact.add_reference(f"r2://{bucket}/{run_id}/data/")  # pointer to R2 data
+artifact.add_reference(
+    f"r2://{bucket}/data/{spec.dataset_config_id}/{spec.dataset_wandb_run_id}/"
+)  # pointer to R2 data
 run.log_artifact(artifact)
 run.finish()
 ```
@@ -1521,7 +1549,7 @@ run.finish()
 Training runs declare the dataset as an input, closing the lineage loop:
 
 ```python
-artifact = run.use_artifact(f"dataset-{run_id}:latest")
+artifact = run.use_artifact(f"data-{dataset_config_id}:latest")
 ```
 
 ______________________________________________________________________


### PR DESCRIPTION
## Summary

- Adopt R2 layout from storage-provenance-spec: `data/{dataset_config_id}/{dataset_wandb_run_id}/`
- Map pipeline IDs to spec conventions: `run_id` → `dataset_wandb_run_id`, `experiment_name` → `dataset_config_id`
- Update W&B conventions: `project="synth-setter"`, `job_type="data-generation"`, artifact name `data-{dataset_config_id}`
- Add metadata placement table (config/summary/artifact.metadata)
- Adopt `YYYYMMDDTHHMMSSZ` timestamp format
- Move config path from `configs/pipeline/` to `configs/dataset/` (filename = `dataset_config_id`)
- Add spec attribution lines to R2, W&B, ID, and lineage sections
- Add dataset immutability rule and promotion pipeline cross-reference
- Update repo URLs from `ktinubu/synth-permutations` → `tinaudio/synth-setter`

## Test plan

- [x] No remaining `surge-data-pipeline` project references
- [x] No remaining `dataset-{run_id}` artifact naming
- [x] No remaining `YYYYMMDD-HHMMSS` timestamp format (except author attribution)
- [x] No remaining `configs/pipeline/` paths
- [x] R2 layout sections reference spec structure
- [x] W&B sections have attribution line to spec
- [x] Promotion pipeline referenced after finalize
- [ ] Review that markdown anchors in index still resolve after section renames

Refs #74, #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)