### PR TITLE
test(testing): wire sweep tests to GPU runner; skip mnist-dependent tests

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -39,6 +39,7 @@ pytest
 pytest-benchmark
 pytest-xdist
 rich
+sh
 rootutils
 runpod==1.8.1
 scipy==1.14.1

--- a/tests/test_sweeps.py
+++ b/tests/test_sweeps.py
@@ -14,7 +14,7 @@ overrides = ["logger=[]", "~callbacks.lr_monitor"]
 
 # TODO(#514): migrate from mnist configs to ksin. test_experiments globs every
 # experiment config including example.yaml, which overrides model=mnist — but
-# configs/model/mnist.yaml does not exist in this repo.
+# configs/model/mnist.yaml doesn't exist in this repo.
 @pytest.mark.skip(reason="Blocked on #514 — example.yaml references missing model=mnist")
 @pytest.mark.gpu
 @RunIf(min_gpus=1)

--- a/tests/test_sweeps.py
+++ b/tests/test_sweeps.py
@@ -6,7 +6,10 @@ from tests.helpers.run_if import RunIf
 from tests.helpers.run_sh_command import run_sh_command
 
 startfile = "src/train.py"
-overrides = ["logger=[]"]
+# logger=[] disables wandb/tensorboard for these throwaway sweep subprocess runs.
+# ~callbacks.lr_monitor works around #517 — LearningRateMonitor hard-requires a
+# logger and crashes at on_train_start when logger is empty.
+overrides = ["logger=[]", "~callbacks.lr_monitor"]
 
 
 # TODO(#514): migrate from mnist configs to ksin. test_experiments globs every

--- a/tests/test_sweeps.py
+++ b/tests/test_sweeps.py
@@ -9,7 +9,12 @@ startfile = "src/train.py"
 overrides = ["logger=[]"]
 
 
-@RunIf(sh=True)
+# TODO(#514): migrate from mnist configs to ksin. test_experiments globs every
+# experiment config including example.yaml, which overrides model=mnist — but
+# configs/model/mnist.yaml does not exist in this repo.
+@pytest.mark.skip(reason="Blocked on #514 — example.yaml references missing model=mnist")
+@pytest.mark.gpu
+@RunIf(min_gpus=1)
 @pytest.mark.slow
 def test_experiments(tmp_path: Path) -> None:
     """Test running all available experiment configs with `fast_dev_run=True.`
@@ -26,7 +31,8 @@ def test_experiments(tmp_path: Path) -> None:
     run_sh_command(command)
 
 
-@RunIf(sh=True)
+@pytest.mark.gpu
+@RunIf(min_gpus=1)
 @pytest.mark.slow
 def test_hydra_sweep(tmp_path: Path) -> None:
     """Test default hydra sweep.
@@ -44,7 +50,8 @@ def test_hydra_sweep(tmp_path: Path) -> None:
     run_sh_command(command)
 
 
-@RunIf(sh=True)
+@pytest.mark.gpu
+@RunIf(min_gpus=1)
 @pytest.mark.slow
 def test_hydra_sweep_ddp_sim(tmp_path: Path) -> None:
     """Test default hydra sweep with ddp sim.
@@ -65,7 +72,12 @@ def test_hydra_sweep_ddp_sim(tmp_path: Path) -> None:
     run_sh_command(command)
 
 
-@RunIf(sh=True)
+# TODO(#514): migrate from mnist_optuna to ksin_optuna. hparams_search=mnist_optuna
+# sweeps model.net.lin1_size/lin2_size/lin3_size — fields only defined on
+# SimpleDenseNet, which is not referenced by any active model config.
+@pytest.mark.skip(reason="Blocked on #514 — mnist_optuna sweeps fields not on active models")
+@pytest.mark.gpu
+@RunIf(min_gpus=1)
 @pytest.mark.slow
 def test_optuna_sweep(tmp_path: Path) -> None:
     """Test Optuna hyperparam sweeping.
@@ -84,7 +96,10 @@ def test_optuna_sweep(tmp_path: Path) -> None:
     run_sh_command(command)
 
 
