### PR TITLE
chore(docker): migrate from pip to uv with --torch-backend

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -144,7 +144,7 @@ jobs:
           build-args: |
             BUILD_MODE=${{ steps.config.outputs.build_mode }}
             BASE_IMAGE=${{ steps.config.outputs.base_image }}
-            TORCH_INDEX_URL=${{ steps.config.outputs.torch_index_url }}
+            TORCH_BACKEND=${{ steps.config.outputs.torch_backend }}
             SYNTH_PERMUTATIONS_GIT_REF=${{ steps.source.outputs.sha }}
             R2_BUCKET=${{ steps.config.outputs.r2_bucket }}
             R2_ENDPOINT=${{ steps.config.outputs.r2_endpoint }}

--- a/.github/workflows/flush-investigation.yml
+++ b/.github/workflows/flush-investigation.yml
@@ -57,7 +57,7 @@ jobs:
             -e SURGE_VST3_PATH="${SURGE_VST3_PATH}" \
             synth-setter:dev-snapshot \
             -c "
-              pip install -q jupyter nbconvert auraloss librosa &&
+              uv pip install -q jupyter nbconvert auraloss librosa &&
               cd /home/build/synth-setter &&
               scripts/run-linux-vst-headless.sh \
                 jupyter nbconvert \

--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,13 @@ test-bats: ## Run BATS shell tests
 	bats --recursive tests/
 
 install: ## Install project in editable mode with dev deps
-	pip install uv
+	command -v uv >/dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
 	uv pip install -r requirements.txt -e .
 
 # coverage runs serially (no -n auto): GPU tests require exclusive device
 # access and VRAM contention causes flaky failures with xdist parallelism.
 coverage: ## Run tests with coverage report
-	pip install uv
+	command -v uv >/dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
 	uv pip install pytest-cov[toml]
 	pytest --cov=src --cov-report=term-missing --cov-report=html -m "not slow"
 

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ train: ## Train the model
 #   DOCKER_IMAGE        Image name                  (default: tinaudio/perm)
 #   DOCKER_BUILD_MODE   "source" or "prebuilt"       (default: prebuilt)
 #   DOCKER_TARGETPLATFORM   "linux/amd64" or "linux/arm64" (default: linux/amd64)
-#   DOCKER_TORCH_IDX    PyTorch wheel index URL      (default: cu128 wheels)
+#   DOCKER_TORCH_BACKEND  PyTorch backend (e.g. cu128, cpu) (default: cu128)
 #   DOCKER_BUILD_FLAGS  Extra flags passed verbatim to docker buildx build.
 # =====================================================================
 DOCKER_FILE       ?= docker/ubuntu22_04/Dockerfile
@@ -79,7 +79,7 @@ DOCKER_BASE_IMAGE_TAG ?= ubuntu22_04
 DOCKER_BUILD_MODE ?= prebuilt
 DOCKER_TARGETPLATFORM ?= linux/amd64
 TARGETARCH ?= amd64
-DOCKER_TORCH_IDX  ?= https://download.pytorch.org/whl/cu128
+DOCKER_TORCH_BACKEND ?= cu128
 DOCKER_BUILD_FLAGS ?=
 _INTERNAL_BUILD_FLAGS :=
 CURRENT_LOCAL_GIT_REF := $(strip $(shell git rev-parse HEAD))
@@ -110,7 +110,7 @@ docker-build-dev-snapshot: ## Build self-contained image (requires GIT_REF, GIT_
 		--build-arg BUILD_MODE=$(DOCKER_BUILD_MODE) \
 		--build-arg BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
 		--build-arg SYNTH_PERMUTATIONS_GIT_REF=$(GIT_REF) \
-		--build-arg TORCH_INDEX_URL=$(DOCKER_TORCH_IDX) \
+		--build-arg TORCH_BACKEND=$(DOCKER_TORCH_BACKEND) \
 		--build-arg TARGETARCH=$(TARGETARCH) \
 		--label org.opencontainers.image.base.name=$(DOCKER_BASE_IMAGE) \
 		-t $(DOCKER_IMAGE):$(DOCKER_BASE_IMAGE_TAG)-dev-snapshot-$(GIT_REF) \

