### PR TITLE
fix(devcontainer): refuse to open from a git worktree

### DIFF
--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -7,7 +7,7 @@
       "--platform=linux/amd64"
     ]
   },
-  "initializeCommand": "[ -f .env ] || touch .env",
+  "initializeCommand": "bash .devcontainer/initialize.sh",
   "runArgs": [
     "--env-file",
     ".env"

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -7,7 +7,7 @@
       "--platform=linux/amd64"
     ]
   },
-  "initializeCommand": "[ -f .env ] || touch .env",
+  "initializeCommand": "bash .devcontainer/initialize.sh",
   "runArgs": [
     "--gpus",
     "all",

--- a/.devcontainer/initialize.sh
+++ b/.devcontainer/initialize.sh
@@ -2,20 +2,27 @@
 # Dev container host-side initialization.
 # Runs on the host before the container is created (initializeCommand).
 #
-# Responsibilities:
-#   1. Ensure .env exists (Docker --env-file requires the file to be present).
-#   2. Refuse to open the devcontainer from a git worktree.
+# Responsibilities, in order:
+#   1. Refuse to open the devcontainer when `.git` is a pointer file — i.e.
+#      a linked worktree, a submodule, or a `git clone --separate-git-dir`
+#      repository. The pointer's target is outside the workspaceMount, so
+#      git operations inside the container fail partway through
+#      post-create.sh (safe.directory config, pre-commit install), leaving
+#      the container half-configured. The common case is worktrees.
+#   2. Ensure .env exists (Docker --env-file requires the file to be present).
+#      Done *after* the refusal so an aborted run doesn't leave a stray .env
+#      in the workspace.
 #
-# WHY THE WORKTREE HARDSTOP (see tinaudio/synth-setter#593 for the full
-# tradeoff analysis):
-# A linked worktree's .git is a pointer file containing an absolute host path
-# into the parent repo's admin directory (e.g. /home/<user>/<repo>/.git/worktrees/<name>).
-# The workspaceMount binds only the worktree itself, so that path doesn't exist
-# inside the container. Without a usable .git, git operations in post-create.sh
-# (git config --global --add safe.directory, pre-commit install) fail partway,
-# leaving the container half-configured.
+# WHY THE HARDSTOP (see tinaudio/synth-setter#593 for the full tradeoff
+# analysis):
+# A pointer-file .git contains an absolute host path to the real gitdir
+# (e.g. /home/<user>/<repo>/.git/worktrees/<name> for a worktree). The
+# workspaceMount binds only the visible workspace, so that path doesn't
+# exist inside the container. Without a resolvable gitdir, git operations
+# fail mid-provisioning.
 #
-# Two supported workflows exist; both let you work on a feature branch:
+# Two supported workflows exist for branch-isolated work; both keep .git as
+# a real directory inside the container:
 #   1. Host-only:    open the host worktree in a host editor, skip the
 #                    devcontainer entirely.
 #   2. Devcontainer: open the main repo in the devcontainer, then create a
@@ -26,12 +33,10 @@
 # EDGE CASE — parallel devcontainers for parallel branches (see #593):
 # If you genuinely need to run two devcontainers on two worktrees simultaneously
 # (e.g. to A/B-test behavior between branches without rebuilding), comment out
-# the worktree check below AND the `git config` / `pre-commit install` lines in
-# .devcontainer/post-create.sh. DO NOT commit those edits.
+# the pointer-file check below AND the `git config` / `pre-commit install`
+# lines in .devcontainer/post-create.sh. DO NOT commit those edits.
 
 set -euo pipefail
-
-[ -f .env ] || touch .env
 
 if [ -f .git ]; then
   first_line=""
@@ -39,11 +44,16 @@ if [ -f .git ]; then
   case "$first_line" in
     gitdir:*)
       cat >&2 <<'ERR'
-ERROR: This devcontainer cannot be opened from a git worktree.
+ERROR: This devcontainer cannot be opened from a workspace whose `.git` is a
+pointer file.
 
-The workspace's .git is a pointer file referencing a host path that is not
-mounted into the container. Supported workflows (both let you work on a
-feature branch):
+Pointer-file `.git` shows up for git worktrees (the common case),
+submodules, and `git clone --separate-git-dir` repositories. The pointer
+target lives on the host outside the workspaceMount, so git operations
+inside the container can't resolve the gitdir.
+
+Supported workflows (both keep `.git` as a real directory and let you work
+on a feature branch):
 
   1. Host-only:    open the host worktree in a host editor, skip the
                    devcontainer entirely.
@@ -58,3 +68,5 @@ ERR
       ;;
   esac
 fi
