### PR TITLE
feat(testing): add requires_vst marker and preset param regression tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@ sync: ## Merge changes from main branch to your current branch
 	git pull
 	git pull origin main
 
-test: ## Run not slow tests
-	pytest -n auto -m "not slow"
+test: ## Run quick tests (excludes slow, requires_vst)
+	pytest -n auto -m "not slow and not requires_vst"
 
 # test-full runs serially: GPU and DDP tests require exclusive device access
 test-full: ## Run all tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ markers = [
   "hypothesis: property-based tests (hypothesis)",
   "pipeline: pipeline integration tests",
   "benchmark: performance benchmarks",
+  "requires_vst: requires a VST plugin binary (Surge XT) — skipped unless plugin is present",
 ]
 minversion = "6.0"
 testpaths = "tests/"

--- a/tests/data/vst/test_preset_params.py
+++ b/tests/data/vst/test_preset_params.py
@@ -1,0 +1,84 @@
+"""Regression test: preset-dependent VST parameters require post-load flush.
+
+Surge XT dynamically exposes parameters based on oscillator type. The
+surge-base preset sets an oscillator type that exposes waveform mix
+parameters (sawtooth, pulse, triangle). These only appear in the
+plugin's parameter map after a process()+reset() cycle following
+load_preset().
+
+Regression for: https://github.com/tinaudio/synth-setter/issues/225
+"""
+
+from pathlib import Path
+
+import pytest
+
+PLUGIN_PATH = "/usr/lib/vst3/Surge XT.vst3"
+PRESET_PATH = "presets/surge-base.vstpreset"
+
+# pedalboard.VST3Plugin.parameters is a dynamic C extension attribute that
+# pyright cannot resolve statically. All .parameters accesses below use
+# type: ignore[attr-defined] for this reason.
+
+requires_vst = pytest.mark.requires_vst
+skip_no_vst = pytest.mark.skipif(
+    not Path(PLUGIN_PATH).exists(),
+    reason=f"VST plugin not found at {PLUGIN_PATH}",
+)
+
+
+@requires_vst
+@skip_no_vst
+def test_preset_dependent_params_accessible_after_flush():
+    """Preset-dependent params (e.g. sawtooth) exist after load + flush + reset."""
+    from pedalboard import VST3Plugin
+
+    plugin = VST3Plugin(PLUGIN_PATH)
+    plugin.load_preset(PRESET_PATH)
+    plugin.process([], 32.0, 44100, 2, 2048, True)
+    plugin.reset()
+
+    assert "a_osc_1_sawtooth" in plugin.parameters  # type: ignore[attr-defined]
+    assert "a_osc_1_pulse" in plugin.parameters  # type: ignore[attr-defined]
+    assert "a_osc_1_triangle" in plugin.parameters  # type: ignore[attr-defined]
+
+
+@requires_vst
+@skip_no_vst
+def test_preset_dependent_params_missing_without_flush():
+    """Without flush+reset after load_preset, dynamic params are not exposed."""
+    from pedalboard import VST3Plugin
+
+    plugin = VST3Plugin(PLUGIN_PATH)
+    plugin.load_preset(PRESET_PATH)
+
+    assert "a_osc_1_sawtooth" not in plugin.parameters  # type: ignore[attr-defined]
+
+
+@requires_vst
+@skip_no_vst
+def test_render_params_sets_preset_dependent_param():
+    """render_params must successfully set preset-dependent params."""
+    from pedalboard import VST3Plugin
+
+    from src.data.vst.core import render_params
+
+    plugin = VST3Plugin(PLUGIN_PATH)
+    params = {"a_osc_1_sawtooth": 0.5}
+
+    # Should not raise KeyError
+    render_params(
+        plugin,
+        params=params,
+        midi_note=60,
+        velocity=100,
+        note_start_and_end=(0.0, 0.5),
+        signal_duration_seconds=1.0,
+        sample_rate=44100.0,
+        channels=2,
+        preset_path=PRESET_PATH,
+    )
+
+    assert plugin.parameters["a_osc_1_sawtooth"].raw_value == pytest.approx(  # type: ignore[attr-defined]
+        0.5, abs=0.01
+    )


### PR DESCRIPTION
## Summary

- Add `@pytest.mark.requires_vst` marker for tests needing Surge XT VST plugin
- Update `make test` to exclude `requires_vst` tests (skipped locally, run in Docker)
- Add regression tests verifying preset-dependent params (e.g. `a_osc_1_sawtooth`) are accessible after `load_preset()` + flush+reset

These tests prevent future changes from accidentally breaking the post-load flush that exposes dynamic VST parameters.

Refs #225

## Verification

- [x] Tests skip locally (no VST plugin)
- [x] `make test` excludes `requires_vst` marker
- [x] All pre-commit hooks pass (including pyright)
- [ ] CI tests pass