### PR TITLE
feat(code-health): add pr-checkbox verification skill

### DIFF
--- a/.claude/skills/pr-checkbox/SKILL.md
+++ b/.claude/skills/pr-checkbox/SKILL.md
@@ -7,6 +7,76 @@ description: Rigid process skill for posting PR verification results. Use this s
 
 This is a **rigid** process skill. Follow every step exactly — no shortcuts, no "PASS" assertions without evidence.
 
+## Verify behavior, not implementation
+
+This is the single most important principle in this skill. Read it twice.
+
+**Grepping a diff is not verification.** Checking that a line exists in a diff proves someone typed it — it does not prove the system works. A config file can have the right content and still be ignored. A workflow can have the right YAML and still fail at runtime. A dependency can be listed and still not install.
+
+When verifying a PR, you must test what the change **does**, not what it **says**. Every verification step should answer: "does the system behave correctly after this change?" — not "does the diff contain the expected string?"
+
+### The hierarchy of verification (strongest to weakest)
+
+1. **Run the actual tool and observe output** — `pyright --project pyrightconfig.json` proves type checking works. `pytest -n auto` proves parallel execution works. `python3 -c "import yaml; yaml.safe_load(open('codecov.yml'))"` proves YAML is valid. This is real verification.
+
+2. **Query the live system** — `gh pr view --json labels` to confirm metadata is set. `gh api repos/.../contents/FILE` to confirm a file exists on the branch. These test actual state, not diff content.
+
+3. **Parse and validate file content** — Read the actual file (not the diff), parse it programmatically, and assert properties. `python3 -c "import json; c=json.load(open('config.json')); assert c['mode'] == 'basic'"` is better than `grep 'basic' config.json`.
+
+4. **Grep the diff** — This is the weakest form. It only confirms a string is present in the change. Use this ONLY for "does the PR body contain `Closes #N`" checks or when no stronger method is possible. Never use `gh pr diff | grep` as the sole verification for functional behavior.
+
+### Examples: bad vs. good
+
+**Bad** (verifying implementation):
+```bash
+$ gh pr diff 191 | grep 'threshold: 1%'
++        threshold: 1% # fail if coverage drops by more than 1%
+```
+This proves someone wrote "1%" in the diff. It doesn't prove codecov will enforce it.
+
+**Good** (verifying behavior):
+```bash
+$ python3 -c "
+import yaml
+cfg = yaml.safe_load(open('.github/codecov.yml'))
+threshold = cfg['coverage']['status']['project']['default']['threshold']
+print(f'Project threshold: {threshold}')
+assert threshold == '1%', f'Expected 1%, got {threshold}'
+"
+Project threshold: 1%
+```
+This parses the actual file and asserts the value programmatically.
+
+**Bad** (verifying implementation):
+```bash
+$ gh pr diff 195 | grep 'typeCheckingMode'
++  "typeCheckingMode": "basic",
+```
+
+**Good** (verifying behavior):
+```bash
+$ pyright --project pyrightconfig.json 2>&1 | tail -1
+0 errors, 0 warnings, 0 informations
+```
+This runs the actual type checker with the actual config and proves it works.
+
+### When to check out the PR branch
+
+To verify behavior, you often need the PR's code locally. Check out the branch or use an existing worktree:
+
+```bash
+# Option 1: Use existing worktree if available
+cd /path/to/worktree
+
+# Option 2: Create a temporary worktree
+git worktree add /tmp/verify-pr-NNN origin/branch-name
+cd /tmp/verify-pr-NNN
+# ... run verification ...
+git worktree remove /tmp/verify-pr-NNN
+```
+
+Diff-grepping should be reserved for metadata checks (labels, milestones, issue references) where the "behavior" IS the text content.
+
 ## Why this matters
 
 Verification without evidence is just opinion. When someone reads a PR months later, they need to see exactly what was run and what came back — not a table of "PASS" labels. Checkboxes with commands and output make verification auditable, reproducible, and trustworthy.
@@ -21,9 +91,10 @@ Every verification step gets a checkbox. Every checkbox shows the command and it
 
 For every verification step defined in the PR:
 
-1. Run the exact command
-2. Capture the full console output
-3. Determine: does this **unambiguously** pass, fail, or is it ambiguous?
+1. Check out the PR branch or use an existing worktree — you need the actual files, not just the diff
+2. Run commands that test **behavior** (run the tool, parse the file, execute the config)
+3. Capture the full console output
+4. Determine: does this **unambiguously** pass, fail, or is it ambiguous?
 
 ### Step 2: Format results with checkboxes
 
@@ -136,8 +207,10 @@ Include the gist URL in your PR comment alongside the summary.
 
 ## Anti-patterns — do NOT do these
 
+- **Grepping the diff as your primary verification** — `gh pr diff | grep 'expected line'` proves a line was typed, not that it works. Always prefer running the tool, parsing the file, or querying live state.
 - Writing a table with "PASS" / "FAIL" columns but no commands or output
 - Ticking `[x]` when output contains warnings you haven't investigated
 - Saying "all checks pass" without showing what was run
 - Posting verification results without the actual console output
 - Summarizing output as "looks good" instead of showing it
+- Using `gh pr diff | grep` for anything other than metadata checks (issue refs, PR body content)

