### PR TITLE
fix(ci): validate GITHUB_OUTPUT values against newline injection

### DIFF
--- a/pipeline/ci/load_image_config.py
+++ b/pipeline/ci/load_image_config.py
@@ -29,7 +29,13 @@ def main() -> None:
 
     try:
         for field_name, value in cfg.model_dump().items():
-            dest.write(f"{field_name}={value}\n")
+            str_value = str(value)
+            if "\n" in str_value or "\r" in str_value:
+                raise ValueError(
+                    f"GITHUB_OUTPUT value for '{field_name}' contains a newline character; "
+                    "this would inject extra output keys"
+                )
+            dest.write(f"{field_name}={str_value}\n")
     finally:
         if dest is not sys.stdout:
             dest.close()

--- a/pipeline/ci/load_image_config.py
+++ b/pipeline/ci/load_image_config.py
@@ -32,8 +32,8 @@ def main() -> None:
             str_value = str(value)
             if "\n" in str_value or "\r" in str_value:
                 raise ValueError(
-                    f"GITHUB_OUTPUT value for '{field_name}' contains a newline character; "
-                    "this would inject extra output keys"
+                    f"GITHUB_OUTPUT value for '{field_name}' contains a newline or carriage-return"
+                    " character; this would inject extra output keys"
                 )
             dest.write(f"{field_name}={str_value}\n")
     finally:

--- a/tests/pipeline/test_ci/test_load_image_config.py
+++ b/tests/pipeline/test_ci/test_load_image_config.py
@@ -238,7 +238,7 @@ class TestMainInvalidSha:
 
 
 class TestNewlineInjection:
-    """Main() rejects config values that contain newlines."""
+    """Main() rejects config values that contain newlines or carriage returns."""
 
     def test_main_rejects_value_with_newline(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -272,7 +272,7 @@ r2_bucket: test-bucket
             ],
         )
 
-        with pytest.raises(ValueError, match="contains a newline"):
+        with pytest.raises(ValueError, match="contains a newline or carriage-return"):
             main()
 
     def test_main_rejects_value_with_carriage_return(
@@ -307,7 +307,7 @@ r2_bucket: test-bucket
             ],
         )
 
-        with pytest.raises(ValueError, match="contains a newline"):
+        with pytest.raises(ValueError, match="contains a newline or carriage-return"):
             main()
 
 

--- a/tests/pipeline/test_ci/test_load_image_config.py
+++ b/tests/pipeline/test_ci/test_load_image_config.py
@@ -233,6 +233,85 @@ class TestMainInvalidSha:
 
 
 # ---------------------------------------------------------------------------
+# main — newline injection prevention
+# ---------------------------------------------------------------------------
+
+
+class TestNewlineInjection:
+    """Main() rejects config values that contain newlines."""
+
+    def test_main_rejects_value_with_newline(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A config value containing a newline raises ValueError."""
+        yaml_with_newline = """\
+dockerfile: docker/ubuntu22_04/Dockerfile
+image: "tinaudio/perm\\nevil_key=evil_value"
+base_image: "ubuntu@sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751"
+base_image_tag: ubuntu22_04
+build_mode: prebuilt
+target_platform: linux/amd64
+torch_index_url: "https://download.pytorch.org/whl/cu128"
+r2_endpoint: "https://example.r2.cloudflarestorage.com"
+r2_bucket: test-bucket
+"""
+        config_path = tmp_path / "dev-snapshot.yaml"
+        config_path.write_text(yaml_with_newline)
+        output_file = tmp_path / "github_output.txt"
+
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+        _set_argv(
+            monkeypatch,
+            [
+                "--config",
+                str(config_path),
+                "--github-sha",
+                VALID_SHA,
+                "--issue-number",
+                VALID_ISSUE,
+            ],
+        )
+
+        with pytest.raises(ValueError, match="contains a newline"):
+            main()
+
+    def test_main_rejects_value_with_carriage_return(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A config value containing a carriage return raises ValueError."""
+        yaml_with_cr = """\
+dockerfile: docker/ubuntu22_04/Dockerfile
+image: "tinaudio/perm\\revil_key=evil_value"
+base_image: "ubuntu@sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146afb8c525a9751"
+base_image_tag: ubuntu22_04
+build_mode: prebuilt
+target_platform: linux/amd64
+torch_index_url: "https://download.pytorch.org/whl/cu128"
+r2_endpoint: "https://example.r2.cloudflarestorage.com"
+r2_bucket: test-bucket
+"""
+        config_path = tmp_path / "dev-snapshot.yaml"
+        config_path.write_text(yaml_with_cr)
+        output_file = tmp_path / "github_output.txt"
+
+        monkeypatch.setenv("GITHUB_OUTPUT", str(output_file))
+        _set_argv(
+            monkeypatch,
+            [
+                "--config",
+                str(config_path),
+                "--github-sha",
+                VALID_SHA,
+                "--issue-number",
+                VALID_ISSUE,
+            ],
+        )
+
+        with pytest.raises(ValueError, match="contains a newline"):
+            main()
+
+
+# ---------------------------------------------------------------------------
 # module invocability
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add newline and carriage-return validation to GITHUB_OUTPUT writes in `load_image_config.py`
- Raises `ValueError` with a descriptive message if any config value contains `\n` or `\r`, preventing key injection via newline characters
- Adds two tests covering newline and carriage-return injection attempts

Fixes #333