### PR TITLE
build(docker): add image creation config schema and loader

### DIFF
--- a/configs/image/dev-snapshot.yaml
+++ b/configs/image/dev-snapshot.yaml
@@ -1,0 +1,6 @@
+# Image type: dev-snapshot (mutable tag for iteration).
+#
+# Runtime inputs (github_sha, issue_number) are provided by the caller,
+# not stored in this file. See scripts/image_config.py for the schema.
+#
+# Future: static fields like base_image, apt_packages, python_version.

--- a/configs/image/dev-snapshot.yaml
+++ b/configs/image/dev-snapshot.yaml
@@ -2,5 +2,11 @@
 #
 # Runtime inputs (github_sha, issue_number) are provided by the caller,
 # not stored in this file. See scripts/image_config.py for the schema.
-#
-# Future: static fields like base_image, apt_packages, python_version.
+
+dockerfile: docker/ubuntu22_04/Dockerfile
+image: tinaudio/perm
+base_image: "ubuntu@sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751"
+base_image_tag: ubuntu22_04
+build_mode: prebuilt
+target_platform: linux/amd64
+torch_index_url: "https://download.pytorch.org/whl/cu128"

--- a/scripts/image_config.py
+++ b/scripts/image_config.py
@@ -67,7 +67,7 @@ def load_image_config(
         FileNotFoundError: config_path doesn't exist.
         pydantic.ValidationError: invalid github_sha or issue_number.
     """
-    if not config_path.exists():
+    if not config_path.is_file():
         raise FileNotFoundError(config_path)
 
     yaml.safe_load(config_path.read_text())

--- a/scripts/image_config.py
+++ b/scripts/image_config.py
@@ -1,0 +1,79 @@
+"""Image creation config schema and loader.
+
+Defines the inputs needed to create a Docker image build, validated at the YAML trust boundary via
+Pydantic.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel, field_validator
+
+_HEX_CHARS = frozenset("0123456789abcdef")
+
+
+class ImageConfig(BaseModel, strict=True):
+    """Validated image creation config: static settings + runtime build inputs.
+
+    Static fields come from the YAML config file.
+    Runtime fields (github_sha, issue_number) come from the caller.
+    image_config_id is derived from the config filename stem.
+    """
+
+    github_sha: str
+    issue_number: int
+    image_config_id: str
+
+    @field_validator("github_sha")
+    @classmethod
+    def github_sha_must_be_40_hex(cls, v: str) -> str:
+        """Reject anything that isn't a full lowercase commit SHA."""
+        if len(v) != 40 or not _HEX_CHARS.issuperset(v):
+            raise ValueError("github_sha must be a 40-character lowercase hex string")
+        return v
+
+    @field_validator("issue_number")
+    @classmethod
+    def issue_number_must_be_positive(cls, v: int) -> int:
+        """Reject zero or negative issue numbers."""
+        if v <= 0:
+            raise ValueError("issue_number must be a positive integer")
+        return v
+
+
+def load_image_config(
+    config_path: Path,
+    *,
+    github_sha: str,
+    issue_number: int,
+) -> ImageConfig:
+    """Load image config from YAML and merge with runtime inputs.
+
+    Reads static fields from the YAML config file (currently empty),
+    merges with runtime inputs, validates via Pydantic, and derives
+    image_config_id from the config filename stem.
+
+    Args:
+        config_path: Path to YAML config under configs/image/.
+        github_sha: 40-char lowercase hex commit SHA.
+        issue_number: Positive GitHub issue number.
+
+    Returns:
+        Validated ImageConfig with all fields populated.
+
+    Raises:
+        FileNotFoundError: config_path doesn't exist.
+        pydantic.ValidationError: invalid github_sha or issue_number.
+    """
+    if not config_path.exists():
+        raise FileNotFoundError(config_path)
+
+    yaml.safe_load(config_path.read_text())
+
+    return ImageConfig(
+        github_sha=github_sha,
+        issue_number=issue_number,
+        image_config_id=config_path.stem,
+    )

--- a/scripts/image_config.py
+++ b/scripts/image_config.py
@@ -7,6 +7,7 @@ Pydantic.
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Literal
 
 import yaml
 from pydantic import BaseModel, field_validator
@@ -14,7 +15,7 @@ from pydantic import BaseModel, field_validator
 _HEX_CHARS = frozenset("0123456789abcdef")
 
 
-class ImageConfig(BaseModel, strict=True):
+class ImageConfig(BaseModel, strict=True, extra="forbid"):
     """Validated image creation config: static settings + runtime build inputs.
 
     Static fields come from the YAML config file.
@@ -22,6 +23,18 @@ class ImageConfig(BaseModel, strict=True):
     image_config_id is derived from the config filename stem.
     """
 
+    # --- Static fields (from YAML config, with defaults) ---
+    dockerfile: str = "docker/ubuntu22_04/Dockerfile"
+    image: str = "tinaudio/perm"
+    base_image: str = (
+        "ubuntu@sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751"
+    )
+    base_image_tag: str = "ubuntu22_04"
+    build_mode: Literal["source", "prebuilt"] = "prebuilt"
+    target_platform: Literal["linux/amd64", "linux/arm64"] = "linux/amd64"
+    torch_index_url: str = "https://download.pytorch.org/whl/cu128"
+
+    # --- Runtime fields (from caller, no defaults) ---
     github_sha: str
     issue_number: int
     image_config_id: str
@@ -51,9 +64,9 @@ def load_image_config(
 ) -> ImageConfig:
     """Load image config from YAML and merge with runtime inputs.
 
-    Reads static fields from the YAML config file (currently empty),
-    merges with runtime inputs, validates via Pydantic, and derives
-    image_config_id from the config filename stem.
+    Reads static fields from the YAML config file, merges with runtime
+    inputs, validates via Pydantic, and derives image_config_id from
+    the config filename stem.
 
     Args:
         config_path: Path to YAML config under configs/image/.
@@ -64,16 +77,29 @@ def load_image_config(
         Validated ImageConfig with all fields populated.
 
     Raises:
-        FileNotFoundError: config_path doesn't exist.
-        pydantic.ValidationError: invalid github_sha or issue_number.
+        FileNotFoundError: config_path doesn't exist or isn't a file.
+        ValueError: top-level YAML is not a mapping.
+        pydantic.ValidationError: invalid field values.
     """
     if not config_path.is_file():
         raise FileNotFoundError(config_path)
 
-    yaml.safe_load(config_path.read_text())
+    raw = yaml.safe_load(config_path.read_text())
 
-    return ImageConfig(
-        github_sha=github_sha,
-        issue_number=issue_number,
-        image_config_id=config_path.stem,
+    if raw is None:
+        raw = {}
+
+    if not isinstance(raw, dict):
+        raise ValueError(
+            f"Top-level YAML in {config_path} must be a mapping, got {type(raw).__name__}"
+        )
+
+    raw.update(
+        {
+            "github_sha": github_sha,
+            "issue_number": issue_number,
+            "image_config_id": config_path.stem,
+        }
     )
+
+    return ImageConfig(**raw)

--- a/tests/scripts/test_image_config.py
+++ b/tests/scripts/test_image_config.py
@@ -149,3 +149,91 @@ class TestLoadImageConfigErrors:
 
         with pytest.raises(FileNotFoundError):
             load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
+
+    def test_is_file_rejects_directory(self, tmp_path: Path) -> None:
+        """Directory path raises FileNotFoundError, not IsADirectoryError."""
+        dir_path = tmp_path / "not-a-file"
+        dir_path.mkdir()
+
+        with pytest.raises(FileNotFoundError):
+            load_image_config(dir_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
+
+    def test_yaml_non_mapping_raises(self, tmp_path: Path) -> None:
+        """YAML with a list instead of a mapping raises ValueError."""
+        config_path = tmp_path / "bad.yaml"
+        config_path.write_text("[1, 2, 3]\n")
+
+        with pytest.raises(ValueError, match="must be a mapping"):
+            load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
+
+    def test_yaml_unknown_key_rejected(self, tmp_path: Path) -> None:
+        """Unknown YAML key is rejected by Pydantic strict mode."""
+        config_path = tmp_path / "unknown.yaml"
+        config_path.write_text("bogus_key: value\n")
+
+        with pytest.raises(ValidationError):
+            load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
+
+
+# ---------------------------------------------------------------------------
+# load_image_config — static fields and YAML merge
+# ---------------------------------------------------------------------------
+
+
+class TestStaticFieldsAndYamlMerge:
+    """Static fields are loaded from YAML and merged with runtime inputs."""
+
+    def test_yaml_static_fields_override_defaults(self, tmp_path: Path) -> None:
+        """YAML value overrides the model default."""
+        config_path = tmp_path / "custom.yaml"
+        config_path.write_text("build_mode: source\n")
+
+        result = load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
+
+        assert result.build_mode == "source"
+
+    def test_yaml_empty_file_uses_defaults(self, tmp_path: Path) -> None:
+        """Empty YAML (comment-only) uses all model defaults for static fields."""
+        config_path = tmp_path / "empty.yaml"
+        config_path.write_text("# just a comment\n")
+
+        result = load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
+
+        assert result.dockerfile == "docker/ubuntu22_04/Dockerfile"
+        assert result.image == "tinaudio/perm"
+        assert result.base_image_tag == "ubuntu22_04"
+        assert result.build_mode == "prebuilt"
+        assert result.target_platform == "linux/amd64"
+
+    def test_build_mode_rejects_invalid_literal(self, tmp_path: Path) -> None:
+        """build_mode only accepts 'source' or 'prebuilt'."""
+        config_path = tmp_path / "bad-mode.yaml"
+        config_path.write_text("build_mode: invalid\n")
+
+        with pytest.raises(ValidationError, match="build_mode"):
+            load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
+
+    def test_target_platform_rejects_invalid_literal(self, tmp_path: Path) -> None:
+        """target_platform only accepts 'linux/amd64' or 'linux/arm64'."""
+        config_path = tmp_path / "bad-platform.yaml"
+        config_path.write_text("target_platform: windows/amd64\n")
+
+        with pytest.raises(ValidationError, match="target_platform"):
+            load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
+
+    def test_static_field_values_match_dev_snapshot_yaml(self) -> None:
+        """Real dev-snapshot.yaml fields match expected defaults (catches drift)."""
+        config_path = Path("configs/image/dev-snapshot.yaml")
+
+        result = load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
+
+        assert result.dockerfile == "docker/ubuntu22_04/Dockerfile"
+        assert result.image == "tinaudio/perm"
+        assert result.base_image == (
+            "ubuntu@sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751"
+        )
+        assert result.base_image_tag == "ubuntu22_04"
+        assert result.build_mode == "prebuilt"
+        assert result.target_platform == "linux/amd64"
+        assert result.torch_index_url == "https://download.pytorch.org/whl/cu128"
+        assert result.image_config_id == "dev-snapshot"

--- a/tests/scripts/test_image_config.py
+++ b/tests/scripts/test_image_config.py
@@ -1,0 +1,151 @@
+"""Tests for scripts/image_config.py — image creation config schema and loader.
+
+Tests are organized around the PUBLIC typed API:
+- load_image_config(): loads YAML config, merges runtime inputs, validates via Pydantic
+- ImageConfig: Pydantic model with github_sha, issue_number, image_config_id
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from scripts.image_config import load_image_config
+
+VALID_SHA = "a" * 40
+VALID_ISSUE = 266
+
+
+# ---------------------------------------------------------------------------
+# load_image_config — valid inputs
+# ---------------------------------------------------------------------------
+
+
+class TestLoadImageConfigValid:
+    """load_image_config returns correct ImageConfig for valid inputs."""
+
+    def test_all_fields_populated(self, tmp_path: Path) -> None:
+        """Valid YAML + runtime inputs produce ImageConfig with all fields set."""
+        config_path = tmp_path / "dev-snapshot.yaml"
+        config_path.write_text("# minimal config\n")
+
+        result = load_image_config(
+            config_path,
+            github_sha=VALID_SHA,
+            issue_number=VALID_ISSUE,
+        )
+
+        assert result.github_sha == VALID_SHA
+        assert result.issue_number == VALID_ISSUE
+        assert result.image_config_id == "dev-snapshot"
+
+
+# ---------------------------------------------------------------------------
+# load_image_config — github_sha validation
+# ---------------------------------------------------------------------------
+
+
+class TestGithubShaValidation:
+    """github_sha must be exactly 40 lowercase hex characters."""
+
+    def test_short_sha_rejected(self, tmp_path: Path) -> None:
+        """SHA shorter than 40 chars is rejected."""
+        config_path = tmp_path / "dev-snapshot.yaml"
+        config_path.write_text("")
+
+        with pytest.raises(ValidationError, match="github_sha"):
+            load_image_config(config_path, github_sha="abc123", issue_number=VALID_ISSUE)
+
+    def test_uppercase_sha_rejected(self, tmp_path: Path) -> None:
+        """Uppercase hex chars are rejected — must be lowercase."""
+        config_path = tmp_path / "dev-snapshot.yaml"
+        config_path.write_text("")
+
+        with pytest.raises(ValidationError, match="github_sha"):
+            load_image_config(config_path, github_sha="A" * 40, issue_number=VALID_ISSUE)
+
+    def test_non_hex_sha_rejected(self, tmp_path: Path) -> None:
+        """Non-hex characters are rejected."""
+        config_path = tmp_path / "dev-snapshot.yaml"
+        config_path.write_text("")
+
+        with pytest.raises(ValidationError, match="github_sha"):
+            load_image_config(config_path, github_sha="g" * 40, issue_number=VALID_ISSUE)
+
+    def test_empty_sha_rejected(self, tmp_path: Path) -> None:
+        """Empty string is rejected."""
+        config_path = tmp_path / "dev-snapshot.yaml"
+        config_path.write_text("")
+
+        with pytest.raises(ValidationError, match="github_sha"):
+            load_image_config(config_path, github_sha="", issue_number=VALID_ISSUE)
+
+
+# ---------------------------------------------------------------------------
+# load_image_config — issue_number validation
+# ---------------------------------------------------------------------------
+
+
+class TestIssueNumberValidation:
+    """issue_number must be a positive integer."""
+
+    def test_zero_rejected(self, tmp_path: Path) -> None:
+        """Zero is not a valid issue number."""
+        config_path = tmp_path / "dev-snapshot.yaml"
+        config_path.write_text("")
+
+        with pytest.raises(ValidationError, match="issue_number"):
+            load_image_config(config_path, github_sha=VALID_SHA, issue_number=0)
+
+    def test_negative_rejected(self, tmp_path: Path) -> None:
+        """Negative numbers are not valid issue numbers."""
+        config_path = tmp_path / "dev-snapshot.yaml"
+        config_path.write_text("")
+
+        with pytest.raises(ValidationError, match="issue_number"):
+            load_image_config(config_path, github_sha=VALID_SHA, issue_number=-1)
+
+
+# ---------------------------------------------------------------------------
+# load_image_config — image_config_id derivation
+# ---------------------------------------------------------------------------
+
+
+class TestImageConfigIdDerivation:
+    """image_config_id is derived from the config filename stem."""
+
+    def test_dev_snapshot_yaml_gives_dev_snapshot_id(self, tmp_path: Path) -> None:
+        """dev-snapshot.yaml produces image_config_id 'dev-snapshot'."""
+        config_path = tmp_path / "dev-snapshot.yaml"
+        config_path.write_text("")
+
+        result = load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
+
+        assert result.image_config_id == "dev-snapshot"
+
+    def test_custom_name_gives_matching_id(self, tmp_path: Path) -> None:
+        """Arbitrary filename stem becomes image_config_id."""
+        config_path = tmp_path / "my-custom-image.yaml"
+        config_path.write_text("")
+
+        result = load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
+
+        assert result.image_config_id == "my-custom-image"
+
+
+# ---------------------------------------------------------------------------
+# load_image_config — error cases
+# ---------------------------------------------------------------------------
+
+
+class TestLoadImageConfigErrors:
+    """load_image_config raises appropriate errors for bad inputs."""
+
+    def test_nonexistent_file_raises_file_not_found(self, tmp_path: Path) -> None:
+        """Missing config file raises FileNotFoundError."""
+        config_path = tmp_path / "nonexistent.yaml"
+
+        with pytest.raises(FileNotFoundError):
+            load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)


### PR DESCRIPTION
## Summary

- Add `ImageConfig` Pydantic model (`strict=True`) with validated `github_sha` (40-char lowercase hex) and `issue_number` (positive int), plus derived `image_config_id` from config filename stem
- Add `load_image_config()` loader that reads static YAML config, merges runtime inputs, and validates at the trust boundary
- Add `configs/image/dev-snapshot.yaml` establishing the dev-snapshot image type (minimal — runtime inputs provided by caller, not stored in YAML)

**Design decision**: `github_sha` and `issue_number` are runtime function arguments, not YAML fields. This matches the spec's workflow patterns where per-invocation inputs come from the caller (like evaluation taking `train_wandb_run_id` as a dispatch input). The YAML establishes image type identity and will hold static settings in future tasks.

Closes #274

## Test plan

- [x] 10 pytest tests covering: valid loading, github_sha validation (short/uppercase/non-hex/empty), issue_number validation (zero/negative), image_config_id derivation (2 filenames), FileNotFoundError
- [x] `make format` — all pre-commit hooks pass
- [ ] `make test` — CI runs full suite