### PR TITLE
docs(pipeline): align design docs and CLAUDE.md with PR #305

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,9 +59,13 @@ Conventional commits, enforced by gitlint (`.gitlint` config). Prefix matters fo
 ### Architecture
 
 - `src/` — ML code (models, data modules, training, evaluation)
-- `scripts/` — pipeline orchestration (generate, finalize, RunPod launch)
-- `configs/` — Hydra YAML configs (pipeline, data, trainer)
-- `tests/` — mirrors `src/` and `scripts/` structure
+- `pipeline/` — distributed data pipeline (`python -m pipeline`)
+  - `schemas/` — Pydantic models (config, spec, report, card, sample)
+  - `stages/` — generate and finalize stage logic
+  - `backends/` — compute providers (local, RunPod)
+- `scripts/` — standalone scripts
+- `configs/` — Hydra YAML configs (`data/`, `trainer/`) and pipeline configs (`dataset/`)
+- `tests/` — mirrors `src/` and `pipeline/` structure
 - `docs/design/` — design documents
 
 ### Git Workflow

--- a/docs/design/data-pipeline-implementation-plan.md
+++ b/docs/design/data-pipeline-implementation-plan.md
@@ -235,14 +235,14 @@ Sub-issues: [#18](https://github.com/tinaudio/synth-setter/issues/18) (config-dr
 **Files to create:**
 
 - `pipeline/__init__.py`
-- `pipeline/schemas.py` — `RunConfig`, `PipelineSpec`, `ShardSpec`, `WorkerReport`, `ShardResult`, `DatasetCard`, `ValidationSummary`, `Sample`
+- `pipeline/schemas/` — Pydantic models split across submodules: `config.py` (`DatasetConfig`, `SplitsConfig`, load/ID helpers), `spec.py` (`PipelineSpec`, `ShardSpec`, `materialize_spec`), `report.py` (`WorkerReport`, `ShardResult`), `card.py` (`DatasetCard`, `ValidationSummary`), `sample.py` (`Sample` dataclass)
 - `configs/dataset/surge-simple-480k-10k.yaml` — sample config (filename = `dataset_config_id`)
 - `tests/pipeline/__init__.py`
-- `tests/pipeline/test_schemas.py`
+- `tests/pipeline/test_schemas/`
 
 **Key behaviors:**
 
-- `RunConfig` (Pydantic strict): validates raw YAML input. Fields match config schema (§4).
+- `DatasetConfig` (Pydantic strict): validates raw YAML input. Fields match config schema (§4).
   `output_format` defaults to `"hdf5"` if missing from config.
 - `PipelineSpec` (frozen, strict): `dataset_config_id`, `dataset_wandb_run_id` (maps to
   `run_id` in code), `created_at`, `code_version`, `is_repo_dirty`,
@@ -269,7 +269,7 @@ Sub-issues: [#18](https://github.com/tinaudio/synth-setter/issues/18) (config-dr
   (per-shard `{shard_id, filename, content_hash}`), `input_spec_sha256`, `input_spec_path`.
 - Run ID format: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}` (see [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids)).
   `dataset_config_id` is the config filename stem, which encodes runtime params for readability.
-- `materialize_spec(config: RunConfig, timestamp=None, renderer_version=None) -> PipelineSpec`.
+- `materialize_spec(config: DatasetConfig, timestamp=None, renderer_version=None) -> PipelineSpec`.
   Optional `renderer_version` override for testing; test fixtures pass `"test-1.0"` explicitly.
 
 **Design doc schema gaps to fix alongside this task:**
@@ -301,7 +301,7 @@ def test_spec_materialization_end_to_end(tmp_path):
         "min_loudness": -55.0, "sample_batch_size": 32,
     }
     fixed_ts = datetime(2026, 3, 15, 12, 0, 0, tzinfo=timezone.utc)
-    spec = materialize_spec(RunConfig(**config), timestamp=fixed_ts)
+    spec = materialize_spec(DatasetConfig(**config), timestamp=fixed_ts)
     spec2 = PipelineSpec.model_validate_json(spec.model_dump_json())
 
     assert len(spec2.shards) == 10
@@ -311,7 +311,7 @@ def test_spec_materialization_end_to_end(tmp_path):
     assert spec2.shards[5].seed == 47
     assert spec2.output_format == "hdf5"
     assert sum(s.row_count for s in spec2.shards) == 10_000
-    assert materialize_spec(RunConfig(**config), timestamp=fixed_ts).model_dump() == spec2.model_dump()
+    assert materialize_spec(DatasetConfig(**config), timestamp=fixed_ts).model_dump() == spec2.model_dump()
 ```
 
 ______________________________________________________________________

--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -1186,6 +1186,14 @@ This section covers how the design is realized — specific libraries, configura
 Schema for the frozen input specification described in [§7.1](#71-storage-as-the-source-of-truth) and [§6 artifact taxonomy](#artifact-taxonomy).
 
 ```python
+class SplitsConfig(BaseModel):
+    """Train/val/test shard counts."""
+    model_config = ConfigDict(strict=True, extra="forbid")
+
+    train: int
+    val: int
+    test: int
+
 class ShardSpec(BaseModel):
     model_config = ConfigDict(strict=True)
 
@@ -1212,7 +1220,7 @@ class PipelineSpec(BaseModel):
     sample_rate: int
     shard_size: int
     num_shards: int
-    splits: dict[str, int]  # {"train": 44, "val": 2, "test": 2} (shard counts, not sample counts)
+    splits: SplitsConfig  # shard counts per split
     shards: list[ShardSpec]
 ```
 
@@ -1242,7 +1250,7 @@ class DatasetCard(BaseModel):
 
     # Structure
     total_samples: int
-    splits: dict[str, int]  # {"train": 440000, "val": 20000, "test": 20000}
+    splits: SplitsConfig  # sample counts per split
     stats: dict[str, float]
 
     # Integrity
@@ -1332,7 +1340,7 @@ splits:
 
 On first `generate`:
 
-1. Load YAML, validate against Pydantic `RunConfig` (strict mode)
+1. Load YAML, validate against Pydantic `DatasetConfig` (strict mode)
 2. Extract `renderer_version` from the plugin bundle (`CFBundleShortVersionString` from `Info.plist` on macOS, `Version` from `moduleinfo.json` on Linux)
 3. Derive `dataset_wandb_run_id`: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}`
 4. Materialize `PipelineSpec` — expand config into shard-level spec (seeds, shapes, row ranges)
@@ -1372,7 +1380,13 @@ pipeline/
 
   storage.py            # R2 operations (list, upload, download, quarantine)
   reconcile.py          # Read spec, validate shards, compute missing set
-  schemas.py            # Pydantic models (PipelineSpec, WorkerReport, DatasetCard)
+  schemas/              # Pydantic models
+    __init__.py
+    config.py           # DatasetConfig, SplitsConfig, load/ID helpers
+    spec.py             # PipelineSpec, ShardSpec, materialize_spec
+    report.py           # WorkerReport, ShardResult
+    card.py             # DatasetCard, ValidationSummary
+    sample.py           # Sample dataclass (HDF5→WDS transcoding)
   validation.py         # Shard validation (structural, shape, value, row count)
   retry.py              # Centralized tenacity retry policy
   logging_config.py     # structlog configuration


### PR DESCRIPTION
## Summary

- Rename `RunConfig` → `DatasetConfig` across design docs (more descriptive, matches PR #305 implementation)
- Replace `splits: dict[str, int]` with `SplitsConfig` Pydantic model (stricter, catches typos at parse time)
- Replace flat `pipeline/schemas.py` with `pipeline/schemas/` package directory
- Update CLAUDE.md architecture section to include `pipeline/` package with subdirectories

Refs #337, Refs #341

## Verification

- [x] `grep -r "RunConfig" docs/design/` — zero matches
- [x] `grep "dict\[str, int\].*split" docs/design/data-pipeline.md` — zero matches
- [x] `make format` — all hooks pass (pre-existing codespell issues in CHANGELOG.md are unrelated)