### PR TITLE
docs: add glossary and architecture overview

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -137,9 +137,9 @@ the same R2 path structure and ID conventions defined in
 
 ## Design Documents
 
-| Document | Covers |
-|----------|--------|
-| [data-pipeline.md](design/data-pipeline.md) | Distributed dataset generation, finalization, reconciliation |
-| [training-pipeline.md](design/training-pipeline.md) | Training orchestration, checkpoint durability, resume |
-| [eval-pipeline.md](design/eval-pipeline.md) | Evaluation pipeline (predict, render, metrics) and R2 integration |
-| [storage-provenance-spec.md](design/storage-provenance-spec.md) | Authoritative R2 paths, W&B artifacts, ID conventions |
+| Document                                                        | Covers                                                            |
+| --------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [data-pipeline.md](design/data-pipeline.md)                     | Distributed dataset generation, finalization, reconciliation      |
+| [training-pipeline.md](design/training-pipeline.md)             | Training orchestration, checkpoint durability, resume             |
+| [eval-pipeline.md](design/eval-pipeline.md)                     | Evaluation pipeline (predict, render, metrics) and R2 integration |
+| [storage-provenance-spec.md](design/storage-provenance-spec.md) | Authoritative R2 paths, W&B artifacts, ID conventions             |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,145 @@
+# Architecture Overview
+
+High-level system overview for synth-setter. For detailed design, see the
+individual design docs linked throughout.
+
+## What This Project Does
+
+synth-setter is a collection of tools for **synthesizer inversion** (predicting
+synthesizer parameters from audio), **sound matching**, and **preset
+exploration**. The system generates large-scale audio datasets by rendering
+random synthesizer configurations through a VST plugin (Surge XT), trains neural
+networks on these datasets, and evaluates how well the models recover the
+original parameters.
+
+## System Diagram
+
+```
+ ┌─────────────────────────────────────────────────────────────────────────┐
+ │                          synth-setter pipeline                         │
+ │                                                                        │
+ │  ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────────────┐  │
+ │  │ GENERATE │───>│ FINALIZE │───>│  TRAIN   │───>│    EVALUATE      │  │
+ │  │          │    │          │    │          │    │                  │  │
+ │  │ Render   │    │ Reshard  │    │ Flow     │    │ Predict → Render │  │
+ │  │ audio via│    │ into     │    │ matching │    │ → Metrics        │  │
+ │  │ Surge XT │    │ splits   │    │ model    │    │                  │  │
+ │  └────┬─────┘    └────┬─────┘    └────┬─────┘    └────────┬─────────┘  │
+ │       │               │               │                   │            │
+ │       ▼               ▼               ▼                   ▼            │
+ │    HDF5 shards   train/val/test   Checkpoints       Metrics CSV       │
+ │    → R2          → R2             → W&B             Rendered audio     │
+ └─────────────────────────────────────────────────────────────────────────┘
+
+ Infrastructure:
+   Storage:   Cloudflare R2 (data, coordination)
+   Compute:   RunPod (on-demand workers)
+   Tracking:  Weights & Biases (metrics, artifacts, lineage)
+   Config:    Hydra (composable YAML configs)
+   Training:  PyTorch Lightning
+```
+
+## Data Flow
+
+1. **Configure** -- Define a dataset in `configs/dataset/*.yaml` (synth, sample
+   count, shard size, parameter spec).
+
+2. **Generate** -- Workers render audio samples through Surge XT, producing HDF5
+   shards uploaded to R2. Each shard contains audio waveforms, mel spectrograms,
+   and ground-truth parameter arrays. Workers are fully parallel with no shared
+   state.
+   Design: [data-pipeline.md](design/data-pipeline.md)
+
+3. **Finalize** -- Downloads validated shards, reshards into train/val/test
+   splits (HDF5 virtual datasets or WebDataset `.tar`), computes normalization
+   statistics, registers the dataset as a W&B artifact, and writes
+   `dataset.complete`.
+   Design: [data-pipeline.md](design/data-pipeline.md)
+
+4. **Train** -- A single long-running job trains a model (flow matching,
+   feed-forward, or FlowVAE) on the generated dataset. Checkpoints are durably
+   stored in W&B via `log_model: "all"`. Hydra composes experiment configs from
+   data, model, trainer, and callback configs.
+   Design: [training-pipeline.md](design/training-pipeline.md)
+
+5. **Evaluate** -- Three stages: **predict** (model inference on test data),
+   **render** (synthesize audio from predicted parameters via Surge XT), and
+   **metrics** (spectral and transport-based distance metrics). Results upload to
+   R2.
+   Design: [eval-pipeline.md](design/eval-pipeline.md)
+
+## Directory Structure
+
+```
+synth-setter/
+├── src/                    # ML code
+│   ├── train.py            #   Training entry point (Hydra)
+│   ├── eval.py             #   Evaluation entry point (Hydra)
+│   ├── metrics.py          #   Metric definitions
+│   ├── data/               #   DataModules (Surge, K-Sin, K-Osc, etc.)
+│   ├── models/             #   LightningModules (flow matching, FF, FlowVAE)
+│   │   └── components/     #   Model building blocks (VAE, networks)
+│   └── utils/              #   Logging, config helpers
+│
+├── pipeline/               # Distributed data pipeline
+│   ├── schemas/            #   Pydantic models (config, spec, prefix, image_config)
+│   ├── entrypoints/        #   Pipeline entry points (generate_dataset)
+│   ├── ci/                 #   CI validation scripts (materialize_spec, validate_shard/spec)
+│   └── constants.py        #   Shared constants (R2 bucket, spec filename)
+│
+├── configs/                # Hydra YAML configs
+│   ├── dataset/            #   Pipeline dataset configs (synth, shard count, sample count)
+│   ├── data/               #   DataModule configs (paths, splits, batch size)
+│   ├── model/              #   Model architecture configs
+│   ├── trainer/            #   Lightning Trainer configs
+│   ├── experiment/         #   Experiment configs (compose data + model + trainer)
+│   ├── callbacks/          #   Callback configs (checkpointing, early stopping)
+│   ├── logger/             #   Logger configs (W&B, CSV, TensorBoard)
+│   └── train.yaml          #   Root training config
+│
+├── scripts/                # Standalone utility scripts
+├── tests/                  # Test suite (mirrors src/ and pipeline/ structure)
+├── docs/                   # Documentation
+│   └── design/             #   Design documents
+└── docker/                 # Dockerfiles and entrypoints
+```
+
+## Key Design Decisions
+
+**R2 as source of truth.** Pipeline state is determined by file existence and
+validation in R2, not by metadata databases or coordination services. One piece
+of infrastructure, one set of credentials, one failure mode. See
+[data-pipeline.md](design/data-pipeline.md) section 7.1.
+
+**Reconciliation over orchestration.** Instead of a job scheduler tracking task
+state, the pipeline compares the desired state (input spec) against actual state
+(validated shards in R2) to determine remaining work. Any command can be re-run
+safely at any time. See [data-pipeline.md](design/data-pipeline.md) section 7.4.
+
+**Deterministic shard identities.** Shard IDs are logical (`shard-000042`),
+defined at run creation, independent of which worker or infrastructure computes
+them. This makes reconciliation straightforward and results reproducible. See
+[data-pipeline.md](design/data-pipeline.md) section 7.3.
+
+**Worker isolation.** Workers are fully parallel with no shared state. Each
+worker independently renders its assigned shards and uploads to R2. One worker
+crashing does not affect others. See
+[data-pipeline.md](design/data-pipeline.md) section 7.7.
+
+**W&B for checkpoint durability.** Training checkpoints are uploaded to W&B
+immediately via `log_model: "all"`, surviving pod death without a custom
+persistence layer. See
+[training-pipeline.md](design/training-pipeline.md) section 6.
+
+**Storage conventions are shared.** All pipelines (data, training, eval) follow
+the same R2 path structure and ID conventions defined in
+[storage-provenance-spec.md](design/storage-provenance-spec.md).
+
+## Design Documents
+
+| Document | Covers |
+|----------|--------|
+| [data-pipeline.md](design/data-pipeline.md) | Distributed dataset generation, finalization, reconciliation |
+| [training-pipeline.md](design/training-pipeline.md) | Training orchestration, checkpoint durability, resume |
+| [eval-pipeline.md](design/eval-pipeline.md) | Evaluation pipeline (predict, render, metrics) and R2 integration |
+| [storage-provenance-spec.md](design/storage-provenance-spec.md) | Authoritative R2 paths, W&B artifacts, ID conventions |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -19,7 +19,7 @@ Project terminology for synth-setter. Grouped by domain.
 | **Flow matching**      | A generative modeling technique used for parameter prediction. Learns a vector field that transports noise to the target parameter distribution. Implemented in `SurgeFlowMatchingModule` and `KSinFlowMatchingModule`. |
 | **Optimal transport**  | A mathematical framework for comparing probability distributions. Used in flow matching training and in the SOT evaluation metric.                                                                                      |
 | **FlowVAE**            | A variational autoencoder variant combined with flow-based generation. Implemented in `FlowVAE` / `SurgeFlowVAEModule`.                                                                                                 |
