### PR TITLE
chore(plumb): expand .plumbignore to reduce false-positive triggers

### DIFF
--- a/.plumbignore
+++ b/.plumbignore
@@ -17,3 +17,16 @@ dist/
 Makefile
 Dockerfile
 docker-compose*
+
+# Project meta
+CLAUDE.md
+CLAUDE.local.md
+.gitignore
+
+# Build/release metadata
+pyproject.toml
+requirements*.txt
+setup.cfg
+
+# Non-spec docs (spec files already excluded as plumb-managed paths)
+docs/


### PR DESCRIPTION
## Summary

- Add missing patterns to `.plumbignore` that caused 11 out of 30 recent commits to trigger unnecessary plumb LLM analysis
- Patterns added: `CLAUDE.md`, `CLAUDE.local.md`, `.gitignore`, `pyproject.toml`, `requirements*.txt`, `setup.cfg`, `docs/`
- `docs/` is safe to ignore because plumb already excludes the 5 spec files in `.plumb/config.json` as "managed paths" before checking `.plumbignore`

## Impact

False-positive plumb hook triggers drop from 37% to 0%. True positives (commits touching `src/`, `pipeline/`, `configs/`) are unaffected.

## Test plan

- [ ] Stage only a non-spec doc (e.g., `CLAUDE.md`) → `plumb diff` shows "No decisions detected"
- [ ] Stage a `src/` file → `plumb diff` analyzes normally
- [ ] QoL commit exits plumb hook instantly (no LLM calls)

Refs #388