### PR TITLE
build(devcontainer): consolidate Dockerfile into main image stages

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,59 +1,12 @@
-FROM tinaudio/synth-setter:dev-snapshot
+FROM tinaudio/synth-setter:devcontainer-tools
 
-ARG USERNAME=dev
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-RUN apt-get update && apt-get install -y --no-install-recommends curl \
-  && rm -rf /var/lib/apt/lists/*
-
-RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
-  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
-      > /etc/apt/sources.list.d/github-cli.list
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  jq \
-  gh \
-  && rm -rf /var/lib/apt/lists/*
-
-# Non-root dev user with bash as the login shell. No sudo: passwordless
-# sudo is security theatre (dev becomes root trivially), and the escape
-# hatch for missing system packages is adding them to the base image
-# (docker/ubuntu22_04/Dockerfile) and rebuilding.
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash -m $USERNAME
-
-# Fix ownership of any repo content the base image left as root
-RUN chown -R $USER_UID:$USER_GID .git
-
-USER $USERNAME
-
-# Claude Code CLI (userspace install via nvm — no root, no sudo).
-# Anthropic's reference devcontainer installs Claude Code globally as root
-# and adds a scoped sudoers grant for a firewall script. We install under
-# the dev user's home instead so this Dockerfile stays root-free. Firewall
-# + scoped sudo are tracked separately (#549).
-ARG NVM_VERSION=0.40.1
-ARG NODE_VERSION=20.18.0
-ARG CLAUDE_CODE_VERSION=2.1.105
-
-ENV NVM_DIR="/home/$USERNAME/.nvm"
-ENV PATH="$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH"
-
-# nvm.sh is intended for bash/zsh. It happens to source under Ubuntu's
-# /bin/sh (dash) today because nvm maintains POSIX compatibility, but the
-# dependency on bash is implicit and could break if nvm's internals change.
-# Set SHELL explicitly so the source + nvm install + npm install chain
-# runs under bash, and enable pipefail so any stage failure aborts the
-# layer cleanly.
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-# Clone nvm at a pinned tag instead of piping install.sh through bash.
-# The cloned tree is auditable on disk, the tag is immutable upstream,
-# and we never execute unverified network content during the image build.
-RUN git clone --depth 1 --branch "v${NVM_VERSION}" https://github.com/nvm-sh/nvm.git "$NVM_DIR" \
-    && . "$NVM_DIR/nvm.sh" \
-    && nvm install "$NODE_VERSION" \
-    && nvm alias default "$NODE_VERSION" \
-    && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
+# Extension point for per-developer customizations.
+# All tools are baked into tinaudio/synth-setter:devcontainer-tools
+# (built from docker/ubuntu22_04/Dockerfile, devcontainer-tools stage).
+#
+# To add a package without modifying the base image:
+#
+#   USER root
+#   RUN apt-get update && apt-get install -y <package> \
+#     && rm -rf /var/lib/apt/lists/*
+#   USER dev

--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -23,9 +23,6 @@
   "workspaceFolder": "/home/build/synth-setter",
   "workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/home/build/synth-setter,consistency=cached",
   "postCreateCommand": ".devcontainer/post-create.sh",
-  "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {}
-  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -26,9 +26,6 @@
   "workspaceFolder": "/home/build/synth-setter",
   "workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/home/build/synth-setter,consistency=cached",
   "postCreateCommand": ".devcontainer/post-create.sh",
-  "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {}
-  },
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Dev container first-run setup for both Codespaces and local devcontainers.
 # Runs once after the container is created. The base image
-# (tinaudio/synth-setter:dev-snapshot) already ships all deps, Surge XT,
+# (tinaudio/synth-setter:devcontainer-tools) already ships all deps, Surge XT,
 # xvfb, and rclone — but NOT credentials. The devcontainer configs do not
 # forward `.env` automatically; R2 and W&B creds must be provided at
 # runtime via Codespaces secrets or other devcontainer environment-variable

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -151,6 +151,27 @@ jobs:
           cache-from: type=registry,ref=tinaudio/synth-setter:buildcache
           cache-to: ${{ github.event_name != 'pull_request' && 'type=registry,ref=tinaudio/synth-setter:buildcache,mode=max' || '' }}
 
+      - name: Build and push devcontainer-tools image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ steps.config.outputs.dockerfile }}
+          target: devcontainer-tools
+          platforms: ${{ steps.config.outputs.target_platform }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ steps.config.outputs.image }}:devcontainer-tools
+            ${{ steps.config.outputs.image }}:devcontainer-tools-${{ steps.source.outputs.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BUILD_MODE=${{ steps.config.outputs.build_mode }}
+            BASE_IMAGE=${{ steps.config.outputs.base_image }}
+            TORCH_BACKEND=${{ steps.config.outputs.torch_backend }}
+            SYNTH_PERMUTATIONS_GIT_REF=${{ steps.source.outputs.sha }}
+          secrets: ""
+          cache-from: type=registry,ref=tinaudio/synth-setter:buildcache
+          cache-to: ""
+
       - name: Smoke test — container starts and Python imports work
         if: github.event_name != 'pull_request'
         env:

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,7 @@ docker-build-dev-snapshot: ## Build self-contained image (requires GIT_REF)
 		--build-arg SYNTH_PERMUTATIONS_GIT_REF=$(GIT_REF) \
 		--build-arg TORCH_BACKEND=$(DOCKER_TORCH_BACKEND) \
 		--build-arg TARGETARCH=$(TARGETARCH) \
+        --target dev-snapshot \
 		--label org.opencontainers.image.base.name=$(DOCKER_BASE_IMAGE) \
 		-t $(DOCKER_IMAGE):$(DOCKER_BASE_IMAGE_TAG)-dev-snapshot-$(GIT_REF) \
 		-t $(DOCKER_IMAGE):dev-snapshot \

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,6 @@ docker-build-dev-snapshot: ## Build self-contained image (requires GIT_REF)
 		-f $(DOCKER_FILE) \
 		$(_INTERNAL_BUILD_FLAGS) $(DOCKER_BUILD_FLAGS) \
 		--platform $(DOCKER_TARGETPLATFORM) \
-		--build-arg IMAGE="dev-snapshot" \
 		--build-arg BUILD_MODE=$(DOCKER_BUILD_MODE) \
 		--build-arg BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
 		--build-arg SYNTH_PERMUTATIONS_GIT_REF=$(GIT_REF) \
@@ -108,4 +107,19 @@ docker-build-dev-snapshot: ## Build self-contained image (requires GIT_REF)
 		--label org.opencontainers.image.base.name=$(DOCKER_BASE_IMAGE) \
 		-t $(DOCKER_IMAGE):$(DOCKER_BASE_IMAGE_TAG)-dev-snapshot-$(GIT_REF) \
 		-t $(DOCKER_IMAGE):dev-snapshot \
+		.
+
+docker-build-devcontainer-tools: ## Build devcontainer-tools image
+	@if [ -z "$(GIT_REF)" ]; then echo "ERROR: GIT_REF is required."; exit 1; fi
+	DOCKER_BUILDKIT=1 docker buildx build \
+		-f $(DOCKER_FILE) \
+		$(_INTERNAL_BUILD_FLAGS) $(DOCKER_BUILD_FLAGS) \
+		--platform $(DOCKER_TARGETPLATFORM) \
+		--build-arg BUILD_MODE=$(DOCKER_BUILD_MODE) \
+		--build-arg BASE_IMAGE=$(DOCKER_BASE_IMAGE) \
+		--build-arg SYNTH_PERMUTATIONS_GIT_REF=$(GIT_REF) \
+		--build-arg TORCH_BACKEND=$(DOCKER_TORCH_BACKEND) \
+		--build-arg TARGETARCH=$(TARGETARCH) \
+		--target devcontainer-tools \
+		-t $(DOCKER_IMAGE):devcontainer-tools \
 		.

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -12,8 +12,6 @@ ARG BASE_IMAGE=ubuntu@sha256:3ba65aa20f86a0fad9df2b2c259c613df006b2e6d0bfcc8a146
 # TODO(ktinubu): Rename to something more useful and distrinct from BASE_IMAGE
 # TODO(ktinubu): Check for unset TARGETARCH or TARGETPLATFORM. Fallback to amd, linux/amd but add tag to container
 # TODO(ktinubu): Add appropriate image labels.
-ARG IMAGE=dev-snapshot
-
 FROM ${BASE_IMAGE} AS amd64-vars
 SHELL ["/bin/bash", "-euxo", "pipefail", "-c"]
 WORKDIR /tmp-artifacts
@@ -67,7 +65,6 @@ RUN { echo 'tzdata tzdata/Areas select Etc'; echo 'tzdata tzdata/Zones/Etc selec
 
 ARG TARGETARCH
 ARG BUILD_MODE
-ARG IMAGE
 # Validate build args
 RUN case "${TARGETARCH:-}" in \
       amd64|arm64) ;; \
@@ -76,10 +73,6 @@ RUN case "${TARGETARCH:-}" in \
 RUN case "${BUILD_MODE}" in \
       source|prebuilt) ;; \
       *) echo "ERROR: BUILD_MODE must be source or prebuilt (got '${BUILD_MODE}')" >&2; exit 1 ;; \
-    esac
-RUN case "${IMAGE}" in \
-      "dev-snapshot") ;; \
-      *) echo "ERROR: IMAGE must be dev-snapshot (got '${IMAGE}')" >&2; exit 1 ;; \
     esac
 # Install base build tools (gcc-12, g++-12, ninja, flex) shared by all builder stages.
 RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
@@ -326,7 +319,7 @@ RUN mkdir -p /home/build/synth-setter/plugins && \
 WORKDIR /home/build/synth-setter
 
 # ==========================================
-# dev-snapshot: deps + live git clone at SYNTH_PERMUTATIONS_GIT_REF.
+# dev-base: deps + live git clone at SYNTH_PERMUTATIONS_GIT_REF.
 #
 # This image contains NO baked credentials and no R2 bucket binding —
 # it is safe to publish on public registries. Callers provide R2 +
@@ -336,7 +329,7 @@ WORKDIR /home/build/synth-setter
 # Useful for CI or one-off runs without mounting local source.
 # Usage: make docker-build-dev-snapshot GIT_REF=<sha>
 # ==========================================
-FROM builder-install-synth-setter-deps AS dev-snapshot
+FROM builder-install-synth-setter-deps AS dev-base
 
 ARG SYNTH_PERMUTATIONS_GIT_REF
 ENV SYNTH_PERMUTATIONS_GIT_REF=${SYNTH_PERMUTATIONS_GIT_REF}
@@ -374,8 +367,53 @@ RUN chmod +x /usr/local/bin/entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD []
 
-FROM ${IMAGE} AS freeze-deps
+# ==========================================
+# devcontainer-tools: dev-base + CLI tools + non-root user.
+# Published as tinaudio/synth-setter:devcontainer-tools.
+# ==========================================
+FROM dev-base AS devcontainer-tools
+
+# --- CLI tools (as root) ---
+RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lib,target=/var/lib/apt,sharing=locked \
+    apt-get update && apt-get install -y --no-install-recommends \
+      curl \
+      jq \
+  && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+  && apt-get update && apt-get install -y --no-install-recommends gh
+
+# --- Non-root dev user ---
+ARG USERNAME=dev
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash -m $USERNAME
+RUN chown -R $USER_UID:$USER_GID .git
+USER $USERNAME
+
+# --- Claude Code CLI (userspace install via nvm) ---
+ARG NVM_VERSION=0.40.1
+ARG NODE_VERSION=20.18.0
+ARG CLAUDE_CODE_VERSION=2.1.105
+
+ENV NVM_DIR="/home/$USERNAME/.nvm"
+ENV PATH="$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN git clone --depth 1 --branch "v${NVM_VERSION}" https://github.com/nvm-sh/nvm.git "$NVM_DIR" \
+    && . "$NVM_DIR/nvm.sh" \
+    && nvm install "$NODE_VERSION" \
+    && nvm alias default "$NODE_VERSION" \
+    && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
+
+FROM dev-base AS freeze-deps
 # Record package versions for audit / reproducibility
 RUN mkdir -p /usr/local/share/audit && \
     uv pip freeze | sort > /usr/local/share/audit/pip-freeze.txt && \
     dpkg-query -W -f='${Package}=${Version}\n' | sort > /usr/local/share/audit/dpkg.txt
+
+FROM dev-base AS dev-snapshot


### PR DESCRIPTION
## Summary

- Move all devcontainer tooling (curl, jq, gh, nvm, node, claude-code, non-root `dev` user) into a new `devcontainer-tools` stage in the main Dockerfile
- Replace `.devcontainer/Dockerfile` with a thin `FROM tinaudio/synth-setter:devcontainer-tools` extension point
- Remove redundant `github-cli` devcontainer feature and `IMAGE` build arg

Closes #573

## Changes

| File | Change |
|---|---|
| `docker/ubuntu22_04/Dockerfile` | Rename `dev-snapshot` → `dev-base`; add `devcontainer-tools` stage; add no-op `dev-snapshot` alias; update `freeze-deps` to `FROM dev-base`; remove `IMAGE` build arg + validation |
| `.devcontainer/Dockerfile` | Replace with thin `FROM` extension point |
| `.devcontainer/cpu/devcontainer.json` | Remove `features` block (github-cli) |
| `.devcontainer/gpu/devcontainer.json` | Remove `features` block (github-cli) |
| `Makefile` | Remove `--build-arg IMAGE`; add `docker-build-devcontainer-tools` target |
| `.github/workflows/docker-build-validation.yml` | Add build+push step for `devcontainer-tools` tag |
| `.devcontainer/post-create.sh` | Update comment reference |

Design doc: `docs/design/devcontainer-dockerfile-consolidation.md`

## Test plan

- [ ] Build `devcontainer-tools` locally: `make docker-build-devcontainer-tools GIT_REF=$(git rev-parse HEAD)`
- [ ] Build `dev-snapshot` locally: `make docker-build-dev-snapshot GIT_REF=$(git rev-parse HEAD)`
- [ ] Confirm `dev-snapshot` image is identical in content to current (same packages, same entrypoint)
- [ ] Open the devcontainer in VS Code — confirm `gh`, `node`, `claude`, `jq` are available
- [ ] Confirm the `dev` user is active (`whoami` → `dev`)
- [ ] Run `make test` inside the devcontainer
- [ ] Test the nvm install under inherited SHELL flags — if `-euxo` works, update the `SHELL` override