### PR TITLE
docs: fix doc drift in wandb-integration.md and storage-provenance-spec.md (13 findings)

### DIFF
--- a/docs/design/storage-provenance-spec.md
+++ b/docs/design/storage-provenance-spec.md
@@ -101,11 +101,11 @@ ______________________________________________________________________
 
 ## 4. W&B Artifact Types
 
-| Type           | Name Pattern               | Logged By               | Example name        |
-| -------------- | -------------------------- | ----------------------- | ------------------- |
-| `dataset`      | `data-{dataset_config_id}` | `pipeline.cli finalize` | `data-diva-v1`      |
-| `model`        | `model-{train_config_id}`  | `src/train.py`          | `model-flow-simple` |
-| `eval-results` | `eval-{eval_config_id}`    | eval script             | `eval-nsynth-v1`    |
+| Type           | Name Pattern               | Logged By                         | Example name        |
+| -------------- | -------------------------- | --------------------------------- | ------------------- |
+| `dataset`      | `data-{dataset_config_id}` | `pipeline.cli finalize` (planned) | `data-diva-v1`      |
+| `model`        | `model-{train_config_id}`  | `src/train.py`                    | `model-flow-simple` |
+| `eval-results` | `eval-{eval_config_id}`    | eval script                       | `eval-nsynth-v1`    |
 
 > **Note:** `pipeline.cli` is the target CLI (Phase 5). Current entrypoint: `pipeline.entrypoints.generate_dataset`.
 
@@ -156,11 +156,11 @@ ______________________________________________________________________
 
 ## 7. `job_type` Values
 
-| `job_type`        | Stage         | Script                  |
-| ----------------- | ------------- | ----------------------- |
-| `data-generation` | Data pipeline | `pipeline.cli finalize` |
-| `training`        | Training      | `src/train.py`          |
-| `evaluation`      | Evaluation    | eval script             |
+| `job_type`        | Stage         | Script                            |
+| ----------------- | ------------- | --------------------------------- |
+| `data-generation` | Data pipeline | `pipeline.cli finalize` (planned) |
+| `training`        | Training      | `src/train.py`                    |
+| `evaluation`      | Evaluation    | eval script                       |
 
 > **Note:** `pipeline.cli` is the target CLI (Phase 5). Current entrypoint: `pipeline.entrypoints.generate_dataset`.
 

--- a/docs/design/storage-provenance-spec.md
+++ b/docs/design/storage-provenance-spec.md
@@ -107,7 +107,7 @@ ______________________________________________________________________
 | `model`        | `model-{train_config_id}`  | `src/train.py`                    | `model-flow-simple` |
 | `eval-results` | `eval-{eval_config_id}`    | eval script                       | `eval-nsynth-v1`    |
 
