### PR TITLE
build(devcontainer): install Claude Code CLI via userspace nvm

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -42,7 +42,18 @@ ARG CLAUDE_CODE_VERSION=2.1.105
 ENV NVM_DIR="/home/$USERNAME/.nvm"
 ENV PATH="$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH"
 
-RUN wget -qO- "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh" | bash \
+# nvm.sh is intended for bash/zsh. It happens to source under Ubuntu's
+# /bin/sh (dash) today because nvm maintains POSIX compatibility, but the
+# dependency on bash is implicit and could break if nvm's internals change.
+# Set SHELL explicitly so the source + nvm install + npm install chain
+# runs under bash, and enable pipefail so any stage failure aborts the
+# layer cleanly.
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Clone nvm at a pinned tag instead of piping install.sh through bash.
+# The cloned tree is auditable on disk, the tag is immutable upstream,
+# and we never execute unverified network content during the image build.
+RUN git clone --depth 1 --branch "v${NVM_VERSION}" https://github.com/nvm-sh/nvm.git "$NVM_DIR" \
     && . "$NVM_DIR/nvm.sh" \
     && nvm install "$NODE_VERSION" \
     && nvm alias default "$NODE_VERSION" \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -29,3 +29,21 @@ RUN mkdir -p /home/$USERNAME/.config \
        fi
 
 USER $USERNAME
+
+# Claude Code CLI (userspace install via nvm — no root, no sudo).
+# Anthropic's reference devcontainer installs Claude Code globally as root
+# and adds a scoped sudoers grant for a firewall script. We install under
+# the dev user's home instead so this Dockerfile stays root-free. Firewall
+# + scoped sudo are tracked separately (#549).
+ARG NVM_VERSION=0.40.1
+ARG NODE_VERSION=20.18.0
+ARG CLAUDE_CODE_VERSION=2.1.105
+
+ENV NVM_DIR="/home/$USERNAME/.nvm"
+ENV PATH="$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH"
+
+RUN wget -qO- "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh" | bash \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install "$NODE_VERSION" \
+    && nvm alias default "$NODE_VERSION" \
+    && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"


### PR DESCRIPTION
## Summary

Install `@anthropic-ai/claude-code` 2.1.105 inside `.devcontainer/Dockerfile` via a userspace `nvm` install, as the existing non-root `dev` user. Zero root, zero sudo, zero base-image changes.

Closes #548

## What changed

`.devcontainer/Dockerfile` — 18-line block added after `USER $USERNAME`:

```dockerfile
# Claude Code CLI (userspace install via nvm — no root, no sudo).
# Anthropic's reference devcontainer installs Claude Code globally as root
# and adds a scoped sudoers grant for a firewall script. We install under
# the dev user's home instead so this Dockerfile stays root-free. Firewall
# + scoped sudo are tracked separately (#549).
ARG NVM_VERSION=0.40.1
ARG NODE_VERSION=20.18.0
ARG CLAUDE_CODE_VERSION=2.1.105

ENV NVM_DIR="/home/$USERNAME/.nvm"
ENV PATH="$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH"

RUN wget -qO- "https://raw.githubusercontent.com/nvm-sh/nvm/v${NVM_VERSION}/install.sh" | bash \
    && . "$NVM_DIR/nvm.sh" \
    && nvm install "$NODE_VERSION" \
    && nvm alias default "$NODE_VERSION" \
    && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
```

## Why this design

- **Respects existing policies** in `.devcontainer/Dockerfile` (lines 7–10): "No sudo: passwordless sudo is security theatre... the escape hatch for missing system packages is adding them to the base image (`docker/ubuntu22_04/Dockerfile`) and rebuilding."
- **No root escalation** — everything runs as `dev`. nvm writes only to `$HOME/.nvm`.
- **No base-image change** — `docker/ubuntu22_04/Dockerfile` is untouched.
- **`wget` not `curl`** — base image `tinaudio/perm:dev-snapshot` has `wget` but not `curl`. nvm's install script supports both.
- **Explicit `ENV PATH`** — guarantees `claude`/`node`/`npm` resolve in any shell mode (interactive, non-interactive, `docker exec`, VSCode tasks), not just bashrc-sourcing interactive shells.
- **Pinned everything** — `NVM_VERSION=0.40.1`, `NODE_VERSION=20.18.0` (matches Anthropic's reference Node 20 line), `CLAUDE_CODE_VERSION=2.1.105` (current latest on npm as of 2026-04-13).

## Alternatives considered

| Option | Rejected because |
|---|---|
| `apt-get install nodejs` in this Dockerfile | Requires root + violates "base image for system packages" policy |
| Node in base image (`docker/ubuntu22_04/Dockerfile`) | Slower iteration loop; no reason to couple Claude Code pins to base image rebuilds |
| Install in `postCreateCommand` (runtime) | Bloats container-start time; requires network on every first open; build-time install caches in image layer |

## Verification

Built locally under amd64 emulation (host is arm64):

```
$ docker build --platform=linux/amd64 -t synth-setter-devcontainer-test:feat-claude .devcontainer/
...
#7 22.60 + npm install -g @anthropic-ai/claude-code@2.1.105
#7 28.72 added 3 packages in 6s
#7 DONE 29.3s
#8 exporting to image
#8 DONE 11.0s
```

### Shell-mode checks (both pass)

```
$ docker run --rm --platform=linux/amd64 --entrypoint=sh <img> -c \
    'node --version && npm --version && claude --version'
v20.18.0
10.8.2
2.1.105 (Claude Code)

$ docker run --rm --platform=linux/amd64 --entrypoint=bash <img> -lc 'claude --version'
2.1.105 (Claude Code)
```

Non-interactive `sh` mode working is the critical check — it proves the explicit `ENV PATH` line is doing its job, not bashrc sourcing.

### User/path check

```
$ docker run --rm --platform=linux/amd64 --entrypoint=sh <img> -c \
    'id && echo HOME=$HOME && ls -la ~/.nvm/versions/node/'
uid=1000(dev) gid=1000(dev) groups=1000(dev)
HOME=/home/dev
drwxr-xr-x 3 dev dev 4096 Apr 14 01:37 .
drwxr-xr-x 3 dev dev 4096 Apr 14 01:37 ..
drwxr-xr-x 6 dev dev 4096 Apr 14 01:37 v20.18.0
```

Runs as `dev` (uid 1000), nvm lives under `/home/dev/.nvm`, all files owned by `dev`. No root artifacts.

## Out of scope

- Network firewall (`init-firewall.sh` + `iptables`/`ipset`/`dnsutils`)
- Scoped `sudoers.d` grant for the firewall script
- Reconciling the existing "no sudo" policy comment with narrow scoped sudo

All tracked in #549 (follow-up Task under Phase #160 / Epic #114).

## Test plan

- [ ] CI `pr-metadata-gate` passes (issue #548 has type Task, label `code-health`, milestone `code-health v1.0.0`)
- [ ] CI build (if any) passes
- [ ] Reviewer rebuilds devcontainer locally (or in Codespaces) and runs `claude --version` in the integrated terminal