### PR TITLE
build(docker): correct Surge install path and workflow SHA

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -30,13 +30,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Capture checked-out SHA
+        id: meta
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Build Docker image (dev-live target)
         env:
           GIT_PAT: ${{ secrets.GIT_PAT }}
           DOCKER_BUILDKIT: "1"
         run: |
           make docker-build-dev-live \
-            GIT_REF=${{ github.sha }} \
+            GIT_REF=${{ steps.meta.outputs.sha }} \
             GIT_PAT=${{ secrets.GIT_PAT }} \
             DOCKER_BUILD_FLAGS="--load"
 

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -30,17 +30,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Capture checked-out SHA
-        id: meta
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
       - name: Build Docker image (dev-live target)
         env:
           GIT_PAT: ${{ secrets.GIT_PAT }}
           DOCKER_BUILDKIT: "1"
         run: |
+          # dev-live uses CURRENT_LOCAL_GIT_REF (git rev-parse HEAD) internally
+          # in the Makefile — no need to pass GIT_REF explicitly.
           make docker-build-dev-live \
-            GIT_REF=${{ steps.meta.outputs.sha }} \
             GIT_PAT=${{ secrets.GIT_PAT }} \
             DOCKER_BUILD_FLAGS="--load"
 

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -229,7 +229,7 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
     libjack-jackd2-dev
 RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lib,target=/var/lib/apt,sharing=locked \
-    pkg="$(cat /tmp-artifacts/surge-package-filepath.txt)" && \
+    pkg="$(cat /surge-package-filepath.txt)" && \
     fname="${pkg##*/}" && \
     apt-get update && apt-get install -y --no-install-recommends "./${fname}" && \
     rm "./${fname}"


### PR DESCRIPTION
## Summary

- Fix Surge install path in Dockerfile prebuilt stage: `/tmp-artifacts/surge-package-filepath.txt` → `/surge-package-filepath.txt`
- Use `git rev-parse HEAD` instead of `github.sha` in docker-build-validation workflow

Both issues were introduced in #229 and caused the Docker build CI to fail.

Refs #228

## Verification

- [ ] `docker-build-validation` workflow passes
- [ ] Surge XT installs correctly in the Docker image