+
+[ -f .env ] || touch .env

--- a/.devcontainer/initialize.sh
+++ b/.devcontainer/initialize.sh
@@ -12,29 +12,6 @@
 #   2. Ensure .env exists (Docker --env-file requires the file to be present).
 #      Done *after* the refusal so an aborted run doesn't leave a stray .env
 #      in the workspace.
-#
-# WHY THE HARDSTOP (see tinaudio/synth-setter#593 for the full tradeoff
-# analysis):
-# A pointer-file .git contains an absolute host path to the real gitdir
-# (e.g. /home/<user>/<repo>/.git/worktrees/<name> for a worktree). The
-# workspaceMount binds only the visible workspace, so that path doesn't
-# exist inside the container. Without a resolvable gitdir, git operations
-# fail mid-provisioning.
-#
-# Two supported workflows exist for branch-isolated work; both keep .git as
-# a real directory inside the container:
-#   1. Host-only:    open the host worktree in a host editor, skip the
-#                    devcontainer entirely.
-#   2. Devcontainer: open the main repo in the devcontainer, then create a
-#                    worktree (or switch branches) INSIDE the container. The
-#                    in-container .git is a directory that resolves normally.
-#                    See docs/getting-started.md §2g for the recommended flow.
-#
-# EDGE CASE — parallel devcontainers for parallel branches (see #593):
-# If you genuinely need to run two devcontainers on two worktrees simultaneously
-# (e.g. to A/B-test behavior between branches without rebuilding), comment out
-# the pointer-file check below AND the `git config` / `pre-commit install`
-# lines in .devcontainer/post-create.sh. DO NOT commit those edits.
 
 set -euo pipefail
 
@@ -45,7 +22,7 @@ if [ -f .git ]; then
     gitdir:*)
       cat >&2 <<'ERR'
 ERROR: This devcontainer cannot be opened from a workspace whose `.git` is a
-pointer file.
+pointer file. See github isse #593 for details.
 
 Pointer-file `.git` shows up for git worktrees (the common case),
 submodules, and `git clone --separate-git-dir` repositories. The pointer
@@ -60,9 +37,6 @@ on a feature branch):
   2. Devcontainer: open the main repo in the devcontainer, then create a
                    worktree (or switch branches) INSIDE the container.
                    See docs/getting-started.md section 2g.
-
-Full tradeoff analysis and escape hatch for parallel-branch devcontainers:
-tinaudio/synth-setter#593 and .devcontainer/initialize.sh.
 ERR
       exit 1
       ;;

--- a/.devcontainer/initialize.sh
+++ b/.devcontainer/initialize.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Dev container host-side initialization.
+# Runs on the host before the container is created (initializeCommand).
+#
+# Responsibilities:
+#   1. Ensure .env exists (Docker --env-file requires the file to be present).
+#   2. Refuse to open the devcontainer from a git worktree.
+#
+# WHY THE WORKTREE HARDSTOP:
+# A linked worktree's .git is a pointer file containing an absolute host path
+# into the parent repo's admin directory (e.g. /home/<user>/<repo>/.git/worktrees/<name>).
+# The workspaceMount binds only the worktree itself, so that path doesn't exist
+# inside the container. Without a usable .git, git operations in post-create.sh
+# (git config --global --add safe.directory, pre-commit install) fail partway,
+# leaving the container half-configured.
+#
+# Two supported branch-isolation workflows already exist:
+#   1. Host-only:    open <worktree>/ in a host editor, skip the devcontainer.
+#   2. Devcontainer: open the main repo in the devcontainer, then
+#                    `git checkout -B <branch>`.
+#
+# EDGE CASE — parallel devcontainers for parallel branches:
+# If you genuinely need to run two devcontainers on two worktrees simultaneously
+# (e.g. to A/B-test behavior between branches without rebuilding), comment out
+# the worktree check below AND the `git config` / `pre-commit install` lines in
+# .devcontainer/post-create.sh. DO NOT commit those edits.
+
+set -euo pipefail
+
+[ -f .env ] || touch .env
+
+if [ -f .git ]; then
+  first_line=""
+  read -r first_line < .git 2>/dev/null || true
+  case "$first_line" in
+    gitdir:*)
+      cat >&2 <<'ERR'
+ERROR: This devcontainer cannot be opened from a git worktree.
+
+The workspace's .git is a pointer file referencing a host path that is not
+mounted into the container. Supported workflows:
+
+  1. Host-only:    open <worktree>/ in a host editor, skip the devcontainer.
+  2. Devcontainer: open the main repo in the devcontainer, then
+                   `git checkout -B <branch>`.
+
+See .devcontainer/initialize.sh for the parallel-devcontainer escape hatch.
+ERR
+      exit 1
+      ;;
+  esac
+fi

