### PR TITLE
docs: reflect devcontainer-tools stage, bash-history volume, post-create privilege drop

### DIFF
--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -16,7 +16,9 @@ docs:
     description: Docker build, run, debug reference
     sources:
       - pattern: "docker/**"
-        covers: "Dockerfile stages, base images, layer structure, BuildKit secret mounts"
+        covers: "Dockerfile stages, base images, layer structure, BuildKit secret mounts, devcontainer-tools stage"
+      - pattern: ".devcontainer/Dockerfile"
+        covers: "Dev container wrapper over devcontainer-tools stage, per-developer customization"
       - pattern: "scripts/docker_entrypoint.sh"
         covers: "All MODE values (idle, passthrough, generate_dataset), env var dispatch, error messages"
       - pattern: "pipeline/schemas/image_config.py"
@@ -24,12 +26,12 @@ docs:
       - pattern: "configs/image/**"
         covers: "YAML field names and values, build parameters, defaults"
       - pattern: "Makefile"
-        covers: "docker-build-* targets, DOCKER_SECRETS, DOCKER_BUILD_FLAGS"
+        covers: "docker-build-* targets (dev-snapshot, devcontainer-tools), DOCKER_SECRETS, DOCKER_BUILD_FLAGS"
         scope: "docker"
       - pattern: "scripts/run-linux-vst-headless.sh"
         covers: "Headless X11 bootstrap, Xvfb setup, LIBGL_ALWAYS_SOFTWARE"
       - pattern: ".github/workflows/docker-build-validation.yml"
-        covers: "CI steps, required secrets, tag scheme, smoke test flow"
+        covers: "CI steps, required secrets, tag scheme, smoke test flow, devcontainer-tools publish"
 
   # ── Docker spec (the contract doc) ──────────────────────────────
   - doc: docs/reference/docker-spec.md
@@ -150,6 +152,17 @@ docs:
         covers: "Checkpoint download from W&B, artifact resolution for eval"
       - pattern: "scripts/audio_dirs/*.txt"
         covers: "Audio directory lists for metric computation reference sets"
+
+  # ── Getting started ─────────────────────────────────────────────
+  - doc: docs/getting-started.md
+    description: Onboarding — local dev, Codespaces, and dev container flows
+    sources:
+      - pattern: ".devcontainer/cpu/devcontainer.json"
+        covers: "CPU dev container config — remoteUser, mounts, postCreateCommand"
+      - pattern: ".devcontainer/gpu/devcontainer.json"
+        covers: "GPU dev container config — remoteUser, mounts, postCreateCommand"
+      - pattern: ".devcontainer/post-create.sh"
+        covers: "First-run setup — git safety, pre-commit install, root-to-dev privilege drop"
 
   # ── GitHub taxonomy ─────────────────────────────────────────────
   - doc: docs/design/github-taxonomy.md

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -158,9 +158,11 @@ docs:
     description: Onboarding — local dev, Codespaces, and dev container flows
     sources:
       - pattern: ".devcontainer/cpu/devcontainer.json"
-        covers: "CPU dev container config — remoteUser, mounts, postCreateCommand"
+        covers: "CPU dev container config — remoteUser, mounts (bash-history named volume + plugins/ anonymous overlay), --env-file .env, initializeCommand, postCreateCommand"
       - pattern: ".devcontainer/gpu/devcontainer.json"
-        covers: "GPU dev container config — remoteUser, mounts, postCreateCommand"
+        covers: "GPU dev container config — remoteUser, mounts (bash-history named volume + plugins/ anonymous overlay), --env-file .env, initializeCommand, postCreateCommand"
+      - pattern: ".devcontainer/initialize.sh"
+        covers: "Host-side initializeCommand — refuses pointer-file `.git` (worktree/submodule/--separate-git-dir), ensures .env exists"
       - pattern: ".devcontainer/post-create.sh"
         covers: "First-run setup — git safety, pre-commit install, root-to-dev privilege drop"
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -93,9 +93,12 @@ credentials are required.
 
 1. On GitHub, click **Code → Codespaces → Create codespace on main**.
 2. First start takes ~5 min (image pull). Subsequent starts are fast.
