### PR TITLE
chore(code-health): add internal-feat and internal-fix commit prefixes

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -3,4 +3,4 @@ contrib=contrib-title-conventional-commits
 ignore=body-is-missing
 
 [contrib-title-conventional-commits]
-types=feat,fix,perf,docs,chore,ci,test,refactor,style,build,revert
+types=feat,fix,perf,docs,chore,ci,test,refactor,style,build,revert,internal-feat,internal-fix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Conventional commits, enforced by gitlint (`.gitlint` config). Prefix matters fo
 **Version-bumping prefixes:**
 
 - `feat:` → **minor** bump. New user-facing capability (new model, new pipeline stage, new CLI command). The feature must be usable after this commit.
-- `fix:` / `perf:` → **patch** bump. Bug fixes and performance improvements.
+- `fix:` / `perf:` / `revert:` → **patch** bump. Bug fixes, performance improvements, and reverts (reverts are roll-forwards on an append-only main).
 - `feat!:` or `BREAKING CHANGE:` footer → **major** bump. Coordinate with a maintainer.
 
 **No-bump prefixes:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,12 +20,24 @@ synth-setter: Synth inversion, sound matching and preset exploration tools
 
 Conventional commits, enforced by gitlint (`.gitlint` config). Prefix matters for semantic versioning:
 
-- `feat:` → **minor** version bump. Reserve for genuinely new user-facing capabilities (new model, new pipeline stage, new CLI command).
-- `fix:` / `perf:` → **patch** version bump. Bug fixes and performance improvements.
-- `feat!:` or `BREAKING CHANGE:` footer → **major** version bump. Coordinate with a maintainer.
-- `docs:`, `chore:`, `ci:`, `test:`, `refactor:`, `style:`, `build:` → **no version bump**.
+**Version-bumping prefixes:**
 
-Most CI improvements, doc updates, config cleanups, and infra work should use `ci:`, `docs:`, or `chore:` — not `feat:`.
+- `feat:` → **minor** bump. New user-facing capability (new model, new pipeline stage, new CLI command). The feature must be usable after this commit.
+- `fix:` / `perf:` → **patch** bump. Bug fixes and performance improvements.
+- `feat!:` or `BREAKING CHANGE:` footer → **major** bump. Coordinate with a maintainer.
+
+**No-bump prefixes:**
+
+- `internal-feat:` → new code building toward a feature not yet exposed to users (new internal API, new module, new config schema). Use this when a feature is being built across multiple PRs and this PR adds real, tested code — but the feature isn't user-facing yet. No version bump.
+- `internal-fix:` → fix to internal code not yet exposed to users. No version bump.
+- `docs:`, `chore:`, `ci:`, `test:`, `refactor:`, `style:`, `build:` → no version bump.
+
+**When to use which:**
+
+- Each PR should leave main in a valid state — no dead code, no unhooked partial implementations.
+- If the PR adds new tested code that will be consumed later, use `internal-feat:`.
+- The PR that wires everything together and makes the feature user-facing uses `feat:`.
+- Don't contort prefixes to avoid bumps. If it's user-facing, it's `feat:`.
 
 ### Writing Code
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ changelog_file = "CHANGELOG.md"
 # Major bumps: handled by default via "feat!:" prefix or "BREAKING CHANGE:" footer
 # Pre-1.0: breaking changes bump minor (standard semver pre-1.0 behavior)
 [tool.semantic_release.commit_parser_options]
-allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "perf", "refactor", "style", "test"]
+allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "internal-feat", "internal-fix", "perf", "refactor", "style", "test"]
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,9 +87,9 @@ changelog_file = "CHANGELOG.md"
 # Major bumps: handled by default via "feat!:" prefix or "BREAKING CHANGE:" footer
 # Pre-1.0: breaking changes bump minor (standard semver pre-1.0 behavior)
 [tool.semantic_release.commit_parser_options]
-allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "internal-feat", "internal-fix", "perf", "refactor", "style", "test"]
+allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "internal-feat", "internal-fix", "perf", "refactor", "revert", "style", "test"]
 minor_tags = ["feat"]
-patch_tags = ["fix", "perf"]
+patch_tags = ["fix", "perf", "revert"]
 
 [tool.coverage.report]
 exclude_lines = [


### PR DESCRIPTION
## Summary

- Add `internal-feat:` and `internal-fix:` conventional commit prefixes for building features incrementally across multiple PRs without triggering version bumps
- `internal-feat:` — new code building toward a feature not yet user-facing (new internal API, module, config schema). Tested, valid, not exposed. No version bump.
- `internal-fix:` — fix to internal code not yet exposed. No version bump.

## Changes

| File | Change |
|---|---|
| `CLAUDE.md` | Commit message guidance rewritten with version-bumping vs no-bump sections, when-to-use guidance |
| `.gitlint` | Added `internal-feat`, `internal-fix` to allowed types |
| `pyproject.toml` | Added to `semantic_release.commit_parser_options.allowed_tags` (no bump) |

## Rationale

Building a feature across 10 PRs shouldn't produce 10 minor version bumps. But calling new internal APIs `refactor:` or `chore:` is a lie — they're new code, not restructuring or maintenance. `internal-feat:` accurately describes what the PR does while keeping version bumps for the final user-facing PR.

Closes #221