--- a/.devcontainer/initialize.sh
+++ b/.devcontainer/initialize.sh
@@ -6,7 +6,8 @@
 #   1. Ensure .env exists (Docker --env-file requires the file to be present).
 #   2. Refuse to open the devcontainer from a git worktree.
 #
-# WHY THE WORKTREE HARDSTOP:
+# WHY THE WORKTREE HARDSTOP (see tinaudio/synth-setter#593 for the full
+# tradeoff analysis):
 # A linked worktree's .git is a pointer file containing an absolute host path
 # into the parent repo's admin directory (e.g. /home/<user>/<repo>/.git/worktrees/<name>).
 # The workspaceMount binds only the worktree itself, so that path doesn't exist
@@ -14,12 +15,15 @@
 # (git config --global --add safe.directory, pre-commit install) fail partway,
 # leaving the container half-configured.
 #
-# Two supported branch-isolation workflows already exist:
-#   1. Host-only:    open <worktree>/ in a host editor, skip the devcontainer.
-#   2. Devcontainer: open the main repo in the devcontainer, then
-#                    `git checkout -B <branch>`.
+# Two supported workflows exist; both let you work on a feature branch:
+#   1. Host-only:    open the host worktree in a host editor, skip the
+#                    devcontainer entirely.
+#   2. Devcontainer: open the main repo in the devcontainer, then create a
+#                    worktree (or switch branches) INSIDE the container. The
+#                    in-container .git is a directory that resolves normally.
+#                    See docs/getting-started.md §2g for the recommended flow.
 #
-# EDGE CASE — parallel devcontainers for parallel branches:
+# EDGE CASE — parallel devcontainers for parallel branches (see #593):
 # If you genuinely need to run two devcontainers on two worktrees simultaneously
 # (e.g. to A/B-test behavior between branches without rebuilding), comment out
 # the worktree check below AND the `git config` / `pre-commit install` lines in
@@ -38,13 +42,17 @@ if [ -f .git ]; then
 ERROR: This devcontainer cannot be opened from a git worktree.
 
 The workspace's .git is a pointer file referencing a host path that is not
-mounted into the container. Supported workflows:
+mounted into the container. Supported workflows (both let you work on a
+feature branch):
 
-  1. Host-only:    open <worktree>/ in a host editor, skip the devcontainer.
-  2. Devcontainer: open the main repo in the devcontainer, then
-                   `git checkout -B <branch>`.
+  1. Host-only:    open the host worktree in a host editor, skip the
+                   devcontainer entirely.
+  2. Devcontainer: open the main repo in the devcontainer, then create a
+                   worktree (or switch branches) INSIDE the container.
+                   See docs/getting-started.md section 2g.
 
-See .devcontainer/initialize.sh for the parallel-devcontainer escape hatch.
+Full tradeoff analysis and escape hatch for parallel-branch devcontainers:
+tinaudio/synth-setter#593 and .devcontainer/initialize.sh.
 ERR
       exit 1
       ;;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -150,6 +150,9 @@ This is the supported local pattern. Mounting a worktree directly from the
 host does not work — the worktree's `.git` file points to
 `<repo>/.git/worktrees/<name>/` on the host, which is outside the container's
 bind mount, so git submodule/hook operations fail to resolve their gitdir.
+`.devcontainer/initialize.sh` detects this case on the host and aborts the
+build with a clear error before the container is created, so the failure
+surfaces immediately rather than partway through `post-create`.
 
 **Caveats:**
 


### PR DESCRIPTION
## Summary

- Moves the devcontainer's host-side `initializeCommand` from an inline shell string into a new `.devcontainer/initialize.sh`.
- The script detects a git worktree pointer file and hard-fails before any image build, with a clear error naming the two supported branch-isolation workflows.
- The parallel-devcontainer edge case is documented inline as a local-only patch — no committed machinery.

Fixes #593

## Test plan

- [ ] From a git worktree, run `devcontainer up --workspace-folder . --config .devcontainer/cpu/devcontainer.json`. Expect non-zero exit, multi-line error to stderr, and **no container or image built**.
- [ ] From the main repo root, run the same command. Expect it to proceed past `initializeCommand` and build/provision normally (including `pre-commit install` succeeding).
- [ ] From the main repo, confirm `.devcontainer/initialize.sh` still creates a `.env` file if absent (preserves the original responsibility).
- [ ] Confirm the GPU config (`--config .devcontainer/gpu/devcontainer.json`) inherits the same hardstop.
