### PR TITLE
fix(testing): use train/loss and val/loss in test_train_resume (ksin_ff_module logs loss, not acc)

### DIFF
--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -137,6 +137,8 @@ def test_train_resume(tmp_path: Path, cfg_train: DictConfig) -> None:
     with open_dict(cfg_train):
         cfg_train.trainer.max_epochs = 1
         cfg_train.trainer.accelerator = "gpu"
+        cfg_train.seed = 42
+        cfg_train.trainer.deterministic = True
 
     HydraConfig().set_config(cfg_train)
     metric_dict_1, _ = train(cfg_train)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -155,5 +155,9 @@ def test_train_resume(tmp_path: Path, cfg_train: DictConfig) -> None:
     assert "epoch_001.ckpt" in files
     assert "epoch_002.ckpt" not in files
 
-    assert metric_dict_1["train/acc"] < metric_dict_2["train/acc"]
-    assert metric_dict_1["val/acc"] < metric_dict_2["val/acc"]
+    # `ksin_ff_module.training_step` logs `train/loss` with `on_step=True, on_epoch=True`, which
+    # populates `train/loss_epoch` in `trainer.callback_metrics`. `validation_step` logs `val/loss`
+    # with `on_epoch=True` only. Resuming for another epoch should drive both losses down, so we
+    # expect strict decrease (note: reversed direction vs. the legacy `train/acc < ...` assertion).
+    assert metric_dict_1["train/loss_epoch"] > metric_dict_2["train/loss_epoch"]
+    assert metric_dict_1["val/loss"] > metric_dict_2["val/loss"]


### PR DESCRIPTION
Fixes #642

## The bug

`tests/test_train.py::test_train_resume` (lines 158-159) asserted on
`metric_dict_1["train/acc"]` and `metric_dict_1["val/acc"]`. These keys are
legacy from when the test was written for `mnist_module`. The active
`ksin_ff_module` never logs `*/acc`:

- `src/models/ksin_ff_module.py::training_step` (line 61) logs `train/loss`
  (`on_step=True, on_epoch=True`)
- `validation_step` (lines 77-79) logs `val/lsd`, `val/chamfer`, `val/loss`
- `test_step` (lines 93-104) logs `test/param_mse`, `test/lsd`, `test/chamfer`,
  `test/loss`, `test/lad`

## Why the bug was hidden until now

The test historically failed much earlier at line 146:

```python
assert "epoch_000.ckpt" in files
```

`tests/conftest.py` used to leave `val_check_interval=10_000` and
`check_val_every_n_epoch=null`, so validation never ran under the fixture's
`limit_train_batches=0.01`, so `ModelCheckpoint(monitor="val/loss")` never
fired, so `epoch_NNN.ckpt` was never saved. The test stopped there.

- #630 (merged) fixed the fixture so validation actually runs.
- #634 (merged) added `weights_only=False` so `trainer.fit(ckpt_path=...)`
  loads the ckpt successfully.
- The test now reaches line 158 and crashes on the stale `train/acc` assertion.

## Empirical reproduction

Ran on RTX 5060 Ti (Lightning 2.6.1, PyTorch 2.11, CUDA 13.0) on a composite
branch combining `main + #630 + #634 + #623`:

```
Restored all states from the checkpoint at .../checkpoints/last.ckpt
`Trainer.fit` stopped: `max_epochs=2` reached.
Restoring states from the checkpoint path at .../checkpoints/epoch_001.ckpt
Loaded model weights from the checkpoint at .../checkpoints/epoch_001.ckpt
...
FAILED tests/test_train.py::test_train_resume - KeyError: 'train/acc'
935.62s call  tests/test_train.py::test_train_resume
```

Confirmed the ckpt load works (all Lightning restore lines pass), the test
reaches its final assertion, and crashes on the missing metric key.

## The fix

Replace the stale `*/acc` assertions with real keys that `ksin_ff_module`
actually logs:

- `train/acc` -> `train/loss_epoch` (because `training_step` uses
  `on_step=True, on_epoch=True`, Lightning populates `train/loss_epoch` in
  `trainer.callback_metrics` with the epoch-aggregated value — the unambiguous
  key to compare across epochs).
- `val/acc` -> `val/loss` (plain key since `validation_step` uses
  `on_epoch=True` only).
- Flip the comparison direction: loss should *decrease* after more training,
  so `>` instead of `<`.

Mirrors the analogous #641 fix, which replaced the stale `test/acc` assertions
in `test_train_eval` with `test/loss`.

## Test plan

- [x] `make format` clean (ran via pre-commit — all hooks passed)
- [ ] GPU end-to-end: `pytest tests/test_train.py::test_train_resume -v -m "slow and gpu"`
      on RTX 5060 Ti (CUDA 13.0). Currently WAITING — another agent is running
      `test_train_eval` on the same GPU (pid 227542, 2194 MiB). Will post the
      pytest result (PASS/FAIL + wall time) as a PR comment once the GPU frees
      and this run completes.