### PR TITLE
fix(monitoring): route plot callbacks through Lightning loggers

### DIFF
--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -99,12 +99,12 @@ Under the default `many_loggers` composition (CSV + TB), plots land in
 TensorBoard; with `logger=wandb` they go to W&B; with both attached they go
 to both.
 
-| Callback                           | Logged key                       | Trigger                                         | File                             |
-| ---------------------------------- | -------------------------------- | ----------------------------------------------- | -------------------------------- |
-| `PlotLossPerTimestep`              | `plot` (image)                   | `on_validation_epoch_end`                       | `src/utils/callbacks.py:91-93`   |
-| `PlotPositionalEncodingSimilarity` | `pos_enc_similarity` (image)     | `on_validation_epoch_end`                       | `src/utils/callbacks.py:148-150` |
-| `PlotLearntProjection`             | `assignment`, `value` (images)   | `on_validation_epoch_end` or every N steps      | `src/utils/callbacks.py:270-273` |
-| `LogPerParamMSE`                   | `per_param_mse/{name}` per param | `on_validation_epoch_end` (via `self.log_dict`) | `src/utils/callbacks.py:389-391` |
+| Callback                           | Logged key                       | Trigger                                         | Symbol                                                               |
+| ---------------------------------- | -------------------------------- | ----------------------------------------------- | -------------------------------------------------------------------- |
+| `PlotLossPerTimestep`              | `plot` (image)                   | `on_validation_epoch_end`                       | `src/utils/callbacks.py::PlotLossPerTimestep._log_plot`              |
+| `PlotPositionalEncodingSimilarity` | `pos_enc_similarity` (image)     | `on_validation_epoch_end`                       | `src/utils/callbacks.py::PlotPositionalEncodingSimilarity._log_plot` |
+| `PlotLearntProjection`             | `assignment`, `value` (images)   | `on_validation_epoch_end` or every N steps      | `src/utils/callbacks.py::PlotLearntProjection._log_plots`            |
+| `LogPerParamMSE`                   | `per_param_mse/{name}` per param | `on_validation_epoch_end` (via `self.log_dict`) | `src/utils/callbacks.py::LogPerParamMSE`                             |
 
 ### 2d. Callbacks — Non-W&B
 
@@ -114,7 +114,7 @@ to both.
 | `LearningRateMonitor` | Logs LR to Lightning logger                            | `configs/callbacks/lr_monitor.yaml`        |
 | `RichProgressBar`     | Terminal display only                                  | `configs/callbacks/rich_progress_bar.yaml` |
 | `ModelSummary`        | Prints param summary to console                        | `configs/callbacks/model_summary.yaml`     |
-| `PredictionWriter`    | Saves predictions to `.pt` files locally               | `src/utils/callbacks.py:320-355`           |
+| `PredictionWriter`    | Saves predictions to `.pt` files locally               | `src/utils/callbacks.py::PredictionWriter` |
 
 ### 2e. Gradient Watching
 

--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -10,9 +10,12 @@ ______________________________________________________________________
 
 W&B runs are created via Lightning's `WandbLogger` — there are no direct
 `wandb.init()` calls in training or eval code. The logger is instantiated via
-Hydra config and passed to the `Trainer`. Most metric logging goes through
-Lightning's `self.log()` / `self.log_dict()` API; a handful of visualization
-callbacks additionally call `wandb.log()` directly for image uploads.
+Hydra config and passed to the `Trainer`. Metric logging goes through
+Lightning's `self.log()` / `self.log_dict()` API; visualization callbacks
+route matplotlib figures through a small logger-dispatch helper
+(`_log_figure` in `src/utils/callbacks.py`) that calls
+`WandbLogger.log_image` or `TensorBoardLogger.experiment.add_figure`
+depending on which loggers are attached.
 
 ______________________________________________________________________
 
@@ -87,14 +90,21 @@ Logged via `self.log()` in each LightningModule:
 |                           | `val/loss`, `val/acc`, `val/acc_best`                    | —    | yes   |
 |                           | `test/loss`, `test/acc`                                  | —    | yes   |
 
