### PR TITLE
tests: use force-add for trainer.max_epochs override in test_hydra_sweep_ddp_sim

### DIFF
--- a/tests/test_sweeps.py
+++ b/tests/test_sweeps.py
@@ -66,7 +66,7 @@ def test_hydra_sweep_ddp_sim(tmp_path: Path) -> None:
         "-m",
         "hydra.sweep.dir=" + str(tmp_path),
         "trainer=ddp_sim",
-        "trainer.max_epochs=3",
+        "+trainer.max_epochs=3",
         "+trainer.limit_train_batches=0.01",
         "+trainer.limit_val_batches=0.1",
         "+trainer.limit_test_batches=0.1",


### PR DESCRIPTION
## Summary

`configs/trainer/default.yaml` defines `min_steps`/`max_steps` but not `max_epochs`. In struct mode, Hydra rejects `trainer.max_epochs=3` (override-existing) because the key is not in the config. The error itself directs to the fix: use `+trainer.max_epochs=3` (force-add). Sibling test `test_hydra_sweep` already uses this same pattern via `++trainer.fast_dev_run=true`.

This PR only changes the test — the trainer config's step-based contract is intentional and left untouched.

Fixes #620

## Test plan

- [ ] `pytest tests/test_sweeps.py::test_hydra_sweep_ddp_sim` passes on GPU CI. The test is marked `@pytest.mark.gpu @pytest.mark.slow`, so full verification requires a GPU runner.
- [ ] `make format` — passed locally.
