### PR TITLE
docs: address post-merge Copilot review feedback on #585

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -125,11 +125,14 @@ container.
   [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
   or the [`devcontainer` CLI](https://github.com/devcontainers/cli).
 - R2 + W&B credentials (see [§4b](#4b-rclone--cloudflare-r2) and
-  [§4c](#4c-weights--biases-wb)). Local dev containers load `.env`
-  automatically via `--env-file .env` (`.devcontainer/initialize.sh`
-  creates an empty one if missing), so rclone and W&B pick up creds
-  on container start. **Codespaces** does not have a host `.env` —
-  forward R2/W&B vars via Codespaces user/org secrets instead.
+  [§4c](#4c-weights--biases-wb)). Both local dev containers and
+  Codespaces use `--env-file .env`, and `.devcontainer/initialize.sh`
+  ensures the file exists (creating an empty one if missing). Locally,
+  populate `.env` on the host before opening the container so rclone
+  and W&B pick up creds on container start. In **Codespaces** the
+  newly-touched `.env` is empty, so populate the same vars via
+  Codespaces user/org secrets — they're injected into the container
+  environment at runtime.
 - Apple Silicon: set `DOCKER_DEFAULT_PLATFORM=linux/amd64` (the image is
   amd64-only).
 

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -291,15 +291,19 @@ ______________________________________________________________________
 
 ## 4. CI Workflow
 
-The GHA workflow `.github/workflows/docker-build-validation.yml` builds a
-dev-snapshot image, pushes to Docker Hub, and runs smoke tests.
+The GHA workflow `.github/workflows/docker-build-validation.yml` builds the
+`dev-snapshot` and `devcontainer-tools` images, pushes both to Docker Hub,
+and runs smoke tests against `dev-snapshot`.
 
 ### What it does
 
 1. Validates the image config (`configs/image/dev-snapshot.yaml` via Pydantic)
-2. Builds the image using Docker Buildx
-3. Pushes tagged images to Docker Hub (dispatch/schedule only)
-4. Runs smoke tests against the SHA-pinned tag (dispatch/schedule only)
+2. Builds the `dev-snapshot` image using Docker Buildx
+3. Builds the `devcontainer-tools` image (separate step, same Dockerfile,
+   different `--target`)
+4. Pushes both images' tags to Docker Hub (dispatch/schedule only)
+5. Runs smoke tests against the SHA-pinned `dev-snapshot` tag
+   (dispatch/schedule only — `devcontainer-tools` is not smoke-tested in CI)
 
 On **pull requests** (Docker-related paths only), the workflow runs steps 1–2
 as build validation — no push, no smoke tests.
@@ -316,10 +320,11 @@ If the YAML violates the schema, the workflow fails before any build starts.
 | `tinaudio/synth-setter:devcontainer-tools`       | Yes      | Latest devcontainer-tools (consumed by `.devcontainer/`)    |
 | `tinaudio/synth-setter:devcontainer-tools-<sha>` | No       | Immutable, pinnable from `.devcontainer/Dockerfile`         |
 
-Mutable tags (`latest`, `dev-snapshot`) are only published on dispatch/schedule
-runs — not on pull-request build validations. `latest` is additionally gated
-to schedule runs or to `workflow_dispatch` with `git_ref=main`, so dispatching
-from main with a non-main `git_ref` does not overwrite `latest`.
+All mutable tags (`latest`, `dev-snapshot`, `devcontainer-tools`) are only
+published on dispatch/schedule runs — not on pull-request build validations.
+`latest` is additionally gated to schedule runs or to `workflow_dispatch`
+with `git_ref=main`, so dispatching from main with a non-main `git_ref`
+does not overwrite `latest`.
 
 Smoke tests pull the SHA-pinned tag to avoid race conditions with concurrent
 workflow runs.

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -305,8 +305,9 @@ and runs smoke tests against `dev-snapshot`.
 5. Runs smoke tests against the SHA-pinned `dev-snapshot` tag
    (dispatch/schedule only — `devcontainer-tools` is not smoke-tested in CI)
 
-On **pull requests** (Docker-related paths only), the workflow runs steps 1–2
-as build validation — no push, no smoke tests.
+On **pull requests** (Docker-related paths only), the workflow runs steps 1–3
+as build validation — both images are built but neither is pushed, and no
+smoke tests run.
 
 If the YAML violates the schema, the workflow fails before any build starts.
 


### PR DESCRIPTION
## Summary

Three Copilot review comments on #585 landed 47 seconds after the PR was squash-merged, so they couldn't be folded in there. All three are small accuracy fixes in the same docs #585 just touched:

1. **`docs/getting-started.md` § 2g Prerequisites** — the `.env` paragraph said *"Codespaces does not have a host `.env`"*, but Codespaces also runs `initializeCommand` which `touch`es `.env` if missing. The real distinction is that locally the host `.env` carries your creds, while in Codespaces the touched file is empty so creds must come from Codespaces user/org secrets at runtime. Reframed without the misleading "no `.env`" claim.
2. **`docs/reference/docker.md` § 4 "What it does"** — the workflow intro and step list only mentioned the `dev-snapshot` build, but `.github/workflows/docker-build-validation.yml:154` has a separate "Build and push devcontainer-tools image" step. Updated to cover both images, with the nuance that smoke tests still only run against `dev-snapshot`.
3. **`docs/reference/docker.md` § 4 "Tags"** — the prose enumeration *"Mutable tags (`latest`, `dev-snapshot`)"* excluded `devcontainer-tools`, which is also a mutable tag published under the same dispatch/schedule rule. Changed to *"All mutable tags (`latest`, `dev-snapshot`, `devcontainer-tools`)"*.

No code or config changes — docs only.

## Original Copilot comments

- [#585 (comment 3107445824)](https://github.com/tinaudio/synth-setter/pull/585#discussion_r3107445824) — `.env` claim
- [#585 (comment 3107445841)](https://github.com/tinaudio/synth-setter/pull/585#discussion_r3107445841) — workflow description
- [#585 (comment 3107445835)](https://github.com/tinaudio/synth-setter/pull/585#discussion_r3107445835) — mutable tags enumeration

## Test plan

- [ ] CI: `pr-metadata-gate.yaml` passes (`Refs #584` is taxonomy-compliant: Task + `documentation` + `documentation v1.0.0` + parent Phase #441)
- [ ] CI: `code-quality-pr.yaml` passes
- [ ] Manual: `docs/getting-started.md` § 2g Prerequisites no longer claims Codespaces lacks `.env`; explains the local-vs-Codespaces creds path correctly
- [ ] Manual: `docs/reference/docker.md` § 4 intro and "What it does" list mention both `dev-snapshot` and `devcontainer-tools` builds; smoke-test scope unchanged
- [ ] Manual: `docs/reference/docker.md` § 4 "Tags" prose includes `devcontainer-tools` in the mutable-tags enumeration

Refs #584