### PR TITLE
fix(ci): set codecov threshold to 1% — was allowing 100% coverage decrease

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,15 +1,9 @@
 coverage:
   status:
-    # measures overall project coverage
     project:
       default:
-        threshold: 100% # how much decrease in coverage is needed to not consider success
+        threshold: 1% # fail if coverage drops by more than 1%
 
-    # measures PR or single commit coverage
     patch:
       default:
-        threshold: 100% # how much decrease in coverage is needed to not consider success
-
-
-    # project: off
-    # patch: off
+        threshold: 1% # fail if new code has >1% less coverage than target


### PR DESCRIPTION
## Summary

- Fix misconfigured Codecov threshold in `.github/codecov.yml`
- Change `threshold` from `100%` to `1%` for both `project` and `patch` status checks
- Update inline comments to accurately describe the threshold behavior

## Rationale

The previous `threshold: 100%` configuration told Codecov to allow up to a 100 percentage-point decrease in coverage before failing the status check. This effectively disabled the coverage gate entirely — any PR could drop coverage to 0% and still pass. Setting the threshold to `1%` means Codecov will fail the check if coverage drops by more than 1 percentage point, providing meaningful protection against coverage regressions.

## Pros / Cons

**Pros:**
- Coverage gates now actually enforce coverage standards
- PRs that significantly reduce coverage will be flagged before merge
- 1% threshold is permissive enough to avoid false positives from minor fluctuations

**Cons:**
- PRs that legitimately remove large amounts of tested code (e.g., deleting a module) may need the threshold temporarily adjusted or the check overridden
- Minor test flakiness could occasionally cause false negatives near the boundary

## Verification

- [ ] Open `.github/codecov.yml` and confirm both `project` and `patch` thresholds are `1%`
- [ ] Confirm YAML is valid (validated locally with `yaml.safe_load`)
- [ ] Confirm no other codecov settings were unintentionally changed
- [ ] After merge, verify Codecov status checks appear on subsequent PRs

Closes #177