### PR TITLE
fix(testing): force validation to run in test_train_resume so epoch checkpoints save

### DIFF
--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -137,6 +137,12 @@ def test_train_resume(tmp_path: Path, cfg_train: DictConfig) -> None:
     with open_dict(cfg_train):
         cfg_train.trainer.max_epochs = 1
         cfg_train.trainer.accelerator = "gpu"
+        # Force validation to run once per epoch so ModelCheckpoint (which
+        # monitors val/loss) fires and writes epoch_NNN.ckpt. The shared
+        # fixture's limit_train_batches=0.01 would otherwise keep the
+        # trainer below the default val_check_interval=10_000.
+        cfg_train.trainer.check_val_every_n_epoch = 1
+        cfg_train.trainer.val_check_interval = None
 
     HydraConfig().set_config(cfg_train)
     metric_dict_1, _ = train(cfg_train)


### PR DESCRIPTION
## Summary

`tests/test_train.py::test_train_resume` was failing at line 146 with `AssertionError: assert 'epoch_000.ckpt' in ['last.ckpt']`.

The `ModelCheckpoint` callback in `configs/callbacks/default.yaml` monitors `val/loss` with `save_last: True` and `filename: "epoch_{epoch:03d}"`, so `last.ckpt` is written unconditionally but `epoch_NNN.ckpt` requires `val/loss` to be logged (i.e., a validation pass). The shared fixture `cfg_train_global` sets `limit_train_batches=0.01`, while `configs/trainer/default.yaml` sets `val_check_interval=10_000` and `check_val_every_n_epoch=null`, so validation never fires during the test.

The fix sets `check_val_every_n_epoch=1` and `val_check_interval=None` inside the test's `open_dict(cfg_train)` block. The same config object is reused for the resume call, so the overrides persist for both `train()` invocations. No production configs are touched.

Fixes #619

## Test plan

This test is marked `@pytest.mark.gpu @pytest.mark.slow`, so full verification runs on GPU CI.

- [ ] `pytest tests/test_train.py::test_train_resume` passes on GPU CI
- [ ] `last.ckpt`, `epoch_000.ckpt`, and (after resume) `epoch_001.ckpt` all appear; `epoch_002.ckpt` does not
- [ ] `make format` passes locally (confirmed)