### PR TITLE
docs(readme): declare Windows unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ it. Built on PyTorch Lightning with Hydra configs.
 
 ## Prerequisites
 
-- **Supported platforms**: Linux and macOS only. Windows is not supported — the `sh` test dependency and the VST rendering tooling are POSIX-only, and CI runs on `ubuntu-latest` and `macos-latest` only.
+- **Supported platforms**: Linux and macOS only. Windows is not supported — the `sh` test dependency and the VST rendering tooling are POSIX-only, and CI covers Ubuntu and macOS only; no Windows.
 - **Python 3.10+**
 - **uv** (recommended) -- [install uv](https://docs.astral.sh/uv/getting-started/installation/)
 - **Git**

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ it. Built on PyTorch Lightning with Hydra configs.
 
 ## Prerequisites
 
+- **Supported platforms**: Linux and macOS only. Windows is not supported — the `sh` test dependency and the VST rendering tooling are POSIX-only, and CI runs on `ubuntu-latest` and `macos-latest` only.
 - **Python 3.10+**
 - **uv** (recommended) -- [install uv](https://docs.astral.sh/uv/getting-started/installation/)
 - **Git**

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,9 +8,10 @@ ______________________________________________________________________
 
 ## 1. Prerequisites
 
+- **Linux or macOS** — Windows is not supported (see the project README).
 - **Python 3.10+** (check with `python --version`)
 - **Git**
-- **make** (ships with macOS/Linux; on Windows use WSL)
+- **make** (ships with macOS/Linux)
 - **A CUDA GPU** is recommended for training. CPU and MPS (Apple Silicon) trainers
   are available but significantly slower.
 
@@ -29,8 +30,7 @@ cd synth-setter
 
 ```bash
 python -m venv .venv
-source .venv/bin/activate  # Linux/macOS
-# .venv\Scripts\activate   # Windows
+source .venv/bin/activate
 ```
 
 ### 2c. Install dependencies


### PR DESCRIPTION
## Summary

Document under Prerequisites that synth-setter only supports Linux and macOS, and remove the contradictory Windows-install hints from `docs/getting-started.md`. Windows is not supported because the `sh` test dependency and the VST rendering tooling are POSIX-only, and CI only covers `ubuntu-latest` and `macos-latest`.

This completes the "explicitly drop Windows" path of #32 (the `run_tests_windows` CI job has already been removed; this PR adds the user-facing documentation that closes the loop).

## Changes

- `README.md` — add a "Supported platforms" bullet to Prerequisites stating Linux/macOS only and explaining why.
- `docs/getting-started.md` — remove the WSL note and the `.venv\Scripts\activate # Windows` line; add an explicit "Linux or macOS" prerequisite pointing at the README.

## Context

Raised in [PR #513 review comment](https://github.com/tinaudio/synth-setter/pull/513#discussion_r3076479826): without the `@RunIf(sh=True)` gate on the sweep tests, `run_sh_command()` would `NameError` on Windows. Rather than re-add the gate, we make the platform stance explicit — Windows isn't a supported target.

Closes #32

## Test plan

- [x] `make format` passes (mdformat + prettier + codespell ran clean on both files).
- [x] No remaining contradictory Windows references in `README.md` / `docs/` (verified via `grep -rn -i windows`).
- [ ] CI green on PR (test.yml, code-quality, pr-metadata-gate).