### PR TITLE
chore: rewrite .env.example with complete variable inventory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,9 +32,15 @@ RCLONE_CONFIG_R2_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com
 
 # Required for W&B to resolve R2 artifact references via S3 protocol
 # (without this, W&B attempts to resolve against AWS S3)
-AWS_ENDPOINT_URL=https://your-account-id.r2.cloudflarestorage.com
-# Alternative: WANDB_S3_ENDPOINT_URL (same value, W&B-specific)
-# WANDB_S3_ENDPOINT_URL=https://your-account-id.r2.cloudflarestorage.com
+#
+# Prefer the W&B-specific endpoint override:
+WANDB_S3_ENDPOINT_URL=https://your-account-id.r2.cloudflarestorage.com
+#
+# WARNING: AWS_ENDPOINT_URL is a global AWS SDK override that redirects ALL
+# AWS SDK calls (boto3, AWS CLI, etc.) in the current shell — not just W&B.
+# Only set it if you are sure no other AWS interactions run in this environment.
+# If you need it, scope it to a subshell:  (export AWS_ENDPOINT_URL=...; your-command)
+# AWS_ENDPOINT_URL=https://your-account-id.r2.cloudflarestorage.com
 
 # =============================================================================
 # Weights & Biases (experiment tracking)
@@ -85,6 +91,24 @@ DOCKERHUB_TOKEN=your-dockerhub-access-token
 # DOCKER_TARGETPLATFORM=linux/amd64
 # DOCKER_TORCH_IDX=https://download.pytorch.org/whl/cu128
 # DOCKER_BUILD_FLAGS=
+
+# =============================================================================
+# Optional: alternative loggers (template-provided, not actively used)
+# =============================================================================
+# These configs ship with the lightning-hydra-template. The project uses W&B
+# (above). Only set these if you switch to an alternative logger config.
+
+# Comet ML (configs/logger/comet.yaml)
+# COMET_API_TOKEN=your-comet-api-token
+
+# Neptune AI (configs/logger/neptune.yaml)
+# NEPTUNE_API_TOKEN=your-neptune-api-token
+
+# =============================================================================
+# Paths (auto-set by rootutils — do NOT add to .env)
+# =============================================================================
+# PROJECT_ROOT is set automatically by rootutils.setup_root() in src/train.py
+# and src/eval.py. It does not need to be in .env. See configs/paths/default.yaml.
 
 # =============================================================================
 # Pipeline / container runtime (set inside Docker containers)

--- a/.env.example
+++ b/.env.example
@@ -66,12 +66,13 @@ WANDB_PROJECT=synth-setter
 GIT_PAT=your-github-pat
 
 # =============================================================================
-# RunPod (GPU cloud compute)
+# RunPod (GPU cloud compute) — planned, not yet used in code
 # =============================================================================
-# Used by: pipeline orchestration, worker submission
+# Listed here for completeness; the RunPod backend is planned (#71) but not yet
+# implemented. No code paths currently read this variable.
 
 # RunPod API key (from runpod.io dashboard)
-RUNPOD_API_KEY=your-runpod-api-key
+# RUNPOD_API_KEY=your-runpod-api-key
 
 # =============================================================================
 # Docker Hub (container registry)

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,96 @@
-# example of file for storing private and user specific environment variables, like keys or system paths
-# rename it to ".env" (excluded from version control by default)
-# .env is loaded by train.py automatically
-# hydra allows you to reference variables in .yaml configs with special syntax: ${oc.env:MY_VAR}
+# =============================================================================
+# .env.example — Environment variables for synth-setter
+# =============================================================================
+# Copy to .env and fill in your values. Never commit .env (it's in .gitignore).
+# Hydra configs can reference these via: ${oc.env:VAR_NAME}
 
