### PR TITLE
docs: add monitoring prefix and git worktree guidance

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -3,4 +3,4 @@ contrib=contrib-title-conventional-commits
 ignore=body-is-missing
 
 [contrib-title-conventional-commits]
-types=feat,fix,perf,docs,chore,ci,test,refactor,style,build,revert,internal-feat,internal-fix
+types=feat,fix,perf,docs,chore,ci,test,refactor,style,build,revert,internal-feat,internal-fix,monitoring

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Conventional commits, enforced by gitlint (`.gitlint` config). Prefix matters fo
 - **Always use isolated git worktrees** for feature work, bug fixes, and PRs. Never edit files directly on a development branch in the main working tree — branch switching and stash conflicts cause lost work and accidental commits to wrong branches.
 - Use `isolation: "worktree"` when spawning subagents that write code or create commits.
 - The main working tree should only be used for read-only operations (exploration, `git log`, `rclone ls`, etc.).
-- Worktrees are automatically cleaned up if no changes are made. If changes are made, the worktree path and branch are returned for review.
+- When using Claude Code's Agent tool with `isolation: "worktree"`, the worktree is automatically cleaned up if the agent makes no changes. If changes are made, the worktree path and branch are returned for review. For manually created worktrees, clean up with `git worktree remove` when done.
 
 ### Pipeline-Specific Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Conventional commits, enforced by gitlint (`.gitlint` config). Prefix matters fo
 
 - `internal-feat:` → new code building toward a feature not yet exposed to users (new internal API, new module, new config schema). Use this when a feature is being built across multiple PRs and this PR adds real, tested code — but the feature isn't user-facing yet. No version bump.
 - `internal-fix:` → fix to internal code not yet exposed to users. No version bump.
-- `docs:`, `chore:`, `ci:`, `test:`, `refactor:`, `style:`, `build:` → no version bump.
+- `monitoring:`, `docs:`, `chore:`, `ci:`, `test:`, `refactor:`, `style:`, `build:` → no version bump.
 
 **When to use which:**
 
@@ -63,6 +63,13 @@ Conventional commits, enforced by gitlint (`.gitlint` config). Prefix matters fo
 - `configs/` — Hydra YAML configs (pipeline, data, trainer)
 - `tests/` — mirrors `src/` and `scripts/` structure
 - `docs/design/` — design documents
+
+### Git Workflow
+
+- **Always use isolated git worktrees** for feature work, bug fixes, and PRs. Never edit files directly on a development branch in the main working tree — branch switching and stash conflicts cause lost work and accidental commits to wrong branches.
+- Use `isolation: "worktree"` when spawning subagents that write code or create commits.
+- The main working tree should only be used for read-only operations (exploration, `git log`, `rclone ls`, etc.).
+- Worktrees are automatically cleaned up if no changes are made. If changes are made, the worktree path and branch are returned for review.
 
 ### Pipeline-Specific Rules
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ changelog_file = "CHANGELOG.md"
 # Major bumps: handled by default via "feat!:" prefix or "BREAKING CHANGE:" footer
 # Pre-1.0: breaking changes bump minor (standard semver pre-1.0 behavior)
 [tool.semantic_release.commit_parser_options]
-allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "internal-feat", "internal-fix", "perf", "refactor", "revert", "style", "test"]
+allowed_tags = ["build", "chore", "ci", "docs", "feat", "fix", "internal-feat", "internal-fix", "monitoring", "perf", "refactor", "revert", "style", "test"]
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf", "revert"]
 


### PR DESCRIPTION
## Summary
- Add `monitoring:` to the no-bump commit prefix list (for observability/health-check tooling like `r2_shard_report.py`)
- Add "Git Workflow" section requiring isolated git worktrees for all feature work and code-writing subagents

## Test plan
- [x] CLAUDE.md is valid markdown
- [x] No code changes — documentation only

Refs #236