### PR TITLE
docs: fix doc drift in unmapped docs (17 findings)

### DIFF
--- a/.github/agents/lint-cleanup.md
+++ b/.github/agents/lint-cleanup.md
@@ -36,7 +36,7 @@ For each file listed in the `exclude` blocks of `pyright`, `interrogate`, `shell
 
 ## Files
 
-See the checkbox list in https://github.com/ktinubu/synth-permutations/issues/25
+See the checkbox list in https://github.com/tinaudio/synth-setter/issues/25
 
 ## Done when
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,52 @@
 <div align="center">
 
-# Audio synthesizer inversion in symmetric parameter spaces with approximately equivariant flow matching
+# synth-setter
 
-This repository accompanies a submission to ISMIR 2025. A full README explaining how to use this code will be provided before the conference. In the meantime, audio examples are available at the [online supplement](https://benhayes.net/synth-perm/).
-
-If you would like to explore the source code, you may find the below helpful:
+Synth inversion, sound matching, and preset exploration tools.
 
 </div>
 
+## Overview
+
+synth-setter provides tools for automatic synthesizer parameter estimation
+(synth inversion), sound matching, and preset exploration. Built on PyTorch
+Lightning with Hydra configs.
+
+## Key Features
+
+- **Flow matching models** for synthesizer parameter estimation
+- **Distributed data pipeline** for VST audio dataset generation (RunPod + Cloudflare R2)
+- **W&B integration** for experiment tracking and model checkpointing
+- **Docker support** for reproducible training and generation environments
+
+## Quick Start
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+
+# Run tests
+make test
+
+# Run all pre-commit hooks
+make format
+
+# See all available targets
+make help
 ```