-| **Feed-forward model** | A direct regression model for parameter prediction (no iterative sampling). Implemented in `SurgeFFModule` and `KSinFFModule`.                                                                                          |
+| **Feed-forward model** | A direct regression model for parameter prediction (no iterative sampling). Implemented in `SurgeFeedForwardModule` and `KSinFeedForwardModule`.                                                                        |
 
 ## Audio & Synthesis
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -4,79 +4,79 @@ Project terminology for synth-setter. Grouped by domain.
 
 ## Core Concepts
 
-| Term | Definition |
-|------|-----------|
-| **Synth inversion** | Predicting synthesizer parameters from an audio recording. Also called **parameter estimation**. The core ML task this project addresses. |
-| **Sound matching** | Finding synthesizer settings that reproduce a target sound. Synth inversion is the neural approach to this problem. |
-| **Preset** | A saved configuration of synthesizer parameters that produces a specific sound. The project generates random presets for training data. |
-| **Parameter space** | The set of all controllable parameters of a synthesizer. For Surge XT, this ranges from 92 parameters (`surge_simple`) to 189 (`surge_xt`) depending on the param spec. |
-| **param_spec** | Configuration selecting which synthesizer parameters to vary during data generation. Determines the dimensionality of the prediction task. Examples: `surge_simple` (92 params), `surge_xt` (189 params). |
+| Term                | Definition                                                                                                                                                                                                |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Synth inversion** | Predicting synthesizer parameters from an audio recording. Also called **parameter estimation**. The core ML task this project addresses.                                                                 |
+| **Sound matching**  | Finding synthesizer settings that reproduce a target sound. Synth inversion is the neural approach to this problem.                                                                                       |
+| **Preset**          | A saved configuration of synthesizer parameters that produces a specific sound. The project generates random presets for training data.                                                                   |
+| **Parameter space** | The set of all controllable parameters of a synthesizer. For Surge XT, this ranges from 92 parameters (`surge_simple`) to 189 (`surge_xt`) depending on the param spec.                                   |
+| **param_spec**      | Configuration selecting which synthesizer parameters to vary during data generation. Determines the dimensionality of the prediction task. Examples: `surge_simple` (92 params), `surge_xt` (189 params). |
 
 ## Model Architecture
 
