### PR TITLE
fix(training): pass weights_only=False to Trainer ckpt_path loads (PyTorch 2.6+)

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -31,7 +31,7 @@ dependencies:
   - python=3.10
   - pytorch>=2.0.0
   - torchvision>=0.15.0
-  - lightning>=2.0.0
+  - lightning>=2.6.0
   - torchmetrics>=0.11.4
 
   # --------- loggers --------- #

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -2,5 +2,5 @@
 # Install with an explicit index in Docker when targeting CUDA wheels.
 torch>=2.0.0
 torchvision>=0.15.0
-lightning>=2.0.0
+lightning>=2.6.0
 torchmetrics>=0.11.4

--- a/src/eval.py
+++ b/src/eval.py
@@ -85,16 +85,27 @@ def evaluate(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
 
     if mode == "test":
         log.info("Starting testing!")
-        trainer.test(model=model, datamodule=datamodule, ckpt_path=cfg.ckpt_path)
+        trainer.test(
+            model=model,
+            datamodule=datamodule,
+            ckpt_path=cfg.ckpt_path,
+            weights_only=False,
+        )
     elif mode == "val" or mode == "validate":
         log.info("Starting validating!")
-        trainer.validate(model=model, datamodule=datamodule, ckpt_path=cfg.ckpt_path)
+        trainer.validate(
+            model=model,
+            datamodule=datamodule,
+            ckpt_path=cfg.ckpt_path,
+            weights_only=False,
+        )
     elif mode == "predict":
         predictions = trainer.predict(
             model=model,
             dataloaders=datamodule,
             ckpt_path=cfg.ckpt_path,
             return_predictions=False,
+            weights_only=False,
         )
 
     # for predictions use trainer.predict(...)

--- a/src/train.py
+++ b/src/train.py
@@ -94,7 +94,12 @@ def train(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
 
     if cfg.get("train"):
         log.info("Starting training!")
-        trainer.fit(model=model, datamodule=datamodule, ckpt_path=cfg.get("ckpt_path"))
+        trainer.fit(
+            model=model,
+            datamodule=datamodule,
+            ckpt_path=cfg.get("ckpt_path"),
+            weights_only=False,
+        )
 
     train_metrics = trainer.callback_metrics
 
@@ -104,7 +109,12 @@ def train(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
         if ckpt_path == "":
             log.warning("Best ckpt not found! Using current weights for testing...")
             ckpt_path = None
-        trainer.test(model=model, datamodule=datamodule, ckpt_path=ckpt_path)
+        trainer.test(
+            model=model,
+            datamodule=datamodule,
+            ckpt_path=ckpt_path,
+            weights_only=False,
+        )
         log.info(f"Best ckpt path: {ckpt_path}")
 
     test_metrics = trainer.callback_metrics


### PR DESCRIPTION
## Summary

PyTorch 2.6 (Jan 2025) flipped `torch.load`'s default to `weights_only=True`, which rejects our user-defined checkpoint classes and breaks every Lightning `trainer.fit / test / validate / predict(ckpt_path=...)` call. Lightning 2.6.1 exposes `weights_only` as a public kwarg on all four `Trainer` entry points, so the minimal clean fix is to opt out at the five call sites in `src/train.py` and `src/eval.py` that load our own (trusted) checkpoints.

Rejected alternative (`torch.serialization.add_safe_globals([...])`) and the long-term cleanup (extract a `TrustedLocalCheckpointIO` plugin) are tracked in the linked issues.

Fixes #627
Refs #633

## Test plan

- [ ] Level 1 GPU verification on this branch — rerun the Level 1 suite previously failing with `_pickle.UnpicklingError` and confirm every `ckpt_path`-based load path passes.
- [ ] Rebase / retry Level 1 GPU CI on PRs #618, #622, #623 once this lands — all three currently block on this same `weights_only` failure and should go green.
- [ ] Follow-up: when #633 lands, drop the five inline kwargs in favor of the plugin-based policy.
