### PR TITLE
fix(devcontainer): derive workspaceFolder from host directory name

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
   },
 
   "remoteUser": "root",
-  "workspaceFolder": "/workspaces/synth-setter",
+  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
   "postCreateCommand": ".devcontainer/post-create.sh",
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -5,7 +5,16 @@
 # only wires up the workspace checkout to the image's venv.
 set -euo pipefail
 
-cd /workspaces/synth-setter
+# Locate the workspace root via the .project-root anchor, not by hardcoded
+# path. GitHub Codespaces mounts at /workspaces/synth-setter, but locally the
+# devcontainer CLI uses the host directory basename (e.g. a git worktree
+# name), so the mount path is not fixed.
+dir="$(cd "$(dirname "$0")" && pwd)"
+while [[ "$dir" != "/" && ! -f "$dir/.project-root" ]]; do
+  dir="$(dirname "$dir")"
+done
+[[ -f "$dir/.project-root" ]] || { echo "ERROR: .project-root not found" >&2; exit 1; }
+cd "$dir"
 
 # Codespaces runs this script as root against a workspace that may be owned
 # by another UID, tripping git's safe.directory check. Mark the repo trusted
@@ -19,7 +28,10 @@ git submodule update --init --recursive
 # --no-deps skips re-downloading the ~2.5GB of deps already in the image.
 uv pip install --no-deps -e .
 
-# Pre-commit hooks (pre-commit itself is in the image's deps).
+# Pre-commit hooks (pre-commit itself is in the image's deps). Strip any
+# absolute host-path core.hooksPath that may leak from the host .git/config
+# (harmless in Codespaces; bites local devcontainer users).
+git config --unset-all core.hooksPath 2>/dev/null || true
 pre-commit install
 
 # plumb writes a native git hook — re-run pre-commit install to chain it.

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,19 +1,25 @@
 #!/usr/bin/env bash
-# Codespace first-run setup. Runs once after the container is created.
-# The base image (tinaudio/perm:dev-snapshot) already ships all deps,
-# Surge XT, xvfb, rclone, and baked R2/W&B credentials — so this script
-# only wires up the workspace checkout to the image's venv.
+# Dev container first-run setup for both Codespaces and local devcontainers.
+# Runs once after the container is created. The base image
+# (tinaudio/perm:dev-snapshot) already ships all deps, Surge XT, xvfb,
+# rclone, and baked R2/W&B credentials — so this script only wires up the
+# workspace checkout to the image's venv.
 set -euo pipefail
 
 # Locate the workspace root via the .project-root anchor, not by hardcoded
 # path. GitHub Codespaces mounts at /workspaces/synth-setter, but locally the
 # devcontainer CLI uses the host directory basename (e.g. a git worktree
 # name), so the mount path is not fixed.
-dir="$(cd "$(dirname "$0")" && pwd)"
+search_start="$(cd "$(dirname "$0")" && pwd)"
+dir="$search_start"
 while [[ "$dir" != "/" && ! -f "$dir/.project-root" ]]; do
   dir="$(dirname "$dir")"
 done
-[[ -f "$dir/.project-root" ]] || { echo "ERROR: .project-root not found" >&2; exit 1; }
+[[ -f "$dir/.project-root" ]] || {
+  echo "ERROR: .project-root anchor not found walking up from $search_start." >&2
+  echo "The dev container must be opened at the repository root containing .project-root." >&2
+  exit 1
+}
 cd "$dir"
 
 # Codespaces runs this script as root against a workspace that may be owned
@@ -31,7 +37,7 @@ uv pip install --no-deps -e .
 # Pre-commit hooks (pre-commit itself is in the image's deps). Strip any
 # absolute host-path core.hooksPath that may leak from the host .git/config
 # (harmless in Codespaces; bites local devcontainer users).
-git config --unset-all core.hooksPath 2>/dev/null || true
+git config --local --unset-all core.hooksPath 2>/dev/null || true
 pre-commit install
 
 # plumb writes a native git hook — re-run pre-commit install to chain it.
@@ -40,4 +46,4 @@ if command -v plumb >/dev/null 2>&1; then
   pre-commit install
 fi
 
-echo "Codespace ready. Run 'make test' to verify."
+echo "Dev container ready. Run 'make test' to verify."

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -118,6 +118,54 @@ rclone lsd r2:intermediate-data
 **Fall back to RunPod for** full GPU training (CUDA kernels, large batch
 sizes) and multi-hour runs.
 
