### PR TITLE
docs: add project-specific doc-map.yaml

### DIFF
--- a/.github/workflows/pr-metadata-gate.yaml
+++ b/.github/workflows/pr-metadata-gate.yaml
@@ -99,7 +99,7 @@ jobs:
 
           # Keep in sync with docs/design/github-taxonomy.md §2 and §6
           VALID_TYPES=("Epic" "Phase" "Task" "Bug" "Feature")
-          DOMAIN_LABELS=("data-pipeline" "ci-automation" "code-health" "evaluation" "storage" "testing" "training")
+          DOMAIN_LABELS=("data-pipeline" "ci-automation" "code-health" "documentation" "evaluation" "storage" "testing" "training")
           FAILURES=""
 
           for ISSUE_NUM in "${ISSUE_NUMBERS[@]}"; do

--- a/docs/design/github-taxonomy.md
+++ b/docs/design/github-taxonomy.md
@@ -78,12 +78,13 @@ All PRs merge to `main`. Phase ordering defines the dependency chain, but PRs wi
 
 ### Current epics
 
-| Epic | Title                                                      | Domain Label    | Design Doc                           |
-| ---- | ---------------------------------------------------------- | --------------- | ------------------------------------ |
-| #74  | feat(pipeline): distributed data pipeline                  | `data-pipeline` | `data-pipeline.md`                   |
-| #98  | feat(eval): evaluation pipeline — predict, render, metrics | `evaluation`    | `eval-pipeline.md` (PR #101)         |
-| #99  | feat(storage): R2 integration for datasets and checkpoints | `evaluation`    | `eval-pipeline.md` §6                |
-| #107 | feat(training): training pipeline & ops                    | `training`      | `training-ops-braindump.md` (PR #84) |
+| Epic | Title                                                          | Domain Label    | Design Doc                           |
+| ---- | -------------------------------------------------------------- | --------------- | ------------------------------------ |
+| #74  | feat(pipeline): distributed data pipeline                      | `data-pipeline` | `data-pipeline.md`                   |
+| #98  | feat(eval): evaluation pipeline — predict, render, metrics     | `evaluation`    | `eval-pipeline.md` (PR #101)         |
+| #99  | feat(storage): R2 integration for datasets and checkpoints     | `evaluation`    | `eval-pipeline.md` §6                |
+| #107 | feat(training): training pipeline & ops                        | `training`      | `training-ops-braindump.md` (PR #84) |
+| #351 | feat(documentation): documentation quality and drift detection | `documentation` | —                                    |
 
 ## 4. Blocking & Dependencies
 
@@ -118,15 +119,16 @@ Priority is tracked via a **Priority** single-select field on the project:
 
 Labels classify issues by **domain**. Type and blocking are handled by native features; priority is a project field.
 
-| Label           | Color   | Description                                   |
-| --------------- | ------- | --------------------------------------------- |
-| `data-pipeline` | #0e8a16 | Data pipeline work stream                     |
-| `ci-automation` | #1d76db | CI & automation work stream                   |
-| `code-health`   | #fbca04 | Code quality and tech debt                    |
-| `evaluation`    | #C5DEF5 | Evaluation pipeline, metrics, and inference   |
-| `storage`       | #D4C5F9 | Storage infrastructure (R2, rclone)           |
-| `testing`       | #0E8A16 | Test infrastructure, fixtures, CI test config |
-| `training`      | #8B5CF6 | Training pipeline, ops, and infrastructure    |
+| Label           | Color   | Description                                                     |
+| --------------- | ------- | --------------------------------------------------------------- |
+| `data-pipeline` | #0e8a16 | Data pipeline work stream                                       |
+| `ci-automation` | #1d76db | CI & automation work stream                                     |
+| `code-health`   | #fbca04 | Code quality and tech debt                                      |
+| `documentation` | #0075ca | Documentation quality, drift detection, and doc-map maintenance |
+| `evaluation`    | #C5DEF5 | Evaluation pipeline, metrics, and inference                     |
+| `storage`       | #D4C5F9 | Storage infrastructure (R2, rclone)                             |
+| `testing`       | #0E8A16 | Test infrastructure, fixtures, CI test config                   |
+| `training`      | #8B5CF6 | Training pipeline, ops, and infrastructure                      |
 
 **Multi-label policy:** Most issues carry a single domain label. Cross-cutting infrastructure (e.g., R2/rclone work that serves both data pipeline and eval pipeline) may carry multiple domain labels to appear in all relevant filtered views. Use multiple labels only when the work genuinely spans work streams — not as a default.
 
