### PR TITLE
test(deps): replace missing pkg_resources with importlib.metadata

### DIFF
--- a/tests/helpers/package_available.py
+++ b/tests/helpers/package_available.py
@@ -1,6 +1,6 @@
 import platform
+from importlib.metadata import PackageNotFoundError, distribution
 
-import pkg_resources
 from lightning.fabric.accelerators import TPUAccelerator
 
 
@@ -12,8 +12,8 @@ def _package_available(package_name: str) -> bool:
     :return: `True` if the package is available. `False` otherwise.
     """
     try:
-        return pkg_resources.require(package_name) is not None
-    except pkg_resources.DistributionNotFound:
+        return distribution(package_name) is not None
+    except PackageNotFoundError:
         return False
 
 

--- a/tests/helpers/run_if.py
+++ b/tests/helpers/run_if.py
@@ -4,12 +4,12 @@ https://github.com/PyTorchLightning/pytorch-lightning/blob/master/tests/helpers/
 """
 
 import sys
+from importlib.metadata import version as get_version
 from typing import Any
 
 import pytest
 import torch
 from packaging.version import Version
-from pkg_resources import get_distribution
 from pytest import MarkDecorator
 
 from tests.helpers.package_available import (
@@ -82,12 +82,12 @@ class RunIf:
             reasons.append(f"GPUs>={min_gpus}")
 
         if min_torch:
-            torch_version = get_distribution("torch").version
+            torch_version = get_version("torch")
             conditions.append(Version(torch_version) < Version(min_torch))
             reasons.append(f"torch>={min_torch}")
 
         if max_torch:
-            torch_version = get_distribution("torch").version
+            torch_version = get_version("torch")
             conditions.append(Version(torch_version) >= Version(max_torch))
             reasons.append(f"torch<{max_torch}")
 


### PR DESCRIPTION
## Summary

- **setuptools 82.0.0 removed `pkg_resources`**, breaking test collection for all 9 test files that import from `tests/helpers/` (cascade from `package_available.py` and `run_if.py`).
- Replace `import pkg_resources` / `pkg_resources.require()` / `pkg_resources.DistributionNotFound` with `importlib.metadata.distribution` / `PackageNotFoundError` in `package_available.py`.
- Replace `from pkg_resources import get_distribution` / `get_distribution("torch").version` with `importlib.metadata.version` in `run_if.py`.
- The fix was already done on the `experiment` branch — this ports only the `pkg_resources` removal to `main`.

This unblocks verification of #265 (5 CI checks currently SKIP due to this breakage).

Refs #265

## Test plan

- [x] `make format` — all 27 hooks pass
- [x] `python -c "from tests.helpers.package_available import _WANDB_AVAILABLE"` — imports cleanly
- [x] `python -c "from tests.helpers.run_if import RunIf"` — imports cleanly
- [x] `python -m pytest tests/test_train.py --co -q` — 8 tests collected (this file imports from `tests/helpers/`)