### PR TITLE
fix(ci): align taxonomy hook issue-ref fallback with CI gate

### DIFF
--- a/.claude/hooks/verify-gh-taxonomy.sh
+++ b/.claude/hooks/verify-gh-taxonomy.sh
@@ -312,6 +312,12 @@ if [ "$MODE" = "pr" ]; then
   PR_BODY=$(gh pr view "$PR_NUM" --repo "${OWNER}/${REPO}" --json body --jq '.body' 2>/dev/null || echo "")
   ISSUE_NUMS=$(echo "$PR_BODY" | grep -oE '(Fixes|Closes|Refs|fixes|closes|refs) #[0-9]+' | grep -oE '[0-9]+' || true)
 
+  # Fallback: check for any #N reference in the body (matches bare #N and
+  # markdown hyperlinks like [#399](url)), same as pr-metadata-gate.yaml.
+  if [ -z "$ISSUE_NUMS" ]; then
+    ISSUE_NUMS=$(echo "$PR_BODY" | grep -oE '#[0-9]+' | tr -d '#' | sort -un | grep -v "^${PR_NUM}$" || true)
+  fi
+
   if [ -z "$ISSUE_NUMS" ]; then
     echo '{"decision":"block","reason":"PR has no linked issue (Fixes #N / Closes #N / Refs #N). The pr-metadata-gate CI check will fail."}'
     exit 0

--- a/.claude/hooks/verify-gh-taxonomy.sh
+++ b/.claude/hooks/verify-gh-taxonomy.sh
@@ -310,7 +310,7 @@ if [ "$MODE" = "pr" ]; then
   # Step 2: Check the PR body for issue references (Fixes/Closes/Refs #N).
   # Without a linked issue, the pr-metadata-gate CI workflow will fail.
   PR_BODY=$(gh pr view "$PR_NUM" --repo "${OWNER}/${REPO}" --json body --jq '.body' 2>/dev/null || echo "")
-  ISSUE_NUMS=$(echo "$PR_BODY" | grep -oE '(Fixes|Closes|Refs|fixes|closes|refs) #[0-9]+' | grep -oE '[0-9]+' || true)
+  ISSUE_NUMS=$(echo "$PR_BODY" | grep -oE '(Fixes|Closes|Refs|fixes|closes|refs) #[0-9]+' | grep -oE '[0-9]+' | sort -un | grep -v "^${PR_NUM}$" || true)
 
   # Fallback: check for any #N reference in the body (matches bare #N and
   # markdown hyperlinks like [#399](url)), same as pr-metadata-gate.yaml.
@@ -319,7 +319,7 @@ if [ "$MODE" = "pr" ]; then
   fi
 
   if [ -z "$ISSUE_NUMS" ]; then
-    echo '{"decision":"block","reason":"PR has no linked issue (Fixes #N / Closes #N / Refs #N). The pr-metadata-gate CI check will fail."}'
+    echo '{"decision":"block","reason":"PR has no linked issue reference. Acceptable patterns include Fixes #N / Closes #N / Refs #N or any bare #N reference in the PR body. The pr-metadata-gate CI check will fail."}'
     exit 0
   fi
 


### PR DESCRIPTION
## Summary
- Adds fallback `#N` regex to `verify-gh-taxonomy.sh` so the local hook accepts bare issue references and markdown hyperlinks, matching `pr-metadata-gate.yaml` behavior
- Without this, the hook blocks PRs that would pass CI

Fixes [#418](https://github.com/tinaudio/synth-setter/issues/418)