### PR TITLE
chore(ci): replace pip with uv in all CI workflows

### DIFF
--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -20,10 +20,11 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+        run: uv pip install --system -r requirements.txt
 
       - name: Run pre-commits
         uses: pre-commit/action@v3.0.1

--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -23,10 +23,11 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
+        run: uv pip install --system -r requirements.txt
 
       - name: Find changed files
         id: changed_files

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -52,8 +52,11 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Install config dependencies
-        run: pip install pyyaml pydantic
+        run: uv pip install --system pyyaml pydantic
 
       - name: Load image config
         id: config

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,14 +20,15 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install sh -r requirements-torch.txt -r requirements-app.txt -e .
+          uv pip install --system sh -r requirements-torch.txt -r requirements-app.txt -e .
 
       - name: List dependencies
-        run: |
-          python -m pip list
+        run: uv pip list --system
 
       - name: Run full test suite
         env:

--- a/.github/workflows/test-expensive.yml
+++ b/.github/workflows/test-expensive.yml
@@ -22,19 +22,20 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Install dependencies
         # GitHub GPU runner ships NVIDIA driver 12080 (CUDA 12.8).
-        # torch >=2.7.0 requires CUDA 13.x — cap it via PIP_CONSTRAINT
+        # torch >=2.7.0 requires CUDA 13.x — cap it via --constraint
         # so CI stays compatible without changing requirements-torch.txt.
         run: |
-          python -m pip install --upgrade pip
           echo 'torch<2.7.0' > /tmp/torch-constraint.txt
-          PIP_CONSTRAINT=/tmp/torch-constraint.txt pip install -r requirements.txt
-          pip install sh
+          uv pip install --system --constraint /tmp/torch-constraint.txt -r requirements.txt
+          uv pip install --system sh
 
       - name: List dependencies
-        run: |
-          python -m pip list
+        run: uv pip list --system
 
       - name: Run GPU tests
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,15 +48,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install sh
+          uv pip install --system -r requirements.txt
+          uv pip install --system sh
 
       - name: List dependencies
-        run: |
-          python -m pip list
+        run: uv pip list --system
 
       - name: Cache MNIST dataset
         uses: actions/cache@v4
@@ -90,15 +91,16 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install sh
+          uv pip install --system -r requirements.txt
+          uv pip install --system sh
 
       - name: List dependencies
-        run: |
-          python -m pip list
+        run: uv pip list --system
 
       - name: Cache MNIST dataset
         uses: actions/cache@v4
@@ -124,12 +126,14 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-          pip install pytest-cov[toml]
-          pip install sh
+          uv pip install --system -r requirements.txt
+          uv pip install --system pytest-cov[toml]
+          uv pip install --system sh
 
       - name: Cache MNIST dataset
         uses: actions/cache@v4


### PR DESCRIPTION
## Summary

- Replace `pip install` with `uv pip install --system` in all CI workflows
- Add `astral-sh/setup-uv@v6` action (handles uv install + caching)
- Drop-in replacement: same requirements files, same packages, 10-50x faster installs

**Workflows changed:**
- `code-quality-pr.yaml` — pre-commit linting on PRs
- `code-quality-main.yaml` — pre-commit linting on main
- `test.yml` — 3 jobs (ubuntu, macos, code-coverage)
- `test-expensive.yml` — GPU tests (switched `PIP_CONSTRAINT` env var → `--constraint` flag)
- `nightly.yml` — full test suite
- `docker-build-validation.yml` — config loading deps

**Not changed:** `flush-investigation.yml` — pip runs inside a Docker container there (Task 5.2 scope)

**Measured impact on code-quality workflow:**
- Before (pip): Install dependencies = 4m 11s
- After (uv): Install uv + Install dependencies = 40s (6.3x faster)

Refs #423