### PR TITLE
security(storage): migrate R2_ENDPOINT to secret, consolidate R2_BUCKET

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,11 +16,9 @@ R2_SECRET_ACCESS_KEY=your-r2-secret-access-key
 # R2 endpoint URL (Cloudflare account-specific)
 R2_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com
 
-# R2 bucket name (used as build-arg and in pipeline.constants)
-# NOTE: The pipeline currently reads the bucket from pipeline.constants.R2_BUCKET,
-#       which is hardcoded to "intermediate-data". To change the bucket used by
-#       the pipeline, update pipeline/constants.py (and related docs/YAML) in
-#       addition to this environment variable.
+# R2 bucket name — source of truth is configs/image/dev-snapshot.yaml.
+# Docker builds derive R2_BUCKET from that YAML (no env var needed for builds).
+# This var is useful for running rclone commands outside Docker.
 R2_BUCKET=intermediate-data
 
 # Rclone-style R2 env vars (used by rclone when no rclone.conf is present)

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -147,11 +147,11 @@ jobs:
             TORCH_BACKEND=${{ steps.config.outputs.torch_backend }}
             SYNTH_PERMUTATIONS_GIT_REF=${{ steps.source.outputs.sha }}
             R2_BUCKET=${{ steps.config.outputs.r2_bucket }}
-            R2_ENDPOINT=${{ steps.config.outputs.r2_endpoint }}
           secrets: |
             git_pat=${{ secrets.GIT_PAT }}
             r2_access_key_id=${{ secrets.R2_ACCESS_KEY_ID }}
             r2_secret_access_key=${{ secrets.R2_SECRET_ACCESS_KEY }}
+            r2_endpoint=${{ secrets.R2_ENDPOINT }}
             wandb_api_key=${{ secrets.WANDB_API_KEY }}
           cache-from: type=registry,ref=tinaudio/perm:buildcache
           cache-to: ${{ github.event_name != 'pull_request' && 'type=registry,ref=tinaudio/perm:buildcache,mode=max' || '' }}

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -82,8 +82,8 @@ jobs:
         env:
           IMAGE: tinaudio/perm:${{ inputs.docker_image_tag || 'dev-snapshot' }}
         run: |
-          # Read R2 bucket from pipeline constants (checked-out code, no Docker needed)
-          R2_BUCKET=$(PYTHONPATH=. python3 -c "from pipeline.constants import R2_BUCKET; print(R2_BUCKET)")
+          # Read R2 bucket from image config YAML (single source of truth)
+          R2_BUCKET=$(python3 -c "import yaml; print(yaml.safe_load(open('configs/image/dev-snapshot.yaml'))['r2_bucket'])")
           R2_PREFIX=$(python3 -c "import json; print(json.load(open('input_spec.json'))['r2_prefix'])")
           SHARD_FILE=$(python3 -c "import json; print(json.load(open('input_spec.json'))['shards'][0]['filename'])")
 

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -78,6 +78,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Install PyYAML for config parsing
+        run: pip install pyyaml
+
       - name: Download shard from R2 and validate
         env:
           IMAGE: tinaudio/perm:${{ inputs.docker_image_tag || 'dev-snapshot' }}

--- a/Makefile
+++ b/Makefile
@@ -88,15 +88,17 @@ CURRENT_LOCAL_GIT_REF := $(strip $(shell git rev-parse HEAD))
 R2_ACCESS_KEY_ID     ?=
 R2_SECRET_ACCESS_KEY ?=
 R2_ENDPOINT          ?=
-R2_BUCKET            ?=
 WANDB_API_KEY        ?=
+
+# R2_BUCKET: single source of truth is configs/image/dev-snapshot.yaml.
+R2_BUCKET := $(shell python3 -c "import yaml; print(yaml.safe_load(open('configs/image/dev-snapshot.yaml'))['r2_bucket'])")
 
 DOCKER_SECRETS = \
 	--secret id=r2_access_key_id,env=R2_ACCESS_KEY_ID \
 	--secret id=r2_secret_access_key,env=R2_SECRET_ACCESS_KEY \
+	--secret id=r2_endpoint,env=R2_ENDPOINT \
 	--secret id=wandb_api_key,env=WANDB_API_KEY \