-### 2c. Callbacks — Visualization (direct `wandb.log()`)
+### 2c. Callbacks — Visualization (via Lightning logger dispatch)
+
+Image-producing callbacks route figures through `_log_figure` in
+`src/utils/callbacks.py`, which dispatches to `WandbLogger.log_image` and/or
+`TensorBoardLogger.experiment.add_figure` depending on the attached loggers.
+Under the default `many_loggers` composition (CSV + TB), plots land in
+TensorBoard; with `logger=wandb` they go to W&B; with both attached they go
+to both.
 
 | Callback                           | Logged key                       | Trigger                                         | File                             |
 | ---------------------------------- | -------------------------------- | ----------------------------------------------- | -------------------------------- |
-| `PlotLossPerTimestep`              | `plot` (image)                   | `on_validation_epoch_end`                       | `src/utils/callbacks.py:77`      |
-| `PlotPositionalEncodingSimilarity` | `pos_enc_similarity` (image)     | `on_validation_epoch_end`                       | `src/utils/callbacks.py:135`     |
-| `PlotLearntProjection`             | `assignment`, `value` (images)   | `on_validation_epoch_end` or every N steps      | `src/utils/callbacks.py:259`     |
-| `LogPerParamMSE`                   | `per_param_mse/{name}` per param | `on_validation_epoch_end` (via `self.log_dict`) | `src/utils/callbacks.py:376-378` |
+| `PlotLossPerTimestep`              | `plot` (image)                   | `on_validation_epoch_end`                       | `src/utils/callbacks.py:91-93`   |
+| `PlotPositionalEncodingSimilarity` | `pos_enc_similarity` (image)     | `on_validation_epoch_end`                       | `src/utils/callbacks.py:148-150` |
+| `PlotLearntProjection`             | `assignment`, `value` (images)   | `on_validation_epoch_end` or every N steps      | `src/utils/callbacks.py:270-273` |
+| `LogPerParamMSE`                   | `per_param_mse/{name}` per param | `on_validation_epoch_end` (via `self.log_dict`) | `src/utils/callbacks.py:389-391` |
 
 ### 2d. Callbacks — Non-W&B
 
@@ -104,7 +114,7 @@ Logged via `self.log()` in each LightningModule:
 | `LearningRateMonitor` | Logs LR to Lightning logger                            | `configs/callbacks/lr_monitor.yaml`        |
 | `RichProgressBar`     | Terminal display only                                  | `configs/callbacks/rich_progress_bar.yaml` |
 | `ModelSummary`        | Prints param summary to console                        | `configs/callbacks/model_summary.yaml`     |
-| `PredictionWriter`    | Saves predictions to `.pt` files locally               | `src/utils/callbacks.py:307-342`           |
+| `PredictionWriter`    | Saves predictions to `.pt` files locally               | `src/utils/callbacks.py:320-355`           |
 
 ### 2e. Gradient Watching
 
@@ -160,13 +170,13 @@ ______________________________________________________________________
 
 ## 5. Known Gaps
 
