### PR TITLE
docs(ci-automation): document 40-char SHA requirement for Docker workflow git_ref

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -6,12 +6,21 @@ name: Docker Image Build and Push
 # Triggers:
 # - Manual dispatch or weekly schedule: full build + push + smoke tests
 # - Pull request (Docker-related paths): build-only validation (no push)
+#
+# git_ref resolution:
+# The git_ref input accepts any ref form (branch, tag, or full SHA). After
+# checkout, `git rev-parse HEAD` resolves it to a 40-char lowercase commit
+# SHA (steps.source.outputs.sha), which is what gets baked into the image
+# via the SYNTH_PERMUTATIONS_GIT_REF build-arg. The build ALWAYS pins to
+# the resolved commit SHA — the original input form is discarded.
+# The resolved SHA is validated as 40-char lowercase hex by load_image_config
+# (pipeline/schemas/image_config.py) in the "Load image config" step.
 
 on:
   workflow_dispatch:
     inputs:
       git_ref:
-        description: "Git ref to build (branch, tag, or SHA). Builds and pushes to Docker Hub."
+        description: "Git ref to build (branch, tag, or full SHA). Resolved to a 40-char commit SHA via `git rev-parse HEAD` after checkout; the build pins to the resolved commit."
         required: false
         default: "main"
       issue_number:

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,13 @@ train: ## Train the model
 #
 # Required variables (pass on the command line):
 #   GIT_PAT             GitHub personal access token with repo read access.
-#   GIT_REF             Commit SHA, tag, or branch to bake. Prefer full SHA.
+#   GIT_REF             Git ref to bake. Passed verbatim to the Dockerfile's
+#                       `git checkout --detach "${SYNTH_PERMUTATIONS_GIT_REF}"`
+#                       after only `git fetch origin`. Use a full 40-char SHA
+#                       — branch/tag names may not be fetched and will fail.
+#                       (The CI workflow's `git_ref` input is different: it
+#                       checks out locally and resolves any ref to a SHA via
+#                       `git rev-parse HEAD` before the build.)
 #
 # Optional overrides:
 #   DOCKER_FILE         Path to Dockerfile          (default: docker/ubuntu22_04/Dockerfile)

--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,13 @@ train: ## Train the model
 #
 # Required variables (pass on the command line):
 #   GIT_PAT             GitHub personal access token with repo read access.
-#   GIT_REF             Git ref to bake. Passed verbatim to the Dockerfile's
+#   GIT_REF             Git ref to bake. Used twice by the Dockerfile: the
+#                       `synth-setter-src` stage downloads a GitHub tarball
+#                       at this ref, and the `dev-snapshot` stage runs
 #                       `git checkout --detach "${SYNTH_PERMUTATIONS_GIT_REF}"`
-#                       after only `git fetch origin`. Use a full 40-char SHA
-#                       — branch/tag names may not be fetched and will fail.
+#                       after `git fetch origin`. A full 40-char SHA reachable
+#                       from a pushed branch/tag satisfies both and pins the
+#                       build deterministically.
 #                       (The CI workflow's `git_ref` input is different: it
 #                       checks out locally and resolves any ref to a SHA via
 #                       `git rev-parse HEAD` before the build.)


### PR DESCRIPTION
## Summary

Documents the `git_ref` → resolved SHA flow in the Docker build workflow and strengthens the Makefile `GIT_REF` doc so users understand the two different contracts.

- **Workflow** (`.github/workflows/docker-build-validation.yml`): added a "git_ref resolution" block to the top comment and updated the `git_ref` input `description:` to state that any ref form (branch, tag, SHA) is resolved to a 40-char commit SHA via `git rev-parse HEAD` after checkout, and the build always pins to the resolved commit.
- **Makefile** (`GIT_REF` doc in the Docker header, lines 63-66): replaced the one-line "Prefer full SHA" note with a warning block explaining that `GIT_REF` is passed verbatim to the Dockerfile's `git checkout --detach` after only `git fetch origin`, so a full 40-char SHA is required for reliable resolution — contrasting this with the CI workflow's input, which resolves any form to a SHA before the build.

## Why no workflow-level regex check (issue proposal #2)

The issue proposed adding a bash regex check after `git rev-parse HEAD`. That is already covered two steps later in "Load image config", which invokes `load_image_config` → Pydantic `github_sha` validator at `pipeline/schemas/image_config.py:42-48` (40-char lowercase hex). Adding a duplicate bash check buys no safety and is YAGNI, so this PR is docs-only.

## Test plan

- [x] `pre-commit run --files .github/workflows/docker-build-validation.yml Makefile` — all hooks pass (YAML validator, prettier, codespell, etc.)
- [x] `git diff main` — only comment/description lines changed in two files; no behavioral keys added or modified
- [ ] After merge, visual check that the updated `git_ref` description renders correctly in the GitHub Actions workflow-dispatch UI

Closes #332