-	--build-arg R2_BUCKET=$(R2_BUCKET) \
-	--build-arg R2_ENDPOINT=$(R2_ENDPOINT)
+	--build-arg R2_BUCKET=$(R2_BUCKET)
 
 docker-build-dev-snapshot: ## Build self-contained image (requires GIT_REF, GIT_PAT)
 	@if [ -z "$(GIT_REF)" ]; then echo "ERROR: GIT_REF is required."; exit 1; fi

--- a/Makefile
+++ b/Makefile
@@ -90,23 +90,21 @@ R2_SECRET_ACCESS_KEY ?=
 R2_ENDPOINT          ?=
 WANDB_API_KEY        ?=
 
-# R2_BUCKET: single source of truth is configs/image/dev-snapshot.yaml.
-R2_BUCKET := $(shell python3 -c "import yaml; print(yaml.safe_load(open('configs/image/dev-snapshot.yaml'))['r2_bucket'])")
-
 DOCKER_SECRETS = \
 	--secret id=r2_access_key_id,env=R2_ACCESS_KEY_ID \
 	--secret id=r2_secret_access_key,env=R2_SECRET_ACCESS_KEY \
 	--secret id=r2_endpoint,env=R2_ENDPOINT \
-	--secret id=wandb_api_key,env=WANDB_API_KEY \
-	--build-arg R2_BUCKET=$(R2_BUCKET)
+	--secret id=wandb_api_key,env=WANDB_API_KEY
 
 docker-build-dev-snapshot: ## Build self-contained image (requires GIT_REF, GIT_PAT)
 	@if [ -z "$(GIT_REF)" ]; then echo "ERROR: GIT_REF is required."; exit 1; fi
+	$(eval R2_BUCKET := $(shell python3 -c "import yaml; print(yaml.safe_load(open('configs/image/dev-snapshot.yaml'))['r2_bucket'])"))
 	DOCKER_BUILDKIT=1 docker buildx build \
 		-f $(DOCKER_FILE) \
 		$(_INTERNAL_BUILD_FLAGS) $(DOCKER_BUILD_FLAGS) \
 		--secret id=git_pat,env=GIT_PAT \
 		$(DOCKER_SECRETS) \
+		--build-arg R2_BUCKET=$(R2_BUCKET) \
 		--platform $(DOCKER_TARGETPLATFORM) \
 		--build-arg IMAGE="dev-snapshot" \
 		--build-arg BUILD_MODE=$(DOCKER_BUILD_MODE) \

--- a/configs/image/dev-snapshot.yaml
+++ b/configs/image/dev-snapshot.yaml
@@ -10,5 +10,4 @@ base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
 torch_backend: "cu128"
-r2_endpoint: "https://efb9275d571811db929e83eb710b74a7.r2.cloudflarestorage.com"
 r2_bucket: "intermediate-data"

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -350,13 +350,13 @@ WORKDIR /home/build/synth-setter
 # ==========================================
 FROM builder-install-synth-setter-deps AS r2-config-base
 ARG R2_BUCKET
-ARG R2_ENDPOINT
 ENV R2_BUCKET=${R2_BUCKET}
 RUN --mount=type=secret,id=r2_access_key_id \
     --mount=type=secret,id=r2_secret_access_key \
+    --mount=type=secret,id=r2_endpoint \
     set -eu; \
-    if [ ! -s /run/secrets/r2_access_key_id ] || [ ! -s /run/secrets/r2_secret_access_key ] || [ -z "${R2_ENDPOINT}" ]; then \
-        echo "WARNING: R2_ENDPOINT build-arg or R2 secrets (r2_access_key_id, r2_secret_access_key) are missing or empty." >&2; \
+    if [ ! -s /run/secrets/r2_access_key_id ] || [ ! -s /run/secrets/r2_secret_access_key ] || [ ! -s /run/secrets/r2_endpoint ]; then \
+        echo "WARNING: R2 secrets (r2_access_key_id, r2_secret_access_key, r2_endpoint) are missing or empty." >&2; \
         echo "         R2 upload/download will not be available in this image." >&2; \
         mkdir -p /root/.config/rclone; \
         printf '[r2]\ntype = s3\nprovider = Cloudflare\n# credentials not configured\n' \
@@ -366,7 +366,7 @@ RUN --mount=type=secret,id=r2_access_key_id \
         printf '[r2]\ntype = s3\nprovider = Cloudflare\naccess_key_id = %s\nsecret_access_key = %s\nendpoint = %s\n' \
             "$(cat /run/secrets/r2_access_key_id)" \
             "$(cat /run/secrets/r2_secret_access_key)" \