+### 2g. Alternative: Local Dev Container
+
+If you want the same image Codespaces uses (VST plugins, rclone, baked R2/W&B
+credentials) but prefer to work on your own machine, open the dev container
+locally **on the main working tree** and create git worktrees *inside* the
+container.
+
+**Prerequisites:**
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) and
+  either the VS Code
+  [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+  or the [`devcontainer` CLI](https://github.com/devcontainers/cli).
+- Docker Hub credentials (`docker login`) — the image is private.
+- Apple Silicon: set `DOCKER_DEFAULT_PLATFORM=linux/amd64` (the image is
+  amd64-only).
+
+**Open the container on main:**
+
+```bash
+cd /path/to/synth-setter
+devcontainer up --workspace-folder .
+# or in VS Code: "Dev Containers: Reopen in Container"
+```
+
+**Create worktrees from inside the container:**
+
+```bash
+# Inside the container, starting from the workspace root on main:
+git worktree add .claude/worktrees/my-feature -b feat/my-feature
+cd .claude/worktrees/my-feature
+```
+
+This is the supported local pattern. Mounting a worktree directly from the
+host does not work — the worktree's `.git` file points to
+`<repo>/.git/worktrees/<name>/` on the host, which is outside the container's
+bind mount, so git submodule/hook operations fail to resolve their gitdir.
+
+**Caveats:**
+
+- `git worktree list` inside the container marks host-created worktrees as
+  `prunable` (their host paths don't resolve inside the mount). Do **not**
+  run `git worktree prune` inside the container — it will drop registry
+  entries for worktrees that are still valid on the host.
+- `git submodule update` for the private `tinaudio/skills` submodule needs
+  GitHub credentials forwarded into the container (VS Code's git credential
+  helper usually does this; for the CLI, export `GITHUB_TOKEN`).
+
 ______________________________________________________________________
 
 ## 3. k-osc Quickstart (No External Dependencies)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -163,8 +163,11 @@ bind mount, so git submodule/hook operations fail to resolve their gitdir.
   run `git worktree prune` inside the container — it will drop registry
   entries for worktrees that are still valid on the host.
 - `git submodule update` for the private `tinaudio/skills` submodule needs
-  GitHub credentials forwarded into the container (VS Code's git credential
-  helper usually does this; for the CLI, export `GITHUB_TOKEN`).
+  GitHub credentials available to git inside the container. VS Code's git
+  credential helper usually forwards these automatically. For the CLI, run
+  `gh auth login && gh auth setup-git` inside the container, or configure
+  git's credential helper with a PAT. Exporting `GITHUB_TOKEN` alone is not
+  sufficient — git will not use it without a credential helper configured.
 
 ______________________________________________________________________
 

--- a/docs/operations/credential-rotation-guide.md
+++ b/docs/operations/credential-rotation-guide.md
@@ -346,6 +346,7 @@ workflows.
 3. Rebuild Docker images if the credential was baked in.
 
 ### 3. Create a github issue assigned to ktinubu@ documenting that rotation took place.
+
 ______________________________________________________________________
 
 ## Notes


### PR DESCRIPTION
## Summary

The devcontainer config hardcoded `workspaceFolder` to `/workspaces/synth-setter` and `post-create.sh` hardcoded `cd` to the same path. This only worked in GitHub Codespaces (repo always cloned to `/workspaces/<repo-name>`) and in local clones literally named "synth-setter". Forks cloned to custom directory names and git worktrees failed with chdir exit 127 in `postCreateCommand`.

See the [bug report comment on #186](https://github.com/tinaudio/synth-setter/issues/186#issuecomment-4189247670) for full reproduction and root cause.

## Changes

- **`devcontainer.json`**: `workspaceFolder` uses `${localWorkspaceFolderBasename}` substitution, matching the devcontainer CLI's mount-target derivation. Unchanged behavior in Codespaces; fixes local clones with any directory name.
- **`post-create.sh`**: Walks up from the script's location to find the `.project-root` anchor (the project's existing `rootutils` convention) instead of hardcoding the workspace path.
- **`post-create.sh`**: Defensively unsets `core.hooksPath` before `pre-commit install`, stripping any absolute host-path that may leak from the host `.git/config` (harmless in Codespaces; breaks local devcontainer users who ran `pre-commit install` on the host).
- **`docs/getting-started.md`**: New §2g documenting the supported local-devcontainer workflow — open the container on the main working tree and create git worktrees *inside* the container. Mounting a worktree directly from the host does not work because the worktree's `.git` file points to a host path outside the container's bind mount.

## Verification

Container run on the main working tree with the fixed `post-create.sh`:

```
✓ .project-root walkup resolves to /workspaces/synth-setter
✓ safe.directory set
✓ git submodule update --init --recursive
✓ uv pip install --no-deps -e .
✓ core.hooksPath stripped → pre-commit install succeeded
  (migrated existing hook to .legacy)
outcome: success
```

Worktree-creation-inside-container separately verified: `git worktree add .claude/worktrees/demo -b test/demo` inside the container succeeds, with the new worktree's `.git` pointer resolving correctly (both inside and outside the mount). `git commit` in the new worktree works end-to-end.

## What this does NOT fix

- **Mounting a worktree directly into the container** still requires `git worktree add --relative-paths` (git 2.48+) + `--mount-git-worktree-common-dir` CLI flag. The base image ships git 2.34.1, so that path is blocked today. Deferred — see §2g in the docs for the supported workaround.
- **Apple Silicon platform mismatch**: still needs `DOCKER_DEFAULT_PLATFORM=linux/amd64` because the base image is amd64-only. Separate concern (multi-arch image build).

## Test plan

- [ ] Open a Codespace from this branch — existing behavior unchanged
- [ ] Run `devcontainer up --workspace-folder .` from a locally-named synth-setter checkout — succeeds
- [ ] Run `devcontainer up --workspace-folder .` from a differently-named fork dir — succeeds (new capability)
- [ ] `make test` inside container

Closes #186


---

**Also includes a 1-line unrelated docs fix** (`b0dd804`): mdformat was failing on `docs/operations/credential-rotation-guide.md` (missing blank line between heading and HR separator), breaking the `Code Quality Main` workflow on main since #498 merged. Found by running `pre-commit run --all-files`. Bundled here to unblock CI; no semantic impact.
