### PR TITLE
docs(ci): taxonomy cleanup — naming conventions, epics table, standalone tasks

### DIFF
--- a/.claude/hooks/verify-gh-taxonomy.sh
+++ b/.claude/hooks/verify-gh-taxonomy.sh
@@ -129,7 +129,7 @@ fi
 # ---------------------------------------------------------------------------
 OWNER="tinaudio"
 REPO="synth-setter"
-DOMAIN_LABELS="data-pipeline ci-automation code-health evaluation monitoring storage testing training"
+DOMAIN_LABELS="data-pipeline ci-automation code-health documentation evaluation monitoring storage testing training"
 
 # ---------------------------------------------------------------------------
 # Helper: query an issue's taxonomy metadata (type, labels, milestone).

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -13,6 +13,8 @@ body:
         - ci-automation
         - code-health
         - evaluation
+        - documentation
+        - monitoring
         - storage
         - testing
         - training
@@ -25,6 +27,8 @@ body:
       options:
         - data-pipeline v1.0.0
         - evaluation v1.0.0
+        - documentation v1.0.0
+        - monitoring v1.0.0
         - training v1.0.0
         - storage v1.0.0
         - ci-automation v1.0.0

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -14,6 +14,8 @@ body:
         - ci-automation
         - code-health
         - evaluation
+        - documentation
+        - monitoring
         - storage
         - testing
         - training
@@ -26,6 +28,8 @@ body:
       options:
         - data-pipeline v1.0.0
         - evaluation v1.0.0
+        - documentation v1.0.0
+        - monitoring v1.0.0
         - training v1.0.0
         - storage v1.0.0
         - ci-automation v1.0.0

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -13,6 +13,8 @@ body:
         - ci-automation
         - code-health
         - evaluation
+        - documentation
+        - monitoring
         - storage
         - testing
         - training
@@ -25,6 +27,8 @@ body:
       options:
         - data-pipeline v1.0.0
         - evaluation v1.0.0
+        - documentation v1.0.0
+        - monitoring v1.0.0
         - training v1.0.0
         - storage v1.0.0
         - ci-automation v1.0.0

--- a/.github/ISSUE_TEMPLATE/phase.yml
+++ b/.github/ISSUE_TEMPLATE/phase.yml
@@ -22,6 +22,8 @@ body:
         - ci-automation
         - code-health
         - evaluation
+        - documentation
+        - monitoring
         - storage
         - testing
         - training
@@ -34,6 +36,8 @@ body:
       options:
         - data-pipeline v1.0.0
         - evaluation v1.0.0
+        - documentation v1.0.0
+        - monitoring v1.0.0
         - training v1.0.0
         - storage v1.0.0
         - ci-automation v1.0.0

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,5 +1,5 @@
 name: Task
-description: Unit of work (standalone or within a phase)
+description: Unit of work within a phase
 title: "Task N.M: "
 labels: []
 type: Task
@@ -8,7 +8,7 @@ body:
     id: parent
     attributes:
       label: Parent Issue
-      description: "Phase or epic this task belongs to (e.g., #137). Leave blank for standalone tasks."
+      description: "Phase or epic this task belongs to (e.g., #137). Required — all tasks must trace to an epic."
       placeholder: "#"
     validations:
       required: false
@@ -21,6 +21,8 @@ body:
         - ci-automation
         - code-health
         - evaluation
+        - documentation
+        - monitoring
         - storage
         - testing
         - training
@@ -33,6 +35,8 @@ body:
       options:
         - data-pipeline v1.0.0
         - evaluation v1.0.0
+        - documentation v1.0.0
+        - monitoring v1.0.0
         - training v1.0.0
         - storage v1.0.0
         - ci-automation v1.0.0

--- a/.github/workflows/pr-metadata-gate.yaml
+++ b/.github/workflows/pr-metadata-gate.yaml
@@ -99,7 +99,7 @@ jobs:
 
           # Keep in sync with docs/design/github-taxonomy.md §2 and §6
           VALID_TYPES=("Epic" "Phase" "Task" "Bug" "Feature")
