### PR TITLE
build(evaluation): pin eval metric dependencies

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -22,6 +22,7 @@ h5py
 hypothesis
 hdf5plugin
 librosa
+loguru==0.7.3
 matplotlib
 mutmut==3.5.*
 mido
@@ -45,4 +46,3 @@ threadpoolctl
 pesto-pitch==2.0.1
 dtw-python==1.7.4
 kymatio==0.3.0
-loguru==0.7.3

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -22,7 +22,6 @@ h5py
 hypothesis
 hdf5plugin
 librosa
-loguru
 matplotlib
 mutmut==3.5.*
 mido
@@ -41,3 +40,9 @@ rootutils
 runpod==1.8.1
 scipy==1.14.1
 threadpoolctl
+
+# --------- eval metrics --------- #
+pesto-pitch==2.0.1
+dtw-python==1.7.4
+kymatio==0.3.0
+loguru==0.7.3


### PR DESCRIPTION
## Summary

Adds `pesto-pitch`, `dtw-python`, `kymatio`, and `loguru` to
`requirements-app.txt` with exact pins so a fresh venv can run
`scripts/compute_audio_metrics.py`.

## Scope

- Deps only. No new requirements file; no README or .env.example edits
  (scope reduced by maintainer from the original issue body).
- `pesto` and `kymatio` are currently only used by dead-code paths in
  `compute_audio_metrics.py` (`compute_f0`, `compute_jtfs_distance`) —
  wiring or removing those is out of scope (owned by #87).

## Test plan

- [ ] `pip install -r requirements-app.txt` on a clean venv succeeds
- [ ] `python scripts/compute_audio_metrics.py --help` prints help output
- [ ] `make test` still passes

Closes #605