### PR TITLE
fix(testing): set check_val_every_n_epoch=1 in test_train_epoch_double_val_loop

### DIFF
--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -80,7 +80,6 @@ def test_train_epoch_gpu_amp(cfg_train: DictConfig) -> None:
     train(cfg_train)
 
 
-# TODO: fix val_check_interval incompatibility with check_val_every_n_epoch=None (#47)
 @pytest.mark.gpu
 @RunIf(min_gpus=1)
 @pytest.mark.slow
@@ -93,6 +92,7 @@ def test_train_epoch_double_val_loop(cfg_train: DictConfig) -> None:
     with open_dict(cfg_train):
         cfg_train.trainer.max_epochs = 1
         cfg_train.trainer.accelerator = "gpu"
+        cfg_train.trainer.check_val_every_n_epoch = 1
         cfg_train.trainer.val_check_interval = 0.5
     train(cfg_train)
 


### PR DESCRIPTION
## Summary

Newer PyTorch Lightning rejects a float `val_check_interval` when
`check_val_every_n_epoch` is `None`, raising `MisconfigurationException`.
Our `configs/trainer/default.yaml` sets `check_val_every_n_epoch: null`,
and `test_train_epoch_double_val_loop` overrides `val_check_interval = 0.5`
(a float). That combination now fails.

Fix is test-only: also set `cfg_train.trainer.check_val_every_n_epoch = 1`
inside the test's `open_dict` block so the test exercises the intended
"two val loops per epoch" behavior without tripping Lightning's
configuration check. Production training config is untouched.

Also removes the TODO comment that referenced this issue.

Fixes #47

## Test plan

- [ ] CI: non-GPU suite stays green.
- [ ] GPU runner: `pytest tests/test_train.py::test_train_epoch_double_val_loop -q`
      (test is `@pytest.mark.gpu` + `@pytest.mark.slow`, cannot be run
      locally without a GPU).
- [ ] Confirm no `MisconfigurationException` about `val_check_interval` /
      `check_val_every_n_epoch` in the GPU test output.