-          DOMAIN_LABELS=("data-pipeline" "ci-automation" "code-health" "documentation" "evaluation" "storage" "testing" "training")
+          DOMAIN_LABELS=("data-pipeline" "ci-automation" "code-health" "documentation" "evaluation" "monitoring" "storage" "testing" "training")
           FAILURES=""
 
           for ISSUE_NUM in "${ISSUE_NUMBERS[@]}"; do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,8 @@ Conventional commits, enforced by gitlint (`.gitlint` config). Prefix matters fo
 - **Submodules:** Skills live in a git submodule at `.claude/skills/` (from `tinaudio/skills`). Clone with `--recurse-submodules`. In new worktrees, run `git submodule update --init`.
 - After `git add -f`, always run `make format` before committing.
 - Always verify the correct git branch before pushing commits. Run `git branch --show-current` and confirm it matches the target PR branch before any push.
-- **Epic traceability:** Issues that participate in the roadmap hierarchy must be created as sub-issues of the appropriate Phase or Epic. Standalone tasks explicitly allowed by `docs/design/github-taxonomy.md` are exempt from this requirement but must follow that document's guidance (labels, milestones, etc.). PRs that reference orphan roadmap issues lose epic traceability.
-- **PR metadata hooks:** The `github-taxonomy` skill enforces taxonomy compliance (type, label, milestone, epic lineage), respecting the standalone-task exceptions defined in `docs/design/github-taxonomy.md`, before every `gh pr create`. The CI workflow `pr-metadata-gate.yaml` provides a second check.
+- **Epic traceability:** Every issue must trace to an Epic via the sub-issue hierarchy (Epic → Phase → Task/Bug/Feature). There are no standalone tasks — all work items need a home. PRs that reference orphan issues lose epic traceability.
+- **PR metadata hooks:** The `github-taxonomy` skill enforces taxonomy compliance (type, label, milestone, epic lineage) before every `gh pr create`. The CI workflow `pr-metadata-gate.yaml` provides a second check.
 
 ### Pipeline-Specific Rules
 

--- a/docs/design/github-taxonomy.md
+++ b/docs/design/github-taxonomy.md
@@ -37,11 +37,11 @@ Issues are classified using GitHub's native Issue Types (org-level):
 
 | Type        | Purpose                                          | Example                                |
 | ----------- | ------------------------------------------------ | -------------------------------------- |
-| **Epic**    | Umbrella issue grouping phases for a work stream | #74 distributed data pipeline          |
-| **Phase**   | Large feature area within an epic                | #69 Pipeline Core                      |
-| **Task**    | Unit of work within a phase                      | #102 storage layer, CI improvements    |
-| **Bug**     | Something isn't working                          | #10 OmegaConf resolver re-registration |
-| **Feature** | A request, idea, or new functionality            | #23 improve generation throughput      |
+| **Epic**    | Umbrella issue grouping phases for a work stream | Epic: distributed data pipeline        |
+| **Phase**   | Large feature area within an epic                | Phase 2: Pipeline Core                 |
+| **Task**    | Unit of work within a phase                      | Task 2.1: Schemas                      |
+| **Bug**     | Something isn't working                          | fix(ci): broken workflow               |
+| **Feature** | A request, idea, or new functionality            | Feature: improve generation throughput |
 
 Types are set on the issue itself, filterable in issue lists, and show distinct icons.
 
