### PR TITLE
chore(ci-automation): one-shot conda env and conda test workflow

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -1,0 +1,68 @@
+name: Tests (conda)
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "pipeline/**"
+      - "tests/**"
+      - "configs/**"
+      - "scripts/**"
+      - "requirements*.txt"
+      - "environment.yaml"
+      - "pyproject.toml"
+      - "setup.py"
+      - ".github/workflows/test-conda.yml"
+  pull_request:
+    branches: [main, "release/*", "dev"]
+    paths:
+      - "src/**"
+      - "pipeline/**"
+      - "tests/**"
+      - "configs/**"
+      - "scripts/**"
+      - "requirements*.txt"
+      - "environment.yaml"
+      - "pyproject.toml"
+      - "setup.py"
+      - ".github/workflows/test-conda.yml"
+
+defaults:
+  run:
+    # Login shell so the conda env activated by setup-micromamba is on PATH.
+    shell: bash -el {0}
+
+jobs:
+  run_tests_conda:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up conda env from environment.yaml
+        uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: environment.yaml
+          environment-name: myenv
+          cache-environment: true
+          init-shell: bash
+
+      - name: List dependencies
+        run: |
+          micromamba list
+          pip list
+
+      - name: Cache MNIST dataset
+        uses: actions/cache@v4
+        with:
+          path: data/MNIST
+          key: mnist-dataset-v1
+
+      - name: Run pytest
+        env:
+          HYDRA_FULL_ERROR: "1"
+        run: pytest -n auto -m "not slow" -vv -s

--- a/environment.yaml
+++ b/environment.yaml
@@ -12,24 +12,24 @@ channels:
   - conda-forge
   - defaults
 
-# it is strongly recommended to specify versions of packages installed through conda
-# to avoid situation when version-unspecified packages install their latest major
-# versions which can sometimes break things
-
-# current approach below keeps the dependencies in the same major versions across all
-# users, but allows for different minor and patch versions of packages where backwards
-# compatibility is usually guaranteed
+# Split of responsibilities between conda and pip:
+# - conda owns the torch stack (python, pytorch, torchvision, lightning, torchmetrics)
+#   because that's the whole reason to use the conda path — precompiled binaries.
+# - pip owns everything else, installed in a single shot via `-r requirements-app.txt`
+#   below. This gives us a non-overlapping dependency set by construction, so the
+#   conda and pip installers cannot fight over the same package.
+#
+# The torch-stack version specs here are kept in lock-step with requirements-torch.txt:
+# if that file raises a lower bound, bump the matching spec here too. Otherwise conda
+# could legally resolve to an older version than the pip spec allows, and the two
+# installers would disagree silently.
 
 dependencies:
   - python=3.10
-  - pytorch=2.*
-  - torchvision=0.*
-  - lightning=2.*
-  - torchmetrics=0.*
-  - hydra-core=1.*
-  - rich=13.*
-  - pre-commit=3.*
-  - pytest=7.*
+  - pytorch>=2.0.0
+  - torchvision>=0.15.0
+  - lightning>=2.0.0
+  - torchmetrics>=0.11.4
 
   # --------- loggers --------- #
   # - wandb
@@ -38,10 +38,11 @@ dependencies:
   # - comet-ml
   # - aim>=3.16.2 # no lower than 3.16.2, see https://github.com/aimhubio/aim/issues/2550
 
+  # torchmetrics imports `pkg_resources`, which ships with setuptools. conda's
+  # minimal base env doesn't include it, so install it explicitly.
+  - setuptools
   - pip>=23
   - pip:
-      # conda already installs the torch stack above (that's the point of the conda path
-      # — precompiled binaries). Pull in only the non-torch pip deps here so
-      # `conda env create -f environment.yaml` is a one-shot without re-installing
-      # torch/torchvision/lightning/torchmetrics through pip.
+      # Non-torch pip deps — conda owns the torch stack above, pip owns everything
+      # else. hydra-core, rich, pre-commit, pytest, etc. all come in via this file.
       - -r requirements-app.txt

--- a/environment.yaml
+++ b/environment.yaml
@@ -40,6 +40,6 @@ dependencies:
 
   - pip>=23
   - pip:
