### PR TITLE
tests: default VST PLUGIN_PATH to in-repo plugins/Surge XT.vst3

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,15 +108,10 @@ first to reinstall.
 > Linux build. Install via your package manager (`apt install surge-xt`) or
 > build from source, then use the manual symlink above.
 
-> **Heads-up — VST tests still hardcode the Linux install path:**
-> `tests/data/vst/test_preset_params.py` and `tests/docker/test_smoke.py`
-> currently hardcode `/usr/lib/vst3/Surge XT.vst3` as the VST3 location, so
-> even after `plugins/Surge XT.vst3` exists, `pytest -m requires_vst` will
-> still skip on macOS (and on Linux installs where the VST3 lives somewhere
-> other than `/usr/lib/vst3/`). Tracked in
-> [#631](https://github.com/tinaudio/synth-setter/issues/631) — the fix
-> will default the tests to `plugins/Surge XT.vst3` with an env-var
-> override for CI.
+> **Pointing the VST tests at a non-default install:** `pytest -m requires_vst`
+> resolves the plugin at `plugins/Surge XT.vst3` by default. If your install
+> lives elsewhere, set `SYNTH_SETTER_PLUGIN_PATH` to the absolute path of the
+> `.vst3` bundle before invoking pytest.
 
 ### 2e. Export environment variables
 

--- a/tests/data/vst/test_preset_params.py
+++ b/tests/data/vst/test_preset_params.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 import pytest
 
-PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH", "plugins/Surge XT.vst3")
+PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
 PRESET_PATH = "presets/surge-base.vstpreset"
 
 # pedalboard.VST3Plugin.parameters is a dynamic C extension attribute that

--- a/tests/data/vst/test_preset_params.py
+++ b/tests/data/vst/test_preset_params.py
@@ -9,11 +9,12 @@ load_preset().
 Regression for: https://github.com/tinaudio/synth-setter/issues/225
 """
 
+import os
 from pathlib import Path
 
 import pytest
 
-PLUGIN_PATH = "/usr/lib/vst3/Surge XT.vst3"
+PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH", "plugins/Surge XT.vst3")
 PRESET_PATH = "presets/surge-base.vstpreset"
 
 # pedalboard.VST3Plugin.parameters is a dynamic C extension attribute that

--- a/tests/docker/test_smoke.py
+++ b/tests/docker/test_smoke.py
@@ -11,11 +11,12 @@ To run all smoke tests manually inside a container:
         pytest tests/docker/test_smoke.py -m "docker_smoke and requires_vst" -v
 """
 
+import os
 from pathlib import Path
 
 import pytest
 
-PLUGIN_PATH = "/usr/lib/vst3/Surge XT.vst3"
+PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH", "plugins/Surge XT.vst3")
 
 skip_no_pedalboard = pytest.mark.skipif(
     not __import__("importlib").util.find_spec("pedalboard"),

--- a/tests/docker/test_smoke.py
+++ b/tests/docker/test_smoke.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH", "plugins/Surge XT.vst3")
+PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
 
 skip_no_pedalboard = pytest.mark.skipif(
     not __import__("importlib").util.find_spec("pedalboard"),


### PR DESCRIPTION
## Summary

- Replace the hardcoded Linux path `/usr/lib/vst3/Surge XT.vst3` in `tests/data/vst/test_preset_params.py` and `tests/docker/test_smoke.py` with the in-repo default `plugins/Surge XT.vst3`.
- Honor a `SYNTH_SETTER_PLUGIN_PATH` env var override so CI/alternate installs can still point at an absolute path.
- Docker smoke tests keep working unchanged because the image already symlinks `/usr/lib/vst3/Surge XT.vst3` to `plugins/Surge XT.vst3` (see `docker/ubuntu22_04/Dockerfile:316-317`).

## Why

macOS users install Surge XT at `plugins/Surge XT.vst3` (via `make install-surge-xt` from #613, or a manual symlink), but the hardcoded Linux path meant `pytest -m requires_vst` still skipped all VST tests on macOS because the `Path(PLUGIN_PATH).exists()` check always failed.

## Test plan

- [x] `pytest tests/data/vst/test_preset_params.py tests/docker/test_smoke.py -m requires_vst` — with `plugins/Surge XT.vst3` symlinked into the worktree, all 4 requires_vst tests pass (previously skipped on the same host).
- [x] `SYNTH_SETTER_PLUGIN_PATH=/absolute/path/to/Surge\ XT.vst3 pytest -m requires_vst` — env var override resolves correctly and tests pass.
- [x] With no plugin present, tests skip cleanly with `VST plugin not found at plugins/Surge XT.vst3`.
- [x] `make format` — all pre-commit hooks pass.

Fixes #631