### PR TITLE
docs: add CLAUDE.md GPU verification rule to prevent false skips

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,7 @@ nvidia-smi --query-gpu=name,memory.free --format=csv,noheader
 python3 -c "import torch; print('cuda:', torch.cuda.is_available(), 'count:', torch.cuda.device_count())"
 ```
 
-Only skip if `nvidia-smi` exits non-zero or `torch.cuda.is_available()` returns `False`. "I assumed there's no GPU" is not justification — the assumption has been wrong before.
+Only skip as "no GPU available" if both probes indicate no usable CUDA GPU: `nvidia-smi` exits non-zero and `torch.cuda.is_available()` returns `False`. If the probes disagree, do not call it "no GPU available" — document it as an environment/setup mismatch (for example, driver/tooling visibility vs. PyTorch CUDA availability) and include both outputs in the rationale. "I assumed there's no GPU" is not justification — the assumption has been wrong before.
 
 ### PR Review Comments
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,17 @@ Before implementing a new abstraction or design pattern, confirm the scope and a
 - Size output appropriately: small (\<20 lines) inline, medium (20-100) in a PR comment, large (100+) in a Gist linked from a comment.
 - Only tick `[x]` if the result unambiguously passes.
 
+### GPU Verification
+
+Before skipping a GPU-gated check with "no GPU available" or similar, run BOTH probes and paste their output into the SKIP rationale:
+
+```bash
+nvidia-smi --query-gpu=name,memory.free --format=csv,noheader
+python3 -c "import torch; print('cuda:', torch.cuda.is_available(), 'count:', torch.cuda.device_count())"
+```
+
+Only skip if `nvidia-smi` exits non-zero or `torch.cuda.is_available()` returns `False`. "I assumed there's no GPU" is not justification — the assumption has been wrong before.
+
 ### PR Review Comments
 
 - Always reply to PR review comments after pushing a fix — never push silently.


### PR DESCRIPTION
## Summary

- Adds a `### GPU Verification` subsection to `CLAUDE.md` under `## Workflow Rules`, right after `### PR Verification`.
- Requires running both `nvidia-smi` and a `torch.cuda.is_available()` probe before skipping a GPU-gated check, and pasting the output into the SKIP rationale.
- Motivated by the false skip on PR #623 / #634 Level 1 verifications where the env had an RTX 5060 Ti but the agent wrote "SKIP: no GPU available" without checking.

## Rule text

```markdown
### GPU Verification

Before skipping a GPU-gated check with "no GPU available" or similar, run BOTH probes and paste their output into the SKIP rationale:

\`\`\`bash
nvidia-smi --query-gpu=name,memory.free --format=csv,noheader
python3 -c "import torch; print('cuda:', torch.cuda.is_available(), 'count:', torch.cuda.device_count())"
\`\`\`

Only skip as "no GPU available" if both probes indicate no usable CUDA GPU: \`nvidia-smi\` exits non-zero and \`torch.cuda.is_available()\` returns \`False\`. If the probes disagree, do not call it "no GPU available" — document it as an environment/setup mismatch (for example, driver/tooling visibility vs. PyTorch CUDA availability) and include both outputs in the rationale. "I assumed there's no GPU" is not justification — the assumption has been wrong before.
```

## Test plan

- [x] Grep CLAUDE.md for "GPU" — the new rule is discoverable.
- [x] `make format` (pre-commit hooks) passes.
- [x] No conflicts or duplication with existing `### PR Verification` or `## Don't` rules.

Fixes #639
