### PR TITLE
docs: add getting-started tutorial for new contributors

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,6 +31,16 @@ If you already cloned without `--recurse-submodules`, initialize the submodules:
 git submodule update --init
 ```
 
+> **Note on submodules:** This repository includes a git submodule whose URL is
+> SSH-based (`git@github.com:...`). If you clone via HTTPS and do not have SSH
+> keys configured, submodule checkout will fail. Work around this by telling Git
+> to rewrite SSH GitHub URLs to HTTPS:
+>
+> ```bash
+> git config url."https://github.com/".insteadOf git@github.com:
+> git submodule update --init --recursive
+> ```
+
 ### 2b. Create a virtual environment (recommended)
 
 ```bash
@@ -180,7 +190,21 @@ rclone config
 
 Follow the prompts to create a new remote named `r2` with provider
 `Cloudflare R2` (or `S3` with the R2 endpoint). Alternatively, set these
-environment variables in your `.env` file:
+environment variables in your `.env` file so rclone can auto-configure the `r2`
+remote:
+
+```
+RCLONE_CONFIG_R2_TYPE=s3
+RCLONE_CONFIG_R2_PROVIDER=Cloudflare
+RCLONE_CONFIG_R2_ACCESS_KEY_ID=<your-access-key>
+RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=<your-secret-key>
+RCLONE_CONFIG_R2_ENDPOINT=<your-r2-endpoint-url>
+```
+
+The Docker build uses a different set of variable names (`R2_ACCESS_KEY_ID`,
+`R2_SECRET_ACCESS_KEY`, etc.) which are passed as BuildKit secrets. Add these
+to `.env` as well if you plan to build Docker images (see
+[section 7](#7-docker-workflow)):
 
 ```
 R2_ACCESS_KEY_ID=<your-access-key>
@@ -328,16 +352,24 @@ rclone/R2 configuration.
 
 **Build the image:**
 
+The Makefile reads secrets from environment variables and passes them as
+BuildKit secrets (never embedded in image layers). Load your `.env` first to
+avoid leaking credentials in shell history or process listings:
+
 ```bash
+# Load secrets from .env into the current shell
+set -a
+source .env
+set +a
+
 make docker-build-dev-snapshot \
   GIT_REF=$(git rev-parse HEAD) \
-  GIT_PAT=<your-github-pat> \
-  R2_ACCESS_KEY_ID=<key> \
-  R2_SECRET_ACCESS_KEY=<secret> \
-  R2_ENDPOINT=<endpoint> \
-  R2_BUCKET=<bucket> \
   DOCKER_BUILD_FLAGS=--load
 ```
+
+The target expects `GIT_PAT`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`,
+`R2_ENDPOINT`, and `R2_BUCKET` to be set in the environment (all of which
+should be in your `.env` file -- see [section 4b](#4b-rclone--cloudflare-r2)).
 
 See `make help` for the full list of Docker-related variables and targets. The
 `GIT_REF` argument controls which commit is baked into the image (use a full

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,11 +86,12 @@ do not need any external datasets, VST plugins, or cloud storage.
 ### 3a. Train a model
 
 ```bash
-python src/train.py +experiment=kosc/ffn_mse trainer.max_epochs=5
+python src/train.py experiment=kosc/ffn_mse trainer.max_steps=5000
 ```
 
-This runs a feed-forward network with MSE loss on the k-osc task for 5 epochs.
-You should see Lightning's progress bar with decreasing loss values.
+This runs a feed-forward network with MSE loss on the k-osc task for 5,000
+training steps. You should see Lightning's progress bar with decreasing loss
+values.
 
 **What happens:**
 
@@ -104,19 +105,19 @@ You should see Lightning's progress bar with decreasing loss values.
 
 The `configs/experiment/kosc/` directory contains several variants:
 
-| Config | Description |
-| --- | --- |
-| `kosc/base` | Base config (used by other variants) |
-| `kosc/ffn_mse` | Feed-forward network, MSE loss |
-| `kosc/ffn_chamfer` | Feed-forward network, Chamfer loss |
-| `kosc/flow` | Flow matching model |
-| `kosc/flow_asym` | Flow matching, asymmetric |
-| `kosc/flowmlp` | Flow MLP variant |
+| Config             | Description                          |
+| ------------------ | ------------------------------------ |
+| `kosc/base`        | Base config (used by other variants) |
+| `kosc/ffn_mse`     | Feed-forward network, MSE loss       |
+| `kosc/ffn_chamfer` | Feed-forward network, Chamfer loss   |
+| `kosc/flow`        | Flow matching model                  |
+| `kosc/flow_asym`   | Flow matching, asymmetric            |
+| `kosc/flowmlp`     | Flow MLP variant                     |
 
 Run any of them with:
 
 ```bash
-python src/train.py +experiment=kosc/<variant>
+python src/train.py experiment=kosc/<variant>
 ```
 
 ______________________________________________________________________
@@ -136,8 +137,8 @@ programmatically driving this plugin.
 **Install:**
 
 1. Download the installer from [surge-synthesizer.github.io](https://surge-synthesizer.github.io/)
-1. Run the installer and follow the prompts
-1. Note the installation path (the test suite needs to find the plugin binary)
+2. Run the installer and follow the prompts
+3. Note the installation path (the test suite needs to find the plugin binary)
 
 **Verify:**
 
@@ -204,8 +205,8 @@ codebase.
 **Setup:**
 
 1. Create an account at [wandb.ai](https://wandb.ai/)
-1. Get your API key from [wandb.ai/authorize](https://wandb.ai/authorize)
-1. Log in:
+2. Get your API key from [wandb.ai/authorize](https://wandb.ai/authorize)
+3. Log in:
 
 ```bash
 wandb login
@@ -227,7 +228,7 @@ WANDB_PROJECT=synth-setter   # W&B project name
 To train **without W&B** (e.g., for local experimentation), override the logger:
 
 ```bash
-python src/train.py +experiment=kosc/ffn_mse logger=csv
+python src/train.py experiment=kosc/ffn_mse logger=csv
 ```
 
 This logs metrics to CSV files instead.
@@ -243,8 +244,8 @@ RunPod for local development or training.**
 If you are working on the data pipeline and need to run distributed generation:
 
 1. Create a RunPod account at [runpod.io](https://www.runpod.io/)
-1. Generate an API key from the RunPod dashboard
-1. Set the environment variable:
+2. Generate an API key from the RunPod dashboard
+3. Set the environment variable:
 
 ```
 RUNPOD_API_KEY=<your-api-key>
@@ -280,22 +281,22 @@ Override any config value from the command line:
 
 ```bash
 # Change batch size
-python src/train.py +experiment=kosc/ffn_mse data.batch_size=32
+python src/train.py experiment=kosc/ffn_mse data.batch_size=32
 
 # Change learning rate
-python src/train.py +experiment=kosc/ffn_mse model.lr=1e-4
+python src/train.py experiment=kosc/ffn_mse model.optimizer.lr=1e-4
 
 # Use CPU trainer instead of GPU
-python src/train.py +experiment=kosc/ffn_mse trainer=cpu
+python src/train.py experiment=kosc/ffn_mse trainer=cpu
 
 # Use TensorBoard logger instead of W&B
-python src/train.py +experiment=kosc/ffn_mse logger=tensorboard
+python src/train.py experiment=kosc/ffn_mse logger=tensorboard
 
-# Limit training epochs
-python src/train.py +experiment=kosc/ffn_mse trainer.max_epochs=10
+# Limit training steps
+python src/train.py experiment=kosc/ffn_mse trainer.max_steps=10000
 
 # Run in debug mode (1 batch per epoch, no logging)
-python src/train.py +experiment=kosc/ffn_mse debug=default
+python src/train.py experiment=kosc/ffn_mse debug=default
 ```
 
 For the full configuration reference, see
@@ -373,13 +374,13 @@ make format
 Reduce the batch size:
 
 ```bash
-python src/train.py +experiment=kosc/ffn_mse data.batch_size=8
+python src/train.py experiment=kosc/ffn_mse data.batch_size=8
 ```
 
 Or switch to CPU for debugging:
 
 ```bash
-python src/train.py +experiment=kosc/ffn_mse trainer=cpu
+python src/train.py experiment=kosc/ffn_mse trainer=cpu
 ```
 
 ### W&B login issues

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,18 +86,20 @@ do not need any external datasets, VST plugins, or cloud storage.
 ### 3a. Train a model
 
 ```bash
-python src/train.py experiment=kosc/ffn_mse trainer.max_steps=5000
+python src/train.py experiment=kosc/ffn_mse trainer.max_steps=5000 trainer.min_steps=null
 ```
 
 This runs a feed-forward network with MSE loss on the k-osc task for 5,000
-training steps. You should see Lightning's progress bar with decreasing loss
-values.
+training steps. The `trainer.min_steps=null` override is needed because the
+default trainer config sets `min_steps: 400_000`, which would otherwise prevent
+the run from stopping at 5,000 steps. You should see Lightning's progress bar
+with decreasing loss values.
 
 **What happens:**
 
 - Hydra composes the config from `configs/train.yaml` + the experiment override
 - Lightning sets up the data module, model, callbacks, and trainer
-- Checkpoints are saved under `logs/train/runs/<timestamp>/checkpoints/`
+- Checkpoints are saved under `logs/{task_name}/{experiment_name}/{run_name}-{timestamp}/checkpoints/` (for this command: `logs/train/kosc/ffn_mse-<timestamp>/checkpoints/`)
 - If W&B is configured (see [section 4c](#4c-weights--biases-wb)), metrics are
   logged to your dashboard
 
@@ -190,10 +192,10 @@ R2_BUCKET=<bucket-name>
 **Verify:**
 
 ```bash
-rclone ls r2:<bucket-name>/ --max-depth 1
+rclone lsd r2:<bucket-name>/
 ```
 
-You should see top-level directories like `data/` and `metadata/`.
+You should see top-level directories like `data/`, `train/`, and `eval/`.
 
 ### 4c. Weights & Biases (W&B)
 
@@ -306,18 +308,15 @@ ______________________________________________________________________
 
 ## 6. Evaluation
 
-After training, evaluate the model on the test set:
-
-```bash
-python src/eval.py
-```
-
-By default, evaluation uses the config and checkpoint from the most recent
-training run. You can point it at a specific checkpoint:
+After training, evaluate the model on the test set. You must provide the
+checkpoint path (`ckpt_path` is required):
 
 ```bash
 python src/eval.py ckpt_path=/path/to/checkpoint.ckpt
 ```
+
+Use the checkpoint saved during training (see the checkpoint path in
+[section 3a](#3a-train-a-model)).
 
 ______________________________________________________________________
 
@@ -336,7 +335,8 @@ make docker-build-dev-snapshot \
   R2_ACCESS_KEY_ID=<key> \
   R2_SECRET_ACCESS_KEY=<secret> \
   R2_ENDPOINT=<endpoint> \
-  R2_BUCKET=<bucket>
+  R2_BUCKET=<bucket> \
+  DOCKER_BUILD_FLAGS=--load
 ```
 
 See `make help` for the full list of Docker-related variables and targets. The

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -99,6 +99,13 @@ do not need any external datasets, VST plugins, or cloud storage.
 python src/train.py experiment=kosc/ffn_mse trainer.max_steps=5000 trainer.min_steps=null
 ```
 
+> **No CUDA GPU?** The default trainer is `gpu` (CUDA). On CPU-only machines use
+> `trainer=cpu`; on Apple Silicon use `trainer=mps`:
+>
+> ```bash
+> python src/train.py experiment=kosc/ffn_mse trainer=cpu trainer.max_steps=5000 trainer.min_steps=null
+> ```
+
 This runs a feed-forward network with MSE loss on the k-osc task for 5,000
 training steps. The `trainer.min_steps=null` override is needed because the
 default trainer config sets `min_steps: 400_000`, which would otherwise prevent
@@ -353,8 +360,13 @@ rclone/R2 configuration.
 **Build the image:**
 
 The Makefile reads secrets from environment variables and passes them as
-BuildKit secrets (never embedded in image layers). Load your `.env` first to
-avoid leaking credentials in shell history or process listings:
+BuildKit secrets. Load your `.env` first to avoid leaking credentials in shell
+history or process listings.
+
+> **Warning:** Although BuildKit secrets are not stored in build cache layers,
+> the Dockerfile writes some injected credentials (for example, R2 and W&B
+> config) into files that persist in the final image filesystem. Treat built
+> images as sensitive artifacts and do **not** push them to public registries.
 
 ```bash
 # Load secrets from .env into the current shell

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,414 @@
+# Getting Started
+
+This guide walks you through setting up synth-setter from scratch, running the
+test suite, training your first model, and configuring the external dependencies
+needed for the full data pipeline.
+
+______________________________________________________________________
+
+## 1. Prerequisites
+
+- **Python 3.10+** (check with `python --version`)
+- **Git** (with `--recurse-submodules` support)
+- **make** (ships with macOS/Linux; on Windows use WSL)
+- **A CUDA GPU** is recommended for training. CPU and MPS (Apple Silicon) trainers
+  are available but significantly slower.
+
+______________________________________________________________________
+
+## 2. Installation
+
+### 2a. Clone the repository
+
+```bash
+git clone --recurse-submodules https://github.com/tinaudio/synth-setter.git
+cd synth-setter
+```
+
+If you already cloned without `--recurse-submodules`, initialize the submodules:
+
+```bash
+git submodule update --init
+```
+
+### 2b. Create a virtual environment (recommended)
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Linux/macOS
+# .venv\Scripts\activate   # Windows
+```
+
+### 2c. Install dependencies
+
+The project uses [uv](https://docs.astral.sh/uv/getting-started/installation/)
+for fast dependency resolution:
+
+```bash
+pip install uv
+uv pip install -r requirements.txt -e .
+```
+
+Or with plain pip:
+
+```bash
+pip install -r requirements.txt -e .
+```
+
+### 2d. Install pre-commit hooks
+
+```bash
+pip install pre-commit
+pre-commit install
+```
+
+The hooks run Ruff (linting + formatting), pyright (type checking), mdformat,
+codespell, and several other checks automatically on each commit.
+
+### 2e. Verify the installation
+
+```bash
+make test
+```
+
+This runs the quick test suite (excluding slow tests and tests that require a
+VST plugin). All tests should pass. If you see import errors, double-check that
+the virtual environment is active and dependencies installed correctly.
+
+______________________________________________________________________
+
+## 3. k-osc Quickstart (No External Dependencies)
+
+The k-osc task is a synthetic benchmark where the model learns to predict
+parameters of a sum-of-sinusoids signal. It generates data on the fly, so you
+do not need any external datasets, VST plugins, or cloud storage.
+
+### 3a. Train a model
+
+```bash
+python src/train.py +experiment=kosc/ffn_mse trainer.max_epochs=5
+```
+
+This runs a feed-forward network with MSE loss on the k-osc task for 5 epochs.
+You should see Lightning's progress bar with decreasing loss values.
+
+**What happens:**
+
+- Hydra composes the config from `configs/train.yaml` + the experiment override
+- Lightning sets up the data module, model, callbacks, and trainer
+- Checkpoints are saved under `logs/train/runs/<timestamp>/checkpoints/`
+- If W&B is configured (see [section 4c](#4c-weights--biases-wb)), metrics are
+  logged to your dashboard
+
+### 3b. Available k-osc experiments
+
+The `configs/experiment/kosc/` directory contains several variants:
+
+| Config | Description |
+| --- | --- |
+| `kosc/base` | Base config (used by other variants) |
+| `kosc/ffn_mse` | Feed-forward network, MSE loss |
+| `kosc/ffn_chamfer` | Feed-forward network, Chamfer loss |
+| `kosc/flow` | Flow matching model |
+| `kosc/flow_asym` | Flow matching, asymmetric |
+| `kosc/flowmlp` | Flow MLP variant |
+
+Run any of them with:
+
+```bash
+python src/train.py +experiment=kosc/<variant>
+```
+
+______________________________________________________________________
+
+## 4. External Dependencies
+
+The sections below cover dependencies needed for the full workflow: generating
+audio datasets from VST plugins, syncing data with cloud storage, and tracking
+experiments. **None of these are needed for the k-osc quickstart above.**
+
+### 4a. Surge XT (VST Plugin)
+
+[Surge XT](https://surge-synthesizer.github.io/) is the open-source synthesizer
+used for audio dataset generation. The data pipeline renders audio by
+programmatically driving this plugin.
+
+**Install:**
+
+1. Download the installer from [surge-synthesizer.github.io](https://surge-synthesizer.github.io/)
+1. Run the installer and follow the prompts
+1. Note the installation path (the test suite needs to find the plugin binary)
+
+**Verify:**
+
+```bash
+pytest -m requires_vst -v
+```
+
+If the plugin is found, VST-dependent tests will run. If not, they are
+automatically skipped (they are excluded from `make test`).
+
+### 4b. rclone + Cloudflare R2
+
+[rclone](https://rclone.org/) is used for all interactions with Cloudflare R2
+object storage, where pipeline data (shards, specs, metadata) is stored. All
+rclone operations in this project use `--checksum` for integrity.
+
+**Install rclone:**
+
+```bash
+# macOS
+brew install rclone
+
+# Linux
+curl https://rclone.org/install.sh | sudo bash
+
+# Or see https://rclone.org/install/
+```
+
+**Configure the R2 remote:**
+
+You need R2 credentials (access key ID, secret access key, and endpoint URL)
+from a project maintainer or your Cloudflare dashboard.
+
+```bash
+rclone config
+```
+
+Follow the prompts to create a new remote named `r2` with provider
+`Cloudflare R2` (or `S3` with the R2 endpoint). Alternatively, set these
+environment variables in your `.env` file:
+
+```
+R2_ACCESS_KEY_ID=<your-access-key>
+R2_SECRET_ACCESS_KEY=<your-secret-key>
+R2_ENDPOINT=<your-r2-endpoint-url>
+R2_BUCKET=<bucket-name>
+```
+
+**Verify:**
+
+```bash
+rclone ls r2:<bucket-name>/ --max-depth 1
+```
+
+You should see top-level directories like `data/` and `metadata/`.
+
+### 4c. Weights & Biases (W&B)
+
+[Weights & Biases](https://wandb.ai/) is used for experiment tracking, metric
+logging, and model checkpoint storage. The integration is handled through
+Lightning's `WandbLogger` -- there are no direct `wandb.init()` calls in the
+codebase.
+
+**Setup:**
+
+1. Create an account at [wandb.ai](https://wandb.ai/)
+1. Get your API key from [wandb.ai/authorize](https://wandb.ai/authorize)
+1. Log in:
+
+```bash
+wandb login
+```
+
+Or set the environment variable in your `.env`:
+
+```
+WANDB_API_KEY=<your-api-key>
+```
+
+**Optional overrides** (defaults are usually fine):
+
+```
+WANDB_ENTITY=tinaudio        # W&B team name
+WANDB_PROJECT=synth-setter   # W&B project name
+```
+
+To train **without W&B** (e.g., for local experimentation), override the logger:
+
+```bash
+python src/train.py +experiment=kosc/ffn_mse logger=csv
+```
+
+This logs metrics to CSV files instead.
+
+For full details, see [docs/reference/wandb-integration.md](reference/wandb-integration.md).
+
+### 4d. RunPod (Optional -- Distributed Generation)
+
+[RunPod](https://www.runpod.io/) is used for distributed dataset generation --
+spinning up multiple GPU workers to render audio in parallel. **You do not need
+RunPod for local development or training.**
+
+If you are working on the data pipeline and need to run distributed generation:
+
+1. Create a RunPod account at [runpod.io](https://www.runpod.io/)
+1. Generate an API key from the RunPod dashboard
+1. Set the environment variable:
+
+```
+RUNPOD_API_KEY=<your-api-key>
+```
+
+______________________________________________________________________
+
+## 5. Hydra Configuration System
+
+synth-setter uses [Hydra](https://hydra.cc/) for configuration management. The
+config is composed from multiple YAML files that layer on top of each other.
+
+### 5a. Config structure
+
+```
+configs/
+  train.yaml          # Top-level training defaults
+  eval.yaml           # Top-level evaluation defaults
+  data/               # Data module configs (kosc, ksin, surge, ...)
+  model/              # Model configs (ffn, flow, flowmlp, ...)
+  trainer/            # Trainer configs (gpu, cpu, mps, ddp, ...)
+  logger/             # Logger configs (wandb, csv, tensorboard, ...)
+  callbacks/          # Callback configs
+  experiment/         # Experiment configs (compose data + model + overrides)
+    kosc/             # k-osc experiments
+    surge/            # Surge XT experiments
+  dataset/            # Pipeline dataset configs
+```
+
+### 5b. Common overrides
+
+Override any config value from the command line:
+
+```bash
+# Change batch size
+python src/train.py +experiment=kosc/ffn_mse data.batch_size=32
+
+# Change learning rate
+python src/train.py +experiment=kosc/ffn_mse model.lr=1e-4
+
+# Use CPU trainer instead of GPU
+python src/train.py +experiment=kosc/ffn_mse trainer=cpu
+
+# Use TensorBoard logger instead of W&B
+python src/train.py +experiment=kosc/ffn_mse logger=tensorboard
+
+# Limit training epochs
+python src/train.py +experiment=kosc/ffn_mse trainer.max_epochs=10
+
+# Run in debug mode (1 batch per epoch, no logging)
+python src/train.py +experiment=kosc/ffn_mse debug=default
+```
+
+For the full configuration reference, see
+[docs/reference/configuration-reference.md](reference/configuration-reference.md).
+
+______________________________________________________________________
+
+## 6. Evaluation
+
+After training, evaluate the model on the test set:
+
+```bash
+python src/eval.py
+```
+
+By default, evaluation uses the config and checkpoint from the most recent
+training run. You can point it at a specific checkpoint:
+
+```bash
+python src/eval.py ckpt_path=/path/to/checkpoint.ckpt
+```
+
+______________________________________________________________________
+
+## 7. Docker Workflow
+
+A Dockerfile is provided for reproducible environments (training, CI, cloud
+deployment). The image bakes in the source code, dependencies, Surge XT, and
+rclone/R2 configuration.
+
+**Build the image:**
+
+```bash
+make docker-build-dev-snapshot \
+  GIT_REF=$(git rev-parse HEAD) \
+  GIT_PAT=<your-github-pat> \
+  R2_ACCESS_KEY_ID=<key> \
+  R2_SECRET_ACCESS_KEY=<secret> \
+  R2_ENDPOINT=<endpoint> \
+  R2_BUCKET=<bucket>
+```
+
+See `make help` for the full list of Docker-related variables and targets. The
+`GIT_REF` argument controls which commit is baked into the image (use a full
+SHA for reproducibility).
+
+For full Docker documentation, see
+[docs/reference/docker.md](reference/docker.md).
+
+______________________________________________________________________
+
+## 8. Troubleshooting
+
+### Tests fail with import errors
+
+Make sure your virtual environment is active and dependencies are installed:
+
+```bash
+source .venv/bin/activate
+uv pip install -r requirements.txt -e .
+```
+
+### `make format` fails on first run
+
+Pre-commit downloads hook environments on first execution. If it fails, try:
+
+```bash
+pre-commit clean
+pre-commit install
+make format
+```
+
+### CUDA out of memory
+
+Reduce the batch size:
+
+```bash
+python src/train.py +experiment=kosc/ffn_mse data.batch_size=8
+```
+
+Or switch to CPU for debugging:
+
+```bash
+python src/train.py +experiment=kosc/ffn_mse trainer=cpu
+```
+
+### W&B login issues
+
+If `wandb login` does not persist, set the API key as an environment variable:
+
+```bash
+export WANDB_API_KEY=<your-api-key>
+```
+
+Or add it to your `.env` file (never commit this file).
+
+### VST tests are skipped
+
+This is expected. VST tests require Surge XT to be installed (see
+[section 4a](#4a-surge-xt-vst-plugin)). They are excluded from `make test` by
+default.
+
+______________________________________________________________________
+
+## 9. What to Try Next
+
+- **Experiment configs:** Browse `configs/experiment/` for pre-configured
+  experiments across different models and datasets.
+- **Data generation:** See `pipeline/entrypoints/generate_dataset.py` for the
+  dataset generation entry point.
+- **Design docs:** Read `docs/design/data-pipeline.md` for the data pipeline
+  architecture and `docs/design/training-pipeline.md` for the training pipeline.
+- **Configuration reference:**
+  [docs/reference/configuration-reference.md](reference/configuration-reference.md)
+  covers all config layers in detail.
+- **Available make targets:** Run `make help` to see all commands.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ cd synth-setter
 If you already cloned without `--recurse-submodules`, initialize the submodules:
 
 ```bash
-git submodule update --init
+git submodule update --init --recursive
 ```
 
 > **Note on submodules:** This repository includes a git submodule whose URL is


### PR DESCRIPTION
## Summary
- Add `docs/getting-started.md` with step-by-step setup tutorial for new users
- Covers prerequisites, installation, pre-commit setup, and virtual environment creation
- Includes k-osc quickstart (no external deps needed) with working training commands
- Documents external dependency setup: Surge XT, rclone/R2, W&B, RunPod
- Covers Hydra config system with common override examples
- Adds evaluation, Docker workflow, and troubleshooting sections

Closes #461
Part of #457