### PR TITLE
ci(gpu): move GPU tests to twice-weekly schedule

### DIFF
--- a/.github/workflows/test-expensive.yml
+++ b/.github/workflows/test-expensive.yml
@@ -1,14 +1,11 @@
 name: GPU Tests
 
 # Runs only @pytest.mark.gpu tests on a GPU runner.
-# Manual dispatch and post-merge to main.
+# Twice-weekly schedule (Mon + Thu) and manual dispatch.
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
+  schedule:
+    - cron: "0 6 * * 1,4" # Mon + Thu 06:00 UTC
 
 jobs:
   run_tests:


### PR DESCRIPTION
## Summary
- Replace `push` trigger on `test-expensive.yml` with `schedule: cron "0 6 * * 1,4"` (Mon + Thu 06:00 UTC)
- Keep `workflow_dispatch` for manual runs
- Reduces GPU runner cost (~$39/755min accumulated from per-push runs)

Refs #334

## Verification
- [ ] `make format` clean
- [ ] Cron syntax valid: `0 6 * * 1,4` = minute 0, hour 6, any day-of-month, any month, Monday + Thursday