### PR TITLE
chore(deps): pin pydantic>=2 and add mutmut

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -9,7 +9,7 @@ wandb
 # --------- pipeline --------- #
 click
 numpy
-pydantic
+pydantic>=2
 pyyaml
 structlog
 tenacity
@@ -24,6 +24,7 @@ hdf5plugin
 librosa
 loguru
 matplotlib
+mutmut==3.5.*
 mido
 pedalboard
 POT


### PR DESCRIPTION
## Summary

- Pin `pydantic>=2` — the repo had `pydantic` unpinned, but PRs #297 and #305 use Pydantic v2-only APIs (`field_validator`, `model_validator`, `ConfigDict(strict=True)`). Environments resolving to v1 would fail at import time.
- Add `mutmut==3.5.*` — needed for mutation testing setup in #302.

Fixes #303

## Test plan

- [ ] `pip install -r requirements-app.txt` resolves successfully
- [ ] `python -c "import pydantic; print(pydantic.VERSION)"` shows v2.x
- [ ] `python -c "import mutmut; print(mutmut.__version__)"` shows 3.5.x