### PR TITLE
feat(ci): add CODEOWNERS for automatic review routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Default owner for everything
+* @ktinubu
+
+# CI/CD workflows
+.github/ @ktinubu
+
+# ML code
+src/ @ktinubu
+
+# Pipeline orchestration
+scripts/ @ktinubu
+
+# Configuration
+configs/ @ktinubu


### PR DESCRIPTION
## Rationale

GitHub's CODEOWNERS mechanism automatically assigns reviewers to pull requests based on which files are changed. Adding a CODEOWNERS file ensures every PR gets a designated reviewer without manual assignment, reducing the chance of unreviewed merges and speeding up the review cycle.

## What this PR does

Adds `.github/CODEOWNERS` with `@ktinubu` as the default owner and path-specific rules for:

| Path | Owner |
|------|-------|
| `*` (default) | `@ktinubu` |
| `.github/` | `@ktinubu` |
| `src/` | `@ktinubu` |
| `scripts/` | `@ktinubu` |
| `configs/` | `@ktinubu` |

## Pros

- **Automatic review assignment** — no manual reviewer selection needed.
- **Audit trail** — required reviews are enforced per path when combined with branch protection rules.
- **Scalable** — as the team grows, ownership lines can be added for new collaborators without changing workflow.

## Cons

- **Single owner** — currently all paths route to `@ktinubu`. If the sole owner is unavailable, PRs may stall. Mitigated by adding more owners later.
- **Maintenance overhead** — CODEOWNERS must be updated when directory structure changes, though this is minimal.

## Verification steps

1. Confirm `.github/CODEOWNERS` exists on the branch.
2. Open a test PR touching `src/` — verify `@ktinubu` is auto-requested as reviewer.
3. Validate syntax: each line must be `<pattern> <owner>` with owners prefixed by `@`.

Closes #176