### PR TITLE
chore: add pre-commit branch-echo hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,7 +13,7 @@
       },
       {
         "matcher": "Bash",
-        "if": "Bash(git commit:*)",
+        "if": "Bash(git commit *)",
         "description": "Branch safety: echoes the current branch name before any git commit. Prints DETACHED HEAD when not on a branch. Goal: catch accidental commits to the wrong branch.",
         "hooks": [
           {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,16 @@
             "command": "file_path=$(echo \"$CLAUDE_TOOL_INPUT\" | grep -oE '\"file_path\"\\s*:\\s*\"[^\"]+\"' | head -1 | sed 's/.*\"\\([^\"]*\\)\"$/\\1/'); case \"$file_path\" in *.env|*.env.*|*.pem|*.key) echo 'BLOCKED: Cannot edit credential/secret files (.env, .pem, .key)' >&2; exit 1;; *) exit 0;; esac"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "if": "Bash(git commit:*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo \"Committing to branch: $(git branch --show-current)\" >&2"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,10 +14,11 @@
       {
         "matcher": "Bash",
         "if": "Bash(git commit:*)",
+        "description": "Branch safety: echoes the current branch name before any git commit. Prints DETACHED HEAD when not on a branch. Goal: catch accidental commits to the wrong branch.",
         "hooks": [
           {
             "type": "command",
-            "command": "echo \"Committing to branch: $(git branch --show-current)\" >&2"
+            "command": "branch=$(git branch --show-current 2>/dev/null || true); if [ -z \"$branch\" ]; then branch=\"DETACHED HEAD\"; fi; echo \"Committing to branch: $branch\" >&2"
           }
         ]
       }

--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ checkpoints/
 # VST3
 plugins/
 
-# Claude Code (keep skills only)
+# Claude Code (keep skills and settings)
 .claude/
 !.claude/skills/
+!.claude/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -164,7 +164,6 @@ checkpoints/
 # VST3
 plugins/
 
-# Claude Code (keep skills and settings)
+# Claude Code (keep skills only)
 .claude/
 !.claude/skills/
-!.claude/settings.json


### PR DESCRIPTION
Fixes #369

## Summary
- Add a `PreToolUse` hook to `.claude/settings.json` that echoes the current branch name before any `git commit` command, acting as a safety net against committing to the wrong branch
- Handles detached HEAD by printing `DETACHED HEAD` instead of empty string
- File is force-added to git index (`.claude/` remains in `.gitignore`; tracked files persist regardless)

## Verification Results

- [x] **Hook command outputs branch name** *(Level 2 — promise is "command echoes branch name to stderr")*
  ```bash
  $ echo '{}' | bash -c 'branch=$(git branch --show-current 2>/dev/null || true); if [ -z "$branch" ]; then branch="DETACHED HEAD"; fi; echo "Committing to branch: $branch" >&2'
  Committing to branch: chore/pre-commit-branch-hook
  ```

- [x] **Hook outputs DETACHED HEAD on detached HEAD** *(Level 2 — verifies fallback behavior)*
  ```bash
  $ git checkout --detach HEAD && echo '{}' | bash -c 'branch=$(git branch --show-current 2>/dev/null || true); if [ -z "$branch" ]; then branch="DETACHED HEAD"; fi; echo "Committing to branch: $branch" >&2'
  Committing to branch: DETACHED HEAD
  ```

- [x] **Existing hooks preserved** *(Level 5 — adversarial: verify edit didn't clobber other hooks)*
  ```bash
  $ jq -e '.hooks.PreToolUse[0].matcher == "Edit|Write" and (.hooks.PostToolUse | length == 4)' .claude/settings.json
  true
  ```

- [ ] **Hook fires during actual Claude Code session** *(Level 1 — SKIP: requires merging this PR and starting a new Claude Code session. To verify: merge PR, start new session, run any git commit command, confirm "Committing to branch: ..." appears in stderr.)*

## Test plan
- [ ] Merge PR, start a new Claude Code session, and ask it to commit — verify branch name echo appears
- [ ] Verify the hook does NOT fire for non-commit bash commands (e.g. `git status`)