### PR TITLE
feat(code-health): run devcontainer as non-root dev user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,22 +9,32 @@ ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
     && apt-get update \
-    && apt-get install -y sudo \
+    && apt-get install -y --no-install-recommends sudo \
     && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
     && chmod 0440 /etc/sudoers.d/$USERNAME \
     && rm -rf /var/lib/apt/lists/*
 
-# Hand /venv/main to the dev user so post-create.sh's `uv pip install -e .`
-# works without sudo. Without this, the editable install fails because
-# /venv/main was created by root in the base image.
-RUN chown -R $USER_UID:$USER_GID /venv/main
+# Give the dev user write access only where post-create.sh's
+# `uv pip install --no-deps -e .` needs to create files (bin/ for entry
+# points, site-packages/ for the .pth file). Avoids a recursive chown of
+# the entire prebuilt ~2.5GB venv layer, which would copy-up every file
+# into a new image layer and balloon build time and image size.
+RUN SITE_PACKAGES="$(/venv/main/bin/python -c 'import site; print(site.getsitepackages()[0])')" \
+    && chown -R $USER_UID:$USER_GID /venv/main/bin "$SITE_PACKAGES"
 
-# R2 (rclone) and W&B credentials are baked into the base image at
+# R2 (rclone) and W&B credentials may be baked into the base image at
 # /root/.config/rclone/rclone.conf and /root/.netrc. Copy them into the dev
-# user's home so rclone and wandb work out of the box without sudo.
+# user's home when present so rclone and wandb work out of the box without
+# sudo, while still allowing builds without credentials baked in.
 RUN mkdir -p /home/$USERNAME/.config \
-    && cp -r /root/.config/rclone /home/$USERNAME/.config/rclone \
-    && cp /root/.netrc /home/$USERNAME/.netrc \
-    && chown -R $USER_UID:$USER_GID /home/$USERNAME/.config /home/$USERNAME/.netrc \
-    && chmod 600 /home/$USERNAME/.netrc \
-    && chmod 600 /home/$USERNAME/.config/rclone/rclone.conf
+    && chown $USER_UID:$USER_GID /home/$USERNAME/.config \
+    && if [ -d /root/.config/rclone ]; then \
+         cp -r /root/.config/rclone /home/$USERNAME/.config/rclone \
+         && chown -R $USER_UID:$USER_GID /home/$USERNAME/.config/rclone \
+         && chmod 600 /home/$USERNAME/.config/rclone/rclone.conf; \
+       fi \
+    && if [ -f /root/.netrc ]; then \
+         cp /root/.netrc /home/$USERNAME/.netrc \
+         && chown $USER_UID:$USER_GID /home/$USERNAME/.netrc \
+         && chmod 600 /home/$USERNAME/.netrc; \
+       fi

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,30 @@
+FROM tinaudio/perm:dev-snapshot
+
+ARG USERNAME=dev
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+# Non-root user with passwordless sudo. Follows the official VS Code pattern:
+# https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && apt-get update \
+    && apt-get install -y sudo \
+    && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    && rm -rf /var/lib/apt/lists/*
+
+# Hand /venv/main to the dev user so post-create.sh's `uv pip install -e .`
+# works without sudo. Without this, the editable install fails because
+# /venv/main was created by root in the base image.
+RUN chown -R $USER_UID:$USER_GID /venv/main
+
+# R2 (rclone) and W&B credentials are baked into the base image at
+# /root/.config/rclone/rclone.conf and /root/.netrc. Copy them into the dev
+# user's home so rclone and wandb work out of the box without sudo.
+RUN mkdir -p /home/$USERNAME/.config \
+    && cp -r /root/.config/rclone /home/$USERNAME/.config/rclone \
+    && cp /root/.netrc /home/$USERNAME/.netrc \
+    && chown -R $USER_UID:$USER_GID /home/$USERNAME/.config /home/$USERNAME/.netrc \
+    && chmod 600 /home/$USERNAME/.netrc \
+    && chmod 600 /home/$USERNAME/.config/rclone/rclone.conf

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,36 +1,20 @@
-# Platform routing for this amd64-only base image is pinned in
-# devcontainer.json's build.options (--platform=linux/amd64). That sets
-# the build target for the whole build — pulling the amd64 manifest AND
-# scheduling RUN steps on an amd64-capable worker — which a FROM --platform
-# flag alone does not do (it only selects the manifest variant).
 FROM tinaudio/perm:dev-snapshot
 
 ARG USERNAME=dev
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
-# Non-root user with passwordless sudo. Follows the official VS Code pattern:
-# https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
+# Non-root dev user with bash as the login shell. No sudo: passwordless
+# sudo is security theatre (dev becomes root trivially), and the escape
+# hatch for missing system packages is adding them to the base image
+# (docker/ubuntu22_04/Dockerfile) and rebuilding.
 RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash -m $USERNAME \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends sudo \
-    && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
-    && chmod 0440 /etc/sudoers.d/$USERNAME \
-    && rm -rf /var/lib/apt/lists/*
+    && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash -m $USERNAME
 
-# Give the dev user write access only where post-create.sh's
-# `uv pip install --no-deps -e .` needs to create files (bin/ for entry
-# points, site-packages/ for the .pth file). Avoids a recursive chown of
-# the entire prebuilt ~2.5GB venv layer, which would copy-up every file
-# into a new image layer and balloon build time and image size.
-RUN SITE_PACKAGES="$(/venv/main/bin/python -c 'import site; print(site.getsitepackages()[0])')" \
-    && chown -R $USER_UID:$USER_GID /venv/main/bin "$SITE_PACKAGES"
-
-# R2 (rclone) and W&B credentials may be baked into the base image at
-# /root/.config/rclone/rclone.conf and /root/.netrc. Copy them into the dev
-# user's home when present so rclone and wandb work out of the box without
-# sudo, while still allowing builds without credentials baked in.
+# R2 (rclone) and W&B credentials are baked into /root in the base image.
+# Copy them into the dev user's home when present so rclone and wandb work
+# out of the box.
+# TODO: remove once the base image bakes credentials into /home/dev directly.
 RUN mkdir -p /home/$USERNAME/.config \
     && chown $USER_UID:$USER_GID /home/$USERNAME/.config \
     && if [ -d /root/.config/rclone ]; then \
@@ -43,3 +27,5 @@ RUN mkdir -p /home/$USERNAME/.config \
          && chown $USER_UID:$USER_GID /home/$USERNAME/.netrc \
          && chmod 600 /home/$USERNAME/.netrc; \
        fi
+
+USER $USERNAME

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@ ARG USER_GID=$USER_UID
 # Non-root user with passwordless sudo. Follows the official VS Code pattern:
 # https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
 RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash -m $USERNAME \
     && apt-get update \
     && apt-get install -y --no-install-recommends sudo \
     && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,9 @@
-# Base image is published only for linux/amd64. On Apple Silicon this runs
-# under Rosetta/qemu — matches the pre-PR behavior of the plain `image:`
-# devcontainer config, but must be explicit now that we build via `build:`
-# because BuildKit resolves the FROM step against the builder's target
-# platform. Multi-arch publishing of the base image is the long-term fix.
-FROM --platform=linux/amd64 tinaudio/perm:dev-snapshot
+# Platform routing for this amd64-only base image is pinned in
+# devcontainer.json's build.options (--platform=linux/amd64). That sets
+# the build target for the whole build — pulling the amd64 manifest AND
+# scheduling RUN steps on an amd64-capable worker — which a FROM --platform
+# flag alone does not do (it only selects the manifest variant).
+FROM tinaudio/perm:dev-snapshot
 
 ARG USERNAME=dev
 ARG USER_UID=1000

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,9 @@
-FROM tinaudio/perm:dev-snapshot
+# Base image is published only for linux/amd64. On Apple Silicon this runs
+# under Rosetta/qemu — matches the pre-PR behavior of the plain `image:`
+# devcontainer config, but must be explicit now that we build via `build:`
+# because BuildKit resolves the FROM step against the builder's target
+# platform. Multi-arch publishing of the base image is the long-term fix.
+FROM --platform=linux/amd64 tinaudio/perm:dev-snapshot
 
 ARG USERNAME=dev
 ARG USER_UID=1000

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
 
   "remoteUser": "dev",
   "updateRemoteUserUID": true,
-  "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
+  "workspaceFolder": "/home/build/synth-setter",
+  "workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/home/build/synth-setter,consistency=cached",
 
   "postCreateCommand": ".devcontainer/post-create.sh",
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,13 @@
 {
   "name": "synth-setter",
-  "image": "tinaudio/perm:dev-snapshot",
+  "build": { "dockerfile": "Dockerfile" },
 
   "containerEnv": {
     "MODE": "idle"
   },
 
-  "remoteUser": "root",
+  "remoteUser": "dev",
+  "updateRemoteUserUID": true,
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
   "postCreateCommand": ".devcontainer/post-create.sh",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
   "name": "synth-setter",
-  "build": { "dockerfile": "Dockerfile" },
+  "build": {
+    "dockerfile": "Dockerfile",
+    "options": ["--platform=linux/amd64"]
+  },
 
   "containerEnv": {
     "MODE": "idle"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -30,9 +30,11 @@ git config --global --add safe.directory "$(pwd)"
 # Skills live in a git submodule (.claude/skills → tinaudio/skills).
 git submodule update --init --recursive
 
-# Install the workspace as an editable package into the image's venv.
-# --no-deps skips re-downloading the ~2.5GB of deps already in the image.
-uv pip install --no-deps -e .
+# No editable install here: the base image already ran `uv pip install
+# --no-deps -e .` at bake time against /home/build/synth-setter (see
+# docker/ubuntu22_04/Dockerfile), and devcontainer.json now mounts the
+# live workspace on top of that same path — so the existing .pth file
+# already points at the workspace.
 
 # Pre-commit hooks (pre-commit itself is in the image's deps). Strip any
 # absolute host-path core.hooksPath that may leak from the host .git/config


### PR DESCRIPTION
## Summary

- Add `.devcontainer/Dockerfile` extending `tinaudio/perm:dev-snapshot` with a non-root `dev` user (UID 1000, `/bin/bash` login shell) and a credential-copy block that forwards baked R2/W&B credentials from `/root` into `/home/dev`. **No sudo** — the dev user is truly unprivileged.
- Update `.devcontainer/devcontainer.json` to build from the Dockerfile, set `remoteUser: dev` with `updateRemoteUserUID: true`, pin the build target platform via `build.options: ["--platform=linux/amd64"]` (required for arm64 hosts and multi-node Build Cloud builders), and mount the host workspace at `/home/build/synth-setter` — the same path the base image's baked editable install already points at.
- Simplify `.devcontainer/post-create.sh` by removing the redundant `uv pip install --no-deps -e .` step. The baked install is already correct under the new mount path.

## Why

Claude Code refuses to run with `--dangerously-skip-permissions` as root, which blocks using it inside the devcontainer. This PR creates a non-root `dev` user following the [official VS Code pattern](https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user), minus the sudo escape hatch.

## Design notes

### Mount at the baked-install path

The base image already runs `uv pip install --no-deps -e .` at bake time against `/home/build/synth-setter/` ([docker/ubuntu22_04/Dockerfile:422](docker/ubuntu22_04/Dockerfile#L422)), writing a `.pth` file in `site-packages/` pointing at that exact path.

Mounting the host workspace **on top of that path** means the baked `.pth` file is automatically correct — no retrofit chown of `/venv/main/*`, no `uv pip install -e .` in `post-create.sh` to re-point the file, no PYTHONPATH hack. The existing editable install resolves to the live workspace via the bind mount. Same image works for CI/production (baked clone) and devcontainer (mount shadows the baked clone) with zero consumer-side machinery.

### No sudo

Passwordless sudo is security theatre — a process running as `dev` can become root with three keystrokes. It exists in most non-root patterns as an ergonomic escape hatch for installing missing packages, not a security boundary. We prefer "if you need a system package, add it to the base image ([docker/ubuntu22_04/Dockerfile](docker/ubuntu22_04/Dockerfile)) and rebuild." More auditable, more reproducible, less surface area in the devcontainer layer.

The truly-unprivileged dev user also gives real accident protection: destructive commands need to be explicitly prefixed with `sudo` to work, so a stray `rm -rf` fails naturally instead of completing silently.

### `--platform=linux/amd64` in `build.options`

`tinaudio/perm:dev-snapshot` is published only as `linux/amd64`. On Apple Silicon or arm64 Build Cloud workers, BuildKit's default target platform is `linux/arm64`, which fails resolving FROM with `no match for platform in manifest` and (if the manifest is somehow resolved) then fails at RUN time with `exec format error` on an arm64 worker running amd64 binaries.

Pinning the build target platform via `build.options` tells BuildKit to schedule the build on an amd64-capable worker: the native `linux-amd64` node on a multi-node Build Cloud builder, or Docker Desktop's local builder via Rosetta-for-Linux. This pin lives in `devcontainer.json`, not in `FROM --platform`, because the two have different effects: `FROM --platform` selects the manifest variant, while `build.options: --platform` sets the build target (which determines where RUN steps execute).

Long-term fix: publish `tinaudio/perm:dev-snapshot` as a multi-arch manifest. Tracked separately.

## Trade-offs

- **`Refs #539` not `Fixes #539`**: CI can build the image but can't exercise the Claude-in-devcontainer flow end-to-end. Full verification requires a human rebuilding the container. This PR ships a partial fix pending that verification.
- **All worktrees map to the same container path** (`/home/build/synth-setter`) regardless of host basename. Arguably an improvement over per-worktree paths — stable and deterministic for stack traces, tool configuration, and debug output.
- **No sudo escape hatch**: if a dev needs a missing system package during iteration, the workflow is edit `docker/ubuntu22_04/Dockerfile`, rebuild the base image, rebuild the devcontainer. Slower than `sudo apt install` but forces system state to live in code.
- **Credentials still copied from `/root` to `/home/dev`**: duct tape for a base-image choice. Removable once `tinaudio/perm:dev-snapshot` bakes credentials into `/home/dev` directly (there's a TODO on the block in the Dockerfile).

## Test plan

CI can only verify the image builds. Full verification is manual — rebuild the container and run:

- [ ] **Identity / shell**
  - `whoami` → expect `dev`
  - `id` → expect `uid=1000(dev) gid=1000(dev)` (or remapped UID on Linux)
  - `getent passwd dev | cut -d: -f7` → expect `/bin/bash`
  - `echo $SHELL` in a fresh terminal → expect `/bin/bash`
- [ ] **Unprivileged by design**
  - `sudo -n true 2>&1 || echo "no sudo (expected)"` → expect the echo message
- [ ] **Mount landed at the baked-install path**
  - `pwd` → expect `/home/build/synth-setter`
  - `ls -la .git | head -3` → expect host git state, not the baked detached HEAD
- [ ] **Imports resolve to the live workspace**
  - `python -c "import pipeline; print(pipeline.__file__)"` → expect a path under `/home/build/synth-setter/src/`
  - Edit a file, re-import, confirm the change is visible without reinstalling
- [ ] **Venv is functional without chown retrofits**
  - `python -c "import sys; print(sys.executable)"` → expect `/venv/main/bin/python`
  - `pip show synth-permutations | head -5` → expect metadata returned
  - `stat -c '%U %G' /venv/main` → expect `root root` (proves we did NOT retrofit ownership)
- [ ] **Credentials work under HOME=/home/dev**
  - `ls -la ~/.netrc ~/.config/rclone/rclone.conf` → both present, dev-owned, mode 600
  - `rclone lsd r2:` → expect bucket list (or clean "not configured" if built without the BuildKit secret)
  - `wandb login --verify` → expect "Currently logged in as: ..."
- [ ] **Pre-commit hooks work as dev**
  - `pre-commit --version`
  - `pre-commit run --all-files` — hooks execute without permission errors
- [ ] **The motivating check**
  - `claude --dangerously-skip-permissions --version` → expect version string, **no** "refuses to run as root" error

Reviewer: please post a PR comment with the output of these commands once you've rebuilt the container.

Refs #539