### PR TITLE
docs(documentation): README + getting-started install overhaul, add make link-plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ test-bats: ## Run BATS shell tests
 install: ## End-to-end: install uv, create .venv (Python 3.10), install deps, set up pre-commit
 	@command -v uv >/dev/null 2>&1 || [ -x "$$HOME/.local/bin/uv" ] || \
 		{ echo "Installing uv..."; curl -LsSf https://astral.sh/uv/install.sh | sh; }
-	@UV=$$(command -v uv 2>/dev/null || echo "$$HOME/.local/bin/uv"); \
+	@set -e; \
+	UV=$$(command -v uv 2>/dev/null || echo "$$HOME/.local/bin/uv"); \
 	[ -x "$$UV" ] || { echo "ERROR: uv not found at $$UV"; exit 1; }; \
 	if [ -d .venv ]; then \
 		PY_VER=$$(.venv/bin/python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null); \
@@ -60,7 +61,8 @@ SURGE_XT_MACOS_ASSET := surge-xt-macos-$(SURGE_XT_VERSION)-pluginsonly.zip
 SURGE_XT_MACOS_MD5 := 8afca4159d9b417c5e07ebc1a5e96ed3
 
 install-surge-xt: ## Download Surge XT VST3 into plugins/ (skipped if already present)
-	@DEST="plugins/Surge XT.vst3"; \
+	@set -e; \
+	DEST="plugins/Surge XT.vst3"; \
 	if [ -e "$$DEST" ]; then \
 		echo "$$DEST already exists — skipping. Remove it first to reinstall."; \
 		exit 0; \
@@ -71,7 +73,7 @@ install-surge-xt: ## Download Surge XT VST3 into plugins/ (skipped if already pr
 			if [ "$$ARCH" != "x86_64" ]; then \
 				echo "ERROR: the Surge XT Linux release only ships an x86_64 build (detected: $$ARCH)."; \
 				echo "Install via your package manager (e.g. apt install surge-xt) or build from source,"; \
-				echo "then run: make link-plugins"; \
+				echo "then symlink it: ln -s /path/to/Surge XT.vst3 plugins/"; \
 				exit 1; \
 			fi; \
 			ASSET="$(SURGE_XT_LINUX_ASSET)"; EXPECTED_MD5="$(SURGE_XT_LINUX_MD5)" ;; \
@@ -89,8 +91,11 @@ install-surge-xt: ## Download Surge XT VST3 into plugins/ (skipped if already pr
 	fi; \
 	if command -v md5sum >/dev/null 2>&1; then \
 		ACTUAL_MD5=$$(md5sum "$$ARCHIVE" | awk '{print $$1}'); \
-	else \
+	elif command -v md5 >/dev/null 2>&1; then \
 		ACTUAL_MD5=$$(md5 -q "$$ARCHIVE"); \
+	else \
+		echo "ERROR: neither 'md5sum' (Linux) nor 'md5' (macOS) is available — cannot verify checksum"; \
+		exit 1; \
 	fi; \
 	if [ "$$ACTUAL_MD5" != "$$EXPECTED_MD5" ]; then \
 		echo "ERROR: md5 mismatch for $$ARCHIVE"; \
@@ -105,43 +110,6 @@ install-surge-xt: ## Download Surge XT VST3 into plugins/ (skipped if already pr
 		Darwin) unzip -q "$$ARCHIVE" "Surge XT.vst3/*" -d plugins/ ;; \
 	esac; \
 	echo "Installed $$DEST"
-
-link-plugins: ## Symlink an existing system-wide Surge XT VST3 into plugins/
-	@PLUGIN_NAME="Surge XT.vst3"; \
-	OS=$$(uname -s); \
-	FOUND=""; \
-	if [ "$$OS" = "Linux" ]; then \
-		if [ -e "/usr/lib/vst3/$$PLUGIN_NAME" ]; then FOUND="/usr/lib/vst3/$$PLUGIN_NAME"; fi; \
-	elif [ "$$OS" = "Darwin" ]; then \
-		for p in "/Library/Audio/Plug-Ins/VST3/$$PLUGIN_NAME" "$$HOME/Library/Audio/Plug-Ins/VST3/$$PLUGIN_NAME"; do \
-			if [ -e "$$p" ]; then FOUND="$$p"; break; fi; \
-		done; \
-	else \
-		echo "ERROR: Unsupported platform: $$OS"; exit 1; \
-	fi; \
-	if [ -z "$$FOUND" ]; then \
-		echo "ERROR: $$PLUGIN_NAME not found. Searched:"; \
-		if [ "$$OS" = "Linux" ]; then \
-			echo "  /usr/lib/vst3/$$PLUGIN_NAME"; \
-		else \
-			echo "  /Library/Audio/Plug-Ins/VST3/$$PLUGIN_NAME"; \
-			echo "  $$HOME/Library/Audio/Plug-Ins/VST3/$$PLUGIN_NAME"; \
-		fi; \
-		echo "Install Surge XT from https://surge-synthesizer.github.io/"; \
-		exit 1; \
-	fi; \
-	mkdir -p plugins; \
-	DEST="plugins/$$PLUGIN_NAME"; \
-	if [ -L "$$DEST" ]; then \
-		rm -f "$$DEST"; \
-	elif [ -d "$$DEST" ]; then \
-		echo "ERROR: $$DEST exists as a directory; remove it before linking."; \
-		exit 1; \
-	elif [ -e "$$DEST" ]; then \
-		rm -f "$$DEST"; \
-	fi; \
-	ln -s "$$FOUND" "$$DEST"; \
-	echo "Linked $$DEST -> $$FOUND"
 
 # coverage runs serially (no -n auto): GPU tests require exclusive device
 # access and VRAM contention causes flaky failures with xdist parallelism.

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,62 @@ install: ## End-to-end: install uv, create .venv (Python 3.10), install deps, se
 	@echo ""
 	@echo "Next: source .venv/bin/activate"
 
