### PR TITLE
build(devcontainer): system-wide Claude Code, parameterize remoteUser, persist bash history

### DIFF
--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -15,7 +15,7 @@
   "containerEnv": {
     "MODE": "idle"
   },
-  "remoteUser": "dev",
+  "remoteUser": "${localEnv:DEVCONTAINER_USER:dev}",
   "updateRemoteUserUID": true,
   "workspaceFolder": "/home/build/synth-setter",
   "workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/home/build/synth-setter,consistency=cached",

--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -16,6 +16,9 @@
     "MODE": "idle"
   },
   "remoteUser": "${localEnv:DEVCONTAINER_USER:dev}",
+  "mounts": [
+    "source=synth-setter-bashhistory,target=/commandhistory,type=volume"
+  ],
   "updateRemoteUserUID": true,
   "workspaceFolder": "/home/build/synth-setter",
   "workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/home/build/synth-setter,consistency=cached",

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -18,7 +18,7 @@
   "containerEnv": {
     "MODE": "idle"
   },
-  "remoteUser": "dev",
+  "remoteUser": "${localEnv:DEVCONTAINER_USER:dev}",
   "updateRemoteUserUID": true,
   "workspaceFolder": "/home/build/synth-setter",
   "workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/home/build/synth-setter,consistency=cached",

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -19,6 +19,9 @@
     "MODE": "idle"
   },
   "remoteUser": "${localEnv:DEVCONTAINER_USER:dev}",
+  "mounts": [
+    "source=synth-setter-bashhistory,target=/commandhistory,type=volume"
+  ],
   "updateRemoteUserUID": true,
   "workspaceFolder": "/home/build/synth-setter",
   "workspaceMount": "type=bind,source=${localWorkspaceFolder},target=/home/build/synth-setter,consistency=cached",

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -8,6 +8,14 @@
 # configuration, or sourced manually inside the container shell.
 set -euo pipefail
 
+# Drop to `dev` when invoked as root so workspace mutations (git config
+# --local, pre-commit install → .git/hooks/*) don't land root-owned in the
+# bind-mounted workspace. Both opt-in DEVCONTAINER_USER=root sessions and
+# Codespaces (which runs postCreateCommand as root) hit this path.
+if [ "$(id -u)" -eq 0 ]; then
+  exec runuser -u dev -- bash "$(readlink -f "${BASH_SOURCE[0]}")"
+fi
+
 # Locate the workspace root via the .project-root anchor, not by hardcoded
 # path. GitHub Codespaces mounts at /workspaces/synth-setter, but locally the
 # devcontainer CLI uses the host directory basename (e.g. a git worktree

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -386,12 +386,22 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
   && apt-get update && apt-get install -y --no-install-recommends gh
 
 # --- Node.js + Claude Code CLI (system-wide) ---
-ARG CLAUDE_CODE_VERSION=2.1.105
-RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=apt-lib,target=/var/lib/apt,sharing=locked \
-    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
- && apt-get install -y --no-install-recommends nodejs \
+COPY --from=node:20-bullseye-slim /usr/local/bin/node /usr/local/bin/
+COPY --from=node:20-bullseye-slim /usr/local/bin/npm /usr/local/bin/
+COPY --from=node:20-bullseye-slim /usr/local/bin/npx /usr/local/bin/
+COPY --from=node:20-bullseye-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+RUN node --version && npm --version \
  && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
+
+# Persist bash history.
+RUN mkdir -p /commandhistory \
+ && touch /commandhistory/.bash_history \
+ && chown -R "$USERNAME:$USERNAME" /commandhistory \
+ && printf '%s\n' \
+      "export PROMPT_COMMAND='history -a'" \
+      "export HISTFILE=/commandhistory/.bash_history" \
+      >> "/home/$USERNAME/.bashrc"
 
 # --- Non-root dev user ---
 ARG USERNAME=dev

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -396,7 +396,14 @@ RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
  && npm --version \
  && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
 
-# Persist bash history.
+ARG USERNAME=dev
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+RUN groupadd --gid $USER_GID $USERNAME \
+    && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash -m $USERNAME
+RUN chown -R $USER_UID:$USER_GID .git
+
+# Persist bash history for non-root dev: user
 RUN mkdir -p /commandhistory \
  && touch /commandhistory/.bash_history \
  && chown -R "$USERNAME:$USERNAME" /commandhistory \
@@ -406,12 +413,6 @@ RUN mkdir -p /commandhistory \
       >> "/home/$USERNAME/.bashrc"
 
 # --- Non-root dev user ---
-ARG USERNAME=dev
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-RUN groupadd --gid $USER_GID $USERNAME \
-    && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash -m $USERNAME
-RUN chown -R $USER_UID:$USER_GID .git
 USER $USERNAME
 
 FROM dev-base AS freeze-deps

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -386,6 +386,7 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
   && apt-get update && apt-get install -y --no-install-recommends gh
 
 # --- Node.js + Claude Code CLI (system-wide) ---
+ARG CLAUDE_CODE_VERSION=latest
 COPY --from=node:20-bullseye-slim /usr/local/bin/node /usr/local/bin/node
 COPY --from=node:20-bullseye-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
 

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -385,6 +385,14 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
       > /etc/apt/sources.list.d/github-cli.list \
   && apt-get update && apt-get install -y --no-install-recommends gh
 
+# --- Node.js + Claude Code CLI (system-wide) ---
+ARG CLAUDE_CODE_VERSION=2.1.105
+RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lib,target=/var/lib/apt,sharing=locked \
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
+
 # --- Non-root dev user ---
 ARG USERNAME=dev
 ARG USER_UID=1000
@@ -393,22 +401,6 @@ RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash -m $USERNAME
 RUN chown -R $USER_UID:$USER_GID .git
 USER $USERNAME
