### PR TITLE
chore(build): warn on undefined Makefile variables to catch typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+MAKEFLAGS += --warn-undefined-variables
 
 help:  ## Show help
 	@grep -E '^[.a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
## Summary

- Add `MAKEFLAGS += --warn-undefined-variables` to catch misspelled variable names (e.g. `CLOUDBUILDER` vs `CLOUD_BUILDER`) that silently expand to empty strings

## Verification

- [ ] `make help` works without spurious warnings
- [ ] `make test` passes

Fixes #244