### PR TITLE
tests: use cfg_train data config in test_train_eval to avoid hardcoded path

### DIFF
--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -29,6 +29,10 @@ def test_train_eval(tmp_path: Path, cfg_train: DictConfig, cfg_eval: DictConfig)
         cfg_train.test = True
     with open_dict(cfg_eval):
         cfg_eval.trainer.accelerator = "gpu"
+        # `configs/eval.yaml` defaults to `data: surge_mini`, which hardcodes a researcher-local
+        # path that does not exist on the CI GPU runner. Reuse the training data config so the
+        # test exercises a self-consistent train->eval roundtrip.
+        cfg_eval.data = cfg_train.data
 
     HydraConfig().set_config(cfg_train)
     train_metric_dict, _ = train(cfg_train)


### PR DESCRIPTION
## Summary

- `tests/test_eval.py::test_train_eval` fails on the CI GPU runner with `FileNotFoundError: '/data/scratch/acw585/surge-mini/train.h5'` because `configs/eval.yaml` defaults to `data: surge_mini`, which hardcodes a researcher-local dataset path that does not exist on the runner.
- The test already runs `train(cfg_train)` successfully on the ksin data config. Override `cfg_eval.data` with `cfg_train.data` inside the test so `evaluate(cfg_eval)` exercises the same (ksin) datamodule, making it a self-consistent train->eval roundtrip.
- Scoped strictly to the test. `configs/eval.yaml` and `configs/data/surge_mini.yaml` are left untouched — those paths are real and used by non-CI workflows.

Fixes #617

## Test plan

- [ ] CI GPU runner: `pytest tests/test_eval.py::test_train_eval -m 'gpu and slow'` passes (requires GPU — cannot be verified locally on a CPU-only host).
- [x] `make format` passes cleanly in the worktree.
- [x] Pyright / ruff / docformatter hooks pass.
- [x] Production configs (`configs/eval.yaml`, `configs/data/surge_mini.yaml`) are unchanged.