### PR TITLE
fix(ci): hash requirements-app.txt in test-conda cache key

### DIFF
--- a/.github/workflows/test-conda.yml
+++ b/.github/workflows/test-conda.yml
@@ -49,6 +49,7 @@ jobs:
           environment-file: environment.yaml
           environment-name: myenv
           cache-environment: true
+          cache-environment-key: env-${{ hashFiles('environment.yaml', 'requirements-app.txt') }}
           init-shell: bash
 
       - name: List dependencies


### PR DESCRIPTION
## Summary

One-line fix: set `cache-environment-key` on the `setup-micromamba` step in
`test-conda.yml` so the conda env cache invalidates whenever either
`environment.yaml` or `requirements-app.txt` changes.

## The bug

`setup-micromamba@v2`'s default `cache-environment` key hashes
`environment.yaml` only. `environment.yaml` references `requirements-app.txt`
via a pip `-r` line, but the action does not follow the nested reference when
computing the default key. PRs that touch only `requirements-app.txt` leave
`environment.yaml` byte-identical, the cached env is reused, and the pip-dep
change is never installed or tested — silent false-green/false-red CI.

`requirements-torch.txt` is intentionally excluded from the new key: the torch
specs are inlined directly in `environment.yaml`'s conda section, so any torch
version change already touches `environment.yaml` and invalidates the default
key. The duplication between the two files is tracked separately and is out
of scope here.

## Change

```diff
           environment-file: environment.yaml
           environment-name: myenv
           cache-environment: true
+          cache-environment-key: env-${{ hashFiles('environment.yaml', 'requirements-app.txt') }}
           init-shell: bash
```

Closes #569

## Test plan

- [ ] Tests (conda) workflow triggers on this PR via the
      `.github/workflows/test-conda.yml` path filter
- [ ] First run shows cache MISS (new key introduced)
- [ ] On a follow-up no-op rerun, the same key yields a cache HIT
- [ ] Behavioral check (separate throwaway PR, optional): touching only
      `requirements-app.txt` invalidates the cache
