### PR TITLE
chore(ci): set up mutmut mutation testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+mutants/
+.mutmut-cache/
 
 # Translations
 *.mo

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ coverage: ## Run tests with coverage report
 benchmark: ## Run performance benchmarks
 	pytest --benchmark-only -m "benchmark" -v
 
+mutmut: ## Run mutation testing
+	mutmut run
+
 train: ## Train the model
 	python src/train.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,4 +111,4 @@ exclude_lines = [
 # assumes src-layout, but this project imports `src` as a package).
 paths_to_mutate = ["scripts/"]
 tests_dir = ["tests/scripts/"]
-pytest_add_cli_args = ["-o", "addopts=--color=yes --durations=0 --strict-markers", "-m", "not slow and not requires_vst and not r2 and not gpu and not benchmark"]
+pytest_add_cli_args = ["-m", "not slow and not requires_vst and not r2 and not gpu and not benchmark"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,3 +105,10 @@ exclude_lines = [
     "raise NotImplementedError()",
     "if __name__ == .__main__.:",
 ]
+
+[tool.mutmut]
+# src/ excluded: mutmut v3 asserts module names don't start with "src." (it
+# assumes src-layout, but this project imports `src` as a package).
+paths_to_mutate = ["scripts/"]
+tests_dir = ["tests/scripts/"]
+pytest_add_cli_args = ["-o", "addopts=--color=yes --durations=0 --strict-markers", "-m", "not slow and not requires_vst and not r2 and not gpu and not benchmark"]


### PR DESCRIPTION
## Summary

- Configure mutmut v3.5 for mutation testing with `[tool.mutmut]` in `pyproject.toml`
- Add `make mutmut` target to Makefile
- Add `mutants/` and `.mutmut-cache/` to `.gitignore`

**Limitation:** `src/` is excluded from `paths_to_mutate` because mutmut v3 has a hard-coded assertion (`assert not name.startswith('src.')`) that prevents instrumenting modules under a package named `src`. Only `scripts/` is mutation-tested for now. Tracked in #301.

Refs #296

## Test plan

- [x] `mutmut run` completes successfully against `scripts/`
- [x] `make format` passes all pre-commit hooks
- [x] `mutmut results` reports mutant outcomes (killed, survived, no tests)