### PR TITLE
fix(devcontainer): GPU passthrough, submodule trust, non-root dev user

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM tinaudio/perm:dev-snapshot
+
+ARG USERNAME=dev
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME \
+    && apt-get update \
+    && apt-get install -y sudo \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "$USERNAME ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/$USERNAME \
+    && chmod 0440 /etc/sudoers.d/$USERNAME \
+    && chown -R $USER_UID:$USER_GID /venv

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,14 @@
 {
   "name": "synth-setter",
-  "image": "tinaudio/perm:dev-snapshot",
+  "build": { "dockerfile": "Dockerfile" },
 
+  "runArgs": ["--gpus", "all"],
   "containerEnv": {
-    "MODE": "idle"
+    "MODE": "passthrough"
   },
 
-  "remoteUser": "root",
+  "remoteUser": "dev",
+  "updateRemoteUserUID": true,
   "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
 
   "postCreateCommand": ".devcontainer/post-create.sh",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -22,10 +22,11 @@ done
 }
 cd "$dir"
 
-# Codespaces runs this script as root against a workspace that may be owned
-# by another UID, tripping git's safe.directory check. Mark the repo trusted
-# before any git operation (submodule update, pre-commit install).
-git config --global --add safe.directory "$(pwd)"
+# Trust the workspace repo and every submodule (e.g. .claude/skills) before
+# any git operation (submodule update, pre-commit install). The wildcard is
+# safe inside a dev container where the repo is the only thing present, and
+# avoids per-submodule entries that broke when .claude/skills was added.
+git config --global --add safe.directory '*'
 
 # Skills live in a git submodule (.claude/skills → tinaudio/skills).
 git submodule update --init --recursive


### PR DESCRIPTION
## Summary

The `.devcontainer/` added in #186 was unusable on three independent axes. This PR fixes all three so the container starts cleanly with GPUs attached and Claude Code can run inside it.

- **GPU passthrough.** `runArgs: ["--gpus", "all"]` plus `MODE=passthrough` (replacing `idle`) so the base image entrypoint starts a usable shell with GPUs attached. The old config was effectively no-op on GPU hosts.
- **Submodule trust.** `post-create.sh` now widens `git safe.directory` to `'*'`. The previous per-path entry only covered the main repo, so `git submodule update --init --recursive` died on `.claude/skills` with *"detected dubious ownership"*. The wildcard is safe inside a dev container where the repo is the only thing present.
- **Non-root dev user.** New `.devcontainer/Dockerfile` extends the base image with a `dev` user (uid 1000) and passwordless sudo — the [official VS Code pattern](https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user). `devcontainer.json` builds from it with `remoteUser: dev` and `updateRemoteUserUID: true`. The Dockerfile also `chown`s `/venv` so post-create's `uv pip install --no-deps -e .` can write to the pre-baked venv as the dev user. This unblocks `claude --dangerously-skip-permissions`, which refuses to run as root.

## Test plan

Run on a Linux host with NVIDIA Container Toolkit (the only environment where `--gpus all` is meaningful):

- [ ] **Rebuild container** — "Dev Containers: Rebuild Container" in VS Code, or `devcontainer up --workspace-folder .` with the CLI. Build must succeed.
- [ ] **Entrypoint starts** — container boots without the `MODE` entrypoint erroring; `postCreateCommand` runs to completion.
- [ ] **Identity** — `whoami` → `dev`; `id` shows `uid=1000(dev)`; `sudo -n whoami` → `root`.
- [ ] **GPU passthrough** — `nvidia-smi` lists at least one GPU inside the container.
- [ ] **Submodules** — `ls .claude/skills/` is non-empty; no "dubious ownership" error in post-create logs.
- [ ] **Venv writable** — `uv pip install --no-deps -e .` from post-create completes without permission error.
- [ ] **Pre-commit wired** — `cat .git/hooks/pre-commit` exists.
- [ ] **Tests smoke** — `make test` runs as the `dev` user.
- [ ] **Claude Code** — `claude --dangerously-skip-permissions` no longer rejects on the root check.

## Notes

- `--gpus all` requires NVIDIA Container Toolkit on the Docker host. Mac Docker Desktop doesn't support it, so this devcontainer must be opened on a Linux host or a Codespaces machine type that has a GPU.
- `chown -R /venv` in the Dockerfile is load-bearing — without it, `uv pip install` in post-create fails with EACCES against root-owned site-packages.

Refs #538