### PR TITLE
chore(evaluation): add interactive Surge XT preview script

### DIFF
--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -10,23 +10,24 @@ CHANNELS = 2
 SAMPLE_RATE = 44100
 BUFFER_SIZE = 512
 
-plugin = VST3Plugin("plugins/Surge XT.vst3")
 
-
-def play_audio():
+def play_audio(plugin: VST3Plugin) -> None:
     """Stream silence through Surge XT and write synthesized audio to the output device."""
+    silence = np.zeros((CHANNELS, BUFFER_SIZE), dtype=np.float32)
     with AudioStream(
         output_device_name=AudioStream.default_output_device_name,
         sample_rate=SAMPLE_RATE,
         buffer_size=BUFFER_SIZE,
     ) as stream:
         while True:
-            silence = np.zeros((CHANNELS, BUFFER_SIZE), dtype=np.float32)
             synth_output = plugin(silence, SAMPLE_RATE, reset=False)
             stream.write(synth_output, SAMPLE_RATE)
 
 
-t = threading.Thread(target=play_audio)
-t.start()
+if __name__ == "__main__":
+    plugin = VST3Plugin("plugins/Surge XT.vst3")
 
-plugin.show_editor()
+    t = threading.Thread(target=play_audio, args=(plugin,), daemon=True)
+    t.start()
+
+    plugin.show_editor()

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -2,6 +2,7 @@
 
 import threading
 
+import click
 import numpy as np
 from pedalboard import VST3Plugin
 from pedalboard.io import AudioStream
@@ -24,10 +25,17 @@ def play_audio(plugin: VST3Plugin) -> None:
             stream.write(synth_output, SAMPLE_RATE)
 
 
-if __name__ == "__main__":
-    plugin = VST3Plugin("plugins/Surge XT.vst3")
+@click.command()
+@click.option("--plugin-path", "-p", default="plugins/Surge XT.vst3", help="Path to VST3 plugin.")
+def main(plugin_path: str) -> None:
+    """Open Surge XT GUI with real-time audio streaming."""
+    plugin = VST3Plugin(plugin_path)
 
     t = threading.Thread(target=play_audio, args=(plugin,), daemon=True)
     t.start()
 
     plugin.show_editor()
+
+
+if __name__ == "__main__":
+    main()  # type: ignore[call-arg]

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -3,15 +3,14 @@
 import threading
 
 import numpy as np
-import pedalboard
-from pedalboard import Pedalboard
+from pedalboard import VST3Plugin
 from pedalboard.io import AudioStream
 
 CHANNELS = 2
 SAMPLE_RATE = 44100
 BUFFER_SIZE = 512
 
-plugin = pedalboard.load_plugin("plugins/Surge XT.vst3")
+plugin = VST3Plugin("plugins/Surge XT.vst3")
 
 
 def play_audio():
@@ -21,10 +20,9 @@ def play_audio():
         sample_rate=SAMPLE_RATE,
         buffer_size=BUFFER_SIZE,
     ) as stream:
-        board = Pedalboard([plugin])
         while True:
             silence = np.zeros((CHANNELS, BUFFER_SIZE), dtype=np.float32)
-            synth_output = board(silence, SAMPLE_RATE, reset=False)
+            synth_output = plugin(silence, SAMPLE_RATE, reset=False)
             stream.write(synth_output, SAMPLE_RATE)
 
 

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -1,0 +1,34 @@
+"""Interactive Surge XT preview with real-time audio streaming via pedalboard."""
+
+import threading
+
+import numpy as np
+import pedalboard
+from pedalboard import Pedalboard
+from pedalboard.io import AudioStream
+
+CHANNELS = 2
+SAMPLE_RATE = 44100
+BUFFER_SIZE = 512
+
+plugin = pedalboard.load_plugin("plugins/Surge XT.vst3")
+
+
+def play_audio():
+    """Stream silence through Surge XT and write synthesized audio to the output device."""
+    with AudioStream(
+        output_device_name=AudioStream.default_output_device_name,
+        sample_rate=SAMPLE_RATE,
+        buffer_size=BUFFER_SIZE,
+    ) as stream:
+        board = Pedalboard([plugin])
+        while True:
+            silence = np.zeros((CHANNELS, BUFFER_SIZE), dtype=np.float32)
+            synth_output = board(silence, SAMPLE_RATE, reset=False)
+            stream.write(synth_output, SAMPLE_RATE)
+
+
+t = threading.Thread(target=play_audio)
+t.start()
+
+plugin.show_editor()


### PR DESCRIPTION
## Summary

- Add `scripts/surge_xt_interactive.py` — opens Surge XT GUI via pedalboard with real-time audio streaming through AudioStream + sounddevice
- Moves experimental `test_pedal.py` into the proper `scripts/` directory

Closes #530