### PR TITLE
build: synth-setter macOS VM 

### DIFF
--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -187,6 +187,14 @@ docs:
       - pattern: "pipeline/constants.py"
         covers: "R2 bucket name, INPUT_SPEC_FILENAME constant"
 
+  # ── macOS VM provisioning (Tart) ────────────────────────────────
+  - doc: docs/getting-started.md
+    description: macOS VM dev-env path via Tart — prebuilt image or Packer build (§ 2h)
+    sources:
+      - pattern: "tart/**"
+        covers: "Packer template, packer variables (synth_setter_git_ref/torch_backend/python_version/vm_name), provisioner steps, brew packages, venv layout, VST3 path, smoke tests, .zshrc auto-activation, prebuilt image at docker.io/tinaudio/synth-setter-macos, Docker Hub publishing workflow"
+        scope: "tart"
+
   # ── rclone reference (placeholder — doc does not exist yet) ─────
   # - doc: docs/reference/rclone.md
   #   description: rclone R2 operations reference

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -192,7 +192,7 @@ docs:
     description: macOS VM dev-env path via Tart — prebuilt image or Packer build (§ 2h)
     sources:
       - pattern: "tart/**"
-        covers: "Packer template, packer variables (synth_setter_git_ref/torch_backend/python_version/vm_name), provisioner steps, brew packages, venv layout, VST3 path, smoke tests, .zshrc auto-activation, prebuilt image at docker.io/tinaudio/synth-setter-macos, Docker Hub publishing workflow"
+        covers: "Packer template, packer variables (synth_setter_git_ref/torch_backend/python_version/vm_name), provisioner steps, brew packages, venv layout, VST3 path, smoke tests, .zshrc auto-activation, prebuilt image at registry-1.docker.io/tinaudio/synth-setter-macos, Docker Hub publishing workflow"
         scope: "tart"
 
   # ── rclone reference (placeholder — doc does not exist yet) ─────

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -166,10 +166,12 @@ bind mount, so git submodule/hook operations fail to resolve their gitdir.
 
 ### 2h. Alternative: macOS VM (Tart)
 
-If you want full dev parity on Apple Silicon inside a reproducible, throwaway
-VM — Python 3.10 venv, Surge XT (native .vst3 via cask), Claude Code
-installed, auto-activated venv — pull the prebuilt Tart image published at
-`docker.io/tinaudio/synth-setter-macos`.
+If you want full dev parity on Apple Silicon inside a throwaway, mostly
+reproducible VM — Python 3.10 venv, Surge XT (native .vst3 via cask), Claude
+Code installed, auto-activated venv — pull the prebuilt Tart image published
+at `docker.io/tinaudio/synth-setter-macos`. Rebuilds from the template are not
+fully pinned: Homebrew formulas/casks may resolve to newer versions over time,
+even if you pin the base image digest and git SHA.
 
 **Prerequisites:**
 
