### PR TITLE
chore: switch skills submodule URL from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".claude/skills"]
 	path = .claude/skills
-	url = git@github.com:tinaudio/skills.git
+	url = https://github.com/tinaudio/skills.git


### PR DESCRIPTION
## Summary
- Change .gitmodules skills submodule URL from SSH to HTTPS
- Required for public access without SSH key configuration

Closes #454