### PR TITLE
build(ci): cap torch<2.7.0 on GPU runner to match driver

### DIFF
--- a/.github/workflows/test-expensive.yml
+++ b/.github/workflows/test-expensive.yml
@@ -26,9 +26,13 @@ jobs:
           python-version: "3.10"
 
       - name: Install dependencies
+        # GitHub GPU runner ships NVIDIA driver 12080 (CUDA 12.0).
+        # torch >=2.7.0 requires CUDA 13.x — cap it via PIP_CONSTRAINT
+        # so CI stays compatible without changing requirements-torch.txt.
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          echo 'torch<2.7.0' > /tmp/torch-constraint.txt
+          PIP_CONSTRAINT=/tmp/torch-constraint.txt pip install -r requirements.txt
           pip install sh
 
       - name: List dependencies

--- a/.github/workflows/test-expensive.yml
+++ b/.github/workflows/test-expensive.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install dependencies
-        # GitHub GPU runner ships NVIDIA driver 12080 (CUDA 12.0).
+        # GitHub GPU runner ships NVIDIA driver 12080 (CUDA 12.8).
         # torch >=2.7.0 requires CUDA 13.x — cap it via PIP_CONSTRAINT
         # so CI stays compatible without changing requirements-torch.txt.
         run: |


### PR DESCRIPTION
## Summary

- Adds `PIP_CONSTRAINT` to the GPU test workflow to cap `torch<2.7.0` in CI only
- Keeps `requirements-torch.txt` unchanged so real training runs get latest torch
- GitHub's `gpu-x64` runner ships driver 12080 (CUDA 12.0); torch >=2.7.0 needs CUDA 13.x

Fixes #258

## Test plan

- [ ] Re-run GPU tests workflow and confirm tests pass with torch <2.7.0
- [ ] Verify `pip list | grep torch` shows a 2.6.x version in the CI log