### PR TITLE
test: shrink test_train_ddp_sim to fix limit_val_batches under DDP sharding

### DIFF
--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -125,6 +125,19 @@ def test_train_ddp_sim(cfg_train: DictConfig) -> None:
         cfg_train.trainer.accelerator = "cpu"
         cfg_train.trainer.devices = 2
         cfg_train.trainer.strategy = "ddp_spawn"
+        # Integer limits avoid the `fraction * batches < 1` error when the
+        # fixture's fractions (0.01, 0.1) shrink too far under DDP sharding.
+        cfg_train.trainer.limit_train_batches = 1
+        cfg_train.trainer.limit_val_batches = 1
+        cfg_train.trainer.limit_test_batches = 1
+        # Shrink model, batch, and dataset to keep DDP-on-CPU fast.
+        cfg_train.data.batch_size = 2
+        cfg_train.data.signal_length = 64
+        cfg_train.data.train_val_test_sizes = [4, 4, 4]
+        cfg_train.model.net.channels = 4
+        cfg_train.model.net.encoder_blocks = 1
+        cfg_train.model.net.trunk_blocks = 1
+        cfg_train.model.net.hidden_dim = 32
     train(cfg_train)
 
 


### PR DESCRIPTION
## Summary

- Fixture default `limit_val_batches=0.1` yielded 0 val batches per rank under `ddp_spawn` with `devices=2` (10 val batches → 5/rank → `0.1 × 5 = 0.5`, which Lightning rejects).
- Override with integer `limit_{train,val,test}_batches=1`, and shrink model / batch / dataset to match the tiny-model test pattern. DDP-on-CPU now finishes in ~13s instead of chewing through the full ksin dataset for many minutes.
- Only `test_train_ddp_sim` needed fixing — every other validating test runs single-device (10 batches → 1.0, passes) or uses `fast_dev_run=True` (bypasses `limit_val_batches`). See analysis comment on #46.

Closes #46

## Test plan

- [x] `pytest tests/test_train.py::test_train_ddp_sim -v` — passes in 13s
- [x] `make test` — 157 passed, 1 skipped, no regressions
- [x] `make format` — clean (one unrelated docs/mdformat drift reverted)