### PR TITLE
monitoring(wandb): wandb provenance helper and config cleanup

### DIFF
--- a/configs/logger/wandb.yaml
+++ b/configs/logger/wandb.yaml
@@ -7,10 +7,10 @@ wandb:
   offline: False
   id: null # pass correct id to resume experiment!
   anonymous: null # enable anonymous logging
-  project: "synth-permutations"
+  project: "${oc.env:WANDB_PROJECT,synth-setter}"
   log_model: true # upload lightning ckpts
   prefix: "" # a string to put at the beginning of metric keys
-  entity: "benhayes" # set to name of your wandb team
+  entity: "${oc.env:WANDB_ENTITY,tinaudio}" # set to name of your wandb team
   group: ""
   tags: []
   job_type: ""

--- a/src/eval.py
+++ b/src/eval.py
@@ -30,6 +30,7 @@ from src.utils import (
     instantiate_callbacks,
     instantiate_loggers,
     log_hyperparameters,
+    log_wandb_provenance,
     register_resolvers,
     task_wrapper,
 )
@@ -78,6 +79,7 @@ def evaluate(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     if logger:
         log.info("Logging hyperparameters!")
         log_hyperparameters(object_dict)
+        log_wandb_provenance()
 
     mode = cfg.get("mode", "test")
 

--- a/src/train.py
+++ b/src/train.py
@@ -33,6 +33,7 @@ from src.utils import (
     instantiate_callbacks,
     instantiate_loggers,
     log_hyperparameters,
+    log_wandb_provenance,
     register_resolvers,
     task_wrapper,
     watch_gradients,
@@ -85,6 +86,7 @@ def train(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     if logger:
         log.info("Logging hyperparameters!")
         log_hyperparameters(object_dict)
+        log_wandb_provenance()
 
     if cfg.get("watch_gradients"):
         log.info("Watching gradients!")

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,5 +1,5 @@
 from src.utils.instantiators import instantiate_callbacks, instantiate_loggers
-from src.utils.logging_utils import log_hyperparameters
+from src.utils.logging_utils import log_hyperparameters, log_wandb_provenance
 from src.utils.pylogger import RankedLogger
 from src.utils.rich_utils import enforce_tags, print_config_tree
 from src.utils.utils import (

--- a/src/utils/logging_utils.py
+++ b/src/utils/logging_utils.py
@@ -1,3 +1,7 @@
+import os
+import subprocess
+import sys
+from importlib.util import find_spec
 from typing import Any
 
 from lightning_utilities.core.rank_zero import rank_zero_only
@@ -55,3 +59,40 @@ def log_hyperparameters(object_dict: dict[str, Any]) -> None:
     # send hparams to all loggers
     for logger in trainer.loggers:
         logger.log_hyperparams(hparams)
+
+
+@rank_zero_only
+def log_wandb_provenance() -> None:
+    """Log provenance metadata to wandb.config.
+
+    Records github_sha, image_tag, and command per storage-provenance-spec.md. Must be called after
+    WandbLogger instantiation (which calls wandb.init). No-op if wandb is not installed or no run
+    is active.
+    """
+    if not find_spec("wandb"):
+        return
+    import wandb
+
+    if not wandb.run:
+        return
+
+    try:
+        sha = (
+            subprocess.check_output(
+                ["git", "rev-parse", "HEAD"],  # noqa: S603, S607
+                stderr=subprocess.DEVNULL,
+            )
+            .decode()
+            .strip()
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        sha = "unknown"
+
+    wandb.config.update(
+        {
+            "github_sha": sha,
+            "image_tag": os.environ.get("IMAGE_TAG", "unknown"),
+            "command": " ".join(sys.argv),
+        },
+        allow_val_change=True,
+    )

--- a/sweeps/ds_size.yaml
+++ b/sweeps/ds_size.yaml
@@ -1,6 +1,6 @@
 program: src/train.py
-entity: benhayes
-project: synth-permutations
+entity: tinaudio
+project: synth-setter
 command:
   - python
   - src/train.py

--- a/sweeps/ds_size.yaml
+++ b/sweeps/ds_size.yaml
@@ -1,4 +1,6 @@
 program: src/train.py
+# Hardcoded — wandb sweep CLI does not support OmegaConf resolvers.
+# WANDB_ENTITY / WANDB_PROJECT env vars override these at runtime.
 entity: tinaudio
 project: synth-setter
 command:

--- a/sweeps/fm.yaml
+++ b/sweeps/fm.yaml
@@ -1,6 +1,6 @@
 program: src/train.py
-entity: benhayes
-project: synth-permutations
+entity: tinaudio
+project: synth-setter
 command:
   - python
   - src/train.py

--- a/sweeps/fm.yaml
+++ b/sweeps/fm.yaml
@@ -1,4 +1,6 @@
 program: src/train.py
+# Hardcoded — wandb sweep CLI does not support OmegaConf resolvers.
+# WANDB_ENTITY / WANDB_PROJECT env vars override these at runtime.
 entity: tinaudio
 project: synth-setter
 command:

--- a/sweeps/kosc.yaml
+++ b/sweeps/kosc.yaml
@@ -1,6 +1,6 @@
 program: src/train.py
-entity: benhayes
-project: synth-permutations
+entity: tinaudio
+project: synth-setter
 command:
   - python
   - src/train.py

--- a/sweeps/kosc.yaml
+++ b/sweeps/kosc.yaml
@@ -1,4 +1,6 @@
 program: src/train.py
+# Hardcoded — wandb sweep CLI does not support OmegaConf resolvers.
+# WANDB_ENTITY / WANDB_PROJECT env vars override these at runtime.
 entity: tinaudio
 project: synth-setter
 command:

--- a/sweeps/ksin.yaml
+++ b/sweeps/ksin.yaml
@@ -1,6 +1,6 @@
 program: src/train.py
-entity: benhayes
-project: synth-permutations
+entity: tinaudio
+project: synth-setter
 command:
   - python
   - src/train.py

--- a/sweeps/ksin.yaml
+++ b/sweeps/ksin.yaml
@@ -1,4 +1,6 @@
 program: src/train.py
+# Hardcoded — wandb sweep CLI does not support OmegaConf resolvers.
+# WANDB_ENTITY / WANDB_PROJECT env vars override these at runtime.
 entity: tinaudio
 project: synth-setter
 command:

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,0 +1,108 @@
+"""Tests for log_wandb_provenance() in src/utils/logging_utils.py."""
+
+import os
+import subprocess
+from unittest.mock import MagicMock, patch
+
+
+class TestLogWandbProvenance:
+    """Tests for log_wandb_provenance — wandb config helper."""
+
+    def test_log_wandb_provenance_logs_all_fields(self):
+        """All three provenance fields are written to wandb.config."""
+        mock_wandb = MagicMock()
+        mock_wandb.run = MagicMock()  # truthy = active run
+
+        mock_sp = MagicMock()
+        mock_sp.check_output.return_value = b"abc123def\n"
+        mock_sp.CalledProcessError = subprocess.CalledProcessError
+        mock_sp.DEVNULL = subprocess.DEVNULL
+
+        with (
+            patch("src.utils.logging_utils.find_spec", return_value=True),
+            patch.dict("sys.modules", {"wandb": mock_wandb}),
+            patch("src.utils.logging_utils.subprocess", mock_sp),
+            patch.dict(os.environ, {"IMAGE_TAG": "v1.2.3"}, clear=False),
+        ):
+            from src.utils.logging_utils import log_wandb_provenance
+
+            log_wandb_provenance()
+
+        mock_wandb.config.update.assert_called_once()
+        call_args = mock_wandb.config.update.call_args[0][0]
+        assert call_args["github_sha"] == "abc123def"
+        assert call_args["image_tag"] == "v1.2.3"
+        assert isinstance(call_args["command"], str)
+
+    def test_log_wandb_provenance_no_wandb_is_noop(self):
+        """When wandb is not installed, function returns without error."""
+        with patch("src.utils.logging_utils.find_spec", return_value=None):
+            from src.utils.logging_utils import log_wandb_provenance
+
+            # Should not raise
+            log_wandb_provenance()
+
+    def test_log_wandb_provenance_no_active_run_is_noop(self):
+        """When wandb.run is None, config.update is not called."""
+        mock_wandb = MagicMock()
+        mock_wandb.run = None  # no active run
+
+        with (
+            patch("src.utils.logging_utils.find_spec", return_value=True),
+            patch.dict("sys.modules", {"wandb": mock_wandb}),
+        ):
+            from src.utils.logging_utils import log_wandb_provenance
+
+            log_wandb_provenance()
+
+        mock_wandb.config.update.assert_not_called()
+
+    def test_log_wandb_provenance_git_failure_uses_unknown(self):
+        """When git rev-parse fails, github_sha falls back to 'unknown'."""
+        mock_wandb = MagicMock()
+        mock_wandb.run = MagicMock()
+
+        mock_sp = MagicMock()
+        mock_sp.check_output.side_effect = subprocess.CalledProcessError(1, "git")
+        mock_sp.CalledProcessError = subprocess.CalledProcessError
+        mock_sp.FileNotFoundError = FileNotFoundError
+        mock_sp.DEVNULL = subprocess.DEVNULL
+
+        with (
+            patch("src.utils.logging_utils.find_spec", return_value=True),
+            patch.dict("sys.modules", {"wandb": mock_wandb}),
+            patch("src.utils.logging_utils.subprocess", mock_sp),
+            patch.dict(os.environ, {"IMAGE_TAG": "v1.0.0"}, clear=False),
+        ):
+            from src.utils.logging_utils import log_wandb_provenance
+
+            log_wandb_provenance()
+
+        call_args = mock_wandb.config.update.call_args[0][0]
+        assert call_args["github_sha"] == "unknown"
+
+    def test_log_wandb_provenance_missing_image_tag_uses_unknown(self):
+        """When IMAGE_TAG env var is not set, image_tag falls back to 'unknown'."""
+        mock_wandb = MagicMock()
+        mock_wandb.run = MagicMock()
+
+        mock_sp = MagicMock()
+        mock_sp.check_output.return_value = b"deadbeef\n"
+        mock_sp.CalledProcessError = subprocess.CalledProcessError
+        mock_sp.DEVNULL = subprocess.DEVNULL
+
+        # Ensure IMAGE_TAG is not in the environment
+        env_copy = {k: v for k, v in os.environ.items() if k != "IMAGE_TAG"}
+
+        with (
+            patch("src.utils.logging_utils.find_spec", return_value=True),
+            patch.dict("sys.modules", {"wandb": mock_wandb}),
+            patch("src.utils.logging_utils.subprocess", mock_sp),
+            patch.dict(os.environ, env_copy, clear=True),
+        ):
+            from src.utils.logging_utils import log_wandb_provenance
+
+            log_wandb_provenance()
+
+        call_args = mock_wandb.config.update.call_args[0][0]
+        assert call_args["image_tag"] == "unknown"

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -1,108 +1,147 @@
-"""Tests for log_wandb_provenance() in src/utils/logging_utils.py."""
+"""Tests for log_wandb_provenance() in src/utils/logging_utils.py.
+
+Uses fakes (not mocks) for wandb, real subprocess where possible, and state assertions throughout.
+See python-testing.md §Fakes.
+"""
 
 import os
 import subprocess
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from src.utils.logging_utils import log_wandb_provenance
+
+# ---------------------------------------------------------------------------
+# Fake wandb module — captures config updates as inspectable state
+# ---------------------------------------------------------------------------
 
 
-class TestLogWandbProvenance:
-    """Tests for log_wandb_provenance — wandb config helper."""
+class FakeWandbConfig:
+    """Fake wandb.config that stores updates for state testing."""
 
-    def test_log_wandb_provenance_logs_all_fields(self):
-        """All three provenance fields are written to wandb.config."""
-        mock_wandb = MagicMock()
-        mock_wandb.run = MagicMock()  # truthy = active run
+    def __init__(self) -> None:
+        self.data: dict[str, str] = {}
 
-        mock_sp = MagicMock()
-        mock_sp.check_output.return_value = b"abc123def\n"
-        mock_sp.CalledProcessError = subprocess.CalledProcessError
-        mock_sp.DEVNULL = subprocess.DEVNULL
+    def update(self, d: dict, **kwargs: object) -> None:
+        self.data.update(d)
+
+
+def make_fake_wandb(*, has_run: bool = True) -> SimpleNamespace:
+    """Factory for a fake wandb module with inspectable config state."""
+    return SimpleNamespace(
+        run=object() if has_run else None,
+        config=FakeWandbConfig(),
+        __spec__=object(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy-path behavior tests (real subprocess, fake wandb only)
+# ---------------------------------------------------------------------------
+
+
+class TestLogWandbProvenanceHappyPath:
+    """Provenance fields are logged correctly when all dependencies are available."""
+
+    def test_logs_git_sha_as_valid_hex(self) -> None:
+        """github_sha is the real 40-char hex SHA from the current git repo."""
+        fake = make_fake_wandb()
+
+        with patch.dict("sys.modules", {"wandb": fake}):
+            log_wandb_provenance()
+
+        sha = fake.config.data["github_sha"]
+        assert len(sha) == 40
+        assert all(c in "0123456789abcdef" for c in sha)
+
+    def test_logs_image_tag_from_env(self) -> None:
+        """image_tag matches the IMAGE_TAG environment variable."""
+        fake = make_fake_wandb()
 
         with (
-            patch("src.utils.logging_utils.find_spec", return_value=True),
-            patch.dict("sys.modules", {"wandb": mock_wandb}),
-            patch("src.utils.logging_utils.subprocess", mock_sp),
-            patch.dict(os.environ, {"IMAGE_TAG": "v1.2.3"}, clear=False),
+            patch.dict("sys.modules", {"wandb": fake}),
+            patch.dict(os.environ, {"IMAGE_TAG": "v1.2.3"}),
         ):
-            from src.utils.logging_utils import log_wandb_provenance
-
             log_wandb_provenance()
 
-        mock_wandb.config.update.assert_called_once()
-        call_args = mock_wandb.config.update.call_args[0][0]
-        assert call_args["github_sha"] == "abc123def"
-        assert call_args["image_tag"] == "v1.2.3"
-        assert isinstance(call_args["command"], str)
+        assert fake.config.data["image_tag"] == "v1.2.3"
 
-    def test_log_wandb_provenance_no_wandb_is_noop(self):
-        """When wandb is not installed, function returns without error."""
-        with patch("src.utils.logging_utils.find_spec", return_value=None):
-            from src.utils.logging_utils import log_wandb_provenance
+    def test_logs_command_from_argv(self) -> None:
+        """Command is a non-empty string derived from sys.argv."""
+        fake = make_fake_wandb()
 
-            # Should not raise
+        with patch.dict("sys.modules", {"wandb": fake}):
             log_wandb_provenance()
 
-    def test_log_wandb_provenance_no_active_run_is_noop(self):
-        """When wandb.run is None, config.update is not called."""
-        mock_wandb = MagicMock()
-        mock_wandb.run = None  # no active run
+        assert isinstance(fake.config.data["command"], str)
+        assert len(fake.config.data["command"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Fallback behavior tests
+# ---------------------------------------------------------------------------
+
+
+class TestLogWandbProvenanceFallbacks:
+    """Graceful fallbacks when git or IMAGE_TAG are unavailable."""
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            FileNotFoundError("git not found"),
+            subprocess.CalledProcessError(128, "git"),
+        ],
+        ids=["git_not_installed", "not_a_git_repo"],
+    )
+    def test_git_sha_unknown_on_subprocess_error(self, error: Exception) -> None:
+        """github_sha falls back to 'unknown' when git rev-parse fails."""
+        fake = make_fake_wandb()
 
         with (
-            patch("src.utils.logging_utils.find_spec", return_value=True),
-            patch.dict("sys.modules", {"wandb": mock_wandb}),
+            patch.dict("sys.modules", {"wandb": fake}),
+            patch(
+                "src.utils.logging_utils.subprocess.check_output",
+                side_effect=error,
+            ),
         ):
-            from src.utils.logging_utils import log_wandb_provenance
-
             log_wandb_provenance()
 
-        mock_wandb.config.update.assert_not_called()
+        assert fake.config.data["github_sha"] == "unknown"
 
-    def test_log_wandb_provenance_git_failure_uses_unknown(self):
-        """When git rev-parse fails, github_sha falls back to 'unknown'."""
-        mock_wandb = MagicMock()
-        mock_wandb.run = MagicMock()
-
-        mock_sp = MagicMock()
-        mock_sp.check_output.side_effect = subprocess.CalledProcessError(1, "git")
-        mock_sp.CalledProcessError = subprocess.CalledProcessError
-        mock_sp.FileNotFoundError = FileNotFoundError
-        mock_sp.DEVNULL = subprocess.DEVNULL
+    def test_image_tag_unknown_when_env_unset(self) -> None:
+        """image_tag falls back to 'unknown' when IMAGE_TAG is absent."""
+        fake = make_fake_wandb()
+        env_without_image_tag = {k: v for k, v in os.environ.items() if k != "IMAGE_TAG"}
 
         with (
-            patch("src.utils.logging_utils.find_spec", return_value=True),
-            patch.dict("sys.modules", {"wandb": mock_wandb}),
-            patch("src.utils.logging_utils.subprocess", mock_sp),
-            patch.dict(os.environ, {"IMAGE_TAG": "v1.0.0"}, clear=False),
+            patch.dict("sys.modules", {"wandb": fake}),
+            patch.dict(os.environ, env_without_image_tag, clear=True),
         ):
-            from src.utils.logging_utils import log_wandb_provenance
-
             log_wandb_provenance()
 
-        call_args = mock_wandb.config.update.call_args[0][0]
-        assert call_args["github_sha"] == "unknown"
+        assert fake.config.data["image_tag"] == "unknown"
 
-    def test_log_wandb_provenance_missing_image_tag_uses_unknown(self):
-        """When IMAGE_TAG env var is not set, image_tag falls back to 'unknown'."""
-        mock_wandb = MagicMock()
-        mock_wandb.run = MagicMock()
 
-        mock_sp = MagicMock()
-        mock_sp.check_output.return_value = b"deadbeef\n"
-        mock_sp.CalledProcessError = subprocess.CalledProcessError
-        mock_sp.DEVNULL = subprocess.DEVNULL
+# ---------------------------------------------------------------------------
+# Guard clause tests
+# ---------------------------------------------------------------------------
 
-        # Ensure IMAGE_TAG is not in the environment
-        env_copy = {k: v for k, v in os.environ.items() if k != "IMAGE_TAG"}
 
-        with (
-            patch("src.utils.logging_utils.find_spec", return_value=True),
-            patch.dict("sys.modules", {"wandb": mock_wandb}),
-            patch("src.utils.logging_utils.subprocess", mock_sp),
-            patch.dict(os.environ, env_copy, clear=True),
-        ):
-            from src.utils.logging_utils import log_wandb_provenance
+class TestLogWandbProvenanceGuards:
+    """Safe noop when wandb is unavailable or no run is active."""
 
+    def test_noop_when_wandb_not_installed(self) -> None:
+        """No crash when wandb is not installed."""
+        with patch.dict("sys.modules", {"wandb": None}):
             log_wandb_provenance()
 
-        call_args = mock_wandb.config.update.call_args[0][0]
-        assert call_args["image_tag"] == "unknown"
+    def test_noop_when_no_active_run(self) -> None:
+        """No config update when wandb.run is None."""
+        fake = make_fake_wandb(has_run=False)
+
+        with patch.dict("sys.modules", {"wandb": fake}):
+            log_wandb_provenance()
+
+        assert fake.config.data == {}


### PR DESCRIPTION
## Summary

- Add `log_wandb_provenance()` helper that logs `github_sha`, `image_tag`, and `command` to `wandb.config` at run start, per storage-provenance-spec §12.3
- Replace hardcoded `benhayes`/`synth-permutations` wandb entity/project with env-var-backed defaults (`tinaudio`/`synth-setter`) per storage-provenance-spec §10

Refs #270, Refs #271

## Changes

### Commit 1: wandb provenance config helper (#270)

- `src/utils/logging_utils.py` — new `log_wandb_provenance()` function (lazy wandb import, git-failure fallback, `@rank_zero_only`)
- `src/utils/__init__.py` — export the new function
- `src/train.py`, `src/eval.py` — call after `log_hyperparameters()`
- `tests/test_logging_utils.py` — 5 tests covering all fields, no-wandb noop, no-run noop, git failure, missing IMAGE_TAG

### Commit 2: remove hardcoded wandb values (#271)

- `configs/logger/wandb.yaml` — `${oc.env:WANDB_ENTITY,tinaudio}` / `${oc.env:WANDB_PROJECT,synth-setter}`
- `sweeps/*.yaml` — plain `tinaudio`/`synth-setter` (W&B sweep configs don't support OmegaConf resolvers; env vars `WANDB_ENTITY`/`WANDB_PROJECT` override at runtime)

### Not changed (intentionally)

- Filesystem paths under `/data/EECS-C4DM-Fazekas/benhayes/` — research cluster paths, not wandb
- `pyproject.toml`/`uv.lock` package name `synth-permutations` — separate concern
- `docs/` references — documentation of historical state; should be updated in a follow-up

## Test plan

- [ ] `make test` passes (5 new tests in `test_logging_utils.py`)
- [ ] `make format` clean (pre-commit hooks pass)
- [ ] Verify `configs/logger/wandb.yaml` resolves correctly with/without env vars
- [ ] Verify sweep configs point to `tinaudio/synth-setter`