### PR TITLE
chore(code-health): label good-first-issue starter set and link from CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,16 @@ Verify your setup:
 make test           # quick tests (excludes slow and VST-dependent tests)
 ```
 
+## Good first issues
+
+If you're looking for a place to start, browse the [good first issue label](https://github.com/tinaudio/synth-setter/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22).
+These are scoped, self-contained tasks that don't require deep audio/ML domain
+knowledge or access to cloud resources (R2, RunPod, GPU runners).
+
+To claim one, comment on the issue to let others know you're working on it, and
+ask any questions in the thread. When you open your PR, reference the issue in
+the PR body with `Closes #N` so it auto-closes on merge.
+
 ## Code standards
 
 ### Formatting and linting


### PR DESCRIPTION
## Summary

- Apply the `good first issue` label to three curated starter issues
- Add a **Good first issues** section to CONTRIBUTING.md that links to the label-filter URL

## Issues labeled

- #33 — docs/logging: add debug log of resolved config in `train()` (single `log.debug()` call)
- #38 — tests: replace deprecated `pkg_resources` with `importlib.metadata`
- #51 — typing: resolve inconsistencies flagged by Copilot in PR #49

These were selected to span three of the four buckets from #464 (docs, tests, typing), require no audio/ML/cloud expertise, and be completable in a single small PR.

## Motivation

#464 notes that the repo has no graduated contribution pathway. The `good first issue` label existed but was unused, and CONTRIBUTING.md never pointed to it. After this PR, a newcomer reading CONTRIBUTING.md sees a direct link to curated starter issues.

Count kept intentionally small (3 vs the ~10 target) — prefer a tight, high-quality starter set and expand later.

## Test plan

- [x] `make format` passes locally
- [x] Labels applied and verified via `gh issue view` (all three show `has_gfi: true`)
- [x] Label filter URL returns the expected issues
- [ ] CI `pr-metadata-gate.yaml` passes

Closes #464
Part of #457