### PR TITLE
build(evaluation): add pandas to requirements-app.txt

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -26,6 +26,7 @@ loguru
 matplotlib
 mutmut==3.5.*
 mido
+pandas
 pedalboard
 POT
 pre-commit


### PR DESCRIPTION
## Summary
- `scripts/predict_vst_audio.py:8` imports `pandas as pd`, but `pandas` was missing from `requirements-app.txt`.
- Running the synth matching CLI in a fresh app env fails with `ModuleNotFoundError: No module named 'pandas'`.
- Adds `pandas` to `requirements-app.txt` (alphabetical in the `others` section).

## Test plan
- [x] Bug reproduces on current env (pandas missing → ModuleNotFoundError)
- [x] `pip install pandas` resolves cleanly without conflicts with existing app deps
- [x] `python scripts/predict_vst_audio.py --help` returns 0 with pandas installed
- [ ] Full `pip install -r requirements-app.txt` in a clean venv (run locally before merge)

See [verification comment](https://github.com/tinaudio/synth-setter/pull/579#issuecomment-4272084673) for evidence.

Fixes #578
