### PR TITLE
feat(testing): add performance benchmarking with pytest-benchmark

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,8 @@ test: ## Run not slow tests
 test-full: ## Run all tests
 	pytest
 
+benchmark: ## Run performance benchmarks
+	pytest --benchmark-only -m "benchmark" -v
+
 train: ## Train the model
 	python src/train.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ markers = [
   "slow: slow tests",
   "gpu: tests requiring a GPU",
   "pipeline: pipeline integration tests",
+  "benchmark: performance benchmarks",
 ]
 minversion = "6.0"
 testpaths = "tests/"

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -30,6 +30,7 @@ pre-commit
 pyloudnorm
 pyright
 pytest
+pytest-benchmark
 pytest-xdist
 rich
 rootutils

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -1,0 +1,16 @@
+"""Performance benchmarks for critical code paths."""
+
+import pytest
+
+
+@pytest.mark.benchmark
+@pytest.mark.slow
+def test_config_resolution_speed(benchmark, cfg_train):
+    """Benchmark Hydra config resolution speed."""
+    from omegaconf import OmegaConf
+
+    def resolve_config():
+        return OmegaConf.to_container(cfg_train, resolve=True)
+
+    result = benchmark(resolve_config)
+    assert result is not None


### PR DESCRIPTION
## Summary

- Adds `pytest-benchmark` to `requirements-app.txt` for structured performance testing
- Registers `benchmark` as a strict pytest marker in `pyproject.toml`
- Adds an initial benchmark test (`tests/test_benchmarks.py`) that measures Hydra config resolution speed
- Adds a `make benchmark` target for convenient benchmark execution

## Rationale

With `pytest-xdist` now merged for parallel test execution, adding `pytest-benchmark` completes the testing infrastructure by enabling reproducible performance measurement. This lets us:

- Track performance regressions in critical code paths (config resolution, data loading, inference)
- Get structured benchmark output (min, max, mean, stddev, rounds) instead of ad-hoc timing
- Run benchmarks in isolation via `pytest --benchmark-only` so they don't slow down the regular test suite

## Pros

- Zero friction: benchmarks are regular pytest tests, decorated with `@pytest.mark.benchmark`
- Excluded from `make test` by default (marked `slow`), run explicitly via `make benchmark`
- `pytest-benchmark` provides statistical rigor (adaptive rounds, warmup, outlier detection)
- Easy to extend: just add more `@pytest.mark.benchmark` tests as needed

## Cons

- Adds one more test dependency
- Benchmark results vary across machines (not suitable for hard CI thresholds without baseline calibration)

## Changes

| File | Change |
|------|--------|
| `requirements-app.txt` | Add `pytest-benchmark` |
| `pyproject.toml` | Register `benchmark` marker |
| `tests/test_benchmarks.py` | Config resolution benchmark |
| `Makefile` | Add `benchmark` target |

Closes #189