### PR TITLE
docs(documentation): clarify W&B opt-in in README and getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ under the GPL-3.0 license.
 
 - **Flow matching and baseline models** for synthesizer parameter estimation
 - **Distributed data pipeline** for VST audio dataset generation with cloud support
-- **W&B integration** for experiment tracking and model checkpointing
+- **W&B integration** (opt-in) for experiment tracking and model checkpointing — fresh installs log to CSV + TensorBoard; pass `logger=wandb` to enable W&B
 - **Docker support** for reproducible training and generation environments
 - **Hydra configs** for flexible experiment management
 
@@ -75,6 +75,12 @@ make install-surge-xt
 # 5. Export environment variables (R2, W&B — see §4b in getting-started)
 set -a && source .env && set +a
 ```
+
+> **Experiment tracking:** the default training run logs to CSV + TensorBoard
+> (no external account needed). W&B is **opt-in** — `python src/train.py
+> ... logger=wandb` after `wandb login` (or setting `WANDB_API_KEY`). See
+> [getting-started §4c](docs/getting-started.md#4c-weights--biases-wb) for
+> the full enable/disable workflow.
 
 > **Already have Surge XT installed system-wide?** Skip `make install-surge-xt`
 > and symlink it manually:

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ set -a && source .env && set +a
 ```
 
 > **Experiment tracking:** the default training run logs to CSV + TensorBoard
