### PR TITLE
build(ci-automation): add --warn-undefined-variables to makefile, add Verified and Won't Fix statuses to taxonomy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+MAKEFLAGS += --warn-undefined-variables
 
 help:  ## Show help
 	@grep -E '^[.a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/docs/design/github-taxonomy.md
+++ b/docs/design/github-taxonomy.md
@@ -223,8 +223,8 @@ ISSUE
 | `Refs #N`                | PR is related but doesn't resolve             | No           |
 | Development sidebar link | Manual non-closing connection from issue page | No           |
 
-09. When the PR merges, move to **Done** and close the issue
-10. After verifying the change works as expected, move to **Verified**
+09. When the PR merges, move to **Done**
+10. After verifying the change works as expected, move to **Verified** and close the issue
 11. If the issue is intentionally declined, move to **Won't Fix** and close the issue with a reason comment
 
 ## 12. Changes Required

--- a/docs/design/github-taxonomy.md
+++ b/docs/design/github-taxonomy.md
@@ -155,7 +155,11 @@ Priority, Start Date, Target Date.
 
 ### Built-in fields
 
-Title, Assignees, Status (`Todo` → `In Progress` → `Done`), Labels, Linked PRs, Milestone, Repository, Reviewers, Parent issue, Sub-issues progress.
+Title, Assignees, Status (`Todo` → `In Progress` → `Done` → `Verified` / `Won't Fix`), Labels, Linked PRs, Milestone, Repository, Reviewers, Parent issue, Sub-issues progress.
+
+`Verified` — done and verified working as expected. The final status for completed work.
+
+`Won't Fix` — issue intentionally closed without resolution (not a bug, out of scope, or superseded by other work). Can be set from any prior status.
 
 ### Views
 
@@ -219,7 +223,9 @@ ISSUE
 | `Refs #N`                | PR is related but doesn't resolve             | No           |
 | Development sidebar link | Manual non-closing connection from issue page | No           |
 
-9. When the PR merges, move to **Done** and close the issue
+09. When the PR merges, move to **Done** and close the issue
+10. After verifying the change works as expected, move to **Verified**
+11. If the issue is intentionally declined, move to **Won't Fix** and close the issue with a reason comment
 
 ## 12. Changes Required
 

--- a/docs/design/github-taxonomy.md
+++ b/docs/design/github-taxonomy.md
@@ -155,7 +155,9 @@ Priority, Start Date, Target Date.
 
 ### Built-in fields
 
-Title, Assignees, Status (`Todo` → `In Progress` → `Done` → `Verified` / `Won't Fix`), Labels, Linked PRs, Milestone, Repository, Reviewers, Parent issue, Sub-issues progress.
+Title, Assignees, Status (`Todo` → `In Progress` → `Done` → `Verified`), Labels, Linked PRs, Milestone, Repository, Reviewers, Parent issue, Sub-issues progress.
+
+`Won't Fix` is a terminal status reachable from any prior status (Todo, In Progress, or Done).
 
 `Verified` — done and verified working as expected. The final status for completed work.
 
@@ -223,7 +225,7 @@ ISSUE
 | `Refs #N`                | PR is related but doesn't resolve             | No           |
 | Development sidebar link | Manual non-closing connection from issue page | No           |
 
-09. When the PR merges, move to **Done**
+09. When the PR merges, move to **Done** (keep the issue open)
 10. After verifying the change works as expected, move to **Verified** and close the issue
 11. If the issue is intentionally declined, move to **Won't Fix** and close the issue with a reason comment
 


### PR DESCRIPTION
## Summary

- Documents two new project board statuses added via GraphQL: **Verified** (blue) and **Won't Fix** (gray)
- Updates §8 (Built-in fields) with status descriptions
- Updates §11 (Issue Lifecycle) with verification and won't-fix transitions

Closes #260