### PR TITLE
build(devcontainer): enable Claude Code agent workflows in CPU+GPU containers

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,12 +4,28 @@ ARG USERNAME=dev
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
 
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  jq \
+  gh \
+  && rm -rf /var/lib/apt/lists/*
+
 # Non-root dev user with bash as the login shell. No sudo: passwordless
 # sudo is security theatre (dev becomes root trivially), and the escape
 # hatch for missing system packages is adding them to the base image
 # (docker/ubuntu22_04/Dockerfile) and rebuilding.
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash -m $USERNAME
+
+# Fix ownership of any repo content the base image left as root
+RUN chown -R $USER_UID:$USER_GID .git
 
 USER $USERNAME
 

--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -7,7 +7,7 @@
       "--platform=linux/amd64"
     ]
   },
-  "initializeCommand": "[ -f .env ] || touch .env",
+  "initializeCommand": "[ -f .env ] || touch .env; mkdir -p ~/.claude && { [ -f ~/.claude/.credentials.json ] || echo '{}' > ~/.claude/.credentials.json; }",
   "runArgs": [
     "--env-file",
     ".env"

--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -7,7 +7,7 @@
       "--platform=linux/amd64"
     ]
   },
-  "initializeCommand": "[ -f .env ] || touch .env; mkdir -p ~/.claude && { [ -f ~/.claude/.credentials.json ] || echo '{}' > ~/.claude/.credentials.json; }",
+  "initializeCommand": "[ -f .env ] || touch .env; mkdir -p ~/.claude && { [ -f ~/.claude/.credentials.json ] || ( umask 077 && echo '{}' > ~/.claude/.credentials.json ); }",
   "runArgs": [
     "--env-file",
     ".env"

--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -3,24 +3,28 @@
   "build": {
     "dockerfile": "../Dockerfile",
     "context": "..",
-    "options": ["--platform=linux/amd64"]
+    "options": [
+      "--platform=linux/amd64"
+    ]
   },
-
+  "runArgs": [
+    "--env-file",
+    ".env"
+  ],
   "containerEnv": {
     "MODE": "idle"
   },
-
+  "mounts": [
+    "source=${localEnv:HOME}/.claude/.credentials.json,target=/home/dev/.claude/.credentials.json,type=bind,readonly"
+  ],
   "remoteUser": "dev",
   "updateRemoteUserUID": true,
   "workspaceFolder": "/home/build/synth-setter",
   "workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/home/build/synth-setter,consistency=cached",
-
   "postCreateCommand": ".devcontainer/post-create.sh",
-
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-
   "customizations": {
     "vscode": {
       "extensions": [
@@ -52,7 +56,9 @@
         "python.terminal.activateEnvironment": false,
         "editor.formatOnSave": true,
         "python.testing.pytestEnabled": true,
-        "python.testing.pytestArgs": ["tests"]
+        "python.testing.pytestArgs": [
+          "tests"
+        ]
       }
     }
   }

--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -7,6 +7,7 @@
       "--platform=linux/amd64"
     ]
   },
+  "initializeCommand": "[ -f .env ] || touch .env",
   "runArgs": [
     "--env-file",
     ".env"

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -3,26 +3,31 @@
   "build": {
     "dockerfile": "../Dockerfile",
     "context": "..",
-    "options": ["--platform=linux/amd64"]
+    "options": [
+      "--platform=linux/amd64"
+    ]
   },
-
-  "runArgs": ["--gpus", "all"],
-
+  "runArgs": [
+    "--gpus",
+    "all",
+    "--shm-size=16g",
+    "--env-file",
+    ".env"
+  ],
   "containerEnv": {
     "MODE": "idle"
   },
-
+  "mounts": [
+    "source=${localEnv:HOME}/.claude/.credentials.json,target=/home/dev/.claude/.credentials.json,type=bind,readonly"
+  ],
   "remoteUser": "dev",
   "updateRemoteUserUID": true,
   "workspaceFolder": "/home/build/synth-setter",
   "workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/home/build/synth-setter,consistency=cached",
-
   "postCreateCommand": ".devcontainer/post-create.sh",
-
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-
   "customizations": {
     "vscode": {
       "extensions": [
@@ -54,7 +59,9 @@
         "python.terminal.activateEnvironment": false,
         "editor.formatOnSave": true,
         "python.testing.pytestEnabled": true,
-        "python.testing.pytestArgs": ["tests"]
+        "python.testing.pytestArgs": [
+          "tests"
+        ]
       }
     }
   }

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -7,7 +7,7 @@
       "--platform=linux/amd64"
     ]
   },
-  "initializeCommand": "[ -f .env ] || touch .env",
+  "initializeCommand": "[ -f .env ] || touch .env; mkdir -p ~/.claude && { [ -f ~/.claude/.credentials.json ] || echo '{}' > ~/.claude/.credentials.json; }",
   "runArgs": [
     "--gpus",
     "all",

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -7,6 +7,7 @@
       "--platform=linux/amd64"
     ]
   },
+  "initializeCommand": "[ -f .env ] || touch .env",
   "runArgs": [
     "--gpus",
     "all",

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -7,7 +7,7 @@
       "--platform=linux/amd64"
     ]
   },
-  "initializeCommand": "[ -f .env ] || touch .env; mkdir -p ~/.claude && { [ -f ~/.claude/.credentials.json ] || echo '{}' > ~/.claude/.credentials.json; }",
+  "initializeCommand": "[ -f .env ] || touch .env; mkdir -p ~/.claude && { [ -f ~/.claude/.credentials.json ] || ( umask 077 && echo '{}' > ~/.claude/.credentials.json ); }",
   "runArgs": [
     "--gpus",
     "all",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -30,9 +30,12 @@ cd "$dir"
 git config --global --add safe.directory "$(pwd)"
 
 if [ -n "${RESTRICTED_AGENT_GIT_PAT:-}" ]; then
-  echo "$RESTRICTED_AGENT_GIT_PAT" | gh auth login --with-token
-  gh auth setup-git
-  echo "Git configured with RESTRICTED_AGENT_GIT_PAT"
+  if echo "$RESTRICTED_AGENT_GIT_PAT" | gh auth login --with-token; then
+    gh auth setup-git
+    echo "Git configured with RESTRICTED_AGENT_GIT_PAT"
+  else
+    echo "WARNING: gh auth login failed — token may be invalid. Continuing without git credential config." >&2
+  fi
 else
   echo "RESTRICTED_AGENT_GIT_PAT not set, skipping git credential config"
 fi

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -29,6 +29,14 @@ cd "$dir"
 # before later git config calls and pre-commit install.
 git config --global --add safe.directory "$(pwd)"
 
+if [ -n "${RESTRICTED_AGENT_GIT_PAT:-}" ]; then
+  echo "$RESTRICTED_AGENT_GIT_PAT" | gh auth login --with-token
+  gh auth setup-git
+  echo "Git configured with RESTRICTED_AGENT_GIT_PAT"
+else
+  echo "RESTRICTED_AGENT_GIT_PAT not set, skipping git credential config"
+fi
+
 # Pre-commit hooks (pre-commit itself is in the image's deps). Strip any
 # absolute host-path core.hooksPath that may leak from the host .git/config
 # (harmless in Codespaces; bites local devcontainer users).

--- a/.env.example
+++ b/.env.example
@@ -58,10 +58,12 @@ WANDB_PROJECT=synth-setter
 # =============================================================================
 # GitHub
 # =============================================================================
-# Used by: Docker builds (source tarball fetch), CI workflows, promotion
+# Used by: the Claude Code agent inside the dev container to authenticate
+# `git` / `gh` operations. Injected via --env-file .env in the devcontainer
+# runArgs and consumed by .devcontainer/post-create.sh via `gh auth login`.
 
-# Personal access token with repo read access (for docker-build-dev-snapshot)
-GIT_PAT=your-github-pat
+# Fine-grained personal access token with scoped repo access
+RESTRICTED_AGENT_GIT_PAT=fine-grained-access-token
 
 # =============================================================================
 # RunPod (GPU cloud compute) — planned, not yet used in code


### PR DESCRIPTION
## Summary

Makes the CPU and GPU devcontainers usable for Claude-Code-driven agent work by mounting credentials, installing `gh`/`jq`, and wiring a scoped in-container PAT.

## Changes

- **`.devcontainer/Dockerfile`** — install `curl`, `jq`, and `gh` (from the official apt repo) at image build time, and `chown -R dev:dev .git` so the non-root dev user can run git against the baked repo tree.
- **`.devcontainer/cpu/devcontainer.json`** — `initializeCommand: "[ -f .env ] || touch .env"`, `runArgs: ["--env-file", ".env"]`, and a read-only bind-mount of `~/.claude/.credentials.json` → `/home/dev/.claude/.credentials.json`. Copy-pasting the Claude auth challenge through remote → host → container was unreliable; bind-mounting the credential file sidesteps it.
- **`.devcontainer/gpu/devcontainer.json`** — same as CPU, plus `--gpus all` and `--shm-size=16g` in `runArgs` (the default 64 MiB `/dev/shm` is too small for PyTorch dataloader workers).
- **`.devcontainer/post-create.sh`** — when `RESTRICTED_AGENT_GIT_PAT` is set, pipe it through `gh auth login --with-token && gh auth setup-git`. Uses `${RESTRICTED_AGENT_GIT_PAT:-}` in the `[ -n ... ]` test so the script doesn't crash under `set -euo pipefail` when the var is unset — the `else` branch stays reachable and `pre-commit install` still runs.
- **`.env.example`** — replace the now-dead `GIT_PAT` stub (removed from all consumers in #567) with a `RESTRICTED_AGENT_GIT_PAT` block documenting it as the scoped in-container agent token.

## `.env` handling

`initializeCommand` runs on the host before the container is created, so `[ -f .env ] || touch .env` ensures `.env` always exists. An empty `--env-file` is a no-op for Docker:

- Users **without** a populated `.env` get an auto-created empty file and a working container (no variables injected).
- Users **with** a populated `.env` get their vars injected into the container as before.

No breaking change. POSIX-compatible shell; the README already declares Windows unsupported.

## Notes

- `gh` is now installed in two places: the devcontainer `Dockerfile` (apt) and via the `ghcr.io/devcontainers/features/github-cli:1` feature in both `devcontainer.json` files. Redundant but harmless. The Dockerfile install is the one `post-create.sh` depends on (available during image build); a follow-up could drop the feature.
- The inline `//` comments explaining the Claude credential mount were stripped to satisfy pre-commit's `check-json` hook (stdlib JSON doesn't allow comments; there's no existing exclusion for `devcontainer.json`).
- Branched off `c21fde8`, rebuilt via worktree, `make format` clean.

Closes #571