-| #   | Gap                                                                                                                                                                                                                           | Impact                                                                                              | Tracking |
-| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------- |
-| 1   | ~~**Entity/project hardcoded** to `benhayes`/`synth-permutations`~~ **RESOLVED** — env-var driven (`WANDB_ENTITY`/`WANDB_PROJECT`); entity defaults to `null` (user's W&B default entity), project defaults to `synth-setter` | ~~Runs log to wrong account~~                                                                       | #133     |
-| 2   | **No `wandb.config` for env vars** — W&B captures `sys.argv` but not env vars like `TRAINING_ARGS`. **Partially resolved:** `IMAGE_TAG` is now captured by `log_wandb_provenance()`.                                          | Config passed via env vars is silently missing from W&B (except `IMAGE_TAG`)                        | #252     |
-| 3   | ~~**No `github_sha` in `wandb.config`**~~ **RESOLVED** — `log_wandb_provenance()` now logs `github_sha` via `git rev-parse HEAD`                                                                                              | ~~Can't reliably link a run to the exact code that produced it~~                                    | —        |
-| 4   | **No GitHub issue integration** — train job doesn't post run ID back to GitHub                                                                                                                                                | Manual lookup to match runs to issues                                                               | #263     |
-| 5   | ~~**`log_model: true` vs `"all"`**~~ **RESOLVED** — changed to `log_model: "all"` for crash resilience (every checkpoint uploaded immediately)                                                                                | —                                                                                                   | —        |
-| 6   | **Visualization callbacks use `wandb.log()` directly** — bypasses Lightning logger abstraction                                                                                                                                | Breaks if logger is swapped; step alignment relies on `trainer.global_step`                         | —        |
-| 7   | **`torch.compile` crashes test-stage `setup()`** — eval after training fails                                                                                                                                                  | Post-training test metrics never logged to W&B                                                      | #248     |
-| 8   | **No structured run ID convention** — `id: null` means W&B generates random IDs                                                                                                                                               | Can't reconstruct run lineage from ID alone; design doc specifies `{config_id}-{timestamp}` pattern | —        |
+| #   | Gap                                                                                                                                                                                                                                                                           | Impact                                                                                              | Tracking |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------- |
+| 1   | ~~**Entity/project hardcoded** to `benhayes`/`synth-permutations`~~ **RESOLVED** — env-var driven (`WANDB_ENTITY`/`WANDB_PROJECT`); entity defaults to `null` (user's W&B default entity), project defaults to `synth-setter`                                                 | ~~Runs log to wrong account~~                                                                       | #133     |
+| 2   | **No `wandb.config` for env vars** — W&B captures `sys.argv` but not env vars like `TRAINING_ARGS`. **Partially resolved:** `IMAGE_TAG` is now captured by `log_wandb_provenance()`.                                                                                          | Config passed via env vars is silently missing from W&B (except `IMAGE_TAG`)                        | #252     |
+| 3   | ~~**No `github_sha` in `wandb.config`**~~ **RESOLVED** — `log_wandb_provenance()` now logs `github_sha` via `git rev-parse HEAD`                                                                                                                                              | ~~Can't reliably link a run to the exact code that produced it~~                                    | —        |
+| 4   | **No GitHub issue integration** — train job doesn't post run ID back to GitHub                                                                                                                                                                                                | Manual lookup to match runs to issues                                                               | #263     |
+| 5   | ~~**`log_model: true` vs `"all"`**~~ **RESOLVED** — changed to `log_model: "all"` for crash resilience (every checkpoint uploaded immediately)                                                                                                                                | —                                                                                                   | —        |
+| 6   | ~~**Visualization callbacks use `wandb.log()` directly** — bypasses Lightning logger abstraction~~ **RESOLVED** — callbacks now dispatch through `_log_figure` to whichever Lightning loggers are attached (WandbLogger and/or TensorBoardLogger); CSV-only setups are silent | ~~Breaks if logger is swapped; step alignment relies on `trainer.global_step`~~                     | #614     |
+| 7   | **`torch.compile` crashes test-stage `setup()`** — eval after training fails                                                                                                                                                                                                  | Post-training test metrics never logged to W&B                                                      | #248     |
+| 8   | **No structured run ID convention** — `id: null` means W&B generates random IDs                                                                                                                                                                                               | Can't reconstruct run lineage from ID alone; design doc specifies `{config_id}-{timestamp}` pattern | —        |

--- a/src/utils/callbacks.py
+++ b/src/utils/callbacks.py
@@ -3,8 +3,10 @@ import os
 import matplotlib.pyplot as plt
 import numpy as np
 import torch
-import wandb
+from lightning.pytorch import Trainer
 from lightning.pytorch.callbacks import BasePredictionWriter, Callback
+from lightning.pytorch.loggers import TensorBoardLogger, WandbLogger
+from matplotlib.figure import Figure
 
 from src.data.vst import param_specs
 from src.models.components.transformer import (
@@ -13,6 +15,20 @@ from src.models.components.transformer import (
 )
 from src.models.ksin_flow_matching_module import KSinFlowMatchingModule
 from src.models.surge_flow_matching_module import SurgeFlowMatchingModule
+
+
+def _log_figure(trainer: Trainer, key: str, fig: Figure) -> None:
+    """Log a matplotlib figure to whichever Lightning loggers support images.
+
+    Dispatches per-logger since Lightning loggers don't share a uniform image API:
+    WandbLogger exposes ``log_image``; TensorBoardLogger wraps a SummaryWriter
+    with ``add_figure``. Loggers without image support (CSV) are skipped.
+    """
+    for logger in trainer.loggers:
+        if isinstance(logger, WandbLogger):
+            logger.log_image(key=key, images=[fig], step=trainer.global_step)
+        elif isinstance(logger, TensorBoardLogger):
+            logger.experiment.add_figure(key, fig, global_step=trainer.global_step)
 
 
 class PlotLossPerTimestep(Callback):
@@ -73,8 +89,7 @@ class PlotLossPerTimestep(Callback):
         return fig
 
     def _log_plot(self, fig, trainer):
-        plot = wandb.Image(fig)
-        wandb.log({"plot": plot}, step=trainer.global_step)
+        _log_figure(trainer, "plot", fig)
         plt.close(fig)
 
     def on_validation_epoch_end(self, trainer, pl_module) -> None:
@@ -131,8 +146,7 @@ class PlotPositionalEncodingSimilarity(Callback):
             return self._plot_multiple_similarities(sim)
 
     def _log_plot(self, fig, trainer):
-        plot = wandb.Image(fig)
-        wandb.log({"pos_enc_similarity": plot}, step=trainer.global_step)
+        _log_figure(trainer, "pos_enc_similarity", fig)
         plt.close(fig)
 
     def on_validation_epoch_end(self, trainer, pl_module) -> None:
@@ -254,9 +268,8 @@ class PlotLearntProjection(Callback):
         return fig
 
     def _log_plots(self, fig_ass, fig_value, trainer):
-        plot_ass = wandb.Image(fig_ass)
-        plot_value = wandb.Image(fig_value)
-        wandb.log({"assignment": plot_ass, "value": plot_value}, step=trainer.global_step)
+        _log_figure(trainer, "assignment", fig_ass)
+        _log_figure(trainer, "value", fig_value)
 
         plt.close(fig_ass)
         plt.close(fig_value)

--- a/src/utils/callbacks.py
+++ b/src/utils/callbacks.py
@@ -23,7 +23,13 @@ def _log_figure(trainer: Trainer, key: str, fig: Figure) -> None:
     Dispatches per-logger since Lightning loggers don't share a uniform image API:
     WandbLogger exposes ``log_image``; TensorBoardLogger wraps a SummaryWriter
     with ``add_figure``. Loggers without image support (CSV) are skipped.
+
+    Only rank 0 emits — TensorBoard's ``SummaryWriter`` is not rank-safe, and
+    duplicate emissions from every DDP worker would corrupt event files or
+    log the same figure N times.
     """
+    if not trainer.is_global_zero:
+        return
     for logger in trainer.loggers:
         if isinstance(logger, WandbLogger):
             logger.log_image(key=key, images=[fig], step=trainer.global_step)

--- a/src/utils/callbacks.py
+++ b/src/utils/callbacks.py
@@ -20,13 +20,19 @@ from src.models.surge_flow_matching_module import SurgeFlowMatchingModule
 def _log_figure(trainer: Trainer, key: str, fig: Figure) -> None:
     """Log a matplotlib figure to whichever Lightning loggers support images.
 
-    Dispatches per-logger since Lightning loggers don't share a uniform image API:
-    WandbLogger exposes ``log_image``; TensorBoardLogger wraps a SummaryWriter
-    with ``add_figure``. Loggers without image support (CSV) are skipped.
+    Lightning's base ``Logger`` only standardizes scalar metrics; image APIs
+    differ per backend, so dispatch is required:
+    ``WandbLogger.log_image`` vs ``TensorBoardLogger.experiment.add_figure``.
 
-    Only rank 0 emits — TensorBoard's ``SummaryWriter`` is not rank-safe, and
-    duplicate emissions from every DDP worker would corrupt event files or
-    log the same figure N times.
+    Any logger outside the two handled here is **intentionally skipped**
+    (silent no-op) — ``CSVLogger`` has no image API, and callers treat that
+    as expected. If a new image-capable logger is introduced (MLflow,
+    Comet, Neptune, ...), add an ``isinstance`` branch below rather than
+    adding the call at the callback site.
+
+    Only rank 0 emits — TensorBoard's ``SummaryWriter`` is not rank-safe,
+    and duplicate emissions from every DDP worker would corrupt event
+    files or log the same figure N times.
     """
     if not trainer.is_global_zero:
         return

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -13,11 +13,16 @@ from matplotlib.figure import Figure
 from src.utils.callbacks import _log_figure
 
 
-def _make_trainer(loggers: list[object], global_step: int = 42) -> MagicMock:
-    """Build a stand-in ``Trainer`` exposing only ``loggers`` and ``global_step``."""
+def _make_trainer(
+    loggers: list[object],
+    global_step: int = 42,
+    is_global_zero: bool = True,
+) -> MagicMock:
+    """Build a stand-in ``Trainer`` exposing ``loggers``, ``global_step``, and rank."""
     trainer = MagicMock()
     trainer.loggers = loggers
     trainer.global_step = global_step
+    trainer.is_global_zero = is_global_zero
     return trainer
 
 
@@ -68,3 +73,16 @@ def test_log_figure_is_noop_when_no_image_capable_loggers_present():
 
     # CSVLogger has no image API; ensure we didn't accidentally invoke anything.
     assert not csv_logger.method_calls
+
+
+def test_log_figure_is_noop_on_non_zero_rank():
+    """Under DDP, only rank 0 should emit — SummaryWriter is not rank-safe."""
+    wandb_logger = MagicMock(spec=WandbLogger)
+    tb_logger = MagicMock(spec=TensorBoardLogger)
+    trainer = _make_trainer([wandb_logger, tb_logger], is_global_zero=False)
+    fig = MagicMock(spec=Figure)
+
+    _log_figure(trainer, "plot", fig)
+
+    wandb_logger.log_image.assert_not_called()
+    tb_logger.experiment.add_figure.assert_not_called()

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,0 +1,70 @@
+"""Tests for ``src.utils.callbacks._log_figure`` logger dispatch.
+
+Uses ``MagicMock(spec=...)`` so ``isinstance`` checks against the real Lightning
+logger classes pass, without instantiating any backends (no W&B auth prompt,
+no TensorBoard file writes).
+"""
+
+from unittest.mock import MagicMock
+
+from lightning.pytorch.loggers import CSVLogger, TensorBoardLogger, WandbLogger
+from matplotlib.figure import Figure
+
+from src.utils.callbacks import _log_figure
+
+
+def _make_trainer(loggers: list[object], global_step: int = 42) -> MagicMock:
+    """Build a stand-in ``Trainer`` exposing only ``loggers`` and ``global_step``."""
+    trainer = MagicMock()
+    trainer.loggers = loggers
+    trainer.global_step = global_step
+    return trainer
+
+
+def test_log_figure_routes_to_wandb_logger_when_only_wandb_logger_present():
+    """A lone WandbLogger receives one ``log_image`` call with the figure and step."""
+    wandb_logger = MagicMock(spec=WandbLogger)
+    trainer = _make_trainer([wandb_logger], global_step=42)
+    fig = MagicMock(spec=Figure)
+
+    _log_figure(trainer, "plot", fig)
+
+    wandb_logger.log_image.assert_called_once_with(key="plot", images=[fig], step=42)
+
+
+def test_log_figure_routes_to_tensorboard_logger_when_only_tensorboard_logger_present():
+    """A lone TensorBoardLogger receives one ``experiment.add_figure`` call."""
+    tb_logger = MagicMock(spec=TensorBoardLogger)
+    trainer = _make_trainer([tb_logger], global_step=7)
+    fig = MagicMock(spec=Figure)
+
+    _log_figure(trainer, "pos_enc_similarity", fig)
+
+    tb_logger.experiment.add_figure.assert_called_once_with(
+        "pos_enc_similarity", fig, global_step=7
+    )
+
+
+def test_log_figure_dispatches_to_both_when_both_loggers_present():
+    """When both loggers are attached, each receives exactly one call."""
+    wandb_logger = MagicMock(spec=WandbLogger)
+    tb_logger = MagicMock(spec=TensorBoardLogger)
+    trainer = _make_trainer([wandb_logger, tb_logger], global_step=3)
+    fig = MagicMock(spec=Figure)
+
+    _log_figure(trainer, "assignment", fig)
+
+    wandb_logger.log_image.assert_called_once_with(key="assignment", images=[fig], step=3)
+    tb_logger.experiment.add_figure.assert_called_once_with("assignment", fig, global_step=3)
+
+
+def test_log_figure_is_noop_when_no_image_capable_loggers_present():
+    """CSV-only setup (the default after #612) stays silent — no calls, no errors."""
+    csv_logger = MagicMock(spec=CSVLogger)
+    trainer = _make_trainer([csv_logger], global_step=5)
+    fig = MagicMock(spec=Figure)
+
+    _log_figure(trainer, "plot", fig)
+
+    # CSVLogger has no image API; ensure we didn't accidentally invoke anything.
+    assert not csv_logger.method_calls


### PR DESCRIPTION
## Summary

Replaces direct `wandb.log()` / `wandb.Image()` calls in the three default plot callbacks with a small Lightning-logger dispatch helper. Plots now land on whichever logger(s) the user has selected — `WandbLogger.log_image` when W&B is active, `TensorBoardLogger.experiment.add_figure` when TB is active, both if both, silently skipped otherwise.

This is the "ideal" fix from #614 (not the minimal `if wandb.run is not None` guard): after #612 made W&B opt-in and the defaults became CSV + TensorBoard, the direct `wandb.log()` calls were still bypassing the Lightning logger system and could trigger W&B auth prompts on fresh checkouts. Routing through `trainer.loggers` closes that gap and also makes plots visible in TensorBoard for the default composition.

## Changes

- `src/utils/callbacks.py`
  - New `_log_figure(trainer, key, fig)` helper that iterates `trainer.loggers` and dispatches per-logger type. Loggers without image support (CSV, etc.) are silently skipped.
  - `PlotLossPerTimestep._log_plot`, `PlotPositionalEncodingSimilarity._log_plot`, and `PlotLearntProjection._log_plots` now route through the helper instead of `wandb.log`/`wandb.Image` directly.
  - Module-level `import wandb` removed — no longer needed.
- `tests/test_callbacks.py` (new) — four behavior tests using `MagicMock(spec=...)` fakes: WandbLogger-only, TensorBoardLogger-only, both-present, and the CSV-only no-op regression guard (the fresh-checkout default must stay silent).

## Test plan

- [x] `make test` passes locally (162 passed, 2 skipped).
- [x] `make format` passes (ruff, ruff format, pyright, interrogate, etc.).
- [ ] CI green on this PR.
- [ ] Manual smoke: `python src/train.py experiment=<exp> +trainer.fast_dev_run=true` with defaults → no W&B auth prompt, plots visible in TB.

## Out of scope

- Callback composition / per-experiment callback config — tracked under #563.

Closes #614
Part of #563