### PR TITLE
feat(evaluation): add CI skill evaluation pipeline with A/B comparator

### DIFF
--- a/.claude/skills/code-health/evals/eval_cognitive_load.yaml
+++ b/.claude/skills/code-health/evals/eval_cognitive_load.yaml
@@ -1,0 +1,40 @@
+name: cognitive_load_reduction
+skill: code-health
+description: Verify Claude identifies high cognitive load and simplifies
+prompt: |
+  Review this function:
+
+  ```python
+  def finalize_dataset(shards, metadata, config, workers, dry_run=False):
+      valid = [s for s in shards if s["status"] == "valid" and s["id"] not in
+               [w["failed"] for w in workers if "failed" in w] and
+               s["num_samples"] >= config.get("min_samples", 100)]
+      if not dry_run:
+          for s in valid:
+              path = Path(config["output_dir"]) / f"data/shards/{s['id']}.h5"
+              if not path.parent.exists():
+                  path.parent.mkdir(parents=True, exist_ok=True)
+              write_hdf5(path, s["data"], attrs={"id": s["id"], "n": s["num_samples"],
+                         "src": s.get("worker_id", "unknown"), "ts": datetime.now().isoformat(),
+                         "cfg": json.dumps({k: v for k, v in config.items() if k != "secret"})})
+              metadata["written"].append({"id": s["id"], "path": str(path), "n": s["num_samples"]})
+      return valid, metadata
+  ```
+context_files: []
+success_criteria:
+  - Identifies the dense list comprehension as hard to read
+  - Flags the long write_hdf5 call with inline dict construction
+  - Suggests extracting the filtering logic into a named function or variable
+  - Suggests extracting HDF5 attribute building into a helper
+  - Notes single-character variable names reduce readability
+failure_criteria:
+  - Approves the code as-is
+  - Only flags style issues (line length, formatting)
+  - Suggests major architectural changes instead of targeted simplification
+comparator_focus: |
+  Does the review identify the TWO main cognitive load sources: the dense
+  list comprehension and the inline HDF5 attrs dict? Are suggestions
+  practical and proportional?
+tags:
+  - code-health
+  - cognitive-load

--- a/.claude/skills/code-health/evals/eval_nesting_reduction.yaml
+++ b/.claude/skills/code-health/evals/eval_nesting_reduction.yaml
@@ -1,0 +1,41 @@
+name: nesting_reduction
+skill: code-health
+description: Verify Claude reduces nesting depth when reviewing deeply nested code
+prompt: |
+  Review this function and suggest improvements:
+
+  ```python
+  def process_shards(shards, config):
+      results = []
+      for shard in shards:
+          if shard is not None:
+              if shard.get("status") == "ready":
+                  if shard.get("num_samples", 0) > 0:
+                      if config.get("validate", True):
+                          if validate_shard(shard):
+                              results.append(transform(shard))
+                          else:
+                              logger.warning(f"Invalid shard: {shard['id']}")
+                      else:
+                          results.append(transform(shard))
+      return results
+  ```
+context_files: []
+success_criteria:
+  - Identifies excessive nesting as the primary issue
+  - Suggests guard clauses / early continues to flatten the loop
+  - Refactored version has max 2-3 levels of nesting
+  - Preserves the original behavior (same filtering logic)
+  - Does not over-engineer (no new classes or abstractions for this)
+failure_criteria:
+  - Doesn't mention nesting depth
+  - Suggests adding more nesting
+  - Creates unnecessary abstractions (helper classes, strategy pattern)
+  - Refactored code changes the behavior
+comparator_focus: |
+  Does the review identify nesting as the core issue? Is the suggested
+  refactoring practical (guard clauses, not over-abstraction)?
+tags:
+  - code-health
+  - nesting
+  - readability

