### PR TITLE
refactor(docker): remove prod and dev-live Docker targets

### DIFF
--- a/.github/workflows/flush-investigation.yml
+++ b/.github/workflows/flush-investigation.yml
@@ -35,12 +35,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image (dev-live target)
+      - name: Build Docker image (dev-snapshot target)
         env:
           GIT_PAT: ${{ secrets.GIT_PAT }}
           DOCKER_BUILDKIT: "1"
         run: |
-          make docker-build-dev-live \
+          make docker-build-dev-snapshot \
             GIT_REF=${{ steps.meta.outputs.sha }} \
             GIT_PAT=${{ secrets.GIT_PAT }} \
             DOCKER_BUILD_FLAGS="--load"
@@ -55,7 +55,7 @@ jobs:
             -v "${{ github.workspace }}/notebooks:/workspace/notebooks" \
             -v "${{ github.workspace }}/reports:/reports" \
             -e SURGE_VST3_PATH="${SURGE_VST3_PATH}" \
-            synth-setter:dev-live \
+            synth-setter:dev-snapshot \
             -c "
               pip install -q jupyter nbconvert auraloss librosa &&
               cd /home/build/synth-setter &&

--- a/Makefile
+++ b/Makefile
@@ -53,15 +53,10 @@ train: ## Train the model
 # Docker targets
 # =====================================================================
 #
-# Two build modes:
-#   1. docker-build-dev-snapshot — self-contained image. Clones repo at GIT_REF,
-#                                  bakes source + deps + Surge XT + rclone/R2 config.
-#                                  Run it anywhere (CI, cloud, vast.ai).
-#
-#   2. docker-build-dev-live     — DEV image. Same base (Surge + deps + R2 config)
-#                                  but does NOT bake source code. Mount your local
-#                                  working tree at runtime with docker-run-dev.
-#                                  Rebuild only when deps or Surge version change.
+# Build mode:
+#   docker-build-dev-snapshot — self-contained image. Clones repo at GIT_REF,
+#                               bakes source + deps + Surge XT + rclone/R2 config.
+#                               Run it anywhere (CI, cloud, vast.ai).
 #
 # Required variables (pass on the command line):
 #   GIT_PAT             GitHub personal access token with repo read access.
@@ -118,22 +113,4 @@ docker-build-dev-snapshot: ## Build self-contained image (requires GIT_REF, GIT_
 		--label org.opencontainers.image.base.name=$(DOCKER_BASE_IMAGE) \
 		-t $(DOCKER_IMAGE):$(DOCKER_BASE_IMAGE_TAG)-dev-snapshot-$(GIT_REF) \
 		-t $(DOCKER_IMAGE):dev-snapshot \
-		.
-
-docker-build-dev-live: ## Build dev image (Surge + deps, no baked-in source)
-	DOCKER_BUILDKIT=1 docker buildx build \
-		-f $(DOCKER_FILE) \
-		$(_INTERNAL_BUILD_FLAGS) $(DOCKER_BUILD_FLAGS) \
-		--secret id=git_pat,env=GIT_PAT \
-		$(DOCKER_SECRETS) \
-		--platform $(DOCKER_TARGETPLATFORM) \
-		--build-arg IMAGE="dev-live" \
-		--build-arg BUILD_MODE=$(DOCKER_BUILD_MODE) \
-		--build-arg BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
-		--build-arg SYNTH_PERMUTATIONS_GIT_REF=$(CURRENT_LOCAL_GIT_REF) \
-		--build-arg TARGETARCH=$(TARGETARCH) \
-		--build-arg TORCH_INDEX_URL=$(DOCKER_TORCH_IDX) \
-		--label org.opencontainers.image.base.name=$(DOCKER_BASE_IMAGE) \
-		-t $(DOCKER_IMAGE):$(DOCKER_BASE_IMAGE_TAG)-dev-live-$(CURRENT_LOCAL_GIT_REF) \
-		-t $(DOCKER_IMAGE):dev-live \
 		.

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -80,8 +80,8 @@ RUN case "${BUILD_MODE}" in \
       *) echo "ERROR: BUILD_MODE must be source or prebuilt (got '${BUILD_MODE}')" >&2; exit 1 ;; \
     esac
 RUN case "${IMAGE}" in \