-      - hydra-optuna-sweeper
-      - hydra-colorlog
-      - rootutils
+      # Single source of truth for pip deps — `conda env create -f environment.yaml`
+      # now installs everything in one shot; no separate `pip install -r requirements.txt`.
+      - -r requirements.txt

--- a/environment.yaml
+++ b/environment.yaml
@@ -8,8 +8,11 @@
 name: myenv
 
 channels:
-  - pytorch
+  # conda-forge first so shared deps (pillow, libtiff, etc.) come from the
+  # well-maintained community channel with bundled system libs. The pytorch
+  # channel is kept as a fallback for torch-specific builds.
   - conda-forge
+  - pytorch
   - defaults
 
 # Split of responsibilities between conda and pip:

--- a/environment.yaml
+++ b/environment.yaml
@@ -40,6 +40,8 @@ dependencies:
 
   - pip>=23
   - pip:
-      # Single source of truth for pip deps — `conda env create -f environment.yaml`
-      # now installs everything in one shot; no separate `pip install -r requirements.txt`.
-      - -r requirements.txt
+      # conda already installs the torch stack above (that's the point of the conda path
+      # — precompiled binaries). Pull in only the non-torch pip deps here so
+      # `conda env create -f environment.yaml` is a one-shot without re-installing
+      # torch/torchvision/lightning/torchmetrics through pip.
+      - -r requirements-app.txt


### PR DESCRIPTION
## Summary

Makes the conda install path a real, tested one-shot: `conda env create -f environment.yaml` sets up the full dev env in a single command, and a new CI workflow keeps it from rotting.

**`environment.yaml` changes:**
- Conda now owns *only* the torch stack: `python`, `pytorch`, `torchvision`, `lightning`, `torchmetrics`, plus `setuptools` (so `torchmetrics` can import `pkg_resources`) and `pip`. That's the whole reason to use the conda path in the first place — precompiled binaries.
- The `pip:` block installs `-r requirements-app.txt` directly (not `requirements.txt`), so pip never redundantly re-installs the torch stack that conda just provided.
- Dropped `hydra-core`, `rich`, `pre-commit`, and `pytest` from the conda block — they come in via `requirements-app.txt` anyway, so conda was duplicating them. After this change the conda and pip dep sets are **non-overlapping by construction**.
- Torch-stack lower bounds now match `requirements-torch.txt` exactly (`pytorch>=2.0.0`, `torchvision>=0.15.0`, `lightning>=2.0.0`, `torchmetrics>=0.11.4`), so the conda resolver cannot legally pick a version the pip specs would reject.
- Channel order flipped: `conda-forge` is now first, with `pytorch` kept as a fallback. Needed because the pytorch channel's `pillow` (pulled in as a torchvision dep) dynamically links `libtiff.so.5`, which isn't present in a minimal conda env — `conda-forge`'s pillow bundles its libs.

**New workflow `.github/workflows/test-conda.yml`:**
- Creates the env from `environment.yaml` via `mamba-org/setup-micromamba@v2` with `cache-environment: true` for cache-hit reruns.
- Runs the exact same pytest invocation as `test.yml`'s green `run_tests_ubuntu` job (`pytest -n auto -m "not slow" -vv -s`), with the same `HYDRA_FULL_ERROR=1` and the same `mnist-dataset-v1` cache key.
- Runs alongside the existing `test.yml` — the two cover different install paths (conda vs uv) and should both stay green.

## Why

Previously, `environment.yaml` and `requirements.txt` were two parallel sources of truth for overlapping dependency sets, with nothing verifying they agreed. The conda path required a manual two-step (`conda env create` then `pip install -r requirements.txt`) and was one forgotten step away from being broken at any time. This PR collapses the flow and adds a CI gate so regressions are caught immediately.

## Test plan

- [x] CI: `Tests (conda)` workflow is green on `bbacfc8` — 156 passed / 5 skipped / 1 warning in 10.15s, identical pass/skip count to `test.yml`'s `run_tests_ubuntu` on main ([verification comment](https://github.com/tinaudio/synth-setter/pull/558#issuecomment-4246808795))
- [x] CI: `check-pr-metadata` gate passes — linked issue #557 is taxonomy-compliant and traces to Epic #148 via Phase #150
- [x] CI: `code-quality` passes
- [ ] Follow-up: verify the conda env also passes the GPU and VST test suites — tracked separately (not in this PR's scope)

Refs #557
