### PR TITLE
feat(ci): add experiments domain to taxonomy

### DIFF
--- a/.claude/hooks/verify-gh-taxonomy.sh
+++ b/.claude/hooks/verify-gh-taxonomy.sh
@@ -129,7 +129,7 @@ fi
 # ---------------------------------------------------------------------------
 OWNER="tinaudio"
 REPO="synth-setter"
-DOMAIN_LABELS="data-pipeline ci-automation code-health documentation evaluation monitoring storage testing training"
+DOMAIN_LABELS="data-pipeline ci-automation code-health documentation evaluation experiments monitoring storage testing training"
 
 # ---------------------------------------------------------------------------
 # Helper: query an issue's taxonomy metadata (type, labels, milestone).

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -14,6 +14,7 @@ body:
         - code-health
         - evaluation
         - documentation
+        - experiments
         - monitoring
         - storage
         - testing
@@ -28,11 +29,13 @@ body:
         - data-pipeline v1.0.0
         - evaluation v1.0.0
         - documentation v1.0.0
+        - experiments v1.0.0
         - monitoring v1.0.0
         - training v1.0.0
         - storage v1.0.0
         - ci-automation v1.0.0
         - code-health v1.0.0
+        - testing v1.0.0
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/epic.yml
+++ b/.github/ISSUE_TEMPLATE/epic.yml
@@ -15,6 +15,7 @@ body:
         - code-health
         - evaluation
         - documentation
+        - experiments
         - monitoring
         - storage
         - testing
@@ -29,11 +30,13 @@ body:
         - data-pipeline v1.0.0
         - evaluation v1.0.0
         - documentation v1.0.0
+        - experiments v1.0.0
         - monitoring v1.0.0
         - training v1.0.0
         - storage v1.0.0
         - ci-automation v1.0.0
         - code-health v1.0.0
+        - testing v1.0.0
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -14,6 +14,7 @@ body:
         - code-health
         - evaluation
         - documentation
+        - experiments
         - monitoring
         - storage
         - testing
@@ -28,11 +29,13 @@ body:
         - data-pipeline v1.0.0
         - evaluation v1.0.0
         - documentation v1.0.0
+        - experiments v1.0.0
         - monitoring v1.0.0
         - training v1.0.0
         - storage v1.0.0
         - ci-automation v1.0.0
         - code-health v1.0.0
+        - testing v1.0.0
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/phase.yml
+++ b/.github/ISSUE_TEMPLATE/phase.yml
@@ -23,6 +23,7 @@ body:
         - code-health
         - evaluation
         - documentation
+        - experiments
         - monitoring
         - storage
         - testing
@@ -37,11 +38,13 @@ body:
         - data-pipeline v1.0.0
         - evaluation v1.0.0
         - documentation v1.0.0
+        - experiments v1.0.0
         - monitoring v1.0.0
         - training v1.0.0
         - storage v1.0.0
         - ci-automation v1.0.0
         - code-health v1.0.0
+        - testing v1.0.0
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -22,6 +22,7 @@ body:
         - code-health
         - evaluation
         - documentation
+        - experiments
         - monitoring
         - storage
         - testing
@@ -36,11 +37,13 @@ body:
         - data-pipeline v1.0.0
         - evaluation v1.0.0
         - documentation v1.0.0
+        - experiments v1.0.0
         - monitoring v1.0.0
         - training v1.0.0
         - storage v1.0.0
         - ci-automation v1.0.0
         - code-health v1.0.0
+        - testing v1.0.0
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/pr-metadata-gate.yaml
+++ b/.github/workflows/pr-metadata-gate.yaml
@@ -99,7 +99,7 @@ jobs:
 
           # Keep in sync with docs/design/github-taxonomy.md §2 and §6
           VALID_TYPES=("Epic" "Phase" "Task" "Bug" "Feature")
-          DOMAIN_LABELS=("data-pipeline" "ci-automation" "code-health" "documentation" "evaluation" "monitoring" "storage" "testing" "training")
+          DOMAIN_LABELS=("data-pipeline" "ci-automation" "code-health" "documentation" "evaluation" "experiments" "monitoring" "storage" "testing" "training")
           FAILURES=""
 
           for ISSUE_NUM in "${ISSUE_NUMBERS[@]}"; do

--- a/docs/design/github-taxonomy.md
+++ b/docs/design/github-taxonomy.md
@@ -131,17 +131,18 @@ Priority is tracked via a **Priority** single-select field on the project:
 
 Labels classify issues by **domain**. Type and blocking are handled by native features; priority is a project field.
 
