### PR TITLE
ci(docker): switch to registry cache and load image locally for smoke tests

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -123,7 +123,7 @@ jobs:
             r2_secret_access_key=${{ secrets.R2_SECRET_ACCESS_KEY }}
             wandb_api_key=${{ secrets.WANDB_API_KEY }}
           cache-from: type=registry,ref=tinaudio/perm:buildcache
-          cache-to: type=registry,ref=tinaudio/perm:buildcache,mode=max
+          cache-to: ${{ github.event_name != 'pull_request' && 'type=registry,ref=tinaudio/perm:buildcache,mode=max' || '' }}
 
       - name: Smoke test — container starts and Python imports work
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -107,6 +107,7 @@ jobs:
           target: dev-snapshot
           platforms: ${{ steps.config.outputs.target_platform }}
           push: ${{ github.event_name != 'pull_request' }}
+          load: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -121,15 +122,14 @@ jobs:
             r2_access_key_id=${{ secrets.R2_ACCESS_KEY_ID }}
             r2_secret_access_key=${{ secrets.R2_SECRET_ACCESS_KEY }}
             wandb_api_key=${{ secrets.WANDB_API_KEY }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=tinaudio/perm:buildcache
+          cache-to: type=registry,ref=tinaudio/perm:buildcache,mode=max
 
       - name: Smoke test — container starts and Python imports work
         if: github.event_name != 'pull_request'
         env:
           SMOKE_IMAGE: ${{ steps.config.outputs.image }}:dev-snapshot-${{ steps.source.outputs.sha }}
         run: |
-          docker pull "$SMOKE_IMAGE"
           docker run --rm --entrypoint bash "$SMOKE_IMAGE" \
             -c "pytest tests/docker/test_smoke.py::test_pedalboard_importable -v"
 

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -294,7 +294,8 @@ Headless X11 issues — check in order:
 
 ### BuildKit cache
 
-The GHA workflow uses GitHub Actions cache (`type=gha`). To clear locally:
+The GHA workflow uses Docker Hub registry cache (`type=registry`). Cache layers
+are stored as `tinaudio/perm:buildcache`. To clear locally:
 
 ```bash
 docker buildx prune

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -295,11 +295,16 @@ Headless X11 issues — check in order:
 ### BuildKit cache
 
 The GHA workflow uses Docker Hub registry cache (`type=registry`). Cache layers
-are stored as `tinaudio/perm:buildcache`. To clear locally:
+are stored as `tinaudio/perm:buildcache`.
+
+To clear local builder cache:
 
 ```bash
 docker buildx prune
 ```
+
+To clear the remote registry cache, delete the `buildcache` tag from Docker Hub
+(Settings → Tags → `buildcache` → Delete).
 
 ### Entrypoint errors
 


### PR DESCRIPTION
## Summary
- Switch Docker build cache from `type=gha` (10GB limit, ~12 min upload) to `type=registry` (stored in Docker Hub, no separate upload phase)
- Add `load: true` for non-PR builds so the image is available locally after build
- Remove `docker pull` from smoke tests since the image is already loaded locally
- Update docs to reflect registry cache

Refs #345

## Test plan
- [ ] PR build validates YAML syntax
- [ ] After merge, manual dispatch confirms: no GHA cache write phase, smoke tests pass without `docker pull`
- [ ] Second run confirms warm cache behavior