-            "${R2_ENDPOINT}" \
+            "$(cat /run/secrets/r2_endpoint)" \
             > /root/.config/rclone/rclone.conf; \
         echo "R2 rclone config written." >&2; \
     fi; \

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -89,12 +89,12 @@ docs:
       - pattern: "scripts/r2_shard_report.py"
         covers: "R2 listing commands, shard status reporting, path parsing"
       - pattern: "configs/image/dev-snapshot.yaml"
-        covers: "r2_endpoint, r2_bucket values, storage configuration"
+        covers: "r2_bucket value, storage configuration"
       - pattern: "pipeline/entrypoints/generate_dataset.py"
         covers: "rclone upload of spec and shard files, R2 path construction"
         scope: "rclone"
       - pattern: "pipeline/constants.py"
-        covers: "R2 bucket name constant (intermediate-data), INPUT_SPEC_FILENAME"
+        covers: "INPUT_SPEC_FILENAME constant"
 
   # ── Training pipeline design doc ────────────────────────────────
   - doc: docs/design/training-pipeline.md

--- a/docs/operations/credential-rotation-guide.md
+++ b/docs/operations/credential-rotation-guide.md
@@ -20,20 +20,20 @@ ______________________________________________________________________
 
 ## Credential Inventory
 
-| Credential                 | Where Used                                     | Storage Locations                                                                               |
-| -------------------------- | ---------------------------------------------- | ----------------------------------------------------------------------------------------------- |
-| `R2_ACCESS_KEY_ID`         | Docker builds, pipeline workers, rclone        | GitHub Secrets, `.env`, Docker image (`rclone.conf`)                                            |
-| `R2_SECRET_ACCESS_KEY`     | Docker builds, pipeline workers, rclone        | GitHub Secrets, `.env`, Docker image (`rclone.conf`)                                            |
-| `R2_ENDPOINT`              | Docker builds (build-arg, not secret)          | Image config YAML (`r2_endpoint` key in `configs/image/`), `.env`, Docker image (`rclone.conf`) |
-| `WANDB_API_KEY`            | Training, evaluation, promotion, Docker images | GitHub Secrets, `.env`, Docker image (`~/.netrc`)                                               |
-| `GIT_PAT`                  | Docker builds, CI workflows                    | GitHub Secrets, `.env`                                                                          |
-| `GITHUB_TOKEN`             | CI workflows (automatic)                       | Automatic per workflow run                                                                      |
-| `RUNPOD_API_KEY`           | Pipeline orchestration                         | GitHub Secrets, `.env`                                                                          |
-| `DOCKERHUB_USERNAME`       | CI image push workflows                        | GitHub Secrets                                                                                  |
-| `DOCKERHUB_TOKEN`          | CI image push workflows                        | GitHub Secrets                                                                                  |
-| `APPROVAL_BOT_APP_ID`      | Auto-approve workflow, release workflow        | GitHub Secrets                                                                                  |
-| `APPROVAL_BOT_PRIVATE_KEY` | Auto-approve workflow, release workflow        | GitHub Secrets                                                                                  |
-| `ANTHROPIC_API_KEY`        | Claude review workflow                         | GitHub Secrets                                                                                  |
+| Credential                 | Where Used                                     | Storage Locations                                    |
+| -------------------------- | ---------------------------------------------- | ---------------------------------------------------- |
+| `R2_ACCESS_KEY_ID`         | Docker builds, pipeline workers, rclone        | GitHub Secrets, `.env`, Docker image (`rclone.conf`) |
+| `R2_SECRET_ACCESS_KEY`     | Docker builds, pipeline workers, rclone        | GitHub Secrets, `.env`, Docker image (`rclone.conf`) |
+| `R2_ENDPOINT`              | Docker builds (BuildKit secret)                | GitHub Secrets, `.env`, Docker image (`rclone.conf`) |
+| `WANDB_API_KEY`            | Training, evaluation, promotion, Docker images | GitHub Secrets, `.env`, Docker image (`~/.netrc`)    |
+| `GIT_PAT`                  | Docker builds, CI workflows                    | GitHub Secrets, `.env`                               |
+| `GITHUB_TOKEN`             | CI workflows (automatic)                       | Automatic per workflow run                           |
+| `RUNPOD_API_KEY`           | Pipeline orchestration                         | GitHub Secrets, `.env`                               |
+| `DOCKERHUB_USERNAME`       | CI image push workflows                        | GitHub Secrets                                       |
+| `DOCKERHUB_TOKEN`          | CI image push workflows                        | GitHub Secrets                                       |
+| `APPROVAL_BOT_APP_ID`      | Auto-approve workflow, release workflow        | GitHub Secrets                                       |
+| `APPROVAL_BOT_PRIVATE_KEY` | Auto-approve workflow, release workflow        | GitHub Secrets                                       |
+| `ANTHROPIC_API_KEY`        | Claude review workflow                         | GitHub Secrets                                       |
 
 ______________________________________________________________________
 