-| Term | Definition |
-|------|-----------|
-| **Flow matching** | A generative modeling technique used for parameter prediction. Learns a vector field that transports noise to the target parameter distribution. Implemented in `SurgeFlowMatchingModule` and `KSinFlowMatchingModule`. |
-| **Optimal transport** | A mathematical framework for comparing probability distributions. Used in flow matching training and in the SOT evaluation metric. |
-| **FlowVAE** | A variational autoencoder variant combined with flow-based generation. Implemented in `FlowVAE` / `SurgeFlowVAEModule`. |
-| **Feed-forward model** | A direct regression model for parameter prediction (no iterative sampling). Implemented in `SurgeFFModule` and `KSinFFModule`. |
+| Term                   | Definition                                                                                                                                                                                                              |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Flow matching**      | A generative modeling technique used for parameter prediction. Learns a vector field that transports noise to the target parameter distribution. Implemented in `SurgeFlowMatchingModule` and `KSinFlowMatchingModule`. |
+| **Optimal transport**  | A mathematical framework for comparing probability distributions. Used in flow matching training and in the SOT evaluation metric.                                                                                      |
+| **FlowVAE**            | A variational autoencoder variant combined with flow-based generation. Implemented in `FlowVAE` / `SurgeFlowVAEModule`.                                                                                                 |
+| **Feed-forward model** | A direct regression model for parameter prediction (no iterative sampling). Implemented in `SurgeFFModule` and `KSinFFModule`.                                                                                          |
 
 ## Audio & Synthesis
 
