### PR TITLE
ci(github): add issue templates for taxonomy metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,64 @@
+name: Bug
+description: Something isn't working
+title: "fix(<domain>): "
+labels: []
+type: Bug
+body:
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain Label
+      options:
+        - data-pipeline
+        - ci-automation
+        - code-health
+        - evaluation
+        - storage
+        - testing
+        - training
+    validations:
+      required: true
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      options:
+        - data-pipeline v1.0.0
+        - evaluation v1.0.0
+        - training v1.0.0
+        - storage v1.0.0
+        - ci-automation v1.0.0
+        - code-health v1.0.0
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Clear description of the bug
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: input
+    id: parent
+    attributes:
+      label: Parent Issue
+      description: "If this bug is scoped to a phase or epic (e.g., #137)"
+      placeholder: "#"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Design Docs
+    url: https://github.com/tinaudio/synth-setter/tree/main/docs/design
+    about: Check existing design docs before filing

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -1,0 +1,59 @@
+name: Epic
+description: Umbrella issue grouping phases for a work stream
+title: "feat(<domain>): "
+labels: []
+type: Epic
+body:
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain Label
+      description: Primary domain for this epic
+      options:
+        - data-pipeline
+        - ci-automation
+        - code-health
+        - evaluation
+        - storage
+        - testing
+        - training
+    validations:
+      required: true
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      options:
+        - data-pipeline v1.0.0
+        - evaluation v1.0.0
+        - training v1.0.0
+        - storage v1.0.0
+        - ci-automation v1.0.0
+        - code-health v1.0.0
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What this epic delivers and why
+    validations:
+      required: true
+  - type: input
+    id: design-doc
+    attributes:
+      label: Design Doc
+      description: Path to the design doc (e.g., docs/design/eval-pipeline.md)
+      placeholder: "docs/design/"
+    validations:
+      required: true
+  - type: textarea
+    id: phases
+    attributes:
+      label: Phases
+      description: List the planned phases (add as sub-issues after creation)
+      placeholder: |
+        - Phase 1: ...
+        - Phase 2: ...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,54 @@
+name: Feature
+description: A request, idea, or new functionality
+title: "feat(<domain>): "
+labels: []
+type: Feature
+body:
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain Label
+      options:
+        - data-pipeline
+        - ci-automation
+        - code-health
+        - evaluation
+        - storage
+        - testing
+        - training
+    validations:
+      required: true
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      options:
+        - data-pipeline v1.0.0
+        - evaluation v1.0.0
+        - training v1.0.0
+        - storage v1.0.0
+        - ci-automation v1.0.0
+        - code-health v1.0.0
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What this feature should do and why
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: input
+    id: parent
+    attributes:
+      label: Parent Issue
+      description: "If this feature belongs to a phase or epic (e.g., #137)"
+      placeholder: "#"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/phase.yml
+++ b/.github/ISSUE_TEMPLATE/phase.yml
@@ -1,0 +1,67 @@
+name: Phase
+description: Large feature area within an epic
+title: "Phase N: "
+labels: []
+type: Phase
+body:
+  - type: input
+    id: parent-epic
+    attributes:
+      label: Parent Epic
+      description: "Issue number of the parent epic (e.g., #98)"
+      placeholder: "#"
+    validations:
+      required: true
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain Label
+      description: Primary domain for this phase
+      options:
+        - data-pipeline
+        - ci-automation
+        - code-health
+        - evaluation
+        - storage
+        - testing
+        - training
+    validations:
+      required: true
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      options:
+        - data-pipeline v1.0.0
+        - evaluation v1.0.0
+        - training v1.0.0
+        - storage v1.0.0
+        - ci-automation v1.0.0
+        - code-health v1.0.0
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What this phase delivers
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: List the planned tasks (add as sub-issues after creation)
+      placeholder: |
+        - Task N.1: ...
+        - Task N.2: ...
+    validations:
+      required: false
+  - type: input
+    id: blocked-by
+    attributes:
+      label: Blocked By
+      description: "Issue numbers this phase is blocked by (set via sidebar after creation)"
+      placeholder: "#94, #85"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,64 @@
+name: Task
+description: Unit of work (standalone or within a phase)
+title: "Task N.M: "
+labels: []
+type: Task
+body:
+  - type: input
+    id: parent
+    attributes:
+      label: Parent Issue
+      description: "Phase or epic this task belongs to (e.g., #137). Leave blank for standalone tasks."
+      placeholder: "#"
+    validations:
+      required: false
+  - type: dropdown
+    id: domain
+    attributes:
+      label: Domain Label
+      options:
+        - data-pipeline
+        - ci-automation
+        - code-health
+        - evaluation
+        - storage
+        - testing
+        - training
+    validations:
+      required: true
+  - type: dropdown
+    id: milestone
+    attributes:
+      label: Milestone
+      options:
+        - data-pipeline v1.0.0
+        - evaluation v1.0.0
+        - training v1.0.0
+        - storage v1.0.0
+        - ci-automation v1.0.0
+        - code-health v1.0.0
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What this task delivers and acceptance criteria
+    validations:
+      required: true
+  - type: input
+    id: design-doc-ref
+    attributes:
+      label: Design Doc Reference
+      description: "Section reference (e.g., eval-pipeline.md §6.2)"
+      placeholder: ""
+    validations:
+      required: false
+  - type: input
+    id: blocked-by
+    attributes:
+      label: Blocked By
+      description: "Issue numbers this task is blocked by (set via sidebar after creation)"
+      placeholder: "#94"
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- Add GitHub issue form templates for all 5 issue types: Epic, Phase, Task, Bug, Feature
- Each template enforces required taxonomy metadata at creation time: domain label, milestone, parent issue
- Blank issues disabled — forces use of templates in the browser UI
- Templates match conventions in `docs/design/github-taxonomy.md`

Refs #148, #149, #114

## Test plan

- [ ] Click "New Issue" on GitHub — verify template picker shows all 5 types
- [ ] Create a test issue with each template — verify required fields are enforced
- [ ] Verify `type:` field sets native issue type automatically