### PR TITLE
monitoring(data-pipeline): add R2 shard report script

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,7 +124,6 @@ repos:
       - id: interrogate
         exclude: >-
           (?x)^(
-            tests/.*|
             scripts/add_music2latent\.py|
             scripts/compute_audio_metrics\.py|
             scripts/generate_surge_xt_data\.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -124,6 +124,7 @@ repos:
       - id: interrogate
         exclude: >-
           (?x)^(
+            tests/.*|
             scripts/add_music2latent\.py|
             scripts/compute_audio_metrics\.py|
             scripts/generate_surge_xt_data\.py|

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,9 +54,12 @@ ignore = ["E501", "S101"]
 "scripts/paramspec_to_table.py" = ["E402", "T201"]
 "scripts/plot_param2tok.py" = ["E402", "E741", "F841", "T201"]
 "scripts/predict_vst_audio.py" = ["E402", "F841"]
+# S603/S607: rclone subprocess calls use CLI args (user-controlled, not untrusted input).
+# T201: click.echo used for CLI output.
 "scripts/r2_shard_report.py" = ["S603", "S607", "T201"]
 "scripts/reshard_data.py" = ["T201"]
 "scripts/subdir_funtime.py" = ["F841"]
+# S603/S607: rclone subprocess calls in R2 integration test fixtures.
 "tests/scripts/test_r2_shard_report.py" = ["S603", "S607"]
 "src/eval.py" = ["E402", "F841"]
 "src/models/components/transformer.py" = ["F841"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ markers = [
   "pipeline: pipeline integration tests",
   "benchmark: performance benchmarks",
   "requires_vst: requires a VST plugin binary (Surge XT) — skipped unless plugin is present",
+  "r2: tests requiring R2/rclone access",
 ]
 minversion = "6.0"
 testpaths = "tests/"
@@ -53,8 +54,10 @@ ignore = ["E501", "S101"]
 "scripts/paramspec_to_table.py" = ["E402", "T201"]
 "scripts/plot_param2tok.py" = ["E402", "E741", "F841", "T201"]
 "scripts/predict_vst_audio.py" = ["E402", "F841"]
+"scripts/r2_shard_report.py" = ["S603", "S607", "T201"]
 "scripts/reshard_data.py" = ["T201"]
 "scripts/subdir_funtime.py" = ["F841"]
+"tests/scripts/test_r2_shard_report.py" = ["S603", "S607"]
 "src/eval.py" = ["E402", "F841"]
 "src/models/components/transformer.py" = ["F841"]
 "src/models/components/vae.py" = ["E402", "T201"]

--- a/scripts/r2_shard_report.py
+++ b/scripts/r2_shard_report.py
@@ -64,8 +64,17 @@ def parse_rclone_ls_output(output: str) -> list[RcloneFile]:
         if not stripped:
             continue
         parts = stripped.split(maxsplit=1)
-        size_bytes = int(parts[0])
-        filename = parts[1]
+        if len(parts) != 2:
+            raise ValueError(
+                f"Malformed rclone ls line (expected 'SIZE FILENAME'): {line!r}"
+            )
+        size_str, filename = parts
+        try:
+            size_bytes = int(size_str)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid size in rclone ls line (expected integer bytes): {line!r}"
+            ) from exc
         files.append(RcloneFile(size_bytes=size_bytes, filename=filename))
     return files
 

--- a/scripts/r2_shard_report.py
+++ b/scripts/r2_shard_report.py
@@ -65,9 +65,7 @@ def parse_rclone_ls_output(output: str) -> list[RcloneFile]:
             continue
         parts = stripped.split(maxsplit=1)
         if len(parts) != 2:
-            raise ValueError(
-                f"Malformed rclone ls line (expected 'SIZE FILENAME'): {line!r}"
-            )
+            raise ValueError(f"Malformed rclone ls line (expected 'SIZE FILENAME'): {line!r}")
         size_str, filename = parts
         try:
             size_bytes = int(size_str)

--- a/scripts/r2_shard_report.py
+++ b/scripts/r2_shard_report.py
@@ -185,7 +185,7 @@ def run_rclone_ls(prefix: str) -> str:
 
 @click.command()
 @click.argument("prefix")
-@click.option("--size-threshold-gib", "-t", type=float, default=1.0)
+@click.option("--size-threshold-gib", "-t", type=click.FloatRange(min=0), default=1.0)
 def main(prefix: str, size_threshold_gib: float) -> None:
     """Generate a report of shards in an R2 bucket."""
     output = run_rclone_ls(prefix)

--- a/scripts/r2_shard_report.py
+++ b/scripts/r2_shard_report.py
@@ -1,0 +1,199 @@
+"""Generate a report of shards stored in an R2 bucket via rclone."""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from typing import NamedTuple, TypedDict
+
+import click
+
+
+class RcloneFile(NamedTuple):
+    """A file entry from rclone ls output."""
+
+    size_bytes: int
+    filename: str
+
+
+class ShardFileInfo(TypedDict):
+    """Info about a single h5 file in the shard report."""
+
+    filename: str
+    size_bytes: int
+    size_human: str
+    is_suspect: bool
+
+
+class ShardReport(TypedDict):
+    """Typed analysis result from analyze_shards."""
+
+    h5_count: int
+    json_count: int
+    other_count: int
+    logical_shard_count: int
+    total_h5_bytes: int
+    total_h5_human: str
+    threshold_gib: float
+    h5_files: list[ShardFileInfo]
+    suspect_files: list[ShardFileInfo]
+
+
+def format_size(size_bytes: int) -> str:
+    """Human-readable file size with binary prefixes."""
+    if size_bytes == 0:
+        return "0 B"
+
+    if size_bytes < 1024:
+        return f"{size_bytes} B"
+
+    if size_bytes < 1024**2:
+        return f"{size_bytes / 1024:.2f} KiB"
+
+    if size_bytes < 1024**3:
+        return f"{size_bytes / 1024**2:.2f} MiB"
+
+    return f"{size_bytes / 1024**3:.2f} GiB"
+
+
+def parse_rclone_ls_output(output: str) -> list[RcloneFile]:
+    """Parse rclone ls stdout into a list of RcloneFile entries."""
+    files: list[RcloneFile] = []
+    for line in output.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        parts = stripped.split(maxsplit=1)
+        size_bytes = int(parts[0])
+        filename = parts[1]
+        files.append(RcloneFile(size_bytes=size_bytes, filename=filename))
+    return files
+
+
+def analyze_shards(files: list[RcloneFile], threshold_gib: float) -> ShardReport:
+    """Classify files and build a shard report."""
+    h5_files: list[RcloneFile] = []
+    json_count = 0
+    other_count = 0
+
+    for f in files:
+        if f.filename.endswith(".h5"):
+            h5_files.append(f)
+        elif f.filename.endswith(".json"):
+            json_count += 1
+        else:
+            other_count += 1
+
+    # Count logical shards by stripping chunk suffix and extension
+    chunk_pattern = re.compile(r"-\d{4,}\.h5$")
+    logical_ids: set[str] = set()
+    for f in h5_files:
+        logical_id = chunk_pattern.sub("", f.filename)
+        # If the pattern didn't match (no chunk suffix), strip just the extension
+        if logical_id == f.filename:
+            logical_id = f.filename.removesuffix(".h5")
+        logical_ids.add(logical_id)
+
+    total_h5_bytes = sum(f.size_bytes for f in h5_files)
+    threshold_bytes = threshold_gib * 1024**3
+
+    h5_file_infos: list[ShardFileInfo] = []
+    suspect_files: list[ShardFileInfo] = []
+
+    for f in h5_files:
+        is_suspect = f.size_bytes < threshold_bytes
+        info = ShardFileInfo(
+            filename=f.filename,
+            size_bytes=f.size_bytes,
+            size_human=format_size(f.size_bytes),
+            is_suspect=is_suspect,
+        )
+        h5_file_infos.append(info)
+        if is_suspect:
+            suspect_files.append(info)
+
+    return ShardReport(
+        h5_count=len(h5_files),
+        json_count=json_count,
+        other_count=other_count,
+        logical_shard_count=len(logical_ids),
+        total_h5_bytes=total_h5_bytes,
+        total_h5_human=format_size(total_h5_bytes),
+        threshold_gib=threshold_gib,
+        h5_files=h5_file_infos,
+        suspect_files=suspect_files,
+    )
+
+
+def format_report(report: ShardReport, prefix: str) -> str:
+    """Render a ShardReport to plain text."""
+    lines: list[str] = []
+
+    lines.append("=== R2 Shard Report ===")
+    lines.append(f"Prefix: {prefix}")
+    lines.append("")
+
+    # Summary
+    lines.append("Summary:")
+    lines.append(f"  H5 files:       {report['h5_count']}")
+    lines.append(f"  JSON files:     {report['json_count']}")
+    lines.append(f"  Logical shards: {report['logical_shard_count']}")
+    lines.append(f"  Total H5 size:  {report['total_h5_human']}")
+    lines.append(f"  Suspect files:  {len(report['suspect_files'])}")
+    lines.append("")
+
+    # H5 files table
+    lines.append("H5 Files:")
+    if report["h5_files"]:
+        # Determine column widths
+        max_name = max(len(f["filename"]) for f in report["h5_files"])
+        max_size = max(len(f["size_human"]) for f in report["h5_files"])
+        max_name = max(max_name, len("Filename"))
+        max_size = max(max_size, len("Size"))
+
+        header = f"  {'Filename':<{max_name}}  {'Size':>{max_size}}  Status"
+        lines.append(header)
+        lines.append(f"  {'-' * max_name}  {'-' * max_size}  ------")
+
+        for f in report["h5_files"]:
+            status = "SUSPECT" if f["is_suspect"] else "OK"
+            lines.append(f"  {f['filename']:<{max_name}}  {f['size_human']:>{max_size}}  {status}")
+    else:
+        lines.append("  (none)")
+    lines.append("")
+
+    # Suspect files section
+    if report["suspect_files"]:
+        lines.append(f"Suspect Files (below {report['threshold_gib']:.2f} GiB):")
+        for f in report["suspect_files"]:
+            lines.append(f"  {f['filename']}  ({f['size_human']})")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def run_rclone_ls(prefix: str) -> str:
+    """Run rclone ls and return stdout."""
+    result = subprocess.run(
+        ["rclone", "ls", prefix],  # noqa: S603, S607
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+@click.command()
+@click.argument("prefix")
+@click.option("--size-threshold-gib", "-t", type=float, default=1.0)
+def main(prefix: str, size_threshold_gib: float) -> None:
+    """Generate a report of shards in an R2 bucket."""
+    output = run_rclone_ls(prefix)
+    files = parse_rclone_ls_output(output)
+    report = analyze_shards(files, size_threshold_gib)
+    text = format_report(report, prefix)
+    click.echo(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_r2_shard_report.py
+++ b/tests/scripts/test_r2_shard_report.py
@@ -1,0 +1,301 @@
+"""Tests for scripts/r2_shard_report.py — R2 shard analysis and reporting.
+
+Tests are organized around the PUBLIC typed API:
+- analyze_shards(): pure function that returns a ShardReport TypedDict
+- format_report(): renders a ShardReport to plain text
+- format_size(): stable utility with well-defined contract
+- run_rclone_ls(): integration test against real R2 (auto-skipped without access)
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import uuid
+
+import pytest
+
+from scripts.r2_shard_report import (
+    RcloneFile,
+    ShardReport,
+    analyze_shards,
+    format_report,
+    format_size,
+    parse_rclone_ls_output,
+    run_rclone_ls,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures / test data
+# ---------------------------------------------------------------------------
+
+SAMPLE_FILES: list[RcloneFile] = [
+    RcloneFile(4_650_191_447, "shard-0t7qvi3i3wyzfb-de99e3c2-0000.h5"),
+    RcloneFile(4_622_813_770, "shard-0t7qvi3i3wyzfb-de99e3c2-0001.h5"),
+    RcloneFile(4_650_191_447, "shard-20f21kt2vpztws-077d464c-0000.h5"),
+    RcloneFile(4_622_813_770, "shard-20f21kt2vpztws-077d464c-0001.h5"),
+    RcloneFile(2296, "shard-9iwsm829v7a92z-14ce64ee-0000.h5"),
+    RcloneFile(2296, "shard-9iwsm829v7a92z-14ce64ee-0001.h5"),
+    RcloneFile(457, "metadata-0t7qvi3i3wyzfb-de99e3c2.json"),
+    RcloneFile(457, "metadata-20f21kt2vpztws-077d464c.json"),
+]
+
+SAMPLE_RCLONE_OUTPUT = """\
+  4650191447 shard-0t7qvi3i3wyzfb-de99e3c2-0000.h5
+  4622813770 shard-0t7qvi3i3wyzfb-de99e3c2-0001.h5
+  4650191447 shard-20f21kt2vpztws-077d464c-0000.h5
+  4622813770 shard-20f21kt2vpztws-077d464c-0001.h5
+       2296 shard-9iwsm829v7a92z-14ce64ee-0000.h5
+       2296 shard-9iwsm829v7a92z-14ce64ee-0001.h5
+        457 metadata-0t7qvi3i3wyzfb-de99e3c2.json
+        457 metadata-20f21kt2vpztws-077d464c.json
+"""
+
+DEFAULT_PREFIX = "r2:intermediate-data/10k_size_205_shard/shards/"
+DEFAULT_THRESHOLD = 1.0
+
+
+# ---------------------------------------------------------------------------
+# analyze_shards — counts
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeShardsCounts:
+    """analyze_shards returns correct file counts, totals, and logical shard counts."""
+
+    def test_h5_count_equals_six(self) -> None:
+        report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
+
+        assert report["h5_count"] == 6
+
+    def test_json_count_equals_two(self) -> None:
+        report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
+
+        assert report["json_count"] == 2
+
+    def test_logical_shard_count_equals_three(self) -> None:
+        report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
+
+        assert report["logical_shard_count"] == 3
+
+    def test_other_count_equals_zero(self) -> None:
+        report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
+
+        assert report["other_count"] == 0
+
+    def test_total_h5_bytes(self) -> None:
+        report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
+
+        assert report["total_h5_bytes"] == 18_546_015_026
+
+    def test_total_h5_human(self) -> None:
+        report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
+
+        assert report["total_h5_human"] == "17.27 GiB"
+
+
+# ---------------------------------------------------------------------------
+# analyze_shards — suspect file detection
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeShardsSuspect:
+    """analyze_shards correctly identifies suspect files below the threshold."""
+
+    def test_suspect_count_with_default_threshold(self) -> None:
+        report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
+
+        assert len(report["suspect_files"]) == 2
+
+    def test_suspect_filenames_are_the_small_ones(self) -> None:
+        report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
+
+        suspect_names = {f["filename"] for f in report["suspect_files"]}
+        assert suspect_names == {
+            "shard-9iwsm829v7a92z-14ce64ee-0000.h5",
+            "shard-9iwsm829v7a92z-14ce64ee-0001.h5",
+        }
+
+    def test_suspect_files_have_is_suspect_true(self) -> None:
+        report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
+
+        for suspect in report["suspect_files"]:
+            assert suspect["is_suspect"] is True
+
+    def test_suspect_files_have_correct_size_bytes(self) -> None:
+        report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
+
+        for suspect in report["suspect_files"]:
+            assert suspect["size_bytes"] == 2296
+
+    def test_all_big_files_no_suspects(self) -> None:
+        all_big: list[RcloneFile] = [
+            RcloneFile(4_650_191_447, "shard-aaa-111-0000.h5"),
+            RcloneFile(4_622_813_770, "shard-aaa-111-0001.h5"),
+        ]
+        report: ShardReport = analyze_shards(all_big, threshold_gib=DEFAULT_THRESHOLD)
+
+        assert len(report["suspect_files"]) == 0
+
+    def test_custom_threshold_flags_medium_file(self) -> None:
+        files: list[RcloneFile] = [
+            RcloneFile(4_650_191_447, "shard-aaa-111-0000.h5"),  # 4.33 GiB
+        ]
+        report: ShardReport = analyze_shards(files, threshold_gib=5.0)
+
+        assert len(report["suspect_files"]) == 1
+        assert report["suspect_files"][0]["filename"] == "shard-aaa-111-0000.h5"
+
+
+# ---------------------------------------------------------------------------
+# analyze_shards — logical shard counting
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeShardsLogicalShards:
+    """analyze_shards correctly counts logical shards from chunk filenames."""
+
+    def test_single_chunk_counts_as_one_logical_shard(self) -> None:
+        files: list[RcloneFile] = [
+            RcloneFile(4_650_191_447, "shard-aaa-111-0000.h5"),
+        ]
+        report: ShardReport = analyze_shards(files, threshold_gib=DEFAULT_THRESHOLD)
+
+        assert report["logical_shard_count"] == 1
+
+    def test_two_chunks_same_id_count_as_one_logical_shard(self) -> None:
+        files: list[RcloneFile] = [
+            RcloneFile(4_650_191_447, "shard-aaa-111-0000.h5"),
+            RcloneFile(4_622_813_770, "shard-aaa-111-0001.h5"),
+        ]
+        report: ShardReport = analyze_shards(files, threshold_gib=DEFAULT_THRESHOLD)
+
+        assert report["logical_shard_count"] == 1
+
+    def test_empty_input_all_counts_zero(self) -> None:
+        report: ShardReport = analyze_shards([], threshold_gib=DEFAULT_THRESHOLD)
+
+        assert report["h5_count"] == 0
+        assert report["json_count"] == 0
+        assert report["other_count"] == 0
+        assert report["logical_shard_count"] == 0
+        assert report["total_h5_bytes"] == 0
+        assert report["suspect_files"] == []
+        assert report["h5_files"] == []
+
+
+# ---------------------------------------------------------------------------
+# format_report — thin smoke tests (formatting is not the contract)
+# ---------------------------------------------------------------------------
+
+
+class TestFormatReport:
+    """format_report produces a human-readable string from a ShardReport."""
+
+    def test_output_contains_prefix(self) -> None:
+        report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
+        text = format_report(report, prefix=DEFAULT_PREFIX)
+
+        assert DEFAULT_PREFIX in text
+
+    def test_output_contains_title(self) -> None:
+        report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
+        text = format_report(report, prefix=DEFAULT_PREFIX)
+
+        assert "R2 Shard Report" in text
+
+    def test_output_contains_suspect_when_suspects_present(self) -> None:
+        report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
+        text = format_report(report, prefix=DEFAULT_PREFIX)
+
+        assert "SUSPECT" in text
+
+
+# ---------------------------------------------------------------------------
+# format_size — stable utility with well-defined contract
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSize:
+    def test_format_size_bytes_small_value(self) -> None:
+        assert format_size(500) == "500 B"
+
+    def test_format_size_kib(self) -> None:
+        assert format_size(2296) == "2.24 KiB"
+
+    def test_format_size_mib(self) -> None:
+        assert format_size(5_242_880) == "5.00 MiB"
+
+    def test_format_size_gib(self) -> None:
+        assert format_size(4_650_191_447) == "4.33 GiB"
+
+    def test_format_size_zero(self) -> None:
+        assert format_size(0) == "0 B"
+
+
+# ---------------------------------------------------------------------------
+# run_rclone_ls — integration test against real R2 (auto-skipped without access)
+# ---------------------------------------------------------------------------
+
+_has_rclone = shutil.which("rclone") is not None
+
+
+def _r2_reachable() -> bool:
+    """Check if rclone can reach the r2: remote."""
+    if not _has_rclone:
+        return False
+    try:
+        subprocess.run(
+            ["rclone", "lsd", "r2:"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+    return True
+
+
+_skip_no_r2 = pytest.mark.skipif(not _r2_reachable(), reason="R2 not reachable")
+
+
+@_skip_no_r2
+@pytest.mark.r2
+@pytest.mark.slow
+class TestRunRcloneLsIntegration:
+    """Integration test: write real files to r2:test-bucket, run report, clean up."""
+
+    def test_end_to_end_report_against_r2(self) -> None:
+        test_prefix = f"r2:test-bucket/test-{uuid.uuid4().hex[:8]}/"
+        test_content = b"fake shard data"
+
+        try:
+            # Upload two small fake h5 files and one metadata json
+            for name in [
+                "shard-test-abc123-0000.h5",
+                "shard-test-abc123-0001.h5",
+                "metadata-test-abc123.json",
+            ]:
+                subprocess.run(
+                    ["rclone", "rcat", f"{test_prefix}{name}"],
+                    input=test_content,
+                    check=True,
+                )
+
+            # Run the actual function under test
+            output = run_rclone_ls(test_prefix)
+            files = parse_rclone_ls_output(output)
+            report = analyze_shards(files, threshold_gib=1.0)
+
+            assert report["h5_count"] == 2
+            assert report["json_count"] == 1
+            assert report["logical_shard_count"] == 1
+            # Both h5 files are 15 bytes — well under 1 GiB threshold
+            assert len(report["suspect_files"]) == 2
+
+        finally:
+            # Clean up: delete the test prefix
+            subprocess.run(
+                ["rclone", "purge", test_prefix],
+                capture_output=True,
+            )

--- a/tests/scripts/test_r2_shard_report.py
+++ b/tests/scripts/test_r2_shard_report.py
@@ -64,31 +64,37 @@ class TestAnalyzeShardsCounts:
     """analyze_shards returns correct file counts, totals, and logical shard counts."""
 
     def test_h5_count_equals_six(self) -> None:
+        """Sample data has 6 h5 files."""
         report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
 
         assert report["h5_count"] == 6
 
     def test_json_count_equals_two(self) -> None:
+        """Sample data has 2 json metadata files."""
         report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
 
         assert report["json_count"] == 2
 
     def test_logical_shard_count_equals_three(self) -> None:
+        """Sample data has 3 unique shard IDs (6 chunks / 2 chunks per shard)."""
         report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
 
         assert report["logical_shard_count"] == 3
 
     def test_other_count_equals_zero(self) -> None:
+        """Sample data contains only h5 and json — no other extensions."""
         report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
 
         assert report["other_count"] == 0
 
     def test_total_h5_bytes(self) -> None:
+        """Sum of all 6 h5 file sizes in bytes."""
         report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
 
         assert report["total_h5_bytes"] == 18_546_015_026
 
     def test_total_h5_human(self) -> None:
+        """Human-readable total matches expected GiB value."""
         report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
 
         assert report["total_h5_human"] == "17.27 GiB"
@@ -103,11 +109,13 @@ class TestAnalyzeShardsSuspect:
     """analyze_shards correctly identifies suspect files below the threshold."""
 
     def test_suspect_count_with_default_threshold(self) -> None:
+        """Two 2296-byte h5 files are below the 1 GiB threshold."""
         report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
 
         assert len(report["suspect_files"]) == 2
 
     def test_suspect_filenames_are_the_small_ones(self) -> None:
+        """Only the 9iwsm829v7a92z-14ce64ee chunks are flagged."""
         report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
 
         suspect_names = {f["filename"] for f in report["suspect_files"]}
@@ -117,18 +125,21 @@ class TestAnalyzeShardsSuspect:
         }
 
     def test_suspect_files_have_is_suspect_true(self) -> None:
+        """Every entry in suspect_files has is_suspect=True."""
         report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
 
         for suspect in report["suspect_files"]:
             assert suspect["is_suspect"] is True
 
     def test_suspect_files_have_correct_size_bytes(self) -> None:
+        """Both suspect files are exactly 2296 bytes."""
         report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
 
         for suspect in report["suspect_files"]:
             assert suspect["size_bytes"] == 2296
 
     def test_all_big_files_no_suspects(self) -> None:
+        """No suspects when all files exceed the threshold."""
         all_big: list[RcloneFile] = [
             RcloneFile(4_650_191_447, "shard-aaa-111-0000.h5"),
             RcloneFile(4_622_813_770, "shard-aaa-111-0001.h5"),
@@ -138,6 +149,7 @@ class TestAnalyzeShardsSuspect:
         assert len(report["suspect_files"]) == 0
 
     def test_custom_threshold_flags_medium_file(self) -> None:
+        """A 4.33 GiB file is suspect when threshold is 5.0 GiB."""
         files: list[RcloneFile] = [
             RcloneFile(4_650_191_447, "shard-aaa-111-0000.h5"),  # 4.33 GiB
         ]
@@ -156,6 +168,7 @@ class TestAnalyzeShardsLogicalShards:
     """analyze_shards correctly counts logical shards from chunk filenames."""
 
     def test_single_chunk_counts_as_one_logical_shard(self) -> None:
+        """One chunk file means one logical shard."""
         files: list[RcloneFile] = [
             RcloneFile(4_650_191_447, "shard-aaa-111-0000.h5"),
         ]
@@ -164,6 +177,7 @@ class TestAnalyzeShardsLogicalShards:
         assert report["logical_shard_count"] == 1
 
     def test_two_chunks_same_id_count_as_one_logical_shard(self) -> None:
+        """Two chunks with the same shard ID count as one logical shard."""
         files: list[RcloneFile] = [
             RcloneFile(4_650_191_447, "shard-aaa-111-0000.h5"),
             RcloneFile(4_622_813_770, "shard-aaa-111-0001.h5"),
@@ -173,6 +187,7 @@ class TestAnalyzeShardsLogicalShards:
         assert report["logical_shard_count"] == 1
 
     def test_empty_input_all_counts_zero(self) -> None:
+        """Empty file list produces all-zero report."""
         report: ShardReport = analyze_shards([], threshold_gib=DEFAULT_THRESHOLD)
 
         assert report["h5_count"] == 0
@@ -193,18 +208,21 @@ class TestFormatReport:
     """format_report produces a human-readable string from a ShardReport."""
 
     def test_output_contains_prefix(self) -> None:
+        """Report text includes the R2 prefix."""
         report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
         text = format_report(report, prefix=DEFAULT_PREFIX)
 
         assert DEFAULT_PREFIX in text
 
     def test_output_contains_title(self) -> None:
+        """Report text includes the title header."""
         report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
         text = format_report(report, prefix=DEFAULT_PREFIX)
 
         assert "R2 Shard Report" in text
 
     def test_output_contains_suspect_when_suspects_present(self) -> None:
+        """Report text flags suspect files when present."""
         report: ShardReport = analyze_shards(SAMPLE_FILES, threshold_gib=DEFAULT_THRESHOLD)
         text = format_report(report, prefix=DEFAULT_PREFIX)
 
@@ -220,6 +238,7 @@ class TestParseRcloneLsOutput:
     """Smoke test: parse_rclone_ls_output produces RcloneFile list from raw output."""
 
     def test_parses_sample_output_into_rclone_files(self) -> None:
+        """Raw rclone ls output is parsed into 8 RcloneFile entries."""
         files = parse_rclone_ls_output(SAMPLE_RCLONE_OUTPUT)
 
         assert len(files) == 8
@@ -234,19 +253,26 @@ class TestParseRcloneLsOutput:
 
 
 class TestFormatSize:
+    """format_size converts byte counts to human-readable strings."""
+
     def test_format_size_bytes_small_value(self) -> None:
+        """Values under 1024 display as bytes."""
         assert format_size(500) == "500 B"
 
     def test_format_size_kib(self) -> None:
+        """Values in the KiB range show 2 decimal places."""
         assert format_size(2296) == "2.24 KiB"
 
     def test_format_size_mib(self) -> None:
+        """Values in the MiB range show 2 decimal places."""
         assert format_size(5_242_880) == "5.00 MiB"
 
     def test_format_size_gib(self) -> None:
+        """Values in the GiB range show 2 decimal places."""
         assert format_size(4_650_191_447) == "4.33 GiB"
 
     def test_format_size_zero(self) -> None:
+        """Zero bytes displays as '0 B'."""
         assert format_size(0) == "0 B"
 
 
@@ -279,6 +305,7 @@ class TestRunRcloneLsIntegration:
     """Integration test: write real files to r2:test-bucket, run report, clean up."""
 
     def test_end_to_end_report_against_r2(self) -> None:
+        """Upload fake shards to r2:test-bucket, analyze, verify, clean up."""
         if not _r2_reachable():
             pytest.skip("R2 not reachable")
         test_prefix = f"r2:test-bucket/test-{uuid.uuid4().hex[:8]}/"

--- a/tests/scripts/test_r2_shard_report.py
+++ b/tests/scripts/test_r2_shard_report.py
@@ -344,9 +344,12 @@ class TestRunRcloneLsIntegration:
                     text=True,
                     check=True,
                 )
-            except subprocess.CalledProcessError:
+            except subprocess.CalledProcessError as exc:
                 import warnings
 
-                warnings.warn(
-                    f"Failed to clean up test prefix: {test_prefix}", stacklevel=1
+                msg = (
+                    f"Failed to clean up test prefix: {test_prefix}\n"
+                    f"stdout:\n{exc.stdout}\n"
+                    f"stderr:\n{exc.stderr}"
                 )
+                warnings.warn(msg, stacklevel=2)

--- a/tests/scripts/test_r2_shard_report.py
+++ b/tests/scripts/test_r2_shard_report.py
@@ -349,7 +349,7 @@ class TestRunRcloneLsIntegration:
 
                 msg = (
                     f"Failed to clean up test prefix: {test_prefix}\n"
-                    f"stdout:\n{exc.stdout}\n"
-                    f"stderr:\n{exc.stderr}"
+                    f"stdout: {exc.stdout}\n"
+                    f"stderr: {exc.stderr}"
                 )
                 warnings.warn(msg, stacklevel=2)

--- a/tests/scripts/test_r2_shard_report.py
+++ b/tests/scripts/test_r2_shard_report.py
@@ -212,6 +212,23 @@ class TestFormatReport:
 
 
 # ---------------------------------------------------------------------------
+# parse_rclone_ls_output — smoke test with raw rclone output
+# ---------------------------------------------------------------------------
+
+
+class TestParseRcloneLsOutput:
+    """Smoke test: parse_rclone_ls_output produces RcloneFile list from raw output."""
+
+    def test_parses_sample_output_into_rclone_files(self) -> None:
+        files = parse_rclone_ls_output(SAMPLE_RCLONE_OUTPUT)
+
+        assert len(files) == 8
+        assert all(isinstance(f, RcloneFile) for f in files)
+        assert files[0].size_bytes == 4650191447
+        assert files[0].filename == "shard-0t7qvi3i3wyzfb-de99e3c2-0000.h5"
+
+
+# ---------------------------------------------------------------------------
 # format_size — stable utility with well-defined contract
 # ---------------------------------------------------------------------------
 
@@ -256,16 +273,14 @@ def _r2_reachable() -> bool:
     return True
 
 
-_skip_no_r2 = pytest.mark.skipif(not _r2_reachable(), reason="R2 not reachable")
-
-
-@_skip_no_r2
 @pytest.mark.r2
 @pytest.mark.slow
 class TestRunRcloneLsIntegration:
     """Integration test: write real files to r2:test-bucket, run report, clean up."""
 
     def test_end_to_end_report_against_r2(self) -> None:
+        if not _r2_reachable():
+            pytest.skip("R2 not reachable")
         test_prefix = f"r2:test-bucket/test-{uuid.uuid4().hex[:8]}/"
         test_content = b"fake shard data"
 
@@ -295,7 +310,16 @@ class TestRunRcloneLsIntegration:
 
         finally:
             # Clean up: delete the test prefix
-            subprocess.run(
-                ["rclone", "purge", test_prefix],
-                capture_output=True,
-            )
+            try:
+                subprocess.run(
+                    ["rclone", "purge", test_prefix],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+            except subprocess.CalledProcessError:
+                import warnings
+
+                warnings.warn(
+                    f"Failed to clean up test prefix: {test_prefix}", stacklevel=1
+                )


### PR DESCRIPTION
## Summary
- CLI script (`scripts/r2_shard_report.py`) to analyze R2 shard prefixes
- Counts h5 files, metadata files, logical shards, total sizes
- Flags corrupt/empty-shell shards under configurable size threshold as SUSPECT
- Typed API: `analyze_shards()` returns `ShardReport` TypedDict, `format_report()` renders to plain text
- `RcloneFile` NamedTuple for self-documenting file entries
- 24 unit tests + 1 R2 integration test (auto-skips without rclone)

## Lint suppressions

| File | Rule | Justification |
|------|------|---------------|
| `scripts/r2_shard_report.py` | `S603` | `subprocess.run(["rclone", ...])` — input is CLI args from the user running the script locally, not untrusted web input |
| `scripts/r2_shard_report.py` | `S607` | `"rclone"` partial path — full path would break portability across systems |
| `scripts/r2_shard_report.py` | `T201` | `click.echo()` used for CLI output |
| `tests/scripts/test_r2_shard_report.py` | `S603` | `subprocess.run(["rclone", ...])` in integration test fixtures (upload/cleanup) |
| `tests/scripts/test_r2_shard_report.py` | `S607` | `"rclone"` partial path in test fixtures |

## Test plan
- [x] Unit tests pass: `pytest tests/scripts/test_r2_shard_report.py -m "not r2"` (24 passed)
- [x] Integration test passes with R2 access: `pytest tests/scripts/test_r2_shard_report.py -m r2`
- [x] End-to-end: `python scripts/r2_shard_report.py r2:intermediate-data/10k_size_205_shard/shards/` correctly identifies 8 suspect files
- [ ] CI passes

Refs #236