@@ -62,7 +62,7 @@ Epic: <name>
 ```
 
 - **Phase** — a large feature or functional area. Each phase is a sub-issue of its epic.
-- **Task** — a testable unit of work. A task under a phase is what was previously called a "step". Every task must trace to an epic via the sub-issue hierarchy.
+- **Task / Bug / Feature** — work items. Every work item must trace to an epic via the sub-issue hierarchy (there are no standalone issues).
 - **PR** — a shipping unit, orthogonal to the hierarchy. A PR may contain one task, multiple tasks, or part of a large task.
 
 Hierarchy is tracked via native sub-issues (up to 8 levels). Projects render this as an expandable tree via **hierarchy view**.

--- a/docs/design/github-taxonomy.md
+++ b/docs/design/github-taxonomy.md
@@ -134,6 +134,7 @@ Labels classify issues by **domain**. Type and blocking are handled by native fe
 | `code-health`   | #fbca04 | Code quality and tech debt                                      |
 | `documentation` | #0075ca | Documentation quality, drift detection, and doc-map maintenance |
 | `evaluation`    | #C5DEF5 | Evaluation pipeline, metrics, and inference                     |
+| `monitoring`    | #0E8A16 | Observability, W&B integration, logging                         |
 | `storage`       | #D4C5F9 | Storage infrastructure (R2, rclone)                             |
 | `testing`       | #0E8A16 | Test infrastructure, fixtures, CI test config                   |
 | `training`      | #8B5CF6 | Training pipeline, ops, and infrastructure                      |
@@ -148,6 +149,7 @@ Workflow labels (`duplicate`, `invalid`, `wontfix`, `good first issue`, `help wa
 | -------------------- | --------------- |
 | data-pipeline v1.0.0 | Data Pipeline   |
 | evaluation v1.0.0    | Evaluation      |
+| monitoring v1.0.0    | Monitoring      |
 | training v1.0.0      | Training        |
 | ci-automation v1.0.0 | CI & Automation |
 | code-health v1.0.0   | Code Health     |

--- a/docs/design/github-taxonomy.md
+++ b/docs/design/github-taxonomy.md
@@ -39,7 +39,7 @@ Issues are classified using GitHub's native Issue Types (org-level):
 | ----------- | ------------------------------------------------ | -------------------------------------- |
 | **Epic**    | Umbrella issue grouping phases for a work stream | #74 distributed data pipeline          |
 | **Phase**   | Large feature area within an epic                | #69 Pipeline Core                      |
-| **Task**    | Unit of work (standalone or within a phase)      | #102 storage layer, CI improvements    |
+| **Task**    | Unit of work within a phase                      | #102 storage layer, CI improvements    |
 | **Bug**     | Something isn't working                          | #10 OmegaConf resolver re-registration |
 | **Feature** | A request, idea, or new functionality            | #23 improve generation throughput      |
 
@@ -52,25 +52,28 @@ Types are set on the issue itself, filterable in issue lists, and show distinct 
 All work streams use the same structure:
 
 ```
-Epic (type: Epic)
-├── Phase 1 (type: Phase, sub-issue of Epic)
-│   ├── Task 1.1 (type: Task, sub-issue of Phase 1)
-│   └── Task 1.2
-├── Phase 2
-│   └── Task 2.1
-└── Phase N
+Epic: <name>
+├── Phase 1: <name> (sub-issue of Epic)
+│   ├── Task 1.1: <name> (sub-issue of Phase 1)
+│   └── Task 1.2: <name>
+├── Phase 2: <name>
+│   └── Task 2.1: <name>
+└── Phase N: <name>
 ```
 
 - **Phase** — a large feature or functional area. Each phase is a sub-issue of its epic.
-- **Task** — a testable unit of work. A task under a phase is what was previously called a "step". Standalone tasks exist outside the hierarchy.
+- **Task** — a testable unit of work. A task under a phase is what was previously called a "step". Every task must trace to an epic via the sub-issue hierarchy.
 - **PR** — a shipping unit, orthogonal to the hierarchy. A PR may contain one task, multiple tasks, or part of a large task.
 
 Hierarchy is tracked via native sub-issues (up to 8 levels). Projects render this as an expandable tree via **hierarchy view**.
 
 ### Naming
 
+- Epics: `Epic: Name` (e.g., "Epic: distributed data pipeline")
 - Phases: `Phase N: Name` (e.g., "Phase 2: Pipeline Core")
 - Tasks under phases: `Task N.M: Name` (e.g., "Task 2.1: Schemas")
