### PR TITLE
fix(testing): align cfg_eval.model/callbacks with cfg_train in test_train_eval

### DIFF
--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -33,6 +33,11 @@ def test_train_eval(tmp_path: Path, cfg_train: DictConfig, cfg_eval: DictConfig)
         # path that does not exist on the CI GPU runner. Reuse the training data config so the
         # test exercises a self-consistent train->eval roundtrip.
         cfg_eval.data = cfg_train.data
+        # `configs/eval.yaml` also defaults `model: surge_flow` and `callbacks: eval_surge`, which
+        # do not match the checkpoint produced by `cfg_train` (ksin feedforward). Align both so the
+        # evaluator loads the same LightningModule the trainer just saved.
+        cfg_eval.model = cfg_train.model
+        cfg_eval.callbacks = cfg_train.callbacks
 
     HydraConfig().set_config(cfg_train)
     train_metric_dict, _ = train(cfg_train)
@@ -45,5 +50,10 @@ def test_train_eval(tmp_path: Path, cfg_train: DictConfig, cfg_eval: DictConfig)
     HydraConfig().set_config(cfg_eval)
     test_metric_dict, _ = evaluate(cfg_eval)
 
-    assert test_metric_dict["test/acc"] > 0.0
-    assert abs(train_metric_dict["test/acc"].item() - test_metric_dict["test/acc"].item()) < 0.001
+    # `ksin_ff_module.test_step` logs `test/loss` (MSE), not `test/acc`. Use loss for the sanity
+    # bound and parity check — the train-time test phase and the standalone eval should produce
+    # identical `test/loss` on the same checkpoint and data.
+    assert test_metric_dict["test/loss"] < float("inf")
+    assert (
+        abs(train_metric_dict["test/loss"].item() - test_metric_dict["test/loss"].item()) < 0.001
+    )


### PR DESCRIPTION
Fixes #624

Stacks on #623. That PR fixed only the `data` mismatch in `test_train_eval`; this PR completes the train<->eval alignment by also overriding `cfg_eval.model` and `cfg_eval.callbacks` to match `cfg_train`, so the evaluator loads the same ksin feedforward LightningModule and callback stack that training just checkpointed (instead of the default `surge_flow` / `eval_surge`).

Also replaces the stale `test/acc` assertions: `src/models/ksin_ff_module.py::test_step` logs `test/loss` (MSE), not `test/acc`. The new assertions use `test/loss < inf` as a sanity bound and keep a tight parity check between train-time test and standalone eval on the same checkpoint.

> **Edit:** the `test/loss < float("inf")` bound added in this PR is being tightened to `math.isfinite(test/loss)` in [#655](https://github.com/tinaudio/synth-setter/pull/655) — `<inf` silently accepts `-inf` and the stricter check rejects `+inf`, `-inf`, and `NaN`. Copilot flagged the gap while reviewing the sibling `test_train_validate` assertion in [#636](https://github.com/tinaudio/synth-setter/pull/636); both lines are swapped together in #655 to keep the canonical E2E template consistent. (The fix was initially committed on the #636 branch post-merge and had to be cherry-picked to a fresh branch in #655.)

When #623 lands in main, this PR should be rebased onto main; the diff will then show only the #624-specific delta.

## Test plan

- [x] `make format` clean
- [x] `pytest --collect-only tests/test_eval.py` still collects `test_train_eval`
- [x] GPU end-to-end: `pytest tests/test_eval.py::test_train_eval -v` PASSED in 489s on RTX 5060 Ti (CUDA 13.0)

