### PR TITLE
build(devcontainer): split into cpu and gpu flavors

### DIFF
--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -1,7 +1,8 @@
 {
-  "name": "synth-setter",
+  "name": "synth-setter (cpu)",
   "build": {
-    "dockerfile": "Dockerfile",
+    "dockerfile": "../Dockerfile",
+    "context": "..",
     "options": ["--platform=linux/amd64"]
   },
 

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -1,0 +1,61 @@
+{
+  "name": "synth-setter (gpu)",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "context": "..",
+    "options": ["--platform=linux/amd64"]
+  },
+
+  "runArgs": ["--gpus", "all"],
+
+  "containerEnv": {
+    "MODE": "idle"
+  },
+
+  "remoteUser": "dev",
+  "updateRemoteUserUID": true,
+  "workspaceFolder": "/home/build/synth-setter",
+  "workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/home/build/synth-setter,consistency=cached",
+
+  "postCreateCommand": ".devcontainer/post-create.sh",
+
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.debugpy",
+        "ms-python.vscode-python-envs",
+        "charliermarsh.ruff",
+        "ms-toolsai.jupyter",
+        "ms-toolsai.jupyter-keymap",
+        "ms-toolsai.jupyter-renderers",
+        "ms-toolsai.vscode-jupyter-cell-tags",
+        "ms-toolsai.vscode-jupyter-slideshow",
+        "redhat.vscode-yaml",
+        "kamilturek.vscode-pyproject-toml-snippets",
+        "ms-vscode.makefile-tools",
+        "jetmartin.bats",
+        "timonwong.shellcheck",
+        "lochbrunner.vscode-hdf5-viewer",
+        "adamviola.parquet-explorer",
+        "mechatroner.rainbow-csv",
+        "github.vscode-pull-request-github",
+        "github.vscode-github-actions",
+        "eamodio.gitlens",
+        "anthropic.claude-code"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/venv/main/bin/python",
+        "python.terminal.activateEnvironment": false,
+        "editor.formatOnSave": true,
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": ["tests"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Replace `.devcontainer/devcontainer.json` with two flavors under `.devcontainer/cpu/` and `.devcontainer/gpu/` that share the existing `Dockerfile` and `post-create.sh`.
- The only difference is `runArgs`: the gpu flavor passes `["--gpus", "all"]` so NVIDIA Container Toolkit hosts get device access. Both keep `MODE=idle` so the entrypoint runs `sleep infinity` and VS Code can attach shells.
- VS Code and Codespaces auto-present a picker when devcontainer configs live under named subfolders.

Partially addresses the GPU passthrough axis of #538. The non-root user axis was already fixed in c8bb6f6, and the submodule trust axis is moot after #546 (skills migrated from submodule to plugin marketplace).

Refs #538

## Test plan

- [ ] VS Code / Codespaces picker shows both `synth-setter (cpu)` and `synth-setter (gpu)` when opening the repo
- [ ] Building the cpu flavor on a CPU host succeeds and the container stays up for shell attach
- [ ] Building the gpu flavor on an NVIDIA host lets `nvidia-smi` run inside the container
- [ ] `post-create.sh` still runs cleanly for both flavors (no path assumptions broke)