-@RunIf(wandb=True, sh=True)
+# TODO(#514): migrate from mnist_optuna to ksin_optuna — same reason as test_optuna_sweep.
+@pytest.mark.skip(reason="Blocked on #514 — mnist_optuna sweeps fields not on active models")
+@pytest.mark.gpu
+@RunIf(min_gpus=1, wandb=True)
 @pytest.mark.slow
 def test_optuna_sweep_ddp_sim_wandb(tmp_path: Path) -> None:
     """Test Optuna sweep with wandb logging and ddp sim.


### PR DESCRIPTION
## Summary

`tests/test_sweeps.py` contained 5 tests that have effectively **never run in any CI workflow**. This PR wires them to the twice-weekly GPU runner and skips 3 of them pending config migration tracked in #514.

Fixes #510

## Evidence: the 5 sweep tests have never run in CI

| Test | `@RunIf(sh=True)` gate | `@pytest.mark.slow` | `@pytest.mark.gpu` | Installed where `sh` available? | Ever ran? |
|---|---|---|---|---|---|
| All 5 `test_sweeps.py` tests | yes | yes | no | `nightly.yml` + `test-expensive.yml` (ad-hoc) | **no** |

- **PR tests (`test.yml`)**: filter `-m "not slow"` → all 5 deselected.
- **GPU tests (`test-expensive.yml`)**: filter `-m gpu` → all 5 deselected (no `gpu` marker).
- **Nightly (`nightly.yml`)**: no `-m` filter, would match, BUT the runner-lost-communication bug killed all 17/17 runs before reaching them. My triggered nightly run [24009780212](https://github.com/tinaudio/synth-setter/actions/runs/24009780212) (after #506 unblocked the hang) is the first one to reach them, and all 5 crashed with `TypeError: _Fail.__call__() got an unexpected keyword argument 'msg'` — a pytest 9 compat bug that was latent because nobody had run these tests (fixed separately in PR #508).

So until this PR, these tests were dormant.

## Changes

1. Add `sh` to `requirements-app.txt` (no longer an ad-hoc install).
2. Replace `@RunIf(sh=True)` with `@pytest.mark.gpu` + `@RunIf(min_gpus=1)` on all 5 tests.
3. Apply `@pytest.mark.skip(reason="Blocked on #514 ...")` to the 3 tests that use mnist-derived configs this repo does not contain (see #514 for the migration to ksin).

## Evidence: 3 of the 5 tests reference mnist configs that don't exist

`configs/experiment/example.yaml`:
```yaml
defaults:
  - override /data: mnist
  - override /model: mnist    # ← configs/model/mnist.yaml does not exist
```
```bash
$ ls configs/model/
encoder  ffn.yaml  flow.yaml  flow_fixed.yaml  flowmlp.yaml
surge_ffn.yaml  surge_flow.yaml  surge_flowmlp.yaml  surge_flowvae.yaml
# → no mnist.yaml
```

`configs/hparams_search/mnist_optuna.yaml` sweeps `model.net.lin1_size`/`lin2_size`/`lin3_size`. Only definition in the repo is on `SimpleDenseNet`, which isn't referenced by any active model config:
```bash
$ grep -rn "simple_dense_net\|SimpleDenseNet" configs/ src/
src/models/components/simple_dense_net.py:5:class SimpleDenseNet(nn.Module):  # definition
src/models/components/simple_dense_net.py:54:    _ = SimpleDenseNet()            # self-smoke-test
configs/experiment/example.yaml:15:tags: ["mnist", "simple_dense_net"]         # string tag only
# → no active config instantiates SimpleDenseNet
```

## Tests kept running

- `test_hydra_sweep` — sweeps `model.optimizer.lr=0.005,0.01` using default `train.yaml` stack (data=ksin, model=ffn). Valid.
- `test_hydra_sweep_ddp_sim` — same, plus `trainer=ddp_sim` + `max_epochs=3`. Valid.

Both carry `@pytest.mark.gpu` + `@RunIf(min_gpus=1)`, so they'll run on `test-expensive.yml` and skip on `nightly.yml`'s GPU-less ubuntu runner.

## Effect

| Suite | Before | After |
|---|---|---|
| PR tests (`test.yml`) | Deselected via `-m "not slow"` | Deselected via `-m "not slow"` (unchanged) |
| GPU tests (`test-expensive.yml`, Mon+Thu) | Never ran | 2 real sweep tests run on GPU runner (3 skipped via `@pytest.mark.skip`) |
| Nightly (`nightly.yml`) | Would crash with `TypeError` if runner survived | All 5 skipped via `@RunIf(min_gpus=1)` on GPU-less ubuntu runner |

## Depends on

- Stacks on top of #508 (merged) for pytest 9 `msg=` kwarg fix.

## Test plan

- [x] **Collection (Level 2)**: `pytest --collect-only -m gpu tests/test_sweeps.py` → 5 tests collected
- [x] **CPU-only skip behavior (Level 1)**: all 5 tests SKIPPED with `Requires: [GPUs>=1]` on local CPU-only host
- [ ] **`test-expensive.yml` on this branch passes** — 2 unskipped tests execute on GPU runner (Level 1, post-push verification)
- [ ] **Next `nightly.yml` completes without crashing in `test_sweeps.py`** (Level 1 — post-merge)