--- a/.claude/skills/pr-checkbox/SKILL.md
+++ b/.claude/skills/pr-checkbox/SKILL.md
@@ -7,6 +7,8 @@ description: Rigid process skill for posting PR verification results. Use this s
 
 This is a **rigid** process skill. No shortcuts. No "PASS" assertions without evidence.
 
+---
+
 ## VERIFY BEHAVIOR, NOT IMPLEMENTATION
 
 This is the foundation of this entire skill. Everything else is formatting. If you get this wrong, perfect checkboxes are worthless.
@@ -21,58 +23,64 @@ Treat the system as a **black box**. You put something in, you check what comes 
 
 **The litmus test:** If someone rewrote the internals from scratch but kept the same inputs and outputs, would your verification still pass? If not, you're testing implementation.
 
-### The hierarchy (strongest → weakest)
+---
 
-| Level | What you do | Example | Tests |
-|-------|------------|---------|-------|
-| **1. Exercise the code path** | Actually invoke the tool/system and observe the result | `pyright --project pyrightconfig.json` | Does type checking actually work? |
-| **2. Trigger the behavior end-to-end** | Create a real input and check the real output | Create an issue with `gh issue create`, then verify it has correct metadata | Does the workflow actually produce the right result? |
-| **3. Parse the actual file and assert properties** | Read the deployed file, parse it, assert | `python3 -c "import yaml; cfg=yaml.safe_load(open('codecov.yml')); assert cfg[...] == '1%'"` | Does the file contain valid, correct values? |
-| **4. Query live system state** | Ask GitHub/CI what the current state is | `gh pr view --json labels` | Is the metadata actually set? |
-| **5. Grep the diff** | Check if a string exists in the change | `gh pr diff \| grep 'Closes #123'` | Was a specific string typed? |
+## The Hierarchy (strongest → weakest)
 
-**Level 5 is almost always wrong for functional checks.** It only confirms someone typed a string. Use it exclusively for PR body content checks ("does it reference the issue?") where the text IS the behavior.
+| Level | What you do | Example |
+|-------|------------|---------|
+| **1. Run the tool** | Invoke the actual tool/system, observe the result | `pyright --project pyrightconfig.json` |
+| **2. Trigger end-to-end** | Create a real input, check the real output | `gh issue create ...` then verify metadata via API |
+| **3. Query live system state** | Ask the live platform what it sees | `gh api repos/.../codeowners/errors` |
+| **4. Parse file and assert** | Read a config, parse it, check values | `python3 -c "import yaml; ..."` |
+| **5. Grep the diff** | Check if a string exists in the change | `gh pr diff \| grep '...'` |
 
-### Concrete DO / DON'T
+### The escalation rule
 
-```
-DO:   Run the tool         →  pyright --project pyrightconfig.json
-DO:   Exercise the path    →  gh issue create ... && gh api .../issues/N to verify metadata
-DO:   Assert on output     →  assert result.exit_code == 0
-DO:   Check side effects   →  ls output_file.json && python3 -c "assert valid"
+**You MUST use the highest level available.** If Level 1 is possible, Levels 2–5 are not acceptable. If Level 2 is possible, Levels 3–5 are not acceptable. You only descend when a higher level is genuinely impossible (tool not installed, no test fixtures, external service unreachable).
 
-DON'T: Grep the diff       →  gh pr diff | grep 'typeCheckingMode'
-DON'T: Check internal state →  assert len(obj._internal_list) == 3
-DON'T: Verify wiring       →  "did the function call parseInput()?"
-DON'T: Read instead of run  →  parse config to check a value when you could run the tool
-```
-
-### If verification steps test implementation, rewrite them
-
-When you encounter verification steps (in a PR description or issue) that test implementation instead of behavior, **rewrite them**. Show what you changed:
+When you descend, you MUST state why:
 
 ```markdown
-- [x] **Pyright config works** *(rewritten: original checked `gh pr diff | grep typeCheckingMode` → now exercises pyright directly)*
-  ```bash
-  $ pyright --project pyrightconfig.json 2>&1 | tail -1
-  0 errors, 0 warnings, 0 informations
-  ```
+- [x] **Config values are correct** *(Level 4 — codecov CLI not available in this environment; fell back to YAML parse)*
 ```
 
-Always include `(rewritten: original checked X → now checks Y)` so reviewers can see what changed and why.
+If you do not state a reason, the check is invalid.
 
-### Spend time understanding what each check is meant to prove
+---
+
+## Parsing Is Not Exercising
+
+This is the #1 way this skill gets violated. Replacing `grep` with `yaml.safe_load()` or `toml.load()` and calling it behavioral is wrong. It is the same thing in a trench coat.
+
+**Parsing a config file proves the VALUE IS IN THE FILE. Running the tool proves THE TOOL WORKS WITH THAT VALUE.** These are different claims.
+
+Ask yourself: **"Am I running the tool, or reading its inputs?"**
+
+| Reading the input (NOT behavioral) | Running the tool (behavioral) |
+|-------------------------------------|-------------------------------|
+| `yaml.safe_load(open('codecov.yml'))` | `codecov validate codecov.yml` |
+| `make -n test` (prints the recipe) | `make test 2>&1 \| grep gw` (runs the recipe) |
+| Parse `.github/workflows/test.yml` | `gh workflow run test.yml && gh run watch` |
+| `toml.load('pyproject.toml')` | `pytest --co -q` (proves pytest loads the config) |
+| `cat CODEOWNERS` | `gh api repos/.../codeowners/errors` |
+| `python3 -c "import json; ..."` on a config | Invoke whatever system consumes that config |
+
+**If your verification command does not INVOKE the system under test, it is not behavioral. Go up the hierarchy.**
+
+---
+
+## Spend Time Understanding What Each Check Proves
 
 Before writing a verification command, ask: **what is this check actually trying to prove?**
 
