### PR TITLE
docs(design): align eval pipeline with storage-provenance-spec

### DIFF
--- a/docs/design/eval-pipeline.md
+++ b/docs/design/eval-pipeline.md
@@ -2,15 +2,8 @@
 
 > **Status**: Draft
 > **Author**: ktinubu@
-> **Last Updated**: 2026-03-20
-> **Tracking**:
->
-> - #98 (Epic: evaluation pipeline)
-> - #99 (Epic: storage / R2 integration)
->
-> **Milestone**: `evaluation v1.0.0`
-> **Domain Labels**: `evaluation`, `storage`
-
+> **Last Updated**: 2026-03-19
+> **Tracking**: #98 (eval epic), #99 (R2 epic)
 > **Storage & provenance conventions**: [storage-provenance-spec.md](storage-provenance-spec.md) (authoritative)
 
 ______________________________________________________________________
@@ -26,11 +19,11 @@ ______________________________________________________________________
 | 5   | [Stage Definitions](#5-stage-definitions)                                     | Predict, render, metrics — inputs, outputs, contracts                                              |
 | 6   | [R2 Integration](#6-r2-integration)                                           | Dataset download, checkpoint download, artifact upload, W&B lineage                                |
 | 7   | [Design Decisions](#7-design-decisions)                                       | Headless rendering, checkpoint resolution, Makefile, storage split, current vs proposed comparison |
-| 8   | [Phase Plan](#8-phase-plan)                                                   | Epic → Phase → Task hierarchy, issue mapping, file lists, test strategy                            |
-| 9   | [Dependency Overview](#9-dependency-overview)                                 | Issue dependencies, parallel execution windows, critical path                                      |
-| 10  | [Alternatives Considered](#10-alternatives-considered)                        | Rejected approaches and why                                                                        |
-| 11  | [Open Questions & Risks](#11-open-questions--risks)                           | Known gaps and trade-offs                                                                          |
-| 12  | [Out of Scope](#12-out-of-scope)                                              | Future work — not referenced elsewhere                                                             |
+| 8   | [Dependency Graph & Parallelism](#8-dependency-graph--parallelism)            | Issue dependencies, parallel execution windows, critical path                                      |
+| 9   | [Alternatives Considered](#9-alternatives-considered)                         | Rejected approaches and why                                                                        |
+| 10  | [Open Questions & Risks](#10-open-questions--risks)                           | Known gaps and trade-offs                                                                          |
+| 11  | [Out of Scope](#11-out-of-scope)                                              | Future work — not referenced elsewhere                                                             |
+| 12  | [Implementation Plan](#12-implementation-plan)                                | Phase breakdown, PR groupings, file lists, test strategy                                           |
 | A–C | [Appendices](#appendix-a-glossary)                                            | Glossary, current file inventory, metric definitions                                               |
 
 ______________________________________________________________________
@@ -83,7 +76,7 @@ defaults:
   - override /callbacks: eval_surge
 
 experiment_name: flow_simple
-ckpt_path: ${wandb:tinaudio/synth-setter/model-flow_simple:latest}
+ckpt_path: ${wandb:tinaudio/synth-setter/model-flow-simple:latest}
 model:
   test_cfg_strength: 2.0
   test_sample_steps: 100
@@ -98,23 +91,20 @@ cp .env.example .env
 # 2. Run full eval — predict → render → metrics in one command
 make eval EXPERIMENT=surge/flow_simple
 # → Checkpoint auto-downloaded from W&B via ${wandb:...} resolver (cached after)
-# → Predictions, audio, and metrics written to
-#   logs/eval/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/
+# → Predictions, audio, and metrics written to logs/eval/flow-simple/flow-simple-20260315T091500Z/surge-simple/surge-simple-20260320T160000Z/
 
 # Or run stages individually:
 make predict EXPERIMENT=surge/flow_simple
-make render \
-  PRED_DIR=logs/eval/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/predictions/ \
-  OUTPUT_DIR=logs/eval/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/audio/
-make metrics \
-  AUDIO_DIR=logs/eval/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/audio/ \
-  OUTPUT_DIR=logs/eval/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/metrics/
+make render PRED_DIR=logs/eval/flow-simple/flow-simple-20260315T091500Z/surge-simple/surge-simple-20260320T160000Z/predictions/ \
+  OUTPUT_DIR=logs/eval/flow-simple/flow-simple-20260315T091500Z/surge-simple/surge-simple-20260320T160000Z/audio/
+make metrics AUDIO_DIR=logs/eval/flow-simple/flow-simple-20260315T091500Z/surge-simple/surge-simple-20260320T160000Z/audio/ \
+  OUTPUT_DIR=logs/eval/flow-simple/flow-simple-20260315T091500Z/surge-simple/surge-simple-20260320T160000Z/metrics/
 
 # 3. (Optional) Upload artifacts to R2
 make upload-eval
 # → rclone sync \
-#     logs/eval/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/ \
-#     r2:synth-data/eval/surge_simple/surge_simple-20260312T143022Z/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/ \
+#     logs/eval/flow-simple/flow-simple-20260315T091500Z/surge-simple/surge-simple-20260320T160000Z/ \
+#     r2:synth-data/eval/surge-simple/surge-simple-20260312T143022Z/flow-simple/flow-simple-20260315T091500Z/surge-simple/surge-simple-20260320T160000Z/ \
 #     --checksum
 ```
 
@@ -172,16 +162,16 @@ portable `make` targets instead. No new code references SGE.
 The evaluation pipeline is a three-stage batch pipeline. Each stage is an independent command with well-defined inputs and outputs. R2 serves as the backing store for datasets and eval artifacts; checkpoints are stored in W&B.
 
 ```
-                    ┌──────────────────────────────────────────────┐
-                    │           R2 (synth-data bucket)             │
-                    │                                              │
-                    │  data/                                       │
-                    │    {dataset_config_id}/{dataset_wandb_run_id}/│
-                    │                                              │
-                    │  eval/                                       │
-                    │    {dataset_config_id}/.../{eval_wandb_run_id}│
-                    │      predictions/ audio/ metrics/            │
-                    └──────┬─────────────────┬─────────────────────┘
+                    ┌───────────────────────────────────────────────────────┐
+                    │             R2 (synth-data bucket)                     │
+                    │                                                       │
+                    │  data/{dataset_config_id}/{dataset_wandb_run_id}/     │
+                    │    e.g. data/surge-simple/surge-simple-20260312.../   │
+                    │                                                       │
+                    │  eval/{dataset_config_id}/.../                        │
+                    │    {eval_config_id}/{eval_wandb_run_id}/             │
+                    │      predictions/ audio/ metrics/                     │
+                    └──────┬─────────────────┬──────────────────────────────┘
                            │                 │
                     download if needed  upload if configured
                            │                 │
@@ -227,7 +217,7 @@ The predict stage loads a trained model checkpoint via PyTorch Lightning's `Trai
 
 **Key behaviors:**
 
-- Dataset path resolved from `data.dataset_root` (default: `${paths.data_dir}/surge_simple/surge_simple-20260312T143022Z`, CLI override for cluster)
+- Dataset path resolved from `data.dataset_root` (default: `${paths.data_dir}/surge-simple/surge-simple-20260312T143022Z`, CLI override for cluster)
 - If `data.r2_path` is explicitly set, `SurgeDataModule.prepare_data()` syncs from R2 before loading
 - Checkpoint path supports `${wandb:...}` resolver — auto-downloads from W&B artifacts to local cache
 - Output directory: `${paths.output_dir}/predictions` (see `configs/callbacks/prediction_writer.yaml`)
@@ -287,7 +277,7 @@ When `data.r2_path` is explicitly provided (via CLI override or experiment confi
 ```yaml
 # configs/data/surge_simple.yaml — no r2_path, no env vars for paths
 _target_: src.data.surge_datamodule.SurgeDataModule
-dataset_root: ${paths.data_dir}/surge_simple/surge_simple-20260312T143022Z  # {dataset_config_id}/{dataset_wandb_run_id}
+dataset_root: ${paths.data_dir}/surge-simple/surge-simple-20260312T143022Z  # {dataset_config_id}/{dataset_wandb_run_id}
 # r2_path: deliberately absent — must be specified explicitly when needed
 batch_size: 128
 num_workers: 11
@@ -297,12 +287,12 @@ To use R2, pass it explicitly:
 
 ```bash
 # CLI override — explicit, visible, no hidden state
-python src/eval.py data.r2_path=r2:synth-data/data/surge_simple/surge_simple-20260312T143022Z/ ...
+python src/eval.py data.r2_path=r2:synth-data/data/surge-simple/surge-simple-20260312T143022Z/ ...
 
 # Or in an experiment config that opts in
 # configs/experiment/surge/flow_simple.yaml
 data:
-  r2_path: r2:synth-data/data/surge_simple/surge_simple-20260312T143022Z/
+  r2_path: r2:synth-data/data/surge-simple/surge-simple-20260312T143022Z/
 ```
 
 Behavior:
@@ -314,7 +304,7 @@ Behavior:
 
 ### 6.2 Checkpoint Storage (W&B Artifacts)
 
-Checkpoints are stored in **W&B artifacts**, not R2. This is a deliberate decision — see [§10](#10-alternatives-considered) for the full R2-vs-W&B analysis.
+Checkpoints are stored in **W&B artifacts**, not R2. This is a deliberate decision — see [§9](#9-alternatives-considered) for the full R2-vs-W&B analysis.
 
 **Upload** (training): `log_model="all"` in `configs/logger/wandb.yaml` uploads every checkpoint
 saved by `ModelCheckpoint` (currently every 5000 steps + best + last). Zero new code — already
@@ -325,17 +315,17 @@ experiment config pins a W&B artifact reference using resolver syntax:
 
 ```yaml
 # configs/experiment/surge/flow_simple.yaml
-ckpt_path: ${wandb:tinaudio/synth-setter/model-flow_simple:latest}
+ckpt_path: ${wandb:tinaudio/synth-setter/model-flow-simple:latest}
 ```
 
-The resolver will be added to `src/utils/utils.py` alongside existing `mul` and `div` resolvers
-(called via `register_resolvers()` at startup). Proposed implementation (Task 3.1, #128):
+The resolver is registered in `src/utils/utils.py` alongside existing `mul` and `div` resolvers
+(already called via `register_resolvers()` at startup):
 
 ```python
 def _wandb_resolver(artifact_ref: str) -> str:
     """Resolve a W&B artifact reference to a local path.
 
-    Usage in config: ${wandb:tinaudio/synth-setter/model-flow_simple:latest}
+    Usage in config: ${wandb:tinaudio/synth-setter/model-flow-simple:latest}
     """
     cache_dir = Path(os.environ["PROJECT_ROOT"]) / ".cache" / "checkpoints"
     safe_name = artifact_ref.replace("/", "_").replace(":", "_")
@@ -361,19 +351,13 @@ See [§7.2](#72-checkpoint-resolution) for the full resolution behavior.
 
 ### 6.3 Eval Artifact Upload
 
-The R2 eval path follows the [storage-provenance-spec](storage-provenance-spec.md) §2 convention:
-
-```
-eval/{dataset_config_id}/{dataset_wandb_run_id}/{train_config_id}/{train_wandb_run_id}/{eval_config_id}/{eval_wandb_run_id}/
-```
-
 After metrics, optionally upload all eval outputs to R2:
 
 ```bash
 make upload-eval
 # rclone sync \
-#   logs/eval/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/ \
-#   r2:synth-data/eval/surge_simple/surge_simple-20260312T143022Z/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/ \
+#   logs/eval/flow-simple/flow-simple-20260315T091500Z/surge-simple/surge-simple-20260320T160000Z/ \
+#   r2:synth-data/eval/surge-simple/surge-simple-20260312T143022Z/flow-simple/flow-simple-20260315T091500Z/surge-simple/surge-simple-20260320T160000Z/ \
 #   --checksum
 ```
 
@@ -382,14 +366,14 @@ Not automatic — explicit `make` target. Toggle via Hydra config or CLI flag.
 **Browsing eval results in R2:**
 
 ```bash
-# All evals for a given training dataset generation run
-rclone ls r2:synth-data/eval/surge_simple/surge_simple-20260312T143022Z/
+# All evals that used the surge-simple dataset generation run
+rclone ls r2:synth-data/eval/surge-simple/surge-simple-20260312T143022Z/
 
 # All evals of a specific training run
-rclone ls r2:synth-data/eval/surge_simple/surge_simple-20260312T143022Z/flow_simple/flow_simple-20260315T091500Z/
+rclone ls r2:synth-data/eval/surge-simple/surge-simple-20260312T143022Z/flow-simple/flow-simple-20260315T091500Z/
 
-# A specific eval run (fully qualified 6-segment path)
-rclone ls r2:synth-data/eval/surge_simple/surge_simple-20260312T143022Z/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/
+# A specific eval run's artifacts
+rclone ls r2:synth-data/eval/surge-simple/surge-simple-20260312T143022Z/flow-simple/flow-simple-20260315T091500Z/surge-simple/surge-simple-20260320T160000Z/
 ```
 
 ### 6.4 W&B Eval Lineage
@@ -400,35 +384,36 @@ W&B run that declares its inputs (model checkpoint + dataset) and logs summary m
 ```python
 # Created automatically by the eval pipeline
 eval_run = wandb.init(
-    project="synth-setter",
-    entity="tinaudio",
+    project="synth-setter", entity="tinaudio",
     job_type="evaluation",
     config={
-        "dataset_config_id": "surge_simple",
-        "dataset_wandb_run_id": "surge_simple-20260312T143022Z",
-        "train_config_id": "flow_simple",
-        "train_wandb_run_id": "flow_simple-20260315T091500Z",
-        "eval_config_id": "surge_simple",
-        "eval_wandb_run_id": "surge_simple-20260320T160000Z",
+        "dataset_config_id": "surge-simple",
+        "dataset_wandb_run_id": "surge-simple-20260312T143022Z",
+        "train_config_id": "flow-simple",
+        "train_wandb_run_id": "flow-simple-20260315T091500Z",
+        "eval_config_id": "surge-simple",
+        "eval_wandb_run_id": "surge-simple-20260320T160000Z",
         "github_sha": os.environ.get("GITHUB_SHA", "local"),
     },
 )
 
 # Declare input artifacts — W&B builds the lineage graph
-model_artifact = eval_run.use_artifact("model-flow_simple:latest")
-dataset_artifact = eval_run.use_artifact("data-surge_simple:latest")
+model_artifact = eval_run.use_artifact("model-flow-simple:latest")
+dataset_artifact = eval_run.use_artifact("data-surge-simple:latest")
 
 # Log summary metrics
 eval_run.log({"mss": 0.42, "wmfcc": 0.31, "sot": 0.18, "rms": 0.94})
 
-# Reference R2 location for bulk artifacts (s3:// protocol — requires AWS_ENDPOINT_URL)
+# Reference R2 location for bulk artifacts
 eval_artifact = wandb.Artifact(
-    "eval-surge_simple", type="eval-results"
+    "eval-surge-simple-flow-simple-20260315T091500Z-surge-simple-20260320T160000Z",
+    type="eval-results",
 )
+# add_reference uses s3:// (R2 is S3-compatible); requires AWS_ENDPOINT_URL.
 eval_artifact.add_reference(
-    "s3://synth-data/eval/surge_simple/surge_simple-20260312T143022Z/"
-    "flow_simple/flow_simple-20260315T091500Z/"
-    "surge_simple/surge_simple-20260320T160000Z/"
+    "s3://synth-data/eval/surge-simple/surge-simple-20260312T143022Z/"
+    "flow-simple/flow-simple-20260315T091500Z/"
+    "surge-simple/surge-simple-20260320T160000Z/"
 )
 eval_run.log_artifact(eval_artifact)
 eval_run.finish()
@@ -437,15 +422,16 @@ eval_run.finish()
 This creates a lineage graph in W&B:
 
 ```
-data-surge_simple:v2 ──→ training run flow_simple-20260315T091500Z ──→ model-flow_simple:latest
-                                                                               │
-data-surge_simple:v2 ──→ eval run (job_type=evaluation) ◄─────────────────────┘
-                                  │
-                                  └──→ eval-surge_simple (R2 ref)
+data-surge-simple:v2 ──→ training run flow-simple-20260315T091500Z ──→ model-...:latest
+                                                                                     │
+data-surge-simple:v2 ──→ eval run (job_type=evaluation) ◄────────────────────────┘
+                                        │
+                                        └──→ eval-surge-simple-flow-simple-...-surge-simple-... (R2 ref)
 ```
 
-> Alias promotion (e.g., `model-flow_simple:latest` to `:production`) follows the
-> strategy in [promotion-pipeline-reference.md](../reference/promotion-pipeline-reference.md).
+Eval artifacts receive the automatic `:latest` alias. The `:production` alias is set by the promotion workflow.
+
+> For model promotion to GitHub Release, see [promotion-pipeline-reference.md](../reference/promotion-pipeline-reference.md).
 
 ## 7. Design Decisions
 
@@ -494,7 +480,7 @@ Each script hardcodes a specific W&B run ID — the checkpoint is **stable per m
 not changing every run:
 
 ```bash
-# jobs/predict/flow_simple.sh
+# jobs/predict/flow-simple.sh
 source jobs/predict/get-ckpt-from-wandb.sh x118ylu9   # always this run ID
 ```
 
@@ -505,7 +491,7 @@ Three resolution patterns, each appropriate for a different use case:
 | Pattern                | Where specified                             | Use case                                                               | Example                                                              |
 | ---------------------- | ------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------------- |
 | CLI arg                | Command line                                | Ad-hoc eval of a new/local checkpoint                                  | `python src/eval.py ckpt_path=./my-ckpt.ckpt`                        |
-| Experiment config      | `configs/experiment/surge/flow_simple.yaml` | Reproducible eval of a known model — checkpoint pinned as W&B artifact | `ckpt_path: ${wandb:tinaudio/synth-setter/model-flow_simple:latest}` |
+| Experiment config      | `configs/experiment/surge/flow_simple.yaml` | Reproducible eval of a known model — checkpoint pinned as W&B artifact | `ckpt_path: ${wandb:tinaudio/synth-setter/model-flow-simple:latest}` |
 | `null` (training only) | `configs/train.yaml`                        | Start training fresh                                                   | Already works                                                        |
 
 **Resolution order** (Hydra's standard override precedence):
@@ -534,12 +520,12 @@ hands Lightning a resolved local path transparently.
 | ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | --------- | ----------------------------- |
 | `ckpt_path: ???` (base eval.yaml)                                                        | Hydra errors — forces user to specify                                              | —         | —                             |
 | `ckpt_path: ./local/best.ckpt` (CLI)                                                     | Uses local file directly                                                           | No        | No (path is machine-specific) |
-| `ckpt_path: ${wandb:tinaudio/synth-setter/model-flow_simple:latest}` (experiment config) | OmegaConf resolves lazily → downloads from W&B, caches locally, returns local path | Yes       | Yes (artifact ref is stable)  |
-| `ckpt_path: ${wandb:tinaudio/synth-setter/model-flow_simple:latest}` (CLI override)      | Same as above, but ad-hoc                                                          | Yes       | No (not pinned in config)     |
+| `ckpt_path: ${wandb:tinaudio/synth-setter/model-flow-simple:latest}` (experiment config) | OmegaConf resolves lazily → downloads from W&B, caches locally, returns local path | Yes       | Yes (artifact ref is stable)  |
+| `ckpt_path: ${wandb:tinaudio/synth-setter/model-flow-simple:latest}` (CLI override)      | Same as above, but ad-hoc                                                          | Yes       | No (not pinned in config)     |
 | `ckpt_path: null` (train.yaml)                                                           | Start training from scratch                                                        | Yes       | Yes                           |
-| `ckpt_path: ${wandb:tinaudio/synth-setter/model-flow_simple:latest}` (training resume)   | Resolves lazily → downloads latest checkpoint, resumes optimizer/epoch state       | Yes       | Yes                           |
+| `ckpt_path: ${wandb:tinaudio/synth-setter/model-flow-simple:latest}` (training resume)   | Resolves lazily → downloads latest checkpoint, resumes optimizer/epoch state       | Yes       | Yes                           |
 
-**Decision:** `ckpt_path` is not in `.env` (not a secret, not machine infrastructure). It is either a required CLI arg (ad-hoc) or pinned in an experiment config (reproducible). The `${wandb:...}` OmegaConf resolver makes pinned values portable across machines — resolution is lazy and cached. Checkpoints are stored in W&B (Teams plan, $50/mo) — see [§10](#10-alternatives-considered) for the full cost/benefit analysis vs R2.
+**Decision:** `ckpt_path` is not in `.env` (not a secret, not machine infrastructure). It is either a required CLI arg (ad-hoc) or pinned in an experiment config (reproducible). The `${wandb:...}` OmegaConf resolver makes pinned values portable across machines — resolution is lazy and cached. Checkpoints are stored in W&B (Teams plan, $50/mo) — see [§9](#9-alternatives-considered) for the full cost/benefit analysis vs R2.
 
 ### 7.3 Makefile as CLI Interface
 
@@ -568,7 +554,7 @@ Each system handles what it's best at:
 
 **Provenance is recorded in three places:**
 
-- **R2 path** → human-readable: `eval/{dataset_config_id}/{dataset_wandb_run_id}/{train_config_id}/{train_wandb_run_id}/{eval_config_id}/{eval_wandb_run_id}/` encodes full provenance at a glance
+- **R2 path** → human-readable: `eval/{dataset_config_id}/{dataset_wandb_run_id}/{train_config_id}/{train_wandb_run_id}/{eval_config_id}/{eval_wandb_run_id}/` tells you what happened at a glance
 - **W&B lineage** → programmatic: `use_artifact()` connects dataset → model → eval with exact versions
 - **Hydra config** → complete: every parameter frozen, reproducible without any external system
 
@@ -580,7 +566,7 @@ This section consolidates every configuration and environment behavior change in
 
 | Concern                   | Current mechanism                                                   | Where defined                              | Portable? | Problem                                            |
 | ------------------------- | ------------------------------------------------------------------- | ------------------------------------------ | --------- | -------------------------------------------------- |
-| **Dataset path**          | Hardcoded `/data/scratch/acw585/surge_simple/`                      | `configs/data/surge_simple.yaml`           | No        | Only works on university cluster                   |
+| **Dataset path**          | Hardcoded `/data/scratch/acw585/surge-simple/`                      | `configs/data/surge_simple.yaml`           | No        | Only works on university cluster                   |
 | **Checkpoint resolution** | `get-ckpt-from-wandb.sh` searches local `logs/train/` by W&B run ID | `jobs/predict/*.sh` (19 scripts)           | No        | Requires training logs on same machine             |
 | **Checkpoint path**       | `ckpt_path: ???` in eval, resolved by shell script to local path    | `configs/eval.yaml` + shell                | No        | Local filesystem dependency                        |
 | **R2 dataset access**     | Not supported                                                       | —                                          | —         | Must manually copy data to machine                 |
@@ -596,25 +582,25 @@ This section consolidates every configuration and environment behavior change in
 
 #### Proposed behavior (to-be)
 
-| Concern                      | Proposed mechanism                                                                                                                                                | Where defined                                 | Portable? | Change from current                              |
-| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | --------- | ------------------------------------------------ |
-| **Dataset path**             | `dataset_root: ${paths.data_dir}/surge_simple/surge_simple-20260312T143022Z` (paths convention + run ID)                                                          | `configs/data/surge_simple.yaml`              | Yes       | Hardcoded → paths convention + run ID            |
-| **Dataset path override**    | CLI: `data.dataset_root=/cluster/path/surge_simple-20260312T143022Z/`                                                                                             | Command line                                  | Yes       | Implicit → explicit                              |
-| **Checkpoint resolution**    | `ckpt_path: ???` (base), pinned in experiment configs                                                                                                             | `configs/eval.yaml` + `configs/experiment/`   | Yes       | Shell script → Hydra config                      |
-| **Checkpoint: ad-hoc**       | CLI: `ckpt_path=./local/best.ckpt`                                                                                                                                | Command line                                  | No        | Same as today but without shell wrapper          |
-| **Checkpoint: reproducible** | `ckpt_path: ${wandb:tinaudio/synth-setter/model-flow_simple:latest}` in experiment config                                                                         | `configs/experiment/surge/flow_simple.yaml`   | Yes       | **New** — portable, pinned                       |
-| **R2 dataset access**        | `data.r2_path=r2:synth-data/...` triggers auto-download in `prepare_data()`                                                                                       | CLI or experiment config (no default)         | Yes       | **New** — explicit opt-in                        |
-| **Checkpoint download**      | `${wandb:...}` OmegaConf resolver → lazy W&B artifact download to `$PROJECT_ROOT/.cache/checkpoints/`                                                             | `src/utils/utils.py` (`register_resolvers()`) | Yes       | **New** — replaces `get-ckpt-from-wandb.sh`      |
-| **Checkpoint upload**        | W&B `log_model="all"` — uploads every saved checkpoint automatically                                                                                              | `configs/logger/wandb.yaml`                   | Yes       | Config change only — `true` → `"all"`            |
-| **Credentials**              | `.env` for R2 + W&B secrets only                                                                                                                                  | `.env` / `.env.example`                       | Yes       | **New** — secrets only, no paths                 |
-| **Display handling**         | Auto-detect: macOS native / Linux Xvfb / Docker baked                                                                                                             | `renderscript.sh`                             | Yes       | Linux-only → cross-platform                      |
-| **Log directory**            | `${paths.root_dir}/logs/` (unchanged)                                                                                                                             | `configs/paths/default.yaml`                  | Yes       | No change                                        |
-| **Predict output**           | `${paths.output_dir}/predictions` (unchanged)                                                                                                                     | `configs/callbacks/prediction_writer.yaml`    | Yes       | No change                                        |
-| **W&B entity**               | `entity: ${oc.env:WANDB_ENTITY,tinaudio}`, `project: ${oc.env:WANDB_PROJECT,synth-setter}`                                                                        | `configs/logger/wandb.yaml`                   | Yes       | Hardcoded → configurable                         |
-| **SGE scripts**              | Deprecated — left as-is, not maintained                                                                                                                           | `jobs/predict/*.sh`                           | No        | Active → deprecated                              |
-| **R2 eval artifact upload**  | `make upload-eval` → `r2:synth-data/eval/{dataset_config_id}/{dataset_wandb_run_id}/{train_config_id}/{train_wandb_run_id}/{eval_config_id}/{eval_wandb_run_id}/` | `Makefile`                                    | Yes       | **New** — 6-segment path encodes full provenance |
-| **W&B eval lineage**         | `use_artifact()` connects dataset → model → eval; R2 reference artifact for bulk files                                                                            | `scripts/compute_audio_metrics.py`            | Yes       | **New** — programmatic provenance chain          |
-| **Eval CLI**                 | `make predict`, `make render`, `make metrics`                                                                                                                     | `Makefile`                                    | Yes       | **New** — discoverable, consistent               |
+| Concern                      | Proposed mechanism                                                                                                                                                | Where defined                                 | Portable? | Change from current                         |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | --------- | ------------------------------------------- |
+| **Dataset path**             | `dataset_root: ${paths.data_dir}/surge-simple/surge-simple-20260312T143022Z` (paths convention)                                                                   | `configs/data/surge_simple.yaml`              | Yes       | Hardcoded → paths convention                |
+| **Dataset path override**    | CLI: `data.dataset_root=/cluster/path/`                                                                                                                           | Command line                                  | Yes       | Implicit → explicit                         |
+| **Checkpoint resolution**    | `ckpt_path: ???` (base), pinned in experiment configs                                                                                                             | `configs/eval.yaml` + `configs/experiment/`   | Yes       | Shell script → Hydra config                 |
+| **Checkpoint: ad-hoc**       | CLI: `ckpt_path=./local/best.ckpt`                                                                                                                                | Command line                                  | No        | Same as today but without shell wrapper     |
+| **Checkpoint: reproducible** | `ckpt_path: ${wandb:tinaudio/synth-setter/model-flow-simple:latest}` in experiment config                                                                         | `configs/experiment/surge/flow_simple.yaml`   | Yes       | **New** — portable, pinned                  |
+| **R2 dataset access**        | `data.r2_path=r2:synth-data/...` triggers auto-download in `prepare_data()`                                                                                       | CLI or experiment config (no default)         | Yes       | **New** — explicit opt-in                   |
+| **Checkpoint download**      | `${wandb:...}` OmegaConf resolver → lazy W&B artifact download to `$PROJECT_ROOT/.cache/checkpoints/`                                                             | `src/utils/utils.py` (`register_resolvers()`) | Yes       | **New** — replaces `get-ckpt-from-wandb.sh` |
+| **Checkpoint upload**        | W&B `log_model="all"` — uploads every saved checkpoint automatically                                                                                              | `configs/logger/wandb.yaml`                   | Yes       | Config change only — `true` → `"all"`       |
+| **Credentials**              | `.env` for R2 + W&B secrets only                                                                                                                                  | `.env` / `.env.example`                       | Yes       | **New** — secrets only, no paths            |
+| **Display handling**         | Auto-detect: macOS native / Linux Xvfb / Docker baked                                                                                                             | `renderscript.sh`                             | Yes       | Linux-only → cross-platform                 |
+| **Log directory**            | `${paths.root_dir}/logs/` (unchanged)                                                                                                                             | `configs/paths/default.yaml`                  | Yes       | No change                                   |
+| **Predict output**           | `${paths.output_dir}/predictions` (unchanged)                                                                                                                     | `configs/callbacks/prediction_writer.yaml`    | Yes       | No change                                   |
+| **W&B entity**               | Configurable via env: `entity: ${oc.env:WANDB_ENTITY,tinaudio}`, `project: ${oc.env:WANDB_PROJECT,synth-setter}`                                                  | `configs/logger/wandb.yaml`                   | Yes       | Hardcoded → configurable                    |
+| **SGE scripts**              | Deprecated — left as-is, not maintained                                                                                                                           | `jobs/predict/*.sh`                           | No        | Active → deprecated                         |
+| **R2 eval artifact upload**  | `make upload-eval` → `r2:synth-data/eval/{dataset_config_id}/{dataset_wandb_run_id}/{train_config_id}/{train_wandb_run_id}/{eval_config_id}/{eval_wandb_run_id}/` | `Makefile`                                    | Yes       | **New** — path encodes full provenance      |
+| **W&B eval lineage**         | `use_artifact()` connects dataset → model → eval; R2 reference artifact for bulk files                                                                            | `scripts/compute_audio_metrics.py`            | Yes       | **New** — programmatic provenance chain     |
+| **Eval CLI**                 | `make predict`, `make render`, `make metrics`                                                                                                                     | `Makefile`                                    | Yes       | **New** — discoverable, consistent          |
 
 #### What changes, what stays
 
@@ -630,32 +616,34 @@ This section consolidates every configuration and environment behavior change in
 
 **1. `.env` scope**
 
-|                      | Current              | Proposed                                                                                                     |
-| -------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **What's in `.env`** | Nothing standardized | R2 credentials + `WANDB_API_KEY` (see [storage-provenance-spec.md §9](storage-provenance-spec.md#9-secrets)) |
-| **Paths**            | Hardcoded in YAML    | Hydra defaults + CLI overrides                                                                               |
-| **Risk eliminated**  | —                    | Invisible state: can't read YAML + `.env` and know what happens                                              |
-| **Trade-off**        | —                    | Cluster users must pass CLI overrides instead of setting one env var                                         |
+|                      | Current              | Proposed                                                             |
+| -------------------- | -------------------- | -------------------------------------------------------------------- |
+| **What's in `.env`** | Nothing standardized | R2 credentials + `WANDB_API_KEY`                                     |
+| **Paths**            | Hardcoded in YAML    | Hydra defaults + CLI overrides                                       |
+| **Risk eliminated**  | —                    | Invisible state: can't read YAML + `.env` and know what happens      |
+| **Trade-off**        | —                    | Cluster users must pass CLI overrides instead of setting one env var |
+
+Secrets are documented in [storage-provenance-spec.md](storage-provenance-spec.md) §9.
 
 **2. Checkpoint resolution (§7.2)**
 
-|                            | Current                                     | Proposed                                                                                        |
-| -------------------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| **Eval checkpoint**        | Shell script finds local file by W&B run ID | Pinned `${wandb:...}` resolver in experiment config or CLI arg                                  |
-| **Training checkpoint**    | `ckpt_path: null` (start fresh)             | Same — no change                                                                                |
-| **Training resume**        | `ckpt_path=/local/path/last.ckpt`           | `ckpt_path=${wandb:tinaudio/synth-setter/model-flow_simple:latest}` (portable)                  |
-| **Upload during training** | W&B `log_model: true` (best only)           | W&B `log_model="all"` (every saved checkpoint — crash resilient)                                |
-| **Risk eliminated**        | —                                           | "Checkpoint is on the cluster" — W&B artifacts available everywhere                             |
-| **Trade-off**              | —                                           | W&B Teams at $50/mo; storage burns faster with `"all"` (see [§10](#10-alternatives-considered)) |
+|                            | Current                                     | Proposed                                                                                      |
+| -------------------------- | ------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **Eval checkpoint**        | Shell script finds local file by W&B run ID | Pinned `${wandb:...}` resolver in experiment config or CLI arg                                |
+| **Training checkpoint**    | `ckpt_path: null` (start fresh)             | Same — no change                                                                              |
+| **Training resume**        | `ckpt_path=/local/path/last.ckpt`           | `ckpt_path=${wandb:tinaudio/synth-setter/model-flow-simple:latest}` (portable)                |
+| **Upload during training** | W&B `log_model: true` (best only)           | W&B `log_model="all"` (every saved checkpoint — crash resilient)                              |
+| **Risk eliminated**        | —                                           | "Checkpoint is on the cluster" — W&B artifacts available everywhere                           |
+| **Trade-off**              | —                                           | W&B Teams at $50/mo; storage burns faster with `"all"` (see [§9](#9-alternatives-considered)) |
 
 **3. Dataset access (§6.3)**
 
-|                     | Current                    | Proposed                                                                                                      |
-| ------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| **Local data**      | Hardcoded path, must exist | `${paths.data_dir}/surge_simple/surge_simple-20260312T143022Z` ({config_id}/{wandb_run_id}), override via CLI |
-| **Remote data**     | Not supported              | `r2_path` opt-in triggers auto-download                                                                       |
-| **Risk eliminated** | —                          | "Data is on the cluster" — R2 makes it available everywhere                                                   |
-| **Trade-off**       | —                          | First download of a 100GB dataset takes time; cached after that                                               |
+|                     | Current                    | Proposed                                                                                            |
+| ------------------- | -------------------------- | --------------------------------------------------------------------------------------------------- |
+| **Local data**      | Hardcoded path, must exist | `${paths.data_dir}/surge-simple/surge-simple-20260312T143022Z` (paths convention), override via CLI |
+| **Remote data**     | Not supported              | `r2_path` opt-in triggers auto-download                                                             |
+| **Risk eliminated** | —                          | "Data is on the cluster" — R2 makes it available everywhere                                         |
+| **Trade-off**       | —                          | First download of a 100GB dataset takes time; cached after that                                     |
 
 **4. Display handling (§7.1)**
 
@@ -672,346 +660,14 @@ This section consolidates every configuration and environment behavior change in
 |                  | Current                            | Proposed                                                                                         |
 | ---------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------ |
 | **SGE scripts**  | 19 scripts, actively used          | Left as-is, not maintained                                                                       |
-| **Cluster eval** | `qsub jobs/predict/flow_simple.sh` | `make predict EXPERIMENT=surge/flow_simple CKPT=r2:...` (SSH to cluster, run make target)        |
+| **Cluster eval** | `qsub jobs/predict/flow-simple.sh` | `make predict EXPERIMENT=surge/flow_simple CKPT=r2:...` (SSH to cluster, run make target)        |
 | **Risk**         | —                                  | If SGE scripts break, no fix is coming. Acceptable — cluster is not the primary dev environment. |
 
-## 8. Phase Plan
-
-> This section follows the Epic → Phase → Task hierarchy defined in
-> [`github-taxonomy.md`](github-taxonomy.md) §3.
-> Issues follow the standard lifecycle ([`github-taxonomy.md`](github-taxonomy.md) §11): Todo → In Progress → Done.
-> Project fields required for all tasks: Priority, Start Date, Target Date.
-> Per-task priority tracked via the project Priority field ([`github-taxonomy.md`](github-taxonomy.md) §5).
->
-> For issue tracking structure see [`github-taxonomy.md`](github-taxonomy.md).
-
-### Issue Mapping
-
-| Issue | Type  | Description                    | Parent |
-| ----- | ----- | ------------------------------ | ------ |
-| #98   | Epic  | Evaluation pipeline            | —      |
-| #99   | Epic  | Storage / R2 integration       | —      |
-| #137  | Phase | Phase 1: Portable eval         | #98    |
-| #138  | Phase | Phase 2: Storage integration   | #99    |
-| #139  | Phase | Phase 3: W&B integration       | #98    |
-| #140  | Phase | Phase 4: CI & containerization | #98    |
-| #141  | Phase | Phase 5: Documentation         | #98    |
-| #94   | Task  | Config cleanup                 | #137   |
-| #85   | Task  | Portable predict               | #137   |
-| #86   | Task  | Portable render                | #137   |
-| #87   | Task  | Portable metrics               | #137   |
-| #90   | Task  | rclone wrapper                 | #138   |
-| #91   | Task  | R2 dataset download            | #138   |
-| #93   | Task  | R2 artifact upload             | #138   |
-| #92   | Task  | R2 checkpoint sync             | #138   |
-| #128  | Task  | W&B checkpoint resolver        | #139   |
-| #96   | Task  | W&B metrics logging            | #139   |
-| #88   | Task  | Docker eval environment        | #140   |
-| #89   | Task  | E2E eval CI                    | #140   |
-| #97   | Task  | Eval runbook                   | #141   |
-| #95   | Task  | Consolidate SGE                | #141   |
-
-### Per-Phase Metadata
-
-| Phase | Issue | Label(s)                      | Milestone           | Epic |
-| ----- | ----- | ----------------------------- | ------------------- | ---- |
-| 1     | #137  | `evaluation`                  | `evaluation v1.0.0` | #98  |
-| 2     | #138  | `evaluation`, `storage`       | `storage v1.0.0`    | #99  |
-| 3     | #139  | `evaluation`                  | `evaluation v1.0.0` | #98  |
-| 4     | #140  | `evaluation`, `ci-automation` | `evaluation v1.0.0` | #98  |
-| 5     | #141  | `evaluation`                  | `evaluation v1.0.0` | #98  |
-
-### Completion Tracking
-
-When tasks are completed, update this section using the taxonomy's design doc linkage pattern:
-
-```
-### Task 1.1: Config Cleanup (#94) ✅ — Completed in PR #XXX
-```
-
-### Branch Strategy
-
-```
-main ──●──────────────●──────────────●──────────────●──────────────●──→
-       │              │              │              │              │
-       Phase 1        Phase 2        Phase 3        Phase 4        Phase 5
-```
-
-### Estimated Change Size
-
-| Task | Area                     | Already works                       | Actual change                      | Lines |
-| ---- | ------------------------ | ----------------------------------- | ---------------------------------- | ----- |
-| 1.1  | Data configs             | mnist.yaml uses `${paths.data_dir}` | Change 2 surge configs to match    | ~2    |
-| 1.2  | Predict                  | src/eval.py works, `ckpt_path: ???` | Add Makefile target                | ~10   |
-| 1.3  | Rendering                | Xvfb auto-launch in renderscript.sh | Add macOS `$OSTYPE` conditional    | ~5    |
-| 1.4  | Metrics                  | All 4 metrics working, portable     | Add Makefile target                | ~5    |
-| 2.1  | rclone wrapper           | —                                   | New utility `src/data/rclone.py`   | ~40   |
-| 2.2  | `prepare_data()` R2 sync | —                                   | Override in SurgeDataModule        | ~15   |
-| 3.1  | W&B resolver             | `register_resolvers()` exists       | Add wandb resolver (~15 lines)     | ~15   |
-| 3.1  | W&B config               | `log_model: true`                   | Change to `"all"`                  | 1     |
-| —    | Makefile targets         | help, test, format, train           | Add predict, render, metrics, etc. | ~40   |
-| —    | Tests                    | conftest.py fixtures exist          | New test files + fixtures          | ~400  |
-
-**Branch:** `dev/eval-pipeline` off `main`
-**Priorities:** TDD first, small commits, always-green CI.
-
-______________________________________________________________________
-
-### Phase 1: Portable Evaluation Pipeline (#137, Epic #98)
-
-> **Label:** `evaluation` · **Milestone:** `evaluation v1.0.0`
-
-#### Task 1.1: Config Cleanup (#94)
-
-**Goal:** Replace all cluster-specific paths in committed configs with sensible Hydra defaults.
-
-**Files to modify:**
-
-- `configs/data/surge_simple.yaml` — `dataset_root` → `${paths.data_dir}/{dataset_config_id}/{dataset_wandb_run_id}` (matches [storage-provenance-spec](storage-provenance-spec.md) §2)
-- `configs/data/surge_mini.yaml` — same pattern
-- `configs/data/surge_simple_onehot.yaml` — same (if exists)
-- `.env.example` — R2 credentials and `WANDB_API_KEY` only (no path vars)
-
-**Tests:**
-
-- `test_no_hardcoded_paths_in_configs` — grep committed YAML for `/data/scratch`
-- `test_configs_have_sensible_defaults` — load each data config, verify `dataset_root` is a relative path
-
-**Note:** The 19 SGE scripts in `jobs/predict/` are left as-is (deprecated, not consolidated — see [§7.5](#75-current-vs-proposed-full-comparison) SGE deprecation).
-
-#### Task 1.2: Portable Predict (#85)
-
-**Goal:** `make predict` works on local machines with portable Hydra config.
-
-**Files to modify:**
-
-- `src/eval.py` — ensure `mode=predict` works without cluster deps
-- `Makefile` — add `predict` target
-
-**Files to create:**
-
-- `tests/test_eval_predict.py` — fixture-based predict test (`@pytest.mark.slow`)
-
-**Key behaviors:**
-
-- `dataset_root` has a sensible Hydra default; override via CLI when needed
-- `ckpt_path` resolved per [§7.2](#72-checkpoint-resolution) — CLI arg or experiment config, supports `${wandb:...}` resolver
-- `paths.log_dir` keeps the existing default (`${paths.root_dir}/logs/`)
-- Fails fast with clear error if dataset not found
-
-#### Task 1.3: Portable Render (#86)
-
-**Goal:** `make render` works on macOS (native display) and Linux (Xvfb auto-detect).
-
-**Files to modify:**
-
-- `renderscript.sh` — add macOS detection, Xvfb auto-launch
-- `scripts/predict_vst_audio.py` — make plugin/preset paths configurable via env
-- `Makefile` — add `render` target
-
-**Files to create:**
-
-- `tests/test_render.py` — test with fixture `.pt` files (`@pytest.mark.slow`)
-
-**Key behaviors:**
-
-- macOS: skip Xvfb, call Python directly
-- Headless Linux: launch Xvfb on `:99`, export `DISPLAY`, clean up on exit
-- Plugin/preset paths default to `plugins/` and `presets/` (overridable)
-
-#### Task 1.4: Portable Metrics (#87)
-
-**Goal:** `make metrics` works with pinned dependencies and clean output schema.
-
-**Files to modify:**
-
-- `scripts/compute_audio_metrics.py` — pin dep versions
-- `Makefile` — add `metrics` target
-
-**Files to create:**
-
-- `tests/test_metrics.py` — test with fixture `.wav` files, validate CSV schema
-
-**Key behaviors:**
-
-- Output CSV: per-sample metrics indexed by directory name, aggregated means/stds
-- `ProcessPoolExecutor` parallelism preserved
-- JTFS and f0 code stays as-is — track reactivation as a separate issue (out of scope)
-
-______________________________________________________________________
-
-### Phase 2: Storage Integration (#138, Epic #99)
-
-> **Labels:** `evaluation`, `storage` · **Milestone:** `storage v1.0.0`
-
-#### Task 2.1: rclone Wrapper (#90)
-
-**Goal:** Shared `rclone_sync()` utility with `--checksum` enforcement.
-
-**Files to create:**
-
-- `src/data/rclone.py` — `rclone_sync()`, `rclone_ls()`, `rclone_copyto()`
-- `tests/test_rclone.py` — mock subprocess, verify flags
-
-**Key behaviors:**
-
-- All operations include `--checksum`
-- R2 config from env vars (`RCLONE_CONFIG_R2_*`)
-- Raises `subprocess.CalledProcessError` on failure
-- Dry-run mode for testing (`--dry-run` flag passthrough)
-
-#### Task 2.2: R2 Dataset Download (#91)
-
-**Goal:** When `data.r2_path` is explicitly specified, `prepare_data()` syncs from R2.
-
-**Files to modify:**
-
-- `src/data/surge_datamodule.py` — add optional `r2_path` field, call `rclone_sync` in `prepare_data()`
-- Data configs unchanged — `r2_path` is absent by default, specified via CLI or experiment config
-
-**Files to create:**
-
-- `tests/test_r2_dataset_download.py` — mock rclone, verify sync logic
-
-**Key behaviors:**
-
-- No-op if `r2_path` not specified (default — local-only mode)
-- No-op if local data matches (checksum)
-- Sync runs in `prepare_data()` (before `setup()`)
-- Logs download progress via structlog
-- **No default value** — R2 download is always an explicit opt-in
-
-#### Task 2.3: R2 Eval Artifact Upload (#93)
-
-**Goal:** `make upload-eval` pushes predictions + audio + metrics to R2.
-
-**Files to modify:**
-
-- `Makefile` — add `upload-eval` target
-
-**Files to create:**
-
-- `scripts/upload_eval_artifacts.py` — rclone sync wrapper for eval outputs
-- `tests/test_upload_eval.py` — mock rclone, verify R2 paths
-
-#### Task 2.4: R2 Checkpoint Sync (#92)
-
-**Goal:** Sync checkpoints to R2 as a secondary backup alongside W&B.
-
-**Depends on:** #90 (rclone wrapper)
-
-______________________________________________________________________
-
-### Phase 3: W&B Integration (#139, Epic #98)
-
-> **Label:** `evaluation` · **Milestone:** `evaluation v1.0.0`
-
-#### Task 3.1: W&B Checkpoint Config + Resolver (#128)
-
-**Goal:** Enable crash-resilient checkpoint upload via W&B and lazy resolution via OmegaConf.
-
-**Files to modify:**
-
-- `configs/logger/wandb.yaml` — change `log_model: true` → `log_model: "all"`
-- `src/utils/utils.py` — add `_wandb_resolver` to `register_resolvers()` (~15 lines)
-
-**Files to create:**
-
-- `tests/test_wandb_resolver.py` — mock W&B API, verify download + cache logic
-
-**Key behaviors:**
-
-- `log_model="all"` uploads every saved checkpoint (every 5000 steps + best + last)
-- `${wandb:...}` OmegaConf resolver handles artifact download + cache
-- Cache dir: `$PROJECT_ROOT/.cache/checkpoints/` (gitignored)
-- Zero new modules — resolver lives in existing `register_resolvers()`
-
-#### Task 3.2: W&B Metrics Logging (#96)
-
-**Goal:** Optionally log metrics to W&B for cross-run comparison.
-
-**Files to modify:**
-
-- `scripts/compute_audio_metrics.py` — add `--wandb-run` flag
-
-**Files to create:**
-
-- `tests/test_metrics_wandb.py` — mock wandb, verify log calls
-
-______________________________________________________________________
-
-### Phase 4: CI & Containerization (#140, Epic #98)
-
-> **Labels:** `evaluation`, `ci-automation` · **Milestone:** `evaluation v1.0.0`
-
-#### Task 4.1: Docker Eval Environment (#88)
-
-**Goal:** `make docker-eval` runs the full pipeline in a container.
-
-**Files to create:**
-
-- `docker/eval/Dockerfile` — multi-stage: base → deps → VST plugin → Xvfb
-- `docker/eval/docker-compose.yaml` — env var passthrough, volume mounts
-- `Makefile` — add `docker-eval`, `docker-eval-build` targets
-
-**Key behaviors:**
-
-- Xvfb baked into image (always headless in Docker)
-- Surge XT plugin installed in image
-- `.env` file mounted for credentials only (R2, W&B)
-- Output directory mounted as volume
-- Paths passed as `docker run` args, not env vars
-
-#### Task 4.2: E2E Eval CI (#89)
-
-**Goal:** GitHub Actions workflow runs predict → render → metrics on a small fixture.
-
-**Files to create:**
-
-- `.github/workflows/eval-ci.yml` — matrix: Ubuntu (Xvfb)
-- `tests/test_eval_e2e.py` — fixture-based integration test (`@pytest.mark.slow`)
-- `tests/fixtures/eval/` — checked-in test fixtures:
-  - `tiny.ckpt` (~1 MB) — checkpoint trained for 2 epochs on a handful of samples
-  - `fixture-shard.h5` (~5 MB) — small HDF5 shard with 10-50 samples (enough for one predict batch)
-  - `audio/sample_0/{pred,target}.wav` (~1 MB) — pre-rendered audio for metrics-only testing without VST plugin
-
-**Key behaviors:**
-
-- Runs on PR (if `src/eval.py`, `scripts/`, or `configs/` changed)
-- Uses checked-in fixtures — no R2 credentials, no network dependency, no secrets in CI
-- Validates: predictions exist, audio renders, metrics CSV has expected schema
-- If fixtures grow past ~10 MB, migrate to Git LFS
-
-______________________________________________________________________
-
-### Phase 5: Documentation (#141, Epic #98)
-
-> **Label:** `evaluation` · **Milestone:** `evaluation v1.0.0`
-
-#### Task 5.1: Eval Runbook (#97)
-
-**Goal:** Document how to run the full eval pipeline locally and in Docker.
-
-**Files to create:**
-
-- `docs/eval-runbook.md` — setup, credentials, make targets, Docker, troubleshooting
-
-#### Task 5.2: Consolidate SGE (#95)
-
-**Goal:** Clean up the 19 deprecated SGE scripts in `jobs/predict/`. SGE deprecation is a design decision (§7.5) — this task handles the file cleanup.
-
-______________________________________________________________________
-
-## 9. Dependency Overview
-
-> Dependencies are implemented using GitHub's native "Blocked by / Blocking"
-> relationships (issue sidebar → Relationships). The canonical dependency DAG
-> lives in GitHub; this section documents the critical path and parallel
-> execution windows for planning.
+## 8. Dependency Graph & Parallelism
 
 ### Blocking Matrix
 
-| Issue | Title               | Blocked by    | Blocking                |
+| Issue | Title               | Blocked by    | Blocks                  |
 | ----- | ------------------- | ------------- | ----------------------- |
 | #94   | Config cleanup      | —             | #85, #91                |
 | #85   | Portable predict    | #94           | #88, #89, #97           |
@@ -1044,20 +700,18 @@ ______________________________________________________________________
 ```
 Mar 31 ─────────── Apr 07 ─────────── Apr 14 ── Apr 15
 │                  │                  │          │
-├── Phase 1: Portable Eval ──────────┤           │
+├── PR#1: Portable Eval ─────────────┤           │
 │   (#94, #85, #86, #87)             │           │
-│                  ├── Phase 2: Storage ─────────┤│
-│                  │   (#90, #91, #93)            ││
-│                  ├── Phase 3: W&B ─────────────┤│
-│                  │   (#128, #96)                ││
-│                  │              ├── Phase 4: CI + Docker ──┤
-│                  │              │   (#88, #89)              │
-│                  │              │              ├── Phase 5 ─┤
-│                  │              │              │   (#97)    │
-│                                                      milestone
+│                  ├── PR#2: R2 + W&B ──────────┤│
+│                  │   (#90, #91, #96)           ││
+│                  │              ├── PR#3: Docker + CI ───┤
+│                  │              │   (#88, #93, #89)      │
+│                  │              │              ├── PR#4: Docs ┤
+│                  │              │              │   (#97)      │
+│                                                        milestone
 ```
 
-## 10. Alternatives Considered
+## 9. Alternatives Considered
 
 ### Quick rejections
 
@@ -1138,7 +792,7 @@ and **eval artifacts** (audio files, prediction tensors — no W&B UI benefit).
 | **R2**              | Datasets (generated shards, train/val/test splits), eval artifacts (audio, predictions, metrics CSVs) | Too large for W&B, cheaper per GB, fast rclone egress, data pipeline already uses R2 |
 | **Local** (`logs/`) | Hydra output dirs, TensorBoard logs, CSV metrics, checkpoints (before W&B upload)                     | Working directory, ephemeral                                                         |
 
-## 11. Open Questions & Risks
+## 10. Open Questions & Risks
 
 | #   | Question / Risk                                                                             | Impact                                              | Status                   |
 | --- | ------------------------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------ |
@@ -1149,7 +803,7 @@ and **eval artifacts** (audio files, prediction tensors — no W&B UI benefit).
 | 5   | **Xvfb availability in Docker base image** — may need to install in Dockerfile              | Low risk, well-documented                           | Resolved by Docker stage |
 | 6   | **rclone version skew** — different rclone versions on dev machines vs CI                   | Pin rclone version in Dockerfile and CI workflow    | Open                     |
 
-## 12. Out of Scope
+## 11. Out of Scope
 
 - **Automated hyperparameter sweeps** — eval runs are manually triggered
 - **Multi-GPU distributed eval** — single-GPU is sufficient at current dataset sizes
@@ -1158,6 +812,256 @@ and **eval artifacts** (audio files, prediction tensors — no W&B UI benefit).
 - **Custom metric development** — existing 4 metrics are fixed for v1.0.0
 - **Training pipeline changes** — this doc covers eval and R2 only
 - **Data pipeline modifications** — covered by [data pipeline design doc](data-pipeline.md) and #74
+
+## 12. Implementation Plan
+
+### Branch Strategy
+
+```
+main ──●──────────────────●──────────────────●──────────────────●──→
+       │                  │                  │                  │
+       PR#1               PR#2               PR#3               PR#4
+```
+
+| PR                              | Issues              | Contents                                                                                          | Integration test                                                                     |
+| ------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **#1: Portable Eval**           | #94, #85, #86, #87  | Config cleanup, portable predict/render/metrics, Makefile targets                                 | `make predict`, `make render`, `make metrics` on local fixture                       |
+| **#2: R2 + W&B**                | #90, #91, #96, #128 | rclone wrapper, R2 dataset download, `log_model="all"`, `${wandb:...}` resolver, W&B eval metrics | `make predict` with `data.r2_path=...` auto-downloads; W&B checkpoint download works |
+| **#3: Docker + CI + Artifacts** | #88, #93, #89       | Docker eval, R2 eval artifact upload, E2E CI                                                      | `make docker-eval` runs full pipeline; GH Actions passes                             |
+| **#4: Documentation**           | #97                 | Eval runbook                                                                                      | Follow runbook from scratch                                                          |
+
+### Estimated change size
+
+| Area                     | Already works                       | Actual change                      | Lines |
+| ------------------------ | ----------------------------------- | ---------------------------------- | ----- |
+| Rendering                | Xvfb auto-launch in renderscript.sh | Add macOS `$OSTYPE` conditional    | ~5    |
+| Metrics                  | All 4 metrics working, portable     | Add Makefile target                | ~5    |
+| Data configs             | mnist.yaml uses `${paths.data_dir}` | Change 2 surge configs to match    | ~2    |
+| Predict                  | src/eval.py works, `ckpt_path: ???` | Add Makefile target                | ~10   |
+| W&B resolver             | `register_resolvers()` exists       | Add wandb resolver (~15 lines)     | ~15   |
+| rclone wrapper           | —                                   | New utility `src/data/rclone.py`   | ~40   |
+| `prepare_data()` R2 sync | —                                   | Override in SurgeDataModule        | ~15   |
+| W&B config               | `log_model: true`                   | Change to `"all"`                  | 1     |
+| Makefile targets         | help, test, format, train           | Add predict, render, metrics, etc. | ~40   |
+| Tests                    | conftest.py fixtures exist          | New test files + fixtures          | ~400  |
+
+**Branch:** `dev/eval-pipeline` off `main`
+**Priorities:** TDD first, small commits, always-green CI.
+
+### PR #1: Portable Eval (#94, #85, #86, #87)
+
+#### Phase 1: Remove Hardcoded Paths (#94)
+
+**Goal:** Replace all cluster-specific paths in committed configs with sensible Hydra defaults.
+
+**Files to modify:**
+
+- `configs/data/surge_simple.yaml` — `dataset_root` → `${paths.data_dir}/surge-simple/{dataset_wandb_run_id}` (matches spec convention)
+- `configs/data/surge_mini.yaml` — same pattern
+- `configs/data/surge_simple_onehot.yaml` — same (if exists)
+- `.env.example` — R2 credentials and `WANDB_API_KEY` only (no path vars)
+
+**Tests:**
+
+- `test_no_hardcoded_paths_in_configs` — grep committed YAML for `/data/scratch`
+- `test_configs_have_sensible_defaults` — load each data config, verify `dataset_root` is a relative path
+
+**Note:** The 19 SGE scripts in `jobs/predict/` are left as-is (deprecated, not consolidated).
+
+#### Phase 2: Portable Predict (#85)
+
+**Goal:** `make predict` works on local machines with portable Hydra config.
+
+**Files to modify:**
+
+- `src/eval.py` — ensure `mode=predict` works without cluster deps
+- `Makefile` — add `predict` target
+
+**Files to create:**
+
+- `tests/test_eval_predict.py` — fixture-based predict test (`@pytest.mark.slow`)
+
+**Key behaviors:**
+
+- `dataset_root` has a sensible Hydra default; override via CLI when needed
+- `ckpt_path` resolved per [§7.2](#72-checkpoint-resolution) — CLI arg or experiment config, supports `${wandb:...}` resolver
+- `paths.log_dir` keeps the existing default (`${paths.root_dir}/logs/`)
+- Fails fast with clear error if dataset not found
+
+#### Phase 3: Portable Render (#86)
+
+**Goal:** `make render` works on macOS (native display) and Linux (Xvfb auto-detect).
+
+**Files to modify:**
+
+- `renderscript.sh` — add macOS detection, Xvfb auto-launch
+- `scripts/predict_vst_audio.py` — make plugin/preset paths configurable via env
+- `Makefile` — add `render` target
+
+**Files to create:**
+
+- `tests/test_render.py` — test with fixture `.pt` files (`@pytest.mark.slow`)
+
+**Key behaviors:**
+
+- macOS: skip Xvfb, call Python directly
+- Headless Linux: launch Xvfb on `:99`, export `DISPLAY`, clean up on exit
+- Plugin/preset paths default to `plugins/` and `presets/` (overridable)
+
+#### Phase 4: Portable Metrics (#87)
+
+**Goal:** `make metrics` works with pinned dependencies and clean output schema.
+
+**Files to modify:**
+
+- `scripts/compute_audio_metrics.py` — pin dep versions
+- `Makefile` — add `metrics` target
+
+**Files to create:**
+
+- `tests/test_metrics.py` — test with fixture `.wav` files, validate CSV schema
+
+**Key behaviors:**
+
+- Output CSV: per-sample metrics indexed by directory name, aggregated means/stds
+- `ProcessPoolExecutor` parallelism preserved
+- JTFS and f0 code stays as-is — track reactivation as a separate issue (out of scope)
+
+### PR #2: R2 + W&B (#90, #91, #96, #128)
+
+#### Phase 5: rclone Wrapper (#90)
+
+**Goal:** Shared `rclone_sync()` utility with `--checksum` enforcement.
+
+**Files to create:**
+
+- `src/data/rclone.py` — `rclone_sync()`, `rclone_ls()`, `rclone_copyto()`
+- `tests/test_rclone.py` — mock subprocess, verify flags
+
+**Key behaviors:**
+
+- All operations include `--checksum`
+- R2 config from env vars (`RCLONE_CONFIG_R2_*`)
+- Raises `subprocess.CalledProcessError` on failure
+- Dry-run mode for testing (`--dry-run` flag passthrough)
+
+#### Phase 6: R2 Dataset Download (#91)
+
+**Goal:** When `data.r2_path` is explicitly specified, `prepare_data()` syncs from R2.
+
+**Files to modify:**
+
+- `src/data/surge_datamodule.py` — add optional `r2_path` field, call `rclone_sync` in `prepare_data()`
+- Data configs unchanged — `r2_path` is absent by default, specified via CLI or experiment config
+
+**Files to create:**
+
+- `tests/test_r2_dataset_download.py` — mock rclone, verify sync logic
+
+**Key behaviors:**
+
+- No-op if `r2_path` not specified (default — local-only mode)
+- No-op if local data matches (checksum)
+- Sync runs in `prepare_data()` (before `setup()`)
+- Logs download progress via structlog
+- **No default value** — R2 download is always an explicit opt-in
+
+#### Phase 7: W&B Checkpoint Config + Resolver (#128)
+
+**Goal:** Enable crash-resilient checkpoint upload via W&B and lazy resolution via OmegaConf.
+
+**Files to modify:**
+
+- `configs/logger/wandb.yaml` — change `log_model: true` → `log_model: "all"`
+- `src/utils/utils.py` — add `_wandb_resolver` to `register_resolvers()` (~15 lines)
+
+**Files to create:**
+
+- `tests/test_wandb_resolver.py` — mock W&B API, verify download + cache logic
+
+**Key behaviors:**
+
+- `log_model="all"` uploads every saved checkpoint (every 5000 steps + best + last)
+- `${wandb:...}` OmegaConf resolver handles artifact download + cache
+- Cache dir: `$PROJECT_ROOT/.cache/checkpoints/` (gitignored)
+- Zero new modules — resolver lives in existing `register_resolvers()`
+
+#### Phase 8: W&B Metrics Logging (#96)
+
+**Goal:** Optionally log metrics to W&B for cross-run comparison.
+
+**Files to modify:**
+
+- `scripts/compute_audio_metrics.py` — add `--wandb-run` flag
+
+**Files to create:**
+
+- `tests/test_metrics_wandb.py` — mock wandb, verify log calls
+
+### PR #3: Docker + CI + Artifacts (#88, #93, #89)
+
+#### Phase 9: Docker Eval Environment (#88)
+
+**Goal:** `make docker-eval` runs the full pipeline in a container.
+
+**Files to create:**
+
+- `docker/eval/Dockerfile` — multi-stage: base → deps → VST plugin → Xvfb
+- `docker/eval/docker-compose.yaml` — env var passthrough, volume mounts
+- `Makefile` — add `docker-eval`, `docker-eval-build` targets
+
+**Key behaviors:**
+
+- Xvfb baked into image (always headless in Docker)
+- Surge XT plugin installed in image
+- `.env` file mounted for credentials only (R2, W&B)
+- Output directory mounted as volume
+- Paths passed as `docker run` args, not env vars
+
+#### Phase 10: R2 Eval Artifact Upload (#93)
+
+**Goal:** `make upload-eval` pushes predictions + audio + metrics to R2.
+
+**Files to modify:**
+
+- `Makefile` — add `upload-eval` target
+
+**Files to create:**
+
+- `scripts/upload_eval_artifacts.py` — rclone sync wrapper for eval outputs
+- `tests/test_upload_eval.py` — mock rclone, verify R2 paths
+
+#### Phase 11: E2E Eval CI (#89)
+
+**Goal:** GitHub Actions workflow runs predict → render → metrics on a small fixture.
+
+**Files to create:**
+
+- `.github/workflows/eval-ci.yml` — matrix: Ubuntu (Xvfb)
+- `tests/test_eval_e2e.py` — fixture-based integration test (`@pytest.mark.slow`)
+- `tests/fixtures/eval/` — checked-in test fixtures:
+  - `tiny.ckpt` (~1 MB) — checkpoint trained for 2 epochs on a handful of samples
+  - `fixture-shard.h5` (~5 MB) — small HDF5 shard with 10-50 samples (enough for one predict batch)
+  - `audio/sample_0/{pred,target}.wav` (~1 MB) — pre-rendered audio for metrics-only testing without VST plugin
+
+**Key behaviors:**
+
+- Runs on PR (if `src/eval.py`, `scripts/`, or `configs/` changed)
+- Uses checked-in fixtures — no R2 credentials, no network dependency, no secrets in CI
+- Validates: predictions exist, audio renders, metrics CSV has expected schema
+- If fixtures grow past ~10 MB, migrate to Git LFS
+
+### PR #4: Documentation (#97)
+
+#### Phase 12: Eval Runbook (#97)
+
+**Goal:** Document how to run the full eval pipeline locally and in Docker.
+
+**Files to create:**
+
+- `docs/eval-runbook.md` — setup, credentials, make targets, Docker, troubleshooting
+
+______________________________________________________________________
 
 ## Appendix A: Glossary
 
@@ -1189,7 +1093,7 @@ and **eval artifacts** (audio files, prediction tensors — no W&B UI benefit).
 
 | File                             | Hardcoded path                       |
 | -------------------------------- | ------------------------------------ |
-| `configs/data/surge_simple.yaml` | `/data/scratch/acw585/surge_simple/` |
+| `configs/data/surge_simple.yaml` | `/data/scratch/acw585/surge-simple/` |
 | `configs/data/surge_mini.yaml`   | `/data/scratch/acw585/surge-mini/`   |
 
 ### Audio Dir Manifests


### PR DESCRIPTION
## Summary

- Align eval pipeline design doc with the authoritative `storage-provenance-spec.md`
- R2 paths: 3-segment → 6-segment eval paths per spec §2
- W&B entity/project: `synth-permutations` → `tinaudio/synth-setter` per spec §10
- W&B artifact naming: conform to spec §4 patterns (`model-flow-simple`, `data-surge-simple`, `eval-surge-simple`, type `eval-results`)
- Fix `job_type` (`eval` → `evaluation`), `add_reference` protocol (`r2://` → `s3://`), add `github_sha` to `wandb.config`
- Adopt spec §1 ID terminology, add cross-references to storage-provenance-spec and promotion-pipeline-reference
- Restructure doc: move Implementation Plan to §12, Dependency Graph to §8

Refs #98, #99, #122

## Test plan

- [ ] Verify no `synth-permutations` references remain
- [ ] Verify no old 3-segment eval paths remain
- [ ] Verify W&B artifact names match spec §4 patterns
- [ ] Confirm `make format` passes