-> **Note:** `pipeline.cli` is the target CLI (Phase 5). Current entrypoint: `pipeline.entrypoints.generate_dataset`.
+> **Note:** `pipeline.cli finalize` is the target CLI (Phase 5). In Docker, the finalize step runs as `MODE=finalize-shards` (scoped, validated on experiment branch — [#408](https://github.com/tinaudio/synth-setter/issues/408)). Current entrypoint: `pipeline.entrypoints.generate_dataset`.
 
 - W&B auto-versions artifacts (`:v0`, `:v1`, `:v2`). Each new run of the same config produces the next version.
 - The `*_wandb_run_id` is stored in `artifact.metadata`, not the artifact name
@@ -162,7 +162,7 @@ ______________________________________________________________________
 | `training`        | Training      | `src/train.py`                    |
 | `evaluation`      | Evaluation    | eval script                       |
 
-> **Note:** `pipeline.cli` is the target CLI (Phase 5). Current entrypoint: `pipeline.entrypoints.generate_dataset`.
+> **Note:** `pipeline.cli finalize` is the target CLI (Phase 5). In Docker, the finalize step runs as `MODE=finalize-shards` (scoped, validated on experiment branch — [#408](https://github.com/tinaudio/synth-setter/issues/408)). Current entrypoint: `pipeline.entrypoints.generate_dataset`.
 
 - Set on every `wandb.init(job_type=...)` call
 

--- a/docs/design/storage-provenance-spec.md
+++ b/docs/design/storage-provenance-spec.md
@@ -170,14 +170,14 @@ ______________________________________________________________________
 
 ## 8. GitHub Actions Workflows
 
-| Workflow        | File                     | Trigger              | Runner                          | Secrets             | Key Inputs                                                       |
-| --------------- | ------------------------ | -------------------- | ------------------------------- | ------------------- | ---------------------------------------------------------------- |
-| Tests           | `test.yml`               | push, PR             | `ubuntu-latest`, `macos-latest` | —                   | —                                                                |
-| Full Tests      | `test-expensive.yml`     | push(main), dispatch | `gpu-x64`                       | —                   | —                                                                |
-| Data Generation | `dataset-generation.yml` | `workflow_dispatch`  | TBD                             | R2, W&B, RunPod     | config, n_workers                                                |
-| Training        | TBD                      | `workflow_dispatch`  | TBD                             | R2, W&B, RunPod     | experiment, overrides                                            |
-| Evaluation      | TBD                      | `workflow_dispatch`  | TBD                             | R2, W&B             | `train_wandb_run_id`, `eval_config_id`                           |
-| Model Promotion | `promote.yml` (planned)  | `workflow_dispatch`  | `ubuntu-latest`                 | W&B, `GITHUB_TOKEN` | `train_wandb_run_id`, `eval_wandb_run_id`, `registry`, `dry_run` |
+| Workflow        | File                     | Trigger             | Runner                          | Secrets             | Key Inputs                                                       |
+| --------------- | ------------------------ | ------------------- | ------------------------------- | ------------------- | ---------------------------------------------------------------- |
+| Tests           | `test.yml`               | push, PR            | `ubuntu-latest`, `macos-latest` | —                   | —                                                                |
+| Full Tests      | `test-expensive.yml`     | schedule, dispatch  | `gpu-x64`                       | —                   | —                                                                |
+| Data Generation | `dataset-generation.yml` | `workflow_call`     | `ubuntu-latest-4core`           | DockerHub           | `image_tag`, `config_path`, `artifact_name`                      |
+| Training        | TBD                      | `workflow_dispatch` | TBD                             | R2, W&B, RunPod     | experiment, overrides                                            |
+| Evaluation      | TBD                      | `workflow_dispatch` | TBD                             | R2, W&B             | `train_wandb_run_id`, `eval_config_id`                           |
+| Model Promotion | `promote.yml` (planned)  | `workflow_dispatch` | `ubuntu-latest`                 | W&B, `GITHUB_TOKEN` | `train_wandb_run_id`, `eval_wandb_run_id`, `registry`, `dry_run` |
 
 - All workflows that create W&B runs must export `GITHUB_SHA` into the run environment.
 - Evaluation requires `train_wandb_run_id` (to find the model artifact) and `eval_config_id` (which dataset to evaluate on).

--- a/docs/design/storage-provenance-spec.md
+++ b/docs/design/storage-provenance-spec.md
@@ -32,7 +32,7 @@ ______________________________________________________________________
 ## 2. R2 Bucket Layout
 
 ```
-synth-data/
+intermediate-data/
 ├── data/{dataset_config_id}/{dataset_wandb_run_id}/
 ├── train/{dataset_config_id}/{dataset_wandb_run_id}/{train_config_id}/{train_wandb_run_id}/
 └── eval/{dataset_config_id}/{dataset_wandb_run_id}/{train_config_id}/{train_wandb_run_id}/{eval_config_id}/{eval_wandb_run_id}/
@@ -43,6 +43,8 @@ ______________________________________________________________________
 ## 3. R2 Contents Per Workflow
 
 ### 3a. Data Generation
+
+> **Implementation status:** The layout below is the target architecture. The current single-shard MVP uses a flat structure: spec and shard upload directly to `data/{config_id}/{run_id}/`.
 
 ```
 data/{dataset_config_id}/{dataset_wandb_run_id}/
@@ -105,6 +107,8 @@ ______________________________________________________________________
 | `model`        | `model-{train_config_id}`  | `src/train.py`          | `model-flow-simple` |
 | `eval-results` | `eval-{eval_config_id}`    | eval script             | `eval-nsynth-v1`    |
 
+> **Note:** `pipeline.cli` is the target CLI (Phase 5). Current entrypoint: `pipeline.entrypoints.generate_dataset`.
+
 - W&B auto-versions artifacts (`:v0`, `:v1`, `:v2`). Each new run of the same config produces the next version.
 - The `*_wandb_run_id` is stored in `artifact.metadata`, not the artifact name
 
@@ -158,20 +162,22 @@ ______________________________________________________________________
 | `training`        | Training      | `src/train.py`          |
 | `evaluation`      | Evaluation    | eval script             |
 
+> **Note:** `pipeline.cli` is the target CLI (Phase 5). Current entrypoint: `pipeline.entrypoints.generate_dataset`.
+
 - Set on every `wandb.init(job_type=...)` call
 
 ______________________________________________________________________
 
 ## 8. GitHub Actions Workflows
 
-| Workflow        | File                 | Trigger              | Runner                          | Secrets             | Key Inputs                                                       |
-| --------------- | -------------------- | -------------------- | ------------------------------- | ------------------- | ---------------------------------------------------------------- |
-| Tests           | `test.yml`           | push, PR             | `ubuntu-latest`, `macos-latest` | —                   | —                                                                |
-| Full Tests      | `test-expensive.yml` | push(main), dispatch | `gpu-x64`                       | —                   | —                                                                |
-| Data Generation | TBD                  | `workflow_dispatch`  | TBD                             | R2, W&B, RunPod     | config, n_workers                                                |
-| Training        | TBD                  | `workflow_dispatch`  | TBD                             | R2, W&B, RunPod     | experiment, overrides                                            |
-| Evaluation      | TBD                  | `workflow_dispatch`  | TBD                             | R2, W&B             | `train_wandb_run_id`, `eval_config_id`                           |
-| Model Promotion | `promote.yml`        | `workflow_dispatch`  | `ubuntu-latest`                 | W&B, `GITHUB_TOKEN` | `train_wandb_run_id`, `eval_wandb_run_id`, `registry`, `dry_run` |
+| Workflow        | File                     | Trigger              | Runner                          | Secrets             | Key Inputs                                                       |
+| --------------- | ------------------------ | -------------------- | ------------------------------- | ------------------- | ---------------------------------------------------------------- |
+| Tests           | `test.yml`               | push, PR             | `ubuntu-latest`, `macos-latest` | —                   | —                                                                |
+| Full Tests      | `test-expensive.yml`     | push(main), dispatch | `gpu-x64`                       | —                   | —                                                                |
+| Data Generation | `dataset-generation.yml` | `workflow_dispatch`  | TBD                             | R2, W&B, RunPod     | config, n_workers                                                |
+| Training        | TBD                      | `workflow_dispatch`  | TBD                             | R2, W&B, RunPod     | experiment, overrides                                            |
+| Evaluation      | TBD                      | `workflow_dispatch`  | TBD                             | R2, W&B             | `train_wandb_run_id`, `eval_config_id`                           |
+| Model Promotion | `promote.yml` (planned)  | `workflow_dispatch`  | `ubuntu-latest`                 | W&B, `GITHUB_TOKEN` | `train_wandb_run_id`, `eval_wandb_run_id`, `registry`, `dry_run` |
 
 - All workflows that create W&B runs must export `GITHUB_SHA` into the run environment.
 - Evaluation requires `train_wandb_run_id` (to find the model artifact) and `eval_config_id` (which dataset to evaluate on).
@@ -251,7 +257,7 @@ ______________________________________________________________________
 
 ## 11. Artifact → Storage Mapping
 
-- W&B artifacts reference R2 objects via `artifact.add_reference("s3://synth-data/...")` (R2 is S3-compatible)
+- W&B artifacts reference R2 objects via `artifact.add_reference("s3://intermediate-data/...")` (R2 is S3-compatible)
 - Requires `AWS_ENDPOINT_URL` (or `WANDB_S3_ENDPOINT_URL`) set to the R2 endpoint in any environment that calls `add_reference` or downloads reference artifacts. Without this, W&B will attempt to resolve against AWS S3.
 - Artifacts do not duplicate large data files — they contain metadata, manifests, and statistics
 - Bulk data lives in R2; W&B provides the index and lineage graph

--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -118,11 +118,11 @@ Source: `src/utils/utils.py:138-149`, called from `src/train.py:91-93`.
 `log_wandb_provenance()` (`src/utils/logging_utils.py:64-98`) is called in both
 `src/train.py:89` and `src/eval.py:82`, after `log_hyperparameters()`.
 
-| Key          | Source               | Example                                     |
-| ------------ | -------------------- | ------------------------------------------- |
-| `github_sha` | `git rev-parse HEAD` | `3e60c47c6131...`                           |
-| `image_tag`  | `IMAGE_TAG` env var  | `dev-snapshot-abc123`                       |
-| `command`    | `sys.argv`           | `['src/train.py', 'experiment=surge/flow']` |
+| Key          | Source               | Example                                |
+| ------------ | -------------------- | -------------------------------------- |
+| `github_sha` | `git rev-parse HEAD` | `3e60c47c6131...`                      |
+| `image_tag`  | `IMAGE_TAG` env var  | `dev-snapshot-abc123`                  |
+| `command`    | `" ".join(sys.argv)` | `"src/train.py experiment=surge/flow"` |
 
 Written via `wandb.config.update(..., allow_val_change=True)`.
 

--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -1,6 +1,6 @@
 # W&B Integration Reference
 
-> **Code version**: `8af7575` (2026-03-24, `main`)
+> **Code version**: `3e60c47` (2026-03-31, `main`)
 > **PyTorch**: see `requirements.txt` · **Lightning**: see `requirements.txt`
 > **Tracking**: #252, #263
 
@@ -18,16 +18,16 @@ ______________________________________________________________________
 
 ## 1. Initialization
 
-| Concern           | How it works                                                     | File                              |
-| ----------------- | ---------------------------------------------------------------- | --------------------------------- |
-| W&B run creation  | `WandbLogger` instantiated by Hydra                              | `configs/logger/wandb.yaml`       |
-| Entity / project  | Hardcoded: `entity: "benhayes"`, `project: "synth-permutations"` | `configs/logger/wandb.yaml:10,13` |
-| Run ID            | `null` (W&B auto-generates)                                      | `configs/logger/wandb.yaml:8`     |
-| Checkpoint upload | `log_model: true`                                                | `configs/logger/wandb.yaml:11`    |
-| Code saving       | `wandb.Settings(code_dir=".")`                                   | `configs/logger/wandb.yaml:17-19` |
-| Run teardown      | `wandb.finish()` in `task_wrapper` finally block                 | `src/utils/utils.py:102-107`      |
+| Concern           | How it works                                                                                                   | File                              |
+| ----------------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| W&B run creation  | `WandbLogger` instantiated by Hydra                                                                            | `configs/logger/wandb.yaml`       |
+| Entity / project  | Env-var driven: `entity: "${oc.env:WANDB_ENTITY,tinaudio}"`, `project: "${oc.env:WANDB_PROJECT,synth-setter}"` | `configs/logger/wandb.yaml:10,13` |
+| Run ID            | `null` (W&B auto-generates)                                                                                    | `configs/logger/wandb.yaml:8`     |
+| Checkpoint upload | `log_model: true`                                                                                              | `configs/logger/wandb.yaml:11`    |
+| Code saving       | `wandb.Settings(code_dir=".")`                                                                                 | `configs/logger/wandb.yaml:17-19` |
+| Run teardown      | `wandb.finish()` in `task_wrapper` finally block                                                               | `src/utils/utils.py:102-107`      |
 
-**No direct `wandb.init()` or `wandb.config.update()` calls exist in runtime code (`src/`, `scripts/`, entrypoints).**
+**No direct `wandb.init()` calls exist in runtime code.** One `wandb.config.update()` call exists: `log_wandb_provenance()` in `src/utils/logging_utils.py:91` writes provenance metadata (see [2g](#2g-provenance-metadata-logged-once-at-run-start)).
 
 ______________________________________________________________________
 
@@ -111,9 +111,22 @@ If `cfg.watch_gradients` is set, `watch_gradients()` calls
 `WandbLogger.watch(model, log="gradients")` — logs gradient histograms per
 layer according to the WandbLogger / W&B logging defaults.
 
-Source: `src/utils/utils.py:138-149`, called from `src/train.py:89-91`.
+Source: `src/utils/utils.py:138-149`, called from `src/train.py:91-93`.
 
-### 2f. Auto-Captured by W&B (not in our code)
+### 2g. Provenance metadata (logged once at run start)
+
+`log_wandb_provenance()` (`src/utils/logging_utils.py:64-98`) is called in both
+`src/train.py:89` and `src/eval.py:82`, after `log_hyperparameters()`.
+
+| Key          | Source               | Example                                     |
+| ------------ | -------------------- | ------------------------------------------- |
+| `github_sha` | `git rev-parse HEAD` | `3e60c47c6131...`                           |
+| `image_tag`  | `IMAGE_TAG` env var  | `dev-snapshot-abc123`                       |
+| `command`    | `sys.argv`           | `['src/train.py', 'experiment=surge/flow']` |
+
+Written via `wandb.config.update(..., allow_val_change=True)`.
+
+### 2h. Auto-Captured by W&B (not in our code)
 
 | What           | How                                            |
 | -------------- | ---------------------------------------------- |
@@ -135,10 +148,10 @@ ______________________________________________________________________
 
 ## 4. Entry Points
 
-| Entry point    | W&B usage                                                                          | File           |
-| -------------- | ---------------------------------------------------------------------------------- | -------------- |
-| `src/train.py` | Full: logger init → hparams → train metrics → test metrics → teardown              | `src/train.py` |
-| `src/eval.py`  | Full: logger init → hparams → test/val metrics (+ optional predictions) → teardown | `src/eval.py`  |
+| Entry point    | W&B usage                                                                                       | File           |
+| -------------- | ----------------------------------------------------------------------------------------------- | -------------- |
+| `src/train.py` | Full: logger init → hparams → provenance → train metrics → test metrics → teardown              | `src/train.py` |
+| `src/eval.py`  | Full: logger init → hparams → provenance → test/val metrics (+ optional predictions) → teardown | `src/eval.py`  |
 
 Both use `@task_wrapper` which ensures `wandb.finish()` runs even on exception.
 
@@ -146,13 +159,13 @@ ______________________________________________________________________
 
 ## 5. Known Gaps
 
-| #   | Gap                                                                                                                               | Impact                                                                                              | Tracking |
-| --- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------- |
-| 1   | **Entity/project hardcoded** to `benhayes`/`synth-permutations`                                                                   | Runs log to wrong account                                                                           | #133     |
-| 2   | **No `wandb.config` for env vars** — W&B captures `sys.argv` but not env vars like `TRAINING_ARGS`                                | Config passed via env vars is silently missing from W&B                                             | #252     |
-| 3   | **No `github_sha` in `wandb.config`** — design docs require it but it's not implemented                                           | Can't reliably link a run to the exact code that produced it (W&B auto-capture is best-effort)      | —        |
-| 4   | **No GitHub issue integration** — train job doesn't post run ID back to GitHub                                                    | Manual lookup to match runs to issues                                                               | #263     |
-| 5   | **`log_model: true` vs `"all"`** — config uses `true` (uploads best + last only), design doc specifies `"all"` (every checkpoint) | Intermediate checkpoints not uploaded to W&B                                                        | —        |
-| 6   | **Visualization callbacks use `wandb.log()` directly** — bypasses Lightning logger abstraction                                    | Breaks if logger is swapped; step alignment relies on `trainer.global_step`                         | —        |
-| 7   | **`torch.compile` crashes test-stage `setup()`** — eval after training fails                                                      | Post-training test metrics never logged to W&B                                                      | #248     |
-| 8   | **No structured run ID convention** — `id: null` means W&B generates random IDs                                                   | Can't reconstruct run lineage from ID alone; design doc specifies `{config_id}-{timestamp}` pattern | —        |
+| #   | Gap                                                                                                                                                                                  | Impact                                                                                              | Tracking |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- | -------- |
+| 1   | ~~**Entity/project hardcoded** to `benhayes`/`synth-permutations`~~ **RESOLVED** — now env-var driven (`WANDB_ENTITY`/`WANDB_PROJECT`), defaults `tinaudio`/`synth-setter`           | ~~Runs log to wrong account~~                                                                       | #133     |
+| 2   | **No `wandb.config` for env vars** — W&B captures `sys.argv` but not env vars like `TRAINING_ARGS`. **Partially resolved:** `IMAGE_TAG` is now captured by `log_wandb_provenance()`. | Config passed via env vars is silently missing from W&B (except `IMAGE_TAG`)                        | #252     |
+| 3   | ~~**No `github_sha` in `wandb.config`**~~ **RESOLVED** — `log_wandb_provenance()` now logs `github_sha` via `git rev-parse HEAD`                                                     | ~~Can't reliably link a run to the exact code that produced it~~                                    | —        |
+| 4   | **No GitHub issue integration** — train job doesn't post run ID back to GitHub                                                                                                       | Manual lookup to match runs to issues                                                               | #263     |
+| 5   | **`log_model: true` vs `"all"`** — config uses `true` (uploads best + last only), design doc specifies `"all"` (every checkpoint)                                                    | Intermediate checkpoints not uploaded to W&B                                                        | —        |
+| 6   | **Visualization callbacks use `wandb.log()` directly** — bypasses Lightning logger abstraction                                                                                       | Breaks if logger is swapped; step alignment relies on `trainer.global_step`                         | —        |
+| 7   | **`torch.compile` crashes test-stage `setup()`** — eval after training fails                                                                                                         | Post-training test metrics never logged to W&B                                                      | #248     |
+| 8   | **No structured run ID convention** — `id: null` means W&B generates random IDs                                                                                                      | Can't reconstruct run lineage from ID alone; design doc specifies `{config_id}-{timestamp}` pattern | —        |


### PR DESCRIPTION
## Summary

- wandb-integration.md: Update entity/project from hardcoded to env-var driven, mark Known Gaps #1 and #3 as resolved, document log_wandb_provenance(), fix code version hash, update entry points
- storage-provenance-spec.md: R2 bucket synth-data -> intermediate-data, mark pipeline.cli as planned, update workflow table, add MVP status note

Refs [#392](https://github.com/tinaudio/synth-setter/issues/392)

## Findings Addressed

| ID | Type | Description |
|---|---|---|
| C-01/C-03 | stale-claim | entity/project hardcoded -> env-var |
| C-04 | stale-claim | Known Gap #3 resolved |
| C-05 | omission | log_wandb_provenance() undocumented |
| C-34 | stale-claim | Known Gap #2 partially resolved |
| C-35 | omission | Entry points missing provenance |
| C-39 | stale-claim | Code version hash stale |
| C-40 | stale-claim | "No wandb.config.update()" false |
| C-10 | incorrect-value | watch_gradients line numbers |
| B-07/B-27 | incorrect-value | R2 bucket rename |
| B-11 | stale-claim | pipeline.cli doesn't exist |
| B-12 | stale-claim | promote.yml doesn't exist |
| B-14/B-15 | stale-claim | Flat MVP vs target layout |
| B-28 | stale-claim | dataset-generation.yml not TBD |

## Test plan

- [ ] Verify wandb.yaml matches doc description
- [ ] Verify no synth-data in storage-provenance-spec.md
- [ ] Verify Known Gaps #1 and #3 marked resolved