### PR TITLE
ci(github): enforce taxonomy metadata in PR gate

### DIFF
--- a/.github/workflows/pr-metadata-gate.yaml
+++ b/.github/workflows/pr-metadata-gate.yaml
@@ -66,4 +66,127 @@ jobs:
           fi
 
           echo "✓ Linked issue found"
+
+          # --- Collect linked issue numbers ---
+          # Extract unique issue numbers from timeline connected events and PR body refs
+          ISSUE_NUMBERS=()
+
+          # From timeline: get issue numbers for currently-connected issues
+          TIMELINE_ISSUES=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/timeline" \
+            --paginate --jq '[.[] | select(.event == "connected") | .source.issue.number // empty] | unique | .[]') || true
+          for num in $TIMELINE_ISSUES; do
+            ISSUE_NUMBERS+=("$num")
+          done
+
+          # From PR body: extract #N references (exclude the PR's own number)
+          BODY_ISSUE_NUMS=$(echo "$PR_BODY" | grep -oE '#[0-9]+' | tr -d '#' | sort -un) || true
+          for num in $BODY_ISSUE_NUMS; do
+            if [ "$num" != "$PR_NUMBER" ]; then
+              ISSUE_NUMBERS+=("$num")
+            fi
+          done
+
+          # Deduplicate
+          ISSUE_NUMBERS=($(printf '%s\n' "${ISSUE_NUMBERS[@]}" | sort -un))
+
+          if [ "${#ISSUE_NUMBERS[@]}" -eq 0 ]; then
+            echo "::warning::Could not extract specific issue numbers to validate taxonomy metadata."
+            echo "All PR metadata checks passed (linked issue present, taxonomy skipped)."
+            exit 0
+          fi
+
+          echo "::group::Checking taxonomy metadata on linked issues"
+
+          VALID_TYPES=("Epic" "Phase" "Task" "Bug" "Feature")
+          DOMAIN_LABELS=("data-pipeline" "ci-automation" "code-health" "evaluation" "storage" "testing" "training")
+          FAILURES=""
+
+          for ISSUE_NUM in "${ISSUE_NUMBERS[@]}"; do
+            echo "--- Checking issue #${ISSUE_NUM} ---"
+            MISSING=""
+
+            # Check issue type via GraphQL (issue types are only available in GraphQL)
+            ISSUE_TYPE=$(gh api graphql -f query='
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issue(number: $number) {
+                    issueType { name }
+                  }
+                }
+              }
+            ' -f owner="${REPO%/*}" -f repo="${REPO#*/}" -F number="$ISSUE_NUM" \
+              --jq '.data.repository.issue.issueType.name // ""') || {
+              echo "::warning::Failed to query issue type for #${ISSUE_NUM} via GraphQL, skipping type check"
+              ISSUE_TYPE=""
+            }
+
+            if [ -n "$ISSUE_TYPE" ]; then
+              TYPE_VALID=false
+              for vt in "${VALID_TYPES[@]}"; do
+                if [ "$ISSUE_TYPE" = "$vt" ]; then
+                  TYPE_VALID=true
+                  break
+                fi
+              done
+              if [ "$TYPE_VALID" = true ]; then
+                echo "  ✓ Issue type: ${ISSUE_TYPE}"
+              else
+                MISSING="${MISSING}  - Issue type '${ISSUE_TYPE}' is not one of: ${VALID_TYPES[*]}\n"
+              fi
+            else
+              MISSING="${MISSING}  - No issue type set (must be one of: ${VALID_TYPES[*]})\n"
+            fi
+
+            # Check labels and milestone via REST
+            ISSUE_JSON=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" \
+              --jq '{labels: [.labels[].name], milestone: .milestone.title}') || {
+              echo "::warning::Failed to fetch issue #${ISSUE_NUM} via REST, skipping label/milestone check"
+              continue
+            }
+
+            LABELS=$(echo "$ISSUE_JSON" | jq -r '.labels[]' 2>/dev/null) || LABELS=""
+            MILESTONE=$(echo "$ISSUE_JSON" | jq -r '.milestone // ""' 2>/dev/null) || MILESTONE=""
+
+            # Check for at least one domain label
+            HAS_DOMAIN=false
+            for label in $LABELS; do
+              for domain in "${DOMAIN_LABELS[@]}"; do
+                if [ "$label" = "$domain" ]; then
+                  HAS_DOMAIN=true
+                  echo "  ✓ Domain label: ${label}"
+                  break 2
+                fi
+              done
+            done
+            if [ "$HAS_DOMAIN" = false ]; then
+              MISSING="${MISSING}  - No domain label (must have one of: ${DOMAIN_LABELS[*]})\n"
+            fi
+
+            # Check milestone
+            if [ -n "$MILESTONE" ] && [ "$MILESTONE" != "null" ]; then
+              echo "  ✓ Milestone: ${MILESTONE}"
+            else
+              MISSING="${MISSING}  - No milestone assigned\n"
+            fi
+
+            if [ -n "$MISSING" ]; then
+              FAILURES="${FAILURES}Issue #${ISSUE_NUM} is missing required taxonomy metadata:\n${MISSING}\n"
+            fi
+          done
+
+          echo "::endgroup::"
+
+          if [ -n "$FAILURES" ]; then
+            echo ""
+            echo "========================================="
+            echo "TAXONOMY METADATA FAILURES"
+            echo "========================================="
+            printf "$FAILURES"
+            echo "========================================="
+            echo ""
+            echo "::error::Linked issues are missing required taxonomy metadata. See above for details."
+            exit 1
+          fi
+
+          echo "✓ All linked issues have required taxonomy metadata"
           echo "All PR metadata checks passed."