-| Term | Definition |
-|------|-----------|
+| Term                                | Definition                                                                                                                                                      |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **VST (Virtual Studio Technology)** | Plugin format for audio synthesizers and effects. Surge XT is loaded as a VST plugin via Spotify's [pedalboard](https://github.com/spotify/pedalboard) library. |
-| **Surge XT** | The open-source VST synthesizer used for audio rendering. See [surge-synthesizer.github.io](https://surge-synthesizer.github.io/). |
-| **Mel spectrogram** | Frequency-domain audio representation used as neural network input. 128 mel bands, ~100 frames/sec. |
-| **pedalboard** | Spotify's Python library for loading and running VST plugins programmatically. |
-| **Xvfb** | X Virtual Framebuffer. Provides a virtual display server on headless Linux machines, required because VST plugins expect a display. |
+| **Surge XT**                        | The open-source VST synthesizer used for audio rendering. See [surge-synthesizer.github.io](https://surge-synthesizer.github.io/).                              |
+| **Mel spectrogram**                 | Frequency-domain audio representation used as neural network input. 128 mel bands, ~100 frames/sec.                                                             |
+| **pedalboard**                      | Spotify's Python library for loading and running VST plugins programmatically.                                                                                  |
+| **Xvfb**                            | X Virtual Framebuffer. Provides a virtual display server on headless Linux machines, required because VST plugins expect a display.                             |
 
 ## Data Pipeline
 
-| Term | Definition |
-|------|-----------|
-| **Shard** | An HDF5 file containing a batch of training samples (audio, mel spectrograms, parameter arrays). Typically 1k--10k samples per shard. Named by logical index (e.g., `shard-000042.h5`). |
-| **Shard ID** | Logical index for a shard (`shard-000042`). Deterministic, defined at run creation, independent of which worker computes it. |
-| **Input spec** | JSON file (`input_spec.json`) freezing all generation parameters for a run: per-shard seeds, shapes, splits, renderer version. Written once, never modified. |
-| **Finalize** | The pipeline stage that downloads all validated shards, reshards into train/val/test splits, computes normalization statistics, registers the dataset in W&B, and writes `dataset.complete`. |
-| **Reconciliation** | Comparing desired state (the spec) against actual state (validated shards in R2) to determine what work remains. The pipeline's coordination mechanism -- no message queues or databases needed. |
-| **Worker** | A cloud compute instance that generates shards. On RunPod, this is a single Docker container ("pod") with assigned shard work. |
-| **dataset.complete** | Marker file written by finalize as the very last step. Signals that finalization is done. Contains run_id and timestamp. Once present, the dataset is immutable. |
-| **Lifecycle marker** | Empty file in worker metadata tracking shard state: `.rendering` (started), `.valid` (committed), `.promoted` (canonical), `.invalid` (failed). Presence is the state -- no content to parse. |
-| **Quarantined shard** | A corrupt shard uploaded to a quarantine path on validation failure. Preserves evidence for debugging. |
-| **Virtual dataset** | HDF5 feature that creates a logical view over multiple files without copying data. Used by finalize to compose train/val/test splits from individual shards. |
-| **WebDataset** | [WebDataset](https://github.com/webdataset/webdataset) format for streaming training data. Sequential `.tar` archives optimized for HTTP/S3 streaming, used for multi-GPU training. |
-| **Dataset card** | JSON file (`dataset.json`) describing the finalized dataset: provenance, structure, stats. References the spec by SHA-256. |
+| Term                  | Definition                                                                                                                                                                                       |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Shard**             | An HDF5 file containing a batch of training samples (audio, mel spectrograms, parameter arrays). Typically 1k--10k samples per shard. Named by logical index (e.g., `shard-000042.h5`).          |
+| **Shard ID**          | Logical index for a shard (`shard-000042`). Deterministic, defined at run creation, independent of which worker computes it.                                                                     |
+| **Input spec**        | JSON file (`input_spec.json`) freezing all generation parameters for a run: per-shard seeds, shapes, splits, renderer version. Written once, never modified.                                     |
+| **Finalize**          | The pipeline stage that downloads all validated shards, reshards into train/val/test splits, computes normalization statistics, registers the dataset in W&B, and writes `dataset.complete`.     |
+| **Reconciliation**    | Comparing desired state (the spec) against actual state (validated shards in R2) to determine what work remains. The pipeline's coordination mechanism -- no message queues or databases needed. |
+| **Worker**            | A cloud compute instance that generates shards. On RunPod, this is a single Docker container ("pod") with assigned shard work.                                                                   |
+| **dataset.complete**  | Marker file written by finalize as the very last step. Signals that finalization is done. Contains run_id and timestamp. Once present, the dataset is immutable.                                 |
+| **Lifecycle marker**  | Empty file in worker metadata tracking shard state: `.rendering` (started), `.valid` (committed), `.promoted` (canonical), `.invalid` (failed). Presence is the state -- no content to parse.    |
+| **Quarantined shard** | A corrupt shard uploaded to a quarantine path on validation failure. Preserves evidence for debugging.                                                                                           |
+| **Virtual dataset**   | HDF5 feature that creates a logical view over multiple files without copying data. Used by finalize to compose train/val/test splits from individual shards.                                     |
+| **WebDataset**        | [WebDataset](https://github.com/webdataset/webdataset) format for streaming training data. Sequential `.tar` archives optimized for HTTP/S3 streaming, used for multi-GPU training.              |
+| **Dataset card**      | JSON file (`dataset.json`) describing the finalized dataset: provenance, structure, stats. References the spec by SHA-256.                                                                       |
 
 ## Evaluation Pipeline
 
-| Term | Definition |
-|------|-----------|
-| **Predict** | Evaluation stage 1: load a trained checkpoint, run inference on test data, output predicted parameter tensors. |
-| **Render** | Evaluation stage 2: feed predicted parameters into the VST plugin to produce audio waveforms for both predictions and ground-truth targets. |
-| **Metrics** | Evaluation stage 3: compute distance metrics (MSS, wMFCC, SOT, RMS) between predicted and target audio. |
-| **MSS** | Multi-Scale Spectrogram distance. Captures temporal characteristics at three mel-scale windows (fine, mid, coarse). |
-| **SOT** | Spectral Optimal Transport. Wasserstein distance on normalized STFT bins. |
+| Term        | Definition                                                                                                                                  |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Predict** | Evaluation stage 1: load a trained checkpoint, run inference on test data, output predicted parameter tensors.                              |
+| **Render**  | Evaluation stage 2: feed predicted parameters into the VST plugin to produce audio waveforms for both predictions and ground-truth targets. |
+| **Metrics** | Evaluation stage 3: compute distance metrics (MSS, wMFCC, SOT, RMS) between predicted and target audio.                                     |
+| **MSS**     | Multi-Scale Spectrogram distance. Captures temporal characteristics at three mel-scale windows (fine, mid, coarse).                         |
+| **SOT**     | Spectral Optimal Transport. Wasserstein distance on normalized STFT bins.                                                                   |
 
 ## IDs & Provenance
 
-| Term | Definition |
-|------|-----------|
-| **dataset_config_id** | Stable identifier for a dataset configuration, derived from the config YAML filename stem. Example: `surge-simple-480k-10k`. See [storage-provenance-spec.md](design/storage-provenance-spec.md). |
-| **dataset_wandb_run_id** | Unique identifier for a pipeline execution. Format: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}`. Example: `surge-simple-480k-10k-20260312T143022Z`. |
-| **train_config_id** | Config filename stem for a training experiment. Example: `flow-simple`. |
-| **train_wandb_run_id** | W&B run ID for a specific training run. Format: `{train_config_id}-{YYYYMMDDTHHMMSSZ}`. |
-| **worker_id** | Infrastructure identifier (e.g., RunPod's `RUNPOD_POD_ID`). Appears only in metadata, not in shard paths. |
+| Term                     | Definition                                                                                                                                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **dataset_config_id**    | Stable identifier for a dataset configuration, derived from the config YAML filename stem. Example: `surge-simple-480k-10k`. See [storage-provenance-spec.md](design/storage-provenance-spec.md). |
+| **dataset_wandb_run_id** | Unique identifier for a pipeline execution. Format: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}`. Example: `surge-simple-480k-10k-20260312T143022Z`.                                                  |
+| **train_config_id**      | Config filename stem for a training experiment. Example: `flow-simple`.                                                                                                                           |
+| **train_wandb_run_id**   | W&B run ID for a specific training run. Format: `{train_config_id}-{YYYYMMDDTHHMMSSZ}`.                                                                                                           |
+| **worker_id**            | Infrastructure identifier (e.g., RunPod's `RUNPOD_POD_ID`). Appears only in metadata, not in shard paths.                                                                                         |
 
 ## Infrastructure & Tools
 
-| Term | Definition |
-|------|-----------|
-| **R2** | [Cloudflare R2](https://developers.cloudflare.com/r2/), S3-compatible object storage with free egress. Used for shard storage, pipeline coordination, and eval artifacts. |
-| **RunPod** | [RunPod](https://www.runpod.io/), cloud compute marketplace for on-demand GPU/CPU instances. Used for data generation workers and training. |
-| **W&B (Weights & Biases)** | [Weights & Biases](https://wandb.ai/), experiment tracking platform. Used for pipeline metrics, dataset artifact registry, checkpoint durability, and lineage tracking. |
-| **Hydra** | [Hydra](https://hydra.cc/), configuration framework for Python. Composes YAML configs with CLI overrides. All training, eval, and dataset configs use Hydra. |
-| **OmegaConf** | Hydra's underlying config library. Supports interpolation (`${...}`) and environment variable resolvers (`${oc.env:VAR}`). |
-| **Lightning** | [PyTorch Lightning](https://lightning.ai/), training framework. Handles training loops, checkpointing, logging, and multi-GPU support. |
-| **rclone** | CLI tool for syncing files to cloud storage. All R2 transfers use `--checksum` (project rule). |
-| **structlog** | Structured logging library used in pipeline code. JSON-rendered, append-only debug log streams. |
+| Term                       | Definition                                                                                                                                                                |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **R2**                     | [Cloudflare R2](https://developers.cloudflare.com/r2/), S3-compatible object storage with free egress. Used for shard storage, pipeline coordination, and eval artifacts. |
+| **RunPod**                 | [RunPod](https://www.runpod.io/), cloud compute marketplace for on-demand GPU/CPU instances. Used for data generation workers and training.                               |
+| **W&B (Weights & Biases)** | [Weights & Biases](https://wandb.ai/), experiment tracking platform. Used for pipeline metrics, dataset artifact registry, checkpoint durability, and lineage tracking.   |
+| **Hydra**                  | [Hydra](https://hydra.cc/), configuration framework for Python. Composes YAML configs with CLI overrides. All training, eval, and dataset configs use Hydra.              |
+| **OmegaConf**              | Hydra's underlying config library. Supports interpolation (`${...}`) and environment variable resolvers (`${oc.env:VAR}`).                                                |
+| **Lightning**              | [PyTorch Lightning](https://lightning.ai/), training framework. Handles training loops, checkpointing, logging, and multi-GPU support.                                    |
+| **rclone**                 | CLI tool for syncing files to cloud storage. All R2 transfers use `--checksum` (project rule).                                                                            |
+| **structlog**              | Structured logging library used in pipeline code. JSON-rendered, append-only debug log streams.                                                                           |

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,82 @@
+# Glossary
+
+Project terminology for synth-setter. Grouped by domain.
+
+## Core Concepts
+
+| Term | Definition |
+|------|-----------|
+| **Synth inversion** | Predicting synthesizer parameters from an audio recording. Also called **parameter estimation**. The core ML task this project addresses. |
+| **Sound matching** | Finding synthesizer settings that reproduce a target sound. Synth inversion is the neural approach to this problem. |
+| **Preset** | A saved configuration of synthesizer parameters that produces a specific sound. The project generates random presets for training data. |
+| **Parameter space** | The set of all controllable parameters of a synthesizer. For Surge XT, this ranges from 92 parameters (`surge_simple`) to 189 (`surge_xt`) depending on the param spec. |
+| **param_spec** | Configuration selecting which synthesizer parameters to vary during data generation. Determines the dimensionality of the prediction task. Examples: `surge_simple` (92 params), `surge_xt` (189 params). |
+
+## Model Architecture
+
+| Term | Definition |
+|------|-----------|
+| **Flow matching** | A generative modeling technique used for parameter prediction. Learns a vector field that transports noise to the target parameter distribution. Implemented in `SurgeFlowMatchingModule` and `KSinFlowMatchingModule`. |
+| **Optimal transport** | A mathematical framework for comparing probability distributions. Used in flow matching training and in the SOT evaluation metric. |
+| **FlowVAE** | A variational autoencoder variant combined with flow-based generation. Implemented in `FlowVAE` / `SurgeFlowVAEModule`. |
+| **Feed-forward model** | A direct regression model for parameter prediction (no iterative sampling). Implemented in `SurgeFFModule` and `KSinFFModule`. |
+
+## Audio & Synthesis
+
+| Term | Definition |
+|------|-----------|
+| **VST (Virtual Studio Technology)** | Plugin format for audio synthesizers and effects. Surge XT is loaded as a VST plugin via Spotify's [pedalboard](https://github.com/spotify/pedalboard) library. |
+| **Surge XT** | The open-source VST synthesizer used for audio rendering. See [surge-synthesizer.github.io](https://surge-synthesizer.github.io/). |
+| **Mel spectrogram** | Frequency-domain audio representation used as neural network input. 128 mel bands, ~100 frames/sec. |
+| **pedalboard** | Spotify's Python library for loading and running VST plugins programmatically. |
+| **Xvfb** | X Virtual Framebuffer. Provides a virtual display server on headless Linux machines, required because VST plugins expect a display. |
+
+## Data Pipeline
+
+| Term | Definition |
+|------|-----------|
+| **Shard** | An HDF5 file containing a batch of training samples (audio, mel spectrograms, parameter arrays). Typically 1k--10k samples per shard. Named by logical index (e.g., `shard-000042.h5`). |
+| **Shard ID** | Logical index for a shard (`shard-000042`). Deterministic, defined at run creation, independent of which worker computes it. |
+| **Input spec** | JSON file (`input_spec.json`) freezing all generation parameters for a run: per-shard seeds, shapes, splits, renderer version. Written once, never modified. |
+| **Finalize** | The pipeline stage that downloads all validated shards, reshards into train/val/test splits, computes normalization statistics, registers the dataset in W&B, and writes `dataset.complete`. |
+| **Reconciliation** | Comparing desired state (the spec) against actual state (validated shards in R2) to determine what work remains. The pipeline's coordination mechanism -- no message queues or databases needed. |
+| **Worker** | A cloud compute instance that generates shards. On RunPod, this is a single Docker container ("pod") with assigned shard work. |
+| **dataset.complete** | Marker file written by finalize as the very last step. Signals that finalization is done. Contains run_id and timestamp. Once present, the dataset is immutable. |
+| **Lifecycle marker** | Empty file in worker metadata tracking shard state: `.rendering` (started), `.valid` (committed), `.promoted` (canonical), `.invalid` (failed). Presence is the state -- no content to parse. |
+| **Quarantined shard** | A corrupt shard uploaded to a quarantine path on validation failure. Preserves evidence for debugging. |
+| **Virtual dataset** | HDF5 feature that creates a logical view over multiple files without copying data. Used by finalize to compose train/val/test splits from individual shards. |
+| **WebDataset** | [WebDataset](https://github.com/webdataset/webdataset) format for streaming training data. Sequential `.tar` archives optimized for HTTP/S3 streaming, used for multi-GPU training. |
+| **Dataset card** | JSON file (`dataset.json`) describing the finalized dataset: provenance, structure, stats. References the spec by SHA-256. |
+
+## Evaluation Pipeline
+
+| Term | Definition |
+|------|-----------|
+| **Predict** | Evaluation stage 1: load a trained checkpoint, run inference on test data, output predicted parameter tensors. |
+| **Render** | Evaluation stage 2: feed predicted parameters into the VST plugin to produce audio waveforms for both predictions and ground-truth targets. |
+| **Metrics** | Evaluation stage 3: compute distance metrics (MSS, wMFCC, SOT, RMS) between predicted and target audio. |
+| **MSS** | Multi-Scale Spectrogram distance. Captures temporal characteristics at three mel-scale windows (fine, mid, coarse). |
+| **SOT** | Spectral Optimal Transport. Wasserstein distance on normalized STFT bins. |
+
+## IDs & Provenance
+
+| Term | Definition |
+|------|-----------|
+| **dataset_config_id** | Stable identifier for a dataset configuration, derived from the config YAML filename stem. Example: `surge-simple-480k-10k`. See [storage-provenance-spec.md](design/storage-provenance-spec.md). |
+| **dataset_wandb_run_id** | Unique identifier for a pipeline execution. Format: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}`. Example: `surge-simple-480k-10k-20260312T143022Z`. |
+| **train_config_id** | Config filename stem for a training experiment. Example: `flow-simple`. |
+| **train_wandb_run_id** | W&B run ID for a specific training run. Format: `{train_config_id}-{YYYYMMDDTHHMMSSZ}`. |
+| **worker_id** | Infrastructure identifier (e.g., RunPod's `RUNPOD_POD_ID`). Appears only in metadata, not in shard paths. |
+
+## Infrastructure & Tools
+
+| Term | Definition |
+|------|-----------|
+| **R2** | [Cloudflare R2](https://developers.cloudflare.com/r2/), S3-compatible object storage with free egress. Used for shard storage, pipeline coordination, and eval artifacts. |
+| **RunPod** | [RunPod](https://www.runpod.io/), cloud compute marketplace for on-demand GPU/CPU instances. Used for data generation workers and training. |
+| **W&B (Weights & Biases)** | [Weights & Biases](https://wandb.ai/), experiment tracking platform. Used for pipeline metrics, dataset artifact registry, checkpoint durability, and lineage tracking. |
+| **Hydra** | [Hydra](https://hydra.cc/), configuration framework for Python. Composes YAML configs with CLI overrides. All training, eval, and dataset configs use Hydra. |
+| **OmegaConf** | Hydra's underlying config library. Supports interpolation (`${...}`) and environment variable resolvers (`${oc.env:VAR}`). |
+| **Lightning** | [PyTorch Lightning](https://lightning.ai/), training framework. Handles training loops, checkpointing, logging, and multi-GPU support. |
+| **rclone** | CLI tool for syncing files to cloud storage. All R2 transfers use `--checksum` (project rule). |
+| **structlog** | Structured logging library used in pipeline code. JSON-rendered, append-only debug log streams. |


### PR DESCRIPTION
## Summary
- Add `docs/glossary.md` with project terminology definitions organized by domain (core concepts, model architecture, audio/synthesis, data pipeline, evaluation, IDs/provenance, infrastructure)
- Add `docs/architecture.md` with high-level system diagram, data flow description, directory structure, key design decisions, and links to detailed design docs

Closes #462
Part of #457