-src/models/components/transformer.py       <- DiT and AST implementations
-src/models/components/residual_mlp.py      <- Residual MLP implementations
-src/models/components/cnn.py               <- CNN encoder implementations
-src/models/components/vae.py               <- VAE+RealNVP baseline implementation
-src/models/*_module.py                     <- LightningModule implementations, containing training logic
-src/data/vst/*                             <- Dataset generation
-src/data/vst/surge_xt_param_spec.py        <- Specification of Surge XT dataset sampling distributions
-src/data/ot.py                             <- Optimal transport minibatch coupling
-src/data/kosc_datamodule.py                <- Implementation of k-osc task
-configs/experiment/kosc                    <- k-osc experiment configs
-configs/experiment/surge                   <- Surge XT experiment configs
+
+## Project Structure
+
 ```
+src/           ML code (models, data modules, training, evaluation)
+pipeline/      Distributed data pipeline (python -m pipeline)
+scripts/       Standalone scripts
+configs/       Hydra YAML configs and pipeline configs
+tests/         Test suite
+docs/design/   Design documents
+```
+
+## Documentation
+
+- Design docs live in `docs/design/`
+- See `make help` for available commands

--- a/README.md
+++ b/README.md
@@ -46,6 +46,28 @@ tests/         Test suite
 docs/design/   Design documents
 ```
 
+## Publication
+
+This repository accompanies a submission to ISMIR 2025. An online supplement with
+audio examples is available at
+[benhayes.net/synth-perm/](https://benhayes.net/synth-perm/).
+
+## Key Files
+
+```
+src/models/components/transformer.py       <- DiT and AST implementations
+src/models/components/residual_mlp.py      <- Residual MLP implementations
+src/models/components/cnn.py               <- CNN encoder implementations
+src/models/components/vae.py               <- VAE+RealNVP baseline implementation
+src/models/*_module.py                     <- LightningModule implementations, containing training logic
+src/data/vst/*                             <- Dataset generation
+src/data/vst/surge_xt_param_spec.py        <- Specification of Surge XT dataset sampling distributions
+src/data/ot.py                             <- Optimal transport minibatch coupling
+src/data/kosc_datamodule.py                <- Implementation of k-osc task
+configs/experiment/kosc                    <- k-osc experiment configs
+configs/experiment/surge                   <- Surge XT experiment configs
+```
+
 ## Documentation
 
 - Design docs live in `docs/design/`

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 <div align="center">
-
-# synth-setter
-
-Synth inversion, sound matching, and preset exploration tools.
-
+<h1>synth-setter</h1>
+<p>Synth inversion, sound matching, and preset exploration tools.</p>
 </div>
 
 ## Overview

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ make help
 
 ```
 src/           ML code (models, data modules, training, evaluation)
-pipeline/      Distributed data pipeline (python -m pipeline)
+pipeline/      Distributed data pipeline
 scripts/       Standalone scripts
 configs/       Hydra YAML configs and pipeline configs
 tests/         Test suite

--- a/docs/design/data-pipeline-implementation-plan.md
+++ b/docs/design/data-pipeline-implementation-plan.md
@@ -1,11 +1,17 @@
 # Implementation Plan: Distributed Data Pipeline
 
+> **Status**: PARTIALLY IMPLEMENTED — Phase 1 (Foundation) is complete. Phase 2
+> (Pipeline Core) is partially complete: schemas (`config.py`, `spec.py`,
+> `prefix.py`, `image_config.py`) exist but `report.py`, `card.py`, `sample.py`
+> are not yet created. Phases 3-6 are not started. Storage layer, validation,
+> reconciliation, compute backend, and CLI modules do not exist yet.
+>
 > **Canonical design:** [data-pipeline.md](data-pipeline.md)
 > **Tracking:** #74
 > **Issue tracking:** [github-taxonomy.md](github-taxonomy.md)
 > **Storage conventions:** [storage-provenance-spec.md](storage-provenance-spec.md)
 > **Builds on:** Generation infrastructure by benhayes@ (see design doc §1)
-> **Last Updated:** 2026-03-20
+> **Last Updated:** 2026-03-31
 
 ______________________________________________________________________
 
@@ -235,7 +241,10 @@ Sub-issues: [#18](https://github.com/tinaudio/synth-setter/issues/18) (config-dr
 **Files to create:**
 
 - `pipeline/__init__.py`
-- `pipeline/schemas/` — Pydantic models split across submodules: `config.py` (`DatasetConfig`, `SplitsConfig`, load/ID helpers), `spec.py` (`DatasetPipelineSpec`, `ShardSpec`, `materialize_spec`), `report.py` (`WorkerReport`, `ShardResult`), `card.py` (`DatasetCard`, `ValidationSummary`), `sample.py` (`Sample` dataclass)
+- `pipeline/schemas/` — Pydantic models split across submodules: `config.py` (`DatasetConfig`, `SplitsConfig`, load/ID helpers), `spec.py` (`DatasetPipelineSpec`, `ShardSpec`, `materialize_spec`), `report.py` (`WorkerReport`, `ShardResult`), `card.py` (`DatasetCard`, `ValidationSummary`), `sample.py` (`Sample` dataclass).
+  **Note:** As of 2026-03-31, only `config.py`, `spec.py`, `prefix.py`, and
+  `image_config.py` exist. `report.py`, `card.py`, and `sample.py` are not yet
+  created.
 - `configs/dataset/surge-simple-480k-10k.yaml` — sample config (filename = `dataset_config_id`)
 - `tests/pipeline/__init__.py`
 - `tests/pipeline/test_schemas/`
@@ -244,17 +253,22 @@ Sub-issues: [#18](https://github.com/tinaudio/synth-setter/issues/18) (config-dr
 
 - `DatasetConfig` (Pydantic strict): validates raw YAML input. Fields match config schema (§4).
   `output_format` defaults to `"hdf5"` if missing from config.
-- `DatasetPipelineSpec` (frozen, strict): `dataset_config_id`, `dataset_wandb_run_id` (maps to
-  `run_id` in code), `created_at`, `code_version`, `is_repo_dirty`,
+- `DatasetPipelineSpec` (frozen, strict): `run_id` (was `dataset_wandb_run_id` in plan),
+  `r2_prefix`, `created_at`, `code_version`, `is_repo_dirty`,
   `param_spec`, `renderer_version`, `output_format` (`"hdf5"` or `"wds"`), `sample_rate`,
-  `shard_size`, `num_shards`, `base_seed`, `splits` (`{"train": N, "val": N, "test": N}`),
-  `shards` (list of `ShardSpec`), plus generation params.
+  `shard_size`, `base_seed`, `num_params`, `splits`, `plugin_path`, `preset_path`,
+  `channels`, `velocity`, `signal_duration_seconds`, `min_loudness`,
+  `sample_batch_size`, `shards` (tuple of `ShardSpec`).
+  **Note:** `num_shards` is a derived property (not a stored field).
+  `dataset_config_id` is not stored on the spec; it is encoded in `run_id`.
   ID conventions follow [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids).
   Splits use explicit `{train: N, val: N, test: N}` matching design doc §14.4.
   Validation: `train + val + test == num_shards`.
-- `ShardSpec`: `shard_id: int`, `filename: str` (`"shard-000042.h5"`), `seed` (= `base_seed + shard_id`),
-  `row_start`, `row_count`, `expected_datasets`, `audio_shape`, `mel_shape`, `param_shape`.
+- `ShardSpec`: `shard_id: int`, `filename: str` (`"shard-000042.h5"`), `seed` (= `base_seed + shard_id`).
   `shard_id` is int in schema; formatted to string for paths via `shard_dir_name(shard_id) -> str`.
+  **Note:** As implemented, `ShardSpec` has only `shard_id`, `filename`, `seed`.
+  Fields `row_start`, `row_count`, `expected_datasets`, `audio_shape`, `mel_shape`,
+  `param_shape` from the original plan are not yet implemented.
 - `Sample` dataclass (frozen, slots): `sample_id: int`, `audio`, `mel_spec`, `params` —
   typed container for HDF5→WDS transcoding (not Pydantic, already-validated data).
   Pydantic for trust boundaries, dataclass for internal typed containers.

--- a/docs/design/data-pipeline-implementation-plan.md
+++ b/docs/design/data-pipeline-implementation-plan.md
@@ -242,14 +242,13 @@ Sub-issues: [#18](https://github.com/tinaudio/synth-setter/issues/18) (config-dr
 
 **Files to create:**
 
-- `pipeline/__init__.py`
-- `pipeline/schemas/` — Pydantic models split across submodules: `config.py` (`DatasetConfig`, `SplitsConfig`, load/ID helpers), `spec.py` (`DatasetPipelineSpec`, `ShardSpec`, `materialize_spec`), `report.py` (`WorkerReport`, `ShardResult`), `card.py` (`DatasetCard`, `ValidationSummary`), `sample.py` (`Sample` dataclass).
-  **Note:** As of 2026-03-31, only `config.py`, `spec.py`, `prefix.py`, and
-  `image_config.py` exist. `report.py`, `card.py`, and `sample.py` are not yet
-  created.
-- `configs/dataset/surge-simple-480k-10k.yaml` — sample config (filename = `dataset_config_id`)
-- `tests/pipeline/__init__.py`
-- `tests/pipeline/test_schemas/`
+- ~~`pipeline/__init__.py`~~ ✅
+- `pipeline/schemas/` — Pydantic models split across submodules: ~~`config.py`~~ ✅ (`DatasetConfig`, `SplitsConfig`, load/ID helpers), ~~`spec.py`~~ ✅ (`DatasetPipelineSpec`, `ShardSpec`, `materialize_spec`), `report.py` (`WorkerReport`, `ShardResult`), `card.py` (`DatasetCard`, `ValidationSummary`), `sample.py` (`Sample` dataclass).
+  **Note:** ~~`prefix.py`~~ ✅ and ~~`image_config.py`~~ ✅ also exist.
+  `report.py`, `card.py`, and `sample.py` are not yet created.
+- ~~`configs/dataset/surge-simple-480k-10k.yaml`~~ ✅ — sample config (filename = `dataset_config_id`)
+- ~~`tests/pipeline/__init__.py`~~ ✅
+- ~~`tests/pipeline/test_schemas/`~~ ✅
 
 **Key behaviors:**
 

--- a/docs/design/data-pipeline-implementation-plan.md
+++ b/docs/design/data-pipeline-implementation-plan.md
@@ -83,7 +83,9 @@ ______________________________________________________________________
 
 ### NOT ported (stays on `experiment`)
 
-- `scripts/generate_shards.py`, `finalize_shards.py`, `runpod_launch.py`, `runpod_stop.py`,
+- `scripts/generate_shards.py` ([#407](https://github.com/tinaudio/synth-setter/issues/407)),
+  `finalize_shards.py` ([#408](https://github.com/tinaudio/synth-setter/issues/408)),
+  `runpod_launch.py`, `runpod_stop.py`,
   `run_dataset_pipeline.py`, `reshard_data_dynamic_shard.py` + all their tests
 - `tests/test_entrypoint.bats`
 - `scripts/setup-dev.sh`, `scripts/setup-rclone.sh`
@@ -516,7 +518,8 @@ ______________________________________________________________________
 **Files to create:**
 
 - `pipeline/backends/__init__.py`, `pipeline/backends/base.py`, `pipeline/backends/local.py`
-- `pipeline/worker.py`
+- `pipeline/worker.py` — note: the experiment branch implements this as
+  `scripts/generate_shards.py` called from the entrypoint, not a separate module
 - `tests/pipeline/test_backends.py`, `tests/pipeline/test_worker.py`
 
 **Key behaviors — Worker:**
@@ -804,7 +807,7 @@ ______________________________________________________________________
 
 **Files to modify:**
 
-- `scripts/docker_entrypoint.sh` — add `MODE=pipeline-worker`
+- `scripts/docker_entrypoint.sh` — add `MODE=generate-shards`
 - `Makefile` — `make pipeline-generate`, `pipeline-status`, `pipeline-finalize`
 
 **RunPodBackend:** `runpod.create_pod()` with env vars, auth check, dry-run. Tags all
@@ -813,7 +816,8 @@ pods with `run_id` for cleanup.
 **`cleanup` CLI command:** `python -m pipeline cleanup --run-id <id>` — queries RunPod API
 for pods tagged with `run_id`, terminates them. Safety net for orphaned pods.
 
-**Docker:** `MODE=pipeline-worker` → `python -m pipeline.worker`. Bash EXIT trap uploads
+**Docker:** `MODE=generate-shards` — entrypoint dispatches to shard generation logic
+(experiment branch `scripts/generate_shards.py` is prior art). Bash EXIT trap uploads
 JSONL debug log + fallback `error.json` to `metadata/workers/attempts/{w}-{a}/` on crash.
 
 **Adhoc Docker script:** Builds image, runs container with test config + mounted storage,
@@ -922,7 +926,7 @@ ______________________________________________________________________
     (`random.seed()` + `np.random.seed()`) for reproducibility (#100, P3). Provides
     OS-level crash isolation (SIGSEGV/OOM kill only one shard), per-shard timeout, and
     clean VST plugin state. See design doc §7.8.1
-08. Entrypoint gets `MODE=pipeline-worker`, existing modes untouched
+08. Entrypoint gets `MODE=generate-shards`, existing modes untouched
 09. Tests in `tests/pipeline/` with own conftest
 10. Finalize implements fresh resharding using HDF5 virtual datasets (not calling
     `reshard_data.py` — it hardcodes 10k shard size)

--- a/docs/design/training-pipeline-implementation-plan.md
+++ b/docs/design/training-pipeline-implementation-plan.md
@@ -1,10 +1,13 @@
 # Implementation Plan: Training Pipeline
 
+> **Status**: NOT STARTED — No phases have been implemented. All phase issues
+> are TBD. This plan describes the intended implementation sequence.
+>
 > **Canonical design:** [training-pipeline.md](training-pipeline.md)
 > **Tracking:** #107
 > **Issue tracking:** [github-taxonomy.md](github-taxonomy.md)
 > **Storage conventions:** [storage-provenance-spec.md](storage-provenance-spec.md)
-> **Last Updated:** 2026-03-20
+> **Last Updated:** 2026-03-31
 
 ______________________________________________________________________
 

--- a/docs/design/training-pipeline-implementation-plan.md
+++ b/docs/design/training-pipeline-implementation-plan.md
@@ -1,7 +1,6 @@
 # Implementation Plan: Training Pipeline
 
-> **Status**: NOT STARTED — No phases have been implemented. All phase issues
-> are TBD. This plan describes the intended implementation sequence.
+> **Status**: INCOMPLETE — Implementation is not yet tracked against the phase criteria.
 >
 > **Canonical design:** [training-pipeline.md](training-pipeline.md)
 > **Tracking:** #107

--- a/docs/org-migration-checklist.md
+++ b/docs/org-migration-checklist.md
@@ -1,8 +1,10 @@
 # Checklist: Migrating to a GitHub Organization
 
-> **Status**: Draft
+> **Status**: COMPLETED — Migration to `tinaudio` org finished. This document
+> is retained for historical reference only.
+>
 > **Author**: ktinubu@
-> **Last Updated**: 2026-03-19
+> **Last Updated**: 2026-03-31
 
 ______________________________________________________________________
 

--- a/docs/reference/promotion-pipeline-reference.md
+++ b/docs/reference/promotion-pipeline-reference.md
@@ -1,7 +1,10 @@
 # Model Promotion Pipeline Reference
 
-> **Status**: Draft
-> **Last Updated**: 2026-03-20
+> **Status**: NOT IMPLEMENTED — `scripts/promote.py` and
+> `.github/workflows/promote.yml` do not exist yet. This document describes
+> the planned design. See #122 for tracking.
+>
+> **Last Updated**: 2026-03-31
 > **Tracking**: #122
 
 Promote a W&B run to a GitHub Release. Secrets are documented in [storage-provenance-spec.md](../design/storage-provenance-spec.md) §9.


### PR DESCRIPTION
## Summary

- Add "COMPLETED" banner to org-migration-checklist.md (migration done)
- Add "NOT IMPLEMENTED" banner to promotion-pipeline-reference.md
- Update README.md from ISMIR 2025 stub to current project description
- Add implementation status notes to data-pipeline and training-pipeline implementation plans
- Fix old repo URL in .github/agents/lint-cleanup.md

Refs [#392](https://github.com/tinaudio/synth-setter/issues/392)

## Findings Addressed

| ID | Type | Description |
|---|---|---|
| D27/D28/D30 | stale-claim | org-migration-checklist.md obsolete |
| D29 | broken-link | Old repo URL in lint-cleanup.md |
| B-13 | stale-claim | promotion-pipeline-reference.md non-existent files |
| B-18/B-19 | incorrect-value | ShardSpec/Spec field names don't match |
| B-20/B-21/B-22 | stale-claim | Non-existent schemas in impl plan |
| B-36/B-37 | stale-claim | Non-existent stages in impl plan |
| C-16/C-17 | stale-claim | Training plan not started |
| C-30/C-31 | stale-claim | README frozen at ISMIR 2025 |

## Test plan

- [ ] Verify README.md has current project description
- [ ] Verify org-migration-checklist.md has COMPLETED banner
- [ ] Verify lint-cleanup.md URL points to tinaudio/synth-setter