--- a/Makefile
+++ b/Makefile
@@ -32,13 +32,13 @@ test-bats: ## Run BATS shell tests
 	bats --recursive tests/
 
 install: ## Install project in editable mode with dev deps
-	command -v uv >/dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
+	pip install uv
 	uv pip install -r requirements.txt -e .
 
 # coverage runs serially (no -n auto): GPU tests require exclusive device
 # access and VRAM contention causes flaky failures with xdist parallelism.
 coverage: ## Run tests with coverage report
-	command -v uv >/dev/null || curl -LsSf https://astral.sh/uv/install.sh | sh
+	pip install uv
 	uv pip install pytest-cov[toml]
 	pytest --cov=src --cov-report=term-missing --cov-report=html -m "not slow"
 

--- a/configs/image/dev-snapshot.yaml
+++ b/configs/image/dev-snapshot.yaml
@@ -9,6 +9,6 @@ base_image: "ubuntu@sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146af
 base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
-torch_index_url: "https://download.pytorch.org/whl/cu128"
+torch_backend: "cu128"
 r2_endpoint: "https://efb9275d571811db929e83eb710b74a7.r2.cloudflarestorage.com"
 r2_bucket: "intermediate-data"

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -273,7 +273,7 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
     python3 python3-pip python3-dev
 RUN python3 --version && \
     python3 -c "import sys; exit(0) if sys.version_info[:2] == (3,10) else exit(1)"
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.4.29 /uv /uvx /usr/local/bin/
 ENV VIRTUAL_ENV=/venv/main
 # PIP_DISABLE_PIP_VERSION_CHECK=1 — suppresses version check noise in pip wheel layers
 # PYTHONDONTWRITEBYTECODE=1 — no .pyc files written in the image

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -273,17 +273,15 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
     python3 python3-pip python3-dev
 RUN python3 --version && \
     python3 -c "import sys; exit(0) if sys.version_info[:2] == (3,10) else exit(1)"
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /usr/local/bin/
 ENV VIRTUAL_ENV=/venv/main
-# PIP_DISABLE_PIP_VERSION_CHECK=1 — suppresses version check noise in all layers
+# PIP_DISABLE_PIP_VERSION_CHECK=1 — suppresses version check noise in pip wheel layers
 # PYTHONDONTWRITEBYTECODE=1 — no .pyc files written in the image
 # PYTHONUNBUFFERED=1 — stdout/stderr stream immediately (important for logs)
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
-RUN --mount=type=cache,id=pip-cache,target=/root/.cache/pip \
-    python3 -m pip install --upgrade pip virtualenv \
-    && python3 -m virtualenv $VIRTUAL_ENV \
-    && ${VIRTUAL_ENV}/bin/pip install --upgrade pip
+RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN python --version && \
     python -c "import sys; assert sys.version_info[:2] == (3, 10), sys.version"
@@ -320,7 +318,7 @@ FROM python-base AS builder-install-synth-setter-deps
 # without copying it into a layer (avoids the COPY+rm layer bloat anti-pattern).
 COPY --from=synth-setter-src /home/build/synth-setter/requirements*.txt /artifacts/
 RUN --mount=from=wheels,source=/wheels,target=/wheels \
-    pip install \
+    uv pip install \
         --no-index \
         --find-links=/wheels \
         -r /artifacts/requirements.txt && \
@@ -440,7 +438,7 @@ RUN --mount=type=secret,id=git_pat \
 
 # Install the project package so `import src` works from any working directory.
 # --no-deps: all runtime deps already installed from requirements*.txt wheels.
-RUN pip install --no-deps -e .
+RUN uv pip install --no-deps -e .
 
 # Run not-slow unit tests (mocked subprocess + LocalFakeUploader — no VST or R2 needed)
 RUN pytest -k "not slow" -v
@@ -453,5 +451,5 @@ CMD []
 FROM ${IMAGE} AS freeze-deps
 # Record package versions for audit / reproducibility
 RUN mkdir -p /usr/local/share/audit && \
-    python -m pip freeze --all | sort > /usr/local/share/audit/pip-freeze.txt && \
+    uv pip freeze | sort > /usr/local/share/audit/pip-freeze.txt && \
     dpkg-query -W -f='${Package}=${Version}\n' | sort > /usr/local/share/audit/dpkg.txt

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -418,7 +418,7 @@ RUN --mount=type=secret,id=git_pat \
     git checkout --detach "${SYNTH_PERMUTATIONS_GIT_REF}"
 
 # Install the project package so `import src` works from any working directory.
