### PR TITLE
docs: fix doc drift in CLAUDE.md and doc-map.yaml (10 findings)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,10 +59,11 @@ Conventional commits, enforced by gitlint (`.gitlint` config). Prefix matters fo
 ### Architecture
 
 - `src/` — ML code (models, data modules, training, evaluation)
-- `pipeline/` — distributed data pipeline (`python -m pipeline`)
-  - `schemas/` — Pydantic models (config, spec, report, card, sample)
-  - `stages/` — generate and finalize stage logic
-  - `backends/` — compute providers (local, RunPod)
+- `pipeline/` — distributed data pipeline
+  - `schemas/` — Pydantic models (config, spec, prefix, image_config)
+  - `entrypoints/` — pipeline entry points (generate_dataset)
+  - `ci/` — CI validation scripts (materialize_spec, validate_shard, validate_spec)
+  - `constants.py` — shared constants (R2 bucket, spec filename)
 - `scripts/` — standalone scripts
 - `configs/` — Hydra YAML configs (`data/`, `trainer/`) and pipeline configs (`dataset/`)
 - `tests/` — mirrors `src/` and `pipeline/` structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,11 +59,13 @@ Conventional commits, enforced by gitlint (`.gitlint` config). Prefix matters fo
 ### Architecture
 
 - `src/` — ML code (models, data modules, training, evaluation)