-- "CODEOWNERS exists" → The real question is: will GitHub auto-assign reviewers? Exercise it: push a change to a covered path and check if a reviewer is requested, or at minimum verify GitHub's API recognizes the file on the branch.
-- "pytest-xdist in requirements" → The real question is: do tests run in parallel? Exercise it: run `pytest -n auto` and check for `[gw0]` worker prefixes in the output.
-- "Nightly workflow has cron trigger" → The real question is: will this workflow fire on schedule? Exercise it: trigger the workflow manually via `gh workflow run` and check it starts, or at minimum validate the cron expression with a parser.
-- "Skill has frontmatter" → The real question is: does the skill trigger and produce the right output? Exercise it: invoke the skill with a test input and check the output shape.
+- "CODEOWNERS exists" → Real question: will GitHub auto-assign reviewers? Exercise: `gh api repos/.../codeowners/errors` returns no errors. Better: push a change and check reviewer assignment.
+- "pytest-xdist in requirements" → Real question: do tests run in parallel? Exercise: run `pytest -n auto` and check for `[gw0]` worker prefixes.
+- "Nightly workflow has cron trigger" → Real question: will this fire on schedule? Exercise: `gh workflow run` and check it starts.
+- "Codecov threshold is 1%" → Real question: will Codecov enforce 1%? Exercise: `codecov validate codecov.yml` or trigger a coverage run.
+- "Makefile has `-n auto`" → Real question: does `make test` run tests in parallel? Exercise: run `make test` and observe parallel workers.
 
-## The Rule
-
-Every verification step gets a checkbox. Every checkbox shows the command run and its console output. The checkbox is only ticked if the result is unambiguous.
+---
 
 ## Process
 
@@ -81,38 +89,53 @@ Every verification step gets a checkbox. Every checkbox shows the command run an
 You need the actual files to exercise actual behavior. Diff-grepping is not acceptable.
 
 ```bash
-git worktree add /tmp/verify-pr-NNN origin/branch-name
+git fetch origin <branch>
+git worktree add /tmp/verify-pr-NNN origin/<branch>
 cd /tmp/verify-pr-NNN
 ```
 
 ### Step 2: Design behavioral checks
 
-For each verification step, ask: "what promise does this change make?" Then design a command that tests whether the promise was kept by exercising the actual code path.
+For each verification step, ask: **"what promise does this change make?"** Then design a command that tests whether the promise was kept by **invoking the actual system**.
 
-If the original verification steps test implementation (grep the diff, check if a line is present), **rewrite them** to test behavior. Show the before → after.
+Start at Level 1. Only descend if Level 1 is impossible, and state why.
 
-### Step 3: Run and capture output
+If the original verification steps (from a PR description, issue, or task) test implementation, **rewrite them**. Show the before → after.
+
+### Step 3: Self-audit (MANDATORY)
+
+Before running anything, review every check you designed and answer these three questions:
+
+1. **Does this command INVOKE the system, or READ/PARSE a file?**
+2. **If someone rewrote the internals, would this check still pass?**
+3. **Is there a higher-level check I skipped because parsing felt easier?**
+
+If any answer is "it parses a file" and a higher-level option exists, rewrite it now. Do not proceed until every check is at the highest feasible level.
+
+**Hard gate:** If more than half your checks parse/read files instead of running tools, STOP and redesign. You are testing implementation.
+
+### Step 4: Run and capture output
 
 Run each command and capture the full console output. Every check must show:
 1. The exact command run (prefixed with `$`)
 2. The actual console output
 3. Your determination: unambiguous pass, fail, or ambiguous
 
-### Step 4: Format with checkboxes
+### Step 5: Format with checkboxes
 
 Size-based placement:
 
 #### Small output (< ~20 lines) — inline
 
 ```markdown
-- [x] **Pyright runs clean with this config**
+- [x] **Pyright runs clean with this config** *(Level 1 — invoked pyright directly)*
   ```bash
   $ pyright --project pyrightconfig.json 2>&1 | tail -1
   0 errors, 0 warnings, 0 informations
   ```
 ```
 
-#### Medium output (20-100 lines) — PR comment with link
+#### Medium output (20–100 lines) — PR comment with link
 
 ```markdown
 - [x] **Tests run in parallel** — [verification output](#issuecomment-12345)
@@ -124,24 +147,109 @@ Size-based placement:
 - [x] **Full test suite passes** — [summary + gist](#issuecomment-67890)
 ```
 
-### Step 5: Tick or leave unchecked
+### Step 6: Tick or leave unchecked
 
 - **`[x]`** — Output unambiguously confirms the promise was kept. Zero doubt.
 - **`[ ]`** — Any ambiguity. Explain what's unclear.
 
 A false `[x]` is worse than a cautious `[ ]`.
 
