### PR TITLE
refactor(pipeline): freeze SplitsConfig for immutability

### DIFF
--- a/pipeline/schemas/config.py
+++ b/pipeline/schemas/config.py
@@ -12,7 +12,7 @@ from pipeline.schemas.prefix import DatasetConfigId
 class SplitsConfig(BaseModel):
     """Train/val/test shard counts."""
 
-    model_config = ConfigDict(strict=True, extra="forbid")
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
 
     train: int
     val: int


### PR DESCRIPTION
## Summary

- Add `frozen=True` to `SplitsConfig` model config, preventing field mutation after construction
- Prep for PipelineSpec deep immutability (#354)

## Test plan

- [ ] `make test` passes (proves no existing code mutates SplitsConfig after construction)
- [ ] `make format` passes

Refs #354