### PR TITLE
feat(testing): add hypothesis property-based testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ log_cli = "True"
 markers = [
   "slow: slow tests",
   "gpu: tests requiring a GPU",
+  "hypothesis: property-based tests (hypothesis)",
   "pipeline: pipeline integration tests",
 ]
 minversion = "6.0"

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -19,6 +19,7 @@ webdataset
 dask[distributed]
 einops
 h5py
+hypothesis
 hdf5plugin
 librosa
 loguru

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -3,6 +3,8 @@
 import pytest
 from hypothesis import given, settings
 from hypothesis import strategies as st
+from omegaconf import OmegaConf
+from omegaconf.errors import OmegaConfBaseException
 
 
 @pytest.mark.hypothesis
@@ -16,14 +18,14 @@ from hypothesis import strategies as st
     )
 )
 @settings(max_examples=50)
-def test_arbitrary_dict_does_not_crash_omegaconf(random_dict):
+def test_arbitrary_dict_does_not_crash_omegaconf(
+    random_dict: dict[str, int | str | None | float],
+) -> None:
     """OmegaConf.create should handle or reject arbitrary dicts without crashing."""
-    from omegaconf import OmegaConf
-
     try:
         cfg = OmegaConf.create(random_dict)
-        # If it accepts the dict, it should be convertible back
-        OmegaConf.to_container(cfg)
-    except Exception:  # noqa: S110
-        # Rejection is fine — crashing is not
-        pass
+    except OmegaConfBaseException:
+        return
+
+    # If it accepts the dict, it should be convertible back without errors
+    OmegaConf.to_container(cfg)

--- a/tests/test_properties.py
+++ b/tests/test_properties.py
@@ -1,0 +1,29 @@
+"""Property-based tests using Hypothesis."""
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+
+@pytest.mark.hypothesis
+@pytest.mark.slow
+@given(
+    st.dictionaries(
+        keys=st.text(min_size=1, max_size=50),
+        values=st.one_of(st.integers(), st.text(), st.none(), st.floats(allow_nan=False)),
+        min_size=0,
+        max_size=20,
+    )
+)
+@settings(max_examples=50)
+def test_arbitrary_dict_does_not_crash_omegaconf(random_dict):
+    """OmegaConf.create should handle or reject arbitrary dicts without crashing."""
+    from omegaconf import OmegaConf
+
+    try:
+        cfg = OmegaConf.create(random_dict)
+        # If it accepts the dict, it should be convertible back
+        OmegaConf.to_container(cfg)
+    except Exception:  # noqa: S110
+        # Rejection is fine — crashing is not
+        pass


### PR DESCRIPTION
## Summary

- Adds `hypothesis` to `requirements-app.txt` for property-based testing
- Registers `hypothesis` pytest marker in `pyproject.toml`
- Adds an example property-based test (`tests/test_properties.py`) that fuzzes `OmegaConf.create` with arbitrary dictionaries

## Rationale

Property-based testing complements example-based tests by exploring edge cases we wouldn't think to write manually. This is especially valuable for:

- **Config parsing** — Hydra/OmegaConf must handle or cleanly reject arbitrary inputs
- **Pydantic trust boundaries** — models with `strict=True` should never crash on unexpected data
- **Numeric pipelines** — float edge cases (inf, subnormals, large values) are hard to cover by hand

### Pros
- Finds edge-case bugs that example-based tests miss
- Hypothesis shrinks failing inputs to minimal reproducible cases
- Integrates cleanly with pytest (marker-based, works with xdist)

### Cons
- Slower than unit tests (marked `@pytest.mark.slow` so `make test` skips them)
- Non-deterministic by default (mitigated by Hypothesis's database of failing examples)

## Test plan

- [x] `make format` passes (all pre-commit hooks green)
- [ ] `make test-full` passes (includes the new slow/hypothesis-marked test)
- [ ] Verify `pytest -m hypothesis` runs only the property-based test

Closes #188