-### Step 6: Post to the PR
+### Step 7: Post to the PR
 
 Post as a comment with header `## Verification Results`.
 
-## Anti-patterns
+---
 
-- **Grepping the diff as verification** — `gh pr diff | grep 'expected line'` proves a line was typed. It does not prove the system works. This is the #1 failure mode.
-- **Parsing a file when you could run the tool** — If you can exercise the code path, do that instead of reading the config. Running `pyright` beats reading `pyrightconfig.json`.
-- **Checking that a file exists instead of checking that it works** — `ls SKILL.md` proves a file is there. Invoking the skill proves it works.
-- **Writing PASS/FAIL tables without commands or output**
-- **Ticking `[x]` when output contains warnings you haven't investigated**
-- **Saying "all checks pass" without showing evidence**
+## Rewriting Implementation Checks
 
-## Tests should be documentation of the requirements, not a transcript of the code.
+When you encounter verification steps that test implementation instead of behavior, **rewrite them**. Always include the annotation showing what changed and why:
+
+### Example: YAML parsing → tool invocation
+
+```markdown
+BEFORE (Level 4 — parses input):
+- [x] **Codecov threshold is 1%**
+  $ python3 -c "import yaml; c=yaml.safe_load(open('codecov.yml'));
+    assert c['coverage']['status']['project']['default']['threshold'] == '1%'"
+
+AFTER (Level 1 — runs the tool):
+- [x] **Codecov config is valid and accepted** *(rewritten: original parsed YAML asserting threshold value → now validates config through codecov CLI)*
+  $ codecov validate codecov.yml
+  Valid!
+```
+
+### Example: Makefile dry-run → actual execution
+
+```markdown
+BEFORE (Level 4 — reads the recipe):
+- [x] **make test invokes parallel**
+  $ make -n test
+  pytest -n auto -m "not slow"
+
+AFTER (Level 1 — runs the recipe):
+- [x] **make test runs tests in parallel** *(rewritten: original used `make -n` dry run → now runs `make test` and checks for worker prefixes)*
+  $ make test 2>&1 | head -20 | grep -E 'gw[0-9]'
+  [gw0] PASSED tests/test_basic.py::test_init
+  [gw1] PASSED tests/test_basic.py::test_load
+```
+
+### Example: Workflow YAML parsing → workflow trigger
+
+```markdown
+BEFORE (Level 4 — parses the workflow file):
+- [x] **CI uses parallel**
+  $ python3 -c "import yaml; wf=yaml.safe_load(open('.github/workflows/test.yml'));
+    assert '-n auto' in wf['jobs']['test']['steps'][2]['run']"
+
+AFTER (Level 2 — triggers the workflow):
+- [x] **CI workflow runs and succeeds** *(rewritten: original parsed workflow YAML for flags → now triggers workflow and checks result)*
+  $ gh workflow run test.yml --ref ci/branch && sleep 30 && gh run list -w test.yml -L 1 --json status --jq '.[0].status'
+  completed
+```
+
+### Annotation format
+
+Always use this pattern so reviewers see what changed:
+
+```
+*(rewritten: original checked X → now exercises Y)*
+```
+
+or when descending:
+
+```
+*(Level N — reason higher level is not feasible)*
+```
+
+---
+
+## Anti-Patterns
+
+1. **Grepping the diff as verification** — `gh pr diff | grep 'expected line'` proves a line was typed. It does not prove the system works.
+2. **Parsing a config when you could run the tool** — `yaml.safe_load` is not behavioral. If the tool exists, run it.
+3. **Dry-running instead of running** — `make -n test` reads the recipe. `make test` runs it. These prove different things.
+4. **Checking that a file exists instead of checking that it works** — `ls SKILL.md` proves a file is there. Invoking the skill proves it works.
+5. **Writing PASS/FAIL tables without commands or output**
+6. **Ticking `[x]` when output contains warnings you haven't investigated**
+7. **Saying "all checks pass" without showing evidence**
+8. **Calling `yaml.safe_load` or `toml.load` "behavioral"** — It is not. It is reading an input, not running a system.
+
+---
+
+## Quick Reference
+
+```
+ALWAYS: Run the tool, trigger the behavior, observe the output.
+NEVER:  Read the config, parse the file, grep the diff — unless forced.
+
+ALWAYS: State the hierarchy level and justify descent.
+NEVER:  Silently drop to Level 4 because it's easier.
+
+ALWAYS: Show the command and its output.
+NEVER:  Assert PASS without evidence.
+
+ALWAYS: Rewrite implementation checks into behavioral checks.
+NEVER:  Accept a check because "it's better than grep."
+```
+
+Tests should be documentation of the requirements, not a transcript of the code.

--- a/.claude/skills/pr-checkbox/SKILL.md
+++ b/.claude/skills/pr-checkbox/SKILL.md
@@ -5,212 +5,143 @@ description: Rigid process skill for posting PR verification results. Use this s
 
 # PR Verification Checkbox Skill
 
-This is a **rigid** process skill. Follow every step exactly — no shortcuts, no "PASS" assertions without evidence.
+This is a **rigid** process skill. No shortcuts. No "PASS" assertions without evidence.
 