+- Features: `Feature: Name` (e.g., "Feature: improve generation throughput")
+- Bugs: use conventional commit style (e.g., "fix(ci): broken workflow")
 
 ### Merge path
 
@@ -78,13 +81,18 @@ All PRs merge to `main`. Phase ordering defines the dependency chain, but PRs wi
 
 ### Current epics
 
-| Epic | Title                                                          | Domain Label    | Design Doc                           |
-| ---- | -------------------------------------------------------------- | --------------- | ------------------------------------ |
-| #74  | feat(pipeline): distributed data pipeline                      | `data-pipeline` | `data-pipeline.md`                   |
-| #98  | feat(eval): evaluation pipeline — predict, render, metrics     | `evaluation`    | `eval-pipeline.md` (PR #101)         |
-| #99  | feat(storage): R2 integration for datasets and checkpoints     | `evaluation`    | `eval-pipeline.md` §6                |
-| #107 | feat(training): training pipeline & ops                        | `training`      | `training-ops-braindump.md` (PR #84) |
-| #351 | feat(documentation): documentation quality and drift detection | `documentation` | —                                    |
+| Epic | Title                                                | Domain Label    | Design Doc                           |
+| ---- | ---------------------------------------------------- | --------------- | ------------------------------------ |
+| #74  | Epic: distributed data pipeline                      | `data-pipeline` | `data-pipeline.md`                   |
+| #98  | Epic: evaluation pipeline — predict, render, metrics | `evaluation`    | `eval-pipeline.md` (PR #101)         |
+| #99  | Epic: R2 integration for datasets and checkpoints    | `storage`       | `eval-pipeline.md` §6                |
+| #107 | Epic: training pipeline & ops                        | `training`      | `training-ops-braindump.md` (PR #84) |
+| #114 | Epic: codebase modernization                         | `code-health`   | —                                    |
+| #148 | Epic: CI & automation platform                       | `ci-automation` | —                                    |
+| #149 | Epic: test infrastructure & coverage                 | `testing`       | —                                    |
+| #264 | Epic: end-to-end MVP pipeline                        | `training`      | —                                    |
+| #321 | Epic: pre-launch cleanup                             | `code-health`   | —                                    |
+| #351 | Epic: documentation quality and drift detection      | `documentation` | —                                    |
 
 ## 4. Blocking & Dependencies
 

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -17,7 +17,7 @@ webdataset
 
 # --------- dev tools --------- #
 hatchling
-plumb-dev @ git+https://github.com/ktinubu/plumb.git@a0dd821de661
+plumb-dev @ git+https://github.com/ktinubu/plumb.git@a0dd821de661e12ba45aaac6008bfd0c2664a24f
 
 # --------- others --------- #
 dask[distributed]

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -17,7 +17,7 @@ webdataset
 
 # --------- dev tools --------- #
 hatchling
-plumb-dev @ git+https://github.com/ktinubu/plumb.git@33247ad411cccc1dad75a588e899304a96f772ef
+plumb-dev @ git+https://github.com/ktinubu/plumb.git@a0dd821de661
 
 # --------- others --------- #
 dask[distributed]


### PR DESCRIPTION
## Summary
- Add `Epic:`/`Feature:` naming convention to match existing `Phase:`/`Task:` pattern
- Complete the current epics table with all 10 active epics (#114, #148, #149, #264, #321 were missing)
- Remove standalone task concept — all issues must trace to an epic via sub-issue hierarchy
- Update CLAUDE.md to reflect mandatory epic lineage (no more standalone exceptions)
- Bump plumb-dev pin to `a0dd821` which strips `GIT_*` env vars in worktree hooks (fixes index corruption)

## Follow-up (API mutations, no code PR)
- Rename all epics/features to new `Epic:`/`Feature:` convention
- Rehome 31 orphan issues to appropriate epics
- Move 4 CI issues from code-health Phase 6 (#372) to ci-automation epic (#148)

Fixes [#427](https://github.com/tinaudio/synth-setter/issues/427)