--- a/.github/workflows/pr-metadata-gate.yaml
+++ b/.github/workflows/pr-metadata-gate.yaml
@@ -97,6 +97,7 @@ jobs:
 
           echo "::group::Checking taxonomy metadata on linked issues"
 
+          # Keep in sync with docs/design/github-taxonomy.md §2 and §6
           VALID_TYPES=("Epic" "Phase" "Task" "Bug" "Feature")
           DOMAIN_LABELS=("data-pipeline" "ci-automation" "code-health" "evaluation" "storage" "testing" "training")
           FAILURES=""

--- a/.github/workflows/pr-metadata-gate.yaml
+++ b/.github/workflows/pr-metadata-gate.yaml
@@ -116,8 +116,9 @@ jobs:
               }
             ' -f owner="${REPO%/*}" -f repo="${REPO#*/}" -F number="$ISSUE_NUM" \
               --jq '.data.repository.issue.issueType.name // ""') || {
-              echo "::warning::Failed to query issue type for #${ISSUE_NUM} via GraphQL, skipping type check"
-              ISSUE_TYPE=""
+              echo "::error::Failed to query issue type for #${ISSUE_NUM} via GraphQL"
+              FAILURES="${FAILURES}Issue #${ISSUE_NUM} is missing required taxonomy metadata:\n  - Could not verify issue type (GraphQL API error)\n\n"
+              continue
             }
 
             if [ -n "$ISSUE_TYPE" ]; then
@@ -139,10 +140,18 @@ jobs:
 
             # Check labels and milestone via REST
             ISSUE_JSON=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" \
-              --jq '{labels: [.labels[].name], milestone: .milestone.title}') || {
-              echo "::warning::Failed to fetch issue #${ISSUE_NUM} via REST, skipping label/milestone check"
+              --jq '{labels: [.labels[].name], milestone: .milestone.title, is_pr: has("pull_request")}') || {
+              echo "::error::Failed to fetch issue #${ISSUE_NUM} via REST"
+              FAILURES="${FAILURES}Issue #${ISSUE_NUM} is missing required taxonomy metadata:\n  - Could not verify labels/milestone (REST API error)\n\n"
               continue
             }
+
+            # Skip pull requests (PRs share the issue number space)
+            IS_PR=$(echo "$ISSUE_JSON" | jq -r '.is_pr') || IS_PR="false"
+            if [ "$IS_PR" = "true" ]; then
+              echo "  (skipping #${ISSUE_NUM} — pull request, not an issue)"
+              continue
+            fi
 
             LABELS=$(echo "$ISSUE_JSON" | jq -r '.labels[]' 2>/dev/null) || LABELS=""
             MILESTONE=$(echo "$ISSUE_JSON" | jq -r '.milestone // ""' 2>/dev/null) || MILESTONE=""
