### PR TITLE
chore(ci): add Claude Code hooks for doc-drift and pr-review-resolver

### DIFF
--- a/.claude/hooks/_lib.sh
+++ b/.claude/hooks/_lib.sh
@@ -44,11 +44,19 @@ gen_id() {
 has_skill() {
   # Usage: has_skill <skill-name>
   # Returns 0 if <name>/SKILL.md exists in any known skill location.
+  # Worktree-aware: also checks the main repo's .claude/skills/ via the
+  # git common dir, since .claude/ is gitignored and lives only in the
+  # primary checkout.
   local name="$1"
   local paths=(
     ".claude/skills/${name}/SKILL.md"
     "${HOME}/.claude/skills/${name}/SKILL.md"
   )
+  local common_dir repo_root
+  if common_dir=$(git rev-parse --git-common-dir 2>/dev/null) && [ -n "$common_dir" ]; then
+    repo_root=$(cd "$common_dir/.." 2>/dev/null && pwd)
+    [ -n "$repo_root" ] && paths+=("${repo_root}/.claude/skills/${name}/SKILL.md")
+  fi
   for p in "${paths[@]}"; do
     [ -f "$p" ] && return 0
   done

--- a/.claude/hooks/_lib.sh
+++ b/.claude/hooks/_lib.sh
@@ -7,6 +7,8 @@
 #   - has_skill <name>         : returns 0 if the named skill is installed
 #   - log <msg>                : append a timestamped line to .agent-reviews/.hook.log
 #   - ensure_reviews_dir       : create .agent-reviews/ if missing
+#   - gen_id                   : portable unique ID for report filenames and lock tokens
+#   - default_branch           : resolve the repo's default branch (origin/HEAD → main → master)
 #
 # Skill detection searches, in order:
 #   1. .claude/skills/<name>/SKILL.md          (project-local, plugin-managed)
@@ -31,7 +33,7 @@ log() {
 }
 
 gen_id() {
-  # Portable unique ID for report filenames.
+  # Portable unique ID for report filenames and lock tokens.
   if command -v uuidgen >/dev/null 2>&1; then
     uuidgen
   elif [ -r /proc/sys/kernel/random/uuid ]; then
@@ -41,17 +43,38 @@ gen_id() {
   fi
 }
 
+default_branch() {
+  # Resolve the repo's default branch name. Order:
+  #   1. origin/HEAD symbolic-ref (best: tracks the real remote default)
+  #   2. local 'main' if it exists
+  #   3. local 'master' if it exists
+  #   4. 'main' (final fallback)
+  local ref
+  ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)
+  if [ -n "$ref" ]; then
+    echo "${ref##*/}"
+    return 0
+  fi
+  for b in main master; do
+    git show-ref --verify --quiet "refs/heads/$b" 2>/dev/null && { echo "$b"; return 0; }
+    git show-ref --verify --quiet "refs/remotes/origin/$b" 2>/dev/null && { echo "$b"; return 0; }
+  done
+  echo "main"
+}
+
 has_skill() {
   # Usage: has_skill <skill-name>
   # Returns 0 if <name>/SKILL.md exists in any known skill location.
   # Worktree-aware: also checks the main repo's .claude/skills/ via the
   # git common dir, since .claude/ is gitignored and lives only in the
-  # primary checkout.
+  # primary checkout. Safe under set -u (unset HOME) and tolerant of
+  # spaces in paths.
   local name="$1"
+  local home="${HOME:-}"
   local paths=(
     ".claude/skills/${name}/SKILL.md"
-    "${HOME}/.claude/skills/${name}/SKILL.md"
   )
+  [ -n "$home" ] && paths+=("${home}/.claude/skills/${name}/SKILL.md")
   local common_dir repo_root
   if common_dir=$(git rev-parse --git-common-dir 2>/dev/null) && [ -n "$common_dir" ]; then
     repo_root=$(cd "$common_dir/.." 2>/dev/null && pwd)
@@ -60,8 +83,10 @@ has_skill() {
   for p in "${paths[@]}"; do
     [ -f "$p" ] && return 0
   done
-  for p in "${HOME}"/.claude/plugins/*/skills/"${name}"/SKILL.md; do
-    [ -f "$p" ] && return 0
-  done
+  if [ -n "$home" ]; then
+    for p in "${home}"/.claude/plugins/*/skills/"${name}"/SKILL.md; do
+      [ -f "$p" ] && return 0
+    done
+  fi
   return 1
 }

--- a/.claude/hooks/_lib.sh
+++ b/.claude/hooks/_lib.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# =============================================================================
+# _lib.sh — shared helpers for .claude/hooks/ scripts
+# =============================================================================
+#
+# Sourced by doc-drift.sh and pr-review-resolver.sh. Provides:
+#   - has_skill <name>         : returns 0 if the named skill is installed
+#   - log <msg>                : append a timestamped line to .agent-reviews/.hook.log
+#   - ensure_reviews_dir       : create .agent-reviews/ if missing
+#
+# Skill detection searches, in order:
+#   1. .claude/skills/<name>/SKILL.md          (project-local, plugin-managed)
+#   2. ~/.claude/skills/<name>/SKILL.md        (user-global)
+#   3. ~/.claude/plugins/*/skills/<name>/SKILL.md  (plugin-managed user-global)
+# =============================================================================
+
+REVIEWS_DIR=".agent-reviews"
+HOOK_LOG="${REVIEWS_DIR}/.hook.log"
+
+ensure_reviews_dir() {
+  mkdir -p "$REVIEWS_DIR"
+}
+
+log() {
+  # Usage: log "message"
+  # Appends "<iso8601> [<hook_name>] <msg>" to .agent-reviews/.hook.log.
+  # Silent on failure — log path may not exist early in a run.
+  local ts
+  ts=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+  printf '%s [%s] %s\n' "$ts" "${HOOK_NAME:-unknown}" "$*" >> "$HOOK_LOG" 2>/dev/null || true
+}
+
+gen_id() {
+  # Portable unique ID for report filenames.
+  if command -v uuidgen >/dev/null 2>&1; then
+    uuidgen
+  elif [ -r /proc/sys/kernel/random/uuid ]; then
+    cat /proc/sys/kernel/random/uuid
+  else
+    printf '%s-%s' "$(date +%s)" "$$"
+  fi
+}
+
+has_skill() {
+  # Usage: has_skill <skill-name>
+  # Returns 0 if <name>/SKILL.md exists in any known skill location.
+  local name="$1"
+  local paths=(
+    ".claude/skills/${name}/SKILL.md"
+    "${HOME}/.claude/skills/${name}/SKILL.md"
+  )
+  for p in "${paths[@]}"; do
+    [ -f "$p" ] && return 0
+  done
+  for p in "${HOME}"/.claude/plugins/*/skills/"${name}"/SKILL.md; do
+    [ -f "$p" ] && return 0
+  done
+  return 1
+}

--- a/.claude/hooks/doc-drift.sh
+++ b/.claude/hooks/doc-drift.sh
@@ -33,10 +33,9 @@ source "${SCRIPT_DIR}/_lib.sh"
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 
-case "$COMMAND" in
-  *"gh pr create"*) ;;
-  *) exit 0 ;;
-esac
+if ! echo "$COMMAND" | grep -qE '(^|[;|&`(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'; then
+  exit 0
+fi
 
 ensure_reviews_dir
 log "matched: ${COMMAND}"

--- a/.claude/hooks/doc-drift.sh
+++ b/.claude/hooks/doc-drift.sh
@@ -31,7 +31,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/_lib.sh"
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 
 case "$COMMAND" in
   *"gh pr create"*) ;;

--- a/.claude/hooks/doc-drift.sh
+++ b/.claude/hooks/doc-drift.sh
@@ -48,34 +48,50 @@ if [ -z "$PR" ]; then
   exit 0
 fi
 
-DIFF_FILES=$(git diff main...HEAD --name-only 2>/dev/null | head -50 || true)
+BASE_BRANCH=$(default_branch)
+log "base branch resolved to: ${BASE_BRANCH}"
+DIFF_FILES=$(git diff "origin/${BASE_BRANCH}...HEAD" --name-only 2>/dev/null | head -50 || true)
 
 if has_skill doc-drift; then
   log "using doc-drift skill"
-  PROMPT="Use the doc-drift skill to review PR #${PR} on branch ${BRANCH}. Cross-reference docs/doc-map.yaml if present. Changed files:
+  PROMPT="Use the doc-drift skill to review PR #${PR} on branch ${BRANCH} against base ${BASE_BRANCH}. Cross-reference docs/doc-map.yaml if present. Changed files:
 ${DIFF_FILES}
 
 Report findings as \"file:line — issue — suggested fix\". If no drift is found, state that explicitly."
 else
   log "doc-drift skill not found, using fallback prompt"
-  PROMPT="Review the diff 'git diff main...HEAD' for documentation drift on PR #${PR}, branch ${BRANCH}. Cross-reference docs/doc-map.yaml if present. Check for: references to renamed/removed files, stale signatures, missing docs for new public APIs, out-of-date examples. Changed files:
+  PROMPT="Review the diff 'git diff origin/${BASE_BRANCH}...HEAD' for documentation drift on PR #${PR}, branch ${BRANCH}. Cross-reference docs/doc-map.yaml if present. Check for: references to renamed/removed files, stale signatures, missing docs for new public APIs, out-of-date examples. Changed files:
 ${DIFF_FILES}
 
 Report findings as \"file:line — issue — suggested fix\". If no drift is found, state that explicitly."
 fi
 
-REVIEW_FILE="${REVIEWS_DIR}/doc-drift-$(gen_id).md"
+REVIEW_ID=$(gen_id)
+REVIEW_FILE="${REVIEWS_DIR}/doc-drift-${REVIEW_ID}.md"
+STDERR_FILE="${REVIEWS_DIR}/doc-drift-${REVIEW_ID}.stderr"
 
 if [ "${DOC_DRIFT_DRY_RUN:-0}" = "1" ]; then
   log "DRY_RUN: writing stub report"
-  printf '# doc-drift (dry-run)\nPR: #%s\nBranch: %s\n\n## Prompt\n%s\n' \
-    "$PR" "$BRANCH" "$PROMPT" > "$REVIEW_FILE"
+  printf '# doc-drift (dry-run)\nPR: #%s\nBranch: %s\nBase: %s\n\n## Prompt\n%s\n' \
+    "$PR" "$BRANCH" "$BASE_BRANCH" "$PROMPT" > "$REVIEW_FILE"
 else
   log "invoking claude -p (headless)"
-  claude -p "$PROMPT" > "$REVIEW_FILE" 2>/dev/null || {
-    log "claude -p failed"
-    exit 0
-  }
+  if ! claude -p "$PROMPT" > "$REVIEW_FILE" 2>"$STDERR_FILE"; then
+    CLAUDE_EXIT=$?
+    log "claude -p failed (exit ${CLAUDE_EXIT})"
+    {
+      printf '# doc-drift (FAILED)\n\n'
+      printf 'PR: #%s\nBranch: %s\nBase: %s\n\n' "$PR" "$BRANCH" "$BASE_BRANCH"
+      printf '## claude -p exit code\n%s\n\n' "$CLAUDE_EXIT"
+      # shellcheck disable=SC2016  # backticks here are literal markdown fences
+      printf '## Prompt\n```\n%s\n```\n\n' "$PROMPT"
+      # shellcheck disable=SC2016
+      printf '## Stderr (tail)\n```\n'
+      tail -40 "$STDERR_FILE" 2>/dev/null || true
+      printf '\n```\n'
+    } > "$REVIEW_FILE"
+  fi
+  rm -f "$STDERR_FILE"
 fi
 
 log "wrote ${REVIEW_FILE}"

--- a/.claude/hooks/doc-drift.sh
+++ b/.claude/hooks/doc-drift.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# =============================================================================
+# doc-drift.sh — PostToolUse hook, runs on `gh pr create`
+# =============================================================================
+#
+# PURPOSE
+# -------
+# After Claude creates a PR, run the doc-drift skill (or an inline fallback
+# if the skill is not installed) in a headless `claude -p` session to produce
+# an advisory documentation-drift report. Written to .agent-reviews/doc-drift-<uuid>.md.
+#
+# Returns exit 2 with a pointer so the active Claude session reads the report
+# and applies doc updates as appropriate. Advisory — does not block.
+#
+# INPUT (stdin)
+#   JSON with .tool_input.command — the Bash command Claude just ran.
+#
+# INVOCATION
+#   Registered in .claude/settings.json as a PostToolUse hook on Bash with
+#   asyncRewake: true and timeout: 900 (15 min).
+#
+# ENV OVERRIDES
+#   DOC_DRIFT_DRY_RUN=1        — skip the actual `claude -p` call; write a
+#                                stub report. Used by the unit harness.
+# =============================================================================
+set -euo pipefail
+
+export HOOK_NAME="doc-drift"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.claude/hooks/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+case "$COMMAND" in
+  *"gh pr create"*) ;;
+  *) exit 0 ;;
+esac
+
+ensure_reviews_dir
+log "matched: ${COMMAND}"
+
+BRANCH=$(git branch --show-current 2>/dev/null || true)
+PR=$(gh pr view --json number -q .number 2>/dev/null || true)
+
+if [ -z "$PR" ]; then
+  log "no PR found for branch ${BRANCH:-?}, skipping"
+  exit 0
+fi
+
+DIFF_FILES=$(git diff main...HEAD --name-only 2>/dev/null | head -50 || true)
+
+if has_skill doc-drift; then
+  log "using doc-drift skill"
+  PROMPT="Use the doc-drift skill to review PR #${PR} on branch ${BRANCH}. Cross-reference docs/doc-map.yaml if present. Changed files:
+${DIFF_FILES}
+
+Report findings as \"file:line — issue — suggested fix\". If no drift is found, state that explicitly."
+else
+  log "doc-drift skill not found, using fallback prompt"
+  PROMPT="Review the diff 'git diff main...HEAD' for documentation drift on PR #${PR}, branch ${BRANCH}. Cross-reference docs/doc-map.yaml if present. Check for: references to renamed/removed files, stale signatures, missing docs for new public APIs, out-of-date examples. Changed files:
+${DIFF_FILES}
+
+Report findings as \"file:line — issue — suggested fix\". If no drift is found, state that explicitly."
+fi
+
+REVIEW_FILE="${REVIEWS_DIR}/doc-drift-$(gen_id).md"
+
+if [ "${DOC_DRIFT_DRY_RUN:-0}" = "1" ]; then
+  log "DRY_RUN: writing stub report"
+  printf '# doc-drift (dry-run)\nPR: #%s\nBranch: %s\n\n## Prompt\n%s\n' \
+    "$PR" "$BRANCH" "$PROMPT" > "$REVIEW_FILE"
+else
+  log "invoking claude -p (headless)"
+  claude -p "$PROMPT" > "$REVIEW_FILE" 2>/dev/null || {
+    log "claude -p failed"
+    exit 0
+  }
+fi
+
+log "wrote ${REVIEW_FILE}"
+
+printf 'doc-drift report for PR #%s at %s. Advisory — read it and apply documentation updates as appropriate before continuing.\n' \
+  "$PR" "$REVIEW_FILE" >&2
+exit 2

--- a/.claude/hooks/pr-review-resolver.sh
+++ b/.claude/hooks/pr-review-resolver.sh
@@ -57,7 +57,7 @@ ensure_reviews_dir
 log "matched: ${COMMAND} (branch=${BRANCH})"
 
 LOCKFILE="${REVIEWS_DIR}/.resolver-${BRANCH//\//_}.lock"
-TOKEN="$$-$(date +%s%N)"
+TOKEN=$(gen_id)
 echo "$TOKEN" > "$LOCKFILE"
 log "wrote lock token ${TOKEN}"
 
@@ -85,7 +85,9 @@ else
   PROMPT="PR #${PR} on branch ${BRANCH}. Fetch review comments with 'gh pr view ${PR} --json reviews,comments' and 'gh api repos/{owner}/{repo}/pulls/${PR}/comments'. Address each actionable comment; reply inline to each comment you addressed with the fix commit SHA. Ignore nits unless trivial."
 fi
 
-REVIEW_FILE="${REVIEWS_DIR}/pr-review-resolver-$(gen_id).md"
+REVIEW_ID=$(gen_id)
+REVIEW_FILE="${REVIEWS_DIR}/pr-review-resolver-${REVIEW_ID}.md"
+STDERR_FILE="${REVIEWS_DIR}/pr-review-resolver-${REVIEW_ID}.stderr"
 
 if [ "${RESOLVER_DRY_RUN:-0}" = "1" ]; then
   log "DRY_RUN: writing stub report"
@@ -93,10 +95,22 @@ if [ "${RESOLVER_DRY_RUN:-0}" = "1" ]; then
     "$PR" "$BRANCH" "$PROMPT" > "$REVIEW_FILE"
 else
   log "invoking claude -p (headless)"
-  claude -p "$PROMPT" > "$REVIEW_FILE" 2>/dev/null || {
-    log "claude -p failed"
-    exit 0
-  }
+  if ! claude -p "$PROMPT" > "$REVIEW_FILE" 2>"$STDERR_FILE"; then
+    CLAUDE_EXIT=$?
+    log "claude -p failed (exit ${CLAUDE_EXIT})"
+    {
+      printf '# pr-review-resolver (FAILED)\n\n'
+      printf 'PR: #%s\nBranch: %s\n\n' "$PR" "$BRANCH"
+      printf '## claude -p exit code\n%s\n\n' "$CLAUDE_EXIT"
+      # shellcheck disable=SC2016  # backticks here are literal markdown fences
+      printf '## Prompt\n```\n%s\n```\n\n' "$PROMPT"
+      # shellcheck disable=SC2016
+      printf '## Stderr (tail)\n```\n'
+      tail -40 "$STDERR_FILE" 2>/dev/null || true
+      printf '\n```\n'
+    } > "$REVIEW_FILE"
+  fi
+  rm -f "$STDERR_FILE"
 fi
 
 log "wrote ${REVIEW_FILE}"

--- a/.claude/hooks/pr-review-resolver.sh
+++ b/.claude/hooks/pr-review-resolver.sh
@@ -40,7 +40,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/_lib.sh"
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 
 case "$COMMAND" in
   *"git push"*) ;;

--- a/.claude/hooks/pr-review-resolver.sh
+++ b/.claude/hooks/pr-review-resolver.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# =============================================================================
+# pr-review-resolver.sh — PostToolUse hook, runs on `git push`
+# =============================================================================
+#
+# PURPOSE
+# -------
+# After Claude pushes a feature branch, wait for reviewers/CI to settle
+# (default 360s), then run the pr-review-resolver skill (or an inline
+# fallback) in a headless `claude -p` session to triage and respond to
+# review comments. Report written to .agent-reviews/pr-review-resolver-<uuid>.md.
+#
+# Returns exit 2 with a pointer so the active Claude session reads the report
+# and acts on unresolved items. Advisory — does not block.
+#
+# GATES (all early-exit silently, no 6-min wait wasted)
+#   - cmd does not contain "git push"
+#   - current branch is main/master
+#   - after the wait: a newer push has overwritten our lock (dedupe)
+#   - after the wait: no PR exists for this branch
+#
+# LOCKFILE DEDUPE
+#   On entry we write a per-branch token to .agent-reviews/.resolver-<branch>.lock.
+#   After the sleep we re-read; if the token changed a newer push is in
+#   flight and this run exits silently. Last push wins.
+#
+# ENV OVERRIDES
+#   RESOLVER_SLEEP_SECS       — override the 360s settle-wait (used by tests)
+#   RESOLVER_DRY_RUN=1        — skip `claude -p`; write a stub report
+#
+# INVOCATION
+#   Registered in .claude/settings.json as a PostToolUse hook on Bash with
+#   asyncRewake: true and timeout: 1200 (20 min: ~6 min wait + resolver runtime).
+# =============================================================================
+set -euo pipefail
+
+export HOOK_NAME="pr-review-resolver"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.claude/hooks/_lib.sh
+source "${SCRIPT_DIR}/_lib.sh"
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+
+case "$COMMAND" in
+  *"git push"*) ;;
+  *) exit 0 ;;
+esac
+
+BRANCH=$(git branch --show-current 2>/dev/null || true)
+case "$BRANCH" in
+  main|master|"")
+    exit 0
+    ;;
+esac
+
+ensure_reviews_dir
+log "matched: ${COMMAND} (branch=${BRANCH})"
+
+LOCKFILE="${REVIEWS_DIR}/.resolver-${BRANCH//\//_}.lock"
+TOKEN="$$-$(date +%s%N)"
+echo "$TOKEN" > "$LOCKFILE"
+log "wrote lock token ${TOKEN}"
+
+SLEEP_SECS="${RESOLVER_SLEEP_SECS:-360}"
+log "sleeping ${SLEEP_SECS}s"
+sleep "$SLEEP_SECS"
+
+CURRENT_TOKEN=$(cat "$LOCKFILE" 2>/dev/null || true)
+if [ "$CURRENT_TOKEN" != "$TOKEN" ]; then
+  log "superseded by newer push (lock now ${CURRENT_TOKEN}), exiting"
+  exit 0
+fi
+
+PR=$(gh pr view --json number -q .number 2>/dev/null || true)
+if [ -z "$PR" ]; then
+  log "no PR for branch ${BRANCH}, exiting"
+  exit 0
+fi
+
+if has_skill pr-review-resolver; then
+  log "using pr-review-resolver skill"
+  PROMPT="Use the pr-review-resolver skill for PR #${PR} on branch ${BRANCH}."
+else
+  log "pr-review-resolver skill not found, using fallback prompt"
+  PROMPT="PR #${PR} on branch ${BRANCH}. Fetch review comments with 'gh pr view ${PR} --json reviews,comments' and 'gh api repos/{owner}/{repo}/pulls/${PR}/comments'. Address each actionable comment; reply inline to each comment you addressed with the fix commit SHA. Ignore nits unless trivial."
+fi
+
+REVIEW_FILE="${REVIEWS_DIR}/pr-review-resolver-$(gen_id).md"
+
+if [ "${RESOLVER_DRY_RUN:-0}" = "1" ]; then
+  log "DRY_RUN: writing stub report"
+  printf '# pr-review-resolver (dry-run)\nPR: #%s\nBranch: %s\n\n## Prompt\n%s\n' \
+    "$PR" "$BRANCH" "$PROMPT" > "$REVIEW_FILE"
+else
+  log "invoking claude -p (headless)"
+  claude -p "$PROMPT" > "$REVIEW_FILE" 2>/dev/null || {
+    log "claude -p failed"
+    exit 0
+  }
+fi
+
+log "wrote ${REVIEW_FILE}"
+
+printf 'pr-review-resolver report for PR #%s at %s. Advisory — read it and act on unresolved items.\n' \
+  "$PR" "$REVIEW_FILE" >&2
+exit 2

--- a/.claude/hooks/pr-review-resolver.sh
+++ b/.claude/hooks/pr-review-resolver.sh
@@ -42,10 +42,9 @@ source "${SCRIPT_DIR}/_lib.sh"
 INPUT=$(cat)
 COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
 
-case "$COMMAND" in
-  *"git push"*) ;;
-  *) exit 0 ;;
-esac
+if ! echo "$COMMAND" | grep -qE '(^|[;|&`(][[:space:]]*)git[[:space:]]+push([[:space:]]|$)'; then
+  exit 0
+fi
 
 BRANCH=$(git branch --show-current 2>/dev/null || true)
 case "$BRANCH" in

--- a/.claude/hooks/test.sh
+++ b/.claude/hooks/test.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# =============================================================================
+# test.sh — unit harness for .claude/hooks/
+# =============================================================================
+#
+# Tests run each hook script with canned stdin and PATH-stubbed `claude`/`gh`/`git`,
+# asserting exit codes, stderr pointers, report files, and logged decisions.
+#
+# Run from repo root:   bash .claude/hooks/test.sh
+# =============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Isolate test artifacts in a temp dir we cd into, so .agent-reviews/ paths
+# used by the hooks land in a sandbox and don't pollute the real worktree.
+TEST_DIR=$(mktemp -d)
+cleanup() { rm -rf "$TEST_DIR"; }
+trap cleanup EXIT
+
+# Copy hook scripts into the sandbox so paths resolve; point GIT_DIR / repo at
+# the sandbox so hooks calling `git` don't see the real repo state.
+SANDBOX="$TEST_DIR/repo"
+mkdir -p "$SANDBOX/.claude/hooks"
+cp .claude/hooks/_lib.sh .claude/hooks/doc-drift.sh .claude/hooks/pr-review-resolver.sh \
+  "$SANDBOX/.claude/hooks/"
+cd "$SANDBOX"
+git init -q
+git config user.email test@test
+git config user.name test
+git commit -q --allow-empty -m init
+
+# Stub PATH with fake claude/gh (git is real — we need it for branch detection).
+STUBS="$TEST_DIR/stubs"
+mkdir -p "$STUBS"
+cat > "$STUBS/claude" <<'EOF'
+#!/usr/bin/env bash
+echo "# STUB claude -p output"
+echo "# prompt was: $*"
+EOF
+cat > "$STUBS/gh" <<'EOF'
+#!/usr/bin/env bash
+# $GH_STUB_PR governs what `gh pr view` returns. Empty = no PR.
+if [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  if [ -n "${GH_STUB_PR:-}" ]; then
+    echo "${GH_STUB_PR}"
+    exit 0
+  fi
+  echo "no PR" >&2
+  exit 1
+fi
+exit 0
+EOF
+chmod +x "$STUBS/claude" "$STUBS/gh"
+export PATH="$STUBS:$PATH"
+
+PASS=0
+FAIL=0
+pass() { printf '  PASS  %s\n' "$1"; PASS=$((PASS+1)); }
+fail() { printf '  FAIL  %s — %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+
+reset_sandbox() {
+  rm -rf .agent-reviews
+}
+
+# -----------------------------------------------------------------------------
+# doc-drift.sh
+# -----------------------------------------------------------------------------
+echo "== doc-drift.sh =="
+
+# 1. Non-matching command → exit 0, no report.
+reset_sandbox
+out=$(echo '{"tool_input":{"command":"echo hello"}}' | bash .claude/hooks/doc-drift.sh 2>&1; echo "EXIT:$?")
+if [[ "$out" == *"EXIT:0"* ]] && [ ! -d .agent-reviews ]; then
+  pass "non-matching command exits 0 silently"
+else
+  fail "non-matching command exits 0 silently" "$out"
+fi
+
+# 2. gh pr create with no PR found → exit 0 silently.
+reset_sandbox
+unset GH_STUB_PR
+out=$(echo '{"tool_input":{"command":"gh pr create --title x"}}' | bash .claude/hooks/doc-drift.sh 2>&1; echo "EXIT:$?")
+if [[ "$out" == *"EXIT:0"* ]] && ! compgen -G ".agent-reviews/doc-drift-*.md" >/dev/null; then
+  pass "gh pr create with no PR → exits 0, no report"
+else
+  fail "gh pr create with no PR → exits 0, no report" "$out"
+fi
+
+# 3. gh pr create with PR → exit 2, report file written, stderr has pointer.
+reset_sandbox
+export GH_STUB_PR=42 DOC_DRIFT_DRY_RUN=1
+stderr_file="$TEST_DIR/stderr.txt"
+out=$(echo '{"tool_input":{"command":"gh pr create --title x"}}' | bash .claude/hooks/doc-drift.sh 2>"$stderr_file"; echo "EXIT:$?")
+report=$(find .agent-reviews -maxdepth 1 -name 'doc-drift-*.md' 2>/dev/null | head -1)
+if [[ "$out" == *"EXIT:2"* ]] && [ -n "$report" ] && grep -q "PR #42" "$stderr_file"; then
+  pass "gh pr create with PR → exit 2, report written, stderr points to it"
+else
+  fail "gh pr create with PR" "exit=$out report=$report stderr=$(cat "$stderr_file")"
+fi
+
+# 4. Fallback prompt when skill is missing.
+if grep -q "docs/doc-map.yaml" "$report"; then
+  pass "doc-drift fallback references docs/doc-map.yaml"
+else
+  fail "doc-drift fallback references docs/doc-map.yaml" "report: $(cat "$report")"
+fi
+
+# -----------------------------------------------------------------------------
+# pr-review-resolver.sh
+# -----------------------------------------------------------------------------
+echo "== pr-review-resolver.sh =="
+unset DOC_DRIFT_DRY_RUN
+export RESOLVER_SLEEP_SECS=1 RESOLVER_DRY_RUN=1
+
+# 5. Non-matching command → exit 0.
+reset_sandbox
+out=$(echo '{"tool_input":{"command":"git commit -m x"}}' | bash .claude/hooks/pr-review-resolver.sh 2>&1; echo "EXIT:$?")
+if [[ "$out" == *"EXIT:0"* ]] && [ ! -d .agent-reviews ]; then
+  pass "non-matching command exits 0 silently"
+else
+  fail "non-matching command exits 0 silently" "$out"
+fi
+
+# 6. Push while on main → exit 0 before the sleep.
+reset_sandbox
+git checkout -q -b main 2>/dev/null || git checkout -q main
+start=$(date +%s)
+out=$(echo '{"tool_input":{"command":"git push origin main"}}' | bash .claude/hooks/pr-review-resolver.sh 2>&1; echo "EXIT:$?")
+elapsed=$(($(date +%s) - start))
+if [[ "$out" == *"EXIT:0"* ]] && [ "$elapsed" -lt 1 ] && [ ! -d .agent-reviews ]; then
+  pass "git push on main → exits 0 before sleeping"
+else
+  fail "git push on main" "exit=$out elapsed=${elapsed}s"
+fi
+
+# 7. Push on feature branch with no PR → exits 0 after sleep, no report.
+git checkout -q -b feature-x
+reset_sandbox
+unset GH_STUB_PR
+out=$(echo '{"tool_input":{"command":"git push"}}' | bash .claude/hooks/pr-review-resolver.sh 2>&1; echo "EXIT:$?")
+if [[ "$out" == *"EXIT:0"* ]] && ! compgen -G ".agent-reviews/pr-review-resolver-*.md" >/dev/null; then
+  pass "feature branch push with no PR → exits 0, no report"
+else
+  fail "feature branch push with no PR" "$out"
+fi
+
+# 8. Push on feature branch with PR → exit 2, report written.
+reset_sandbox
+export GH_STUB_PR=99
+stderr_file="$TEST_DIR/stderr.txt"
+out=$(echo '{"tool_input":{"command":"git push"}}' | bash .claude/hooks/pr-review-resolver.sh 2>"$stderr_file"; echo "EXIT:$?")
+report=$(find .agent-reviews -maxdepth 1 -name 'pr-review-resolver-*.md' 2>/dev/null | head -1)
+if [[ "$out" == *"EXIT:2"* ]] && [ -n "$report" ] && grep -q "PR #99" "$stderr_file"; then
+  pass "feature branch push with PR → exit 2, report written"
+else
+  fail "feature branch push with PR" "exit=$out report=$report"
+fi
+
+# 9. Fallback prompt content.
+if grep -q "gh api repos" "$report"; then
+  pass "resolver fallback references gh api repos"
+else
+  fail "resolver fallback references gh api repos" "report: $(cat "$report")"
+fi
+
+# 10. Lockfile dedupe: a newer run overwrites the lock, older run exits silently.
+reset_sandbox
+export GH_STUB_PR=99 RESOLVER_SLEEP_SECS=3
+# Launch first hook in background; overwrite its lock mid-sleep; observe no report.
+( echo '{"tool_input":{"command":"git push"}}' | bash .claude/hooks/pr-review-resolver.sh >/dev/null 2>&1; echo $? > "$TEST_DIR/bg_exit" ) &
+bg_pid=$!
+sleep 1
+# Overwrite the lock with a different token.
+mkdir -p .agent-reviews
+echo "intruder-token" > .agent-reviews/.resolver-feature-x.lock
+wait "$bg_pid"
+bg_exit=$(cat "$TEST_DIR/bg_exit")
+if [ "$bg_exit" = "0" ] && ! compgen -G ".agent-reviews/pr-review-resolver-*.md" >/dev/null; then
+  pass "lockfile dedupe: superseded run exits 0 with no report"
+else
+  report_glob=$(compgen -G ".agent-reviews/pr-review-resolver-*.md" 2>/dev/null || true)
+  fail "lockfile dedupe" "bg_exit=$bg_exit, report=$report_glob"
+fi
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+echo
+echo "== Summary =="
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/.claude/hooks/test.sh
+++ b/.claude/hooks/test.sh
@@ -78,6 +78,17 @@ else
   fail "non-matching command exits 0 silently" "$out"
 fi
 
+# 1b. Substring-only match (e.g. 'gh pr create' inside echo text) → no match.
+reset_sandbox
+export GH_STUB_PR=42
+out=$(echo '{"tool_input":{"command":"echo testing the gh pr create matcher"}}' | bash .claude/hooks/doc-drift.sh 2>&1; echo "EXIT:$?")
+if [[ "$out" == *"EXIT:0"* ]] && [ ! -d .agent-reviews ]; then
+  pass "quoted 'gh pr create' substring inside echo does NOT trigger (word-boundary match)"
+else
+  fail "quoted substring should not trigger" "$out"
+fi
+unset GH_STUB_PR
+
 # 2. gh pr create with no PR found → exit 0 silently.
 reset_sandbox
 unset GH_STUB_PR
@@ -121,6 +132,15 @@ if [[ "$out" == *"EXIT:0"* ]] && [ ! -d .agent-reviews ]; then
   pass "non-matching command exits 0 silently"
 else
   fail "non-matching command exits 0 silently" "$out"
+fi
+
+# 5b. Commit message containing 'git push' substring → no match.
+reset_sandbox
+out=$(echo '{"tool_input":{"command":"git commit -m \"fix git push bug\""}}' | bash .claude/hooks/pr-review-resolver.sh 2>&1; echo "EXIT:$?")
+if [[ "$out" == *"EXIT:0"* ]] && [ ! -d .agent-reviews ]; then
+  pass "quoted 'git push' substring inside commit message does NOT trigger"
+else
+  fail "quoted substring should not trigger resolver" "$out"
 fi
 
 # 6. Push while on main → exit 0 before the sleep.

--- a/.claude/hooks/test.sh
+++ b/.claude/hooks/test.sh
@@ -3,7 +3,8 @@
 # test.sh — unit harness for .claude/hooks/
 # =============================================================================
 #
-# Tests run each hook script with canned stdin and PATH-stubbed `claude`/`gh`/`git`,
+# Tests run each hook script with canned stdin and PATH-stubbed `claude`/`gh`
+# (`git` is intentionally real — the tests operate inside a sandbox git repo),
 # asserting exit codes, stderr pointers, report files, and logged decisions.
 #
 # Run from repo root:   bash .claude/hooks/test.sh
@@ -36,6 +37,10 @@ STUBS="$TEST_DIR/stubs"
 mkdir -p "$STUBS"
 cat > "$STUBS/claude" <<'EOF'
 #!/usr/bin/env bash
+if [ "${CLAUDE_STUB_FAIL:-0}" = "1" ]; then
+  echo "simulated claude -p auth failure" >&2
+  exit 3
+fi
 echo "# STUB claude -p output"
 echo "# prompt was: $*"
 EOF
@@ -117,6 +122,23 @@ if grep -q "docs/doc-map.yaml" "$report"; then
 else
   fail "doc-drift fallback references docs/doc-map.yaml" "report: $(cat "$report")"
 fi
+
+# 4b. claude -p failure → verbose FAILED report with exit code, prompt, stderr tail.
+reset_sandbox
+export GH_STUB_PR=42 CLAUDE_STUB_FAIL=1
+unset DOC_DRIFT_DRY_RUN
+out=$(echo '{"tool_input":{"command":"gh pr create --title x"}}' | bash .claude/hooks/doc-drift.sh 2>&1; echo "EXIT:$?")
+report=$(find .agent-reviews -maxdepth 1 -name 'doc-drift-*.md' 2>/dev/null | head -1)
+if [[ "$out" == *"EXIT:2"* ]] && [ -n "$report" ] \
+   && grep -q "FAILED" "$report" \
+   && grep -q "exit code" "$report" \
+   && grep -q "simulated claude -p auth failure" "$report"; then
+  pass "claude -p failure → verbose FAILED report (exit code + stderr captured)"
+else
+  fail "claude -p failure → verbose FAILED report" "out=$out report=$(cat "$report" 2>/dev/null)"
+fi
+unset CLAUDE_STUB_FAIL
+export DOC_DRIFT_DRY_RUN=1
 
 # -----------------------------------------------------------------------------
 # pr-review-resolver.sh

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,7 +75,8 @@
       },
       {
         "matcher": "Bash",
-        "description": "Doc-drift advisory review: on gh pr create, runs a headless claude -p session invoking the doc-drift skill (or an inline fallback referencing docs/doc-map.yaml) against git diff main...HEAD. Output saved to .agent-reviews/doc-drift-<uuid>.md. asyncRewake wakes the active session with a pointer so it can read the report and apply doc updates as appropriate. Advisory only — does not block.",
+        "if": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[;|&`(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'",
+        "description": "Doc-drift advisory review: on gh pr create, runs a headless claude -p session invoking the doc-drift skill (or an inline fallback referencing docs/doc-map.yaml) against git diff against the default branch. Output saved to .agent-reviews/doc-drift-<uuid>.md. On claude -p failure, writes a verbose error report (stderr tail + exit code) and still wakes the session. The `if` guard is a cheap pre-filter matching gh pr create at start-of-line or after a shell operator; doc-drift.sh re-validates with the same regex. asyncRewake. Advisory only — does not block.",
         "hooks": [
           {
             "type": "command",
@@ -88,7 +89,8 @@
       },
       {
         "matcher": "Bash",
-        "description": "PR review resolver: on git push (excluding main/master), waits RESOLVER_SLEEP_SECS (default 360s) for CI and reviewers to settle, then runs the pr-review-resolver skill (or inline fallback) headlessly. Per-branch lockfile dedupes stacked pushes (last push wins). Output saved to .agent-reviews/pr-review-resolver-<uuid>.md. asyncRewake wakes the active session with a pointer. Advisory only — does not block.",
+        "if": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[;|&`(][[:space:]]*)git[[:space:]]+push([[:space:]]|$)'",
+        "description": "PR review resolver: on git push (excluding main/master), waits RESOLVER_SLEEP_SECS (default 360s) for CI and reviewers to settle, then runs the pr-review-resolver skill (or inline fallback) headlessly. Per-branch lockfile dedupes stacked pushes (last push wins). On claude -p failure, writes a verbose error report and still wakes the session. The `if` guard is a cheap pre-filter matching git push at shell-word boundaries; pr-review-resolver.sh re-validates with the same regex. asyncRewake. Advisory only — does not block.",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -72,6 +72,32 @@
             "statusMessage": "Checking for PR creation..."
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "description": "Doc-drift advisory review: on gh pr create, runs a headless claude -p session invoking the doc-drift skill (or an inline fallback referencing docs/doc-map.yaml) against git diff main...HEAD. Output saved to .agent-reviews/doc-drift-<uuid>.md. asyncRewake wakes the active session with a pointer so it can read the report and apply doc updates as appropriate. Advisory only — does not block.",
+        "hooks": [
+          {
+            "type": "command",
+            "asyncRewake": true,
+            "timeout": 900,
+            "statusMessage": "doc-drift reviewing PR...",
+            "command": "bash .claude/hooks/doc-drift.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "description": "PR review resolver: on git push (excluding main/master), waits RESOLVER_SLEEP_SECS (default 360s) for CI and reviewers to settle, then runs the pr-review-resolver skill (or inline fallback) headlessly. Per-branch lockfile dedupes stacked pushes (last push wins). Output saved to .agent-reviews/pr-review-resolver-<uuid>.md. asyncRewake wakes the active session with a pointer. Advisory only — does not block.",
+        "hooks": [
+          {
+            "type": "command",
+            "asyncRewake": true,
+            "timeout": 1200,
+            "statusMessage": "pr-review-resolver scheduled (6 min delay)...",
+            "command": "bash .claude/hooks/pr-review-resolver.sh"
+          }
+        ]
       }
     ]
   }

--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,6 @@ plugins/
 
 # Claude Code
 .claude/
+
+# Advisory reports written by .claude/hooks/doc-drift.sh and pr-review-resolver.sh
+.agent-reviews/


### PR DESCRIPTION
## Summary

Two new PostToolUse hooks in `.claude/settings.json` that run headless, advisory reviews after Claude creates a PR or pushes.

**doc-drift** — fires after `gh pr create`. Headless `claude -p` runs the `doc-drift` skill against `git diff main...HEAD`; fallback prompt references `docs/doc-map.yaml`. `timeout: 900`.

**pr-review-resolver** — fires after `git push`. Skips main/master. Waits `RESOLVER_SLEEP_SECS` (default 360s) for CI and reviewers to settle. Per-branch lockfile dedupes stacked pushes (last push wins). Headless `claude -p` runs the `pr-review-resolver` skill; fallback prompt tells Claude to address comments via `gh pr view` / `gh api`. `timeout: 1200`.

Both hooks use `asyncRewake`, write to `.agent-reviews/<uuid>.md`, and exit 2 with a stderr pointer so the active Claude session reads the report. Advisory only — neither blocks.

## Files

- `.claude/settings.json` — wires the two hooks
- `.claude/hooks/_lib.sh` — shared helpers (`has_skill`, `log`, `ensure_reviews_dir`, `gen_id`)
- `.claude/hooks/doc-drift.sh`
- `.claude/hooks/pr-review-resolver.sh`
- `.claude/hooks/test.sh` — 10-assertion unit harness (canned stdin + PATH-stubbed `claude`/`gh`)
- `.gitignore` — add `.agent-reviews/`

## Test plan

See the posted pr-checkbox verification comment (to follow) with results from:

- **Layer 1** static — `jq`, `bash -n`, pre-commit shellcheck
- **Layer 2** unit — `bash .claude/hooks/test.sh` (10/10 assertions)
- **Layer 3** live — meta-test (this PR fires doc-drift on `gh pr create`); throwaway-branch test (resolver + lockfile dedupe with shortened `RESOLVER_SLEEP_SECS`)

## Caveats

- Hooks load at Claude session start. A session begun before the commit won't see them — restart the session in the worktree for live tests.
- The existing PR-checkbox trigger (and these new hooks) substring-match the command text, so `git commit` messages that literally contain `gh pr create` will fire them. Mitigated in the new hooks because `gh pr view` returns no PR and we exit silently.

Closes #586