-## Verify behavior, not implementation
+## VERIFY BEHAVIOR, NOT IMPLEMENTATION
 
-This is the single most important principle in this skill. Read it twice.
+This is the foundation of this entire skill. Everything else is formatting. If you get this wrong, perfect checkboxes are worthless.
 
-**Grepping a diff is not verification.** Checking that a line exists in a diff proves someone typed it — it does not prove the system works. A config file can have the right content and still be ignored. A workflow can have the right YAML and still fail at runtime. A dependency can be listed and still not install.
+### What this means
 
-When verifying a PR, you must test what the change **does**, not what it **says**. Every verification step should answer: "does the system behave correctly after this change?" — not "does the diff contain the expected string?"
+Treat the system as a **black box**. You put something in, you check what comes out. You do not care how the inside works. You care whether the *promise* was kept.
 
-### The hierarchy of verification (strongest to weakest)
+**The restaurant test:** You order a medium-rare steak. When the plate arrives, you check if the steak is medium-rare. You do NOT go into the kitchen and check if the chef used a cast-iron skillet, flipped it three times, or seasoned it with kosher salt. If the chef switches to a better grill tomorrow, the steak is still medium-rare — your test should still pass.
 
-1. **Run the actual tool and observe output** — `pyright --project pyrightconfig.json` proves type checking works. `pytest -n auto` proves parallel execution works. `python3 -c "import yaml; yaml.safe_load(open('codecov.yml'))"` proves YAML is valid. This is real verification.
+**The contract:** Every change makes a promise. "This config will make pyright check types in basic mode." "This workflow will run tests every night at 6am UTC." "This Makefile target will run tests in parallel." The verification tests the *promise*, not the *wiring* that fulfills it.
 
-2. **Query the live system** — `gh pr view --json labels` to confirm metadata is set. `gh api repos/.../contents/FILE` to confirm a file exists on the branch. These test actual state, not diff content.
+**The litmus test:** If someone rewrote the internals from scratch but kept the same inputs and outputs, would your verification still pass? If not, you're testing implementation.
 
-3. **Parse and validate file content** — Read the actual file (not the diff), parse it programmatically, and assert properties. `python3 -c "import json; c=json.load(open('config.json')); assert c['mode'] == 'basic'"` is better than `grep 'basic' config.json`.
+### The hierarchy (strongest → weakest)
 
-4. **Grep the diff** — This is the weakest form. It only confirms a string is present in the change. Use this ONLY for "does the PR body contain `Closes #N`" checks or when no stronger method is possible. Never use `gh pr diff | grep` as the sole verification for functional behavior.
+| Level | What you do | Example | Tests |
+|-------|------------|---------|-------|
+| **1. Exercise the code path** | Actually invoke the tool/system and observe the result | `pyright --project pyrightconfig.json` | Does type checking actually work? |
+| **2. Trigger the behavior end-to-end** | Create a real input and check the real output | Create an issue with `gh issue create`, then verify it has correct metadata | Does the workflow actually produce the right result? |
+| **3. Parse the actual file and assert properties** | Read the deployed file, parse it, assert | `python3 -c "import yaml; cfg=yaml.safe_load(open('codecov.yml')); assert cfg[...] == '1%'"` | Does the file contain valid, correct values? |
+| **4. Query live system state** | Ask GitHub/CI what the current state is | `gh pr view --json labels` | Is the metadata actually set? |
+| **5. Grep the diff** | Check if a string exists in the change | `gh pr diff \| grep 'Closes #123'` | Was a specific string typed? |
 
-### Examples: bad vs. good
+**Level 5 is almost always wrong for functional checks.** It only confirms someone typed a string. Use it exclusively for PR body content checks ("does it reference the issue?") where the text IS the behavior.
 
-**Bad** (verifying implementation):
-```bash
-$ gh pr diff 191 | grep 'threshold: 1%'
-+        threshold: 1% # fail if coverage drops by more than 1%
+### Concrete DO / DON'T
+
 ```
-This proves someone wrote "1%" in the diff. It doesn't prove codecov will enforce it.
+DO:   Run the tool         →  pyright --project pyrightconfig.json
+DO:   Exercise the path    →  gh issue create ... && gh api .../issues/N to verify metadata
+DO:   Assert on output     →  assert result.exit_code == 0
+DO:   Check side effects   →  ls output_file.json && python3 -c "assert valid"
 
-**Good** (verifying behavior):
-```bash
-$ python3 -c "
-import yaml
-cfg = yaml.safe_load(open('.github/codecov.yml'))
-threshold = cfg['coverage']['status']['project']['default']['threshold']
-print(f'Project threshold: {threshold}')
-assert threshold == '1%', f'Expected 1%, got {threshold}'
-"
-Project threshold: 1%
-```
-This parses the actual file and asserts the value programmatically.
-
-**Bad** (verifying implementation):
-```bash
-$ gh pr diff 195 | grep 'typeCheckingMode'
-+  "typeCheckingMode": "basic",
+DON'T: Grep the diff       →  gh pr diff | grep 'typeCheckingMode'
+DON'T: Check internal state →  assert len(obj._internal_list) == 3
+DON'T: Verify wiring       →  "did the function call parseInput()?"
+DON'T: Read instead of run  →  parse config to check a value when you could run the tool
 ```
 
