### PR TITLE
feat(ci): add stale issue/PR bot with 120-day threshold

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,5 +26,3 @@ jobs:
             This PR has been inactive for 120 days. It has been labeled as
             `stale`. If this PR is still relevant, please comment to remove
             the stale label.
-          exempt-issue-labels: "Epic,Phase"
-          exempt-pr-labels: "Epic,Phase"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: Stale Issues
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Weekly on Monday at 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 120
+          days-before-close: -1 # Never auto-close
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"
+          stale-issue-message: >-
+            This issue has been inactive for 120 days. It has been labeled as
+            `stale`. If this issue is still relevant, please comment to remove
+            the stale label.
+          stale-pr-message: >-
+            This PR has been inactive for 120 days. It has been labeled as
+            `stale`. If this PR is still relevant, please comment to remove
+            the stale label.
+          exempt-issue-labels: "Epic,Phase"
+          exempt-pr-labels: "Epic,Phase"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: Stale Issues
+name: Stale Issues and PRs
 on:
   schedule:
     - cron: "0 8 * * 1" # Weekly on Monday at 08:00 UTC


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow using `actions/stale@v9` to automatically label inactive issues and PRs as `stale` after 120 days of inactivity.

- Runs weekly on Monday at 08:00 UTC (plus manual `workflow_dispatch`)
- Labels stale issues/PRs but **never auto-closes** them (`days-before-close: -1`)
- Exempts issues and PRs labeled `Epic` or `Phase` from staleness checks
- Posts a clear comment explaining the label and how to remove it

## Rationale

As the project grows, older issues and PRs can accumulate without resolution. A stale bot provides passive housekeeping — surfacing forgotten items so maintainers can triage them — without the risk of auto-closing legitimate work.

## Trade-offs

**Pros:**
- Low-friction way to keep the tracker tidy
- Conservative config: label-only, no auto-close, long threshold (120 days)
- Epics and Phases are exempt, so long-lived tracking issues are unaffected
- Easy to tune thresholds or add more exempt labels later

**Cons:**
- Stale comments can be noisy on issues that are intentionally parked
- Requires maintainers to periodically review stale-labeled items

Closes #183

- [ ] Verify that stale issues can be seen via a view in project (make sure that view is saved in the repo project)