### PR TITLE
docs: expand README with badges, install guide, and project overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ pipeline/      Distributed data pipeline
   schemas/     Pydantic models (config, spec, prefix, image_config)
   entrypoints/ Pipeline entry points
   ci/          CI validation scripts
-  stages/      Generate and finalize stage logic
-  backends/    Compute providers (local, RunPod)
 configs/       Hydra YAML configs and pipeline configs
 scripts/       Standalone scripts
 tests/         Test suite (mirrors src/ and pipeline/ structure)

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ pip install -r requirements.txt
 ### Using conda
 
 ```bash
-conda env create -f environment.yaml
+conda env create -f environment.yaml  # creates the "myenv" environment by default
+conda activate myenv
 ```
 
 ### Editable install

--- a/README.md
+++ b/README.md
@@ -75,10 +75,11 @@ make install
 
 ### GPU vs CPU
 
-The default installation installs CPU-only PyTorch. For GPU training, install
-PyTorch with CUDA wheels for your system -- see the
-[PyTorch install matrix](https://pytorch.org/get-started/locally/) for the
-correct command.
+This project depends on PyTorch (`torch>=2.0.0`), but the requirements do not fix
+whether you use a CPU-only build or a CUDA-enabled build. Choose and install the
+appropriate PyTorch package for your system (CPU-only or a specific CUDA version)
+using the [PyTorch install matrix](https://pytorch.org/get-started/locally/), then
+install the remaining dependencies as described above.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,120 @@
 <div align="center">
 <h1>synth-setter</h1>
-<p>Synth inversion, sound matching, and preset exploration tools.</p>
+<p>Synthesizer parameter prediction, sound matching, and preset exploration tools.</p>
+<p>
+  <a href="https://github.com/tinaudio/synth-setter/actions/workflows/test.yml"><img src="https://github.com/tinaudio/synth-setter/actions/workflows/test.yml/badge.svg" alt="CI"></a>
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/github/license/tinaudio/synth-setter" alt="License"></a>
+</p>
 </div>
 
 ## Overview
 
 synth-setter provides tools for automatic synthesizer parameter estimation
-(synth inversion), sound matching, and preset exploration. Built on PyTorch
-Lightning with Hydra configs.
+(synth inversion), sound matching, and preset exploration. Given an audio
+recording of a synthesizer sound, models predict the parameters that reproduce
+it. Built on PyTorch Lightning with Hydra configs.
 
-## Key Features
+## Features
 
 - **Flow matching models** for synthesizer parameter estimation
 - **Distributed data pipeline** for VST audio dataset generation (RunPod + Cloudflare R2)
 - **W&B integration** for experiment tracking and model checkpointing
 - **Docker support** for reproducible training and generation environments
+- **Hydra configs** for flexible experiment management
+
+## Prerequisites
+
+- **Python 3.10+**
+- **uv** (recommended) -- [install uv](https://docs.astral.sh/uv/getting-started/installation/)
+- **Git** with submodule support (clone with `--recurse-submodules`)
+- **System dependencies for VST rendering** -- see [getting started guide](docs/getting-started.md) for details
+
+## Installation
+
+Clone the repository:
+
+```bash
+git clone --recurse-submodules https://github.com/tinaudio/synth-setter.git
+cd synth-setter
+```
+
+### Using uv (recommended)
+
+```bash
+uv pip install -r requirements.txt
+```
+
+### Using pip
+
+```bash
+pip install -r requirements.txt
+```
+
+### Using conda
+
+```bash
+conda env create -f environment.yaml
+```
+
+### Editable install
+
+```bash
+make install
+```
+
+### GPU vs CPU
+
+The default installation installs CPU-only PyTorch. For GPU training, install
+PyTorch with CUDA wheels for your system -- see the
+[PyTorch install matrix](https://pytorch.org/get-started/locally/) for the
+correct command.
 
 ## Quick Start
 
 ```bash
-# Install uv (https://docs.astral.sh/uv/getting-started/installation/)
-# Install dependencies
-uv pip install -r requirements.txt
-
 # Run tests
 make test
 
-# Run all pre-commit hooks
+# Run all pre-commit hooks (formatting + linting)
 make format
 
 # See all available targets
 make help
 ```
 
+See the [getting started guide](docs/getting-started.md) for a full walkthrough.
+
 ## Project Structure
 
 ```
 src/           ML code (models, data modules, training, evaluation)
 pipeline/      Distributed data pipeline
-scripts/       Standalone scripts
+  schemas/     Pydantic models (config, spec, prefix, image_config)
+  entrypoints/ Pipeline entry points
+  ci/          CI validation scripts
+  stages/      Generate and finalize stage logic
+  backends/    Compute providers (local, RunPod)
 configs/       Hydra YAML configs and pipeline configs
-tests/         Test suite
+scripts/       Standalone scripts
+tests/         Test suite (mirrors src/ and pipeline/ structure)
 docs/design/   Design documents
+```
+
+## Key Files
+
+```
+src/models/components/transformer.py       DiT and AST implementations
+src/models/components/residual_mlp.py      Residual MLP implementations
+src/models/components/cnn.py               CNN encoder implementations
+src/models/components/vae.py               VAE+RealNVP baseline implementation
+src/models/*_module.py                     LightningModule implementations
+src/data/vst/*                             Dataset generation
+src/data/vst/surge_xt_param_spec.py        Surge XT dataset sampling distributions
+src/data/ot.py                             Optimal transport minibatch coupling
+src/data/kosc_datamodule.py                k-osc task data module
+configs/experiment/kosc                    k-osc experiment configs
+configs/experiment/surge                   Surge XT experiment configs
 ```
 
 ## Publication
@@ -50,23 +123,14 @@ This repository accompanies a submission to ISMIR 2025. An online supplement wit
 audio examples is available at
 [benhayes.net/synth-perm/](https://benhayes.net/synth-perm/).
 
-## Key Files
-
-```
-src/models/components/transformer.py       <- DiT and AST implementations
-src/models/components/residual_mlp.py      <- Residual MLP implementations
-src/models/components/cnn.py               <- CNN encoder implementations
-src/models/components/vae.py               <- VAE+RealNVP baseline implementation
-src/models/*_module.py                     <- LightningModule implementations, containing training logic
-src/data/vst/*                             <- Dataset generation
-src/data/vst/surge_xt_param_spec.py        <- Specification of Surge XT dataset sampling distributions
-src/data/ot.py                             <- Optimal transport minibatch coupling
-src/data/kosc_datamodule.py                <- Implementation of k-osc task
-configs/experiment/kosc                    <- k-osc experiment configs
-configs/experiment/surge                   <- Surge XT experiment configs
-```
-
 ## Documentation
 
-- Design docs live in `docs/design/`
-- See `make help` for available commands
+- [Getting started guide](docs/getting-started.md)
+- [Design documents](docs/design/)
+- [Contributing](CONTRIBUTING.md)
+- Run `make help` for available commands
+
+## License
+
+This project is licensed under the MIT License -- see [LICENSE](LICENSE) for
+details.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 <p>
   <a href="https://github.com/tinaudio/synth-setter/actions/workflows/test.yml"><img src="https://github.com/tinaudio/synth-setter/actions/workflows/test.yml/badge.svg" alt="CI"></a>
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10%2B-blue" alt="Python 3.10+"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/github/license/tinaudio/synth-setter" alt="License"></a>
 </p>
 </div>
 
@@ -28,7 +27,7 @@ it. Built on PyTorch Lightning with Hydra configs.
 - **Python 3.10+**
 - **uv** (recommended) -- [install uv](https://docs.astral.sh/uv/getting-started/installation/)
 - **Git** with submodule support (clone with `--recurse-submodules`)
-- **System dependencies for VST rendering** -- see [getting started guide](docs/getting-started.md) for details
+- **System dependencies for VST rendering** -- see the project documentation for details
 
 ## Installation
 
@@ -38,6 +37,16 @@ Clone the repository:
 git clone --recurse-submodules https://github.com/tinaudio/synth-setter.git
 cd synth-setter
 ```
+
+> **Note on submodules**
+>
+> This repository uses Git submodules that are configured with SSH URLs (`git@github.com:...`).
+> If you clone via HTTPS as above and do not have SSH access set up, submodule fetching may fail.
+> You can either configure an SSH key with GitHub, or ask Git to rewrite SSH URLs to HTTPS:
+>
+> ```bash
+> git config --global url."https://github.com/".insteadOf git@github.com:
+> ```
 
 ### Using uv (recommended)
 
@@ -83,7 +92,7 @@ make format
 make help
 ```
 
-See the [getting started guide](docs/getting-started.md) for a full walkthrough.
+See the project documentation for a full walkthrough.
 
 ## Project Structure
 
@@ -125,12 +134,11 @@ audio examples is available at
 
 ## Documentation
 
-- [Getting started guide](docs/getting-started.md)
+- Getting started guide (coming soon)
 - [Design documents](docs/design/)
-- [Contributing](CONTRIBUTING.md)
+- Contributing guidelines (coming soon)
 - Run `make help` for available commands
 
 ## License
 
-This project is licensed under the MIT License -- see [LICENSE](LICENSE) for
-details.
+License information will be added soon. See the repository for updates.

--- a/README.md
+++ b/README.md
@@ -124,18 +124,22 @@ configs/experiment/kosc                    k-osc experiment configs
 configs/experiment/surge                   Surge XT experiment configs
 ```
 
-## Publication
-
-This repository accompanies a submission to ISMIR 2025. An online supplement with
-audio examples is available at
-[benhayes.net/synth-perm/](https://benhayes.net/synth-perm/).
-
 ## Documentation
 
 - Getting started guide (coming soon)
 - [Design documents](docs/design/)
 - Contributing guidelines (coming soon)
 - Run `make help` for available commands
+
+## Acknowledgments
+
+This project builds on prior work by Ben Hayes (Queen Mary University of London),
+whose research and generation infrastructure provided the foundation for the
+synthesizer parameter estimation pipeline. The accompanying paper is available at
+[benhayes.net/synth-perm](https://benhayes.net/synth-perm/).
+
+[Surge XT](https://surge-synthesizer.github.io/) is developed by the
+Surge Synth Team and is used in this project under the GPL-3.0 license.
 
 ## License
 


### PR DESCRIPTION
## Summary
- Expand README from ~73 lines to comprehensive project overview
- Add CI and Python badges, prerequisites, install options, project structure
- Link to CONTRIBUTING.md, getting-started guide, and design docs

Closes #460