### PR TITLE
Add shared project hooks

### DIFF
--- a/.claude/hooks/verify-gh-taxonomy.sh
+++ b/.claude/hooks/verify-gh-taxonomy.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# =============================================================================
+# verify-gh-taxonomy.sh — Claude Code PostToolUse hook
+# =============================================================================
+#
+# PURPOSE
+# -------
+# Enforces the project's GitHub taxonomy conventions (defined in
+# docs/design/github-taxonomy.md) every time Claude creates an issue, a PR,
+# or modifies issue hierarchy. Without this hook, the github-taxonomy skill
+# can silently skip steps (project board, priority, hierarchy) even though
+# the skill text requires them.
+#
+# HOW IT WORKS
+# ------------
+# This script is registered as a PostToolUse hook on the Bash tool in
+# .claude/settings.json:
+#
+#   {
+#     "hooks": {
+#       "PostToolUse": [{
+#         "matcher": "Bash",
+#         "hooks": [{
+#           "type": "command",
+#           "command": "bash .claude/hooks/verify-gh-taxonomy.sh",
+#           "timeout": 30
+#         }]
+#       }]
+#     }
+#   }
+#
+# After every Bash tool call, Claude Code pipes a JSON payload to this
+# script's stdin containing:
+#   - tool_input.command: the shell command that was executed
+#   - tool_response: the stdout/stderr from that command
+#
+# The script pattern-matches the command to detect three triggers:
+#   1. `gh issue create`  → MODE=issue
+#   2. `gh pr create`     → MODE=pr
+#   3. `addSubIssue`      → MODE=hierarchy
+#
+# For any other command, the script exits 0 immediately (no-op).
+#
+# RESPONSE FORMAT
+# ---------------
+# The script communicates back to Claude via JSON on stdout:
+#
+#   BLOCK (hard stop — Claude must fix before continuing):
+#     {"decision":"block","reason":"..."}
+#
+#   WARN (advisory — Claude sees the message and should act on it):
+#     {"hookSpecificOutput":{"hookEventName":"PostToolUse",
+#       "additionalContext":"WARNING: ..."}}
+#
+#   PASS (informational — confirms compliance):
+#     {"hookSpecificOutput":{"hookEventName":"PostToolUse",
+#       "additionalContext":"Taxonomy check passed: ..."}}
+#
+# WHAT EACH MODE CHECKS
+# ---------------------
+#
+# MODE=issue (after `gh issue create`):
+#   Checks the newly created issue for the "CI minimum three":
+#     - Issue type (Bug, Task, Feature, Phase, Epic)
+#     - Domain label (data-pipeline, ci-automation, etc.)
+#     - Milestone
+#   Result: WARN if missing (not block — the agent still needs to set
+#   issue type via GraphQL, which is a separate Bash call).
+#   Also warns that project board, priority, and hierarchy are still needed.
+#
+# MODE=pr (after `gh pr create`):
+#   1. Checks the PR body for issue references (Fixes/Closes/Refs #N).
+#      Result: BLOCK if no linked issue — the pr-metadata-gate CI will fail.
+#   2. For each linked issue, checks the "CI minimum three" (type, label, milestone).
+#      Result: BLOCK if any are missing.
+#   3. For each linked issue, checks project board membership and priority.
+#      Result: WARN if missing — these don't fail CI but are required by the
+#      taxonomy lifecycle.
+#
+# MODE=hierarchy (after `addSubIssue` GraphQL mutation):
+#   Validates that Tasks/Bugs/Features are attached to Phases, not directly
+#   to Epics. The taxonomy requires: Epic → Phase → Task/Bug/Feature.
+#   Result: WARN if a leaf issue is attached directly to an Epic.
+#
+# =============================================================================
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+# ---------------------------------------------------------------------------
+# Route: match the command to a mode, or exit early for unrelated commands.
+# ---------------------------------------------------------------------------
+case "$COMMAND" in
+  *"gh pr create"*) MODE="pr" ;;
+  *"gh issue create"*) MODE="issue" ;;
+  *"addSubIssue"*) MODE="hierarchy" ;;
+  *) exit 0 ;;
+esac
+
+TOOL_RESPONSE=$(echo "$INPUT" | jq -r '.tool_response // empty')
+
+# ---------------------------------------------------------------------------
+# Scope: only run for commands that targeted synth-setter.
+# The hook lives in the synth-setter project, but commands may target other
+# repos (e.g. `gh pr create` run from a skills repo clone). We extract the
+# actual GitHub URL from the response and check its repo path. We can't just
+# grep the whole response for "synth-setter" because Bash tool output always
+# includes "Shell cwd was reset to .../synth-setter" when cwd changes.
+# For addSubIssue mutations, check the GraphQL query in the command string.
+# ---------------------------------------------------------------------------
+if [ "$MODE" = "hierarchy" ]; then
+  if ! echo "$COMMAND" | grep -qE 'owner.*synth-setter|repo.*synth-setter'; then
+    exit 0
+  fi
+else
+  # Extract the GitHub URL (PR or issue) and check if it's synth-setter
+  GITHUB_URL=$(echo "$TOOL_RESPONSE" | grep -oE 'https://github.com/[^/]+/[^/]+/(pull|issues)/[0-9]+' | head -1)
+  if [ -z "$GITHUB_URL" ]; then exit 0; fi
+  if ! echo "$GITHUB_URL" | grep -q 'synth-setter'; then
+    exit 0
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+OWNER="tinaudio"
+REPO="synth-setter"
+DOMAIN_LABELS="data-pipeline ci-automation code-health evaluation monitoring storage testing training"
+
+# ---------------------------------------------------------------------------
+# Helper: query an issue's taxonomy metadata (type, labels, milestone).
+# Usage: query_issue_metadata <issue_number>
+# Sets: ISSUE_TYPE, LABELS, MILESTONE, HAS_DOMAIN
+# ---------------------------------------------------------------------------
+query_issue_metadata() {
+  local issue_num="$1"
+
+  local result
+  # shellcheck disable=SC2016
+  result=$(gh api graphql -f query='
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $number) {
+          issueType { name }
+          labels(first: 10) { nodes { name } }
+          milestone { title }
+        }
+      }
+    }
+  ' -f owner="$OWNER" -f repo="$REPO" -F number="$issue_num" 2>/dev/null || echo "{}")
+
+  ISSUE_TYPE=$(echo "$result" | jq -r '.data.repository.issue.issueType.name // empty')
+  LABELS=$(echo "$result" | jq -r '[.data.repository.issue.labels.nodes[].name] | join(", ")' 2>/dev/null || echo "")
+  MILESTONE=$(echo "$result" | jq -r '.data.repository.issue.milestone.title // empty')
+
+  HAS_DOMAIN=false
+  for dl in $DOMAIN_LABELS; do
+    if echo "$LABELS" | grep -q "$dl"; then HAS_DOMAIN=true; break; fi
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Helper: check the "CI minimum three" — issue type, domain label, milestone.
+# Usage: check_ci_minimum <issue_number>
+# Returns: space-separated list of missing fields, or empty string if all set.
+# Requires query_issue_metadata to have been called first.
+# ---------------------------------------------------------------------------
+check_ci_minimum() {
+  local missing=""
+  [ -z "$ISSUE_TYPE" ] && missing="${missing} issue-type"
+  [ "$HAS_DOMAIN" = "false" ] && missing="${missing} domain-label"
+  [ -z "$MILESTONE" ] && missing="${missing} milestone"
+  echo "$missing"
+}
+
+# ---------------------------------------------------------------------------
+# Helper: check if an issue is on the project board and has priority set.
+# Usage: check_project_fields <issue_number>
+# Returns: space-separated list of missing fields, or empty string if all set.
+# ---------------------------------------------------------------------------
+check_project_fields() {
+  local issue_num="$1"
+
+  # Get the issue's node ID, then check project items on it.
+  local node_id
+  # shellcheck disable=SC2016
+  node_id=$(gh api graphql -f query='
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $number) { id }
+      }
+    }
+  ' -f owner="$OWNER" -f repo="$REPO" -F number="$issue_num" \
+    --jq '.data.repository.issue.id' 2>/dev/null || echo "")
+
+  if [ -z "$node_id" ]; then
+    echo " project-board priority"
+    return
+  fi
+
+  # Query project items on this issue. Check if any project item exists
+  # and whether it has a Priority field set.
+  local project_result
+  # shellcheck disable=SC2016
+  project_result=$(gh api graphql -f query='
+    query($id: ID!) {
+      node(id: $id) {
+        ... on Issue {
+          projectItems(first: 5) {
+            nodes {
+              project { title }
+              fieldValues(first: 10) {
+                nodes {
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    field { ... on ProjectV2SingleSelectField { name } }
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  ' -f id="$node_id" 2>/dev/null || echo "{}")
+
+  local on_board
+  on_board=$(echo "$project_result" | jq -r '.data.node.projectItems.nodes | length' 2>/dev/null || echo "0")
+
+  local missing=""
+  if [ "$on_board" = "0" ]; then
+    missing="${missing} project-board priority"
+  else
+    # Check if Priority field is set on any project item
+    local has_priority
+    has_priority=$(echo "$project_result" | jq -r '
+      [.data.node.projectItems.nodes[].fieldValues.nodes[]
+        | select(.field.name == "Priority")
+        | .name] | length' 2>/dev/null || echo "0")
+    if [ "$has_priority" = "0" ]; then
+      missing="${missing} priority"
+    fi
+  fi
+
+  echo "$missing"
+}
+
+
+# ===========================================================================
+# MODE: pr — runs after `gh pr create`
+# ===========================================================================
+if [ "$MODE" = "pr" ]; then
+  # Step 1: Extract PR number from the tool response URL.
+  PR_URL=$(echo "$TOOL_RESPONSE" | grep -oE 'https://github.com/[^/]+/[^/]+/pull/[0-9]+' | head -1)
+  if [ -z "$PR_URL" ]; then exit 0; fi
+  PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+
+  # Step 2: Check the PR body for issue references (Fixes/Closes/Refs #N).
+  # Without a linked issue, the pr-metadata-gate CI workflow will fail.
+  PR_BODY=$(gh pr view "$PR_NUM" --repo "${OWNER}/${REPO}" --json body --jq '.body' 2>/dev/null || echo "")
+  ISSUE_NUMS=$(echo "$PR_BODY" | grep -oE '(Fixes|Closes|Refs|fixes|closes|refs) #[0-9]+' | grep -oE '[0-9]+' || true)
+
+  if [ -z "$ISSUE_NUMS" ]; then
+    echo '{"decision":"block","reason":"PR has no linked issue (Fixes #N / Closes #N / Refs #N). The pr-metadata-gate CI check will fail."}'
+    exit 0
+  fi
+
+  # Step 3: For each linked issue, verify the "CI minimum three" (BLOCK if missing)
+  # and project board + priority (WARN if missing).
+  WARNINGS=""
+  for ISSUE_NUM in $ISSUE_NUMS; do
+    query_issue_metadata "$ISSUE_NUM"
+    CI_MISSING=$(check_ci_minimum)
+
+    if [ -n "$CI_MISSING" ]; then
+      echo "{\"decision\":\"block\",\"reason\":\"Issue #${ISSUE_NUM} is missing taxonomy metadata:${CI_MISSING}. Fix before the pr-metadata-gate CI check fails.\"}"
+      exit 0
+    fi
+
+    # CI gate will pass, but check the full taxonomy lifecycle too.
+    PROJECT_MISSING=$(check_project_fields "$ISSUE_NUM")
+    if [ -n "$PROJECT_MISSING" ]; then
+      WARNINGS="${WARNINGS}Issue #${ISSUE_NUM} is missing:${PROJECT_MISSING}. "
+    fi
+  done
+
+  if [ -n "$WARNINGS" ]; then
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Taxonomy check passed (CI gate OK), but full lifecycle incomplete: ${WARNINGS}Add to project board and set priority before merging.\"}}"
+  else
+    echo '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"Taxonomy check passed: linked issue(s) have issue type, domain label, and milestone."}}'
+  fi
+
+
+# ===========================================================================
+# MODE: issue — runs after `gh issue create`
+# ===========================================================================
+elif [ "$MODE" = "issue" ]; then
+  # Extract the issue number from the tool response URL.
+  ISSUE_URL=$(echo "$TOOL_RESPONSE" | grep -oE 'https://github.com/[^/]+/[^/]+/issues/[0-9]+' | head -1)
+  if [ -z "$ISSUE_URL" ]; then exit 0; fi
+  ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$')
+
+  # Check the CI minimum three. At this point, issue type is often not yet
+  # set because `gh issue create` can't set it — it requires a separate
+  # GraphQL mutation. So this is a WARN, not a BLOCK.
+  query_issue_metadata "$ISSUE_NUM"
+  CI_MISSING=$(check_ci_minimum)
+
+  if [ -n "$CI_MISSING" ]; then
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"WARNING: Issue #${ISSUE_NUM} is missing taxonomy metadata:${CI_MISSING}. Set these now before creating a PR. Also remember: add to project board, set priority, and establish hierarchy.\"}}"
+    exit 0
+  fi
+
+  echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Taxonomy check passed: issue has type, domain label, and milestone. Remember: add to project board, set priority, and establish hierarchy.\"}}"
+
+
+# ===========================================================================
+# MODE: hierarchy — runs after `addSubIssue` GraphQL mutation
+# ===========================================================================
+elif [ "$MODE" = "hierarchy" ]; then
+  # Validate that Tasks/Bugs/Features are attached to Phases, not directly
+  # to Epics. The taxonomy hierarchy is: Epic → Phase → Task/Bug/Feature.
+  #
+  # Extract issue node IDs (format: I_kw...) from the GraphQL mutation command.
+  NODE_IDS=$(echo "$COMMAND" | grep -oE 'I_kw[A-Za-z0-9_/+=.-]+' || true)
+  if [ -z "$NODE_IDS" ]; then exit 0; fi
+
+  PARENT_TYPE=""
+  PARENT_NUM=""
+  CHILD_TYPE=""
+  CHILD_NUM=""
+
+  for NODE_ID in $NODE_IDS; do
+    # shellcheck disable=SC2016
+    RESULT=$(gh api graphql -f query='
+      query($id: ID!) {
+        node(id: $id) {
+          ... on Issue { number issueType { name } }
+        }
+      }
+    ' -f id="$NODE_ID" 2>/dev/null || echo "{}")
+
+    TYPE=$(echo "$RESULT" | jq -r '.data.node.issueType.name // empty')
+    NUM=$(echo "$RESULT" | jq -r '.data.node.number // empty')
+
+    # The addSubIssue mutation takes (parentId, childId). We infer which is
+    # which from the issue type: Epic/Phase are parents, Task/Bug/Feature
+    # are children.
+    case "$TYPE" in
+      Epic|Phase)
+        PARENT_TYPE="$TYPE"
+        PARENT_NUM="$NUM"
+        ;;
+      Task|Bug|Feature)
+        CHILD_TYPE="$TYPE"
+        CHILD_NUM="$NUM"
+        ;;
+    esac
+  done
+
+  # Warn if a leaf issue is attached directly to an Epic (should go to a Phase).
+  if [ "$PARENT_TYPE" = "Epic" ] && [ -n "$CHILD_TYPE" ]; then
+    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"WARNING: ${CHILD_TYPE} #${CHILD_NUM} attached directly to Epic #${PARENT_NUM}. It should be a sub-issue of a Phase, not the Epic itself.\"}}"
+    exit 0
+  fi
+
+  echo '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"Hierarchy check passed."}}'
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,61 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "description": "Credential protection: blocks edits to .env, .pem, and .key files. Fires on every Edit/Write tool call. Goal: prevent secrets from being modified or leaked into commits.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file_path=$(echo \"$CLAUDE_TOOL_INPUT\" | grep -oE '\"file_path\"\\s*:\\s*\"[^\"]+\"' | head -1 | sed 's/.*\"\\([^\"]*\\)\"$/\\1/'); case \"$file_path\" in *.env|*.env.*|*.pem|*.key) echo 'BLOCKED: Cannot edit credential/secret files (.env, .pem, .key)' >&2; exit 1;; *) exit 0;; esac"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "description": "Auto-format: runs ruff check --fix and ruff format on Python files after every edit. Goal: catch lint and formatting errors immediately rather than waiting for pre-commit.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file_path=$(echo \"$CLAUDE_TOOL_INPUT\" | grep -oE '\"file_path\"\\s*:\\s*\"[^\"]+\"' | head -1 | sed 's/.*\"\\([^\"]*\\)\"$/\\1/'); case \"$file_path\" in *.py) ruff check --fix --quiet \"$file_path\" 2>/dev/null; ruff format --quiet \"$file_path\" 2>/dev/null;; esac; exit 0"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "description": "Auto-test: runs the matching pytest file when src/, scripts/, or tests/ Python files are edited. For src/foo.py, runs tests/test_foo.py if it exists. For test files, runs the file directly. Goal: catch regressions immediately after code changes.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "file_path=$(echo \"$CLAUDE_TOOL_INPUT\" | grep -oE '\"file_path\"\\s*:\\s*\"[^\"]+\"' | head -1 | sed 's/.*\"\\([^\"]*\\)\"$/\\1/'); case \"$file_path\" in */src/*|*/scripts/*) base=$(basename \"$file_path\" .py); test_file=\"tests/test_${base}.py\"; if [ -f \"$test_file\" ]; then echo \"Running $test_file\" >&2; pytest \"$test_file\" -x -q --no-header --tb=short 2>&1 | tail -5 >&2; fi;; */tests/*) echo \"Running $file_path\" >&2; pytest \"$file_path\" -x -q --no-header --tb=short 2>&1 | tail -5 >&2;; esac; exit 0"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "description": "Taxonomy verification: validates GitHub metadata after gh issue create, gh pr create, and addSubIssue mutations. Checks issue type, domain label, milestone, project board, and hierarchy. Goal: enforce the project's GitHub taxonomy conventions (docs/design/github-taxonomy.md) before metadata gaps compound.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/verify-gh-taxonomy.sh",
+            "timeout": 30,
+            "statusMessage": "Verifying GitHub taxonomy compliance..."
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "description": "PR checkbox trigger: detects gh pr create commands and prompts Claude to invoke the /pr-checkbox skill for verification checkboxes. Goal: ensure every PR gets behavioral verification results before review.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command // \"\"' | grep -q 'gh pr create' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"A PR was just created. You MUST now invoke the /pr-checkbox skill to add verification checkboxes to this PR.\"}}' || true",
+            "statusMessage": "Checking for PR creation..."
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Move shared hook configurations to `.claude/settings.json` (project-level, committed)
- Hooks are force-added since `.claude/` is gitignored (except skills/)
- Personal permissions remain in `settings.local.json`

### Hooks included:
- **Credential protection**: blocks edits to .env/.pem/.key
- **Pre-push review**: runs review gate before git push
- **Ruff auto-format**: auto-formats Python on edit
- **Auto-test runner**: runs matching pytest on file edit
- **Taxonomy verification**: validates GitHub metadata on gh commands
- **PR checkbox trigger**: prompts /pr-checkbox after gh pr create

Refs #265