-link-plugins: ## Symlink Surge XT VST3 into plugins/
+SURGE_XT_VERSION := 1.3.4
+SURGE_XT_CACHE := $(HOME)/.cache/synth-setter/surge-xt-$(SURGE_XT_VERSION)
+SURGE_XT_RELEASE_URL := https://github.com/surge-synthesizer/releases-xt/releases/download/$(SURGE_XT_VERSION)
+SURGE_XT_LINUX_ASSET := surge-xt-linux-$(SURGE_XT_VERSION)-pluginsonly.tar.gz
+SURGE_XT_LINUX_MD5 := 0180f06ec7a8445b1c749471e29c702b
+SURGE_XT_MACOS_ASSET := surge-xt-macos-$(SURGE_XT_VERSION)-pluginsonly.zip
+SURGE_XT_MACOS_MD5 := 8afca4159d9b417c5e07ebc1a5e96ed3
+
+install-surge-xt: ## Download Surge XT VST3 into plugins/ (skipped if already present)
+	@DEST="plugins/Surge XT.vst3"; \
+	if [ -e "$$DEST" ]; then \
+		echo "$$DEST already exists — skipping. Remove it first to reinstall."; \
+		exit 0; \
+	fi; \
+	OS=$$(uname -s); ARCH=$$(uname -m); \
+	case "$$OS" in \
+		Linux) \
+			if [ "$$ARCH" != "x86_64" ]; then \
+				echo "ERROR: the Surge XT Linux release only ships an x86_64 build (detected: $$ARCH)."; \
+				echo "Install via your package manager (e.g. apt install surge-xt) or build from source,"; \
+				echo "then run: make link-plugins"; \
+				exit 1; \
+			fi; \
+			ASSET="$(SURGE_XT_LINUX_ASSET)"; EXPECTED_MD5="$(SURGE_XT_LINUX_MD5)" ;; \
+		Darwin) \
+			ASSET="$(SURGE_XT_MACOS_ASSET)"; EXPECTED_MD5="$(SURGE_XT_MACOS_MD5)" ;; \
+		*) echo "ERROR: Unsupported platform: $$OS"; exit 1 ;; \
+	esac; \
+	mkdir -p "$(SURGE_XT_CACHE)" plugins; \
+	ARCHIVE="$(SURGE_XT_CACHE)/$$ASSET"; \
+	if [ ! -f "$$ARCHIVE" ]; then \
+		echo "Downloading $(SURGE_XT_RELEASE_URL)/$$ASSET"; \
+		curl -fSL -o "$$ARCHIVE" "$(SURGE_XT_RELEASE_URL)/$$ASSET"; \
+	else \
+		echo "Using cached $$ARCHIVE"; \
+	fi; \
+	if command -v md5sum >/dev/null 2>&1; then \
+		ACTUAL_MD5=$$(md5sum "$$ARCHIVE" | awk '{print $$1}'); \
+	else \
+		ACTUAL_MD5=$$(md5 -q "$$ARCHIVE"); \
+	fi; \
+	if [ "$$ACTUAL_MD5" != "$$EXPECTED_MD5" ]; then \
+		echo "ERROR: md5 mismatch for $$ARCHIVE"; \
+		echo "  expected: $$EXPECTED_MD5"; \
+		echo "  actual:   $$ACTUAL_MD5"; \
+		echo "Remove the cached file and retry: rm '$$ARCHIVE'"; \
+		exit 1; \
+	fi; \
+	echo "md5 OK. Extracting Surge XT.vst3 into plugins/..."; \
+	case "$$OS" in \
+		Linux) tar -xzf "$$ARCHIVE" -C plugins/ "./Surge XT.vst3" ;; \
+		Darwin) unzip -q "$$ARCHIVE" "Surge XT.vst3/*" -d plugins/ ;; \
+	esac; \
+	echo "Installed $$DEST"
+
+link-plugins: ## Symlink an existing system-wide Surge XT VST3 into plugins/
 	@PLUGIN_NAME="Surge XT.vst3"; \
 	OS=$$(uname -s); \
 	FOUND=""; \

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,25 @@ test-full: ## Run all tests
 test-bats: ## Run BATS shell tests
 	bats --recursive tests/
 
