### PR TITLE
chore(code-health): add conventional commit guidance and gitlint enforcement

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -1,0 +1,6 @@
+[general]
+contrib=contrib-title-conventional-commits
+ignore=body-is-missing
+
+[contrib-title-conventional-commits]
+types=feat,fix,perf,docs,chore,ci,test,refactor,style,build,revert

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,11 @@ synth-setter: Synth inversion, sound matching and preset exploration tools
 
 ### Commit Messages
 
-Conventional commits, enforced by gitlint. Prefix matters for semantic versioning:
+Conventional commits, enforced by gitlint (`.gitlint` config). Prefix matters for semantic versioning:
 
 - `feat:` → **minor** version bump. Reserve for genuinely new user-facing capabilities (new model, new pipeline stage, new CLI command).
 - `fix:` / `perf:` → **patch** version bump. Bug fixes and performance improvements.
+- `feat!:` or `BREAKING CHANGE:` footer → **major** version bump. Coordinate with a maintainer.
 - `docs:`, `chore:`, `ci:`, `test:`, `refactor:`, `style:`, `build:` → **no version bump**.
 
 Most CI improvements, doc updates, config cleanups, and infra work should use `ci:`, `docs:`, or `chore:` — not `feat:`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,16 @@ synth-setter: Synth inversion, sound matching and preset exploration tools
 - **Ruff** (rules: E, F, I, S, T, UP, W)
 - Run `make format` before committing
 
+### Commit Messages
+
+Conventional commits, enforced by gitlint. Prefix matters for semantic versioning:
+
+- `feat:` → **minor** version bump. Reserve for genuinely new user-facing capabilities (new model, new pipeline stage, new CLI command).
+- `fix:` / `perf:` → **patch** version bump. Bug fixes and performance improvements.
+- `docs:`, `chore:`, `ci:`, `test:`, `refactor:`, `style:`, `build:` → **no version bump**.
+
+Most CI improvements, doc updates, config cleanups, and infra work should use `ci:`, `docs:`, or `chore:` — not `feat:`.
+
 ### Writing Code
 
 - Write readable code. Prefer clarity over cleverness.


### PR DESCRIPTION
## Summary

- Adds `.gitlint` config with `contrib-title-conventional-commits` rule — gitlint was already in pre-commit but running with defaults only, so conventional commits weren't actually enforced
- Documents conventional commit prefixes and their semantic versioning impact in CLAUDE.md (`feat:` → minor, `fix:`/`perf:` → patch, `feat!:`/`BREAKING CHANGE:` → major)
- Clarifies that most CI/docs/config work should use `ci:`, `docs:`, or `chore:` — not `feat:`

Closes #215