### PR TITLE
docs: fix doc drift in docker-spec.md and docker.md (12 findings)

### DIFF
--- a/docs/reference/docker-spec.md
+++ b/docs/reference/docker-spec.md
@@ -31,6 +31,8 @@ MODE is required -- container errors if unset.
 
 `generate_dataset` uses env vars instead of CLI args — see § MODE=generate_dataset env vars below.
 
+> **Note:** `generate_dataset` is the current single-shard MVP. It will be deprecated when `generate-shards` lands on main ([#411](https://github.com/tinaudio/synth-setter/issues/411)).
+
 ### Exit codes
 
 | Condition                  | Exit code |
@@ -39,7 +41,14 @@ MODE is required -- container errors if unset.
 | Unknown MODE value         | 1         |
 | `passthrough` with no args | 0         |
 
-Future modes: `pipeline-worker` (see `docs/design/data-pipeline-implementation-plan.md`).
+### Next modes
+
+| MODE              | Status                     | Description                                                                  | Tracking                                                    |
+| ----------------- | -------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| `generate-shards` | Scoped (experiment branch) | Multi-shard parallel generation with R2 upload. Replaces `generate_dataset`. | [#407](https://github.com/tinaudio/synth-setter/issues/407) |
+| `finalize-shards` | Scoped (experiment branch) | Reshard into train/val/test, compute stats, upload to R2.                    | [#408](https://github.com/tinaudio/synth-setter/issues/408) |
+| `train`           | Scoped (experiment branch) | Download dataset from R2, run training, upload checkpoints.                  | [#409](https://github.com/tinaudio/synth-setter/issues/409) |
+| `eval`            | Planned                    | Download checkpoint + dataset, run eval, upload results.                     | [#410](https://github.com/tinaudio/synth-setter/issues/410) |
 
 ______________________________________________________________________
 
@@ -105,5 +114,5 @@ ______________________________________________________________________
 ## 5. Cross-references
 
 - `docs/design/storage-provenance-spec.md` -- R2 paths, W&B artifacts, secrets
-- `docs/design/data-pipeline-implementation-plan.md` -- future `MODE=pipeline-worker`
+- `docs/design/data-pipeline-implementation-plan.md` -- `MODE=generate-shards` ([#407](https://github.com/tinaudio/synth-setter/issues/407))
 - `docs/reference/wandb-integration.md` -- W&B logging reference

--- a/docs/reference/docker-spec.md
+++ b/docs/reference/docker-spec.md
@@ -8,6 +8,7 @@ ______________________________________________________________________
 ## Current vs. Planned
 
 MODE dispatch is fully implemented in `scripts/docker_entrypoint.sh` on `main`.
+MODE dispatch was implemented as part of [#265](https://github.com/tinaudio/synth-setter/issues/265).
 The entrypoint supports three modes (`idle`, `passthrough`, `generate_dataset`),
 exits with an error if MODE is unset or unknown, and exits 0 for `passthrough`
 with no arguments. The spec below matches the current implementation.

--- a/docs/reference/docker-spec.md
+++ b/docs/reference/docker-spec.md
@@ -7,12 +7,10 @@ ______________________________________________________________________
 
 ## Current vs. Planned
 
-The entrypoint on `main` today (`scripts/docker_entrypoint.sh`) is a passthrough stub:
-`exec "$@"` if args are given, error if not. It has no MODE dispatch.
-
-Everything in this spec that differs from that behavior — MODE dispatch, `idle` mode,
-`passthrough` with no args exiting 0 — is **planned work** tracked in #265.
-The spec documents the target contract, not the current implementation.
+MODE dispatch is fully implemented in `scripts/docker_entrypoint.sh` on `main`.
+The entrypoint supports three modes (`idle`, `passthrough`, `generate_dataset`),
+exits with an error if MODE is unset or unknown, and exits 0 for `passthrough`
+with no arguments. The spec below matches the current implementation.
 
 ______________________________________________________________________
 
@@ -32,6 +30,14 @@ MODE is required -- container errors if unset.
 
 `generate_dataset` uses env vars instead of CLI args — see § MODE=generate_dataset env vars below.
 
+### Exit codes
+
+| Condition                  | Exit code |
+| -------------------------- | --------- |
+| Unset or empty MODE        | 1         |
+| Unknown MODE value         | 1         |
+| `passthrough` with no args | 0         |
+
 Future modes: `pipeline-worker` (see `docs/design/data-pipeline-implementation-plan.md`).
 
 ______________________________________________________________________
@@ -46,7 +52,7 @@ ______________________________________________________________________
 | `dev-snapshot` | `docker_entrypoint.sh`          | Git clone at `GIT_REF`       | CI, cloud runs |
 | `dev-live`     | fallback (errors without mount) | Volume-mounted               | Local dev      |
 
-All targets inherit from `r2-config-base`. R2 credentials are baked only when BuildKit secrets are provided at build time (placeholder rclone config otherwise). W&B auth is not baked — `WANDB_API_KEY` is required at runtime.
+All targets inherit from `r2-config-base`. R2 credentials are baked only when BuildKit secrets are provided at build time (placeholder rclone config otherwise). W&B auth is baked into `~/.netrc` when the `wandb_api_key` BuildKit secret is provided at build time; if the secret is missing, `WANDB_API_KEY` is required at runtime.
 
 ______________________________________________________________________
 

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -385,16 +385,29 @@ To clear the remote registry cache, delete the `buildcache` tag from Docker Hub
 
 ______________________________________________________________________
 
-## 6. Future plans
+## 6. Scoped and planned modes
+
+### Scoped — validated on experiment branch, pending port to main
+
+- **MODE=generate-shards** ([#407](https://github.com/tinaudio/synth-setter/issues/407)) — multi-shard parallel VST
+  dataset generation with R2 upload. Replaces `generate_dataset` (which becomes
+  deprecated, [#411](https://github.com/tinaudio/synth-setter/issues/411)).
+  See [data-pipeline.md](../design/data-pipeline.md) § Generate stage.
+- **MODE=finalize-shards** ([#408](https://github.com/tinaudio/synth-setter/issues/408)) — download shards from R2,
+  reshard into train/val/test, compute normalization stats, upload.
+- **MODE=train** ([#409](https://github.com/tinaudio/synth-setter/issues/409)) — download dataset from R2, run
+  `src/train.py` via Hydra, upload checkpoints. Currently handled manually.
+
+### Planned — not yet implemented
+
+- **MODE=eval** ([#410](https://github.com/tinaudio/synth-setter/issues/410)) — download checkpoint + dataset,
+  run evaluation, upload results. Counterpart to `MODE=train`.
+
+### Other future work
 
 - **dev-live MODE support** — currently dev-live uses a fallback entrypoint
-  that requires a volume mount at `/home/build/synth-setter`. A future change
-  would add `docker_entrypoint.sh` to dev-live so it supports MODE dispatch
-  like dev-snapshot/prod, removing the need for `--entrypoint bash` overrides.
-- **MODE=train** — dedicated training mode in the entrypoint that downloads
-  data from R2, runs training, and uploads results. Currently handled manually.
-- **MODE=pipeline-worker** — for distributed shard generation on RunPod.
-  See [data-pipeline.md](../design/data-pipeline.md) § Generate stage.
+  that requires a volume mount. A future change would add `docker_entrypoint.sh`
+  to dev-live so it supports MODE dispatch like dev-snapshot/prod.
 
 ______________________________________________________________________
 

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -94,7 +94,8 @@ ______________________________________________________________________
 > `docker buildx build` directly with `--build-arg IMAGE=prod` — the Makefile's
 > `docker-build-*` targets override the `IMAGE` build arg after `DOCKER_BUILD_FLAGS`.
 
-All targets require `GIT_PAT`. `dev-snapshot` and `prod` additionally require `GIT_REF`:
+All targets require `GIT_PAT`. `dev-snapshot` and `prod` should set `GIT_REF`
+for reproducible builds (defaults to `main` if omitted):
 
 ```bash
 # dev-snapshot — self-contained image at a specific commit
@@ -121,7 +122,8 @@ YAML (see Image config below). CLI takes precedence.
 > **BUILD_MODE default divergence:** The Makefile defaults `DOCKER_BUILD_MODE`
 > to `prebuilt`, which is passed as `--build-arg BUILD_MODE`. The Dockerfile's
 > own `ARG BUILD_MODE=source` default only applies when the arg is not provided
-> at all. In practice, builds through `make` always use `prebuilt`.
+> at all. In practice, builds through `make` default to `prebuilt` (override with
+> `DOCKER_BUILD_MODE=source`).
 
 ### Image config (CI)
 

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -50,7 +50,7 @@ that persist in the final image:
 > `docker history`), but the resulting config files **are baked into the image**.
 > Push only to private registries. Rotate R2 tokens after each build campaign.
 
-The rclone reference doc is planned but does not yet exist.
+The rclone reference doc is planned ([#310](https://github.com/tinaudio/synth-setter/issues/310)).
 
 ### First build (dev-live)
 
@@ -401,7 +401,7 @@ ______________________________________________________________________
 ## 7. Cross-references
 
 - [docker-spec.md](docker-spec.md) — image target contract, entrypoint spec, env vars
-- rclone.md (planned) — R2 setup, Docker credential baking
+- rclone.md (planned — [#310](https://github.com/tinaudio/synth-setter/issues/310)) — R2 setup, Docker credential baking
 - [wandb-integration.md](wandb-integration.md) — W&B logging and auth
 - [data-pipeline.md](../design/data-pipeline.md) — pipeline architecture, worker provisioning
 - [image_config.py](../../pipeline/schemas/image_config.py) — image config schema (Pydantic model)

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -90,8 +90,9 @@ ______________________________________________________________________
 | `prod`         | Baked at `GIT_REF` (tarball) | Production            |
 
 > **Note:** The Makefile only has `docker-build-dev-live` and
-> `docker-build-dev-snapshot` targets. To build the `prod` target, pass
-> `--build-arg IMAGE=prod` via `DOCKER_BUILD_FLAGS` or invoke `docker buildx build` directly.
+> `docker-build-dev-snapshot` targets. To build the `prod` target, invoke
+> `docker buildx build` directly with `--build-arg IMAGE=prod` — the Makefile's
+> `docker-build-*` targets override the `IMAGE` build arg after `DOCKER_BUILD_FLAGS`.
 
 All targets require `GIT_PAT`. `dev-snapshot` and `prod` additionally require `GIT_REF`:
 

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -37,8 +37,12 @@ that persist in the final image:
 | `git_pat`              | `GIT_PAT`              | *(not persisted)*                  | GitHub API access for source tarball |
 | `r2_access_key_id`     | `R2_ACCESS_KEY_ID`     | `/root/.config/rclone/rclone.conf` | R2 rclone config                     |
 | `r2_secret_access_key` | `R2_SECRET_ACCESS_KEY` | `/root/.config/rclone/rclone.conf` | R2 rclone config                     |
-| `r2_endpoint`          | `R2_ENDPOINT`          | `/root/.config/rclone/rclone.conf` | R2 rclone config                     |
 | `wandb_api_key`        | `WANDB_API_KEY`        | `/root/.netrc`                     | W&B auth                             |
+
+> **Note:** `R2_ENDPOINT` and `R2_BUCKET` are passed as `--build-arg`, not as
+> BuildKit secrets. `R2_ENDPOINT` is written into `rclone.conf` by the
+> `r2-config-base` stage; `R2_BUCKET` is set as an `ENV` in the image. Both
+> appear in `docker history`. See the build-arg table below.
 
 > [!WARNING]
 > R2 and W&B credentials persist in the final image filesystem (`rclone.conf`,
@@ -46,7 +50,7 @@ that persist in the final image:
 > `docker history`), but the resulting config files **are baked into the image**.
 > Push only to private registries. Rotate R2 tokens after each build campaign.
 
-See [rclone.md](rclone.md) § Docker for the full R2 credential flow.
+The rclone reference doc is planned but does not yet exist.
 
 ### First build (dev-live)
 
@@ -79,12 +83,17 @@ ______________________________________________________________________
 
 ### Make targets
 
-| Target         | Source code            | Typical use           |
-| -------------- | ---------------------- | --------------------- |
-| `dev-live`     | Volume-mounted         | Local development     |
-| `dev-snapshot` | Git clone at `GIT_REF` | CI, cloud, evaluation |
+| Target         | Source code                  | Typical use           |
+| -------------- | ---------------------------- | --------------------- |
+| `dev-live`     | Volume-mounted               | Local development     |
+| `dev-snapshot` | Git clone at `GIT_REF`       | CI, cloud, evaluation |
+| `prod`         | Baked at `GIT_REF` (tarball) | Production            |
 
-Both targets require `GIT_PAT`. `dev-snapshot` additionally requires `GIT_REF`:
+> **Note:** The Makefile only has `docker-build-dev-live` and
+> `docker-build-dev-snapshot` targets. To build the `prod` target, pass
+> `--build-arg IMAGE=prod` via `DOCKER_BUILD_FLAGS` or invoke `docker buildx build` directly.
+
+All targets require `GIT_PAT`. `dev-snapshot` and `prod` additionally require `GIT_REF`:
 
 ```bash
 # dev-snapshot — self-contained image at a specific commit
@@ -96,17 +105,22 @@ make docker-build-dev-snapshot \
 
 ### Build variables
 
-| Variable                | Default                         | Purpose                               | Override via |
-| ----------------------- | ------------------------------- | ------------------------------------- | ------------ |
-| `DOCKER_FILE`           | `docker/ubuntu22_04/Dockerfile` | Dockerfile path                       | CLI only     |
-| `DOCKER_IMAGE`          | `synth-setter`                  | Image name (local builds)             | CLI only     |
-| `DOCKER_BUILD_MODE`     | `prebuilt`                      | Surge install: `source` or `prebuilt` | CLI only     |
-| `DOCKER_TARGETPLATFORM` | `linux/amd64`                   | Target platform                       | CLI only     |
-| `DOCKER_TORCH_IDX`      | CUDA 12.8 wheels                | PyTorch wheel index URL               | CLI or YAML  |
-| `DOCKER_BUILD_FLAGS`    | *(empty)*                       | `--load` (local) or `--push` (remote) | CLI only     |
+| Variable                | Default                         | Purpose                                          | Override via |
+| ----------------------- | ------------------------------- | ------------------------------------------------ | ------------ |
+| `DOCKER_FILE`           | `docker/ubuntu22_04/Dockerfile` | Dockerfile path                                  | CLI only     |
+| `DOCKER_IMAGE`          | `synth-setter`                  | Image name (local builds)                        | CLI only     |
+| `DOCKER_BUILD_MODE`     | `prebuilt`                      | Surge install: `source` or `prebuilt` (see note) | CLI only     |
+| `DOCKER_TARGETPLATFORM` | `linux/amd64`                   | Target platform                                  | CLI only     |
+| `DOCKER_TORCH_IDX`      | CUDA 12.8 wheels                | PyTorch wheel index URL                          | CLI or YAML  |
+| `DOCKER_BUILD_FLAGS`    | *(empty)*                       | `--load` (local) or `--push` (remote)            | CLI only     |
 
 `DOCKER_TORCH_IDX` can also be set via `torch_index_url` in the image config
 YAML (see Image config below). CLI takes precedence.
+
+> **BUILD_MODE default divergence:** The Makefile defaults `DOCKER_BUILD_MODE`
+> to `prebuilt`, which is passed as `--build-arg BUILD_MODE`. The Dockerfile's
+> own `ARG BUILD_MODE=source` default only applies when the arg is not provided
+> at all. In practice, builds through `make` always use `prebuilt`.
 
 ### Image config (CI)
 
@@ -125,11 +139,13 @@ base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
 torch_index_url: "https://download.pytorch.org/whl/cu128"
+r2_endpoint: "https://efb9275d571811db929e83eb710b74a7.r2.cloudflarestorage.com"
+r2_bucket: "intermediate-data"
 ```
 
 Runtime inputs (`github_sha`, `issue_number`) are provided by the caller, not
 stored in the YAML. The schema is tested in
-[test_image_config.py](../../tests/scripts/test_image_config.py) (18 tests
+[test_image_config.py](../../tests/pipeline/test_schemas/test_image_config.py) (22 tests
 covering validation, defaults, and drift detection against the real YAML).
 
 ______________________________________________________________________
@@ -385,7 +401,7 @@ ______________________________________________________________________
 ## 7. Cross-references
 
 - [docker-spec.md](docker-spec.md) — image target contract, entrypoint spec, env vars
-- [rclone.md](rclone.md) — R2 setup, Docker credential baking
+- rclone.md (planned) — R2 setup, Docker credential baking
 - [wandb-integration.md](wandb-integration.md) — W&B logging and auth
 - [data-pipeline.md](../design/data-pipeline.md) — pipeline architecture, worker provisioning
 - [image_config.py](../../pipeline/schemas/image_config.py) — image config schema (Pydantic model)


### PR DESCRIPTION
## Summary

- Rewrite stale "Current vs. Planned" section in docker-spec.md — MODE dispatch is fully implemented
- Fix W&B auth claim: baked into .netrc, not runtime-only
- Fix broken links: rclone.md doesn't exist, test_image_config.py wrong path
- Correct BuildKit secrets table: r2_endpoint is a build-arg, not a secret
- Add missing R2_BUCKET build-arg documentation
- Update YAML snippet with r2_endpoint and r2_bucket fields
- Fix test count, add prod target note, BUILD_MODE default clarification

Refs [#392](https://github.com/tinaudio/synth-setter/issues/392)

## Findings Addressed

| ID | Type | Description |
|---|---|---|
| D12 | stale-claim | "Current vs. Planned" says MODE unimplemented |
| D13/D21 | stale-claim | "W&B auth not baked" — it is |
| D03 | incorrect-value | r2_endpoint listed as secret, is build-arg |
| D04 | omission | R2_BUCKET undocumented |
| D05 | broken-link | rclone.md doesn't exist |
| D06 | broken-link | test_image_config.py wrong path |
| D07 | incorrect-value | test count wrong |
| D08 | omission | YAML snippet missing fields |
| D10 | omission | Build targets missing prod |
| D02 | incorrect-value | BUILD_MODE default divergence |
| D16 | omission | Exit codes not documented |

## Test plan

- [ ] Verify all links in docker.md resolve to existing files
- [ ] Verify YAML snippet matches actual configs/image/dev-snapshot.yaml
- [ ] Verify test count matches grep -c "def test_" tests/pipeline/test_schemas/test_image_config.py