@@ -184,6 +186,12 @@ tart clone docker.io/tinaudio/synth-setter-macos:latest synth-setter-macos
 tart run synth-setter-macos                       # opens a GUI window
 ssh admin@$(tart ip synth-setter-macos)           # password: admin
 ```
+
+> **Security note:** the VM inherits the cirruslabs base image's well-known
+> `admin`/`admin` credentials. Treat it as a local-only dev VM. On a shared or
+> untrusted network, change the password in the GUI on first boot, or add an
+> SSH key to `~admin/.ssh/authorized_keys` and disable `PasswordAuthentication`
+> in `/etc/ssh/sshd_config` before exposing port 22.
 
 The image ships with the repo cloned at `~/synth-setter`, a venv with all
 `requirements.txt` deps (CPU torch wheels — Tart VMs have no GPU), Surge XT

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -204,12 +204,15 @@ on first boot.
 
 **Build the image yourself (advanced):**
 
-If you need a custom build (pinned repo ref, different torch backend, etc.),
-the Packer template at [`tart/macos.pkr.hcl`](../tart/macos.pkr.hcl) builds
-the same image locally. See the bottom of the file for the full publishing
-workflow to Docker Hub. Overridable packer vars: `synth_setter_git_ref`
-(default `main`), `torch_backend` (default `cpu`), `python_version` (default
-`3.10`), `vm_name` (default `synth-setter-macos`).
+If you need a custom build (pinned repo ref, different torch backend, pinned
+base image, updated `uv`, updated Surge XT, etc.), the Packer template at
+[`tart/macos.pkr.hcl`](../tart/macos.pkr.hcl) builds the same image locally.
+See the bottom of the file for the full publishing workflow to Docker Hub.
+The template's `variable` blocks are the authoritative source for supported
+overrides. User-overridable packer vars: `synth_setter_git_ref` (default
+`main`), `torch_backend` (default `cpu`), `python_version` (default `3.10`),
+`vm_name` (default `synth-setter-macos`), `base_image_digest`, `uv_version`,
+and `surge_xt_version`.
 
 ```bash
 brew install cirruslabs/cli/tart packer

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -169,7 +169,7 @@ bind mount, so git submodule/hook operations fail to resolve their gitdir.
 If you want full dev parity on Apple Silicon inside a throwaway, mostly
 reproducible VM — Python 3.10 venv, Surge XT (native .vst3 via cask), Claude
 Code installed, auto-activated venv — pull the prebuilt Tart image published
-at `docker.io/tinaudio/synth-setter-macos`. Rebuilds from the template are not
+at `registry-1.docker.io/tinaudio/synth-setter-macos`. Rebuilds from the template are not
 fully pinned: Homebrew formulas/casks may resolve to newer versions over time,
 even if you pin the base image digest and git SHA.
 
