### PR TITLE
fix(ci): deduplicate check runs in auto-approve to ignore stale failures

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -90,7 +90,23 @@ jobs:
             exit 0
           fi
           # --- Condition 2: All CI checks pass ---
-          CHECK_DATA=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --jq '.check_runs[] | select(.name != "auto-approve" and .name != "Auto-approve status" and .name != "claude-review") | "\(.status) \(.conclusion // "none") \(.name)"')
+          # BUG FIX: The check-runs API returns ALL runs for a commit, including
+          # superseded re-runs of the same check. If check-pr-metadata failed on
+          # the first trigger but passed on re-run, the old failure still appears.
+          # We must deduplicate by check name and only consider the LATEST run per
+          # name (highest ID = most recent). Without this, a stale failure from a
+          # re-triggered check permanently blocks auto-approve.
+          # See: PR #142 — check-pr-metadata passed on re-run but auto-approve
+          # still saw "1 check(s) failed" from the original run.
+          CHECK_DATA=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate --jq '
+            [.check_runs[]
+              | select(.name != "auto-approve" and .name != "Auto-approve status" and .name != "claude-review")
+            ]
+            | group_by(.name)
+            | map(sort_by(.id) | last)
+            | .[]
+            | "\(.status) \(.conclusion // "none") \(.name)"
+          ')
           PENDING=$(echo "$CHECK_DATA" | grep -c "^queued\|^in_progress" || true)
           FAILED=$(echo "$CHECK_DATA" | grep -v "^completed success\|^completed skipped\|^completed neutral\|^queued\|^in_progress" | grep -c . || true)
           if [ "$PENDING" -gt 0 ]; then

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -98,7 +98,7 @@ jobs:
           # re-triggered check permanently blocks auto-approve.
           # See: PR #142 — check-pr-metadata passed on re-run but auto-approve
           # still saw "1 check(s) failed" from the original run.
-          CHECK_DATA=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --paginate --jq '
+          CHECK_DATA=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --jq '
             [.check_runs[]
               | select(.name != "auto-approve" and .name != "Auto-approve status" and .name != "claude-review")
             ]


### PR DESCRIPTION
## Summary

- Fix auto-approve workflow counting superseded/stale check runs as failures
- The check-runs API returns ALL runs for a commit, including re-runs of the same check. If `check-pr-metadata` failed once then passed on re-trigger, the old failure was still counted, permanently blocking auto-approve.
- Fix: group check runs by name, sort by ID, take only the latest run per name before evaluating pass/fail/pending
- Add `PR Linked Issue Check` to the `workflow_run` trigger list so auto-approve re-evaluates after the metadata gate completes (previously required manual `workflow_dispatch`)

## Root cause

Observed on PR #142: `check-pr-metadata` passed on re-run but auto-approve reported "1 check(s) failed" from the original stale run. See [workflow run logs](https://github.com/tinaudio/synth-setter/actions/runs/23367370690/job/67983960745#step:6:185).

## Related

- Extends auto-approve originally added in PR #57 / #109
- Issue #174 tracks the stale check-run bug

## Test plan

- [ ] Re-run auto-approve on PR #142 via workflow_dispatch — should now pass
- [ ] Open a PR where check-pr-metadata fails, then re-trigger it to pass — auto-approve should see only the passing run
- [ ] Open a PR — auto-approve should trigger automatically after PR Linked Issue Check completes (no manual dispatch needed)

Fixes #174