@@ -181,7 +190,7 @@ jobs:
             echo "========================================="
             echo "TAXONOMY METADATA FAILURES"
             echo "========================================="
-            printf "$FAILURES"
+            printf '%b' "$FAILURES"
             echo "========================================="
             echo ""
             echo "::error::Linked issues are missing required taxonomy metadata. See above for details."

--- a/.github/workflows/pr-metadata-gate.yaml
+++ b/.github/workflows/pr-metadata-gate.yaml
@@ -105,6 +105,21 @@ jobs:
             echo "--- Checking issue #${ISSUE_NUM} ---"
             MISSING=""
 
+            # Fetch via REST first — needed to detect PRs before GraphQL call
+            ISSUE_JSON=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" \
+              --jq '{labels: [.labels[].name], milestone: .milestone.title, is_pr: has("pull_request")}') || {
+              echo "::error::Failed to fetch issue #${ISSUE_NUM} via REST"
+              FAILURES="${FAILURES}Issue #${ISSUE_NUM} is missing required taxonomy metadata:\n  - Could not verify (REST API error)\n\n"
+              continue
+            }
+
+            # Skip pull requests (PRs share the issue number space)
+            IS_PR=$(echo "$ISSUE_JSON" | jq -r '.is_pr') || IS_PR="false"
+            if [ "$IS_PR" = "true" ]; then
+              echo "  (skipping #${ISSUE_NUM} — pull request, not an issue)"
+              continue
+            fi
+
             # Check issue type via GraphQL (issue types are only available in GraphQL)
             ISSUE_TYPE=$(gh api graphql -f query='
               query($owner: String!, $repo: String!, $number: Int!) {
@@ -136,21 +151,6 @@ jobs:
               fi
             else
               MISSING="${MISSING}  - No issue type set (must be one of: ${VALID_TYPES[*]})\n"
-            fi
-
-            # Check labels and milestone via REST
-            ISSUE_JSON=$(gh api "repos/${REPO}/issues/${ISSUE_NUM}" \
-              --jq '{labels: [.labels[].name], milestone: .milestone.title, is_pr: has("pull_request")}') || {
-              echo "::error::Failed to fetch issue #${ISSUE_NUM} via REST"
-              FAILURES="${FAILURES}Issue #${ISSUE_NUM} is missing required taxonomy metadata:\n  - Could not verify labels/milestone (REST API error)\n\n"
-              continue
-            }
-
-            # Skip pull requests (PRs share the issue number space)
-            IS_PR=$(echo "$ISSUE_JSON" | jq -r '.is_pr') || IS_PR="false"
-            if [ "$IS_PR" = "true" ]; then
-              echo "  (skipping #${ISSUE_NUM} — pull request, not an issue)"
-              continue
             fi
 
             LABELS=$(echo "$ISSUE_JSON" | jq -r '.labels[]' 2>/dev/null) || LABELS=""


### PR DESCRIPTION
## Summary

- Extends the PR metadata gate workflow to validate taxonomy metadata on all linked issues
- Checks that each linked issue has: an issue type (Epic/Phase/Task/Bug/Feature), at least one domain label (data-pipeline, ci-automation, code-health, evaluation, storage, testing, training), and a milestone assigned
- Uses GraphQL for issue type (not available via REST) and REST for labels/milestones
- Fails with a clear summary listing which issues are missing which metadata

## Test plan

- [ ] Open a PR linking an issue that has all three metadata fields set -- gate should pass
- [ ] Open a PR linking an issue missing an issue type -- gate should fail naming the issue and missing field
- [ ] Open a PR linking an issue missing a domain label -- gate should fail
- [ ] Open a PR linking an issue missing a milestone -- gate should fail
- [ ] Open a PR linking multiple issues where one is complete and one is missing metadata -- gate should fail listing only the incomplete issue

Refs #148, #149, #114