@@ -182,7 +182,7 @@ even if you pin the base image digest and git SHA.
 
 ```bash
 brew install cirruslabs/cli/tart
-tart clone docker.io/tinaudio/synth-setter-macos:latest synth-setter-macos
+tart clone registry-1.docker.io/tinaudio/synth-setter-macos:latest synth-setter-macos
 tart run synth-setter-macos                       # opens a GUI window
 ssh admin@$(tart ip synth-setter-macos)           # password: admin
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -164,6 +164,51 @@ bind mount, so git submodule/hook operations fail to resolve their gitdir.
   git's credential helper with a PAT. Exporting `GITHUB_TOKEN` alone is not
   sufficient — git will not use it without a credential helper configured.
 
+### 2h. Alternative: macOS VM (Tart)
+
+If you want full dev parity on Apple Silicon inside a reproducible, throwaway
+VM — Python 3.10 venv, Surge XT (native .vst3 via cask), Claude Code
+installed, auto-activated venv — pull the prebuilt Tart image published at
+`docker.io/tinaudio/synth-setter-macos`.
+
+**Prerequisites:**
+
+- Apple Silicon Mac (M1 or later)
+- [Homebrew](https://brew.sh/)
+
+**Pull and run the prebuilt image (recommended):**
+
+```bash
+brew install cirruslabs/cli/tart
+tart clone docker.io/tinaudio/synth-setter-macos:latest synth-setter-macos
+tart run synth-setter-macos                       # opens a GUI window
+ssh admin@$(tart ip synth-setter-macos)           # password: admin
+```
+
+The image ships with the repo cloned at `~/synth-setter`, a venv with all
+`requirements.txt` deps (CPU torch wheels — Tart VMs have no GPU), Surge XT
+at `/Library/Audio/Plug-Ins/VST3/Surge XT.vst3`, and
+`source ~/synth-setter/.venv/bin/activate` appended to `~/.zshrc` so every
+interactive shell has the venv active from login.
+
+Credentials for Claude Code, `gh`, R2, and W&B are **not** baked in — log in
+on first boot.
+
+**Build the image yourself (advanced):**
+
+If you need a custom build (pinned repo ref, different torch backend, etc.),
+the Packer template at [`tart/macos.pkr.hcl`](../tart/macos.pkr.hcl) builds
+the same image locally. See the bottom of the file for the full publishing
+workflow to Docker Hub. Overridable packer vars: `synth_setter_git_ref`
+(default `main`), `torch_backend` (default `cpu`), `python_version` (default
+`3.10`), `vm_name` (default `synth-setter-macos`).
+
+```bash
+brew install cirruslabs/cli/tart packer
+packer init tart/macos.pkr.hcl
+packer build -var "synth_setter_git_ref=$(git rev-parse HEAD)" tart/macos.pkr.hcl
+```
+
 ______________________________________________________________________
 
 ## 3. k-osc Quickstart (No External Dependencies)

--- a/tart/macos.pkr.hcl
+++ b/tart/macos.pkr.hcl
@@ -1,0 +1,179 @@
+# ==============================================================================
+# Quick start — pull and run the prebuilt VM:
+#
+#   brew install cirruslabs/cli/tart
+#   tart clone docker.io/tinaudio/synth-setter-macos:latest synth-setter-macos
+#   tart run synth-setter-macos                          # GUI window opens
+#
+#   # In another terminal:
+#   ssh admin@$(tart ip synth-setter-macos)              # password: admin
+#
+#
+# See https://tart.run/faq/ for ssh troubleshooting information.
+# run tart --help for additional commands
+# To build and publish a new image yourself, see the instructions at the
+# bottom of this file.
+# ==============================================================================
+
+
+packer {
+  required_plugins {
+    tart = {
+      version = ">= 1.12.0"
+      source  = "github.com/cirruslabs/tart"
+    }
+  }
+}
+
+variable "base_image_digest" {
+  type    = string
+  default = "sha256:6abd551a46da4e595b6a9f678535a8f1bbd61bdc275a363265cd39281d3abdef"
+}
+
+variable "synth_setter_git_ref" {
+  type        = string
+  default     = "main"
+  description = "Git ref (branch, tag, or SHA) to check out for synth-setter. Prefer a SHA for reproducible builds."
+}
+
+variable "torch_backend" {
+  type        = string
+  default     = "cpu"
+  description = "Value passed to `uv pip install --torch-backend`. Tart VMs have no GPU, so keep `cpu`."
+}
+
+variable "python_version" {
+  type        = string
+  default     = "3.10"
+  description = "Python interpreter version installed and pinned via uv."
+}
+
+variable "vm_name" {
+  type        = string
+  default     = "synth-setter-macos"
+  description = "Name of the built Tart VM. Used with `tart run <name>` and `tart ip <name>`."
+}
+
+source "tart-cli" "tart" {
+  vm_base_name = "ghcr.io/cirruslabs/macos-tahoe-base@${var.base_image_digest}"
+  vm_name      = var.vm_name
+  cpu_count    = 4
+  memory_gb    = 8
+  # Credentials Packer uses to SSH into the VM to run provisioners.
+  # These are the defaults baked into cirruslabs base images. If you
+  # change the password inside a provisioner, subsequent provisioners
+  # in the same build will fail to reconnect.
+  ssh_password = "admin"
+  ssh_username = "admin"
+  ssh_timeout  = "120s"
+}
+
+build {
+  sources = ["source.tart-cli.tart"]
+
+  # CLI + GUI tools. Parity with the CLI stack in the Docker
+  # devcontainer-tools stage, adapted to macOS: surge-xt ships as a cask
+  # (.vst3 installed to /Library/Audio/Plug-Ins/VST3/Surge XT.vst3).
+  provisioner "shell" {
+    inline = [
+      "source ~/.zprofile",
+      "brew --version",
+      "brew update",
+      "brew upgrade",
+      "brew install git gh jq rclone uv codex bats-core",
+      "brew install --cask claude-code",
+      "brew install --cask surge-xt",
+    ]
+  }
+
+  # Install and pin Python via uv.
+  provisioner "shell" {
+    inline = [
+      "source ~/.zprofile",
+      "uv python install ${var.python_version}",
+      "uv python pin ${var.python_version}",
+    ]
+  }
+
+  # Clone the repo, use venv with all runtime deps (parity with Docker dev-base
+  # stage).
+  provisioner "shell" {
+    inline = [
+      "source ~/.zprofile",
+      "git clone https://github.com/tinaudio/synth-setter.git ~/synth-setter",
+      "cd ~/synth-setter && git checkout ${var.synth_setter_git_ref}",
+      "cd ~/synth-setter && uv venv --python ${var.python_version}",
+      "cd ~/synth-setter && uv pip install --torch-backend ${var.torch_backend} -r requirements.txt",
+      "cd ~/synth-setter && uv pip install --no-deps -e .",
+      # Auto-activate the venv for every interactive shell so tools installed
+      # into .venv/bin (pre-commit, pyright, pytest, ruff, etc.) are on PATH
+      # from login without a manual `source .venv/bin/activate`.
+      "printf '\\nsource ~/synth-setter/.venv/bin/activate\\n' >> ~/.zshrc",
+    ]
+  }
+
+  # Smoke tests — mirror the two gates from Docker dev-base. No xvfb wrapper
+  # is needed; the macOS VM has a native window server.
+  provisioner "shell" {
+    inline = [
+      "source ~/.zprofile",
+      "cd ~/synth-setter && .venv/bin/python -X faulthandler -c \"from src.data.vst.core import load_plugin; load_plugin('/Library/Audio/Plug-Ins/VST3/Surge XT.vst3')\"",
+      "cd ~/synth-setter && .venv/bin/pytest -k 'not slow' -v",
+    ]
+  }
+}
+
+# ==============================================================================
+# Publishing a new image to Docker Hub (tinaudio/synth-setter-macos):
+#   https://hub.docker.com/repository/docker/tinaudio/synth-setter-macos/general
+#
+#   # 1. One-time: create a Docker Hub personal access token with
+#   #    Read, Write, Delete scopes at https://hub.docker.com/settings/security
+#   #    and use it as your password in step 2.
+#
+#   # 2. Log in (credentials are stored by tart for subsequent pushes).
+#   tart login docker.io
+#   # Username: <your-dockerhub-username>
+#   # Password: <access-token-from-step-1>
+#
+#   # 3. Build the VM (requires Apple Silicon Mac).
+#
+#   #   3a. Install Homebrew if you don't have it.
+#   /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+#
+#   #   3b. Install Tart and Packer.
+#   brew install cirruslabs/cli/tart
+#   brew install packer
+#
+#   #   3c. Fetch the Tart plugin declared below.
+#   packer init tart/macos.pkr.hcl
+#
+#   #   3d. (Optional) Sanity-check the template before building.
+#   packer validate tart/macos.pkr.hcl
+#
+#   #   3e. Build the VM (pulls the base image on first run, then provisions).
+#   #       For a reproducible image, pin the repo to a specific commit:
+#   #         packer build -var "synth_setter_git_ref=<40-char-sha>" tart/macos.pkr.hcl
+#   packer build tart/macos.pkr.hcl
+#
+#   #   3f. (Optional) Smoke-test the built VM locally before publishing.
+#   tart run synth-setter-macos                          # GUI window opens
+#   # In another terminal:
+#   ssh admin@$(tart ip synth-setter-macos)              # password: admin
+#
+#   #   One-time host setup if you're on a headless Mac or want to skip the
+#   #   Sequoia/Tahoe "Local Network" permission prompt during `tart run`:
+#   sudo defaults write com.apple.network.local-network AllowedEthernetLocalNetworkAddresses -array "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16"
+#   sudo defaults write com.apple.network.local-network AllowedWiFiLocalNetworkAddresses -array "10.0.0.0/8" "172.16.0.0/12" "192.168.0.0/16"
+#   sudo reboot
+#
+#   # 4. Push two tags — :latest as the moving pointer, and a dated tag as
+#   #    an immutable rollback point. The local VM name comes from var.vm_name.
+#   DATE_TAG="$(date -u +%Y-%m-%d)"
+#   tart push synth-setter-macos docker.io/tinaudio/synth-setter-macos:${DATE_TAG}
+#   tart push synth-setter-macos docker.io/tinaudio/synth-setter-macos:latest
+#
+#   # 5. (Optional) Free local disk once the push succeeds.
+#   tart delete synth-setter-macos
+#
+# ==============================================================================

--- a/tart/macos.pkr.hcl
+++ b/tart/macos.pkr.hcl
@@ -10,7 +10,7 @@
 #
 #
 # See https://tart.run/faq/ for ssh troubleshooting information.
-# run tart --help for additional commands
+# Run `tart --help` for additional commands.
 # To build and publish a new image yourself, see the instructions at the
 # bottom of this file.
 # ==============================================================================
@@ -76,10 +76,9 @@ build {
   # (.vst3 installed to /Library/Audio/Plug-Ins/VST3/Surge XT.vst3).
   provisioner "shell" {
     inline = [
-      "source ~/.zprofile",
+      ". ~/.zprofile",
       "brew --version",
       "brew update",
-      "brew upgrade",
       "brew install git gh jq rclone uv codex bats-core",
       "brew install --cask claude-code",
       "brew install --cask surge-xt",
@@ -89,7 +88,7 @@ build {
   # Install and pin Python via uv.
   provisioner "shell" {
     inline = [
-      "source ~/.zprofile",
+      ". ~/.zprofile",
       "uv python install ${var.python_version}",
       "uv python pin ${var.python_version}",
     ]
@@ -99,7 +98,7 @@ build {
   # stage).
   provisioner "shell" {
     inline = [
-      "source ~/.zprofile",
+      ". ~/.zprofile",
       "git clone https://github.com/tinaudio/synth-setter.git ~/synth-setter",
       "cd ~/synth-setter && git checkout ${var.synth_setter_git_ref}",
       "cd ~/synth-setter && uv venv --python ${var.python_version}",
@@ -116,7 +115,7 @@ build {
   # is needed; the macOS VM has a native window server.
   provisioner "shell" {
     inline = [
-      "source ~/.zprofile",
+      ". ~/.zprofile",
       "cd ~/synth-setter && .venv/bin/python -X faulthandler -c \"from src.data.vst.core import load_plugin; load_plugin('/Library/Audio/Plug-Ins/VST3/Surge XT.vst3')\"",
       "cd ~/synth-setter && .venv/bin/pytest -k 'not slow' -v",
     ]

--- a/tart/macos.pkr.hcl
+++ b/tart/macos.pkr.hcl
@@ -87,7 +87,7 @@ build {
   # (.vst3 installed to /Library/Audio/Plug-Ins/VST3/Surge XT.vst3).
   provisioner "shell" {
     inline = [
-      ". ~/.zprofile",
+      "touch ~/.zprofile && . ~/.zprofile",
       "brew --version",
       "brew update",
       "brew install git gh jq rclone codex bats-core",
@@ -108,7 +108,7 @@ build {
   # Install and pin Python via uv.
   provisioner "shell" {
     inline = [
-      ". ~/.zprofile",
+      "touch ~/.zprofile && . ~/.zprofile",
       "uv python install ${var.python_version}",
       "uv python pin ${var.python_version}",
     ]
@@ -118,7 +118,7 @@ build {
   # stage).
   provisioner "shell" {
     inline = [
-      ". ~/.zprofile",
+      "touch ~/.zprofile && . ~/.zprofile",
       "git clone https://github.com/tinaudio/synth-setter.git ~/synth-setter",
       "cd ~/synth-setter && git checkout ${var.synth_setter_git_ref}",
       "cd ~/synth-setter && uv venv --python ${var.python_version}",
@@ -141,7 +141,7 @@ build {
   # is needed; the macOS VM has a native window server.
   provisioner "shell" {
     inline = [
-      ". ~/.zprofile",
+      "touch ~/.zprofile && . ~/.zprofile",
       "cd ~/synth-setter && .venv/bin/python -X faulthandler -c \"from src.data.vst.core import load_plugin; load_plugin('plugins/Surge XT.vst3')\"",
       "cd ~/synth-setter && .venv/bin/pytest -k 'not slow' -v",
     ]

--- a/tart/macos.pkr.hcl
+++ b/tart/macos.pkr.hcl
@@ -8,6 +8,11 @@
 #   # In another terminal:
 #   ssh admin@$(tart ip synth-setter-macos)              # password: admin
 #
+# Security note: the VM inherits the cirruslabs base image's well-known
+# admin/admin credentials. Treat this as a local-only dev VM. If the host is
+# on a shared or untrusted network, change the password in the GUI on first
+# boot, or add an SSH key to ~admin/.ssh/authorized_keys and disable
+# PasswordAuthentication in /etc/ssh/sshd_config before exposing port 22.
 #
 # See https://tart.run/faq/ for ssh troubleshooting information.
 # Run `tart --help` for additional commands.
@@ -79,7 +84,11 @@ build {
       ". ~/.zprofile",
       "brew --version",
       "brew update",
-      "brew install git gh jq rclone uv codex bats-core",
+      "brew install git gh jq rclone codex bats-core",
+      "brew install uv",
+      # Pin uv to match the Docker dev-base image (docker/ubuntu22_04/Dockerfile).
+      # Prevents drift in `uv pip install --torch-backend` behavior between envs.
+      "test \"$(uv --version | awk '{print $2}')\" = \"0.11.2\"",
       "brew install --cask claude-code",
       "brew install --cask surge-xt",
     ]
@@ -107,7 +116,7 @@ build {
       # Auto-activate the venv for every interactive shell so tools installed
       # into .venv/bin (pre-commit, pyright, pytest, ruff, etc.) are on PATH
       # from login without a manual `source .venv/bin/activate`.
-      "printf '\\nsource ~/synth-setter/.venv/bin/activate\\n' >> ~/.zshrc",
+      "touch ~/.zshrc && (grep -qxF 'source ~/synth-setter/.venv/bin/activate' ~/.zshrc || printf '\\nsource ~/synth-setter/.venv/bin/activate\\n' >> ~/.zshrc)",
     ]
   }
 
@@ -127,8 +136,9 @@ build {
 #   https://hub.docker.com/repository/docker/tinaudio/synth-setter-macos/general
 #
 #   # 1. One-time: create a Docker Hub personal access token with
-#   #    Read, Write, Delete scopes at https://hub.docker.com/settings/security
-#   #    and use it as your password in step 2.
+#   #    Read, Write scopes at https://hub.docker.com/settings/security
+#   #    and use it as your password in step 2. Delete is not required
+#   #    for the push flow documented here.
 #
 #   # 2. Log in (credentials are stored by tart for subsequent pushes).
 #   tart login docker.io

--- a/tart/macos.pkr.hcl
+++ b/tart/macos.pkr.hcl
@@ -206,8 +206,9 @@ build {
 #   # 4. Push two tags — :latest as the moving pointer, and a dated tag as
 #   #    an immutable rollback point. The local VM name comes from var.vm_name.
 #   DATE_TAG="$(date -u +%Y-%m-%d)"
-#   tart push synth-setter-macos registry-1.docker.io/tinaudio/synth-setter-macos:${DATE_TAG}
-#   tart push synth-setter-macos registry-1.docker.io/tinaudio/synth-setter-macos:latest
+#   tart push synth-setter-macos \
+#   registry-1.docker.io/tinaudio/synth-setter-macos:${DATE_TAG} \
+#   registry-1.docker.io/tinaudio/synth-setter-macos:latest
 #
 #   # 5. (Optional) Free local disk once the push succeeds.
 #   tart delete synth-setter-macos

--- a/tart/macos.pkr.hcl
+++ b/tart/macos.pkr.hcl
@@ -53,6 +53,12 @@ variable "python_version" {
   description = "Python interpreter version installed and pinned via uv."
 }
 
+variable "uv_version" {
+  type        = string
+  default     = "0.11.2"
+  description = "uv version installed via Astral's versioned installer (https://astral.sh/uv/<version>/install.sh). Keep in sync with docker/ubuntu22_04/Dockerfile (`ghcr.io/astral-sh/uv:<version>`) so Tart and Docker dev-base resolve identical wheels."
+}
+
 variable "vm_name" {
   type        = string
   default     = "synth-setter-macos"
@@ -85,10 +91,15 @@ build {
       "brew --version",
       "brew update",
       "brew install git gh jq rclone codex bats-core",
-      "brew install uv",
-      # Pin uv to match the Docker dev-base image (docker/ubuntu22_04/Dockerfile).
-      # Prevents drift in `uv pip install --torch-backend` behavior between envs.
-      "test \"$(uv --version | awk '{print $2}')\" = \"0.11.2\"",
+      # Install uv from Astral's versioned installer rather than `brew install uv`.
+      # Homebrew's uv formula is rolling, so it cannot reliably hold a specific
+      # version; the Astral installer URL embeds the version and is reproducible.
+      # Keep ${var.uv_version} in sync with docker/ubuntu22_04/Dockerfile so
+      # `uv pip install --torch-backend` resolves identically in Docker and Tart.
+      "curl -LsSf https://astral.sh/uv/${var.uv_version}/install.sh | sh",
+      "grep -qxF 'export PATH=\"$HOME/.local/bin:$PATH\"' ~/.zprofile || printf '\\nexport PATH=\"$HOME/.local/bin:$PATH\"\\n' >> ~/.zprofile",
+      ". ~/.zprofile",
+      "test \"$(uv --version | awk '{print $2}')\" = \"${var.uv_version}\"",
       "brew install --cask claude-code",
       "brew install --cask surge-xt",
     ]

--- a/tart/macos.pkr.hcl
+++ b/tart/macos.pkr.hcl
@@ -2,7 +2,7 @@
 # Quick start — pull and run the prebuilt VM:
 #
 #   brew install cirruslabs/cli/tart
-#   tart clone docker.io/tinaudio/synth-setter-macos:latest synth-setter-macos
+#   tart clone registry-1.docker.io/tinaudio/synth-setter-macos:latest synth-setter-macos
 #   tart run synth-setter-macos                          # GUI window opens
 #
 #   # In another terminal:
@@ -141,7 +141,7 @@ build {
 #   #    for the push flow documented here.
 #
 #   # 2. Log in (credentials are stored by tart for subsequent pushes).
-#   tart login docker.io
+#   tart login registry-1.docker.io
 #   # Username: <your-dockerhub-username>
 #   # Password: <access-token-from-step-1>
 #
@@ -179,8 +179,8 @@ build {
 #   # 4. Push two tags — :latest as the moving pointer, and a dated tag as
 #   #    an immutable rollback point. The local VM name comes from var.vm_name.
 #   DATE_TAG="$(date -u +%Y-%m-%d)"
-#   tart push synth-setter-macos docker.io/tinaudio/synth-setter-macos:${DATE_TAG}
-#   tart push synth-setter-macos docker.io/tinaudio/synth-setter-macos:latest
+#   tart push synth-setter-macos registry-1.docker.io/tinaudio/synth-setter-macos:${DATE_TAG}
+#   tart push synth-setter-macos registry-1.docker.io/tinaudio/synth-setter-macos:latest
 #
 #   # 5. (Optional) Free local disk once the push succeeds.
 #   tart delete synth-setter-macos

--- a/tart/macos.pkr.hcl
+++ b/tart/macos.pkr.hcl
@@ -96,7 +96,7 @@ build {
       "touch ~/.zprofile && . ~/.zprofile",
       "brew --version",
       "brew update",
-      "brew install git gh jq rclone codex bats-core",
+      "brew install git gh jq rclone bats-core",
       # Install uv from Astral's versioned installer rather than `brew install uv`.
       # Homebrew's uv formula is rolling, so it cannot reliably hold a specific
       # version; the Astral installer URL embeds the version and is reproducible.

--- a/tart/macos.pkr.hcl
+++ b/tart/macos.pkr.hcl
@@ -124,6 +124,12 @@ build {
       "cd ~/synth-setter && uv venv --python ${var.python_version}",
       "cd ~/synth-setter && uv pip install --torch-backend ${var.torch_backend} -r requirements.txt",
       "cd ~/synth-setter && uv pip install --no-deps -e .",
+      # Mirror the Docker dev-base convention: symlink the cask-installed
+      # VST3 bundle to the repo-relative `plugins/Surge XT.vst3` path that
+      # configs, CLI `--plugin_path` defaults, and tests all assume. See
+      # docker/ubuntu22_04/Dockerfile step `ln -s "/usr/lib/vst3/Surge XT.vst3" ...`.
+      "mkdir -p ~/synth-setter/plugins",
+      "ln -sfn '/Library/Audio/Plug-Ins/VST3/Surge XT.vst3' ~/synth-setter/'plugins/Surge XT.vst3'",
       # Auto-activate the venv for every interactive shell so tools installed
       # into .venv/bin (pre-commit, pyright, pytest, ruff, etc.) are on PATH
       # from login without a manual `source .venv/bin/activate`.
@@ -136,7 +142,7 @@ build {
   provisioner "shell" {
     inline = [
       ". ~/.zprofile",
-      "cd ~/synth-setter && .venv/bin/python -X faulthandler -c \"from src.data.vst.core import load_plugin; load_plugin('/Library/Audio/Plug-Ins/VST3/Surge XT.vst3')\"",
+      "cd ~/synth-setter && .venv/bin/python -X faulthandler -c \"from src.data.vst.core import load_plugin; load_plugin('plugins/Surge XT.vst3')\"",
       "cd ~/synth-setter && .venv/bin/pytest -k 'not slow' -v",
     ]
   }

--- a/tart/macos.pkr.hcl
+++ b/tart/macos.pkr.hcl
@@ -65,6 +65,12 @@ variable "vm_name" {
   description = "Name of the built Tart VM. Used with `tart run <name>` and `tart ip <name>`."
 }
 
+variable "surge_xt_version" {
+  type        = string
+  default     = "1.3.4"
+  description = "Required Surge XT version. Asserted after `brew install --cask surge-xt` so the build fails loudly if Homebrew's cask has rolled past this — bump only after validating the new release against the pipeline."
+}
+
 source "tart-cli" "tart" {
   vm_base_name = "ghcr.io/cirruslabs/macos-tahoe-base@${var.base_image_digest}"
   vm_name      = var.vm_name
@@ -102,6 +108,10 @@ build {
       "test \"$(uv --version | awk '{print $2}')\" = \"${var.uv_version}\"",
       "brew install --cask claude-code",
       "brew install --cask surge-xt",
+      # Hard-fail if Homebrew's cask resolves to a Surge XT version we haven't
+      # qualified against the pipeline. `brew list --cask --versions` prints
+      # `surge-xt <version>`; extract the second field and assert equality.
+      "test \"$(brew list --cask --versions surge-xt | awk '{print $2}')\" = \"${var.surge_xt_version}\"",
     ]
   }
 


### PR DESCRIPTION
## Summary

- Adds `tart/macos.pkr.hcl` — a Packer template that builds a macOS Tart VM mirroring the `docker/ubuntu22_04` `dev-base` runtime: Surge XT (Homebrew cask), Python 3.10 (uv), all `requirements.txt` deps in a venv auto-activated on shell login.
- Smoke-test gates match the Docker build: VST3 load check via `src.data.vst.core.load_plugin` and `pytest -k "not slow"`.
- Quick-start consumer commands at the top of the file (`tart clone` → `tart run` → `ssh`); full build/publish flow at the bottom (including Docker Hub PAT setup, `tart login docker.io`, tagging strategy, and cleanup).

No image is published by this PR; publishing to `docker.io/tinaudio/synth-setter-macos` remains a manual one-off (see §Publishing at the bottom of the file).

Refs #380

## Test plan

- [ ] `packer validate tart/macos.pkr.hcl` succeeds on an Apple Silicon host
- [ ] `packer build tart/macos.pkr.hcl` succeeds end-to-end (brew install + uv python + venv + pip install + VST3 smoke test + `pytest -k "not slow"`)
- [ ] `tart run synth-setter-macos` boots the VM and the Surge XT cask is present under `/Library/Audio/Plug-Ins/VST3/`
- [ ] Inside the booted VM, a new shell has `pre-commit`, `pyright`, and `pytest` on PATH via the `.zshrc` venv auto-activation
- [ ] `tart push synth-setter-macos docker.io/tinaudio/synth-setter-macos:<date>` succeeds (manual smoke, out of CI)