### PR TITLE
fix(testing): switch test_hydra_sweep_ddp_sim to integer batch limits to avoid DDP sharding to 0

### DIFF
--- a/tests/test_sweeps.py
+++ b/tests/test_sweeps.py
@@ -67,9 +67,9 @@ def test_hydra_sweep_ddp_sim(tmp_path: Path) -> None:
         "hydra.sweep.dir=" + str(tmp_path),
         "trainer=ddp_sim",
         "+trainer.max_epochs=3",
-        "+trainer.limit_train_batches=0.01",
-        "+trainer.limit_val_batches=0.1",
-        "+trainer.limit_test_batches=0.1",
+        "+trainer.limit_train_batches=1",
+        "+trainer.limit_val_batches=1",
+        "+trainer.limit_test_batches=1",
         "model.optimizer.lr=0.005,0.01,0.02",
     ] + overrides
     run_sh_command(command)


### PR DESCRIPTION
## Summary

- Switch `tests/test_sweeps.py::test_hydra_sweep_ddp_sim` from fraction-based limits (`0.01` / `0.1` / `0.1`) to integer limits (`1` / `1` / `1`).
- Lightning shards val/test loaders across DDP ranks before applying `limit_*_batches`. With `limit_val_batches=0.1` on a 5-batch val loader under DDP sim, the per-rank slice rounds to 0 batches and Lightning raises `MisconfigurationException` before `trainer.fit` can progress.
- This is a sibling fix to #515, which applied the same integer-limits template to `test_train_ddp_sim` for the same root cause (#46). The template was never carried over to the sweep test.
- `test_hydra_sweep` (non-DDP) is intentionally left untouched — its fractions work fine without DDP sharding. The skipped `test_optuna_sweep*` tests are also left alone; #514 owns their rewrite.

Fixes #626

## Test plan

- [ ] GPU CI runs `pytest tests/test_sweeps.py::test_hydra_sweep_ddp_sim -v -m "slow and gpu"` and it passes end-to-end (cannot be verified locally without GPU + DDP sim).
- [x] `make format` passes cleanly on the changed file.
