### PR TITLE
docs: add CITATION.cff for project citation metadata

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,7 @@ authors:
   - family-names: Tinubu
     given-names: Khaled
     alias: ktinubu
+    affiliation: Google
 repository-code: https://github.com/tinaudio/synth-setter
 license: MIT
 keywords:
@@ -32,6 +33,7 @@ preferred-citation:
       affiliation: Queen Mary University of London
     - family-names: Tinubu
       given-names: Khaled
+      affiliation: Google
   year: 2025
   conference:
     name: "ISMIR 2025"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,38 +3,7 @@ title: synth-setter
 message: "If you use this software, please cite it as below."
 type: software
 authors:
-  - family-names: Hayes
-    given-names: Ben
-    email: b.j.hayes@qmul.ac.uk
-    affiliation: Queen Mary University of London
-  - family-names: Tinubu
-    given-names: Khaled
-    alias: ktinubu
-    affiliation: Google
+  - given-names: Khaled
+    family-names: Tinubu
+license: GPL-3.0-only
 repository-code: https://github.com/tinaudio/synth-setter
-license: MIT
-keywords:
-  - synthesizer
-  - sound-matching
-  - machine-learning
-  - audio
-  - vst
-abstract: >-
-  synth-setter provides tools for automatic synthesizer parameter estimation
-  (synth inversion), sound matching, and preset exploration. Built on PyTorch
-  Lightning with Hydra configs, it includes flow matching models for parameter
-  estimation and a distributed data pipeline for VST audio dataset generation.
-preferred-citation:
-  type: conference-paper
-  title: "synth-setter: Synth Inversion, Sound Matching and Preset Exploration"
-  authors:
-    - family-names: Hayes
-      given-names: Ben
-      affiliation: Queen Mary University of London
-    - family-names: Tinubu
-      given-names: Khaled
-      affiliation: Google
-  year: 2025
-  conference:
-    name: "ISMIR 2025"
-  url: https://benhayes.net/synth-perm/

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,38 @@
+cff-version: 1.2.0
+title: synth-setter
+message: "If you use this software, please cite it as below."
+type: software
+authors:
+  - family-names: Hayes
+    given-names: Ben
+    email: b.j.hayes@qmul.ac.uk
+    affiliation: Queen Mary University of London
+  - family-names: Tinubu
+    given-names: Khaled
+    alias: ktinubu
+repository-code: https://github.com/tinaudio/synth-setter
+license: MIT
+keywords:
+  - synthesizer
+  - sound-matching
+  - machine-learning
+  - audio
+  - vst
+abstract: >-
+  synth-setter provides tools for automatic synthesizer parameter estimation
+  (synth inversion), sound matching, and preset exploration. Built on PyTorch
+  Lightning with Hydra configs, it includes flow matching models for parameter
+  estimation and a distributed data pipeline for VST audio dataset generation.
+preferred-citation:
+  type: conference-paper
+  title: "synth-setter: Synth Inversion, Sound Matching and Preset Exploration"
+  authors:
+    - family-names: Hayes
+      given-names: Ben
+      affiliation: Queen Mary University of London
+    - family-names: Tinubu
+      given-names: Khaled
+  year: 2025
+  conference:
+    name: "ISMIR 2025"
+  url: https://benhayes.net/synth-perm/


### PR DESCRIPTION
## Summary
- Add `CITATION.cff` with project citation metadata following the Citation File Format standard
- Lists Ben Hayes and Khaled Tinubu as authors with appropriate affiliations
- Includes ISMIR 2025 preferred-citation reference
- Enables GitHub's "Cite this repository" sidebar feature

Closes #456