### PR TITLE
build(devcontainer): overlay plugins/ with anonymous volume

### DIFF
--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -17,7 +17,8 @@
   },
   "remoteUser": "${localEnv:DEVCONTAINER_USER:dev}",
   "mounts": [
-    "source=synth-setter-bashhistory,target=/commandhistory,type=volume"
+    "source=synth-setter-bashhistory,target=/commandhistory,type=volume",
+    "target=/home/build/synth-setter/plugins,type=volume"
   ],
   "updateRemoteUserUID": true,
   "workspaceFolder": "/home/build/synth-setter",

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -20,7 +20,8 @@
   },
   "remoteUser": "${localEnv:DEVCONTAINER_USER:dev}",
   "mounts": [
-    "source=synth-setter-bashhistory,target=/commandhistory,type=volume"
+    "source=synth-setter-bashhistory,target=/commandhistory,type=volume",
+    "target=/home/build/synth-setter/plugins,type=volume"
   ],
   "updateRemoteUserUID": true,
   "workspaceFolder": "/home/build/synth-setter",


### PR DESCRIPTION
## Summary

- Overlays `plugins/` in both devcontainer configs with an anonymous Docker volume so the base image's baked `plugins/Surge XT.vst3 -> /usr/lib/vst3/Surge XT.vst3` symlink is no longer shadowed by the workspace bind-mount.
- Auto-seeds from the image on container creation; no host filesystem writes, no code changes.

Fixes #591

## Test plan

- [ ] Rebuild the CPU devcontainer; inside the container run `ls -l "plugins/Surge XT.vst3"` and confirm it resolves to `/usr/lib/vst3/Surge XT.vst3`.
- [ ] Inside the container run `python -c "from src.data.vst.core import load_plugin; load_plugin('plugins/Surge XT.vst3')"` (or the equivalent headless script) and confirm it loads without error.
- [ ] Confirm the host workspace `plugins/` directory is unchanged after opening the devcontainer.
- [ ] Repeat the `ls -l` check for the GPU devcontainer.
