### PR TITLE
fix(ci): narrow test.yml path filter and fix taxonomy hook regex

### DIFF
--- a/.claude/hooks/verify-gh-taxonomy.sh
+++ b/.claude/hooks/verify-gh-taxonomy.sh
@@ -315,7 +315,7 @@ if [ "$MODE" = "pr" ]; then
   # Fallback: check for any #N reference in the body (matches bare #N and
   # markdown hyperlinks like [#399](url)), same as pr-metadata-gate.yaml.
   if [ -z "$ISSUE_NUMS" ]; then
-    ISSUE_NUMS=$(echo "$PR_BODY" | grep -oE '#[0-9]+' | tr -d '#' || true)
+    ISSUE_NUMS=$(echo "$PR_BODY" | grep -oE '#[0-9]+' | tr -d '#' | sort -un | grep -v "^${PR_NUM}$" || true)
   fi
 
   if [ -z "$ISSUE_NUMS" ]; then

--- a/.claude/hooks/verify-gh-taxonomy.sh
+++ b/.claude/hooks/verify-gh-taxonomy.sh
@@ -312,6 +312,12 @@ if [ "$MODE" = "pr" ]; then
   PR_BODY=$(gh pr view "$PR_NUM" --repo "${OWNER}/${REPO}" --json body --jq '.body' 2>/dev/null || echo "")
   ISSUE_NUMS=$(echo "$PR_BODY" | grep -oE '(Fixes|Closes|Refs|fixes|closes|refs) #[0-9]+' | grep -oE '[0-9]+' || true)
 
+  # Fallback: check for any #N reference in the body (matches bare #N and
+  # markdown hyperlinks like [#399](url)), same as pr-metadata-gate.yaml.
+  if [ -z "$ISSUE_NUMS" ]; then
+    ISSUE_NUMS=$(echo "$PR_BODY" | grep -oE '#[0-9]+' | tr -d '#' || true)
+  fi
+
   if [ -z "$ISSUE_NUMS" ]; then
     echo '{"decision":"block","reason":"PR has no linked issue (Fixes #N / Closes #N / Refs #N). The pr-metadata-gate CI check will fail."}'
     exit 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,28 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
+    paths:
+      - "src/**"
+      - "pipeline/**"
+      - "tests/**"
+      - "configs/**"
+      - "scripts/**"
+      - "requirements*.txt"
+      - "pyproject.toml"
+      - "setup.py"
+      - ".github/workflows/test.yml"
   pull_request:
     branches: [main, "release/*", "dev"]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
+    paths:
+      - "src/**"
+      - "pipeline/**"
+      - "tests/**"
+      - "configs/**"
+      - "scripts/**"
+      - "requirements*.txt"
+      - "pyproject.toml"
+      - "setup.py"
+      - ".github/workflows/test.yml"
 
 jobs:
   run_tests_ubuntu:


### PR DESCRIPTION
## Summary

- Switch both `push` and `pull_request` triggers in `test.yml` from `paths-ignore` to explicit `paths` so only changes to `src/`, `pipeline/`, `tests/`, `configs/`, `scripts/`, `requirements*.txt`, `pyproject.toml`, `setup.py`, and the workflow itself trigger the test suite. Previously, changes to `docker/`, `notebooks/`, `jobs/`, `.github/` templates, and other non-test files would trigger unnecessary runs.
- Add fallback `#N` regex to `verify-gh-taxonomy.sh` so the hook recognizes issue references inside markdown hyperlinks like `Fixes [#399](url)`, matching the same pattern `pr-metadata-gate.yaml` uses.

Fixes [#399](https://github.com/tinaudio/synth-setter/issues/399)

## Test plan

- [ ] Open a docs-only PR (change only a `.md` file) → confirm Tests workflow does NOT trigger
- [ ] Open a code PR (change a `.py` file) → confirm Tests workflow DOES trigger
- [ ] Merge a PR to main with only doc changes → confirm Tests workflow does NOT trigger on push
- [ ] `workflow_dispatch` still available as manual override
- [ ] Create a PR with `Fixes [#N](url)` hyperlink format → confirm taxonomy hook does NOT block