### PR TITLE
feat(ci): add automated semantic versioning with python-semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,24 @@
+name: Semantic Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: python-semantic-release/python-semantic-release@v9
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# Coexists with release-drafter.yml:
+# - Release Drafter maintains a rolling draft release from PR labels (preview)
+# - This workflow creates published releases from conventional commits (official)
 name: Semantic Release
 
 on:
@@ -10,12 +13,16 @@ permissions:
 
 jobs:
   release:
+    if: "!contains(github.event.head_commit.message, 'chore(release)')"
     runs-on: ubuntu-latest
+    concurrency:
+      group: release-${{ github.ref }}
+      cancel-in-progress: false
     permissions:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,11 @@ black = true
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"
 build_command = ""
-commit_message = "chore(release): {version}"
+commit_message = "chore(release): {version} [skip ci]"
 changelog_file = "CHANGELOG.md"
 
+# Major bumps: handled by default via "feat!:" prefix or "BREAKING CHANGE:" footer
+# Pre-1.0: breaking changes bump minor (standard semver pre-1.0 behavior)
 [tool.semantic_release.commit_parser_options]
 allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"]
 minor_tags = ["feat"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,18 @@ wrap-descriptions = 99
 style = "sphinx"
 black = true
 
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+branch = "main"
+build_command = ""
+commit_message = "chore(release): {version}"
+changelog_file = "CHANGELOG.md"
+
+[tool.semantic_release.commit_parser_options]
+allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"]
+minor_tags = ["feat"]
+patch_tags = ["fix", "perf"]
+
 [tool.coverage.report]
 exclude_lines = [
     "pragma: nocover",


### PR DESCRIPTION
## Summary

- Add `python-semantic-release` configuration to `pyproject.toml` and a GitHub Actions workflow to automate versioning, changelog generation, and GitHub Releases on every push to `main`.

## Rationale

Conventional commits are already enforced via the gitlint pre-commit hook, so all the structured metadata needed for automatic version bumps is already present in the commit history. This PR wires up `python-semantic-release` to consume that metadata and produce:

- **Semantic version bumps** in `pyproject.toml` (`feat` -> minor, `fix`/`perf` -> patch)
- **Auto-generated CHANGELOG.md**
- **GitHub Releases** with release notes

Release Drafter remains in place for draft release notes from PR labels; semantic-release handles the actual tagging and versioning.

## Pros

- Zero manual effort for versioning — merge to `main` and the pipeline handles the rest
- Version in `pyproject.toml` stays in sync with git tags automatically
- Changelog is generated from commit messages, which are already validated
- No PyPI publishing configured (`build_command = ""`), keeping scope minimal

## Cons

- Adds another CI workflow that runs on every push to `main` (lightweight — single action, no Python install needed)
- Release Drafter and semantic-release both create GitHub Releases; may want to consolidate later

## Changes

- `pyproject.toml`: added `[tool.semantic_release]` and `[tool.semantic_release.commit_parser_options]` sections
- `.github/workflows/release.yml`: new workflow using `python-semantic-release/python-semantic-release@v9`

## Verification steps

### 1. Config validation

```bash
# TOML is valid
python3 -c "import tomllib; tomllib.load(open('pyproject.toml', 'rb'))"

# Workflow YAML is valid
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"

# Pre-commit hooks pass
make format
```

### 2. Dry-run version detection

```bash
# Verify semantic-release can parse commit history and determine next version
# (requires pip install python-semantic-release)
semantic-release version --noop --print
```

### 3. Commit loop protection

```bash
# Verify the release commit won't re-trigger the workflow
# Check that commit_message contains [skip ci] OR the job has an if-guard
grep -E 'skip ci|chore\(release\)' pyproject.toml
grep -E 'if:.*chore.release|skip ci' .github/workflows/release.yml
```

### 4. Release Drafter conflict check

```bash
# List all workflows that create GitHub Releases
grep -rl 'releases' .github/workflows/ | head -10

# Verify Release Drafter and semantic-release won't produce duplicate releases
# Either: Release Drafter is removed, or semantic-release skips GH release creation,
# or Release Drafter only drafts (doesn't publish)
```

### 5. Breaking change handling

```bash
# Verify major version bumps are configured (or explicitly disabled for pre-1.0)
grep -A5 'commit_parser_options' pyproject.toml
# Should show major_tags or a comment explaining the pre-1.0 policy
```

### 6. Workflow permissions and checkout

```bash
# contents: write is set at job level
grep 'contents: write' .github/workflows/release.yml

# fetch-depth: 0 is set (required for commit history analysis)
grep 'fetch-depth: 0' .github/workflows/release.yml
```

Closes #182