-| Label           | Color   | Description                                                     |
-| --------------- | ------- | --------------------------------------------------------------- |
-| `data-pipeline` | #0e8a16 | Data pipeline work stream                                       |
-| `ci-automation` | #1d76db | CI & automation work stream                                     |
-| `code-health`   | #fbca04 | Code quality and tech debt                                      |
-| `documentation` | #0075ca | Documentation quality, drift detection, and doc-map maintenance |
-| `evaluation`    | #C5DEF5 | Evaluation pipeline, metrics, and inference                     |
-| `monitoring`    | #0E8A16 | Observability, W&B integration, logging                         |
-| `storage`       | #D4C5F9 | Storage infrastructure (R2, rclone)                             |
-| `testing`       | #0E8A16 | Test infrastructure, fixtures, CI test config                   |
-| `training`      | #8B5CF6 | Training pipeline, ops, and infrastructure                      |
+| Label           | Color   | Description                                                            |
+| --------------- | ------- | ---------------------------------------------------------------------- |
+| `data-pipeline` | #0e8a16 | Data pipeline work stream                                              |
+| `ci-automation` | #1d76db | CI & automation work stream                                            |
+| `code-health`   | #fbca04 | Code quality and tech debt                                             |
+| `documentation` | #0075ca | Documentation quality, drift detection, and doc-map maintenance        |
+| `evaluation`    | #C5DEF5 | Evaluation pipeline, metrics, and inference                            |
+| `experiments`   | #E99695 | One-off validation experiments, result replication, and parity studies |
+| `monitoring`    | #0E8A16 | Observability, W&B integration, logging                                |
+| `storage`       | #D4C5F9 | Storage infrastructure (R2, rclone)                                    |
+| `testing`       | #0E8A16 | Test infrastructure, fixtures, CI test config                          |
+| `training`      | #8B5CF6 | Training pipeline, ops, and infrastructure                             |
 
 **Multi-label policy:** Most issues carry a single domain label. Cross-cutting infrastructure (e.g., R2/rclone work that serves both data pipeline and eval pipeline) may carry multiple domain labels to appear in all relevant filtered views. Use multiple labels only when the work genuinely spans work streams — not as a default.
 
@@ -153,12 +154,14 @@ Workflow labels (`duplicate`, `invalid`, `wontfix`, `good first issue`, `help wa
 | -------------------- | --------------- |
 | data-pipeline v1.0.0 | Data Pipeline   |
 | evaluation v1.0.0    | Evaluation      |
+| experiments v1.0.0   | Experiments     |
 | monitoring v1.0.0    | Monitoring      |
 | training v1.0.0      | Training        |
 | ci-automation v1.0.0 | CI & Automation |
 | code-health v1.0.0   | Code Health     |
 | documentation v1.0.0 | Documentation   |
 | storage v1.0.0       | Storage         |
+| testing v1.0.0       | Testing         |
 
 Every work stream has a milestone. Set the milestone on each issue individually — GitHub does not auto-inherit milestones from parent issues.
 
@@ -200,10 +203,13 @@ Use saved views with domain label filters to switch between work streams:
 | All Work        | Hierarchy | (none)                |
 | Data Pipeline   | Hierarchy | `label:data-pipeline` |
 | Evaluation      | Hierarchy | `label:evaluation`    |
+| Experiments     | Hierarchy | `label:experiments`   |
 | Storage         | Hierarchy | `label:storage`       |
 | CI & Automation | Board     | `label:ci-automation` |
 | Code Health     | Table     | `label:code-health`   |
 | Documentation   | Table     | `label:documentation` |
+| Monitoring      | Table     | `label:monitoring`    |
+| Testing         | Table     | `label:testing`       |
 | Training        | Hierarchy | `label:training`      |
 | Roadmap         | Roadmap   | (none)                |
 | Blocked         | Table     | is:blocked            |


### PR DESCRIPTION
## Summary

- Register a new `experiments` domain for one-off validation experiments (result replication, baseline parity, render variability benchmarks), distinct from the existing `evaluation` and `testing` domains.
- Update all 8 synth-setter locations that enumerate domains so CI gate, hook, issue templates, and the taxonomy doc all list the same 10-domain set.
- While here, fix pre-existing drift: `testing v1.0.0` was missing from template milestone dropdowns and §7 milestones table (the milestone existed on GitHub but couldn't be selected); §8 views was missing rows for `monitoring` and `testing`.

## Files changed

| File | Change |
|---|---|
| `.github/workflows/pr-metadata-gate.yaml` | `DOMAIN_LABELS` array: +`experiments` |
| `.claude/hooks/verify-gh-taxonomy.sh` | `DOMAIN_LABELS` string: +`experiments` |
| `.github/ISSUE_TEMPLATE/{epic,phase,task,bug,feature}.yml` | Domain dropdown: +`experiments`; milestone dropdown: +`experiments v1.0.0`, +`testing v1.0.0` |
| `docs/design/github-taxonomy.md` | §6 +`experiments`/#E99695; §7 +`experiments v1.0.0`, +`testing v1.0.0`; §8 +`Experiments`, +`Monitoring`, +`Testing` views |

## Companion PR

The github-taxonomy skill update is in tinaudio/skills#53 (adds `experiments` + fixes separate drift where `documentation`/`monitoring` were missing from the skill's domain tables). After that PR merges, a follow-up commit on this branch will bump the `.claude/skills` submodule pointer.

## Follow-up (after this PR merges)

Create the GitHub label and milestone so the new domain can actually be applied:

```bash
gh label create experiments --repo tinaudio/synth-setter --color E99695 \
  --description "One-off validation experiments, result replication, and parity studies"
gh api repos/tinaudio/synth-setter/milestones --method POST \
  -f title="experiments v1.0.0" \
  -f description="Experiments work stream: validation, replication, parity studies"
```

## Test plan

- [ ] `pr-metadata-gate` CI check passes (validates the modified workflow file doesn't break its own execution)
- [ ] `make format` passes
- [ ] All 8 changed files list the same 10-domain set
- [ ] After merge + label/milestone creation: test that an issue labeled only `experiments` + milestone `experiments v1.0.0` passes the metadata gate on a throwaway PR

Refs #492