--- a/.claude/skills/code-health/evals/eval_yagni.yaml
+++ b/.claude/skills/code-health/evals/eval_yagni.yaml
@@ -1,0 +1,38 @@
+name: yagni_violation_detection
+skill: code-health
+description: Verify Claude catches YAGNI violations in code review
+prompt: |
+  Review this PR diff:
+
+  ```python
+  # src/data/shard_writer.py
+  + class ShardWriter:
+  +     def __init__(self, output_dir: Path, format: str = "hdf5",
+  +                  compression: str = "gzip", compression_level: int = 4,
+  +                  chunk_size: int = 1024, enable_checksums: bool = True,
+  +                  enable_encryption: bool = False, encryption_key: str | None = None,
+  +                  enable_dedup: bool = False, dedup_algorithm: str = "xxhash",
+  +                  max_retries: int = 3, retry_delay: float = 1.0,
+  +                  callback: Callable | None = None):
+  ```
+
+  PR description says: "Add shard writer for the pipeline. Currently we only
+  write HDF5 shards to local disk."
+context_files: []
+success_criteria:
+  - Flags YAGNI violation -- encryption, dedup, callbacks are not needed yet
+  - Notes the mismatch between PR description (simple HDF5 writing) and interface (14 params)
+  - Suggests starting with only the parameters needed now
+  - Uses WARN or BLOCK severity appropriately
+  - Does not flag format/compression params (those are reasonable)
+failure_criteria:
+  - Approves all parameters as "good forward-thinking design"
+  - Misses the YAGNI violation entirely
+  - Flags compression/chunk_size as unnecessary (they're reasonable)
+comparator_focus: |
+  Does the review catch the YAGNI violation? The encryption, dedup, and callback
+  params are clearly premature. The PR description confirms only HDF5-to-disk
+  is needed. Weight this detection heavily.
+tags:
+  - code-health
+  - yagni

--- a/.claude/skills/eval-schema.yaml
+++ b/.claude/skills/eval-schema.yaml
@@ -1,0 +1,42 @@
+# Skill Evaluation Case Schema
+#
+# Each eval case is a YAML file in .claude/skills/<skill-name>/evals/
+# The eval runner (scripts/eval_skills.py) uses these to benchmark skills
+# via A/B comparator methodology.
+#
+# Schema:
+#   name: str           - Unique identifier for this eval case
+#   skill: str          - Skill name (must match directory name in .claude/skills/)
+#   description: str    - Human-readable description of what this eval tests
+#   prompt: str         - The task prompt given to Claude (multiline ok)
+#   context_files: list - Optional list of repo files to include in agent context
+#   success_criteria: list - What the output MUST exhibit (scored by comparator)
+#   failure_criteria: list - What the output MUST NOT exhibit (scored by comparator)
+#   comparator_focus: str  - Guidance for the comparator on what to prioritize
+#   tags: list          - Optional tags for filtering (e.g. ["tdd", "behavior-testing"])
+#
+# Example:
+#
+#   name: red_green_refactor_ordering
+#   skill: tdd-implementation
+#   description: Verify Claude writes tests before implementation code
+#   prompt: |
+#     Implement a function `validate_shard_id(shard_id: str) -> bool`
+#     that returns True if shard_id matches pattern `shard-NNNNNN`.
+#   context_files:
+#     - src/utils/shard.py
+#   success_criteria:
+#     - Test file created before or simultaneously with implementation
+#     - Test contains at least one failing assertion scenario
+#     - Implementation is minimal -- no extra features beyond spec
+#     - Test name follows test_<what>_<condition>_<expected> pattern
+#   failure_criteria:
+#     - Implementation written without any test
+#     - Test only covers happy path
+#   comparator_focus: |
+#     Focus on whether the TDD cycle was followed: tests written first,
+#     minimal implementation, then refactor. Weight test-first ordering
+#     most heavily.
+#   tags:
+#     - tdd
+#     - red-green-refactor

--- a/.claude/skills/ml-test/evals/eval_invariance_directional.yaml
+++ b/.claude/skills/ml-test/evals/eval_invariance_directional.yaml
@@ -1,0 +1,32 @@
+name: invariance_and_directional_tests
+skill: ml-test
+description: Verify Claude writes post-train behavioral tests (invariance + directional)
+prompt: |
+  Write post-train behavioral tests for an audio classifier that predicts
+  instrument type from mel spectrograms. The model is already trained.
+  Write tests that verify the model's behavior is robust and sensible:
+  - Invariance: predictions shouldn't change for certain input transformations
+  - Directional: certain input changes should predictably affect outputs
+
+  Assume the model has a `predict(mel: torch.Tensor) -> str` method.
+context_files:
+  - src/models/__init__.py
+success_criteria:
+  - At least one invariance test (e.g., time-shift, small noise, gain change)
+  - At least one directional test (e.g., silence -> low confidence)
+  - Tests use real-ish synthetic audio patterns, not pure random noise
+  - Tests are deterministic (seeded)
+  - Tests document what behavioral property they verify
+failure_criteria:
+  - Only tests output shape or type
+  - No invariance tests
+  - No directional tests
+  - Uses pure random noise as input (not meaningful)
+comparator_focus: |
+  Does Claude understand the invariance/directional testing paradigm?
+  Quality matters: are the transformations musically/acoustically meaningful
+  (e.g., time-shift invariance for instrument classification)?
+tags:
+  - ml-testing
+  - behavioral-tests
+  - post-train

--- a/.claude/skills/ml-test/evals/eval_overfit_single_batch.yaml
+++ b/.claude/skills/ml-test/evals/eval_overfit_single_batch.yaml
@@ -1,0 +1,31 @@
+name: overfit_single_batch_quality
+skill: ml-test
+description: Verify the overfit-single-batch test is well-constructed
+prompt: |
+  Write a test that verifies a `SynthDecoder` model can overfit a single batch.
+  The model takes embeddings (batch, embed_dim=256) and outputs mel spectrograms
+  (batch, n_mels=128, time=64). Use MSE loss and Adam optimizer.
+  This is a pre-train sanity check -- if the model can't memorize one batch,
+  something is wrong with the architecture or training loop.
+context_files:
+  - src/models/__init__.py
+success_criteria:
+  - Uses a fixed random seed for reproducibility
+  - Creates a single batch of synthetic data
+  - Runs multiple optimization steps (not just 1)
+  - Asserts final loss is significantly lower than initial loss
+  - Uses model.train() mode
+  - Does not use real data -- synthetic tensors only
+failure_criteria:
+  - Only runs 1 optimization step
+  - No assertion on loss decrease
+  - Uses model.eval() mode for training
+  - No fixed seed (test is non-deterministic)
+  - Compares loss to an arbitrary threshold instead of initial loss
+comparator_focus: |
+  Quality of the overfit test: is it deterministic (seeded)? Does it run
+  enough steps? Does it compare final loss to initial loss (not an arbitrary
+  number)? Is synthetic data used correctly?
+tags:
+  - ml-testing
+  - overfit-single-batch

--- a/.claude/skills/ml-test/evals/eval_pretrain_checks.yaml
+++ b/.claude/skills/ml-test/evals/eval_pretrain_checks.yaml
@@ -1,0 +1,30 @@
+name: pretrain_sanity_checks
+skill: ml-test
+description: Verify Claude includes pre-train sanity checks for a new model
+prompt: |
+  Write tests for a new `SynthEncoder` model (PyTorch nn.Module) that takes
+  mel spectrograms (batch, n_mels, time) and outputs embeddings (batch, embed_dim).
+  The model has:
+  - __init__(n_mels: int = 128, embed_dim: int = 256)
+  - forward(x: torch.Tensor) -> torch.Tensor
+  Focus on pre-training validation tests.
+context_files:
+  - src/models/__init__.py
+success_criteria:
+  - Output shape test (correct batch size and embed_dim)
+  - Output range test (no NaN/Inf in outputs)
+  - Loss at initialization test (close to expected random loss)
+  - Single-batch overfit test (loss decreases over N steps)
+  - Parameter count or gradient flow test
+failure_criteria:
+  - Only tests forward pass shape, nothing else
+  - No test for NaN/Inf detection
+  - No overfit-single-batch test
+  - Tests use random seeds without fixing them
+comparator_focus: |
+  Count how many of the 5 pre-train check categories are covered.
+  The overfit-single-batch test and loss-at-init test are the most
+  important signals of ML testing competence.
+tags:
+  - ml-testing
+  - pre-train

--- a/.claude/skills/pr-checkbox/evals/eval_behavioral_focus.yaml
+++ b/.claude/skills/pr-checkbox/evals/eval_behavioral_focus.yaml
@@ -1,0 +1,39 @@
+name: behavioral_testing_emphasis
+skill: pr-checkbox
+description: Verify PR verification emphasizes behavioral testing over implementation checking
+prompt: |
+  Verify this PR that refactors the shard validation logic. The internal implementation
+  changed completely but the public API is identical.
+
+  Old implementation used regex, new uses string slicing:
+  ```python
+  # Before:
+  - import re
+  - def validate_shard_id(sid: str) -> bool:
+  -     return bool(re.match(r'^shard-\d{6}$', sid))
+
+  # After:
+  + def validate_shard_id(sid: str) -> bool:
+  +     if len(sid) != 12 or not sid.startswith('shard-'):
+  +         return False
+  +     return sid[6:].isdigit()
+  ```
+
+  Tests are unchanged and all pass.
+context_files: []
+success_criteria:
+  - Recognizes this is a pure refactor with preserved behavior
+  - Focuses on whether existing tests still pass (behavioral)
+  - Does NOT flag the implementation change as a concern
+  - Acknowledges that passing tests validate the refactor
+failure_criteria:
+  - Flags the implementation change as problematic
+  - Requests new tests for the new implementation details
+  - Focuses on HOW the code works rather than WHAT it does
+  - Misses that this is a behavior-preserving refactor
+comparator_focus: |
+  Key test: does the verification recognize a behavior-preserving refactor?
+  It should focus on whether tests pass, not on implementation changes.
+tags:
+  - pr-verification
+  - behavioral-testing

--- a/.claude/skills/pr-checkbox/evals/eval_missing_tests.yaml
+++ b/.claude/skills/pr-checkbox/evals/eval_missing_tests.yaml
@@ -1,0 +1,41 @@
+name: detect_missing_test_coverage
+skill: pr-checkbox
+description: Verify PR verification catches missing edge case tests
+prompt: |
+  Verify this PR that adds audio clipping detection:
+
+  ```python
+  # src/data/audio.py
+  + def detect_clipping(signal: np.ndarray, threshold: float = 0.99) -> dict:
+  +     clipped_samples = np.sum(np.abs(signal) >= threshold)
+  +     return {
+  +         "is_clipped": clipped_samples > 0,
+  +         "clipped_ratio": clipped_samples / len(signal),
+  +         "max_amplitude": float(np.max(np.abs(signal))),
+  +     }
+  ```
+
+  ```python
+  # tests/test_audio.py
+  + def test_detect_clipping_clean_signal():
+  +     signal = np.sin(np.linspace(0, 2*np.pi, 1000)) * 0.5
+  +     result = detect_clipping(signal)
+  +     assert result["is_clipped"] is False
+  ```
+context_files: []
+success_criteria:
+  - Identifies that edge cases are not tested (empty signal, all-clipped signal)
+  - Notes the division-by-zero risk with empty signal (len(signal) = 0)
+  - Flags missing test for the clipped case (is_clipped=True)
+  - Uses WARN or BLOCK appropriately for severity
+failure_criteria:
+  - Marks all checks as PASS without noticing missing tests
+  - Misses the division-by-zero edge case
+  - Only checks cosmetic issues (naming, formatting)
+comparator_focus: |
+  Does the verification catch the missing edge case tests? The empty-signal
+  division-by-zero is the most critical finding. Missing clipped-case test
+  is also important.
+tags:
+  - pr-verification
+  - edge-cases

--- a/.claude/skills/pr-checkbox/evals/eval_verification_table.yaml
+++ b/.claude/skills/pr-checkbox/evals/eval_verification_table.yaml
@@ -1,0 +1,49 @@
+name: verification_table_format
+skill: pr-checkbox
+description: Verify PR verification produces correct PASS/FAIL table format
+prompt: |
+  Review this PR that adds a new `normalize_audio` function to `src/data/audio.py`.
+  The PR includes tests in `tests/test_audio.py`. Run the verification steps
+  and post the results.
+
+  Here is the diff:
+  ```python
+  # src/data/audio.py
+  + def normalize_audio(signal: np.ndarray, target_db: float = -20.0) -> np.ndarray:
+  +     rms = np.sqrt(np.mean(signal ** 2))
+  +     if rms == 0:
+  +         return signal
+  +     target_rms = 10 ** (target_db / 20)
+  +     return signal * (target_rms / rms)
+  ```
+
+  ```python
+  # tests/test_audio.py
+  + def test_normalize_audio_silent_signal_unchanged():
+  +     signal = np.zeros(1000)
+  +     result = normalize_audio(signal)
+  +     np.testing.assert_array_equal(result, signal)
+  +
+  + def test_normalize_audio_scales_to_target():
+  +     signal = np.ones(1000) * 0.5
+  +     result = normalize_audio(signal, target_db=-20.0)
+  +     assert abs(np.sqrt(np.mean(result ** 2)) - 0.1) < 1e-6
+  ```
+context_files: []
+success_criteria:
+  - Output includes a structured verification table
+  - Each check has PASS or FAIL status with evidence
+  - Behavioral verification emphasized over implementation checking
+  - Verification hierarchy followed (behavioral > structural > cosmetic)
+  - Table uses the pr-checkbox skill's prescribed format
+failure_criteria:
+  - No verification table produced
+  - Bare PASS/FAIL without evidence
+  - Only checks code style, not behavior
+  - Claims verification without actually running anything
+comparator_focus: |
+  Does the output follow the pr-checkbox skill's prescribed verification format?
+  Is it evidence-based? Does it prioritize behavioral testing over cosmetic checks?
+tags:
+  - pr-verification
+  - format-compliance

--- a/.claude/skills/review/evals/eval_all_checklists_invoked.yaml
+++ b/.claude/skills/review/evals/eval_all_checklists_invoked.yaml
@@ -1,0 +1,46 @@
+name: all_checklists_invoked
+skill: review
+description: Verify the review skill invokes all 7 sub-checklists before reviewing
+prompt: |
+  Review this diff that touches both Python and shell code:
+
+  ```python
+  # src/pipeline/launcher.py
+  + def launch_workers(config: dict, num_workers: int) -> list[str]:
+  +     worker_ids = []
+  +     for i in range(num_workers):
+  +         wid = f"worker-{i:04d}"
+  +         subprocess.run(["bash", "scripts/launch.sh", wid, json.dumps(config)])
+  +         worker_ids.append(wid)
+  +     return worker_ids
+  ```
+
+  ```bash
+  # scripts/launch.sh
+  + #!/bin/bash
+  + WORKER_ID=$1
+  + CONFIG=$2
+  + echo "Launching $WORKER_ID"
+  + python -c "import json; c=json.loads('$CONFIG'); print(c)"
+  ```
+context_files: []
+success_criteria:
+  - All 7 skill invocations attempted (tdd, code-health, ml-pipeline, project, python-style, shell-style, ml-test)
+  - Findings use BLOCK/WARN format with file:line and category
+  - Categories map to the 7 checklist names
+  - Shell injection vulnerability detected (json.loads with unquoted $CONFIG)
+  - Summary line with X BLOCK, Y WARN count
+failure_criteria:
+  - Fewer than 5 checklists invoked
+  - shell-style checklist skipped despite .sh file in diff
+  - Shell injection vulnerability missed
+  - No BLOCK/WARN format used
+  - No summary line
+comparator_focus: |
+  Count how many of the 7 checklists are represented in the output. The shell
+  injection vulnerability ($CONFIG unquoted in python -c) is the most critical
+  finding -- it should be BLOCK severity. Also verify the BLOCK/WARN format.
+tags:
+  - review
+  - orchestration
+  - completeness

--- a/.claude/skills/review/evals/eval_planted_bugs.yaml
+++ b/.claude/skills/review/evals/eval_planted_bugs.yaml
@@ -1,0 +1,66 @@
+name: planted_bug_detection
+skill: review
+description: Verify the review skill catches planted violations across multiple checklists
+prompt: |
+  Review this diff:
+
+  ```python
+  # src/data/processor.py
+  + import os
+  + from pathlib import Path
+  +
+  + def process_audio_batch(audio_files, output_dir, config):
+  +     """Process a batch of audio files."""
+  +     results = []
+  +     for f in audio_files:
+  +         try:
+  +             data = load_audio(f)
+  +             if data is not None:
+  +                 if len(data) > 0:
+  +                     if config.get("normalize"):
+  +                         data = normalize(data)
+  +                         if config.get("trim"):
+  +                             data = trim_silence(data)
+  +                             result = {"file": f, "samples": len(data), "processed": True}
+  +                             results.append(result)
+  +             path = Path(output_dir) / "data" / "shards" / f"{os.path.basename(f)}.h5"
+  +             path.parent.mkdir(parents=True, exist_ok=True)
+  +             save_hdf5(path, data)
+  +         except:
+  +             pass
+  +     MAGIC_THRESHOLD = 42
+  +     return [r for r in results if r["samples"] > MAGIC_THRESHOLD]
+  ```
+
+  No tests were included in this PR.
+
+  Planted violations:
+  - [code-health] Deep nesting (5 levels)
+  - [code-health] Magic number (42)
+  - [python-style] Bare except
+  - [python-style] Missing type annotations
+  - [project] Writing to data/shards/ outside finalize
+  - [project] No type annotations on function signature
+  - [tdd] No tests included
+context_files: []
+success_criteria:
+  - Catches bare except (BLOCK)
+  - Catches deep nesting (WARN or BLOCK)
+  - Catches magic number 42 (WARN)
+  - Catches missing type annotations (WARN)
+  - Catches writing to data/shards/ outside finalize (BLOCK -- pipeline rule)
+  - Catches missing tests (BLOCK or WARN)
+  - At least 5 of 7 planted violations detected
+failure_criteria:
+  - Fewer than 3 planted violations detected
+  - Bare except not flagged
+  - Pipeline rule violation (data/shards/) not flagged
+  - Output not in BLOCK/WARN format
+comparator_focus: |
+  This is a planted-bug test. Count how many of the 7 known violations are
+  detected. The bare except and data/shards/ pipeline violation are the most
+  critical. Score = violations detected / 7.
+tags:
+  - review
+  - false-negative-rate
+  - planted-bugs

--- a/.claude/skills/tdd-implementation/evals/eval_behavior_not_implementation.yaml
+++ b/.claude/skills/tdd-implementation/evals/eval_behavior_not_implementation.yaml
@@ -1,0 +1,29 @@
+name: behavior_not_implementation_testing
+skill: tdd-implementation
+description: Verify tests check behavior (outputs/effects) not implementation details
+prompt: |
+  Implement a `ShardNamer` class in `src/data/shard_namer.py` that generates
+  deterministic shard names from a base index. It should have:
+  - `name(index: int) -> str` returning `shard-{index:06d}`
+  - `parse(name: str) -> int` returning the index from a shard name
+  Write tests for this class.
+context_files:
+  - src/data/__init__.py
+success_criteria:
+  - Tests verify return values and observable outputs, not internal state
+  - Tests would survive an internal refactor that preserves the same API
+  - No mocking of internal methods or private attributes
+  - Tests read as specifications -- given X, when Y, then Z
+  - State testing preferred over interaction testing
+failure_criteria:
+  - Tests assert on private attributes or internal method calls
+  - Tests mock internal collaborators unnecessarily
+  - Tests mirror production code logic (e.g. f-string in test matches f-string in impl)
+  - Tests break on renaming private methods
+comparator_focus: |
+  Evaluate whether tests are behavior-focused or implementation-focused.
+  Key signal: would the tests still pass after a complete internal rewrite
+  that preserves the same public API?
+tags:
+  - tdd
+  - behavior-testing

--- a/.claude/skills/tdd-implementation/evals/eval_compliance_report.yaml
+++ b/.claude/skills/tdd-implementation/evals/eval_compliance_report.yaml
@@ -1,0 +1,26 @@
+name: tdd_compliance_report
+skill: tdd-implementation
+description: Verify Claude produces a TDD compliance report after implementation
+prompt: |
+  Implement a function `merge_shard_metadata(shards: list[dict]) -> dict` in
+  `src/utils/metadata.py` that merges metadata from multiple shards into a single
+  summary dict with keys: total_samples, total_bytes, shard_ids.
+  Each input dict has: shard_id (str), num_samples (int), size_bytes (int).
+context_files:
+  - src/utils/__init__.py
+success_criteria:
+  - A TDD compliance report table is produced after implementation
+  - Report covers all 16 checklist items
+  - Each item has Applied status (checkmark, warning, or X) and evidence
+  - Narrative summary follows the table
+  - Report is honest about which principles were/weren't applied
+failure_criteria:
+  - No compliance report produced
+  - Report claims all items applied without evidence
+  - Report omits items or is incomplete
+comparator_focus: |
+  Does Claude produce the 16-item TDD compliance report table after finishing?
+  Is it honest and evidence-based, or is it a rubber-stamp?
+tags:
+  - tdd
+  - compliance-report

--- a/.claude/skills/tdd-implementation/evals/eval_mock_usage.yaml
+++ b/.claude/skills/tdd-implementation/evals/eval_mock_usage.yaml
@@ -1,0 +1,30 @@
+name: appropriate_mock_usage
+skill: tdd-implementation
+description: Verify mocks are used sparingly and only at architectural boundaries
+prompt: |
+  Implement a `ShardUploader` class in `src/pipeline/uploader.py` that:
+  - Takes an rclone binary path and R2 bucket URL
+  - Has an `upload(local_path: Path, remote_key: str) -> bool` method
+  - Uses subprocess to call rclone with --checksum flag
+  - Retries once on CalledProcessError
+  Write tests for this class.
+context_files:
+  - src/pipeline/__init__.py
+success_criteria:
+  - subprocess.run is mocked (it's an external boundary)
+  - pytest-mock (mocker fixture) used instead of unittest.mock decorators
+  - Mock is at the architectural boundary (subprocess), not between internal classes
+  - Retry behavior tested by simulating failure then success
+  - No mocking of ShardUploader's own internal methods
+failure_criteria:
+  - Real subprocess.run called in tests (would hit filesystem/network)
+  - unittest.mock.patch decorators used instead of pytest-mock
+  - Internal methods of ShardUploader mocked
+  - Mock used where a real object or fake would work
+comparator_focus: |
+  Focus on mock placement: is subprocess.run mocked at the boundary?
+  Is pytest-mock used? Are internal methods left unmocked?
+  The retry behavior test is the key scenario.
+tags:
+  - tdd
+  - mocking

--- a/.claude/skills/tdd-implementation/evals/eval_red_green_refactor.yaml
+++ b/.claude/skills/tdd-implementation/evals/eval_red_green_refactor.yaml
@@ -1,0 +1,26 @@
+name: red_green_refactor_ordering
+skill: tdd-implementation
+description: Verify Claude writes tests before implementation code (Red-Green-Refactor)
+prompt: |
+  Implement a function `validate_shard_id(shard_id: str) -> bool` in `src/utils/validation.py`
+  that returns True if shard_id matches the pattern `shard-NNNNNN` (exactly 6 digits).
+  Invalid inputs should return False, not raise exceptions.
+context_files:
+  - src/utils/__init__.py
+success_criteria:
+  - Test file created before or simultaneously with implementation
+  - At least one test is written and run before the implementation exists
+  - Test contains both valid and invalid shard ID scenarios
+  - Implementation is minimal -- validates pattern only, no extras
+  - Test names follow test_<what>_<condition>_<expected> pattern
+failure_criteria:
+  - Implementation written without any test file
+  - All tests written after implementation is complete
+  - Test only covers the happy path (valid shard IDs)
+comparator_focus: |
+  Focus on TDD cycle adherence: were tests written FIRST? Was the implementation
+  minimal (just enough to pass)? Did Claude explicitly run a failing test before
+  writing implementation code?
+tags:
+  - tdd
+  - red-green-refactor

--- a/.github/workflows/skill-eval.yml
+++ b/.github/workflows/skill-eval.yml
@@ -1,0 +1,82 @@
+name: Skill Evaluation
+
+on:
+  workflow_dispatch:
+    inputs:
+      skill:
+        description: "Skill to evaluate ('all' for Tier 1, or specific skill name)"
+        required: true
+        default: "all"
+        type: string
+      max_evals:
+        description: "Max eval cases per skill"
+        required: false
+        default: "5"
+        type: string
+      model:
+        description: "Claude model for evals"
+        required: false
+        default: "claude-sonnet-4-20250514"
+        type: string
+  pull_request:
+    paths:
+      - ".claude/skills/**/SKILL.md"
+
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install anthropic pyyaml
+
+      - name: Determine skill to evaluate
+        id: skill
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "name=${{ inputs.skill }}" >> "$GITHUB_OUTPUT"
+            echo "max_evals=${{ inputs.max_evals }}" >> "$GITHUB_OUTPUT"
+            echo "model=${{ inputs.model }}" >> "$GITHUB_OUTPUT"
+          else
+            # Auto-detect which skills changed in the PR
+            CHANGED=$(git diff --name-only "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}" \
+              -- '.claude/skills/*/SKILL.md' | \
+              sed 's|.claude/skills/\(.*\)/SKILL.md|\1|' | tr '\n' ',')
+            if [ -z "$CHANGED" ]; then
+              echo "name=all" >> "$GITHUB_OUTPUT"
+            else
+              echo "name=${CHANGED%,}" >> "$GITHUB_OUTPUT"
+            fi
+            echo "max_evals=5" >> "$GITHUB_OUTPUT"
+            echo "model=claude-sonnet-4-20250514" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run skill evals
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          IFS=',' read -ra SKILLS <<< "${{ steps.skill.outputs.name }}"
+          for skill in "${SKILLS[@]}"; do
+            python scripts/eval_skills.py \
+              --skill "$skill" \
+              --max-evals "${{ steps.skill.outputs.max_evals }}" \
+              --model "${{ steps.skill.outputs.model }}" \
+              --run \
+              --verbose
+          done
+
+      - name: Upload eval results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results-${{ github.run_id }}
+          path: eval-results/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,9 @@ checkpoints/
 # VST3
 plugins/
 
+# Skill eval results (generated, not committed)
+eval-results/
+
 # Claude Code (keep skills only)
 .claude/
 !.claude/skills/

--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,6 @@ test-full: ## Run all tests
 
 train: ## Train the model
 	python src/train.py
+
+eval-skills: ## Run skill evals (dry run by default, use EVAL_RUN=1 for real)
+	python scripts/eval_skills.py --skill all $(if $(EVAL_RUN),--run,--dry-run) --verbose

--- a/docs/issues/skill-eval-pipeline.md
+++ b/docs/issues/skill-eval-pipeline.md
@@ -1,0 +1,87 @@
+# GitHub Issue: feat(evaluation): CI skill evaluation pipeline with A/B comparator
+
+**Type:** Feature
+**Domain label:** `evaluation`
+**Milestone:** `evaluation v1.0.0`
+**Priority:** P1
+
+---
+
+## Summary
+
+Set up a CI evaluation pipeline that benchmarks Claude Code skills using A/B comparator
+methodology, enabling iterative improvement through the native Skills Creator and prompt
+engineering best practices.
+
+## Motivation
+
+We have 11 Claude Code skills in `.claude/skills/` governing code review, TDD, ML testing, and
+project standards -- but no way to **measure** whether they actually improve Claude's output.
+Without measurement, skill iteration is guesswork.
+
+## Methodology
+
+Based on [Anthropic: Test, Measure, and Refine Agent Skills](https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills)
+and the [Claude Prompt Engineering Guide](https://github.com/ThamJiaHe/claude-prompt-engineering-guide/blob/main/Claude-Prompt-Guide.md):
+
+- **A/B comparator evals**: Run two versions of a skill (current vs candidate) in parallel
+  isolated contexts. A comparator agent blindly judges which output is better against defined
+  success/failure criteria.
+- **Fallback**: If A/B proves too costly or inconsistent, fall back to prompt + golden-output
+  evals (deterministic grading, 1 API call per case instead of 3).
+
+## Skill Priority Tiers
+
+| Tier | Skills | Focus |
+|------|--------|-------|
+| **Tier 1** (now) | `tdd-implementation`, `pr-checkbox`, `ml-test` | Code testing, implementation, feature verification |
+| **Tier 1.5** (now) | `code-health`, `review` | Enhance code review quality |
+| **Tier 2** (next) | `project-standards`, `ml-data-pipeline` | Narrow domain: DSP coding, ML pipeline standards |
+| **Tier 3** (later) | `python-style`, `shell-style`, `github-taxonomy`, `design-doc` | Style and process skills |
+
+## Implementation Plan
+
+### Eval Case Format (co-located YAML)
+
+Each skill gets an `evals/` subfolder with eval cases as YAML files:
+
+```
+.claude/skills/<skill-name>/evals/
+  eval_<scenario>.yaml
+```
+
+Each eval case defines: `name`, `skill`, `description`, `prompt`, `context_files`,
+`success_criteria`, `failure_criteria`, `comparator_focus`.
+
+### Eval Runner (`scripts/eval_skills.py`)
+
+- Parses eval YAML files from a skill's `evals/` directory
+- Runs A/B Claude API calls (skill-on vs skill-off/candidate)
+- Blind comparator scores outputs against criteria
+- Results written to `eval-results/` (gitignored)
+- Cost guard: `--max-evals N` flag, `--dry-run` by default
+
+### CI Workflow (`.github/workflows/skill-eval.yml`)
+
+- **Auto-trigger**: on PRs that modify `.claude/skills/**/SKILL.md`
+- **Manual trigger**: `workflow_dispatch` for on-demand evaluation
+- Uploads results as GitHub Actions artifacts
+
+### Code Review Enhancement
+
+- Planted-bug test fixtures for the `review` skill
+- Measure false positive/negative rates
+- Verify all 7 sub-checklists are invoked
+
+## Deliverables
+
+- [ ] Eval case YAML schema (`.claude/skills/eval-schema.yaml`)
+- [ ] Eval runner script (`scripts/eval_skills.py`)
+- [ ] CI workflow (`.github/workflows/skill-eval.yml`)
+- [ ] ~15 eval cases across 5 Tier 1/1.5 skills
+- [ ] Makefile target (`make eval-skills`)
+
+## References
+
+- [Anthropic: Improving Skill Creator](https://claude.com/blog/improving-skill-creator-test-measure-and-refine-agent-skills)
+- [Claude Prompt Engineering Guide](https://github.com/ThamJiaHe/claude-prompt-engineering-guide/blob/main/Claude-Prompt-Guide.md)

--- a/scripts/eval_skills.py
+++ b/scripts/eval_skills.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""Skill evaluation runner with A/B comparator methodology.
+
+Benchmarks Claude Code skills by running two versions (A: skill-enabled, B: skill-disabled
+or candidate) against eval cases, then using a blind comparator to judge quality.
+
+Usage:
+    # Dry run (no API calls)
+    python scripts/eval_skills.py --dry-run --skill tdd-implementation
+
+    # Run evals for a single skill
+    python scripts/eval_skills.py --skill tdd-implementation --max-evals 2
+
+    # Run all Tier 1 skills
+    python scripts/eval_skills.py --skill all
+
+    # Compare current skill against a candidate file
+    python scripts/eval_skills.py --skill tdd-implementation --candidate path/to/SKILL.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import random
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+SKILLS_DIR = Path(".claude/skills")
+RESULTS_DIR = Path("eval-results")
+
+TIER1_SKILLS = [
+    "tdd-implementation",
+    "pr-checkbox",
+    "ml-test",
+    "code-health",
+    "review",
+]
+
+
+@dataclass
+class EvalCase:
+    """A single evaluation case loaded from YAML."""
+
+    name: str
+    skill: str
+    description: str
+    prompt: str
+    success_criteria: list[str]
+    failure_criteria: list[str]
+    comparator_focus: str
+    context_files: list[str] = field(default_factory=list)
+    tags: list[str] = field(default_factory=list)
+
+
+@dataclass
+class EvalResult:
+    """Result from evaluating a single case."""
+
+    case_name: str
+    skill: str
+    winner: str  # "A" (skill-on), "B" (skill-off/candidate), or "tie"
+    score_a: float
+    score_b: float
+    comparator_reasoning: str
+    criteria_scores: dict[str, dict[str, bool]]
+    timestamp: str
+    duration_seconds: float
+
+
+def load_eval_cases(skill_name: str) -> list[EvalCase]:
+    """Load eval cases from a skill's evals/ directory."""
+    evals_dir = SKILLS_DIR / skill_name / "evals"
+    if not evals_dir.exists():
+        logger.warning("No evals directory for skill: %s", skill_name)
+        return []
+
+    cases = []
+    for yaml_path in sorted(evals_dir.glob("eval_*.yaml")):
+        with open(yaml_path) as f:
+            data = yaml.safe_load(f)
+        cases.append(
+            EvalCase(
+                name=data["name"],
+                skill=data["skill"],
+                description=data["description"],
+                prompt=data["prompt"],
+                success_criteria=data["success_criteria"],
+                failure_criteria=data["failure_criteria"],
+                comparator_focus=data["comparator_focus"],
+                context_files=data.get("context_files", []),
+                tags=data.get("tags", []),
+            )
+        )
+    return cases
+
+
+def load_skill_content(skill_name: str) -> str:
+    """Load a skill's SKILL.md content."""
+    skill_path = SKILLS_DIR / skill_name / "SKILL.md"
+    if not skill_path.exists():
+        msg = f"SKILL.md not found: {skill_path}"
+        raise FileNotFoundError(msg)
+    return skill_path.read_text()
+
+
+def build_task_prompt(case: EvalCase) -> str:
+    """Build the task prompt with context files if specified."""
+    parts = [case.prompt]
+    for ctx_file in case.context_files:
+        ctx_path = Path(ctx_file)
+        if ctx_path.exists():
+            parts.append(f"\n--- {ctx_file} ---\n{ctx_path.read_text()}")
+    return "\n".join(parts)
+
+
+def call_claude(
+    system_prompt: str,
+    user_prompt: str,
+    model: str = "claude-sonnet-4-20250514",
+) -> str:
+    """Call Claude API and return the response text.
+
+    Uses claude-sonnet-4-20250514 by default for cost efficiency on evals.
+    """
+    try:
+        import anthropic  # noqa: S404
+    except ImportError:
+        logger.error("anthropic package not installed. Run: pip install anthropic")
+        sys.exit(1)
+
+    client = anthropic.Anthropic()
+    message = client.messages.create(
+        model=model,
+        max_tokens=4096,
+        system=system_prompt,
+        messages=[{"role": "user", "content": user_prompt}],
+    )
+    return message.content[0].text
+
+
+def build_comparator_prompt(
+    case: EvalCase,
+    output_x: str,
+    output_y: str,
+) -> str:
+    """Build the blind comparator prompt."""
+    criteria_list = "\n".join(f"  - {c}" for c in case.success_criteria)
+    failure_list = "\n".join(f"  - {c}" for c in case.failure_criteria)
+
+    return f"""You are an expert evaluator comparing two AI assistant outputs for the same task.
+You do NOT know which output used a skill prompt and which did not. Judge purely on quality.
+
+## Task Given to Both
+{case.prompt}
+
+## Success Criteria (output SHOULD exhibit these)
+{criteria_list}
+
+## Failure Criteria (output MUST NOT exhibit these)
+{failure_list}
+
+## Comparator Focus
+{case.comparator_focus}
+
+## Output X
+{output_x}
+
+## Output Y
+{output_y}
+
+## Instructions
+1. Score each output on each success criterion (met=1, partial=0.5, not met=0).
+2. Penalize each output for each failure criterion exhibited (-1 per violation).
+3. Compute a total score for each output.
+4. Declare a winner: X, Y, or tie.
+
+Respond in this exact JSON format:
+{{
+  "criteria_scores": {{
+    "X": {{"<criterion>": true/false, ...}},
+    "Y": {{"<criterion>": true/false, ...}}
+  }},
+  "score_x": <float>,
+  "score_y": <float>,
+  "winner": "X" or "Y" or "tie",
+  "reasoning": "<brief explanation>"
+}}"""
+
+
+def run_eval_case(
+    case: EvalCase,
+    skill_content: str,
+    candidate_content: Optional[str] = None,
+    model: str = "claude-sonnet-4-20250514",
+) -> EvalResult:
+    """Run A/B eval for a single case.
+
+    Version A: skill_content injected as system prompt.
+    Version B: no skill (or candidate_content if provided).
+    """
+    start = time.monotonic()
+    task_prompt = build_task_prompt(case)
+
+    # Version A: skill-enabled
+    output_a = call_claude(
+        system_prompt=f"Follow these guidelines:\n\n{skill_content}",
+        user_prompt=task_prompt,
+        model=model,
+    )
+
+    # Version B: skill-disabled or candidate
+    if candidate_content:
+        system_b = f"Follow these guidelines:\n\n{candidate_content}"
+    else:
+        system_b = "You are a helpful coding assistant."
+
+    output_b = call_claude(
+        system_prompt=system_b,
+        user_prompt=task_prompt,
+        model=model,
+    )
+
+    # Randomize presentation order to avoid position bias
+    if random.random() < 0.5:  # noqa: S311
+        output_x, output_y = output_a, output_b
+        mapping = {"X": "A", "Y": "B"}
+    else:
+        output_x, output_y = output_b, output_a
+        mapping = {"X": "B", "Y": "A"}
+
+    # Comparator judges blindly
+    comparator_prompt = build_comparator_prompt(case, output_x, output_y)
+    comparator_response = call_claude(
+        system_prompt="You are an expert code quality evaluator. Respond only in valid JSON.",
+        user_prompt=comparator_prompt,
+        model=model,
+    )
+
+    # Parse comparator response
+    try:
+        result_data = json.loads(comparator_response)
+    except json.JSONDecodeError:
+        # Try extracting JSON from markdown code block
+        import re
+
+        json_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", comparator_response, re.DOTALL)
+        if json_match:
+            result_data = json.loads(json_match.group(1))
+        else:
+            result_data = {
+                "score_x": 0,
+                "score_y": 0,
+                "winner": "tie",
+                "reasoning": f"Failed to parse comparator response: {comparator_response[:200]}",
+                "criteria_scores": {"X": {}, "Y": {}},
+            }
+
+    # Map X/Y back to A/B
+    raw_winner = result_data.get("winner", "tie")
+    if raw_winner in mapping:
+        winner = mapping[raw_winner]
+    else:
+        winner = "tie"
+
+    duration = time.monotonic() - start
+
+    return EvalResult(
+        case_name=case.name,
+        skill=case.skill,
+        winner=winner,
+        score_a=result_data.get(f"score_{mapping.get('X', 'x').lower()}", result_data.get("score_x", 0)),
+        score_b=result_data.get(f"score_{mapping.get('Y', 'y').lower()}", result_data.get("score_y", 0)),
+        comparator_reasoning=result_data.get("reasoning", ""),
+        criteria_scores=result_data.get("criteria_scores", {}),
+        timestamp=datetime.now(tz=timezone.utc).isoformat(),
+        duration_seconds=round(duration, 2),
+    )
+
+
+def run_skill_evals(
+    skill_name: str,
+    max_evals: int = 5,
+    candidate_path: Optional[Path] = None,
+    dry_run: bool = False,
+    model: str = "claude-sonnet-4-20250514",
+) -> list[EvalResult]:
+    """Run all eval cases for a skill."""
+    cases = load_eval_cases(skill_name)
+    if not cases:
+        logger.info("No eval cases found for skill: %s", skill_name)
+        return []
+
+    cases = cases[:max_evals]
+    skill_content = load_skill_content(skill_name)
+
+    candidate_content = None
+    if candidate_path:
+        candidate_content = candidate_path.read_text()
+
+    if dry_run:
+        logger.info("[DRY RUN] Would run %d eval(s) for skill: %s", len(cases), skill_name)
+        for case in cases:
+            logger.info("  - %s: %s", case.name, case.description)
+        return []
+
+    logger.info("Running %d eval(s) for skill: %s", len(cases), skill_name)
+    results = []
+    for i, case in enumerate(cases, 1):
+        logger.info("  [%d/%d] %s ...", i, len(cases), case.name)
+        result = run_eval_case(case, skill_content, candidate_content, model=model)
+        results.append(result)
+        logger.info(
+            "    Winner: %s (A=%.1f, B=%.1f) - %s",
+            result.winner,
+            result.score_a,
+            result.score_b,
+            result.comparator_reasoning[:80],
+        )
+
+    return results
+
+
+def save_results(results: list[EvalResult], skill_name: str) -> Path:
+    """Save eval results to JSON."""
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
+    output_path = RESULTS_DIR / f"{skill_name}_{timestamp}.json"
+
+    data = {
+        "skill": skill_name,
+        "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+        "num_cases": len(results),
+        "wins_a": sum(1 for r in results if r.winner == "A"),
+        "wins_b": sum(1 for r in results if r.winner == "B"),
+        "ties": sum(1 for r in results if r.winner == "tie"),
+        "results": [
+            {
+                "case_name": r.case_name,
+                "winner": r.winner,
+                "score_a": r.score_a,
+                "score_b": r.score_b,
+                "reasoning": r.comparator_reasoning,
+                "criteria_scores": r.criteria_scores,
+                "timestamp": r.timestamp,
+                "duration_seconds": r.duration_seconds,
+            }
+            for r in results
+        ],
+    }
+
+    output_path.write_text(json.dumps(data, indent=2))
+    return output_path
+
+
+def print_summary(all_results: dict[str, list[EvalResult]]) -> None:
+    """Print a summary table of all eval results."""
+    print("\n" + "=" * 60)
+    print("SKILL EVALUATION SUMMARY")
+    print("=" * 60)
+
+    total_a = 0
+    total_b = 0
+    total_ties = 0
+
+    for skill_name, results in all_results.items():
+        wins_a = sum(1 for r in results if r.winner == "A")
+        wins_b = sum(1 for r in results if r.winner == "B")
+        ties = sum(1 for r in results if r.winner == "tie")
+        total_a += wins_a
+        total_b += wins_b
+        total_ties += ties
+
+        status = "PASS" if wins_a >= wins_b else "NEEDS IMPROVEMENT"
+        print(f"\n  {skill_name}:")
+        print(f"    Skill wins: {wins_a}  |  Baseline wins: {wins_b}  |  Ties: {ties}")
+        print(f"    Status: {status}")
+
+        for r in results:
+            marker = {"A": "+", "B": "-", "tie": "="}[r.winner]
+            print(f"      [{marker}] {r.case_name}: A={r.score_a:.1f} B={r.score_b:.1f}")
+
+    print(f"\n  TOTAL: Skill={total_a}  Baseline={total_b}  Ties={total_ties}")
+    print("=" * 60)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Evaluate Claude Code skills via A/B comparator",
+    )
+    parser.add_argument(
+        "--skill",
+        required=True,
+        help="Skill to evaluate (or 'all' for all Tier 1 skills)",
+    )
+    parser.add_argument(
+        "--max-evals",
+        type=int,
+        default=5,
+        help="Maximum eval cases per skill (default: 5)",
+    )
+    parser.add_argument(
+        "--candidate",
+        type=Path,
+        default=None,
+        help="Path to candidate SKILL.md for A/B comparison",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=True,
+        help="Print what would run without making API calls (default: True)",
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Actually run evals (overrides --dry-run default)",
+    )
+    parser.add_argument(
+        "--model",
+        default="claude-sonnet-4-20250514",
+        help="Model to use for evals (default: claude-sonnet-4-20250514)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Main entry point."""
+    args = parse_args()
+
+    log_level = logging.DEBUG if args.verbose else logging.INFO
+    logging.basicConfig(level=log_level, format="%(levelname)s: %(message)s")
+
+    dry_run = args.dry_run and not args.run
+
+    skills = TIER1_SKILLS if args.skill == "all" else [args.skill]
+
+    all_results: dict[str, list[EvalResult]] = {}
+
+    for skill_name in skills:
+        results = run_skill_evals(
+            skill_name=skill_name,
+            max_evals=args.max_evals,
+            candidate_path=args.candidate,
+            dry_run=dry_run,
+            model=args.model,
+        )
+
+        if results:
+            output_path = save_results(results, skill_name)
+            logger.info("Results saved to: %s", output_path)
+            all_results[skill_name] = results
+
+    if all_results:
+        print_summary(all_results)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add infrastructure to benchmark and iteratively improve Claude Code skills
using A/B comparator methodology (blind evaluation of skill-on vs skill-off).

- Eval runner (scripts/eval_skills.py): runs A/B evals with blind comparator,
  randomized presentation order, JSON results output, dry-run by default
- 15 eval cases across 5 Tier 1 skills: tdd-implementation (4), pr-checkbox (3),
  ml-test (3), code-health (3), review (2)
- CI workflow (.github/workflows/skill-eval.yml): auto-triggers on SKILL.md
  changes in PRs, manual workflow_dispatch for on-demand evaluation
- Eval case YAML schema with success/failure criteria and comparator focus
- Makefile target (make eval-skills) and .gitignore for eval-results/

Refs: docs/issues/skill-eval-pipeline.md

https://claude.ai/code/session_01RrwBr1sAduUqxLgFuH1fYe