### PR TITLE
test(testing): rename pytest.fail msg= kwarg to reason= for pytest 9 compat

### DIFF
--- a/tests/helpers/run_sh_command.py
+++ b/tests/helpers/run_sh_command.py
@@ -17,4 +17,4 @@ def run_sh_command(command: list[str]) -> None:
     except sh.ErrorReturnCode as e:
         msg = e.stderr.decode()
     if msg:
-        pytest.fail(msg=msg)
+        pytest.fail(reason=msg)


### PR DESCRIPTION
## Summary

pytest 9 removed the `msg=` keyword alias from `pytest.fail` (renamed to `reason=` in pytest 7). [tests/helpers/run_sh_command.py:20](tests/helpers/run_sh_command.py#L20) still called `pytest.fail(msg=msg)`, which raised `TypeError: _Fail.__call__() got an unexpected keyword argument 'msg'` on every call — breaking all 5 tests in `tests/test_sweeps.py` whenever the `sh` package was installed (nightly.yml, test-expensive.yml).

The failures were masked by the nightly runner hang (#500, #505) until #506 unblocked the nightly.

Fixes #507

## Test plan

- [x] **Behavioral before/after on a failing sweep test** — verified locally with pytest 9.0.2 + sh 2.2.2

  ```bash
  # BEFORE (on main, msg=msg):
  $ pytest tests/test_sweeps.py::test_experiments -v
  FAILED - TypeError: _Fail.__call__() got an unexpected keyword argument 'msg'

  # AFTER (this branch, reason=msg):
  $ pytest tests/test_sweeps.py::test_experiments -v
  FAILED - Failed: In 'train.yaml': Could not find 'model/mnist'
  ```

  The `TypeError` is gone. The remaining `model/mnist` failure is a pre-existing, unrelated config issue surfaced now that `pytest.fail` no longer crashes first.

- [ ] Next `nightly.yml` run shows `test_sweeps.py` tests fail with their real underlying reasons (or pass) rather than the `TypeError` — can only be verified after merge.