### PR TITLE
chore: gitignore .worktrees/ and /worktrees/ directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,7 @@ plugins/
 
 # Advisory reports written by .claude/hooks/doc-drift.sh and pr-review-resolver.sh
 .agent-reviews/
+
+# Git worktrees
+.worktrees/
+/worktrees/


### PR DESCRIPTION
## Summary

- Add `.worktrees/` and `/worktrees/` to `.gitignore` under a new "Git worktrees" section
- Users regularly run `git worktree add` into these subdirectories (per CLAUDE.md's isolated-worktree workflow), and git was reporting them as untracked
- Uses the repo convention of a trailing slash for directories

Closes #615

## Test plan

- [x] `git status` in the main working tree no longer reports `.worktrees/` as untracked after this lands
- [x] `make format` / pre-commit passes on the staged change (codespell, ruff, prettier, etc. all pass on the `.gitignore` change)
- [x] No other files are modified