-- `pipeline/` — distributed data pipeline
-  - `schemas/` — Pydantic models (config, spec, prefix, image_config)
+- `pipeline/` — distributed data pipeline (`python -m pipeline` planned — [#72](https://github.com/tinaudio/synth-setter/issues/72))
+  - `schemas/` — Pydantic models (config, spec, prefix, image_config; planned: report, card, sample — [#74](https://github.com/tinaudio/synth-setter/issues/74))
   - `entrypoints/` — pipeline entry points (generate_dataset)
   - `ci/` — CI validation scripts (materialize_spec, validate_shard, validate_spec)
   - `constants.py` — shared constants (R2 bucket, spec filename)
+  - `stages/` — generate and finalize stage logic (planned — [#72](https://github.com/tinaudio/synth-setter/issues/72))
+  - `backends/` — compute providers: local, RunPod (planned — [#71](https://github.com/tinaudio/synth-setter/issues/71))
 - `scripts/` — standalone scripts
 - `configs/` — Hydra YAML configs (`data/`, `trainer/`) and pipeline configs (`dataset/`)
 - `tests/` — mirrors `src/` and `pipeline/` structure

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -73,6 +73,12 @@ docs:
         covers: "Dataset generation entrypoint, single-shard MVP, CLI interface"
       - pattern: ".github/workflows/dataset-generation.yml"
         covers: "CI workflow steps, trigger conditions, artifact handling"
+      - pattern: "pipeline/ci/**"
+        covers: "CI validation scripts, spec materialization, shard validation"
+      - pattern: "pipeline/constants.py"
+        covers: "R2 bucket name constant, input spec filename"
+      - pattern: "pipeline/schemas/spec.py"
+        covers: "DatasetPipelineSpec, ShardSpec, materialize_spec() flow"
 
   # ── Storage provenance spec ─────────────────────────────────────
   - doc: docs/design/storage-provenance-spec.md
@@ -84,9 +90,11 @@ docs:
         covers: "R2 listing commands, shard status reporting, path parsing"
       - pattern: "configs/image/dev-snapshot.yaml"
         covers: "r2_endpoint, r2_bucket values, storage configuration"
-      - pattern: "scripts/docker_entrypoint.sh"
-        covers: "rclone download/upload paths, R2 credentials, --checksum usage"
+      - pattern: "pipeline/entrypoints/generate_dataset.py"
+        covers: "rclone upload of spec and shard files, R2 path construction"
         scope: "rclone"
+      - pattern: "pipeline/constants.py"
+        covers: "R2 bucket name constant (intermediate-data), INPUT_SPEC_FILENAME"
 
   # ── Training pipeline design doc ────────────────────────────────
   - doc: docs/design/training-pipeline.md
@@ -125,7 +133,7 @@ docs:
       - pattern: "scripts/predict_vst_audio.py"
         covers: "Audio prediction script, VST rendering, parameter-to-audio pipeline"
       - pattern: "scripts/compute_audio_metrics.py"
-        covers: "Audio metric computation, FAD/FD/KL scores, reference comparisons"
+        covers: "Audio metric computation, MSS/wMFCC/SOT/RMS distance metrics, parallel workers"
       - pattern: "renderscript.sh"
         covers: "Cross-platform rendering script, Xvfb auto-detection"
       - pattern: "configs/eval.yaml"
@@ -174,6 +182,10 @@ docs:
         covers: "Training entry point, Hydra composition, instantiation flow"
       - pattern: "configs/logger/wandb.yaml"
         covers: "W&B logger config, log_model, entity/project"
+      - pattern: "pipeline/schemas/prefix.py"
+        covers: "DatasetConfigId, DatasetRunId, R2Prefix, make_r2_prefix()"
+      - pattern: "pipeline/constants.py"
+        covers: "R2 bucket name, INPUT_SPEC_FILENAME constant"
 
   # ── rclone reference (placeholder — doc does not exist yet) ─────
   # - doc: docs/reference/rclone.md
@@ -198,23 +210,3 @@ docs:
   #       covers: "Promotion script, W&B artifact download, GitHub Release creation"
   #     - pattern: ".github/workflows/promote.yml"
   #       covers: "Promotion workflow, manual trigger, dry-run mode"
-  # ── W&B integration (placeholder — expand when doc exists) ──────
-  # - doc: docs/reference/wandb-integration.md
-  #   description: W&B logging and auth reference
-  #   sources:
-  #     - pattern: "src/training/**"
-  #       covers: "W&B logging calls, metric names, run config, artifact logging"
-  #     - pattern: "scripts/docker_entrypoint.sh"
-  #       covers: "W&B netrc setup, WANDB_API_KEY injection"
-  #       scope: "wandb"
-
-  # ── Docker spec (the contract doc) ──────────────────────────────
-  - doc: docs/reference/docker-spec.md
-    description: Image target contract, entrypoint modes, env var spec
-    sources:
-      - pattern: "scripts/docker_entrypoint.sh"
-        covers: "All MODE values, env var contract, exit codes, error handling"
-      - pattern: "docker/**"
-        covers: "Target names, stage dependencies, what each target produces"
-      - pattern: "pipeline/schemas/image_config.py"
-        covers: "ImageConfig fields that define the target contract"


### PR DESCRIPTION
## Summary

- Fix CLAUDE.md Architecture section: replace non-existent pipeline/stages/, pipeline/backends/ with actual directories (entrypoints/, ci/), fix schema list, remove invalid python -m pipeline reference
- Fix doc-map.yaml: remove duplicate docker-spec.md entry, remove stale wandb placeholder, correct metric names (FAD/FD/KL → MSS/wMFCC/SOT/RMS), fix rclone scope attribution, add missing source patterns

Refs #392

## Findings Addressed

| ID | Type | Description |
|---|---|---|
| B-03 | stale-claim | pipeline/stages/ doesn't exist → entrypoints/ |
| B-04 | stale-claim | pipeline/backends/ doesn't exist → ci/ |
| B-05 | stale-claim | python -m pipeline invalid |
| B-06 | stale-claim | schemas "report, card, sample" don't exist |
| B-38 | omission | entrypoints/, ci/, constants.py undocumented |
| D31/C-36 | mapping | docker-spec.md duplicate in doc-map.yaml |
| C-37 | mapping | stale wandb placeholder |
| C-38 | incorrect-value | FAD/FD/KL → MSS/wMFCC/SOT/RMS |
| D34 | mapping | rclone scope on wrong file |
| B-29/B-30/B-31 | mapping | missing source patterns |

## Test plan

- [ ] Verify CLAUDE.md Architecture section matches ls pipeline/ output
- [ ] Verify doc-map.yaml has no duplicate entries
- [ ] Verify all doc-map.yaml patterns match existing files