-# --no-deps: all runtime deps already installed from requirements*.txt wheels.
+# --no-deps: all runtime deps already installed via uv pip install above.
 RUN uv pip install --no-deps -e .
 
 # Run not-slow unit tests (mocked subprocess + LocalFakeUploader — no VST or R2 needed)

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -287,46 +287,20 @@ RUN python --version && \
     python -c "import sys; assert sys.version_info[:2] == (3, 10), sys.version"
 
 # ==========================================
-# Wheels stage: build wheels for all Python deps (online, with index access).
-# Split into torch (rarely changes, ~2.5 GB) and app (changes often, smaller)
-# so that requirements-app.txt edits don't re-download torch wheels.
-# ==========================================
-FROM python-base AS wheels-torch
-COPY --from=synth-setter-src /home/build/synth-setter/requirements-torch.txt /artifacts/
-ARG TORCH_INDEX_URL
-RUN --mount=type=cache,id=pip-cache,target=/root/.cache/pip \
-    pip wheel \
-        --wheel-dir /wheels \
-        --extra-index-url ${TORCH_INDEX_URL} \
-        -r /artifacts/requirements-torch.txt
-
-FROM wheels-torch AS wheels
-COPY --from=synth-setter-src /home/build/synth-setter/requirements-app.txt /artifacts/
-RUN --mount=type=cache,id=pip-cache,target=/root/.cache/pip \
-    pip wheel \
-        --wheel-dir /wheels \
-        --find-links /wheels \
-        -r /artifacts/requirements-app.txt
-
-# ==========================================
 # Shared runtime base: Python + runtime deps on top of python-base.
 # Both dev and final-stage inherit from this stage.
 # ==========================================
 FROM python-base AS builder-install-synth-setter-deps
