### PR TITLE
feat(code-health): add doc-drift detection skill

### DIFF
--- a/.claude/skills/doc-drift/SKILL.md
+++ b/.claude/skills/doc-drift/SKILL.md
@@ -1,0 +1,247 @@
+______________________________________________________________________
+
+## name: doc-drift description: > Detect when documentation has drifted out of sync with the codebase after code changes. Use this skill whenever the user asks to check if docs are up to date, review doc freshness, find stale documentation, audit reference docs, or asks "did this change break any docs?" Also trigger when the user mentions doc drift, doc rot, doc sync, doc consistency, or says things like "my docs might be out of date" or "check the docs after that refactor." Trigger even on indirect cues like "I just merged a big change" or "we renamed a bunch of files" — these are doc drift events. If the user asks to create or update a doc-map.yaml, that also triggers this skill.
+
+# Doc Drift — Documentation Consistency Checker
+
+Detect and fix documentation that has gone stale after code changes. Combines
+two complementary strategies: **grep-based detection** (automatic, finds textual
+references) and **structural mapping** (manual, catches drift by omission).
+
+## When to use
+
+- After merging code changes — "did this break any docs?"
+- Periodic audits — "are my docs still accurate?"
+- After refactors — "we renamed X to Y, what docs need updating?"
+- When docs feel wrong — "something in the docker doc doesn't match reality"
+- To bootstrap or update the structural mapping — "create/update doc-map.yaml"
+
+______________________________________________________________________
+
+## Core concepts
+
+### Two detection strategies
+
+**Grep-based detection** scans documentation files for references to source
+paths, function names, CLI flags, env vars, and other identifiers that appear
+in the code diff. This is automatic and zero-config, but only catches drift
+when the doc already mentions the thing that changed.
+
+**Structural mapping** (`doc-map.yaml`) encodes which source files *should* be
+documented where — regardless of whether the doc currently references them.
+This catches drift by omission: a new entrypoint mode that no doc mentions,
+a config field that was added but never documented. The mapping file lives in
+the user's repo and is itself subject to drift review.
+
+Both strategies run together. Grep catches the common case (doc says X, code
+changed X). The mapping catches the dangerous case (code added Y, no doc
+mentions Y at all).
+
+### Drift categories
+
+1. **Stale reference** — doc describes behavior that the code no longer
+   implements. Example: doc says MODE accepts `idle` and `passthrough`, but
+   code now also supports `train`.
+
+1. **Broken path** — doc references a file, function, class, or CLI flag that
+   was renamed, moved, or deleted.
+
+1. **Inconsistent value** — doc states a default, threshold, URL, or env var
+   name that differs from the code.
+
+1. **Omission** — source file is in the structural mapping's coverage set for
+   a doc, but the doc doesn't mention new features/modes/flags added in the
+   diff. This is only detectable via `doc-map.yaml`.
+
+1. **Cross-doc inconsistency** — two docs describe the same thing differently.
+   Example: rclone.md says MODE=train exists, docker.md doesn't mention it.
+
+1. **Mapping staleness** — `doc-map.yaml` references files that no longer exist,
+   or the repo has source files in mapped directories that aren't covered.
+
+______________________________________________________________________
+
+## Workflow
+
+### Step 1: Determine scope
+
+Ask: what changed? The answer determines the diff source.
+
+| Trigger | Diff source |
+|---|---|
+| "Check after last merge" | `git diff HEAD~1 HEAD` |
+| "Check after last N commits" | `git diff HEAD~N HEAD` |
+| "Check after branch merged" | `git diff main..HEAD` or `git log --merges -1` |
+| "Full audit" | No diff — review all mappings and all docs |
+| "These specific files changed" | User-provided file list |
+
+Run the diff and extract:
+
+- Changed file paths
+- Changed function/class/method names (from the diff hunks)
+- Changed env var names, CLI flags, config keys (grep the diff for patterns)
+- Renamed/moved/deleted files (`git diff --name-status` for R/D entries)
+
+### Step 2: Find candidate docs
+
+**Grep-based scan:**
+
+```bash
+# For each changed file, find docs that reference it
+for f in $CHANGED_FILES; do
+  basename=$(basename "$f")
+  grep -rl "$basename" docs/ --include="*.md"
+  # Also search by path fragments
+  grep -rl "$f" docs/ --include="*.md"
+done
+
+# For renamed/deleted files, search for the OLD name
+for old_name in $DELETED_OR_RENAMED; do
+  grep -rl "$old_name" docs/ --include="*.md"
+done
+
+# For changed identifiers (env vars, flags, function names)
+for ident in $CHANGED_IDENTIFIERS; do
+  grep -rl "$ident" docs/ --include="*.md"
+done
+```
+
+Deduplicate the results. These are docs with textual references to things
+that changed — high probability of drift.
+
+**Structural mapping scan:**
+
+If `doc-map.yaml` exists, load it (see schema in `references/doc-map-schema.md`).
+For each changed file, check whether it falls under any mapping entry's
+`sources` patterns. If so, add the mapped `doc` to the candidate set — even
+if the grep found nothing. This is how omission drift is detected.
+
+Also check for **mapping staleness**: do any `sources` patterns in the YAML
+match zero files in the current repo? If so, flag the mapping entry as
+potentially stale.
+
+### Step 3: Analyze each candidate doc
+
+For each candidate doc, read it fully. Then for each changed file that
+triggered it, read the relevant code (the current version, not the diff).
+
+Check for each drift category:
+
+1. **Stale references**: Does the doc describe behavior (modes, flags, defaults,
+   workflows) that doesn't match the current code?
+
+1. **Broken paths**: Does the doc reference files, functions, or identifiers
+   that were renamed or deleted in the diff?
+
+1. **Inconsistent values**: Does the doc state specific values (defaults, URLs,
+   env var names, flag names) that differ from the code?
+
+1. **Omissions** (mapping-triggered only): The structural mapping says this
+   source file should be covered in this doc. Does the doc mention the
+   features/modes/flags that the source file implements? If the diff added
+   something new and the doc doesn't cover it, that's omission drift.
+
+1. **Cross-doc inconsistency**: If multiple docs are in the candidate set and
+   they describe overlapping topics, do they agree?
+
+### Step 4: Report and propose fixes
+
+For each drift instance found, report:
+
+```
+## Drift report
+
+### <doc_path>
+
+#### <drift_category>: <short_description>
+
+**Source:** <source_file>:<line_range_or_function>
+**Doc location:** <doc_file>, § <section_name>
+**Issue:** <what's wrong>
+**Suggested fix:** <concrete corrected text or action>
+**Confidence:** high | medium | low
+```
+
+Confidence levels:
+
+- **High**: The doc makes a specific factual claim that directly contradicts
+  the code (e.g., lists 2 modes, code has 3).
+- **Medium**: The doc is vague or incomplete in a way that *might* mislead
+  (e.g., doesn't mention a new flag, but doesn't claim to be exhaustive).
+- **Low**: Structural mapping suggests coverage, but the doc may intentionally
+  omit the topic (e.g., an advanced feature documented elsewhere).
+
+### Step 5: Act on findings
+
+Depending on context:
+
+**In Claude Code:** Apply fixes directly via `str_replace` on the doc files,
+then commit to a `doc-drift/<date>` branch and open a PR. Group all fixes in
+one PR, one commit per doc file.
+
+**In Claude.ai:** Present the drift report and proposed fixes in conversation.
+Offer to produce the corrected doc files.
+
+**In a GitHub Action:** Output the drift report as a PR comment or open a
+follow-up PR with fixes (see `references/github-action-integration.md`).
+
+______________________________________________________________________
+
+## Bootstrapping doc-map.yaml
+
+If the repo doesn't have a `doc-map.yaml` yet, offer to create one.
+
+### Auto-generation approach
+
+1. Find all docs: `find docs/ -name "*.md" -type f`
+1. For each doc, extract source file references (paths, script names, module
+   names) via grep
+1. For each referenced source file, find its parent directory
+1. Generate mapping entries with the source directory as a glob pattern
+
+This produces a first draft that captures existing textual cross-references.
+The user should review and add structural relationships that aren't yet
+referenced in the docs (this is the whole point — the mapping should be a
+*superset* of what the docs currently reference).
+
+### Placement
+
+`doc-map.yaml` lives at the repo root (or `docs/doc-map.yaml`). It should be
+version-controlled — changes to the mapping are reviewable like any other code.
+
+______________________________________________________________________
+
+## Edge cases and judgment calls
+
+**Intentional omission vs. drift:** Some docs intentionally don't cover
+everything. A "quickstart" doc that skips advanced modes isn't drifted — it's
+scoped. Use confidence levels to distinguish. If the doc says "for the full
+spec, see X," and X covers the topic, it's not an omission.
+
+**Generated docs:** If a doc is auto-generated (e.g., from docstrings or a
+build script), flag it but don't propose inline fixes — propose fixing the
+generator input instead.
+
+**Doc freshness markers:** If a doc has a "Last verified" date (like the rclone
+and docker references in this project), update it when applying fixes.
+
+**Large diffs:** If the diff touches 50+ files, don't try to analyze every
+possible doc. Focus on high-confidence matches: structural mapping hits and
+grep hits where the doc makes specific claims about the changed code. Report
+that a full audit may be needed.
+
+**Monorepo considerations:** If docs/ isn't the only doc location (READMEs in
+subdirectories, inline doc comments, SKILL.md files), the grep scan should
+cover the full tree, filtered to markdown files. The structural mapping can
+specify non-standard doc locations.
+
+______________________________________________________________________
+
+## Reference files
+
+- `references/doc-map-schema.md` — YAML schema for the structural mapping file,
+  with annotated examples.
+- `references/github-action-integration.md` — How to wire this into a
+  post-merge GitHub Action (workflow YAML, prompt template, PR creation).
+
+Read these when needed — they're supplementary to the core workflow above.

