### PR TITLE
chore: add .devcontainer config for GitHub Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,53 @@
+{
+  "name": "synth-setter",
+  "image": "tinaudio/perm:dev-snapshot",
+
+  "containerEnv": {
+    "MODE": "idle"
+  },
+
+  "remoteUser": "root",
+  "workspaceFolder": "/workspaces/synth-setter",
+
+  "postCreateCommand": ".devcontainer/post-create.sh",
+
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.debugpy",
+        "ms-python.vscode-python-envs",
+        "charliermarsh.ruff",
+        "ms-toolsai.jupyter",
+        "ms-toolsai.jupyter-keymap",
+        "ms-toolsai.jupyter-renderers",
+        "ms-toolsai.vscode-jupyter-cell-tags",
+        "ms-toolsai.vscode-jupyter-slideshow",
+        "redhat.vscode-yaml",
+        "kamilturek.vscode-pyproject-toml-snippets",
+        "ms-vscode.makefile-tools",
+        "jetmartin.bats",
+        "timonwong.shellcheck",
+        "lochbrunner.vscode-hdf5-viewer",
+        "adamviola.parquet-explorer",
+        "mechatroner.rainbow-csv",
+        "github.vscode-pull-request-github",
+        "github.vscode-github-actions",
+        "eamodio.gitlens",
+        "anthropic.claude-code"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/venv/main/bin/python",
+        "python.terminal.activateEnvironment": false,
+        "editor.formatOnSave": true,
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": ["tests"]
+      }
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -7,6 +7,11 @@ set -euo pipefail
 
 cd /workspaces/synth-setter
 
+# Codespaces runs this script as root against a workspace that may be owned
+# by another UID, tripping git's safe.directory check. Mark the repo trusted
+# before any git operation (submodule update, pre-commit install).
+git config --global --add safe.directory "$(pwd)"
+
 # Skills live in a git submodule (.claude/skills → tinaudio/skills).
 git submodule update --init --recursive
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Codespace first-run setup. Runs once after the container is created.
+# The base image (tinaudio/perm:dev-snapshot) already ships all deps,
+# Surge XT, xvfb, rclone, and baked R2/W&B credentials — so this script
+# only wires up the workspace checkout to the image's venv.
+set -euo pipefail
+
+cd /workspaces/synth-setter
+
+# Skills live in a git submodule (.claude/skills → tinaudio/skills).
+git submodule update --init --recursive
+
+# Install the workspace as an editable package into the image's venv.
+# --no-deps skips re-downloading the ~2.5GB of deps already in the image.
+uv pip install --no-deps -e .
+
+# Pre-commit hooks (pre-commit itself is in the image's deps).
+pre-commit install
+
+# plumb writes a native git hook — re-run pre-commit install to chain it.
+if command -v plumb >/dev/null 2>&1; then
+  plumb init || true
+  pre-commit install
+fi
+
+echo "Codespace ready. Run 'make test' to verify."

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,6 +85,39 @@ This runs the quick test suite (excluding slow tests and tests that require a
 VST plugin). All tests should pass. If you see import errors, double-check that
 the virtual environment is active and dependencies installed correctly.
 
+### 2f. Alternative: GitHub Codespaces
+
+Instead of setting up locally, you can open the repo in a GitHub Codespace. The
+Codespace uses the same Docker image (`tinaudio/perm:dev-snapshot`) we run on
+RunPod, so VST-dependent tests, `generate_dataset` → R2 uploads, and CPU
+training all work identically — no local Surge XT, rclone, or R2 setup needed.
+GPU training still runs on RunPod.
+
+**Prerequisites** (one-time, org admin):
+
+- Docker Hub registry credentials configured as org-level Codespace registry
+  secrets (`*_CONTAINER_REGISTRY_USER`, `*_CONTAINER_REGISTRY_PASSWORD`) so
+  Codespaces can pull the private image.
+
+**Open a Codespace:**
+
+1. On GitHub, click **Code → Codespaces → Create codespace on main**.
+2. First start takes ~5 min (image pull). Subsequent starts are fast.
+3. `.devcontainer/post-create.sh` initializes submodules, installs the
+   workspace editable, and wires up pre-commit hooks — then the terminal is
+   ready.
+
+**Verify:**
+
+```bash
+make test
+python -c "import torch; print(torch.cuda.is_available())"   # False (CPU)
+rclone lsd r2:intermediate-data
+```
+
+**Fall back to RunPod for** full GPU training (CUDA kernels, large batch
+sizes) and multi-hour runs.
+
 ______________________________________________________________________
 
 ## 3. k-osc Quickstart (No External Dependencies)


### PR DESCRIPTION
## Summary

- Adds `.devcontainer/devcontainer.json` + `post-create.sh` that open a GitHub Codespace backed by the existing `tinaudio/perm:dev-snapshot` image (the same one we run on RunPod). Workspace tests, VST-dependent code, `generate_dataset` → R2 uploads, and CPU training all work identically in the Codespace — no local Surge XT, rclone, or R2 setup required.
- Uses the image's built-in `MODE=idle` entrypoint path to keep the container alive, rather than `overrideCommand: true` — the image's own API, not a bypass.
- Adds a "2f. Alternative: GitHub Codespaces" subsection to `docs/getting-started.md`.

## Design notes

- **Reuses the existing private image** — no new Dockerfile target, no new CI workflow, no public image. Codespaces pulls it via the org's pre-configured `*_CONTAINER_REGISTRY_USER` / `*_CONTAINER_REGISTRY_PASSWORD` secrets.
- **`post-create.sh` uses `uv pip install --no-deps -e .`**, not `make install` — the image already has all deps (including ~2.5GB of torch wheels) baked in; re-running `make install` would redownload everything. We only need to install the editable workspace pointing at `/workspaces/synth-setter`.
- **Baked R2/W&B credentials in `dev-snapshot` are inherited** — acceptable because only repo collaborators can open Codespaces, and those credentials are the same ones they'd use locally.
- **CPU-only** — the image's PyTorch is CUDA 12.8-built, so `torch.cuda.is_available() == False` in a standard Codespace and training needs `trainer=cpu`. Full GPU training stays on RunPod.
- Curated VSCode extensions (auto-install in devcontainer) are a subset of the existing `.vscode/extensions.json` recommendations — excludes remote-* extensions (redundant inside a Codespace), C++ tooling (not needed in the dev container), and AI tools other than Claude Code (personal preference).

## Test plan

- [ ] Open a Codespace from this branch on a GPU-less machine type.
- [ ] `make test` passes.
- [ ] `python -c "import torch; print(torch.__version__, torch.cuda.is_available())"` prints `False`.
- [ ] `python -c "import src; print(src.__file__)"` resolves under `/workspaces/synth-setter/src/`.
- [ ] `rclone lsd r2:intermediate-data` lists the bucket (baked creds work).
- [ ] `pytest -k "requires_vst and not slow"` passes (xvfb + Surge XT work).
- [ ] `python src/train.py experiment=kosc/ffn_mse trainer.max_steps=10 trainer=cpu` completes and logs to W&B.
- [ ] `git submodule status` shows `.claude/skills` populated.
- [ ] Pre-commit runs clean via `make format`.

Closes #186