### PR TITLE
ci(automation): add snooze-issue GitHub Action

### DIFF
--- a/.github/workflows/snooze-issue.yml
+++ b/.github/workflows/snooze-issue.yml
@@ -1,0 +1,20 @@
+name: snooze issue
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  snooze_issue:
+    runs-on: ubuntu-latest
+    name: snooze issue
+    permissions:
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: snooze issue
+        uses: multilocale/snooze-issue-action/snooze@v1.0.0
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snooze-issue.yml
+++ b/.github/workflows/snooze-issue.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: snooze issue
         uses: multilocale/snooze-issue-action/snooze@v1.0.0
         with:

--- a/.github/workflows/snooze-issue.yml
+++ b/.github/workflows/snooze-issue.yml
@@ -9,7 +9,9 @@ jobs:
   snooze_issue:
     runs-on: ubuntu-latest
     name: snooze issue
+    if: ${{ !github.event.issue.pull_request }}
     permissions:
+      contents: read
       issues: write
     steps:
       - name: Checkout

--- a/.github/workflows/unsnooze-issues.yml
+++ b/.github/workflows/unsnooze-issues.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: unsnooze issues
     permissions:
+      contents: read
       issues: write
     steps:
       - name: Checkout

--- a/.github/workflows/unsnooze-issues.yml
+++ b/.github/workflows/unsnooze-issues.yml
@@ -1,0 +1,20 @@
+name: unsnooze issues
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * *" # daily at 08:00 UTC
+
+jobs:
+  unsnooze_issue:
+    runs-on: ubuntu-latest
+    name: unsnooze issues
+    permissions:
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: unsnooze issues
+        uses: multilocale/snooze-issue-action/unsnooze@v1.0.0
+        with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/unsnooze-issues.yml
+++ b/.github/workflows/unsnooze-issues.yml
@@ -13,7 +13,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: unsnooze issues
         uses: multilocale/snooze-issue-action/unsnooze@v1.0.0
         with:


### PR DESCRIPTION
## Summary

- Adds `snooze-issue.yml` workflow — listens for `/snooze` comments on issues to close them temporarily
- Adds `unsnooze-issues.yml` workflow — daily cron (08:00 UTC) + manual dispatch to reopen snoozed issues
- Pinned to `multilocale/snooze-issue-action@v1.0.0`, `actions/checkout@v4`, explicit `issues: write` permissions

Refs #249

## Test plan

- [ ] Verify workflows pass YAML validation in CI
- [ ] After merge, comment `/snooze 1 days` on a test issue and confirm it closes
- [ ] Confirm the bot comment contains the hidden HTML reopen timestamp
- [ ] Run `unsnooze-issues` via workflow_dispatch and confirm snoozed issues reopen