--- a/.claude/skills/doc-drift/doc-map-schema.md
+++ b/.claude/skills/doc-drift/doc-map-schema.md
@@ -1,0 +1,164 @@
+# doc-map.yaml Schema
+
+The structural mapping file that encodes which source files *should* be
+documented where. This is the mechanism that catches drift by omission —
+when code adds something new and no doc mentions it.
+
+______________________________________________________________________
+
+## Schema
+
+```yaml
+# doc-map.yaml
+version: 1
+
+docs:
+  - doc: docs/reference/docker.md
+    description: Docker build, run, debug reference
+    sources:
+      - pattern: "docker/**"
+        covers: "Dockerfile stages, build targets, layer structure"
+      - pattern: "scripts/docker_entrypoint.sh"
+        covers: "Entrypoint modes, env var dispatch, MODE values"
+      - pattern: "scripts/image_config.py"
+        covers: "Image config schema, Pydantic model, validation"
+      - pattern: "configs/image/**"
+        covers: "Image config YAML files, build parameters"
+      - pattern: "Makefile"
+        covers: "Docker build targets, secret injection, build flags"
+        scope: "docker"  # only review docker-related sections of Makefile
+
+  - doc: docs/reference/rclone.md
+    description: rclone R2 operations reference
+    sources:
+      - pattern: "src/data/uploader.py"
+        covers: "Upload commands, flags, dry-run behavior"
+      - pattern: "scripts/finalize_shards.py"
+        covers: "Download commands, resharding workflow"
+      - pattern: "scripts/docker_entrypoint.sh"
+        covers: "Train-mode download/upload, stats flags"
+        scope: "rclone"
+      - pattern: "scripts/r2_shard_report.py"
+        covers: "Listing commands, report usage"
+      - pattern: "tests/scripts/test_r2_shard_report.py"
+        covers: "Test commands, fixture upload, cleanup"
+
+  - doc: docs/reference/wandb-integration.md
+    description: W&B logging and auth reference
+    sources:
+      - pattern: "src/training/**"
+        covers: "W&B logging calls, metric names, run config"
+      - pattern: "scripts/docker_entrypoint.sh"
+        covers: "W&B auth setup, netrc configuration"
+        scope: "wandb"
+```
+
+______________________________________________________________________
+
+## Field reference
+
+### Top-level
+
+| Field | Type | Required | Description |
+|-----------|---------|----------|--------------------------------------|
+| `version` | integer | Yes | Schema version. Currently `1`. |
+| `docs` | list | Yes | List of doc mapping entries. |
+
+### Doc entry
+
+| Field | Type | Required | Description |
+|---------------|--------|----------|--------------------------------------------|
+| `doc` | string | Yes | Path to the documentation file (from repo root). |
+| `description` | string | No | Human-readable summary of what the doc covers. Used in reports. |
+| `sources` | list | Yes | Source files/directories this doc should cover. |
+
+### Source entry
+
+| Field | Type | Required | Description |
+|-----------|--------|----------|-------------------------------------------------|
+| `pattern` | string | Yes | Glob pattern matching source files. Relative to repo root. Supports `*` and `**`. |
+| `covers` | string | Yes | What aspects of this source the doc should cover. This is the key field — it tells the drift checker *what to look for* in the doc. Be specific. |
+| `scope` | string | No | If the source file is large or multi-purpose, which section/aspect is relevant to this doc. Helps avoid false positives when a file serves multiple docs. |
+
+______________________________________________________________________
+
+## Design principles
+
+### `covers` is the contract
+
+The `covers` field is what makes the mapping useful. Without it, all you know
+is "this doc should mention this file somehow." With it, you know *what* the
+doc should say about the file. When the drift checker reads the doc and the
+source, it compares the doc's content against the `covers` description to
+determine whether the doc adequately covers the expected topics.
+
+Good `covers` values are specific and verifiable:
+
+- "Entrypoint modes, env var dispatch, MODE values" — checker can verify the
+  doc lists all modes the entrypoint implements.
+- "Upload commands, flags, dry-run behavior" — checker can verify the doc
+  shows the flags the code actually uses.
+
+Bad `covers` values are vague:
+
+- "General usage" — checker can't verify anything specific.
+- "Everything" — not actionable.
+
+### `scope` prevents false positives
+
+Large files like `Makefile` or `docker_entrypoint.sh` serve multiple docs.
+Without `scope`, a change to the Makefile's `lint` target would trigger a
+drift check against docker.md — a false positive. With `scope: "docker"`,
+the checker only reviews Makefile changes related to Docker build targets.
+
+`scope` is a hint, not a filter. The checker uses it to focus attention but
+can still flag issues outside the scope if they're clearly relevant.
+
+### Glob patterns
+
+Patterns follow standard glob syntax:
+
+| Pattern | Matches |
+|----------------------------|------------------------------------------------|
+| `scripts/docker_entrypoint.sh` | Exactly that file |
+| `docker/**` | All files under docker/, recursively |
+| `configs/image/*.yaml` | YAML files directly in configs/image/ |
+| `src/data/*.py` | Python files directly in src/data/ |
+| `src/training/**` | All files under src/training/, recursively |
+
+______________________________________________________________________
+
+## Bootstrapping
+
+When generating a doc-map.yaml for the first time, the skill scans each doc
+for source file references, then groups them into mapping entries. The
+auto-generated `covers` field is derived from the context around each reference
+in the doc (the section heading, surrounding sentences).
+
+The user should then:
+
+1. Review and correct the auto-generated `covers` values.
+1. Add source files that *should* be covered but aren't yet referenced in
+   the doc. **This is the most important step** — it's where you encode
+   knowledge that the grep can't discover.
+1. Add `scope` fields where a source file serves multiple docs.
+1. Remove any entries that are false positives (doc mentions a file in
+   passing but isn't responsible for documenting it).
+
+______________________________________________________________________
+
+## Self-maintenance
+
+The doc-map.yaml is itself subject to drift. The skill checks for:
+
+- **Dead patterns**: glob patterns that match zero files in the repo.
+  Suggests the source was renamed, moved, or deleted.
+- **Uncovered additions**: new files in directories covered by existing glob
+  patterns. These are automatically covered — no action needed unless the
+  `covers` field should be updated.
+- **Orphan docs**: doc files in `docs/` that have no mapping entry. May be
+  intentional (standalone docs like a changelog) or may indicate a missing
+  mapping.
+- **Orphan sources**: source files in frequently-mapped directories that
+  aren't covered by any mapping. Suggests a new file was added without
+  updating the mapping.

--- a/.claude/skills/doc-drift/github-action-integration.md
+++ b/.claude/skills/doc-drift/github-action-integration.md
@@ -1,0 +1,224 @@
+# GitHub Action Integration
+
+Wire doc-drift into a post-merge GitHub Action that automatically checks for
+documentation staleness and opens a PR with fixes.
+
+______________________________________________________________________
+
+## Workflow
+
+```yaml
+# .github/workflows/doc-drift.yml
+name: doc-drift-check
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'           # doc-only changes can't cause code drift
+      - 'doc-map.yaml'      # mapping changes don't need a drift check
+      - '.github/**'        # workflow changes
+
+jobs:
+  check-drift:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # parent commit for diff
+
+      - name: Get changed files
+        id: diff
+        run: |
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          git diff --name-only HEAD~1 HEAD >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          echo "status<<EOF" >> "$GITHUB_OUTPUT"
+          git diff --name-status HEAD~1 HEAD >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Find candidate docs (grep-based)
+        id: grep-candidates
+        run: |
+          candidates=""
+          while IFS= read -r file; do
+            [ -z "$file" ] && continue
+            base=$(basename "$file")
+            # Find docs referencing this file by basename or full path
+            hits=$(grep -rl "$base" docs/ --include="*.md" 2>/dev/null || true)
+            if [ -n "$file" ]; then
+              hits="$hits"$'\n'"$(grep -rl "$file" docs/ --include="*.md" 2>/dev/null || true)"
+            fi
+            candidates="$candidates"$'\n'"$hits"
+          done <<< "${{ steps.diff.outputs.files }}"
+
+          # Deduplicate
+          candidates=$(echo "$candidates" | sort -u | grep -v '^$')
+          echo "docs<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$candidates" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Find candidate docs (mapping-based)
+        id: map-candidates
+        run: |
+          if [ ! -f doc-map.yaml ]; then
+            echo "docs=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Parse doc-map.yaml for source patterns matching changed files
+          # This is a simplified matcher — production version should use
+          # a proper YAML parser (yq or a Python script)
+          python3 -c "
+          import yaml, fnmatch, sys
+
+          with open('doc-map.yaml') as f:
+              mapping = yaml.safe_load(f)
+
+          changed = '''${{ steps.diff.outputs.files }}'''.strip().split('\n')
+          candidates = set()
+
+          for entry in mapping.get('docs', []):
+              for source in entry.get('sources', []):
+                  pattern = source['pattern']
+                  for cf in changed:
+                      if fnmatch.fnmatch(cf, pattern):
+                          candidates.add(entry['doc'])
+                          break
+
+          print('\n'.join(sorted(candidates)))
+          " > /tmp/map-candidates.txt
+
+          echo "docs<<EOF" >> "$GITHUB_OUTPUT"
+          cat /tmp/map-candidates.txt >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Combine candidates and check drift
+        if: steps.grep-candidates.outputs.docs != '' || steps.map-candidates.outputs.docs != ''
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          # Combine and deduplicate candidate docs
+          all_docs=$(echo -e "${{ steps.grep-candidates.outputs.docs }}\n${{ steps.map-candidates.outputs.docs }}" | sort -u | grep -v '^$')
+
+          if [ -z "$all_docs" ]; then
+            echo "No candidate docs found. Skipping drift check."
+            exit 0
+          fi
+
+          echo "Candidate docs:"
+          echo "$all_docs"
+
+          # Build context payload: diff + candidate docs + mapping
+          python3 scripts/ci/doc_drift_check.py \
+            --diff <(git diff HEAD~1 HEAD) \
+            --changed-files <(echo "${{ steps.diff.outputs.files }}") \
+            --candidate-docs $all_docs \
+            --mapping doc-map.yaml \
+            --output /tmp/drift-report.md
+
+      - name: Create PR if drift found
+        if: steps.grep-candidates.outputs.docs != '' || steps.map-candidates.outputs.docs != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const reportPath = '/tmp/drift-report.md';
+
+            if (!fs.existsSync(reportPath)) {
+              console.log('No drift report generated. Skipping.');
+              return;
+            }
+
+            const report = fs.readFileSync(reportPath, 'utf8');
+            if (report.includes('No drift detected')) {
+              console.log('No drift detected.');
+              return;
+            }
+
+            // Check for existing doc-drift PR
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              head: `${context.repo.owner}:doc-drift/auto`,
+            });
+
+            if (prs.length > 0) {
+              // Update existing PR body with new report
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prs[0].number,
+                body: report,
+              });
+              console.log(`Updated existing PR #${prs[0].number}`);
+            } else {
+              // Open new PR
+              // (assumes the drift check step already committed fixes
+              //  to a doc-drift/auto branch)
+              await github.rest.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: 'docs: fix documentation drift',
+                body: report,
+                head: 'doc-drift/auto',
+                base: 'main',
+              });
+            }
+```
+
+______________________________________________________________________
+
+## Design notes
+
+### Batching
+
+The workflow checks for an existing open `doc-drift/auto` PR before creating
+a new one. If multiple merges happen in sequence, the later runs update the
+existing PR rather than creating duplicates. This prevents PR spam during
+active development periods.
+
+### paths-ignore
+
+Changes to docs/ alone can't cause doc-vs-code drift (they might fix it).
+Filtering them out avoids unnecessary runs. If someone edits a doc *and* code
+in the same commit, the code paths still trigger the workflow.
+
+### The check script
+
+`scripts/ci/doc_drift_check.py` is a thin wrapper that:
+
+1. Reads the diff, changed files, candidate docs, and mapping.
+1. Builds a prompt with all context.
+1. Calls the Anthropic API (Claude) to analyze drift.
+1. Parses the response into a structured report.
+1. If drift is found, applies fixes to doc files and writes the report.
+
+The prompt should instruct Claude to:
+
+- Focus on factual inconsistencies, not style.
+- Report confidence levels.
+- Produce exact replacement text, not vague suggestions.
+- Check cross-doc consistency when multiple docs are candidates.
+
+### Cost control
+
+Each workflow run makes one API call with the diff + candidate docs as context.
+For a typical merge touching 5-10 files with 2-3 candidate docs, this is ~10K
+tokens input, ~2K tokens output — roughly $0.03-0.05 per run with Sonnet.
+
+For large diffs (50+ files), the check script should truncate to high-confidence
+candidates only and note in the report that a full audit may be needed.
+
+### False positive management
+
+The workflow should not auto-merge its own PRs. A human reviews the drift
+report and proposed fixes. Over time, if the false positive rate is low,
+you can add auto-merge for high-confidence fixes.
+
+If the same drift is flagged repeatedly across runs (doc hasn't been fixed
+yet), the PR update mechanism handles this — it updates the existing PR body
+rather than creating noise.

--- a/.claude/skills/doc-drift/starter-doc-map.yaml
+++ b/.claude/skills/doc-drift/starter-doc-map.yaml
@@ -1,0 +1,76 @@
+# doc-map.yaml — Structural mapping for doc-drift detection
+#
+# This file encodes which source files SHOULD be documented where.
+# Grep-based detection catches drift when docs reference changed files.
+# This mapping catches drift by OMISSION — when code adds something
+# new and no doc mentions it.
+#
+# Review after each major refactor. The doc-drift skill checks this
+# file for staleness (dead patterns, orphan sources) automatically.
+
+version: 1
+
+docs:
+  # ── Docker reference ────────────────────────────────────────────
+  - doc: docs/reference/docker.md
+    description: Docker build, run, debug reference
+    sources:
+      - pattern: "docker/**"
+        covers: "Dockerfile stages, base images, layer structure, BuildKit secret mounts"
+      - pattern: "scripts/docker_entrypoint.sh"
+        covers: "All MODE values (idle, passthrough, train, …), env var dispatch, error messages"
+      - pattern: "scripts/image_config.py"
+        covers: "Pydantic model fields, validation behavior, strict/forbid semantics"
+      - pattern: "configs/image/**"
+        covers: "YAML field names and values, build parameters, defaults"
+      - pattern: "Makefile"
+        covers: "docker-build-* targets, DOCKER_SECRETS, DOCKER_BUILD_FLAGS"
+        scope: "docker"
+      - pattern: "scripts/run-linux-vst-headless.sh"
+        covers: "Headless X11 bootstrap, Xvfb setup, LIBGL_ALWAYS_SOFTWARE"
+      - pattern: ".github/workflows/docker-build-validation.yml"
+        covers: "CI steps, required secrets, tag scheme, smoke test flow"
+
+  # ── rclone reference ────────────────────────────────────────────
+  - doc: docs/reference/rclone.md
+    description: rclone R2 operations reference
+    sources:
+      - pattern: "src/data/uploader.py"
+        covers: "rclone copy flags, --dry-run control, upload entry point"
+      - pattern: "scripts/finalize_shards.py"
+        covers: "Download command, resharding to train/val/test, re-upload"
+      - pattern: "scripts/docker_entrypoint.sh"
+        covers: "MODE=train download/upload, --stats-one-line, SKIP_UPLOAD"
+        scope: "rclone"
+      - pattern: "scripts/r2_shard_report.py"
+        covers: "rclone ls command, --size-threshold-gib, CLI usage"
+      - pattern: "scripts/generate_shards.py"
+        covers: "Post-shard-validation upload trigger"
+      - pattern: "tests/scripts/test_r2_shard_report.py"
+        covers: "rclone lsd reachability check, rcat fixture upload, purge cleanup"
+      - pattern: "scripts/setup-rclone.sh"
+        covers: "Local rclone config creation, env var validation"
+      - pattern: "docs/design/storage-provenance-spec.md"
+        covers: "R2 bucket layout, path conventions, --checksum rule"
+        scope: "rclone-rules"
+
+  # ── W&B integration (placeholder — expand when doc exists) ──────
+  # - doc: docs/reference/wandb-integration.md
+  #   description: W&B logging and auth reference
+  #   sources:
+  #     - pattern: "src/training/**"
+  #       covers: "W&B logging calls, metric names, run config, artifact logging"
+  #     - pattern: "scripts/docker_entrypoint.sh"
+  #       covers: "W&B netrc setup, WANDB_API_KEY injection"
+  #       scope: "wandb"
+
+  # ── Docker spec (the contract doc) ──────────────────────────────
+  - doc: docs/reference/docker-spec.md
+    description: Image target contract, entrypoint modes, env var spec
+    sources:
+      - pattern: "scripts/docker_entrypoint.sh"
+        covers: "All MODE values, env var contract, exit codes, error handling"
+      - pattern: "docker/**"
+        covers: "Target names, stage dependencies, what each target produces"
+      - pattern: "scripts/image_config.py"
+        covers: "ImageConfig fields that define the target contract"


### PR DESCRIPTION
## Summary
- Add doc-drift skill for detecting when documentation has drifted out of sync with the codebase
- Includes SKILL.md (main workflow), doc-map schema spec, starter doc-map.yaml template, and GitHub Actions integration guide

Closes #328