### PR TITLE
security: add Docker Hub private visibility gate to CI

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -51,8 +51,22 @@ jobs:
 
           REPO_URL="https://hub.docker.com/v2/repositories/tinaudio/perm/"
 
-          # Fetch repository metadata; fail with a clear error if the API call fails.
-          RESPONSE=$(curl -sSf -u "${DH_USER}:${DH_TOKEN}" "$REPO_URL") || {
+          # Docker Hub v2 API requires JWT auth, not basic auth.
+          JWT=$(curl -sSf -H "Content-Type: application/json" \
+            -d "{\"username\":\"${DH_USER}\",\"password\":\"${DH_TOKEN}\"}" \
+            "https://hub.docker.com/v2/users/login/" \
+            | jq -r '.token // empty') || {
+            echo "::error::Failed to authenticate with Docker Hub. Check DOCKERHUB_USERNAME / DOCKERHUB_TOKEN secrets."
+            exit 1
+          }
+
+          if [ -z "$JWT" ]; then
+            echo "::error::Docker Hub login returned empty token. Check DOCKERHUB_USERNAME / DOCKERHUB_TOKEN secrets."
+            exit 1
+          fi
+
+          # Fetch repository metadata with JWT auth.
+          RESPONSE=$(curl -sSf -H "Authorization: JWT ${JWT}" "$REPO_URL") || {
             echo "::error::Failed to query Docker Hub API at ${REPO_URL} when checking repo visibility."
             exit 1
           }

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -51,22 +51,8 @@ jobs:
 
           REPO_URL="https://hub.docker.com/v2/repositories/tinaudio/perm/"
 
-          # Docker Hub v2 API requires JWT auth, not basic auth.
-          JWT=$(curl -sSf -H "Content-Type: application/json" \
-            -d "{\"username\":\"${DH_USER}\",\"password\":\"${DH_TOKEN}\"}" \
-            "https://hub.docker.com/v2/users/login/" \
-            | jq -r '.token // empty') || {
-            echo "::error::Failed to authenticate with Docker Hub. Check DOCKERHUB_USERNAME / DOCKERHUB_TOKEN secrets."
-            exit 1
-          }
-
-          if [ -z "$JWT" ]; then
-            echo "::error::Docker Hub login returned empty token. Check DOCKERHUB_USERNAME / DOCKERHUB_TOKEN secrets."
-            exit 1
-          fi
-
-          # Fetch repository metadata with JWT auth.
-          RESPONSE=$(curl -sSf -H "Authorization: JWT ${JWT}" "$REPO_URL") || {
+          # Docker Hub PATs authenticate as Bearer tokens against the Hub API.
+          RESPONSE=$(curl -sSf -H "Authorization: Bearer ${DH_TOKEN}" "$REPO_URL") || {
             echo "::error::Failed to query Docker Hub API at ${REPO_URL} when checking repo visibility."
             exit 1
           }

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -32,8 +32,33 @@ on:
       - "tests/docker/**"
 
 jobs:
+  visibility-check:
+    name: Verify Docker Hub repo is private
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Check tinaudio/perm visibility
+        env:
+          DH_USER: ${{ secrets.DOCKERHUB_USERNAME }}
+          DH_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          HTTP_CODE=$(curl -s -o /tmp/dh-repo.json -w '%{http_code}' \
+            -u "${DH_USER}:${DH_TOKEN}" \
+            "https://hub.docker.com/v2/repositories/tinaudio/perm/")
+          if [ "$HTTP_CODE" != "200" ]; then
+            echo "::error::Docker Hub API returned HTTP ${HTTP_CODE} for tinaudio/perm. Check DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets."
+            exit 1
+          fi
+          IS_PRIVATE=$(jq -r '.is_private' /tmp/dh-repo.json)
+          if [ "$IS_PRIVATE" != "true" ]; then
+            echo "::error::Docker Hub repository tinaudio/perm is NOT private (is_private=${IS_PRIVATE}). Dev-snapshot images contain baked-in R2 and W&B credentials. Set the repo to private immediately."
+            exit 1
+          fi
+          echo "Docker Hub repository tinaudio/perm is private."
+
   docker-build:
     name: Build and push Docker image
+    needs: visibility-check
     runs-on: ubuntu-latest-4core
     timeout-minutes: 60
 

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -42,14 +42,27 @@ jobs:
           DH_USER: ${{ secrets.DOCKERHUB_USERNAME }}
           DH_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
-          HTTP_CODE=$(curl -s -o /tmp/dh-repo.json -w '%{http_code}' \
-            -u "${DH_USER}:${DH_TOKEN}" \
-            "https://hub.docker.com/v2/repositories/tinaudio/perm/")
-          if [ "$HTTP_CODE" != "200" ]; then
-            echo "::error::Docker Hub API returned HTTP ${HTTP_CODE} for tinaudio/perm. Check DOCKERHUB_USERNAME and DOCKERHUB_TOKEN secrets."
+          set -euo pipefail
+
+          if [ -z "${DH_USER:-}" ] || [ -z "${DH_TOKEN:-}" ]; then
+            echo "::error::Docker Hub credentials (DOCKERHUB_USERNAME / DOCKERHUB_TOKEN) are not configured."
             exit 1
           fi
-          IS_PRIVATE=$(jq -r '.is_private' /tmp/dh-repo.json)
+
+          REPO_URL="https://hub.docker.com/v2/repositories/tinaudio/perm/"
+
+          # Fetch repository metadata; fail with a clear error if the API call fails.
+          RESPONSE=$(curl -sSf -u "${DH_USER}:${DH_TOKEN}" "$REPO_URL") || {
+            echo "::error::Failed to query Docker Hub API at ${REPO_URL} when checking repo visibility."
+            exit 1
+          }
+
+          # Parse is_private flag; fail explicitly if the response shape is unexpected.
+          IS_PRIVATE=$(printf '%s' "$RESPONSE" | jq -re '.is_private') || {
+            echo "::error::Failed to parse Docker Hub API response (missing or invalid .is_private field) when checking repo visibility."
+            exit 1
+          }
+
           if [ "$IS_PRIVATE" != "true" ]; then
             echo "::error::Docker Hub repository tinaudio/perm is NOT private (is_private=${IS_PRIVATE}). Dev-snapshot images contain baked-in R2 and W&B credentials. Set the repo to private immediately."
             exit 1

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -38,36 +38,25 @@ jobs:
     timeout-minutes: 2
     steps:
       - name: Check tinaudio/perm visibility
-        env:
-          DH_USER: ${{ secrets.DOCKERHUB_USERNAME }}
-          DH_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           set -euo pipefail
 
-          if [ -z "${DH_USER:-}" ] || [ -z "${DH_TOKEN:-}" ]; then
-            echo "::error::Docker Hub credentials (DOCKERHUB_USERNAME / DOCKERHUB_TOKEN) are not configured."
-            exit 1
-          fi
-
           REPO_URL="https://hub.docker.com/v2/repositories/tinaudio/perm/"
 
-          # Docker Hub PATs authenticate as Bearer tokens against the Hub API.
-          RESPONSE=$(curl -sSf -H "Authorization: Bearer ${DH_TOKEN}" "$REPO_URL") || {
-            echo "::error::Failed to query Docker Hub API at ${REPO_URL} when checking repo visibility."
-            exit 1
-          }
+          # Query WITHOUT credentials: if an anonymous user can see the repo,
+          # it's public and leaking baked-in secrets. A 404 means the repo is
+          # private (or doesn't exist — either way, not publicly exposed).
+          HTTP_CODE=$(curl -so /dev/null -w "%{http_code}" "$REPO_URL")
 
-          # Parse is_private flag; fail explicitly if the response shape is unexpected.
-          IS_PRIVATE=$(printf '%s' "$RESPONSE" | jq -re '.is_private') || {
-            echo "::error::Failed to parse Docker Hub API response (missing or invalid .is_private field) when checking repo visibility."
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "::error::Docker Hub repository tinaudio/perm is PUBLIC (HTTP 200). Dev-snapshot images contain baked-in R2 and W&B credentials. Set the repo to private immediately."
             exit 1
-          }
-
-          if [ "$IS_PRIVATE" != "true" ]; then
-            echo "::error::Docker Hub repository tinaudio/perm is NOT private (is_private=${IS_PRIVATE}). Dev-snapshot images contain baked-in R2 and W&B credentials. Set the repo to private immediately."
+          elif [ "$HTTP_CODE" = "404" ]; then
+            echo "Docker Hub repository tinaudio/perm is not publicly visible (HTTP 404)."
+          else
+            echo "::error::Unexpected HTTP ${HTTP_CODE} from Docker Hub API at ${REPO_URL}."
             exit 1
           fi
-          echo "Docker Hub repository tinaudio/perm is private."
 
   docker-build:
     name: Build and push Docker image

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -50,6 +50,14 @@ that persist in the final image:
 > `docker history`), but the resulting config files **are baked into the image**.
 > Push only to private registries. Rotate R2 tokens after each build campaign.
 
+> [!IMPORTANT]
+> **Invariant: The Docker Hub repository `tinaudio/perm` must remain private.**
+> Dev-snapshot images contain baked-in R2 and W&B credentials. If the repository
+> were public, anyone could pull the image and extract these secrets. CI enforces
+> this via a visibility check in the `docker-build-validation` workflow
+> ([docker-build-validation.yml](../../.github/workflows/docker-build-validation.yml))
+> that queries the Docker Hub API and fails the build if `is_private` is not `true`.
+
 The rclone reference doc is planned ([#310](https://github.com/tinaudio/synth-setter/issues/310)).
 
 ### First build (dev-snapshot)


### PR DESCRIPTION
## Summary
- Add `visibility-check` job to `docker-build-validation.yml` that queries the Docker Hub API and fails the build if `tinaudio/perm` is not set to private
- The `docker-build` job now depends on `visibility-check`, so no build or push proceeds if the repo is public
- Distinguishes API errors (bad credentials, HTTP failures) from actual public visibility for clear error messages
- Document the private-registry invariant in `docs/reference/docker.md`

Fixes #450