-MY_VAR="/home/user/my/system/path"
+# =============================================================================
+# Cloudflare R2 (S3-compatible object storage)
+# =============================================================================
+# Used by: Docker builds (BuildKit secrets), rclone, pipeline entrypoints
+
+# R2 access credentials (from Cloudflare R2 dashboard → Manage R2 API Tokens)
+R2_ACCESS_KEY_ID=your-r2-access-key-id
+R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
+
+# R2 endpoint URL (Cloudflare account-specific)
+R2_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com
+
+# R2 bucket name (used as build-arg and in pipeline.constants)
+R2_BUCKET=your-bucket-name
+
+# Rclone-style R2 env vars (used by rclone when no rclone.conf is present)
+RCLONE_CONFIG_R2_ACCESS_KEY_ID=your-r2-access-key-id
+RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
+RCLONE_CONFIG_R2_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com
+
+# Required for W&B to resolve R2 artifact references via S3 protocol
+# (without this, W&B attempts to resolve against AWS S3)
+AWS_ENDPOINT_URL=https://your-account-id.r2.cloudflarestorage.com
+# Alternative: WANDB_S3_ENDPOINT_URL (same value, W&B-specific)
+
+# =============================================================================
+# Weights & Biases (experiment tracking)
+# =============================================================================
+# Used by: training, evaluation, promotion, Docker builds
+
+# W&B API key (from wandb.ai/settings)
+WANDB_API_KEY=your-wandb-api-key
+
+# W&B entity and project (defaults in configs/logger/wandb.yaml)
+WANDB_ENTITY=tinaudio
+WANDB_PROJECT=synth-setter
+
+# Local directory for W&B run data (used by prediction jobs)
+# WANDB_DIR=/path/to/wandb/runs
+
+# =============================================================================
+# GitHub
+# =============================================================================
+# Used by: Docker builds (source tarball fetch), CI workflows, promotion
+
+# Personal access token with repo read access (for docker-build-dev-snapshot)
+GIT_PAT=ghp_your-github-pat
+
+# =============================================================================
+# RunPod (GPU cloud compute)
+# =============================================================================
+# Used by: pipeline orchestration, worker submission
+
+# RunPod API key (from runpod.io dashboard)
+RUNPOD_API_KEY=your-runpod-api-key
+
+# =============================================================================
+# Docker Hub (container registry)
+# =============================================================================
+# Used by: CI workflows for image push/pull authentication
+
+DOCKERHUB_USERNAME=your-dockerhub-username
+DOCKERHUB_TOKEN=your-dockerhub-access-token
+
+# =============================================================================
+# Docker build overrides (optional — defaults defined in Makefile)
+# =============================================================================
+
+# DOCKER_FILE=docker/ubuntu22_04/Dockerfile
+# DOCKER_IMAGE=synth-setter
+# DOCKER_BUILD_MODE=prebuilt
+# DOCKER_TARGETPLATFORM=linux/amd64
+# DOCKER_TORCH_IDX=https://download.pytorch.org/whl/cu128
+# DOCKER_BUILD_FLAGS=
+
+# =============================================================================
+# Pipeline / container runtime (set inside Docker containers)
+# =============================================================================
+
+# Container dispatch mode: idle, passthrough, or generate_dataset
+# MODE=generate_dataset
+
+# Path to dataset config YAML (required for MODE=generate_dataset)
+# DATASET_CONFIG=configs/dataset/ci-smoke-test.yaml
+
+# Directory where input_spec.json is written (default: /run-metadata)
+# RUN_METADATA_DIR=/run-metadata
+
+# Docker image tag — captured by log_wandb_provenance() for experiment tracking
+# IMAGE_TAG=dev-snapshot-abc1234

--- a/.env.example
+++ b/.env.example
@@ -17,9 +17,15 @@ R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
 R2_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com
 
 # R2 bucket name (used as build-arg and in pipeline.constants)
-R2_BUCKET=your-bucket-name
+# NOTE: The pipeline currently reads the bucket from pipeline.constants.R2_BUCKET,
+#       which is hardcoded to "intermediate-data". To change the bucket used by
+#       the pipeline, update pipeline/constants.py (and related docs/YAML) in
+#       addition to this environment variable.
+R2_BUCKET=intermediate-data
 
 # Rclone-style R2 env vars (used by rclone when no rclone.conf is present)
+RCLONE_CONFIG_R2_TYPE=s3
+RCLONE_CONFIG_R2_PROVIDER=Cloudflare
 RCLONE_CONFIG_R2_ACCESS_KEY_ID=your-r2-access-key-id
 RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
 RCLONE_CONFIG_R2_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com
@@ -28,6 +34,7 @@ RCLONE_CONFIG_R2_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com
 # (without this, W&B attempts to resolve against AWS S3)
 AWS_ENDPOINT_URL=https://your-account-id.r2.cloudflarestorage.com
 # Alternative: WANDB_S3_ENDPOINT_URL (same value, W&B-specific)
+# WANDB_S3_ENDPOINT_URL=https://your-account-id.r2.cloudflarestorage.com
 
 # =============================================================================
 # Weights & Biases (experiment tracking)
@@ -50,7 +57,7 @@ WANDB_PROJECT=synth-setter
 # Used by: Docker builds (source tarball fetch), CI workflows, promotion
 
 # Personal access token with repo read access (for docker-build-dev-snapshot)
-GIT_PAT=ghp_your-github-pat
+GIT_PAT=your-github-pat
 
 # =============================================================================
 # RunPod (GPU cloud compute)


### PR DESCRIPTION
## Summary
- Rewrite .env.example with all environment variables used across the project
- Organize by service: R2 (Cloudflare), W&B, GitHub, RunPod, Docker Hub, Docker build overrides, pipeline/container runtime
- Add comments explaining each variable's purpose and where credentials come from
- Include rclone-style R2 vars and AWS_ENDPOINT_URL for W&B artifact resolution

Closes #82