@@ -81,20 +81,18 @@ ______________________________________________________________________
 
 ### R2 Endpoint (`R2_ENDPOINT`)
 
-**What:** The Cloudflare R2 S3-compatible endpoint URL. This is not a secret
-(it is a well-known Cloudflare URL), but it is listed here for completeness
-since it is passed as a Docker build-arg and stored alongside R2 credentials.
+**What:** The Cloudflare R2 S3-compatible endpoint URL. Contains the
+permanent Cloudflare account ID — treated as a secret to avoid exposing
+the account ID in git history or `docker history`.
 
 **Where stored:**
 
-- Image config YAML — stored under the key `r2_endpoint` in
-  `configs/image/dev-snapshot.yaml`, read by CI via
-  `pipeline.ci.load_image_config` and passed as a Docker `--build-arg`
+- GitHub Secrets (`R2_ENDPOINT`) — passed as BuildKit secret at build time
 - Local `.env` files
 - Baked into Docker images (written to `rclone.conf`)
 
 **Rotation:** Only changes if the Cloudflare account ID changes. Update the
-value in the image config YAML and `.env` files if the account is migrated.
+GitHub Secret and `.env` files if the account is migrated.
 
 ______________________________________________________________________
 

--- a/docs/operations/credential-rotation-guide.md
+++ b/docs/operations/credential-rotation-guide.md
@@ -346,6 +346,7 @@ workflows.
 3. Rebuild Docker images if the credential was baked in.
 
 ### 3. Create a github issue assigned to ktinubu@ documenting that rotation took place.
+
 ______________________________________________________________________
 
 ## Notes

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -32,17 +32,18 @@ data is available only during the `RUN` instruction and never appears in
 `docker history`. However, the build writes some secrets into config files
 that persist in the final image:
 
-| Secret                 | Source env var         | Persisted to                       | Purpose                              |
-| ---------------------- | ---------------------- | ---------------------------------- | ------------------------------------ |
-| `git_pat`              | `GIT_PAT`              | *(not persisted)*                  | GitHub API access for source tarball |
-| `r2_access_key_id`     | `R2_ACCESS_KEY_ID`     | `/root/.config/rclone/rclone.conf` | R2 rclone config                     |
-| `r2_secret_access_key` | `R2_SECRET_ACCESS_KEY` | `/root/.config/rclone/rclone.conf` | R2 rclone config                     |
-| `wandb_api_key`        | `WANDB_API_KEY`        | `/root/.netrc`                     | W&B auth                             |
+| Secret                 | Source env var         | Persisted to                       | Purpose                                |
+| ---------------------- | ---------------------- | ---------------------------------- | -------------------------------------- |
+| `git_pat`              | `GIT_PAT`              | *(not persisted)*                  | GitHub API access for source tarball   |
+| `r2_access_key_id`     | `R2_ACCESS_KEY_ID`     | `/root/.config/rclone/rclone.conf` | R2 rclone config                       |
+| `r2_secret_access_key` | `R2_SECRET_ACCESS_KEY` | `/root/.config/rclone/rclone.conf` | R2 rclone config                       |
+| `r2_endpoint`          | `R2_ENDPOINT`          | `/root/.config/rclone/rclone.conf` | R2 rclone config (Cloudflare endpoint) |
+| `wandb_api_key`        | `WANDB_API_KEY`        | `/root/.netrc`                     | W&B auth                               |
 