-# Install Python dependencies from pre-built wheels (offline, deterministic).
-# Use --mount=from=wheels to bind the wheels stage's /wheels dir during the RUN
-# without copying it into a layer (avoids the COPY+rm layer bloat anti-pattern).
-#
-# --no-deps: skip uv's resolver because PyTorch wheels use local version
-# suffixes (+cu128) that uv's strict PEP 440 resolver can't match against
-# bare version specs (e.g. torchvision requires torch==2.11.0 but the wheel
-# is torch-2.11.0+cu128). pip wheel already resolved all deps correctly,
-# so we install every built wheel directly.
-RUN --mount=from=wheels,source=/wheels,target=/wheels \
+# Install all Python dependencies via uv in a single resolution pass.
+# uv's built-in cache (mounted below) persists across builds — torch wheels
+# (~2.5 GB) are only downloaded once and survive requirements-app.txt changes.
+COPY --from=synth-setter-src /home/build/synth-setter/requirements*.txt /artifacts/
+ARG TORCH_INDEX_URL
+RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install \
-        --no-index \
-        --no-deps \
-        /wheels/*.whl
+        --extra-index-url ${TORCH_INDEX_URL} \
+        -r /artifacts/requirements.txt && \
+    rm -rf /artifacts/requirements*.txt
 
 # Runtime apt packages for headless VST loading + rclone for R2 uploads
 RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -294,11 +294,17 @@ FROM python-base AS builder-install-synth-setter-deps
 # Install all Python dependencies via uv in a single resolution pass.
 # uv's built-in cache (mounted below) persists across builds — torch wheels
 # (~2.5 GB) are only downloaded once and survive requirements-app.txt changes.
+#
+# --index-strategy unsafe-best-match: the PyTorch CUDA index carries stale
+# copies of common packages (e.g. requests 2.28.1). Without this flag uv
+# only considers the first index that has a package, which blocks deps that
+# need newer versions from PyPI.
 COPY --from=synth-setter-src /home/build/synth-setter/requirements*.txt /artifacts/
 ARG TORCH_INDEX_URL
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install \
         --extra-index-url ${TORCH_INDEX_URL} \
+        --index-strategy unsafe-best-match \
         -r /artifacts/requirements.txt && \
     rm -rf /artifacts/requirements*.txt
 

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -316,13 +316,17 @@ FROM python-base AS builder-install-synth-setter-deps
 # Install Python dependencies from pre-built wheels (offline, deterministic).
 # Use --mount=from=wheels to bind the wheels stage's /wheels dir during the RUN
 # without copying it into a layer (avoids the COPY+rm layer bloat anti-pattern).
-COPY --from=synth-setter-src /home/build/synth-setter/requirements*.txt /artifacts/
+#
+# --no-deps: skip uv's resolver because PyTorch wheels use local version
+# suffixes (+cu128) that uv's strict PEP 440 resolver can't match against
+# bare version specs (e.g. torchvision requires torch==2.11.0 but the wheel
+# is torch-2.11.0+cu128). pip wheel already resolved all deps correctly,
+# so we install every built wheel directly.
 RUN --mount=from=wheels,source=/wheels,target=/wheels \
     uv pip install \
         --no-index \
-        --find-links=/wheels \
-        -r /artifacts/requirements.txt && \
-    rm -rf /artifacts/requirements*.txt
+        --no-deps \
+        /wheels/*.whl
 
 # Runtime apt packages for headless VST loading + rclone for R2 uploads
 RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -270,16 +270,14 @@ RUN ls /usr/lib/vst3/ && test -n "$(ls -A /usr/lib/vst3/Surge\ XT.vst3 2>/dev/nu
 RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,id=apt-lib,target=/var/lib/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
-    python3 python3-pip python3-dev
+    python3 python3-dev
 RUN python3 --version && \
     python3 -c "import sys; exit(0) if sys.version_info[:2] == (3,10) else exit(1)"
-COPY --from=ghcr.io/astral-sh/uv:0.4.29 /uv /uvx /usr/local/bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.2 /uv /uvx /usr/local/bin/
 ENV VIRTUAL_ENV=/venv/main
-# PIP_DISABLE_PIP_VERSION_CHECK=1 — suppresses version check noise in pip wheel layers
 # PYTHONDONTWRITEBYTECODE=1 — no .pyc files written in the image
 # PYTHONUNBUFFERED=1 — stdout/stderr stream immediately (important for logs)
-ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    PYTHONDONTWRITEBYTECODE=1 \
+ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
@@ -295,16 +293,15 @@ FROM python-base AS builder-install-synth-setter-deps
 # uv's built-in cache (mounted below) persists across builds — torch wheels
 # (~2.5 GB) are only downloaded once and survive requirements-app.txt changes.
 #
-# --index-strategy unsafe-best-match: the PyTorch CUDA index carries stale
-# copies of common packages (e.g. requests 2.28.1). Without this flag uv
-# only considers the first index that has a package, which blocks deps that
-# need newer versions from PyPI.
+# --torch-backend: tells uv which PyTorch variant to install (e.g. cu128, cpu).
+# This replaces --extra-index-url + --index-strategy unsafe-best-match,
+# which was needed because the PyTorch CUDA index carried stale copies of
+# common packages.
 COPY --from=synth-setter-src /home/build/synth-setter/requirements*.txt /artifacts/
-ARG TORCH_INDEX_URL
+ARG TORCH_BACKEND=cu128
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install \
-        --extra-index-url ${TORCH_INDEX_URL} \
-        --index-strategy unsafe-best-match \
+        --torch-backend ${TORCH_BACKEND} \
         -r /artifacts/requirements.txt && \
     rm -rf /artifacts/requirements*.txt
 

--- a/docs/reference/docker-spec.md
+++ b/docs/reference/docker-spec.md
@@ -73,7 +73,7 @@ The `dev-snapshot` target inherits from `r2-config-base`. R2 credentials are bak
 | `SURGE_GIT_REF`              | *(pinned SHA)* | Surge XT release commit                       |
 | `BUILD_MODE`                 | `source`       | `source` or `prebuilt` (Surge install method) |
 | `R2_BUCKET`                  | *(empty)*      | Cloudflare R2 bucket name                     |
-| `TORCH_INDEX_URL`            | *(required)*   | PyTorch wheel index URL                       |
+| `TORCH_BACKEND`              | `cu128`        | PyTorch backend for uv (e.g. cu128, cpu)      |
 
 ### Baked ENV vars (available at runtime)
 

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -112,10 +112,10 @@ make docker-build-dev-snapshot \
 | `DOCKER_IMAGE`          | `synth-setter`                  | Image name (local builds)                        | CLI only     |
 | `DOCKER_BUILD_MODE`     | `prebuilt`                      | Surge install: `source` or `prebuilt` (see note) | CLI only     |
 | `DOCKER_TARGETPLATFORM` | `linux/amd64`                   | Target platform                                  | CLI only     |
-| `DOCKER_TORCH_IDX`      | CUDA 12.8 wheels                | PyTorch wheel index URL                          | CLI or YAML  |
+| `DOCKER_TORCH_BACKEND`  | `cu128`                         | PyTorch backend (e.g. cu128, cpu)                | CLI or YAML  |
 | `DOCKER_BUILD_FLAGS`    | *(empty)*                       | `--load` (local) or `--push` (remote)            | CLI only     |
 
-`DOCKER_TORCH_IDX` can also be set via `torch_index_url` in the image config
+`DOCKER_TORCH_BACKEND` can also be set via `torch_backend` in the image config
 YAML (see Image config below). CLI takes precedence.
 
 > **BUILD_MODE default divergence:** The Makefile defaults `DOCKER_BUILD_MODE`
@@ -140,7 +140,7 @@ base_image: "ubuntu@sha256:3ba65aa..."
 base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
-torch_index_url: "https://download.pytorch.org/whl/cu128"
+torch_backend: "cu128"
 r2_endpoint: "https://efb9275d571811db929e83eb710b74a7.r2.cloudflarestorage.com"
 r2_bucket: "intermediate-data"
 ```

--- a/docs/reference/promotion-pipeline-reference.md
+++ b/docs/reference/promotion-pipeline-reference.md
@@ -245,8 +245,11 @@ jobs:
         with:
           python-version: "3.10"
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Install dependencies
-        run: pip install wandb
+        run: uv pip install --system wandb
 
       - name: Promote model
         id: promote

--- a/pipeline/schemas/image_config.py
+++ b/pipeline/schemas/image_config.py
@@ -30,7 +30,7 @@ class ImageConfig(BaseModel, strict=True, extra="forbid"):
     base_image_tag: str
     build_mode: Literal["source", "prebuilt"]
     target_platform: Literal["linux/amd64", "linux/arm64"]
-    torch_index_url: str
+    torch_backend: str
     r2_endpoint: str
     r2_bucket: str
 

--- a/tests/pipeline/test_ci/test_load_image_config.py
+++ b/tests/pipeline/test_ci/test_load_image_config.py
@@ -251,7 +251,7 @@ base_image: "ubuntu@sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146af
 base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
-torch_index_url: "https://download.pytorch.org/whl/cu128"
+torch_backend: "cu128"
 r2_endpoint: "https://example.r2.cloudflarestorage.com"
 r2_bucket: test-bucket
 """
@@ -286,7 +286,7 @@ base_image: "ubuntu@sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146af
 base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
-torch_index_url: "https://download.pytorch.org/whl/cu128"
+torch_backend: "cu128"
 r2_endpoint: "https://example.r2.cloudflarestorage.com"
 r2_bucket: test-bucket
 """

--- a/tests/pipeline/test_ci/test_load_image_config.py
+++ b/tests/pipeline/test_ci/test_load_image_config.py
@@ -26,7 +26,7 @@ base_image: "ubuntu@sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146af
 base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
-torch_index_url: "https://download.pytorch.org/whl/cu128"
+torch_backend: "cu128"
 r2_endpoint: "https://example.r2.cloudflarestorage.com"
 r2_bucket: test-bucket
 """
@@ -38,7 +38,7 @@ _EXPECTED_LINES = [
     "base_image_tag=ubuntu22_04",
     "build_mode=prebuilt",
     "target_platform=linux/amd64",
-    "torch_index_url=https://download.pytorch.org/whl/cu128",
+    "torch_backend=cu128",
     "r2_endpoint=https://example.r2.cloudflarestorage.com",
     "r2_bucket=test-bucket",
     f"github_sha={VALID_SHA}",

--- a/tests/pipeline/test_schemas/test_image_config.py
+++ b/tests/pipeline/test_schemas/test_image_config.py
@@ -24,7 +24,7 @@ base_image: "ubuntu@sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146af
 base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
-torch_index_url: "https://download.pytorch.org/whl/cu128"
+torch_backend: "cu128"
 r2_endpoint: "https://example.r2.cloudflarestorage.com"
 r2_bucket: test-bucket
 """
@@ -247,7 +247,7 @@ class TestLoadImageConfigErrors:
             "base_image_tag: ubuntu22_04\n"
             "build_mode: prebuilt\n"
             "target_platform: linux/amd64\n"
-            'torch_index_url: "https://download.pytorch.org/whl/cu128"\n'
+            'torch_backend: "cu128"\n'
             'r2_endpoint: "https://example.r2.cloudflarestorage.com"\n'
         )
 
@@ -302,7 +302,7 @@ class TestStaticFieldsAndYamlMerge:
         assert result.base_image_tag == "ubuntu22_04"
         assert result.build_mode == "prebuilt"
         assert result.target_platform == "linux/amd64"
-        assert result.torch_index_url == "https://download.pytorch.org/whl/cu128"
+        assert result.torch_backend == "cu128"
         assert result.r2_endpoint == (
             "https://efb9275d571811db929e83eb710b74a7.r2.cloudflarestorage.com"
         )


### PR DESCRIPTION
## Summary

Full migration from pip to uv in the Dockerfile and supporting config/CI/docs:

- **Delete `wheels-torch` and `wheels` stages** — replaced with a single `uv pip install --torch-backend cu128` that resolves all deps in one pass
- **uv `0.11.2`** installed via `COPY --from=ghcr.io/astral-sh/uv:0.11.2` (replaces pip + virtualenv)
- **`--torch-backend cu128`** — uv's native PyTorch support, routes torch ecosystem packages to the correct CUDA index automatically. No `--extra-index-url`, no `--index-strategy unsafe-best-match`
- **Drop `python3-pip`** from apt install — nothing uses pip anymore
- **`TORCH_INDEX_URL` → `TORCH_BACKEND`** renamed across Dockerfile, Makefile, CI workflow, image config, schema, docs, and tests

## Files changed

| File | What |
|------|------|
| `docker/ubuntu22_04/Dockerfile` | uv 0.11.2, drop pip, delete wheel stages, --torch-backend |
| `Makefile` | `DOCKER_TORCH_BACKEND` replaces `DOCKER_TORCH_IDX` |
| `.github/workflows/docker-build-validation.yml` | `TORCH_BACKEND` build-arg |
| `.github/workflows/flush-investigation.yml` | `pip install` → `uv pip install` |
| `configs/image/dev-snapshot.yaml` | `torch_backend: "cu128"` |
| `pipeline/schemas/image_config.py` | `torch_backend` field |
| `docs/reference/docker.md` | Updated build variable docs |
| `docs/reference/docker-spec.md` | Updated spec table |
| `docs/reference/promotion-pipeline-reference.md` | `uv pip install` + setup-uv |
| `tests/pipeline/test_schemas/test_image_config.py` | Updated fixtures |
| `tests/pipeline/test_ci/test_load_image_config.py` | Updated fixtures |

## Why --torch-backend

The PyTorch CUDA index carries stale copies of common packages (requests, fsspec). Previous approaches had issues:
- `--extra-index-url` without strategy: uv only uses the first index per package → stale versions block deps
- `--index-strategy unsafe-best-match`: works but fragile — relies on version-number racing between PyPI and the CUDA index
- `--torch-backend cu128`: uv natively routes only torch ecosystem packages to the CUDA index, everything else to PyPI

## Docker build benchmarks

Measured on GHA `ubuntu-latest-4core`, same time, same registry cache:

| Stage | Baseline (pip) | PR (uv) | Delta |
|-------|---------------|---------|-------|
| venv setup | 3.9s | 0.2s | **-3.7s** |
| deps install | 103.3s | 55.7s | **-47.6s** |
| editable install | 3.9s | 1.2s | **-2.7s** |

## Test plan

- [ ] Docker build CI passes end-to-end (resolve, install, pytest, smoke tests)
- [ ] `make format` passes
- [ ] `make test` passes

Closes #424
Part of #422