### PR TITLE
build(devcontainer): fix git and claude auth issues

### DIFF
--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -7,7 +7,7 @@
       "--platform=linux/amd64"
     ]
   },
-  "initializeCommand": "[ -f .env ] || touch .env; mkdir -p ~/.claude && { [ -f ~/.claude/.credentials.json ] || ( umask 077 && echo '{}' > ~/.claude/.credentials.json ); }",
+  "initializeCommand": "[ -f .env ] || touch .env",
   "runArgs": [
     "--env-file",
     ".env"

--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -15,9 +15,6 @@
   "containerEnv": {
     "MODE": "idle"
   },
-  "mounts": [
-    "source=${localEnv:HOME}/.claude/.credentials.json,target=/home/dev/.claude/.credentials.json,type=bind,readonly"
-  ],
   "remoteUser": "dev",
   "updateRemoteUserUID": true,
   "workspaceFolder": "/home/build/synth-setter",

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -7,7 +7,7 @@
       "--platform=linux/amd64"
     ]
   },
-  "initializeCommand": "[ -f .env ] || touch .env; mkdir -p ~/.claude && { [ -f ~/.claude/.credentials.json ] || ( umask 077 && echo '{}' > ~/.claude/.credentials.json ); }",
+  "initializeCommand": "[ -f .env ] || touch .env",
   "runArgs": [
     "--gpus",
     "all",

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -18,9 +18,6 @@
   "containerEnv": {
     "MODE": "idle"
   },
-  "mounts": [
-    "source=${localEnv:HOME}/.claude/.credentials.json,target=/home/dev/.claude/.credentials.json,type=bind,readonly"
-  ],
   "remoteUser": "dev",
   "updateRemoteUserUID": true,
   "workspaceFolder": "/home/build/synth-setter",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -36,7 +36,7 @@ if [ -n "${RESTRICTED_AGENT_GIT_PAT:-}" ]; then
   RESTRICTED_AGENT_GIT_PAT="${RESTRICTED_AGENT_GIT_PAT#\"}"
   RESTRICTED_AGENT_GIT_PAT="${RESTRICTED_AGENT_GIT_PAT%\'}"
   RESTRICTED_AGENT_GIT_PAT="${RESTRICTED_AGENT_GIT_PAT#\'}"
-  if echo "$RESTRICTED_AGENT_GIT_PAT" | gh auth login --with-token; then
+  if printf '%s' "$RESTRICTED_AGENT_GIT_PAT" | gh auth login --with-token; then
     gh auth setup-git
     echo "Git configured with RESTRICTED_AGENT_GIT_PAT"
   else

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -30,6 +30,12 @@ cd "$dir"
 git config --global --add safe.directory "$(pwd)"
 
 if [ -n "${RESTRICTED_AGENT_GIT_PAT:-}" ]; then
+  # Strip surrounding double or single quotes if present
+  # (Docker's --env-file doesn't strip them like shell `source` does)
+  RESTRICTED_AGENT_GIT_PAT="${RESTRICTED_AGENT_GIT_PAT%\"}"
+  RESTRICTED_AGENT_GIT_PAT="${RESTRICTED_AGENT_GIT_PAT#\"}"
+  RESTRICTED_AGENT_GIT_PAT="${RESTRICTED_AGENT_GIT_PAT%\'}"
+  RESTRICTED_AGENT_GIT_PAT="${RESTRICTED_AGENT_GIT_PAT#\'}"
   if echo "$RESTRICTED_AGENT_GIT_PAT" | gh auth login --with-token; then
     gh auth setup-git
     echo "Git configured with RESTRICTED_AGENT_GIT_PAT"


### PR DESCRIPTION
- use user set env variable instead of mounting ~/.claude/.credentials.json from host to avoid auth failures due to claude version/OS mismatches
   - .credentials.json varies with claude version and OS
   - different claude versions look for different env variables  (e.g. ANTHROPIC_API_KEY vs  ANTHROPIC_AUTH_TOKEN vs export CLAUDE_CODE_OAUTH_TOKEN)

- Strip quotes from `RESTRICTED_AGENT_GIT_PAT` environment variable in `post-create.sh`, fixing  `gh auth setup-git` failures

Fixes #576