-> **Note:** `R2_ENDPOINT` and `R2_BUCKET` are passed as `--build-arg`, not as
-> BuildKit secrets. `R2_ENDPOINT` is written into `rclone.conf` by the
-> `r2-config-base` stage; `R2_BUCKET` is set as an `ENV` in the image. Both
-> appear in `docker history`. See the build-arg table below.
+> **Note:** `R2_BUCKET` is passed as `--build-arg` (not a BuildKit secret) and
+> set as an `ENV` in the image. Its value is sourced from
+> `configs/image/dev-snapshot.yaml` (single source of truth). It appears in
+> `docker history` — this is intentional since the bucket name is not sensitive.
 
 > [!WARNING]
 > R2 and W&B credentials persist in the final image filesystem (`rclone.conf`,
@@ -141,7 +142,6 @@ base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
 torch_backend: "cu128"
-r2_endpoint: "https://efb9275d571811db929e83eb710b74a7.r2.cloudflarestorage.com"
 r2_bucket: "intermediate-data"
 ```
 
@@ -299,15 +299,15 @@ gh workflow run docker-build-validation.yml --ref main
 
 ### Required secrets
 
-| Secret                 | Purpose                              |
-| ---------------------- | ------------------------------------ |
-| `GIT_PAT`              | GitHub API access for source tarball |
-| `DOCKERHUB_USERNAME`   | Docker Hub login                     |
-| `DOCKERHUB_TOKEN`      | Docker Hub access token              |
-| `R2_ACCESS_KEY_ID`     | R2 credentials (baked via BuildKit)  |
-| `R2_SECRET_ACCESS_KEY` | R2 credentials                       |
-| `R2_ENDPOINT`          | R2 endpoint                          |
-| `WANDB_API_KEY`        | W&B auth                             |
+| Secret                 | Purpose                                 |
+| ---------------------- | --------------------------------------- |
+| `GIT_PAT`              | GitHub API access for source tarball    |
+| `DOCKERHUB_USERNAME`   | Docker Hub login                        |
+| `DOCKERHUB_TOKEN`      | Docker Hub access token                 |
+| `R2_ACCESS_KEY_ID`     | R2 credentials (baked via BuildKit)     |
+| `R2_SECRET_ACCESS_KEY` | R2 credentials                          |
+| `R2_ENDPOINT`          | R2 endpoint (baked via BuildKit secret) |
+| `WANDB_API_KEY`        | W&B auth                                |
 
 ______________________________________________________________________
 

--- a/pipeline/constants.py
+++ b/pipeline/constants.py
@@ -5,6 +5,3 @@ Canonical names from docs/design/data-pipeline.md §7.1 (storage layout).
 
 # Frozen input specification — written once by materialize_spec, never modified.
 INPUT_SPEC_FILENAME = "input_spec.json"
-
-# Cloudflare R2 bucket for pipeline data (shards, specs, worker metadata).
-R2_BUCKET = "intermediate-data"

--- a/pipeline/entrypoints/generate_dataset.py
+++ b/pipeline/entrypoints/generate_dataset.py
@@ -10,6 +10,7 @@ Public API:
 
 Expected env vars:
     DATASET_CONFIG   (required): Path to dataset config YAML inside the container.
+    R2_BUCKET        (required): Cloudflare R2 bucket name for uploads.
     RUN_METADATA_DIR (optional): Dir for input_spec.json output. Default: /run-metadata.
 """
 
@@ -21,7 +22,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-from pipeline.constants import INPUT_SPEC_FILENAME, R2_BUCKET
+from pipeline.constants import INPUT_SPEC_FILENAME
 from pipeline.schemas.config import dataset_config_id_from_path, load_dataset_config
 from pipeline.schemas.spec import DatasetPipelineSpec, ShardSpec, materialize_spec
 
@@ -70,12 +71,13 @@ def build_generate_args(
     return args
 
 
-def run(config_path: Path, metadata_dir: Path) -> None:
+def run(config_path: Path, metadata_dir: Path, r2_bucket: str) -> None:
     """Full generate_dataset flow: materialize, upload spec, generate, upload shard.
 
     Args:
         config_path: Path to dataset config YAML.
         metadata_dir: Dir for input_spec.json (bind-mounted, host reads this).
+        r2_bucket: Cloudflare R2 bucket name for uploads.
 
     Raises:
         NotImplementedError: If num_shards > 1.
@@ -103,7 +105,7 @@ def run(config_path: Path, metadata_dir: Path) -> None:
     spec_path.write_text(spec.model_dump_json(indent=2))
 
     # Upload spec to R2 before generation
-    r2_dest = f"r2:{R2_BUCKET}/{spec.r2_prefix}"
+    r2_dest = f"r2:{r2_bucket}/{spec.r2_prefix}"
     _rclone_copy(str(spec_path), r2_dest)
 
     # Generate shard in temp dir, then upload to R2
@@ -118,9 +120,10 @@ def run(config_path: Path, metadata_dir: Path) -> None:
 def main() -> None:
     """Read env vars and run."""
     config_path = Path(os.environ["DATASET_CONFIG"])
+    r2_bucket = os.environ["R2_BUCKET"]
     metadata_dir = Path(os.environ.get("RUN_METADATA_DIR", "/run-metadata"))
 
-    run(config_path, metadata_dir)
+    run(config_path, metadata_dir, r2_bucket)
 
 
 if __name__ == "__main__":

--- a/pipeline/schemas/image_config.py
+++ b/pipeline/schemas/image_config.py
@@ -31,7 +31,6 @@ class ImageConfig(BaseModel, strict=True, extra="forbid"):
     build_mode: Literal["source", "prebuilt"]
     target_platform: Literal["linux/amd64", "linux/arm64"]
     torch_backend: str
-    r2_endpoint: str
     r2_bucket: str
 
     # --- Runtime fields (from caller, no defaults) ---
@@ -55,7 +54,7 @@ class ImageConfig(BaseModel, strict=True, extra="forbid"):
             raise ValueError("issue_number must be a positive integer")
         return v
 
-    @field_validator("r2_endpoint", "r2_bucket")
+    @field_validator("r2_bucket")
     @classmethod
     def must_not_be_blank(cls, v: str) -> str:
         """Reject empty or whitespace-only strings."""

--- a/tests/pipeline/test_ci/test_load_image_config.py
+++ b/tests/pipeline/test_ci/test_load_image_config.py
@@ -27,7 +27,6 @@ base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
 torch_backend: "cu128"
-r2_endpoint: "https://example.r2.cloudflarestorage.com"
 r2_bucket: test-bucket
 """
 
@@ -39,7 +38,6 @@ _EXPECTED_LINES = [
     "build_mode=prebuilt",
     "target_platform=linux/amd64",
     "torch_backend=cu128",
-    "r2_endpoint=https://example.r2.cloudflarestorage.com",
     "r2_bucket=test-bucket",
     f"github_sha={VALID_SHA}",
     "issue_number=311",
@@ -252,7 +250,6 @@ base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
 torch_backend: "cu128"
-r2_endpoint: "https://example.r2.cloudflarestorage.com"
 r2_bucket: test-bucket
 """
         config_path = tmp_path / "dev-snapshot.yaml"
@@ -287,7 +284,6 @@ base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
 torch_backend: "cu128"
-r2_endpoint: "https://example.r2.cloudflarestorage.com"
 r2_bucket: test-bucket
 """
         config_path = tmp_path / "dev-snapshot.yaml"

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -17,8 +17,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
-from pipeline.constants import R2_BUCKET
 from pipeline.entrypoints.generate_dataset import build_generate_args, main, run
+
+_TEST_R2_BUCKET = "test-bucket"
 
 _COMPLETE_CONFIG = {
     "param_spec": "surge_simple",
@@ -119,7 +120,7 @@ class TestRun:
         metadata_dir = tmp_path / "metadata"
         mock_materialize.return_value = real_spec
 
-        run(config_path, metadata_dir)
+        run(config_path, metadata_dir, _TEST_R2_BUCKET)
 
         spec_path = metadata_dir / "input_spec.json"
         assert spec_path.exists()
@@ -150,13 +151,13 @@ class TestRun:
         manager.attach_mock(mock_rclone, "rclone")
         manager.attach_mock(mock_check_call, "check_call")
 
-        run(config_path, metadata_dir)
+        run(config_path, metadata_dir, _TEST_R2_BUCKET)
 
         rclone_calls = mock_rclone.call_args_list
         assert len(rclone_calls) == 2
         spec_upload = rclone_calls[0]
         assert "input_spec.json" in spec_upload[0][0]
-        assert f"r2:{R2_BUCKET}/" in spec_upload[0][1]
+        assert f"r2:{_TEST_R2_BUCKET}/" in spec_upload[0][1]
 
         # Ordering: spec upload must appear before check_call in the shared call log
         call_names = [c[0] for c in manager.mock_calls]
@@ -180,7 +181,7 @@ class TestRun:
         metadata_dir = tmp_path / "metadata"
         mock_materialize.return_value = real_spec
 
-        run(config_path, metadata_dir)
+        run(config_path, metadata_dir, _TEST_R2_BUCKET)
 
         mock_check_call.assert_called_once()
         args = mock_check_call.call_args[0][0]
@@ -203,7 +204,7 @@ class TestRun:
         metadata_dir = tmp_path / "metadata"
         mock_materialize.return_value = real_spec
 
-        run(config_path, metadata_dir)
+        run(config_path, metadata_dir, _TEST_R2_BUCKET)
 
         rclone_calls = mock_rclone.call_args_list
         assert len(rclone_calls) == 2
@@ -229,7 +230,7 @@ class TestRun:
         mock_check_call.side_effect = subprocess.CalledProcessError(1, "generate_vst_dataset.py")
 
         with pytest.raises(subprocess.CalledProcessError):
-            run(config_path, metadata_dir)
+            run(config_path, metadata_dir, _TEST_R2_BUCKET)
 
     @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
     @patch("pipeline.entrypoints.generate_dataset._rclone_copy")
@@ -249,7 +250,7 @@ class TestRun:
         mock_rclone.side_effect = subprocess.CalledProcessError(1, "rclone")
 
         with pytest.raises(subprocess.CalledProcessError):
-            run(config_path, metadata_dir)
+            run(config_path, metadata_dir, _TEST_R2_BUCKET)
 
     def test_num_shards_greater_than_one_raises(self, tmp_path: Path) -> None:
         # plumb:req-bbe52a4d
@@ -262,7 +263,7 @@ class TestRun:
         metadata_dir = tmp_path / "metadata"
 
         with pytest.raises(NotImplementedError, match="num_shards > 1"):
-            run(config_path, metadata_dir)
+            run(config_path, metadata_dir, _TEST_R2_BUCKET)
 
     def test_wds_output_format_raises(self, tmp_path: Path) -> None:
         """output_format 'wds' raises ValueError."""
@@ -270,7 +271,7 @@ class TestRun:
         metadata_dir = tmp_path / "metadata"
 
         with pytest.raises(ValueError, match="only supports hdf5"):
-            run(config_path, metadata_dir)
+            run(config_path, metadata_dir, _TEST_R2_BUCKET)
 
 
 # ---------------------------------------------------------------------------
@@ -355,8 +356,22 @@ class TestMainEnvVars:
         """Missing DATASET_CONFIG env var raises KeyError."""
         monkeypatch.delenv("DATASET_CONFIG", raising=False)
         monkeypatch.delenv("RUN_METADATA_DIR", raising=False)
+        monkeypatch.delenv("R2_BUCKET", raising=False)
 
         with pytest.raises(KeyError, match="DATASET_CONFIG"):
+            main()
+
+    def test_missing_r2_bucket_raises(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Missing R2_BUCKET env var raises KeyError."""
+        config_path = _write_config(tmp_path)
+        monkeypatch.setenv("DATASET_CONFIG", str(config_path))
+        monkeypatch.delenv("R2_BUCKET", raising=False)
+
+        with pytest.raises(KeyError, match="R2_BUCKET"):
             main()
 
     @patch("pipeline.entrypoints.generate_dataset.run")
@@ -371,11 +386,12 @@ class TestMainEnvVars:
         """Default RUN_METADATA_DIR is /run-metadata when env unset."""
         config_path = _write_config(tmp_path)
         monkeypatch.setenv("DATASET_CONFIG", str(config_path))
+        monkeypatch.setenv("R2_BUCKET", _TEST_R2_BUCKET)
         monkeypatch.delenv("RUN_METADATA_DIR", raising=False)
 
         main()
 
-        mock_run.assert_called_once_with(config_path, Path("/run-metadata"))
+        mock_run.assert_called_once_with(config_path, Path("/run-metadata"), _TEST_R2_BUCKET)
 
     @patch("pipeline.entrypoints.generate_dataset.run")
     def test_custom_metadata_dir(
@@ -389,8 +405,9 @@ class TestMainEnvVars:
         config_path = _write_config(tmp_path)
         custom_dir = tmp_path / "custom-meta"
         monkeypatch.setenv("DATASET_CONFIG", str(config_path))
+        monkeypatch.setenv("R2_BUCKET", _TEST_R2_BUCKET)
         monkeypatch.setenv("RUN_METADATA_DIR", str(custom_dir))
 
         main()
 
-        mock_run.assert_called_once_with(config_path, custom_dir)
+        mock_run.assert_called_once_with(config_path, custom_dir, _TEST_R2_BUCKET)

--- a/tests/pipeline/test_schemas/test_image_config.py
+++ b/tests/pipeline/test_schemas/test_image_config.py
@@ -25,7 +25,6 @@ base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
 torch_backend: "cu128"
-r2_endpoint: "https://example.r2.cloudflarestorage.com"
 r2_bucket: test-bucket
 """
 
@@ -65,7 +64,6 @@ class TestLoadImageConfigValid:
         assert result.github_sha == VALID_SHA
         assert result.issue_number == VALID_ISSUE
         assert result.image_config_id == "dev-snapshot"
-        assert result.r2_endpoint == "https://example.r2.cloudflarestorage.com"
         assert result.r2_bucket == "test-bucket"
 
 
@@ -135,22 +133,8 @@ class TestIssueNumberValidation:
 # ---------------------------------------------------------------------------
 
 
-class TestR2FieldValidation:
-    """r2_endpoint and r2_bucket must not be empty or whitespace-only."""
-
-    def test_empty_r2_endpoint_rejected(self, tmp_path: Path) -> None:
-        """Empty r2_endpoint is rejected."""
-        config_path = _write_config(tmp_path, overrides='r2_endpoint: ""\n')
-
-        with pytest.raises(ValidationError, match="must not be blank"):
-            load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
-
-    def test_whitespace_r2_endpoint_rejected(self, tmp_path: Path) -> None:
-        """Whitespace-only r2_endpoint is rejected."""
-        config_path = _write_config(tmp_path, overrides='r2_endpoint: "  "\n')
-
-        with pytest.raises(ValidationError, match="must not be blank"):
-            load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
+class TestR2BucketValidation:
+    """r2_bucket must not be empty or whitespace-only."""
 
     def test_empty_r2_bucket_rejected(self, tmp_path: Path) -> None:
         """Empty r2_bucket is rejected."""
@@ -248,7 +232,6 @@ class TestLoadImageConfigErrors:
             "build_mode: prebuilt\n"
             "target_platform: linux/amd64\n"
             'torch_backend: "cu128"\n'
-            'r2_endpoint: "https://example.r2.cloudflarestorage.com"\n'
         )
 
         with pytest.raises(ValidationError):
@@ -303,8 +286,5 @@ class TestStaticFieldsAndYamlMerge:
         assert result.build_mode == "prebuilt"
         assert result.target_platform == "linux/amd64"
         assert result.torch_backend == "cu128"
-        assert result.r2_endpoint == (
-            "https://efb9275d571811db929e83eb710b74a7.r2.cloudflarestorage.com"
-        )
         assert result.r2_bucket == "intermediate-data"
         assert result.image_config_id == "dev-snapshot"


### PR DESCRIPTION
## Summary

- **R2_ENDPOINT** → BuildKit secret (was `--build-arg`, exposed Cloudflare account ID in `docker history`)
- **R2_BUCKET** → single source of truth in `configs/image/dev-snapshot.yaml` (deleted from `pipeline/constants.py`); runtime Python reads `os.environ["R2_BUCKET"]`
- Documentation updated across `docker.md`, `credential-rotation-guide.md`, `.env.example`, and `doc-map.yaml`

### Commits

1. `refactor(pipeline)` — delete `R2_BUCKET` from constants, `run()` takes `r2_bucket` param, `main()` reads env var, workflow parses YAML
2. `security(storage)` — remove `r2_endpoint` from YAML + schema, Dockerfile reads `/run/secrets/r2_endpoint`, CI/Makefile pass as secret
3. `docs` — update BuildKit secrets table, YAML example, required secrets table
4. `docs` — update credential rotation guide and doc-map

### Prerequisites

`R2_ENDPOINT` must be added as a GitHub repository secret before merging (the CI `docker-build-validation` workflow reads it from `secrets.R2_ENDPOINT`).

## Test plan

- [ ] `make test` passes (141 passed, 4 skipped; 1 pre-existing Hydra failure unrelated)
- [ ] `make format` passes clean
- [ ] Orphan grep: `r2_endpoint` does not appear in `configs/image/`, `pipeline/schemas/`, or test fixtures
- [ ] `docker-build-validation.yml` CI passes after `R2_ENDPOINT` secret is added
- [ ] `docker history` output does not contain the Cloudflare account ID
- [ ] `test-dataset-generation.yml` CI passes (exercises new YAML-parsing path for bucket)

Closes #465
Refs #438
Part of #321