### PR TITLE
test(datamodules): skip flaky test_mnist_datamodule

### DIFF
--- a/tests/test_datamodules.py
+++ b/tests/test_datamodules.py
@@ -6,6 +6,7 @@ import torch
 from src.data.mnist_datamodule import MNISTDataModule
 
 
+@pytest.mark.skip(reason="Blocked on #243 — flaky MNIST download from public mirror")
 @pytest.mark.parametrize("batch_size", [32, 128])
 def test_mnist_datamodule(batch_size: int) -> None:
     """Tests `MNISTDataModule` to verify that it can be downloaded correctly, that the necessary


### PR DESCRIPTION
## Summary

- Skip `test_mnist_datamodule` unconditionally. The public MNIST mirror download has been flaky, causing `make test` to fail locally with `RuntimeError: Error downloading train-images-idx3-ubyte.gz`.
- Matches the skip style used in `b45973f` (`@pytest.mark.skip(reason="Blocked on #N — ...")`).
- macOS CI `-k "not test_mnist_datamodule"` filter left in place; removing it is tracked separately on #243.

## Test plan

- [x] `uv run pytest tests/test_datamodules.py -q` — both parametrizations report `SKIPPED` (reason: "Blocked on #243 — flaky MNIST download from public mirror")
- [x] `make test` — `154 passed, 3 skipped` (previous 1 skip + 2 new MNIST skips), exit 0
- [x] `make format` — all pre-commit hooks pass
- [x] No `--no-verify` used

Refs #243