-
-# --- Claude Code CLI (userspace install via nvm) ---
-ARG NVM_VERSION=0.40.1
-ARG NODE_VERSION=20.18.0
-ARG CLAUDE_CODE_VERSION=2.1.105
-
-ENV NVM_DIR="/home/$USERNAME/.nvm"
-ENV PATH="$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH"
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-RUN git clone --depth 1 --branch "v${NVM_VERSION}" https://github.com/nvm-sh/nvm.git "$NVM_DIR" \
-    && . "$NVM_DIR/nvm.sh" \
-    && nvm install "$NODE_VERSION" \
-    && nvm alias default "$NODE_VERSION" \
-    && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
 
 FROM dev-base AS freeze-deps
 # Record package versions for audit / reproducibility

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -386,12 +386,13 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
   && apt-get update && apt-get install -y --no-install-recommends gh
 
 # --- Node.js + Claude Code CLI (system-wide) ---
-COPY --from=node:20-bullseye-slim /usr/local/bin/node /usr/local/bin/
-COPY --from=node:20-bullseye-slim /usr/local/bin/npm /usr/local/bin/
-COPY --from=node:20-bullseye-slim /usr/local/bin/npx /usr/local/bin/
+COPY --from=node:20-bullseye-slim /usr/local/bin/node /usr/local/bin/node
 COPY --from=node:20-bullseye-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
 
-RUN node --version && npm --version \
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+ && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+ && node --version \
+ && npm --version \
  && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
 
 # Persist bash history.


### PR DESCRIPTION
## Summary

Three changes to the devcontainer tooling, plus a post-create privilege drop:

1. **Move Claude Code to a system-wide install** (`docker/ubuntu22_04/Dockerfile`)

   The `devcontainer-tools` stage previously installed Node + Claude Code under `/home/dev/.nvm/...` via a per-user nvm install, after the `USER dev` switch. Root could exec the binary but couldn't `npm install -g` to update it (the nvm prefix was dev-owned). Each user also ended up with their own `$HOME/.claude/` state (`/root/.claude/` vs `/home/dev/.claude/`), so config, MCP servers, credentials, and skills never crossed over.

   This PR installs Node.js and `@anthropic-ai/claude-code` system-wide, as root, *before* the `USER dev` switch. Node/npm are copied from the official `node:20-bullseye-slim` image (`COPY --from=...`), then `npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"` runs as root. Binary lives at `/usr/local/bin/claude`; both root and dev run the same binary, each with their own `$HOME/.claude/` state. Root can now update Claude Code. `CLAUDE_CODE_VERSION` defaults to `latest`; pass `--build-arg CLAUDE_CODE_VERSION=<x.y.z>` to pin a specific version at build time.

2. **Parameterize `remoteUser`** (`.devcontainer/{cpu,gpu}/devcontainer.json`)

   Both configs hard-coded `"remoteUser": "dev"`, making it awkward to run a container session as root (e.g., to inspect the image, install system packages, or debug permissions) without editing checked-in JSON. This PR changes both to `"remoteUser": "${localEnv:DEVCONTAINER_USER:dev}"`. Default behavior is unchanged (`dev`). Set `DEVCONTAINER_USER=root` on the host before reopening the folder in container to run sessions as root. `dev` remains unprivileged (no sudo).

3. **Persist bash history** (`docker/ubuntu22_04/Dockerfile`, `.devcontainer/{cpu,gpu}/devcontainer.json`)

   The Dockerfile creates `/commandhistory` owned by `dev` and appends `HISTFILE=/commandhistory/.bash_history` + `PROMPT_COMMAND='history -a'` to `/home/dev/.bashrc`. Both cpu and gpu devcontainer configs mount a named volume `synth-setter-bashhistory` at `/commandhistory` so history survives container rebuilds.

4. **Drop `post-create.sh` privileges to `dev` when invoked as root** (`.devcontainer/post-create.sh`)

   With `remoteUser` now parameterizable, setting `DEVCONTAINER_USER=root` would cause `postCreateCommand` to run as root and leave root-owned files in the bind-mounted workspace (`git config --local` writes to `.git/config`; `pre-commit install` writes to `.git/hooks/*`). Codespaces already runs `postCreateCommand` as root and hit the same issue. The script now guards at the top:

   ```bash
   if [ "$(id -u)" -eq 0 ]; then
     exec runuser -u dev -- bash "$(readlink -f "${BASH_SOURCE[0]}")"
   fi
   ```

   Workspace mutations always land with `dev` ownership, regardless of how the script is invoked.

## Image rebuild required

The Dockerfile change only takes effect after `tinaudio/synth-setter:devcontainer-tools` is rebuilt and republished. That rebuild is a separate, manual step (gated by the `make docker-*` rule) and is **out of scope for this PR** — this PR only lands the source change.

## Test plan

- [ ] CI: `pr-metadata-gate.yaml` passes (issue link + taxonomy)
- [ ] CI: `code-quality-pr.yaml` passes
- [ ] After image rebuild: `claude --version` works as root in the container
- [ ] After image rebuild: `claude --version` works as dev in the container
- [ ] After image rebuild: `npm install -g @anthropic-ai/claude-code@latest` works as root
- [ ] After image rebuild: `/usr/local/bin/claude` and `/usr/local/bin/node` both exist
- [ ] After image rebuild: `DEVCONTAINER_USER=root` + Reopen in Container starts the session as root
- [ ] After image rebuild: bash history persists across container rebuilds (as `dev`)
- [ ] After image rebuild: under `DEVCONTAINER_USER=root`, `.git/hooks/*` and `.git/config` remain `dev`-owned after post-create

Closes #580