### PR TITLE
test(testing): move heavy training tests to GPU runner

### DIFF
--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -7,8 +7,11 @@ from omegaconf import DictConfig, open_dict
 
 from src.eval import evaluate
 from src.train import train
+from tests.helpers.run_if import RunIf
 
 
+@pytest.mark.gpu
+@RunIf(min_gpus=1)
 @pytest.mark.slow
 def test_train_eval(tmp_path: Path, cfg_train: DictConfig, cfg_eval: DictConfig) -> None:
     # plumb:req-f4e6204e
@@ -27,7 +30,10 @@ def test_train_eval(tmp_path: Path, cfg_train: DictConfig, cfg_eval: DictConfig)
 
     with open_dict(cfg_train):
         cfg_train.trainer.max_epochs = 1
+        cfg_train.trainer.accelerator = "gpu"
         cfg_train.test = True
+    with open_dict(cfg_eval):
+        cfg_eval.trainer.accelerator = "gpu"
 
     HydraConfig().set_config(cfg_train)
     train_metric_dict, _ = train(cfg_train)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -37,20 +37,6 @@ def test_train_fast_dev_run_tiny_model_tiny_data(cfg_train: DictConfig) -> None:
     train(cfg_train)
 
 
-@pytest.mark.slow
-def test_train_fast_dev_run(cfg_train: DictConfig) -> None:
-    """Run for 1 train, val and test step with torch.compile enabled.
-
-    :param cfg_train: A DictConfig containing a valid training configuration.
-    """
-    HydraConfig().set_config(cfg_train)
-    with open_dict(cfg_train):
-        cfg_train.trainer.fast_dev_run = True
-        cfg_train.trainer.accelerator = "cpu"
-        cfg_train.model.compile = True
-    train(cfg_train)
-
-
 @pytest.mark.gpu
 @RunIf(min_gpus=1)
 def test_train_fast_dev_run_gpu(cfg_train: DictConfig) -> None:
@@ -100,6 +86,8 @@ def test_train_epoch_gpu_amp(cfg_train: DictConfig) -> None:
 
 
 # TODO: fix val_check_interval incompatibility with check_val_every_n_epoch=None (#47)
+@pytest.mark.gpu
+@RunIf(min_gpus=1)
 @pytest.mark.slow
 def test_train_epoch_double_val_loop(cfg_train: DictConfig) -> None:
     """Train 1 epoch with validation loop twice per epoch.
@@ -109,6 +97,7 @@ def test_train_epoch_double_val_loop(cfg_train: DictConfig) -> None:
     HydraConfig().set_config(cfg_train)
     with open_dict(cfg_train):
         cfg_train.trainer.max_epochs = 1
+        cfg_train.trainer.accelerator = "gpu"
         cfg_train.trainer.val_check_interval = 0.5
     train(cfg_train)
 
@@ -128,6 +117,8 @@ def test_train_ddp_sim(cfg_train: DictConfig) -> None:
     train(cfg_train)
 
 
+@pytest.mark.gpu
+@RunIf(min_gpus=1)
 @pytest.mark.slow
 def test_train_resume(tmp_path: Path, cfg_train: DictConfig) -> None:
     # plumb:req-931b548d
@@ -143,6 +134,7 @@ def test_train_resume(tmp_path: Path, cfg_train: DictConfig) -> None:
     """
     with open_dict(cfg_train):
         cfg_train.trainer.max_epochs = 1
+        cfg_train.trainer.accelerator = "gpu"
 
     HydraConfig().set_config(cfg_train)
     metric_dict_1, _ = train(cfg_train)


### PR DESCRIPTION
## Summary

- The `nightly-full-suite` job (`.github/workflows/nightly.yml`) has failed every single run (17/17) since it was added 2026-03-21 — the ubuntu-latest runner (2 vCPU / 7 GB, no GPU) is killed by GitHub infra (`"runner lost communication"`) while running the CPU training tests. Confirmed culprit: `tests/test_eval.py::test_train_eval` hangs mid-run.
- Move the 4 heavy `@pytest.mark.slow` training tests to the twice-weekly GPU runner (`test-expensive.yml`):
  - `test_eval.py::test_train_eval`
  - `test_train.py::test_train_epoch_double_val_loop`
  - `test_train.py::test_train_resume`
  - `test_train.py::test_train_fast_dev_run` (**deleted** — after GPU migration it would be identical to the existing `test_train_fast_dev_run_gpu_compile`)
- Keep `test_train_ddp_sim` on CPU (its purpose is to verify `ddp_spawn` on CPU).
- `test_train_fast_dev_run_tiny_model_tiny_data` remains the single tiny CPU training test on every PR.

## Effect on each suite

| Suite | Before | After |
|---|---|---|
| PR tests (`test.yml`) | 1 CPU training test | 1 CPU training test (unchanged) |
| GPU tests (`test-expensive.yml`, Mon+Thu) | 3 tests | 6 tests |
| Nightly full-suite (`nightly.yml`) | 6 CPU training tests (hangs) | 2 CPU training tests (should pass) |

GPU-marked tests skip via `@RunIf(min_gpus=1)` on the nightly's GPU-less ubuntu runner, so the nightly's CPU load drops from 6 training tests to 2.

Fixes #505

## Test plan

- [ ] Pytest collection confirms 6 GPU-marked tests in `test_train.py` + `test_eval.py` (verified locally: `pytest --collect-only -m gpu` returns 6 tests)
- [ ] Pytest collection confirms CPU suite unchanged: `pytest --collect-only -m "not slow and not gpu and not requires_vst and not r2 and not benchmark"` returns 1 test (`test_train_fast_dev_run_tiny_model_tiny_data`)
- [ ] Next `test-expensive.yml` run (Mon/Thu or manual dispatch) passes with the 3 newly migrated tests
- [ ] Next `nightly.yml` run completes without runner-killed (the blocking question — can only be verified post-merge with a triggered nightly run)