-3. `.devcontainer/post-create.sh` initializes submodules, installs the
-   workspace editable, and wires up pre-commit hooks — then the terminal is
-   ready.
+3. `.devcontainer/post-create.sh` configures git safety settings,
+   optionally authenticates with `RESTRICTED_AGENT_GIT_PAT`, and installs
+   pre-commit hooks. If invoked as root (Codespaces default, or opt-in
+   `DEVCONTAINER_USER=root` locally), it drops to the `dev` user first so
+   workspace mutations under `.git/` land with dev ownership. Then the
+   terminal is ready.
 
 **Verify:**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -125,11 +125,11 @@ container.
   [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
   or the [`devcontainer` CLI](https://github.com/devcontainers/cli).
 - R2 + W&B credentials (see [§4b](#4b-rclone--cloudflare-r2) and
-  [§4c](#4c-weights--biases-wb)). The checked-in dev container configs
-  do **not** automatically load `.env` — after opening the container,
-  source the vars inside the container shell (`set -a && source .env && set +a`)
-  or set them via Codespaces secrets / Dev Container environment settings
-  so rclone and W&B can access them.
+  [§4c](#4c-weights--biases-wb)). Local dev containers load `.env`
+  automatically via `--env-file .env` (`.devcontainer/initialize.sh`
+  creates an empty one if missing), so rclone and W&B pick up creds
+  on container start. **Codespaces** does not have a host `.env` —
+  forward R2/W&B vars via Codespaces user/org secrets instead.
 - Apple Silicon: set `DOCKER_DEFAULT_PLATFORM=linux/amd64` (the image is
   amd64-only).
 
@@ -152,10 +152,10 @@ cd .claude/worktrees/my-feature
 This is the supported local pattern. Mounting a worktree directly from the
 host does not work — the worktree's `.git` file points to
 `<repo>/.git/worktrees/<name>/` on the host, which is outside the container's
-bind mount, so git submodule/hook operations fail to resolve their gitdir.
-`.devcontainer/initialize.sh` detects this case on the host and aborts the
-build with a clear error before the container is created, so the failure
-surfaces immediately rather than partway through `post-create`.
+bind mount, so git hook operations (and anything else needing the gitdir)
+fail to resolve. `.devcontainer/initialize.sh` detects this case on the host
+and aborts the build with a clear error before the container is created, so
+the failure surfaces immediately rather than partway through `post-create`.
 
 **Caveats:**
 
@@ -163,12 +163,13 @@ surfaces immediately rather than partway through `post-create`.
   `prunable` (their host paths don't resolve inside the mount). Do **not**
   run `git worktree prune` inside the container — it will drop registry
   entries for worktrees that are still valid on the host.
-- `git submodule update` for the private `tinaudio/skills` submodule needs
-  GitHub credentials available to git inside the container. VS Code's git
-  credential helper usually forwards these automatically. For the CLI, run
-  `gh auth login && gh auth setup-git` inside the container, or configure
-  git's credential helper with a PAT. Exporting `GITHUB_TOKEN` alone is not
-  sufficient — git will not use it without a credential helper configured.
+- `plugins/` inside the container is an anonymous Docker volume seeded
+  from the base image, which ships `plugins/Surge XT.vst3` as a symlink
+  to `/usr/lib/vst3/Surge XT.vst3`. Without this overlay, the host
+  workspace bind mount would shadow the baked symlink and break
+  VST-dependent tests. Host edits under `plugins/` are not visible
+  inside the container; container edits under `plugins/` are not
+  visible on the host.
 
 ### 2h. Alternative: macOS VM (Tart)
 

--- a/docs/reference/docker-spec.md
+++ b/docs/reference/docker-spec.md
@@ -54,17 +54,24 @@ ______________________________________________________________________
 
 ## 2. Image Targets
 
-`docker/ubuntu22_04/Dockerfile` defines a single target via `--target`:
+`docker/ubuntu22_04/Dockerfile` defines two consumable targets via `--target`:
 
-| Target         | Entrypoint             | Source code            | Use case       |
-| -------------- | ---------------------- | ---------------------- | -------------- |
-| `dev-snapshot` | `docker_entrypoint.sh` | Git clone at `GIT_REF` | CI, cloud runs |
+| Target               | Entrypoint             | Source code            | Use case                                          |
+| -------------------- | ---------------------- | ---------------------- | ------------------------------------------------- |
+| `dev-snapshot`       | `docker_entrypoint.sh` | Git clone at `GIT_REF` | CI, cloud runs                                    |
+| `devcontainer-tools` | *(inherits)*           | Git clone at `GIT_REF` | Dev container base (CLI tools + non-root `dev`)   |
 
 The `dev-snapshot` target inherits directly from
 `builder-install-synth-setter-deps`. It contains no baked credentials
 and no baked runtime configuration. R2 credentials, the W&B API key,
 and the target R2 bucket name are all provided at runtime via env vars
 (see `docs/reference/docker.md` § Runtime secrets).
+
+The `devcontainer-tools` target extends `dev-base` with `gh`, `jq`, Node.js
++ `@anthropic-ai/claude-code` (installed system-wide), a non-root `dev` user,
+and a `/commandhistory` directory for persisted bash history. It is consumed
+by `.devcontainer/Dockerfile` as the base for local and Codespaces dev
+containers.
 
 ## 3. Environment Variables
 

--- a/docs/reference/docker-spec.md
+++ b/docs/reference/docker-spec.md
@@ -56,10 +56,10 @@ ______________________________________________________________________
 
 `docker/ubuntu22_04/Dockerfile` defines two consumable targets via `--target`:
 
-| Target               | Entrypoint             | Source code            | Use case                                          |
-| -------------------- | ---------------------- | ---------------------- | ------------------------------------------------- |
-| `dev-snapshot`       | `docker_entrypoint.sh` | Git clone at `GIT_REF` | CI, cloud runs                                    |
-| `devcontainer-tools` | *(inherits)*           | Git clone at `GIT_REF` | Dev container base (CLI tools + non-root `dev`)   |
+| Target               | Entrypoint             | Source code            | Use case                                        |
+| -------------------- | ---------------------- | ---------------------- | ----------------------------------------------- |
+| `dev-snapshot`       | `docker_entrypoint.sh` | Git clone at `GIT_REF` | CI, cloud runs                                  |
+| `devcontainer-tools` | *(inherits)*           | Git clone at `GIT_REF` | Dev container base (CLI tools + non-root `dev`) |
 
 The `dev-snapshot` target inherits directly from
 `builder-install-synth-setter-deps`. It contains no baked credentials

--- a/docs/reference/docker-spec.md
+++ b/docs/reference/docker-spec.md
@@ -67,8 +67,8 @@ and no baked runtime configuration. R2 credentials, the W&B API key,
 and the target R2 bucket name are all provided at runtime via env vars
 (see `docs/reference/docker.md` § Runtime secrets).
 
-The `devcontainer-tools` target extends `dev-base` with `gh`, `jq`, Node.js
-+ `@anthropic-ai/claude-code` (installed system-wide), a non-root `dev` user,
+The `devcontainer-tools` target extends `dev-base` with `gh`, `jq`, Node.js,
+`@anthropic-ai/claude-code` (installed system-wide), a non-root `dev` user,
 and a `/commandhistory` directory for persisted bash history. It is consumed
 by `.devcontainer/Dockerfile` as the base for local and Codespaces dev
 containers.

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -92,9 +92,10 @@ ______________________________________________________________________
 
 ### Make targets
 
-| Target         | Source code            | Typical use           |
-| -------------- | ---------------------- | --------------------- |
-| `dev-snapshot` | Git clone at `GIT_REF` | CI, cloud, evaluation |
+| Target               | Source code            | Typical use                                   |
+| -------------------- | ---------------------- | --------------------------------------------- |
+| `dev-snapshot`       | Git clone at `GIT_REF` | CI, cloud, evaluation                         |
+| `devcontainer-tools` | Git clone at `GIT_REF` | Dev container base (CLI tools + non-root dev) |
 
 Set `GIT_REF` for reproducible builds (defaults to `main` if omitted):
 
@@ -103,7 +104,19 @@ Set `GIT_REF` for reproducible builds (defaults to `main` if omitted):
 make docker-build-dev-snapshot \
   GIT_REF="$(git rev-parse HEAD)" \
   DOCKER_BUILD_FLAGS="--load"
+
+# devcontainer-tools — dev-snapshot + gh, jq, Node.js, Claude Code, dev user
+make docker-build-devcontainer-tools \
+  GIT_REF="$(git rev-parse HEAD)" \
+  DOCKER_BUILD_FLAGS="--load"
 ```
+
+The `devcontainer-tools` stage extends `dev-snapshot` with CLI tooling
+(`gh`, `jq`), Node.js + `@anthropic-ai/claude-code` installed system-wide, a
+non-root `dev` user, and a `/commandhistory` directory (owned by `dev`) that
+`.devcontainer/{cpu,gpu}/devcontainer.json` mounts as a named volume so bash
+history survives container rebuilds. `.devcontainer/Dockerfile` consumes it
+via `FROM tinaudio/synth-setter:devcontainer-tools`.
 
 ### Build variables
 
@@ -289,11 +302,13 @@ If the YAML violates the schema, the workflow fails before any build starts.
 
 ### Tags
 
-| Tag                                        | Mutable? | Purpose                                                     |
-| ------------------------------------------ | -------- | ----------------------------------------------------------- |
-| `tinaudio/synth-setter:latest`             | Yes      | Convenience pointer to the most recent default-branch build |
-| `tinaudio/synth-setter:dev-snapshot`       | Yes      | Latest dev-snapshot (convenience)                           |
-| `tinaudio/synth-setter:dev-snapshot-<sha>` | No       | Immutable, used for smoke tests                             |
+| Tag                                              | Mutable? | Purpose                                                     |
+| ------------------------------------------------ | -------- | ----------------------------------------------------------- |
+| `tinaudio/synth-setter:latest`                   | Yes      | Convenience pointer to the most recent default-branch build |
+| `tinaudio/synth-setter:dev-snapshot`             | Yes      | Latest dev-snapshot (convenience)                           |
+| `tinaudio/synth-setter:dev-snapshot-<sha>`       | No       | Immutable, used for smoke tests                             |
+| `tinaudio/synth-setter:devcontainer-tools`       | Yes      | Latest devcontainer-tools (consumed by `.devcontainer/`)    |
+| `tinaudio/synth-setter:devcontainer-tools-<sha>` | No       | Immutable, pinnable from `.devcontainer/Dockerfile`         |
 
 Mutable tags (`latest`, `dev-snapshot`) are only published on dispatch/schedule
 runs — not on pull-request build validations. `latest` is additionally gated

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -105,15 +105,17 @@ make docker-build-dev-snapshot \
   GIT_REF="$(git rev-parse HEAD)" \
   DOCKER_BUILD_FLAGS="--load"
 
-# devcontainer-tools — dev-snapshot + gh, jq, Node.js, Claude Code, dev user
+# devcontainer-tools — dev-base + gh, jq, Node.js, Claude Code, dev user
 make docker-build-devcontainer-tools \
   GIT_REF="$(git rev-parse HEAD)" \
   DOCKER_BUILD_FLAGS="--load"
 ```
 
-The `devcontainer-tools` stage extends `dev-snapshot` with CLI tooling
-(`gh`, `jq`), Node.js + `@anthropic-ai/claude-code` installed system-wide, a
-non-root `dev` user, and a `/commandhistory` directory (owned by `dev`) that
+The `devcontainer-tools` stage is a sibling of `dev-snapshot` — both stages
+build `FROM dev-base`, the shared parent that holds Surge XT, the venv, and
+the synth-setter source. `devcontainer-tools` adds CLI tooling (`gh`, `jq`),
+Node.js + `@anthropic-ai/claude-code` installed system-wide, a non-root
+`dev` user, and a `/commandhistory` directory (owned by `dev`) that
 `.devcontainer/{cpu,gpu}/devcontainer.json` mounts as a named volume so bash
 history survives container rebuilds. The same devcontainer configs also
 overlay `/home/build/synth-setter/plugins` with an anonymous volume so the

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -115,8 +115,12 @@ The `devcontainer-tools` stage extends `dev-snapshot` with CLI tooling
 (`gh`, `jq`), Node.js + `@anthropic-ai/claude-code` installed system-wide, a
 non-root `dev` user, and a `/commandhistory` directory (owned by `dev`) that
 `.devcontainer/{cpu,gpu}/devcontainer.json` mounts as a named volume so bash
-history survives container rebuilds. `.devcontainer/Dockerfile` consumes it
-via `FROM tinaudio/synth-setter:devcontainer-tools`.
+history survives container rebuilds. The same devcontainer configs also
+overlay `/home/build/synth-setter/plugins` with an anonymous volume so the
+baked `plugins/Surge XT.vst3` symlink survives the workspace bind mount —
+without it, the host's gitignored `plugins/` would shadow the baked file and
+VST-dependent tests would fail. `.devcontainer/Dockerfile` consumes the
+stage via `FROM tinaudio/synth-setter:devcontainer-tools`.
 
 ### Build variables
 


### PR DESCRIPTION
## Summary

Follow-up to #581. After that PR merged, `/doc-drift` found four reference docs still describe the pre-#581 devcontainer world. This PR brings them in line.

- **`docs/reference/docker.md`** — `devcontainer-tools` added to the Make targets and Tags tables. Short paragraph covers what the stage contains (Node + `@anthropic-ai/claude-code` system-wide, non-root `dev`, `/commandhistory` bash-history volume) and how `.devcontainer/Dockerfile` consumes it.
- **`docs/reference/docker-spec.md`** — target table changed from "a single target" to two; new row for `devcontainer-tools` with its use case.
- **`docs/getting-started.md`** — corrected the `post-create.sh` description. Prior text claimed submodule init + workspace-editable install, which were already stale before #581; this rewrite describes the actual behavior (git safety, optional gh auth via `RESTRICTED_AGENT_GIT_PAT`, pre-commit install) and adds the new root-to-dev privilege drop.
- **`docs/doc-map.yaml`** — `.devcontainer/**` had zero coverage in the map. Added coverage under `getting-started.md` for `.devcontainer/{cpu,gpu}/devcontainer.json` and `.devcontainer/post-create.sh`, and under `docker.md` for `.devcontainer/Dockerfile`.

No code or config changes — docs and the doc-map only.

## Test plan

- [ ] CI: `pr-metadata-gate.yaml` passes (issue link + taxonomy)
- [ ] CI: `code-quality-pr.yaml` passes
- [ ] Manual: `docs/reference/docker.md` "Make targets" and "Tags" tables both list `devcontainer-tools`
- [ ] Manual: `docs/reference/docker-spec.md` target table shows two rows
- [ ] Manual: `docs/getting-started.md` § 2f step 3 describes the current `post-create.sh` behavior including the privilege drop
- [ ] Manual: `docs/doc-map.yaml` has a `docs/getting-started.md` entry covering `.devcontainer/**`

Closes #584
Refs #580