-**Good** (verifying behavior):
-```bash
-$ pyright --project pyrightconfig.json 2>&1 | tail -1
-0 errors, 0 warnings, 0 informations
-```
-This runs the actual type checker with the actual config and proves it works.
+### If verification steps test implementation, rewrite them
 
-### When to check out the PR branch
+When you encounter verification steps (in a PR description or issue) that test implementation instead of behavior, **rewrite them**. Show what you changed:
 
-To verify behavior, you often need the PR's code locally. Check out the branch or use an existing worktree:
-
-```bash
-# Option 1: Use existing worktree if available
-cd /path/to/worktree
-
-# Option 2: Create a temporary worktree
-git worktree add /tmp/verify-pr-NNN origin/branch-name
-cd /tmp/verify-pr-NNN
-# ... run verification ...
-git worktree remove /tmp/verify-pr-NNN
+```markdown
+- [x] **Pyright config works** *(rewritten: original checked `gh pr diff | grep typeCheckingMode` → now exercises pyright directly)*
+  ```bash
+  $ pyright --project pyrightconfig.json 2>&1 | tail -1
+  0 errors, 0 warnings, 0 informations
+  ```
 ```
 
-Diff-grepping should be reserved for metadata checks (labels, milestones, issue references) where the "behavior" IS the text content.
+Always include `(rewritten: original checked X → now checks Y)` so reviewers can see what changed and why.
 
-## Why this matters
+### Spend time understanding what each check is meant to prove
 
-Verification without evidence is just opinion. When someone reads a PR months later, they need to see exactly what was run and what came back — not a table of "PASS" labels. Checkboxes with commands and output make verification auditable, reproducible, and trustworthy.
+Before writing a verification command, ask: **what is this check actually trying to prove?**
+
+- "CODEOWNERS exists" → The real question is: will GitHub auto-assign reviewers? Exercise it: push a change to a covered path and check if a reviewer is requested, or at minimum verify GitHub's API recognizes the file on the branch.
+- "pytest-xdist in requirements" → The real question is: do tests run in parallel? Exercise it: run `pytest -n auto` and check for `[gw0]` worker prefixes in the output.
+- "Nightly workflow has cron trigger" → The real question is: will this workflow fire on schedule? Exercise it: trigger the workflow manually via `gh workflow run` and check it starts, or at minimum validate the cron expression with a parser.
+- "Skill has frontmatter" → The real question is: does the skill trigger and produce the right output? Exercise it: invoke the skill with a test input and check the output shape.
 
 ## The Rule
 
-Every verification step gets a checkbox. Every checkbox shows the command and its output. The checkbox is only ticked if the result is unambiguous.
+Every verification step gets a checkbox. Every checkbox shows the command run and its console output. The checkbox is only ticked if the result is unambiguous.
 
 ## Process
 
-### Step 1: Run each verification step and capture output
+### Step 1: Check out the PR branch
 
-For every verification step defined in the PR:
+You need the actual files to exercise actual behavior. Diff-grepping is not acceptable.
 
-1. Check out the PR branch or use an existing worktree — you need the actual files, not just the diff
-2. Run commands that test **behavior** (run the tool, parse the file, execute the config)
-3. Capture the full console output
-4. Determine: does this **unambiguously** pass, fail, or is it ambiguous?
+```bash
+git worktree add /tmp/verify-pr-NNN origin/branch-name
+cd /tmp/verify-pr-NNN
+```
 
-### Step 2: Format results with checkboxes
+### Step 2: Design behavioral checks
 
-Each verification step becomes a checkbox item. The format depends on output size:
+For each verification step, ask: "what promise does this change make?" Then design a command that tests whether the promise was kept by exercising the actual code path.
 
-#### Small output (< ~20 lines) — inline in PR description
+If the original verification steps test implementation (grep the diff, check if a line is present), **rewrite them** to test behavior. Show the before → after.
 
-Put the command and output directly next to the checkbox:
+### Step 3: Run and capture output
+
+Run each command and capture the full console output. Every check must show:
+1. The exact command run (prefixed with `$`)
+2. The actual console output
+3. Your determination: unambiguous pass, fail, or ambiguous
+
+### Step 4: Format with checkboxes
+
+Size-based placement:
+
+#### Small output (< ~20 lines) — inline
 
 ```markdown
-- [x] **JSON syntax valid**
+- [x] **Pyright runs clean with this config**
   ```bash
-  $ python3 -c "import json; json.load(open('pyrightconfig.json'))"
-  # (no output — exit code 0)
+  $ pyright --project pyrightconfig.json 2>&1 | tail -1
+  0 errors, 0 warnings, 0 informations
   ```
-
-- [x] **Threshold is 1% not 100%**
-  ```bash
-  $ grep threshold .github/codecov.yml
-  threshold: 1%  # fail if coverage drops by more than 1%
-  threshold: 1%  # fail if new code has >1% less coverage than target
-  ```
-
-- [ ] **Type checking passes** *(ambiguous — see comment)*
-  ```bash
-  $ pyright --project pyrightconfig.json
-  0 errors, 3 warnings, 0 informations
-  ```
-  > Warnings present — needs review to determine if these are expected.
 ```
 
 #### Medium output (20-100 lines) — PR comment with link
 
-1. Post a PR comment containing the command and full output
-2. In the PR description checkbox, link to that comment:
-
 ```markdown