-install: ## Install project in editable mode with dev deps
-	pip install uv
-	uv pip install -r requirements.txt -e .
+install: ## End-to-end: install uv, create .venv (Python 3.10), install deps, set up pre-commit
+	@command -v uv >/dev/null 2>&1 || [ -x "$$HOME/.local/bin/uv" ] || \
+		{ echo "Installing uv..."; curl -LsSf https://astral.sh/uv/install.sh | sh; }
+	@UV=$$(command -v uv 2>/dev/null || echo "$$HOME/.local/bin/uv"); \
+	[ -x "$$UV" ] || { echo "ERROR: uv not found at $$UV"; exit 1; }; \
+	if [ -d .venv ]; then \
+		PY_VER=$$(.venv/bin/python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')" 2>/dev/null); \
+		[ "$$PY_VER" = "3.10" ] || { echo "ERROR: existing .venv has Python $$PY_VER, need 3.10 (rm -rf .venv to recreate)"; exit 1; }; \
+	else \
+		"$$UV" venv --python 3.10 --prompt synth-setter .venv; \
+	fi; \
+	"$$UV" pip install --python .venv/bin/python -r requirements.txt -e .; \
+	if [ -n "$$(git config --get core.hooksPath 2>/dev/null)" ]; then \
+		echo "Skipping pre-commit install (core.hooksPath is set; run '.venv/bin/pre-commit install' manually if you want to override)."; \
+	else \
+		.venv/bin/pre-commit install; \
+	fi
+	@echo ""
+	@echo "Next: source .venv/bin/activate"
 
 link-plugins: ## Symlink Surge XT VST3 into plugins/
 	@PLUGIN_NAME="Surge XT.vst3"; \

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,17 @@ link-plugins: ## Symlink Surge XT VST3 into plugins/
 		exit 1; \
 	fi; \
 	mkdir -p plugins; \
-	ln -sfn "$$FOUND" "plugins/$$PLUGIN_NAME"; \
-	echo "Linked plugins/$$PLUGIN_NAME -> $$FOUND"
+	DEST="plugins/$$PLUGIN_NAME"; \
+	if [ -L "$$DEST" ]; then \
+		rm -f "$$DEST"; \
+	elif [ -d "$$DEST" ]; then \
+		echo "ERROR: $$DEST exists as a directory; remove it before linking."; \
+		exit 1; \
+	elif [ -e "$$DEST" ]; then \
+		rm -f "$$DEST"; \
+	fi; \
+	ln -s "$$FOUND" "$$DEST"; \
+	echo "Linked $$DEST -> $$FOUND"
 
 # coverage runs serially (no -n auto): GPU tests require exclusive device
 # access and VRAM contention causes flaky failures with xdist parallelism.

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,34 @@ install: ## Install project in editable mode with dev deps
 	pip install uv
 	uv pip install -r requirements.txt -e .
 
+link-plugins: ## Symlink Surge XT VST3 into plugins/
+	@PLUGIN_NAME="Surge XT.vst3"; \
+	OS=$$(uname -s); \
+	FOUND=""; \
+	if [ "$$OS" = "Linux" ]; then \
+		if [ -e "/usr/lib/vst3/$$PLUGIN_NAME" ]; then FOUND="/usr/lib/vst3/$$PLUGIN_NAME"; fi; \
+	elif [ "$$OS" = "Darwin" ]; then \
+		for p in "/Library/Audio/Plug-Ins/VST3/$$PLUGIN_NAME" "$$HOME/Library/Audio/Plug-Ins/VST3/$$PLUGIN_NAME"; do \
+			if [ -e "$$p" ]; then FOUND="$$p"; break; fi; \
+		done; \
+	else \
+		echo "ERROR: Unsupported platform: $$OS"; exit 1; \
+	fi; \
+	if [ -z "$$FOUND" ]; then \
+		echo "ERROR: $$PLUGIN_NAME not found. Searched:"; \
+		if [ "$$OS" = "Linux" ]; then \
+			echo "  /usr/lib/vst3/$$PLUGIN_NAME"; \
+		else \
+			echo "  /Library/Audio/Plug-Ins/VST3/$$PLUGIN_NAME"; \
+			echo "  $$HOME/Library/Audio/Plug-Ins/VST3/$$PLUGIN_NAME"; \
+		fi; \
+		echo "Install Surge XT from https://surge-synthesizer.github.io/"; \
+		exit 1; \
+	fi; \
+	mkdir -p plugins; \
+	ln -sfn "$$FOUND" "plugins/$$PLUGIN_NAME"; \
+	echo "Linked plugins/$$PLUGIN_NAME -> $$FOUND"
+
 # coverage runs serially (no -n auto): GPU tests require exclusive device
 # access and VRAM contention causes flaky failures with xdist parallelism.
 coverage: ## Run tests with coverage report

--- a/README.md
+++ b/README.md
@@ -79,10 +79,10 @@ set -a && source .env && set +a
 ```
 
 > **pip / conda users:** If you manage your own Python environment, you can
-> skip steps 2-3 and run `make install` (or `pip install -r requirements.txt
-> -e .`) directly. See [docs/getting-started.md
-> &sect;2](docs/getting-started.md#2-installation) for the full walkthrough and
-> alternatives.
+> skip steps 2-3 and run `make install` directly
+> (or `pip install -r requirements.txt -e .`).
+> See [docs/getting-started.md &sect;2](docs/getting-started.md#2-installation)
+> for the full walkthrough and alternatives.
 
 ### GPU vs CPU
 
@@ -191,7 +191,9 @@ Surge XT, rclone, and all Python dependencies already installed. See
 
 > **Devcontainer as root:** The default dev container runs as a non-root user.
 > If your workflow requires root (e.g., installing system packages), set
-> `"remoteUser": "root"` in `.devcontainer/devcontainer.json`. See the
+> `"remoteUser": "root"` in the devcontainer config you use
+> (`.devcontainer/cpu/devcontainer.json` or
+> `.devcontainer/gpu/devcontainer.json`). See the
 > [devcontainer docs](https://containers.dev/implementors/json_reference/)
 > for details.
 

--- a/README.md
+++ b/README.md
@@ -56,37 +56,33 @@ under the GPL-3.0 license.
 
 ## Installation
 
-Clone the repository:
-
 ```bash
+# 1. Clone
 git clone https://github.com/tinaudio/synth-setter.git
 cd synth-setter
-```
 
-### Using uv (recommended)
+# 2. Install uv (if you don't have it)
+curl -LsSf https://astral.sh/uv/install.sh | sh
 
-```bash
-uv pip install -r requirements.txt
-```
+# 3. Create and activate a Python 3.10 venv
+uv venv --python 3.10 .venv
+source .venv/bin/activate
 
-### Using pip
-
-```bash
-pip install -r requirements.txt
-```
-
-### Using conda
-
-```bash
-conda env create -f environment.yaml  # creates the "myenv" environment by default
-conda activate myenv
-```
-
-### Editable install
-
-```bash
+# 4. Install the project and all dev tooling
 make install
+
+# 5. Symlink the Surge XT VST3 into plugins/
+make link-plugins
+
+# 6. Export environment variables (R2, W&B — see §4b in getting-started)
+set -a && source .env && set +a
 ```
+
+> **pip / conda users:** If you manage your own Python environment, you can
+> skip steps 2-3 and run `make install` (or `pip install -r requirements.txt
+> -e .`) directly. See [docs/getting-started.md
+> &sect;2](docs/getting-started.md#2-installation) for the full walkthrough and
+> alternatives.
 
 ### GPU vs CPU
 
@@ -183,6 +179,21 @@ Further reading (mostly for contributors and maintainers):
   GitHub Actions, W&B integration
 
 Run `make help` for available commands.
+
+## Codespaces & Docker
+
+GitHub Codespaces and local dev containers provide a pre-built environment with
+Surge XT, rclone, and all Python dependencies already installed. See
+[docs/getting-started.md &sect;2g](docs/getting-started.md#2g-alternative-github-codespaces)
+(Codespaces) and
+[&sect;2h](docs/getting-started.md#2h-alternative-local-dev-container)
+(local dev container) for setup instructions.
+
+> **Devcontainer as root:** The default dev container runs as a non-root user.
+> If your workflow requires root (e.g., installing system packages), set
+> `"remoteUser": "root"` in `.devcontainer/devcontainer.json`. See the
+> [devcontainer docs](https://containers.dev/implementors/json_reference/)
+> for details.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ under the GPL-3.0 license.
 ## Prerequisites
 
 - **Supported platforms**: Linux and macOS only. Windows is not supported — the `sh` test dependency and the VST rendering tooling are POSIX-only, and CI covers Ubuntu and macOS only.
-- **Python 3.10+**
-- **uv** (recommended) — [install uv](https://docs.astral.sh/uv/getting-started/installation/)
-- **Git**
+- **Git**, **curl**, **make** (for the canonical install path)
 - **[Surge XT](https://github.com/surge-synthesizer/surge) 1.3.4** — the VST synthesizer used for dataset generation. See the [Surge XT downloads page](https://surge-synthesizer.github.io/downloads/) for installation instructions.
 - **System dependencies for VST rendering** — see the project documentation for details
+
+`make install` handles uv and Python 3.10 for you — no pre-existing Python interpreter needed.
 
 ## Installation
 
@@ -61,28 +61,24 @@ under the GPL-3.0 license.
 git clone https://github.com/tinaudio/synth-setter.git
 cd synth-setter
 
-# 2. Install uv (if you don't have it)
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# 3. Create and activate a Python 3.10 venv
-uv venv --python 3.10 .venv
-source .venv/bin/activate
-
-# 4. Install the project and all dev tooling
+# 2. Install uv, create .venv (Python 3.10), install deps, set up pre-commit
 make install
 
-# 5. Symlink the Surge XT VST3 into plugins/
+# 3. Activate the venv
+source .venv/bin/activate
+
+# 4. Symlink the Surge XT VST3 into plugins/
 make link-plugins
 
-# 6. Export environment variables (R2, W&B — see §4b in getting-started)
+# 5. Export environment variables (R2, W&B — see §4b in getting-started)
 set -a && source .env && set +a
 ```
 
-> **pip / conda users:** If you manage your own Python environment, you can
-> skip steps 2-3 and run `make install` directly
-> (or `pip install -r requirements.txt -e .`).
-> See [docs/getting-started.md &sect;2](docs/getting-started.md#2-installation)
-> for the full walkthrough and alternatives.
+> **Prefer pip or conda?** If you'd rather manage the Python interpreter and
+> venv yourself, see
+> [docs/getting-started.md Appendix A](docs/getting-started.md#appendix-a-manual-environment-setup)
+> for a walkthrough using `pip install -r requirements.txt -e .` inside your
+> own environment.
 
 ### GPU vs CPU
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ under the GPL-3.0 license.
 
 ## Prerequisites
 
-- **Supported platforms**: Linux and macOS only. Windows is not supported — the `sh` test dependency and the VST rendering tooling are POSIX-only, and CI covers Ubuntu and macOS only.
+- **Supported platforms**: Linux (x86_64) and macOS only. Windows is not supported — the `sh` test dependency and the VST rendering tooling are POSIX-only, and CI covers Ubuntu and macOS only.
 - **Git**, **curl**, **make** (for the canonical install path)
-- **[Surge XT](https://github.com/surge-synthesizer/surge) 1.3.4** — the VST synthesizer used for dataset generation. See the [Surge XT downloads page](https://surge-synthesizer.github.io/downloads/) for installation instructions.
-- **System dependencies for VST rendering** — see the project documentation for details
 
-`make install` handles uv and Python 3.10 for you — no pre-existing Python interpreter needed.
+`make install` handles uv, Python 3.10, and all dependencies for you.
+`make install-surge-xt` fetches the pinned Surge XT VST3 release — no need
+to install Surge XT yourself.
 
 ## Installation
 
@@ -67,12 +67,16 @@ make install
 # 3. Activate the venv
 source .venv/bin/activate
 
-# 4. Symlink the Surge XT VST3 into plugins/
-make link-plugins
+# 4. Download the Surge XT VST3 into plugins/
+make install-surge-xt
 
 # 5. Export environment variables (R2, W&B — see §4b in getting-started)
 set -a && source .env && set +a
 ```
+
+> **Already have Surge XT installed system-wide?** Use `make link-plugins`
+> instead of `make install-surge-xt` to symlink the existing install into
+> `plugins/`. See [docs/getting-started.md &sect;2d](docs/getting-started.md#2d-install-the-surge-xt-vst3).
 
 > **Prefer pip or conda?** If you'd rather manage the Python interpreter and
 > venv yourself, see
@@ -180,10 +184,8 @@ Run `make help` for available commands.
 
 GitHub Codespaces and local dev containers provide a pre-built environment with
 Surge XT, rclone, and all Python dependencies already installed. See
-[docs/getting-started.md &sect;2g](docs/getting-started.md#2g-alternative-github-codespaces)
-(Codespaces) and
-[&sect;2h](docs/getting-started.md#2h-alternative-local-dev-container)
-(local dev container) for setup instructions.
+[docs/getting-started.md Appendix B](docs/getting-started.md#appendix-b-container-based-setup)
+for setup instructions covering both paths.
 
 > **Devcontainer as root:** The default dev container runs as a non-root user.
 > If your workflow requires root (e.g., installing system packages), set

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ to install Surge XT yourself.
 git clone https://github.com/tinaudio/synth-setter.git
 cd synth-setter
 
-# 2. Install uv, create .venv (Python 3.10), install deps, set up pre-commit
+# 2. Install uv, create .venv (Python 3.10), install deps, register pre-commit
+#    (pre-commit install is skipped if core.hooksPath is set, e.g. in the dev
+#    container)
 make install
 
 # 3. Activate the venv
@@ -74,9 +76,10 @@ make install-surge-xt
 set -a && source .env && set +a
 ```
 
-> **Already have Surge XT installed system-wide?** Use `make link-plugins`
-> instead of `make install-surge-xt` to symlink the existing install into
-> `plugins/`. See [docs/getting-started.md &sect;2d](docs/getting-started.md#2d-install-the-surge-xt-vst3).
+> **Already have Surge XT installed system-wide?** Skip `make install-surge-xt`
+> and symlink it manually:
+> `ln -s "/path/to/Surge XT.vst3" "plugins/Surge XT.vst3"`.
+> See [docs/getting-started.md &sect;2d](docs/getting-started.md#2d-install-the-surge-xt-vst3).
 
 > **Prefer pip or conda?** If you'd rather manage the Python interpreter and
 > venv yourself, see

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -158,7 +158,7 @@ docs:
     description: Onboarding — local dev, Codespaces, and dev container flows
     sources:
       - pattern: "Makefile"
-        covers: "Local dev targets — install (uv + .venv + deps + pre-commit), install-surge-xt (download + md5 verify + extract Surge XT VST3), link-plugins (symlink system-wide Surge XT), SURGE_XT_VERSION + related vars"
+        covers: "Local dev targets — install (uv + .venv + deps + pre-commit), install-surge-xt (download + md5 verify + extract Surge XT VST3), SURGE_XT_VERSION + related vars"
         scope: "local-dev"
       - pattern: ".devcontainer/cpu/devcontainer.json"
         covers: "CPU dev container config — remoteUser, mounts (bash-history named volume + plugins/ anonymous overlay), --env-file .env, initializeCommand, postCreateCommand"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,8 +8,10 @@ ______________________________________________________________________
 
 ## 1. Prerequisites
 
-- **Linux or macOS** — Windows is not supported (see the project README).
-- **Git**, **curl**, **make** (all ship with macOS/Linux)
+- **Linux (x86_64) or macOS** — Windows is not supported (see the project README).
+- **Git**, **curl**, **make** — standard on most macOS and Linux developer
+  machines, but not guaranteed on minimal/server images. Install via your
+  package manager (`apt`, `brew`, etc.) if missing.
 - **A CUDA GPU** is recommended for training. CPU and MPS (Apple Silicon) trainers
   are available but significantly slower.
 
@@ -38,7 +40,11 @@ cd synth-setter
    if you do not have one locally). The venv prompt label is `synth-setter`.
 3. Installs everything in `requirements.txt` plus the project itself in
    editable mode (`pip install -e .`).
-4. Registers the pre-commit hooks.
+4. Registers the pre-commit hooks — **unless** `git config core.hooksPath`
+   is set (as it is in the dev container, where hooks are managed by the
+   image). In that case `make install` prints a skip note and leaves the
+   configured hooks path untouched; run `.venv/bin/pre-commit install`
+   manually if you want to override.
 
 ```bash
 make install
@@ -68,7 +74,7 @@ guide assume the venv is active.
 ### 2d. Install the Surge XT VST3
 
 The test suite and data pipeline need the [Surge XT](https://surge-synthesizer.github.io/)
-VST3 at `plugins/Surge XT.vst3`. The canonical path downloads the pinned
+VST3 at `plugins/Surge XT.vst3`. `make install-surge-xt` downloads the pinned
 release directly from GitHub:
 
 ```bash
@@ -83,14 +89,34 @@ have to re-extract (e.g. after `rm -rf plugins/`) skip the download. If
 `plugins/Surge XT.vst3` already exists, the target is a no-op — remove it
 first to reinstall.
 
-> **Already have Surge XT installed system-wide?** `make link-plugins`
-> symlinks an existing install (`/usr/lib/vst3/Surge XT.vst3` on Linux,
-> `/Library/Audio/Plug-Ins/VST3/Surge XT.vst3` on macOS) into `plugins/`
-> instead of downloading a second copy.
+> **Already have Surge XT installed system-wide?** Skip
+> `make install-surge-xt` and symlink your existing install into `plugins/`:
+>
+> ```bash
+> # Linux
+> ln -s "/usr/lib/vst3/Surge XT.vst3" "plugins/Surge XT.vst3"
+>
+> # macOS
+> ln -s "/Library/Audio/Plug-Ins/VST3/Surge XT.vst3" "plugins/Surge XT.vst3"
+> ```
+>
+> The project used to ship a `make link-plugins` wrapper for this; it was
+> removed in favour of this one-line symlink so the discovery path stays
+> explicit and there's only one way to populate `plugins/`.
 >
 > **On arm64 Linux?** The official Surge XT release only ships an x86_64
 > Linux build. Install via your package manager (`apt install surge-xt`) or
-> build from source, then run `make link-plugins`.
+> build from source, then use the manual symlink above.
+
+> **Heads-up — VST tests still hardcode the Linux install path:**
+> `tests/data/vst/test_preset_params.py` and `tests/docker/test_smoke.py`
+> currently hardcode `/usr/lib/vst3/Surge XT.vst3` as the VST3 location, so
+> even after `plugins/Surge XT.vst3` exists, `pytest -m requires_vst` will
+> still skip on macOS (and on Linux installs where the VST3 lives somewhere
+> other than `/usr/lib/vst3/`). Tracked in
+> [#631](https://github.com/tinaudio/synth-setter/issues/631) — the fix
+> will default the tests to `plugins/Surge XT.vst3` with an env-var
+> override for CI.
 
 ### 2e. Export environment variables
 
@@ -189,8 +215,8 @@ used for audio dataset generation. The data pipeline renders audio by
 programmatically driving this plugin.
 
 Installation is covered in [section 2d](#2d-install-the-surge-xt-vst3) —
-`make install-surge-xt` is the canonical path, with `make link-plugins` as an
-alternative for users who already have a system-wide install.
+`make install-surge-xt` is the canonical path; a manual symlink from a
+system-wide install is an alternative.
 
 **Verify:**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,11 +57,14 @@ editable mode:
 make install
 ```
 
-Or with plain pip (no editable install):
+Or with plain pip:
 
 ```bash
 pip install -r requirements.txt
+pip install -e .
 ```
+
+(Drop `-e` for a non-editable install.)
 
 After installing, activate pre-commit hooks:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,11 +9,14 @@ ______________________________________________________________________
 ## 1. Prerequisites
 
 - **Linux or macOS** — Windows is not supported (see the project README).
-- **Python 3.10+** (check with `python --version`)
-- **Git**
-- **make** (ships with macOS/Linux)
+- **Git**, **curl**, **make** (all ship with macOS/Linux)
 - **A CUDA GPU** is recommended for training. CPU and MPS (Apple Silicon) trainers
   are available but significantly slower.
+
+`make install` installs [uv](https://docs.astral.sh/uv/) and a managed
+Python 3.10 interpreter for you — you do not need to install Python
+yourself. If you prefer to manage the interpreter and venv manually, see
+[Appendix A](#appendix-a-manual-environment-setup).
 
 ______________________________________________________________________
 
@@ -26,54 +29,41 @@ git clone https://github.com/tinaudio/synth-setter.git
 cd synth-setter
 ```
 
-### 2b. Create a virtual environment
+### 2b. Install
 
-The recommended approach uses [uv](https://docs.astral.sh/uv/getting-started/installation/)
-to create a venv with a pinned Python version:
+`make install` is the canonical end-to-end install. It:
 
-```bash
-# Install uv (if you don't have it)
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Create and activate a Python 3.10 venv
-uv venv --python 3.10 .venv
-source .venv/bin/activate
-```
-
-Alternatively, if you already have Python 3.10+ installed:
-
-```bash
-python -m venv .venv
-source .venv/bin/activate
-```
-
-### 2c. Install dependencies
-
-`make install` is the canonical command. It installs uv, all dependencies from
-`requirements.txt` (including pre-commit and dev tooling), and the project in
-editable mode:
+1. Installs [uv](https://docs.astral.sh/uv/) if it is not already on your PATH.
+2. Creates `.venv/` using a managed Python 3.10 interpreter (downloaded by uv
+   if you do not have one locally). The venv prompt label is `synth-setter`.
+3. Installs everything in `requirements.txt` plus the project itself in
+   editable mode (`pip install -e .`).
+4. Registers the pre-commit hooks.
 
 ```bash
 make install
 ```
 
-Or with plain pip:
+Re-running `make install` is safe: it reuses `.venv/` if it already exists and
+is Python 3.10, and refreshes the installed packages. If `.venv/` exists with a
+different Python version, `make install` errors and asks you to remove it
+first.
+
+The pre-commit hooks run Ruff (linting + formatting), pyright (type checking),
+mdformat, codespell, and several other checks automatically on each commit.
+
+> **Prefer pip or conda?** See
+> [Appendix A](#appendix-a-manual-environment-setup) for a
+> walkthrough using your own Python interpreter and environment tooling.
+
+### 2c. Activate the venv
 
 ```bash
-pip install -r requirements.txt
-pip install -e .
+source .venv/bin/activate
 ```
 
-(Drop `-e` for a non-editable install.)
-
-After installing, activate pre-commit hooks:
-
-```bash
-pre-commit install
-```
-
-The hooks run Ruff (linting + formatting), pyright (type checking), mdformat,
-codespell, and several other checks automatically on each commit.
+Your prompt should change to `(synth-setter)`. All subsequent commands in this
+guide assume the venv is active.
 
 ### 2d. Symlink the Surge XT VST3
 
@@ -577,3 +567,72 @@ ______________________________________________________________________
   [docs/reference/configuration-reference.md](reference/configuration-reference.md)
   covers all config layers in detail.
 - **Available make targets:** Run `make help` to see all commands.
+
+______________________________________________________________________
+
+## Appendix A: Manual environment setup
+
+`make install` is the canonical path for most users — it installs uv, a
+managed Python 3.10 interpreter, the venv, dependencies, and pre-commit.
+This appendix is for users who want to manage Python and the environment
+themselves (pip, conda, pyenv, system Python, etc.).
+
+**Requirement:** Python 3.10 or newer (the project declares
+`requires-python = ">=3.10"` in `pyproject.toml`; `pip` enforces this).
+
+### A.1. Plain pip + venv
+
+```bash
+# Use any Python 3.10+ interpreter
+python3.10 -m venv .venv
+source .venv/bin/activate
+
+pip install -r requirements.txt
+pip install -e .
+pre-commit install
+```
+
+Drop `-e` on the second line for a non-editable install.
+
+### A.2. conda
+
+```bash
+conda create -n synth-setter python=3.10
+conda activate synth-setter
+
+pip install -r requirements.txt
+pip install -e .
+pre-commit install
+```
+
+`requirements.txt` contains pip-only packages (torch, lightning, hydra-core,
+etc.), so we install them with pip inside the conda environment rather than
+through conda-forge.
+
+### A.3. uv pip without `make install`
+
+If you want to drive uv directly (e.g., to point at a specific interpreter
+you manage yourself):
+
+```bash
+uv venv --python 3.10 --prompt synth-setter .venv
+source .venv/bin/activate
+uv pip install -r requirements.txt -e .
+pre-commit install
+```
+
+This is what `make install` does under the hood.
+
+### A.4. GPU vs CPU PyTorch
+
+`requirements.txt` pins `torch>=2.0.0` without fixing the CPU/CUDA build.
+After installing requirements, override with the wheel you want from the
+[PyTorch install matrix](https://pytorch.org/get-started/locally/):
+
+```bash
+# Example: CUDA 12.1 wheel
+pip install --index-url https://download.pytorch.org/whl/cu121 torch
+```
+
+`make install` inherits the same CPU/CUDA choice — it does not pick a wheel
+for you.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -65,18 +65,32 @@ source .venv/bin/activate
 Your prompt should change to `(synth-setter)`. All subsequent commands in this
 guide assume the venv is active.
 
-### 2d. Symlink the Surge XT VST3
+### 2d. Install the Surge XT VST3
 
-If you have [Surge XT](https://surge-synthesizer.github.io/) installed, symlink
-it into `plugins/` so the test suite and data pipeline can find it:
+The test suite and data pipeline need the [Surge XT](https://surge-synthesizer.github.io/)
+VST3 at `plugins/Surge XT.vst3`. The canonical path downloads the pinned
+release directly from GitHub:
 
 ```bash
-make link-plugins
+make install-surge-xt
 ```
 
-This detects your platform (Linux / macOS) and creates a symlink at
-`plugins/Surge XT.vst3`. See [section 4a](#4a-surge-xt-vst-plugin) for
-installation instructions if you don't have Surge XT yet.
+This downloads the `pluginsonly` archive for your platform (Linux x86_64 or
+macOS universal) from the [Surge XT 1.3.4 release](https://github.com/surge-synthesizer/releases-xt/releases/tag/1.3.4),
+verifies its md5 checksum, and extracts `Surge XT.vst3` into `plugins/`. The
+archive is cached at `~/.cache/synth-setter/surge-xt-1.3.4/`, so re-runs that
+have to re-extract (e.g. after `rm -rf plugins/`) skip the download. If
+`plugins/Surge XT.vst3` already exists, the target is a no-op — remove it
+first to reinstall.
+
+> **Already have Surge XT installed system-wide?** `make link-plugins`
+> symlinks an existing install (`/usr/lib/vst3/Surge XT.vst3` on Linux,
+> `/Library/Audio/Plug-Ins/VST3/Surge XT.vst3` on macOS) into `plugins/`
+> instead of downloading a second copy.
+>
+> **On arm64 Linux?** The official Surge XT release only ships an x86_64
+> Linux build. Install via your package manager (`apt install surge-xt`) or
+> build from source, then run `make link-plugins`.
 
 ### 2e. Export environment variables
 
@@ -101,100 +115,9 @@ This runs the quick test suite (excluding slow tests and tests that require a
 VST plugin). All tests should pass. If you see import errors, double-check that
 the virtual environment is active and dependencies installed correctly.
 
-### 2g. Alternative: GitHub Codespaces
-
-Instead of setting up locally, you can open the repo in a GitHub Codespace. The
-Codespace uses the same Docker image (`tinaudio/synth-setter:dev-snapshot`) we run on
-RunPod, so VST-dependent tests, `generate_dataset` → R2 uploads, and CPU
-training all work identically — no local Surge XT, rclone, or R2 setup needed.
-GPU training still runs on RunPod.
-
-**Prerequisites:**
-
-Configure these as Codespaces user/org secrets so they're forwarded into
-the container at runtime:
-
-- `RCLONE_CONFIG_R2_ACCESS_KEY_ID`, `RCLONE_CONFIG_R2_SECRET_ACCESS_KEY`,
-  `RCLONE_CONFIG_R2_ENDPOINT` — for R2 uploads/downloads via rclone
-- `WANDB_API_KEY` — for W&B logging
-
-The image itself is public and pulls anonymously; no Docker Hub
-credentials are required.
-
-**Open a Codespace:**
-
-1. On GitHub, click **Code → Codespaces → Create codespace on main**.
-2. First start takes ~5 min (image pull). Subsequent starts are fast.
-3. `.devcontainer/post-create.sh` initializes submodules, installs the
-   workspace editable, and wires up pre-commit hooks — then the terminal is
-   ready.
-
-**Verify:**
-
-```bash
-make test
-python -c "import torch; print(torch.cuda.is_available())"   # False (CPU)
-rclone lsd r2:intermediate-data
-```
-
-**Fall back to RunPod for** full GPU training (CUDA kernels, large batch
-sizes) and multi-hour runs.
-
-### 2h. Alternative: Local Dev Container
-
-If you want the same image Codespaces uses (VST plugins, rclone, Python
-deps) but prefer to work on your own machine, open the dev container
-locally **on the main working tree** and create git worktrees *inside* the
-container.
-
-**Prerequisites:**
-
-- [Docker Desktop](https://www.docker.com/products/docker-desktop/) and
-  either the VS Code
-  [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-  or the [`devcontainer` CLI](https://github.com/devcontainers/cli).
-- R2 + W&B credentials (see [§4b](#4b-rclone--cloudflare-r2) and
-  [§4c](#4c-weights--biases-wb)). The checked-in dev container configs
-  do **not** automatically load `.env` — after opening the container,
-  source the vars inside the container shell (`set -a && source .env && set +a`)
-  or set them via Codespaces secrets / Dev Container environment settings
-  so rclone and W&B can access them.
-- Apple Silicon: set `DOCKER_DEFAULT_PLATFORM=linux/amd64` (the image is
-  amd64-only).
-
-**Open the container on main:**
-
-```bash
-cd /path/to/synth-setter
-devcontainer up --workspace-folder .
-# or in VS Code: "Dev Containers: Reopen in Container"
-```
-
-**Create worktrees from inside the container:**
-
-```bash
-# Inside the container, starting from the workspace root on main:
-git worktree add .claude/worktrees/my-feature -b feat/my-feature
-cd .claude/worktrees/my-feature
-```
-
-This is the supported local pattern. Mounting a worktree directly from the
-host does not work — the worktree's `.git` file points to
-`<repo>/.git/worktrees/<name>/` on the host, which is outside the container's
-bind mount, so git submodule/hook operations fail to resolve their gitdir.
-
-**Caveats:**
-
-- `git worktree list` inside the container marks host-created worktrees as
-  `prunable` (their host paths don't resolve inside the mount). Do **not**
-  run `git worktree prune` inside the container — it will drop registry
-  entries for worktrees that are still valid on the host.
-- `git submodule update` for the private `tinaudio/skills` submodule needs
-  GitHub credentials available to git inside the container. VS Code's git
-  credential helper usually forwards these automatically. For the CLI, run
-  `gh auth login && gh auth setup-git` inside the container, or configure
-  git's credential helper with a PAT. Exporting `GITHUB_TOKEN` alone is not
-  sufficient — git will not use it without a credential helper configured.
+> **Prefer a container-based setup?** GitHub Codespaces and the local dev
+> container come with Python, Surge XT, and rclone pre-installed. See
+> [Appendix B: Container-based setup](#appendix-b-container-based-setup).
 
 ______________________________________________________________________
 
@@ -264,11 +187,9 @@ experiments. **None of these are needed for the k-osc quickstart above.**
 used for audio dataset generation. The data pipeline renders audio by
 programmatically driving this plugin.
 
-**Install:**
-
-1. Download the installer from [surge-synthesizer.github.io](https://surge-synthesizer.github.io/)
-2. Run the installer and follow the prompts
-3. Note the installation path (the test suite needs to find the plugin binary)
+Installation is covered in [section 2d](#2d-install-the-surge-xt-vst3) —
+`make install-surge-xt` is the canonical path, with `make link-plugins` as an
+alternative for users who already have a system-wide install.
 
 **Verify:**
 
@@ -636,3 +557,107 @@ pip install --index-url https://download.pytorch.org/whl/cu121 torch
 
 `make install` inherits the same CPU/CUDA choice — it does not pick a wheel
 for you.
+
+______________________________________________________________________
+
+## Appendix B: Container-based setup
+
+The canonical local flow in [section 2](#2-installation) works on any
+POSIX machine. If you'd rather skip installing Surge XT, rclone, and
+Python deps yourself, the project also ships a dev container image with
+all of these pre-installed.
+
+### B.1. GitHub Codespaces
+
+Instead of setting up locally, you can open the repo in a GitHub Codespace. The
+Codespace uses the same Docker image (`tinaudio/synth-setter:dev-snapshot`) we run on
+RunPod, so VST-dependent tests, `generate_dataset` → R2 uploads, and CPU
+training all work identically — no local Surge XT, rclone, or R2 setup needed.
+GPU training still runs on RunPod.
+
+**Prerequisites:**
+
+Configure these as Codespaces user/org secrets so they're forwarded into
+the container at runtime:
+
+- `RCLONE_CONFIG_R2_ACCESS_KEY_ID`, `RCLONE_CONFIG_R2_SECRET_ACCESS_KEY`,
+  `RCLONE_CONFIG_R2_ENDPOINT` — for R2 uploads/downloads via rclone
+- `WANDB_API_KEY` — for W&B logging
+
+The image itself is public and pulls anonymously; no Docker Hub
+credentials are required.
+
+**Open a Codespace:**
+
+1. On GitHub, click **Code → Codespaces → Create codespace on main**.
+2. First start takes ~5 min (image pull). Subsequent starts are fast.
+3. `.devcontainer/post-create.sh` initializes submodules, installs the
+   workspace editable, and wires up pre-commit hooks — then the terminal is
+   ready.
+
+**Verify:**
+
+```bash
+make test
+python -c "import torch; print(torch.cuda.is_available())"   # False (CPU)
+rclone lsd r2:intermediate-data
+```
+
+**Fall back to RunPod for** full GPU training (CUDA kernels, large batch
+sizes) and multi-hour runs.
+
+### B.2. Local dev container
+
+If you want the same image Codespaces uses (VST plugins, rclone, Python
+deps) but prefer to work on your own machine, open the dev container
+locally **on the main working tree** and create git worktrees *inside* the
+container.
+
+**Prerequisites:**
+
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/) and
+  either the VS Code
+  [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+  or the [`devcontainer` CLI](https://github.com/devcontainers/cli).
+- R2 + W&B credentials (see [§4b](#4b-rclone--cloudflare-r2) and
+  [§4c](#4c-weights--biases-wb)). The checked-in dev container configs
+  do **not** automatically load `.env` — after opening the container,
+  source the vars inside the container shell (`set -a && source .env && set +a`)
+  or set them via Codespaces secrets / Dev Container environment settings
+  so rclone and W&B can access them.
+- Apple Silicon: set `DOCKER_DEFAULT_PLATFORM=linux/amd64` (the image is
+  amd64-only).
+
+**Open the container on main:**
+
+```bash
+cd /path/to/synth-setter
+devcontainer up --workspace-folder .
+# or in VS Code: "Dev Containers: Reopen in Container"
+```
+
+**Create worktrees from inside the container:**
+
+```bash
+# Inside the container, starting from the workspace root on main:
+git worktree add .claude/worktrees/my-feature -b feat/my-feature
+cd .claude/worktrees/my-feature
+```
+
+This is the supported local pattern. Mounting a worktree directly from the
+host does not work — the worktree's `.git` file points to
+`<repo>/.git/worktrees/<name>/` on the host, which is outside the container's
+bind mount, so git submodule/hook operations fail to resolve their gitdir.
+
+**Caveats:**
+
+- `git worktree list` inside the container marks host-created worktrees as
+  `prunable` (their host paths don't resolve inside the mount). Do **not**
+  run `git worktree prune` inside the container — it will drop registry
+  entries for worktrees that are still valid on the host.
+- `git submodule update` for the private `tinaudio/skills` submodule needs
+  GitHub credentials available to git inside the container. VS Code's git
+  credential helper usually forwards these automatically. For the CLI, run
+  `gh auth login && gh auth setup-git` inside the container, or configure
+  git's credential helper with a PAT. Exporting `GITHUB_TOKEN` alone is not
+  sufficient — git will not use it without a credential helper configured.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -26,7 +26,21 @@ git clone https://github.com/tinaudio/synth-setter.git
 cd synth-setter
 ```
 
-### 2b. Create a virtual environment (recommended)
+### 2b. Create a virtual environment
+
+The recommended approach uses [uv](https://docs.astral.sh/uv/getting-started/installation/)
+to create a venv with a pinned Python version:
+
+```bash
+# Install uv (if you don't have it)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Create and activate a Python 3.10 venv
+uv venv --python 3.10 .venv
+source .venv/bin/activate
+```
+
+Alternatively, if you already have Python 3.10+ installed:
 
 ```bash
 python -m venv .venv
@@ -35,31 +49,56 @@ source .venv/bin/activate
 
 ### 2c. Install dependencies
 
-The project uses [uv](https://docs.astral.sh/uv/getting-started/installation/)
-for fast dependency resolution:
+`make install` is the canonical command. It installs uv, all dependencies from
+`requirements.txt` (including pre-commit and dev tooling), and the project in
+editable mode:
 
 ```bash
-pip install uv
-uv pip install -r requirements.txt -e .
+make install
 ```
 
-Or with plain pip:
+Or with plain pip (no editable install):
 
 ```bash
-pip install -r requirements.txt -e .
+pip install -r requirements.txt
 ```
 
-### 2d. Install pre-commit hooks
+After installing, activate pre-commit hooks:
 
 ```bash
-pip install pre-commit
 pre-commit install
 ```
 
 The hooks run Ruff (linting + formatting), pyright (type checking), mdformat,
 codespell, and several other checks automatically on each commit.
 
-### 2e. Verify the installation
+### 2d. Symlink the Surge XT VST3
+
+If you have [Surge XT](https://surge-synthesizer.github.io/) installed, symlink
+it into `plugins/` so the test suite and data pipeline can find it:
+
+```bash
+make link-plugins
+```
+
+This detects your platform (Linux / macOS) and creates a symlink at
+`plugins/Surge XT.vst3`. See [section 4a](#4a-surge-xt-vst-plugin) for
+installation instructions if you don't have Surge XT yet.
+
+### 2e. Export environment variables
+
+The project reads R2 credentials, W&B keys, and other config from a `.env` file.
+After creating your `.env` (see [section 4b](#4b-rclone--cloudflare-r2) for the
+template), export the variables into your shell:
+
+```bash
+set -a && source .env && set +a
+```
+
+> Environment variable management is being consolidated under
+> [#563](https://github.com/tinaudio/synth-setter/issues/563).
+
+### 2f. Verify the installation
 
 ```bash
 make test
@@ -69,7 +108,7 @@ This runs the quick test suite (excluding slow tests and tests that require a
 VST plugin). All tests should pass. If you see import errors, double-check that
 the virtual environment is active and dependencies installed correctly.
 
-### 2f. Alternative: GitHub Codespaces
+### 2g. Alternative: GitHub Codespaces
 
 Instead of setting up locally, you can open the repo in a GitHub Codespace. The
 Codespace uses the same Docker image (`tinaudio/synth-setter:dev-snapshot`) we run on
@@ -108,7 +147,7 @@ rclone lsd r2:intermediate-data
 **Fall back to RunPod for** full GPU training (CUDA kernels, large batch
 sizes) and multi-hour runs.
 
-### 2g. Alternative: Local Dev Container
+### 2h. Alternative: Local Dev Container
 
 If you want the same image Codespaces uses (VST plugins, rclone, Python
 deps) but prefer to work on your own machine, open the dev container

--- a/uv.lock
+++ b/uv.lock
@@ -1,7 +1,0 @@
-version = 1
-requires-python = ">=3.10"
-
-[[package]]
-name = "synth-permutations"
-version = "0.1.0"
-source = { virtual = "." }


### PR DESCRIPTION
## Summary
- Rewrite README install section around a 5-step flow; `make install` is now the canonical end-to-end setup.
- `make install` is end-to-end: installs uv (if missing), creates `.venv/` with a uv-managed Python 3.10 interpreter (so users don't need Python pre-installed), installs `requirements.txt` + the project in editable mode, and registers pre-commit (skipped when `core.hooksPath` is set so it plays nicely with the dev container).
- Add `make link-plugins`: detects Linux/macOS and symlinks the installed Surge XT VST3 into `plugins/`, with explicit destination-safety handling (replaces symlinks/files, errors on real directory).
- Deduplicate README vs `docs/getting-started.md` §2 — README has a terse flow, getting-started has the walkthrough.
- Move Codespaces & Docker content below the primary install + quick-start flow in README.
- Add env-var export section and devcontainer-as-root note (pointing at the real `.devcontainer/{cpu,gpu}/devcontainer.json` paths).
- Streamline getting-started §2 to the uv-first canonical flow. Move the pip / conda / plain-venv walkthrough to a new **Appendix A: Manual environment setup** at the end of the doc.
- Drop `uv.lock`: we're committing to `uv pip` rather than `uv sync`. `uv sync` has known edge cases around torch indexes, transitive-dep resolution, and CPU/CUDA wheel selection that make it unsuitable here today.

## Test plan
- [x] Fresh Linux (Ubuntu 22.04 devcontainer) with Surge XT pre-installed: `make install` creates `.venv/` at Python 3.10.12 with prompt `synth-setter`, installs deps, `make test` → 155 passed / 2 skipped.
- [x] `make install` reruns idempotently (reuses `.venv/` if already 3.10).
- [x] `make install` errors when `.venv/` exists at a different Python version (tested with a 3.11 venv — clear error, suggests `rm -rf .venv`).
- [x] `make install` skips pre-commit install when `core.hooksPath` is set (dev container case).
- [x] `make link-plugins` creates symlink on Linux (`/usr/lib/vst3/Surge XT.vst3`).
- [x] `make link-plugins` destination safety: replaces existing symlink, replaces regular file, errors when destination is a real directory.
- [x] `make link-plugins` prints searched paths + install URL when Surge XT is not found.
- [x] `make help` lists the new `link-plugins` target.
- [x] No content duplication between README and getting-started §2 (README is terse, getting-started has the full walkthrough + appendix).
- [x] README ↔ getting-started anchors all resolve (`#appendix-a-manual-environment-setup`, `#2g-alternative-github-codespaces`, `#2h-alternative-local-dev-container`).
- [x] `grep -rn "ln -s.*Surge XT.vst3" docker/` still finds Dockerfile symlink references (ubuntu22_04/Dockerfile:173, :317).
- [ ] Fresh macOS (Apple Silicon) without Python pre-installed: `make install` → `make test` passes end-to-end (needs manual verification).
- [ ] Fresh Ubuntu 24.04 without uv pre-installed: `curl | sh` install branch of `make install` fires and succeeds (needs manual verification).

Closes #601
Closes #487