-      "dev-snapshot" | "dev-live" | "prod") ;; \
-      *) echo "ERROR: IMAGE must be dev-snapshot, dev-live, or prod (got '${IMAGE}')" >&2; exit 1 ;; \
+      "dev-snapshot") ;; \
+      *) echo "ERROR: IMAGE must be dev-snapshot (got '${IMAGE}')" >&2; exit 1 ;; \
     esac
 RUN --mount=type=secret,id=git_pat \
     set -eu; \
@@ -412,46 +412,6 @@ RUN --mount=type=secret,id=wandb_api_key \
         chmod 600 /root/.netrc; \
         echo "W&B netrc config written." >&2; \
     fi
-
-# ==========================================
-# Dev target: Surge + Python deps pre-installed, no baked-in source code.
-# Contains baked R2 credentials — keep registry PRIVATE.
-# Usage: make docker-build-dev-live GIT_PAT=<token> && make docker-run-dev
-# TODO: consider a lighter dev base without Surge for faster builds when VST is not needed.
-# ==========================================
-FROM r2-config-base AS dev-live
-# No COPY of entrypoint — it comes from the runtime mount in docker-run-dev.
-# Bake a fallback that prints a helpful error if run without a mount.
-RUN printf '#!/bin/bash\necho "ERROR: dev-live requires a volume mount at /home/build/synth-setter" >&2\nexit 1\n' \
-      > /usr/local/bin/entrypoint-fallback.sh && \
-    chmod +x /usr/local/bin/entrypoint-fallback.sh
-ENTRYPOINT ["/usr/local/bin/entrypoint-fallback.sh"]
-CMD []
-
-# ==========================================
-# prod: full self-contained image — deps + baked-in source at SYNTH_PERMUTATIONS_GIT_REF.
-# Contains baked R2 credentials — keep registry PRIVATE.
-# ==========================================
-# TODO: Add linting.
-FROM r2-config-base AS prod
-
-ARG SYNTH_PERMUTATIONS_GIT_REF
-ENV SYNTH_PERMUTATIONS_GIT_REF=${SYNTH_PERMUTATIONS_GIT_REF}
-
-# Copy full source (after deps for caching)
-COPY --from=synth-setter-src /home/build/synth-setter /home/build/synth-setter
-
-# Install the project package so `import src` works from any working directory.
-# --no-deps: all runtime deps already installed from requirements*.txt wheels.
-RUN pip install --no-deps -e .
-
-# Run not-slow unit tests (mocked subprocess + LocalFakeUploader — no VST or R2 needed)
-RUN pytest -k "not slow" -v
-
-COPY scripts/docker_entrypoint.sh /usr/local/bin/entrypoint.sh
-RUN chmod +x /usr/local/bin/entrypoint.sh
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
-CMD []
 
 # ==========================================
 # dev-snapshot: deps + live git clone at SYNTH_PERMUTATIONS_GIT_REF.


### PR DESCRIPTION
## Summary

- Remove `prod` and `dev-live` stages from `docker/ubuntu22_04/Dockerfile`
- Remove `docker-build-dev-live` target from Makefile
- Update IMAGE validation to only accept `dev-snapshot`
- Update `flush-investigation.yml` workflow from `dev-live` to `dev-snapshot`

Fixes [#415](https://github.com/tinaudio/synth-setter/issues/415)

## Test plan

- [ ] Verify `make docker-build-dev-snapshot` still works (no changes to that target)
- [ ] Verify no remaining `dev-live` or `prod` Docker target references in non-doc code
- [ ] Verify Dockerfile builds successfully with only `dev-snapshot` target