-- [x] **All tests pass in parallel mode** — [verification output](#issuecomment-12345)
+- [x] **Tests run in parallel** — [verification output](#issuecomment-12345)
 ```
 
-The comment itself should contain:
-
-```markdown
-## Verification: All tests pass in parallel mode
-
-```bash
-$ pytest -n auto -m "not slow" -vv
-========================= test session starts ==========================
-platform darwin -- Python 3.10.12, pytest-7.4.0, pluggy-1.2.0
-...
-========================= 42 passed in 12.34s ==========================
-```
-```
-
-#### Large output (100+ lines) — GitHub Gist with summary
-
-1. Create a GitHub Gist with the full console output
-2. Post a PR comment with a summary, key lines, and link to the gist
-3. In the PR description checkbox, link to the comment:
+#### Large output (100+ lines) — Gist with summary
 
 ```markdown
 - [x] **Full test suite passes** — [summary + gist](#issuecomment-67890)
 ```
 
-The comment should contain:
+### Step 5: Tick or leave unchecked
 
-```markdown
-## Verification: Full test suite passes
+- **`[x]`** — Output unambiguously confirms the promise was kept. Zero doubt.
+- **`[ ]`** — Any ambiguity. Explain what's unclear.
 
-**Result:** 142 passed, 0 failed, 3 skipped
+A false `[x]` is worse than a cautious `[ ]`.
 
-Key output:
-```bash
-$ pytest -n auto
-...
-========================= 142 passed, 3 skipped in 45.12s =============
-```
+### Step 6: Post to the PR
 
-Full output: https://gist.github.com/user/abc123
-```
+Post as a comment with header `## Verification Results`.
 
-### Step 3: Tick or leave unchecked
+## Anti-patterns
 
-- **`[x]` (ticked):** The output unambiguously confirms the check passes. Zero doubt.
-- **`[ ]` (unchecked):** Any ambiguity at all. Add a brief explanation of what's unclear:
-  - Warnings present that might or might not matter
-  - Output doesn't cleanly confirm the expected result
-  - Exit code 0 but output contains error-like text
-  - Test passed but with unexpected side effects in the output
+- **Grepping the diff as verification** — `gh pr diff | grep 'expected line'` proves a line was typed. It does not prove the system works. This is the #1 failure mode.
+- **Parsing a file when you could run the tool** — If you can exercise the code path, do that instead of reading the config. Running `pyright` beats reading `pyrightconfig.json`.
+- **Checking that a file exists instead of checking that it works** — `ls SKILL.md` proves a file is there. Invoking the skill proves it works.
+- **Writing PASS/FAIL tables without commands or output**
+- **Ticking `[x]` when output contains warnings you haven't investigated**
+- **Saying "all checks pass" without showing evidence**
 
-When in doubt, leave unchecked. A false `[x]` is worse than a cautious `[ ]`.
-
-### Step 4: Post to the PR
-
-Place the verification checklist in the PR description (if writing it for the first time) or as a comment (if verifying after the PR was created). Use a clear header:
-
-```markdown
-## Verification Results
-```
-
-## Creating Gists for large output
-
-When output exceeds ~100 lines, create a gist:
-
-```bash
-gh gist create --public -f "verification-<step-name>.log" /path/to/output.log
-```
-
-Include the gist URL in your PR comment alongside the summary.
-
-## Anti-patterns — do NOT do these
-
-- **Grepping the diff as your primary verification** — `gh pr diff | grep 'expected line'` proves a line was typed, not that it works. Always prefer running the tool, parsing the file, or querying live state.
-- Writing a table with "PASS" / "FAIL" columns but no commands or output
-- Ticking `[x]` when output contains warnings you haven't investigated
-- Saying "all checks pass" without showing what was run
-- Posting verification results without the actual console output
-- Summarizing output as "looks good" instead of showing it
-- Using `gh pr diff | grep` for anything other than metadata checks (issue refs, PR body content)
+## Tests should be documentation of the requirements, not a transcript of the code.

--- a/.claude/skills/pr-checkbox/SKILL.md
+++ b/.claude/skills/pr-checkbox/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: pr-checkbox
+description: Rigid process skill for posting PR verification results. Use this skill whenever running verification steps on a PR, posting validation results to a PR, or claiming that checks pass. Also trigger when writing verification sections in PR descriptions, commenting verification outcomes, or updating verification checkboxes. If you are about to write "PASS" or "FAIL" or a verification table on a PR, you MUST use this skill first. Trigger on any PR review, validation, or verification activity.
+---
+
+# PR Verification Checkbox Skill
+
+This is a **rigid** process skill. Follow every step exactly — no shortcuts, no "PASS" assertions without evidence.
+
+## Why this matters
+
+Verification without evidence is just opinion. When someone reads a PR months later, they need to see exactly what was run and what came back — not a table of "PASS" labels. Checkboxes with commands and output make verification auditable, reproducible, and trustworthy.
+
+## The Rule
+
+Every verification step gets a checkbox. Every checkbox shows the command and its output. The checkbox is only ticked if the result is unambiguous.
+
+## Process
+
+### Step 1: Run each verification step and capture output
+
+For every verification step defined in the PR:
+
+1. Run the exact command
+2. Capture the full console output
+3. Determine: does this **unambiguously** pass, fail, or is it ambiguous?
+
+### Step 2: Format results with checkboxes
+
+Each verification step becomes a checkbox item. The format depends on output size:
+
+#### Small output (< ~20 lines) — inline in PR description
+
+Put the command and output directly next to the checkbox:
+
+```markdown
+- [x] **JSON syntax valid**
+  ```bash
+  $ python3 -c "import json; json.load(open('pyrightconfig.json'))"
+  # (no output — exit code 0)
+  ```
+
+- [x] **Threshold is 1% not 100%**
+  ```bash
+  $ grep threshold .github/codecov.yml
+  threshold: 1%  # fail if coverage drops by more than 1%
+  threshold: 1%  # fail if new code has >1% less coverage than target
+  ```
+
+- [ ] **Type checking passes** *(ambiguous — see comment)*
+  ```bash
+  $ pyright --project pyrightconfig.json
+  0 errors, 3 warnings, 0 informations
+  ```
+  > Warnings present — needs review to determine if these are expected.
+```
+
+#### Medium output (20-100 lines) — PR comment with link
+
+1. Post a PR comment containing the command and full output
+2. In the PR description checkbox, link to that comment:
+
+```markdown
+- [x] **All tests pass in parallel mode** — [verification output](#issuecomment-12345)
+```
+
+The comment itself should contain:
+
+```markdown
+## Verification: All tests pass in parallel mode
+
+```bash
+$ pytest -n auto -m "not slow" -vv
+========================= test session starts ==========================
+platform darwin -- Python 3.10.12, pytest-7.4.0, pluggy-1.2.0
+...
+========================= 42 passed in 12.34s ==========================
+```
+```
+
+#### Large output (100+ lines) — GitHub Gist with summary
+
+1. Create a GitHub Gist with the full console output
+2. Post a PR comment with a summary, key lines, and link to the gist
+3. In the PR description checkbox, link to the comment:
+
+```markdown
+- [x] **Full test suite passes** — [summary + gist](#issuecomment-67890)
+```
+
+The comment should contain:
+
+```markdown
+## Verification: Full test suite passes
+
+**Result:** 142 passed, 0 failed, 3 skipped
+
+Key output:
+```bash
+$ pytest -n auto
+...
+========================= 142 passed, 3 skipped in 45.12s =============
+```
+
+Full output: https://gist.github.com/user/abc123
+```
+
+### Step 3: Tick or leave unchecked
+
+- **`[x]` (ticked):** The output unambiguously confirms the check passes. Zero doubt.
+- **`[ ]` (unchecked):** Any ambiguity at all. Add a brief explanation of what's unclear:
+  - Warnings present that might or might not matter
+  - Output doesn't cleanly confirm the expected result
+  - Exit code 0 but output contains error-like text
+  - Test passed but with unexpected side effects in the output
+
+When in doubt, leave unchecked. A false `[x]` is worse than a cautious `[ ]`.
+
+### Step 4: Post to the PR
+
+Place the verification checklist in the PR description (if writing it for the first time) or as a comment (if verifying after the PR was created). Use a clear header:
+
+```markdown
+## Verification Results
+```
+
+## Creating Gists for large output
+
+When output exceeds ~100 lines, create a gist:
+
+```bash
+gh gist create --public -f "verification-<step-name>.log" /path/to/output.log
+```
+
+Include the gist URL in your PR comment alongside the summary.
+
+## Anti-patterns — do NOT do these
+
+- Writing a table with "PASS" / "FAIL" columns but no commands or output
+- Ticking `[x]` when output contains warnings you haven't investigated
+- Saying "all checks pass" without showing what was run
+- Posting verification results without the actual console output
+- Summarizing output as "looks good" instead of showing it


### PR DESCRIPTION
## Summary

Adds a new rigid process skill (`pr-checkbox`) that enforces verification checkbox standards for PRs.

### Rationale

Currently, verification results on PRs can take any format — tables with "PASS"/"FAIL" labels, free-text summaries, or bare assertions like "all checks pass." None of these are auditable or reproducible. This skill establishes a single standard: every verification step gets a checkbox backed by the actual command and its console output.

### What this adds

- `.claude/skills/pr-checkbox/SKILL.md` — a rigid skill that triggers on any PR review, validation, or verification activity
- Tiered output formatting: inline for small output, PR comments for medium, GitHub Gists for large
- Clear rules for when to tick `[x]` vs leave `[ ]` unchecked (only tick on unambiguous pass)
- Anti-patterns section to prevent common shortcuts

### Pros

- **Auditable**: months later, anyone can see exactly what was run and what came back
- **Reproducible**: commands are captured, so verification can be re-run
- **Honest**: ambiguous results stay unchecked instead of getting a false "PASS"
- **Scalable**: tiered formatting prevents PR descriptions from becoming walls of text

### Cons

- **More effort per verification**: requires capturing and formatting output instead of writing "PASS"
- **Skill trigger scope is broad**: may activate in contexts where lightweight verification is sufficient

Closes #198