-> (no external account needed). W&B is **opt-in** — `python src/train.py
-> ... logger=wandb` after `wandb login` (or setting `WANDB_API_KEY`). See
+> (no external account needed). W&B is **opt-in** — run training with
+> `logger=wandb` after `wandb login` (or setting `WANDB_API_KEY`). See
 > [getting-started §4c](docs/getting-started.md#4c-weights--biases-wb) for
 > the full enable/disable workflow.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -288,10 +288,10 @@ rclone lsd r2:<bucket-name>/
 
 You should see top-level directories like `data/`, `train/`, and `eval/`.
 
-### 4c. Weights & Biases (W&B) — opt-in
+### 4c. Weights & Biases (W&B)
 
-[Weights & Biases](https://wandb.ai/) provides experiment tracking, metric
-logging, and model checkpoint storage. **It is opt-in.** The default training
+**W&B is opt-in.** [Weights & Biases](https://wandb.ai/) provides experiment
+tracking, metric logging, and model checkpoint storage. The default training
 logger (`configs/logger/many_loggers.yaml`) composes CSV + TensorBoard, so
 `python src/train.py ...` works out of the box with no W&B account and no
 `wandb login` prompt. The integration is handled through Lightning's

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -173,8 +173,9 @@ with decreasing loss values.
 - Hydra composes the config from `configs/train.yaml` + the experiment override
 - Lightning sets up the data module, model, callbacks, and trainer
 - Checkpoints are saved under `logs/{task_name}/{experiment_name}/{run_name}-{timestamp}/checkpoints/` (for this command: `logs/train/kosc/ffn_mse-<timestamp>/checkpoints/`)
-- If W&B is configured (see [section 4c](#4c-weights--biases-wb)), metrics are
-  logged to your dashboard
+- Metrics are logged locally to CSV + TensorBoard by default. If you opt into
+  W&B (see [section 4c](#4c-weights--biases-wb)), metrics also go to your W&B
+  dashboard
 
 ### 3b. Available k-osc experiments
 
@@ -287,43 +288,57 @@ rclone lsd r2:<bucket-name>/
 
 You should see top-level directories like `data/`, `train/`, and `eval/`.
 
-### 4c. Weights & Biases (W&B)
+### 4c. Weights & Biases (W&B) — opt-in
 
-[Weights & Biases](https://wandb.ai/) is used for experiment tracking, metric
-logging, and model checkpoint storage. The integration is handled through
-Lightning's `WandbLogger` -- there are no direct `wandb.init()` calls in the
-codebase.
+[Weights & Biases](https://wandb.ai/) provides experiment tracking, metric
+logging, and model checkpoint storage. **It is opt-in.** The default training
+logger (`configs/logger/many_loggers.yaml`) composes CSV + TensorBoard, so
+`python src/train.py ...` works out of the box with no W&B account and no
+`wandb login` prompt. The integration is handled through Lightning's
+`WandbLogger` -- there are no direct `wandb.init()` calls in the codebase.
 
-**Setup:**
+**Disabled (default):** do nothing. Fresh runs log to CSV + TensorBoard only.
+No W&B account is required.
 
-1. Create an account at [wandb.ai](https://wandb.ai/)
-2. Get your API key from [wandb.ai/authorize](https://wandb.ai/authorize)
-3. Log in:
+**Enabled — per-run override (recommended):**
 
-```bash
-wandb login
+1. Create an account at [wandb.ai](https://wandb.ai/).
+
+2. Get your API key from [wandb.ai/authorize](https://wandb.ai/authorize).
+
+3. Log in once, or set `WANDB_API_KEY` in your `.env`:
+
+   ```bash
+   wandb login
+   ```
+
+   ```
+   WANDB_API_KEY=<your-api-key>
+   ```
+
+4. Pass `logger=wandb` on the command line:
+
+   ```bash
+   python src/train.py experiment=kosc/ffn_mse logger=wandb
+   ```
+
+   This replaces the default logger composition with W&B only. To log to
+   **both** CSV/TensorBoard **and** W&B, uncomment the `- wandb` line in
+   `configs/logger/many_loggers.yaml`.
+
+**Enabled — as the default:** edit `configs/logger/many_loggers.yaml` and
+uncomment `- wandb`, or change the `logger:` default in `configs/train.yaml`
+to `wandb`.
+
+**Optional entity / project overrides:**
+
+```
+# WANDB_ENTITY=<your-wandb-team>   # leave unset to use your W&B default entity
+WANDB_PROJECT=synth-setter         # W&B project name (default: synth-setter)
 ```
 
-Or set the environment variable in your `.env`:
-
-```
-WANDB_API_KEY=<your-api-key>
-```
-
-**Optional overrides** (defaults are usually fine):
-
-```
-WANDB_ENTITY=tinaudio        # W&B team name
-WANDB_PROJECT=synth-setter   # W&B project name
-```
-
-To train **without W&B** (e.g., for local experimentation), override the logger:
-
-```bash
-python src/train.py experiment=kosc/ffn_mse logger=csv
-```
-
-This logs metrics to CSV files instead.
+`WANDB_ENTITY` is unset by default — W&B falls back to the user's default
+entity. Set it only if you want to push runs to a specific team.
 
 For full details, see [docs/reference/wandb-integration.md](reference/wandb-integration.md).
 
@@ -381,8 +396,8 @@ python src/train.py experiment=kosc/ffn_mse model.optimizer.lr=1e-4
 # Use CPU trainer instead of GPU
 python src/train.py experiment=kosc/ffn_mse trainer=cpu
 
-# Use TensorBoard logger instead of W&B
-python src/train.py experiment=kosc/ffn_mse logger=tensorboard
+# Enable W&B logging (opt-in; default logger is CSV + TensorBoard)
+python src/train.py experiment=kosc/ffn_mse logger=wandb
 
 # Limit training steps
 python src/train.py experiment=kosc/ffn_mse trainer.max_steps=10000


### PR DESCRIPTION
## Summary

[#612](https://github.com/tinaudio/synth-setter/pull/612) makes W&B opt-in (CSV + TensorBoard becomes the default logger compose). Two reader-facing docs still framed W&B as always-on — this PR fixes the drift.

- **README:** Features line now marks W&B as `(opt-in)`; added a blockquote after the install block with the enable/disable one-liner + link to getting-started §4c.
- **getting-started §3a, §4c, §5b:** re-framed around the new default.
  - §3a: "CSV + TensorBoard by default; if you opt into W&B, metrics also go to your dashboard."
  - §4c: explicit Disabled (do nothing) / Enabled per-run (`logger=wandb`) / Enabled by default (uncomment `- wandb` in `many_loggers.yaml`) paths.
  - §5b: stale `# Use TensorBoard logger instead of W&B` override example replaced with `# Enable W&B logging`.
- Removed the hard-coded `WANDB_ENTITY=tinaudio` example so external users don't route runs to the `tinaudio` org by default. `WANDB_ENTITY` now documented as "leave unset to use your W&B default entity."

Partial coverage of [#602](https://github.com/tinaudio/synth-setter/issues/602): `.env.example` (still sets `WANDB_ENTITY=tinaudio`) and `docs/reference/wandb-integration.md` (gap #1 still asserts the `tinaudio` default, line 3 freshness marker stale) are already edited by [#612](https://github.com/tinaudio/synth-setter/pull/612) — raised as review feedback there rather than fixed here to avoid a merge conflict.

Refs #602, refs #598.

## Test plan

- [ ] `make format` clean locally (mdformat, prettier, codespell all pass)
- [ ] `grep -rn "tinaudio" docs/getting-started.md` returns no matches
- [ ] Anchor `#4c-weights--biases-wb` preserved (section title kept; suffix `— opt-in` does not affect the anchor)
- [ ] Render README + getting-started §4c and confirm the enable/disable path reads coherently for a reader who doesn't have a W&B account

