### PR TITLE
chore(ci): enable uv caching and migrate remaining pip references

### DIFF
--- a/.github/workflows/code-quality-main.yaml
+++ b/.github/workflows/code-quality-main.yaml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: uv pip install --system -r requirements.txt

--- a/.github/workflows/code-quality-pr.yaml
+++ b/.github/workflows/code-quality-pr.yaml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: uv pip install --system -r requirements.txt

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Install config dependencies
         run: uv pip install --system pyyaml pydantic

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-expensive.yml
+++ b/.github/workflows/test-expensive.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         # GitHub GPU runner ships NVIDIA driver 12080 (CUDA 12.8).

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |
@@ -93,6 +95,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |
@@ -128,6 +132,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,13 @@ test-bats: ## Run BATS shell tests
 	bats --recursive tests/
 
 install: ## Install project in editable mode with dev deps
+	pip install uv
 	uv pip install -r requirements.txt -e .
 
 # coverage runs serially (no -n auto): GPU tests require exclusive device
 # access and VRAM contention causes flaky failures with xdist parallelism.
 coverage: ## Run tests with coverage report
+	pip install uv
 	uv pip install pytest-cov[toml]
 	pytest --cov=src --cov-report=term-missing --cov-report=html -m "not slow"
 

--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ test-bats: ## Run BATS shell tests
 	bats --recursive tests/
 
 install: ## Install project in editable mode with dev deps
-	pip install -r requirements.txt -e .
+	uv pip install -r requirements.txt -e .
 
 # coverage runs serially (no -n auto): GPU tests require exclusive device
 # access and VRAM contention causes flaky failures with xdist parallelism.
 coverage: ## Run tests with coverage report
-	pip install pytest-cov[toml]
+	uv pip install pytest-cov[toml]
 	pytest --cov=src --cov-report=term-missing --cov-report=html -m "not slow"
 
 benchmark: ## Run performance benchmarks

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Lightning with Hydra configs.
 
 ```bash
 # Install dependencies
-pip install -r requirements.txt
+uv pip install -r requirements.txt
 
 # Run tests
 make test

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Lightning with Hydra configs.
 ## Quick Start
 
 ```bash
+# Install uv (https://docs.astral.sh/uv/getting-started/installation/)
 # Install dependencies
 uv pip install -r requirements.txt
 

--- a/docs/design/data-pipeline-implementation-plan.md
+++ b/docs/design/data-pipeline-implementation-plan.md
@@ -159,7 +159,7 @@ ______________________________________________________________________
 - `pyproject.toml` — added `pipeline` pytest marker
 - `checkmake.ini` (new)
 
-**Verification:** `pip install -r requirements.txt && ruff check . && pytest tests/ -x`
+**Verification:** `uv pip install -r requirements.txt && ruff check . && pytest tests/ -x`
 
 **Design notes:**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Backward-compatible umbrella requirements file.
 # Docker/CI can install these files separately for tighter control and better caching:
-#   pip install -r requirements-torch.txt
-#   pip install -r requirements-app.txt
+#   uv pip install -r requirements-torch.txt
+#   uv pip install -r requirements-app.txt
 -r requirements-torch.txt
 -r requirements-app.txt


### PR DESCRIPTION
## Summary

- Enable `enable-cache: true` on all 8 `astral-sh/setup-uv@v6` steps across 6 CI workflows for warm-cache speedups
- Migrate Makefile `install` and `coverage` targets from `pip` to `uv pip`
- Update docs (README, requirements.txt comments, design doc) to reference `uv pip install`

## Files changed

**CI workflows** (caching):
- `.github/workflows/test.yml` (3 steps)
- `.github/workflows/code-quality-pr.yaml`
- `.github/workflows/code-quality-main.yaml`
- `.github/workflows/nightly.yml`
- `.github/workflows/test-expensive.yml`
- `.github/workflows/docker-build-validation.yml`

**Local dev**:
- `Makefile` — `install` and `coverage` targets

**Docs**:
- `README.md` — quick-start command
- `requirements.txt` — comments
- `docs/design/data-pipeline-implementation-plan.md` — verification step

Closes #423