### PR TITLE
feat(testing): add syrupy snapshot testing with config example

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ markers = [
   "slow: slow tests",
   "gpu: tests requiring a GPU",
   "pipeline: pipeline integration tests",
+  "snapshot: snapshot/golden-file tests",
 ]
 minversion = "6.0"
 testpaths = "tests/"

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -31,6 +31,7 @@ pyloudnorm
 pyright
 pytest
 pytest-xdist
+syrupy
 rich
 rootutils
 runpod==1.8.1

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,0 +1,16 @@
+"""Snapshot tests for config resolution and data structures."""
+
+import pytest
+
+
+@pytest.mark.snapshot
+def test_train_config_snapshot(cfg_train, snapshot):
+    """Train config resolves to expected structure."""
+    # Convert to dict for snapshot comparison
+    from omegaconf import OmegaConf
+
+    cfg_dict = OmegaConf.to_container(cfg_train, resolve=True)
+    assert isinstance(cfg_dict, dict)
+    # Snapshot the top-level keys and their types
+    structure = {k: type(v).__name__ for k, v in cfg_dict.items()}
+    assert structure == snapshot


### PR DESCRIPTION
## Summary

- Add `syrupy` to `requirements-app.txt` for snapshot/golden-file testing
- Register `snapshot` pytest marker in `pyproject.toml` (strict markers enabled)
- Add example snapshot test at `tests/test_snapshots.py` that captures the resolved train config structure

## Rationale

Snapshot (golden-file) testing catches unintended changes to config resolution, data structures, and model outputs. `syrupy` integrates natively with pytest and stores snapshots as human-readable files that go through code review alongside the changes that caused them.

**Pros:**
- Catches accidental config drift or structural regressions automatically
- Snapshots are committed to the repo, providing a reviewable history of expected outputs
- `syrupy` supports multiple serializers (Amber, JSON, YAML) and custom extensions
- `--snapshot-update` flag makes intentional changes easy to apply

**Cons:**
- Snapshot files add to repo size (minimal for structure-level snapshots)
- Developers must remember to run `--snapshot-update` when changes are intentional

## Test plan

- [ ] `pip install syrupy` and verify import works
- [ ] Run `pytest tests/test_snapshots.py --snapshot-update` to generate initial snapshot
- [ ] Run `pytest tests/test_snapshots.py` again to verify snapshot matches
- [ ] Confirm `pytest --co -m snapshot` collects the new test

Closes #187