### PR TITLE
build(pre-commit): exclude CHANGELOG.md from mdformat and codespell

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -219,6 +219,7 @@ repos:
         args: ["--number"]
         exclude: >-
           (?x)^(
+            CHANGELOG\.md|
             README\.md|
             \.claude/.*
           )$
@@ -233,6 +234,7 @@ repos:
       - id: codespell
         exclude: >-
           (?x)^(
+            CHANGELOG\.md|
             src/models/ksin_flow_matching_module\.py|
             \.claude/.*
           )$


### PR DESCRIPTION
## Summary
- Exclude `CHANGELOG.md` from **mdformat** and **codespell** pre-commit hooks
- Machine-generated changelog trips both: mdformat reformats it (mixed bullet markers, line wrapping, thematic breaks); codespell flags typos from commit messages

Fixes #339

## Verification

- [x] `pre-commit run mdformat --all-files`
```
mdformat.................................................................Passed
```

- [x] `pre-commit run codespell --all-files`
```
codespell................................................................Passed
```

- [x] `git diff --name-only` after hook run
```
Modified: .pre-commit-config.yaml
```