### PR TITLE
fix(devcontainer): codespell typo in initialize.sh error message

### DIFF
--- a/.devcontainer/initialize.sh
+++ b/.devcontainer/initialize.sh
@@ -22,7 +22,7 @@ if [ -f .git ]; then
     gitdir:*)
       cat >&2 <<'ERR'
 ERROR: This devcontainer cannot be opened from a workspace whose `.git` is a
-pointer file. See github isse #593 for details.
+pointer file. See github issue #593 for details.
 
 Pointer-file `.git` shows up for git worktrees (the common case),
 submodules, and `git clone --separate-git-dir` repositories. The pointer


### PR DESCRIPTION
## Summary

- Single-character typo fix: `isse` → `issue` in the multi-line error emitted by `.devcontainer/initialize.sh` when the devcontainer is opened from a worktree.
- Unblocks the `codespell` pre-commit hook, which currently fails on `.devcontainer/initialize.sh:25` and breaks CI for any PR that touches this file.

Fixes #595

## Test plan

- [ ] `pre-commit run --files .devcontainer/initialize.sh` passes locally (codespell clean).
- [ ] CI `code-quality` job passes on this PR.