### PR TITLE
chore(vst): isolate VST headless runtime files in mktemp dir

### DIFF
--- a/scripts/run-linux-vst-headless.sh
+++ b/scripts/run-linux-vst-headless.sh
@@ -20,14 +20,12 @@
 set -euo pipefail
 
 TMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TMP_DIR"' EXIT
 export XAUTHORITY="${XAUTHORITY:-$TMP_DIR/.Xauthority}"
 
 export LIBGL_ALWAYS_SOFTWARE=1
 export NO_AT_BRIDGE=1
 export JUCE_USE_XINPUT2=0
 
-# Create temp dir for display number coordination
 DISPLAY_FILE="$TMP_DIR/display_num"
 
 cleanup() {

--- a/scripts/run-linux-vst-headless.sh
+++ b/scripts/run-linux-vst-headless.sh
@@ -19,14 +19,15 @@
 
 set -euo pipefail
 
-export XAUTHORITY=${XAUTHORITY:-/tmp/.Xauthority}
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+export XAUTHORITY="${XAUTHORITY:-$TMP_DIR/.Xauthority}"
 
 export LIBGL_ALWAYS_SOFTWARE=1
 export NO_AT_BRIDGE=1
 export JUCE_USE_XINPUT2=0
 
 # Create temp dir for display number coordination
-TMP_DIR=$(mktemp -d)
 DISPLAY_FILE="$TMP_DIR/display_num"
 
 cleanup() {
@@ -48,7 +49,7 @@ trap cleanup EXIT
 # Start Xvfb (let it pick a display)
 # -displayfd 3 writes the chosen display number to file descriptor 3
 # 3>"$DISPLAY_FILE" redirects FD 3 to our temp file so we can read it later
-Xvfb -displayfd 3 -screen 0 1920x1080x24 -nolisten tcp 3>"$DISPLAY_FILE" 2>/tmp/xvfb.log &
+Xvfb -displayfd 3 -screen 0 1920x1080x24 -nolisten tcp 3>"$DISPLAY_FILE" 2>"$TMP_DIR/xvfb.log" &
 XVFB_PID=$!
 
 # Wait for Xvfb to output the display number
@@ -58,13 +59,13 @@ while [ ! -s "$DISPLAY_FILE" ]; do
   count=$((count+1))
   if [ "$count" -ge 100 ]; then
      echo "Timeout waiting for Xvfb to start" >&2
-     cat /tmp/xvfb.log >&2
+     cat "$TMP_DIR/xvfb.log" >&2
      exit 1
   fi
   # Check if Xvfb died
   if ! kill -0 "$XVFB_PID" 2>/dev/null; then
     echo "Xvfb died unexpectedly" >&2
-    cat /tmp/xvfb.log >&2
+    cat "$TMP_DIR/xvfb.log" >&2
     exit 1
   fi
 done
@@ -79,14 +80,14 @@ for _ in {1..50}; do
   fi
   sleep 0.1
 done
-xdpyinfo -display "$DISPLAY" >/dev/null 2>&1 || { echo "Xvfb did not start"; cat /tmp/xvfb.log || true; exit 1; }
+xdpyinfo -display "$DISPLAY" >/dev/null 2>&1 || { echo "Xvfb did not start"; cat "$TMP_DIR/xvfb.log" || true; exit 1; }
 
 # Start an XSettings manager
-xsettingsd --config /dev/null >/tmp/xsettingsd.log 2>&1 &
+xsettingsd --config /dev/null >"$TMP_DIR/xsettingsd.log" 2>&1 &
 XSETTINGS_PID=$!
 
 # Start a lightweight window manager (important for many plugins)
-openbox-session >/tmp/openbox.log 2>&1 &
+openbox-session >"$TMP_DIR/openbox.log" 2>&1 &
 OPENBOX_PID=$!
 
 # Run the actual command inside a D-Bus session


### PR DESCRIPTION
## Summary

- Move `XAUTHORITY` and the xvfb/xsettingsd/openbox log paths out of hardcoded `/tmp/*.log` and `/tmp/.Xauthority` into the script's own `mktemp` `TMP_DIR`.
- Concurrent invocations on the same host no longer race on shared `/tmp` files (e.g. two parallel VST eval runs overwriting each other's `xvfb.log` or stomping on each other's `XAUTHORITY`).
- Also drops a redundant first `trap … EXIT` (it was overwritten by the later `trap cleanup EXIT` and never fired) and a now-stale comment — review feedback from `copilot-pull-request-reviewer`.

### What this PR does NOT fix

An earlier draft of this description claimed the `EXIT` trap cleans up `TMP_DIR` automatically. That is not the case in practice: the script ends with `exec dbus-run-session -- "$@"`, which replaces the bash process, so `trap cleanup EXIT` never fires on the happy path. `TMP_DIR` (and the `Xvfb` / `xsettingsd` / `openbox` background processes `cleanup()` is supposed to reap) persists after each run.

Impact is negligible for ephemeral CI runners but accumulates on long-lived hosts (e.g. RunPod workers). Fixing it requires a process-lifecycle change (dropping `exec`, forwarding signals to the child, and reaping background processes) that deserves its own PR and test. Tracked as #583.

Refs #528
Refs #583

## Test plan

- [x] Script syntax is valid (`bash -n`).
- [x] End-to-end: script starts Xvfb and exports a working DISPLAY.
- [x] Concurrent invocations get distinct `TMP_DIR`s and distinct `DISPLAY` numbers.
- [x] Pre-set `XAUTHORITY` is respected (env override still works).
- [ ] `TMP_DIR` cleaned up after normal exit — **fails as expected; tracked in #583** (see verification comment).

See the verification comment for commands and console output.