@@ -141,6 +143,7 @@ Workflow labels (`duplicate`, `invalid`, `wontfix`, `good first issue`, `help wa
 | training v1.0.0      | Training        |
 | ci-automation v1.0.0 | CI & Automation |
 | code-health v1.0.0   | Code Health     |
+| documentation v1.0.0 | Documentation   |
 | storage v1.0.0       | Storage         |
 
 Every work stream has a milestone. Set the milestone on each issue individually — GitHub does not auto-inherit milestones from parent issues.
@@ -175,6 +178,7 @@ Use saved views with domain label filters to switch between work streams:
 | Storage         | Hierarchy | `label:storage`       |
 | CI & Automation | Board     | `label:ci-automation` |
 | Code Health     | Table     | `label:code-health`   |
+| Documentation   | Table     | `label:documentation` |
 | Training        | Hierarchy | `label:training`      |
 | Roadmap         | Roadmap   | (none)                |
 | Blocked         | Table     | is:blocked            |

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -18,7 +18,7 @@ docs:
       - pattern: "docker/**"
         covers: "Dockerfile stages, base images, layer structure, BuildKit secret mounts"
       - pattern: "scripts/docker_entrypoint.sh"
-        covers: "All MODE values (idle, passthrough, generate_shards), env var dispatch, error messages"
+        covers: "Supported MODE values (idle, passthrough), env var dispatch, error messages"
       - pattern: "pipeline/schemas/image_config.py"
         covers: "Pydantic model fields, validation behavior, strict/forbid semantics"
       - pattern: "configs/image/**"

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -1,0 +1,108 @@
+# doc-map.yaml — Structural mapping for doc-drift detection
+#
+# This file encodes which source files SHOULD be documented where.
+# Grep-based detection catches drift when docs reference changed files.
+# This mapping catches drift by OMISSION — when code adds something
+# new and no doc mentions it.
+#
+# Review after each major refactor. The doc-drift skill checks this
+# file for staleness (dead patterns, orphan sources) automatically.
+
+version: 1
+
+docs:
+  # ── Docker reference ────────────────────────────────────────────
+  - doc: docs/reference/docker.md
+    description: Docker build, run, debug reference
+    sources:
+      - pattern: "docker/**"
+        covers: "Dockerfile stages, base images, layer structure, BuildKit secret mounts"
+      - pattern: "scripts/docker_entrypoint.sh"
+        covers: "All MODE values (idle, passthrough, generate_dataset), env var dispatch, error messages"
+      - pattern: "pipeline/schemas/image_config.py"
+        covers: "Pydantic model fields, validation behavior, strict/forbid semantics"
+      - pattern: "configs/image/**"
+        covers: "YAML field names and values, build parameters, defaults"
+      - pattern: "Makefile"
+        covers: "docker-build-* targets, DOCKER_SECRETS, DOCKER_BUILD_FLAGS"
+        scope: "docker"
+      - pattern: "scripts/run-linux-vst-headless.sh"
+        covers: "Headless X11 bootstrap, Xvfb setup, LIBGL_ALWAYS_SOFTWARE"
+      - pattern: ".github/workflows/docker-build-validation.yml"
+        covers: "CI steps, required secrets, tag scheme, smoke test flow"
+
+  # ── Docker spec (the contract doc) ──────────────────────────────
+  - doc: docs/reference/docker-spec.md
+    description: Image target contract, entrypoint modes, env var spec
+    sources:
+      - pattern: "scripts/docker_entrypoint.sh"
+        covers: "All MODE values, env var contract, exit codes, error handling"
+      - pattern: "docker/**"
+        covers: "Target names, stage dependencies, what each target produces"
+      - pattern: "pipeline/schemas/image_config.py"
+        covers: "ImageConfig fields that define the target contract"
+
+  # ── W&B integration reference ───────────────────────────────────
+  - doc: docs/reference/wandb-integration.md
+    description: W&B logging, auth, metrics, and artifact reference
+    sources:
+      - pattern: "configs/logger/wandb.yaml"
+        covers: "Entity, project, log_model setting, offline mode"
+      - pattern: "src/train.py"
+        covers: "WandbLogger instantiation, trainer integration, run lifecycle"
+      - pattern: "src/eval.py"
+        covers: "Checkpoint resolution from W&B, evaluation logging"
+      - pattern: "src/utils/logging_utils.py"
+        covers: "Metric logging helpers, hyperparameter logging, log_hyperparameters"
+      - pattern: "src/utils/callbacks.py"
+        covers: "W&B callback integrations, visualization uploads"
+      - pattern: "scripts/get-ckpt-from-wandb.sh"
+        covers: "CLI checkpoint download from W&B, artifact resolution"
+
+  # ── Data pipeline design doc ────────────────────────────────────
+  - doc: docs/design/data-pipeline.md
+    description: Distributed data pipeline design (RunPod + R2)
+    sources:
+      - pattern: "pipeline/schemas/config.py"
+        covers: "Pipeline config schema, dataset config fields, validation rules"
+      - pattern: "pipeline/schemas/prefix.py"
+        covers: "Run ID prefix generation, shard ID scheme, deterministic naming"
+      - pattern: "scripts/entrypoint_generate_dataset.py"
+        covers: "Dataset generation entrypoint, single-shard MVP, CLI interface"
+      - pattern: "scripts/ci/load_dataset_config.py"
+        covers: "Dataset config loading from YAML, CI integration"
+      - pattern: "scripts/ci/resolve_dataset_run_params.py"
+        covers: "Run parameter resolution, shard count, worker allocation"
+      - pattern: "configs/dataset/**"
+        covers: "Dataset generation configs, shard counts, sample counts, synth params"
+      - pattern: ".github/workflows/dataset-generation.yml"
+        covers: "CI workflow steps, trigger conditions, artifact handling"
+
+  # ── Storage provenance spec ─────────────────────────────────────
+  - doc: docs/design/storage-provenance-spec.md
+    description: R2 bucket layout, path conventions, ID schemes
+    sources:
+      - pattern: "pipeline/schemas/prefix.py"
+        covers: "Run ID format, shard ID format, prefix construction rules"
+      - pattern: "scripts/r2_shard_report.py"
+        covers: "R2 listing commands, shard status reporting, path parsing"
+      - pattern: "configs/image/dev-snapshot.yaml"
+        covers: "r2_endpoint, r2_bucket values, storage configuration"
+      - pattern: "scripts/docker_entrypoint.sh"
+        covers: "rclone download/upload paths, R2 credentials, --checksum usage"
+        scope: "rclone"
+
+  # ── rclone reference (placeholder — doc does not exist yet) ─────
+  # - doc: docs/reference/rclone.md
+  #   description: rclone R2 operations reference
+  #   sources:
+  #     - pattern: "scripts/docker_entrypoint.sh"
+  #       covers: "rclone download/upload commands, --stats-one-line, SKIP_UPLOAD"
+  #       scope: "rclone"
+  #     - pattern: "scripts/r2_shard_report.py"
+  #       covers: "rclone ls command, --size-threshold-gib, CLI usage"
+  #     - pattern: "scripts/entrypoint_generate_dataset.py"
+  #       covers: "Post-shard-validation upload trigger"
+  #     - pattern: "docs/design/storage-provenance-spec.md"
+  #       covers: "R2 bucket layout, path conventions, --checksum rule"
+  #       scope: "rclone-rules"

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -18,7 +18,7 @@ docs:
       - pattern: "docker/**"
         covers: "Dockerfile stages, base images, layer structure, BuildKit secret mounts"
       - pattern: "scripts/docker_entrypoint.sh"
-        covers: "All MODE values (idle, passthrough, generate_dataset), env var dispatch, error messages"
+        covers: "All MODE values (idle, passthrough, generate_shards), env var dispatch, error messages"
       - pattern: "pipeline/schemas/image_config.py"
         covers: "Pydantic model fields, validation behavior, strict/forbid semantics"
       - pattern: "configs/image/**"
@@ -67,16 +67,17 @@ docs:
         covers: "Pipeline config schema, dataset config fields, validation rules"
       - pattern: "pipeline/schemas/prefix.py"
         covers: "Run ID prefix generation, shard ID scheme, deterministic naming"
-      - pattern: "scripts/entrypoint_generate_dataset.py"
-        covers: "Dataset generation entrypoint, single-shard MVP, CLI interface"
-      - pattern: "scripts/ci/load_dataset_config.py"
-        covers: "Dataset config loading from YAML, CI integration"
-      - pattern: "scripts/ci/resolve_dataset_run_params.py"
-        covers: "Run parameter resolution, shard count, worker allocation"
       - pattern: "configs/dataset/**"
         covers: "Dataset generation configs, shard counts, sample counts, synth params"
-      - pattern: ".github/workflows/dataset-generation.yml"
-        covers: "CI workflow steps, trigger conditions, artifact handling"
+      # Sources below will be activated when the pipeline work lands:
+      # - pattern: "scripts/entrypoint_generate_shards.py"
+      #   covers: "Shard generation entrypoint, worker orchestration, CLI interface"
+      # - pattern: "scripts/ci/load_dataset_config.py"
+      #   covers: "Dataset config loading from YAML, CI integration"
+      # - pattern: "scripts/ci/resolve_dataset_run_params.py"
+      #   covers: "Run parameter resolution, shard count, worker allocation"
+      # - pattern: ".github/workflows/dataset-generation.yml"
+      #   covers: "CI workflow steps, trigger conditions, artifact handling"
 
   # ── Storage provenance spec ─────────────────────────────────────
   - doc: docs/design/storage-provenance-spec.md
@@ -92,6 +93,72 @@ docs:
         covers: "rclone download/upload paths, R2 credentials, --checksum usage"
         scope: "rclone"
 
+  # ── Training pipeline design doc ────────────────────────────────
+  - doc: docs/design/training-pipeline.md
+    description: Training pipeline design — Hydra configs, Lightning training, RunPod portability
+    sources:
+      - pattern: "src/train.py"
+        covers: "Training entry point, Hydra config composition, rootutils setup"
+      - pattern: "src/models/**"
+        covers: "Lightning module definitions, forward pass, loss computation, optimizer config"
+      - pattern: "src/data/**"
+        covers: "Data modules, dataset classes, VST rendering, data loading"
+      - pattern: "configs/train.yaml"
+        covers: "Top-level training config, Hydra defaults list, config groups"
+      - pattern: "configs/trainer/**"
+        covers: "Trainer configs (CPU, GPU, MPS, DDP), accelerator settings"
+      - pattern: "configs/model/**"
+        covers: "Model architecture configs, encoder variants, flow/FFN/VAE configs"
+      - pattern: "configs/data/**"
+        covers: "Data module configs, dataset paths, batch sizes, preprocessing"
+      - pattern: "configs/callbacks/**"
+        covers: "Training callbacks, checkpoint saving, early stopping, visualization"
+      - pattern: "configs/experiment/**"
+        covers: "Experiment overrides, hyperparameter combinations, ablation configs"
+      - pattern: "configs/logger/wandb.yaml"
+        covers: "W&B entity, project, log_model for checkpoint durability"
+      - pattern: "docker/**"
+        covers: "Training Docker image, GPU support, environment portability"
+        scope: "training"
+
+  # ── Eval pipeline design doc ────────────────────────────────────
+  - doc: docs/design/eval-pipeline.md
+    description: Evaluation pipeline design — predict, render, metrics, R2 integration
+    sources:
+      - pattern: "src/eval.py"
+        covers: "Evaluation entry point, checkpoint loading, Hydra config composition"
+      - pattern: "scripts/predict_vst_audio.py"
+        covers: "Audio prediction script, VST rendering, parameter-to-audio pipeline"
+      - pattern: "scripts/compute_audio_metrics.py"
+        covers: "Audio metric computation, FAD/FD/KL scores, reference comparisons"
+      - pattern: "renderscript.sh"
+        covers: "Cross-platform rendering script, Xvfb auto-detection"
+      - pattern: "configs/eval.yaml"
+        covers: "Evaluation config entry point, Hydra defaults"
+      - pattern: "configs/callbacks/eval_surge.yaml"
+        covers: "Eval-specific callback config, prediction writer setup"
+      - pattern: "configs/callbacks/prediction_writer.yaml"
+        covers: "Prediction writer callback, output format, batch handling"
+      - pattern: "src/metrics.py"
+        covers: "Metric definitions, evaluation scoring functions"
+      - pattern: "src/data/vst/**"
+        covers: "VST plugin loading, parameter specs, audio generation for eval"
+      - pattern: "scripts/get-ckpt-from-wandb.sh"
+        covers: "Checkpoint download from W&B, artifact resolution for eval"
+      - pattern: "scripts/audio_dirs/*.txt"
+        covers: "Audio directory lists for metric computation reference sets"
+
+  # ── GitHub taxonomy ─────────────────────────────────────────────
+  - doc: docs/design/github-taxonomy.md
+    description: Issue types, labels, milestones, project board, CI metadata gate
+    sources:
+      - pattern: ".github/workflows/pr-metadata-gate.yaml"
+        covers: "Domain label list, issue type validation, milestone enforcement"
+      - pattern: ".github/ISSUE_TEMPLATE/**"
+        covers: "Issue templates, required fields, type-specific forms"
+      - pattern: ".github/PULL_REQUEST_TEMPLATE.md"
+        covers: "PR template structure, required sections"
+
   # ── rclone reference (placeholder — doc does not exist yet) ─────
   # - doc: docs/reference/rclone.md
   #   description: rclone R2 operations reference
@@ -101,8 +168,17 @@ docs:
   #       scope: "rclone"
   #     - pattern: "scripts/r2_shard_report.py"
   #       covers: "rclone ls command, --size-threshold-gib, CLI usage"
-  #     - pattern: "scripts/entrypoint_generate_dataset.py"
+  #     - pattern: "scripts/entrypoint_generate_shards.py"
   #       covers: "Post-shard-validation upload trigger"
   #     - pattern: "docs/design/storage-provenance-spec.md"
   #       covers: "R2 bucket layout, path conventions, --checksum rule"
   #       scope: "rclone-rules"
+
+  # ── Promotion pipeline reference (placeholder — doc is forward-looking) ──
+  # - doc: docs/reference/promotion-pipeline-reference.md
+  #   description: W&B run promotion to GitHub Release
+  #   sources:
+  #     - pattern: "scripts/promote.py"
+  #       covers: "Promotion script, W&B artifact download, GitHub Release creation"
+  #     - pattern: ".github/workflows/promote.yml"
+  #       covers: "Promotion workflow, manual trigger, dry-run mode"


### PR DESCRIPTION
## Summary
- Move project-specific doc-map.yaml from tinaudio/skills submodule to synth-setter repo at `docs/doc-map.yaml`
- Bump `.claude/skills` submodule to include starter-doc-map removal (tinaudio/skills#38)

Refs #328

## Verification
- [x] `ls .claude/skills/doc-drift/` — starter-doc-map.yaml is gone
  ```
  SKILL.md
  doc-map-schema.md
  github-action-integration.md
  ```
- [x] `ls docs/doc-map.yaml` — exists with synth-setter mappings
  ```
  docs/doc-map.yaml
  ```
- [x] `git submodule status` — points to ffdbb68
  ```
  ffdbb685c769e5c54053d799f2302d588387190b .claude/skills (heads/main)
  ```
- [x] `make test` — passes
  ```
  91 passed, 1 skipped, 1 warning in 11.78s
  ```
- [x] `make format` — passes
  ```
  All hooks passed
  ```