### PR TITLE
docs(documentation): add contributor-facing testing primer

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,6 +136,11 @@ This runs the quick test suite (excluding slow tests and tests that require a
 VST plugin). All tests should pass. If you see import errors, double-check that
 the virtual environment is active and dependencies installed correctly.
 
+> **Writing or reading tests?** See
+> [docs/reference/testing.md](reference/testing.md) for the fixtures,
+> marker conventions, and canonical train→eval pattern — scoped to what
+> you need before editing `tests/`.
+
 > **Prefer a container- or VM-based setup?** GitHub Codespaces, the local
 > dev container, and the Tart macOS VM all come with Python, Surge XT,
 > and rclone pre-installed. See

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -24,7 +24,7 @@ Browse [`tests/`](../../tests) for the current layout. The tree has several **di
 | VST integration tests                             | [`tests/data/vst/test_preset_params.py`](../../tests/data/vst/test_preset_params.py)                                               | Requires a Surge XT VST3 binary on disk                                                | `requires_vst`                                                |
 | Test helpers                                      | [`tests/helpers/`](../../tests/helpers) — `RunIf`, `run_sh_command`, `package_available`                                           | Not tests themselves — import from `tests.helpers.<name>`                              | —                                                             |
 
-Two top-level conftests: [`tests/conftest.py`](../../tests/conftest.py) (Hydra `cfg_train` / `cfg_eval` fixtures) and [`tests/pipeline/conftest.py`](../../tests/pipeline/conftest.py) (pipeline-specific fixtures). They don't interact — pipeline tests don't see `cfg_train`.
+Two top-level conftests: [`tests/conftest.py`](../../tests/conftest.py) (Hydra `cfg_train` / `cfg_eval` fixtures) and [`tests/pipeline/conftest.py`](../../tests/pipeline/conftest.py) (pipeline-specific fixtures). Pytest resolves parent conftests, so the Hydra fixtures are reachable under `tests/pipeline/` too; pipeline tests typically don't use them and lean on their own fixtures.
 
 ______________________________________________________________________
 
@@ -40,8 +40,8 @@ CI selectors live in [`.github/workflows/`](../../.github/workflows):
 
 - [`test.yml`](../../.github/workflows/test.yml) — CPU tests on every PR.
 - [`test-expensive.yml`](../../.github/workflows/test-expensive.yml) — GPU-gated tests on a GPU runner.
-- [`test-conda.yml`](../../.github/workflows/test-conda.yml) — conda-env matrix.
-- [`nightly.yml`](../../.github/workflows/nightly.yml) — the expensive-runs-only suite.
+- [`test-conda.yml`](../../.github/workflows/test-conda.yml) — single conda-env run (micromamba from `environment.yaml`) on `ubuntu-latest`; covers the non-slow suite under the locked conda deps.
+- [`nightly.yml`](../../.github/workflows/nightly.yml) — scheduled full `pytest` run on CPU (`ubuntu-latest`); no marker filter, so GPU-gated tests skip via `RunIf`.
 
 CI and `make` selectors are **not identical** — CI may use different marker combinations to partition work across runners. Source of truth is always the file, not this doc.
 
@@ -101,7 +101,7 @@ from tests.helpers.run_if import RunIf
 @pytest.mark.gpu
 @RunIf(min_gpus=1)
 @pytest.mark.slow
-def test_train_<what>(tmp_path: Path, cfg_train: DictConfig, cfg_eval: DictConfig) -> None:
+def test_train_e2e(tmp_path: Path, cfg_train: DictConfig, cfg_eval: DictConfig) -> None:  # rename `_e2e` to describe your case
     assert str(tmp_path) == cfg_train.paths.output_dir == cfg_eval.paths.output_dir
 
     # 1. Override cfg_train for this run

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -1,68 +1,88 @@
 # Testing Primer
 
-> **Code version**: `1bfeff0` (2026-04-20, `main`)
-> **Scope**: what you need to read a test in this repo and write a new one that won't eat eight review comments. Not a complete testing philosophy — see `ml-test` skill for that.
+> **Scope**: enough to read a test in this repo and write a new one without eight review comments. Not a complete testing philosophy — see the `ml-test` skill for that.
+>
+> This primer deliberately **points at source files rather than echoing their contents**. Specifics (marker names, Makefile flags, fixture presets, CI selectors) drift fast; open the linked source to see today's truth.
 
 ______________________________________________________________________
 
-## 1. Layout + invocation
+## 1. What lives under `tests/`
 
-Tests mirror the source tree — `tests/` shadows `src/` and `pipeline/`. Locations roughly:
+Browse [`tests/`](../../tests) for the current layout. The tree has several **distinct categories**, not all of which use the same patterns:
 
-- `tests/test_eval.py`, `tests/test_train.py` — end-to-end train/eval round-trips
-- `tests/test_configs.py` — Hydra config composition + env-var interpolation
-- `tests/test_instantiators.py`, `tests/test_datamodules.py` — unit-level checks of setup helpers
-- `tests/helpers/` — shared test utilities (`RunIf`, `package_available`, `run_sh_command`)
+| Category                                          | Where                                                                                                                              | Style                                                                                  | Typical markers                                               |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Hydra-config validation                           | [`tests/test_configs.py`](../../tests/test_configs.py)                                                                             | Uses `cfg_train` / `cfg_eval` fixtures; light assertions + `hydra.utils.instantiate()` | (none by default)                                             |
+| Hydra+Lightning **E2E** train/eval                | [`tests/test_eval.py`](../../tests/test_eval.py), [`tests/test_train.py`](../../tests/test_train.py)                               | Uses fixtures; round-trips `train()` → checkpoint → `evaluate()`                       | `@pytest.mark.gpu`, `@pytest.mark.slow`, `@RunIf(min_gpus=1)` |
+| Hydra sweeps                                      | [`tests/test_sweeps.py`](../../tests/test_sweeps.py)                                                                               | Invokes `src/train.py` as a subprocess via `run_sh_command` helper                     | `gpu`, `slow`                                                 |
+| Pure-Python unit tests                            | [`tests/test_logging_utils.py`](../../tests/test_logging_utils.py), [`tests/test_datamodules.py`](../../tests/test_datamodules.py) | No Hydra fixtures; direct module/class tests                                           | (usually none)                                                |
+| Property-based tests                              | [`tests/test_properties.py`](../../tests/test_properties.py)                                                                       | Hypothesis (`@given`, `@settings`); no fixtures                                        | `hypothesis`, `slow`                                          |
+| Performance benchmarks                            | [`tests/test_benchmarks.py`](../../tests/test_benchmarks.py)                                                                       | `pytest-benchmark`'s `benchmark` fixture                                               | `benchmark`, `slow`                                           |
+| Pipeline tests (schemas, CI scripts, entrypoints) | [`tests/pipeline/`](../../tests/pipeline) — has its own [`conftest.py`](../../tests/pipeline/conftest.py)                          | Pydantic-style unit tests; no Lightning involvement                                    | (none)                                                        |
+| Script tests                                      | [`tests/scripts/`](../../tests/scripts)                                                                                            | Direct-import tests for utilities under `scripts/`                                     | (none)                                                        |
+| Docker image smoke tests                          | [`tests/docker/test_smoke.py`](../../tests/docker/test_smoke.py)                                                                   | Runs inside the built container image                                                  | `docker_smoke`                                                |
+| VST integration tests                             | [`tests/data/vst/test_preset_params.py`](../../tests/data/vst/test_preset_params.py)                                               | Requires a Surge XT VST3 binary on disk                                                | `requires_vst`                                                |
+| Test helpers                                      | [`tests/helpers/`](../../tests/helpers) — `RunIf`, `run_sh_command`, `package_available`                                           | Not tests themselves — import from `tests.helpers.<name>`                              | —                                                             |
 
-Invocation:
-
-| Command                                        | What it runs                                                                       |
-| ---------------------------------------------- | ---------------------------------------------------------------------------------- |
-| `make test`                                    | Quick tests — excludes `slow` and skips anything gated behind missing dependencies |
-| `make test-full`                               | Everything — includes `slow` and GPU-gated tests                                   |
-| `pytest -m "slow and gpu"`                     | Only the GPU end-to-end tests (what GPU CI runs)                                   |
-| `pytest -m "not slow"`                         | Same as `make test` under the hood                                                 |
-| `pytest tests/path/to/test_x.py::test_name -v` | One test, verbose                                                                  |
-
-Markers registered in `pyproject.toml` (must be applied via `@pytest.mark.<name>`):
-`slow`, `gpu`, `hypothesis`, `pipeline`, `benchmark`, `requires_vst`, `r2`, `docker_smoke`.
-
-Strict markers are on — unknown marker names fail collection, so new markers must be added to `pyproject.toml` first.
+Two top-level conftests: [`tests/conftest.py`](../../tests/conftest.py) (Hydra `cfg_train` / `cfg_eval` fixtures) and [`tests/pipeline/conftest.py`](../../tests/pipeline/conftest.py) (pipeline-specific fixtures). They don't interact — pipeline tests don't see `cfg_train`.
 
 ______________________________________________________________________
 
-## 2. Fixtures (`tests/conftest.py`)
+## 2. Running tests
 
-Two canonical fixtures, both defined at `tests/conftest.py`. Use these rather than composing Hydra yourself.
+All common selectors are defined as Makefile targets — read [`Makefile`](../../Makefile) for the exact `pytest` flags each invokes (they evolve; don't memorize):
 
-### `cfg_train`
+- `make test` — quick local suite. Exact marker filter + parallelism settings live in the Makefile.
+- `make test-full` — everything, including slow / GPU / VST-gated tests.
+- `pytest tests/path/to/test_x.py::test_name -v` — one test, for iteration.
 
-Per-function fixture wrapping `cfg_train_global`. Returns a `DictConfig` pre-composed from `configs/train.yaml` with test-friendly overrides already applied:
+CI selectors live in [`.github/workflows/`](../../.github/workflows):
 
-- `trainer.max_epochs=1`, `trainer.max_steps=-1` (epoch-bounded, not step-bounded)
-- `trainer.limit_train_batches=0.01`, `trainer.limit_val_batches=0.1`, `trainer.limit_test_batches=0.1`
-- `trainer.accelerator="cpu"`, `trainer.devices=1`
-- `data.num_workers=0`, `data.pin_memory=False`
-- `logger=None` (no W&B/TB in tests)
-- `paths.output_dir` / `paths.log_dir` point at pytest's `tmp_path`
+- [`test.yml`](../../.github/workflows/test.yml) — CPU tests on every PR.
+- [`test-expensive.yml`](../../.github/workflows/test-expensive.yml) — GPU-gated tests on a GPU runner.
+- [`test-conda.yml`](../../.github/workflows/test-conda.yml) — conda-env matrix.
+- [`nightly.yml`](../../.github/workflows/nightly.yml) — the expensive-runs-only suite.
 
-If your test needs a different data module, model, or trainer config, override inside an `open_dict(cfg_train):` block before calling `train(cfg_train)`.
+CI and `make` selectors are **not identical** — CI may use different marker combinations to partition work across runners. Source of truth is always the file, not this doc.
 
-### `cfg_eval`
-
-Per-function fixture wrapping `cfg_eval_global`. Same treatment, composed from `configs/eval.yaml`:
-
-- Same trainer defaults as `cfg_train` **except** `limit_val_batches` is **not** preset (only `limit_test_batches=0.1` is). See gotcha #3.
-- `ckpt_path="."` as a placeholder — set it to the real checkpoint inside your test
-- Defaults for `data`, `model`, `callbacks` come from `configs/eval.yaml` and **differ from** `cfg_train`'s defaults — if you want a train→eval round-trip, you must align them (gotcha #2)
-
-Both fixtures clear the global Hydra state on teardown via `GlobalHydra.instance().clear()`.
+**Markers** are registered in [`pyproject.toml`](../../pyproject.toml) under `[tool.pytest.ini_options].markers`. The file lists each marker's purpose. Strict markers are on — unknown marker names fail collection, so new markers must be added to `pyproject.toml` first.
 
 ______________________________________________________________________
 
-## 3. The train → eval e2e pattern
+## 3. Which shape fits your test?
 
-Canonical template, lightly annotated. Use `tests/test_eval.py::test_train_eval` as the reference implementation when you write a new one.
+| Goal                                            | Pattern to copy from                                     | Fixtures                            | Markers                            |
+| ----------------------------------------------- | -------------------------------------------------------- | ----------------------------------- | ---------------------------------- |
+| Assert a Hydra config composes and instantiates | `tests/test_configs.py::test_train_config`               | `cfg_train` / `cfg_eval`            | —                                  |
+| E2E `train → ckpt → evaluate` round-trip        | `tests/test_eval.py::test_train_eval`                    | `cfg_train`, `cfg_eval`, `tmp_path` | `gpu`, `slow`, `RunIf(min_gpus=1)` |
+| Unit-test a pure helper / utility               | `tests/test_logging_utils.py`                            | —                                   | —                                  |
+| Hypothesis property test                        | `tests/test_properties.py`                               | —                                   | `hypothesis`, `slow`               |
+| Benchmark a hot path                            | `tests/test_benchmarks.py::test_config_resolution_speed` | `benchmark` (from pytest-benchmark) | `benchmark`, `slow`                |
+| Pydantic schema / pipeline logic                | `tests/pipeline/test_schemas/test_config.py`             | pipeline conftest                   | —                                  |
+| CLI script behavior                             | `tests/scripts/test_r2_shard_report.py`                  | —                                   | —                                  |
+| VST-dependent integration                       | `tests/data/vst/test_preset_params.py`                   | —                                   | `requires_vst`                     |
+
+Most categories don't need the `cfg_train` / `cfg_eval` fixtures. They're specifically for Hydra-composed code paths.
+
+______________________________________________________________________
+
+## 4. `cfg_train` / `cfg_eval` fixtures (`tests/conftest.py`)
+
+Only needed for tests that exercise Hydra-composed configs (test_configs, test_train, test_eval, test_benchmarks, etc.).
+
+Both defined in [`tests/conftest.py`](../../tests/conftest.py) as package-scoped `*_global` fixtures wrapped by function-scoped fixtures that inject `tmp_path`. Each `*_global` fixture's `open_dict(cfg):` block shows the test-friendly overrides applied on top of `configs/train.yaml` / `configs/eval.yaml`. Read that block for today's presets — they change as the fixtures evolve.
+
+**Key asymmetry to know:** `cfg_eval_global` does **not** mirror `cfg_train_global`'s preset list. Notably, several `limit_*_batches` knobs are set on `cfg_train` but not on `cfg_eval`. If your test cares about val-loop or train-loop batch counts on the eval side, pin them explicitly — see gotcha #3.
+
+`cfg_eval`'s `data` / `model` / `callbacks` defaults come from `configs/eval.yaml` and differ from `cfg_train`'s (composed from `configs/train.yaml`). For a train→eval round-trip, align them — see gotcha #2.
+
+Both fixtures clear global Hydra state on teardown via `GlobalHydra.instance().clear()`.
+
+______________________________________________________________________
+
+## 5. The train → eval E2E template
+
+Reference implementation: [`tests/test_eval.py::test_train_eval`](../../tests/test_eval.py). The shape is four phases: override `cfg_train`, train + assert checkpoint, align `cfg_eval` with `cfg_train`, evaluate + assert metrics.
 
 ```python
 import os
@@ -86,20 +106,20 @@ def test_train_<what>(tmp_path: Path, cfg_train: DictConfig, cfg_eval: DictConfi
     # 1. Override cfg_train for this run
     with open_dict(cfg_train):
         cfg_train.trainer.accelerator = "gpu"
-        cfg_train.test = False                 # skip the post-train test phase if you don't need it
+        cfg_train.test = False                 # skip post-train test phase if not needed
 
     # 2. Train; assert the checkpoint landed
     HydraConfig().set_config(cfg_train)
     train_metric_dict, _ = train(cfg_train)
     assert "last.ckpt" in os.listdir(tmp_path / "checkpoints")
 
-    # 3. Align cfg_eval with cfg_train so the checkpoint loads cleanly
+    # 3. Align cfg_eval with cfg_train so the checkpoint loads
     with open_dict(cfg_eval):
         cfg_eval.trainer.accelerator = "gpu"
-        cfg_eval.trainer.limit_val_batches = cfg_train.trainer.limit_val_batches  # parity (gotcha #3)
-        cfg_eval.data      = cfg_train.data                                        # ckpt's DataModule
-        cfg_eval.model     = cfg_train.model                                       # ckpt's LightningModule
-        cfg_eval.callbacks = cfg_train.callbacks                                   # matches train hooks
+        cfg_eval.trainer.limit_val_batches = cfg_train.trainer.limit_val_batches  # gotcha #3
+        cfg_eval.data      = cfg_train.data                                        # gotcha #2
+        cfg_eval.model     = cfg_train.model
+        cfg_eval.callbacks = cfg_train.callbacks
         cfg_eval.ckpt_path = str(tmp_path / "checkpoints" / "last.ckpt")
         cfg_eval.mode = "validate"             # or "test", or "predict"
 
@@ -111,35 +131,36 @@ def test_train_<what>(tmp_path: Path, cfg_train: DictConfig, cfg_eval: DictConfi
     assert abs(train_metric_dict["val/loss"].item() - eval_metric_dict["val/loss"].item()) < 0.001
 ```
 
-The three-marker stack (`@pytest.mark.gpu`, `@RunIf(min_gpus=1)`, `@pytest.mark.slow`) is what makes GPU CI pick the test up and CPU-only `make test` skip it. Drop all three for CPU-only unit tests.
+The three-marker stack (`gpu` + `slow` + `RunIf`) exists because each does a different job — the `pytest.mark` stack lets the Makefile / CI workflow select tests, `RunIf` is a runtime guard that skips when no CUDA device is present. Drop all three for CPU-only unit tests.
+
+Non-E2E categories (unit, property-based, benchmark, pipeline) use **simpler** shapes — don't over-apply this template to them. Start from a sibling test in the same file.
 
 ______________________________________________________________________
 
-## 4. Gotchas
+## 6. Gotchas
 
-1. **DataModule `setup(stage)` must cover every stage you invoke.** Lightning passes one of `{"fit", "validate", "test", "predict"}` depending on which Trainer method you call. A `setup()` that only handles `"fit"` will silently build the wrong dataloader (or none at all) for other stages. See Lightning's [DataModule docs](https://lightning.ai/docs/pytorch/stable/data/datamodule.html) and `src/data/ksin_datamodule.py` for the canonical three-branch pattern (`fit` → train, `{fit, validate}` → val, `{test, predict}` → test).
+1. **DataModule `setup(stage)` must cover every stage you invoke.** Lightning passes one of `{"fit", "validate", "test", "predict"}` depending on which Trainer method runs. A `setup()` that only handles `"fit"` silently builds the wrong (or no) dataloader for the others. See Lightning's [DataModule docs](https://lightning.ai/docs/pytorch/stable/data/datamodule.html) for the contract, and [`src/data/ksin_datamodule.py`](../../src/data/ksin_datamodule.py) for the canonical three-branch pattern in this repo.
 
-2. **`cfg_eval.data/model/callbacks` default to different values than `cfg_train`'s.** `configs/eval.yaml` composes surge-oriented defaults; `configs/train.yaml` composes ksin defaults. If you want to round-trip a checkpoint produced by `train(cfg_train)`, align `cfg_eval.data`, `cfg_eval.model`, and `cfg_eval.callbacks` with `cfg_train`'s before loading the checkpoint — otherwise Lightning refuses to restore state into a differently-shaped LightningModule.
+2. **`cfg_eval` and `cfg_train` defaults don't agree.** `configs/train.yaml` and `configs/eval.yaml` compose different `data` / `model` / `callbacks` defaults. For a checkpoint round-trip, align them explicitly before calling `evaluate()` or Lightning refuses to restore state into a differently-shaped module.
 
-3. **Pin `cfg_eval.trainer.limit_val_batches = cfg_train.trainer.limit_val_batches` for train→val parity checks.** The fixture presets `limit_val_batches=0.1` on `cfg_train` but **not** on `cfg_eval`. Without the pin, `train()`'s in-fit val loop runs on 10% of batches while `evaluate()` runs on 100%, and any parity assertion becomes noise.
+3. **Pin trainer `limit_*_batches` when doing train→val parity checks.** `cfg_train_global` presets several `limit_*` values; `cfg_eval_global` presets a subset (read the conftest for the current asymmetry). Without explicit pinning, train's in-fit val loop and a standalone `evaluate()` can iterate over different batch counts, making any parity assertion unreliable.
 
-4. **Three-marker stack for GPU e2e tests.** `@pytest.mark.slow`, `@pytest.mark.gpu`, and `@RunIf(min_gpus=1)` are all needed:
+4. **GPU tests use a three-marker stack.** `@pytest.mark.gpu`, `@pytest.mark.slow`, `@RunIf(min_gpus=1)` each do distinct things. The CI selector for GPU tests lives in [`.github/workflows/test-expensive.yml`](../../.github/workflows/test-expensive.yml); local `make test` filter lives in the Makefile. If the CI filter changes, the docs don't need updating — the code does.
 
-   - `slow` + `gpu` markers tell `make test` to skip the test locally and tell GPU CI to include it via `-m "slow and gpu"`
-   - `RunIf(min_gpus=1)` is a runtime guard that skips on hosts without a CUDA GPU (protects against mismatches between marker and environment)
+5. **`weights_only=False` when loading a checkpoint for eval.** PyTorch 2.6 tightened `torch.load`'s default to `weights_only=True`, which refuses Lightning checkpoint metadata. `src/eval.py` passes `weights_only=False` explicitly to `trainer.test/validate/predict(ckpt_path=...)`. New standalone loader code needs the same.
 
-5. **`weights_only=False` when loading a checkpoint for eval.** PyTorch 2.6 tightened the default for `torch.load` to `weights_only=True`, which refuses to unpickle the Lightning checkpoint metadata. `src/eval.py` passes `weights_only=False` explicitly to `trainer.test/validate/predict(ckpt_path=...)` — any new standalone loader code needs the same flag.
-
-6. **If you add a new `mode=<x>` dispatch to `src/eval.py`, audit every affected DataModule's `setup()`.** `src/eval.py` dispatches on `cfg.mode` to `trainer.test/validate/predict`, each of which passes a different `stage` to `DataModule.setup()`. Adding a mode without verifying the DataModules handle its stage is how gotcha #1 bites.
+6. **Adding a new `cfg.mode=<x>` dispatch?** Audit every DataModule's `setup()` for that stage. `src/eval.py` routes `mode` to `trainer.test/validate/predict`, each passing a different `stage` string. Gotcha #1 bites if a DataModule doesn't handle the new stage.
 
 ______________________________________________________________________
 
-## 5. Pointers
+## 7. Pointers
 
-- **Conftest**: [`tests/conftest.py`](../../tests/conftest.py) — source of `cfg_train` / `cfg_eval` fixtures, all preset overrides visible in one file
-- **Reference e2e test**: [`tests/test_eval.py::test_train_eval`](../../tests/test_eval.py) — cleanest example of the open_dict → train → ckpt → open_dict → evaluate pattern
-- **Markers config**: [`pyproject.toml`](../../pyproject.toml) `[tool.pytest.ini_options]` — source of truth for registered marker names
-- **GPU skipping helper**: [`tests/helpers/run_if.py`](../../tests/helpers/run_if.py) — ported from Lightning's own test harness
-- **Lightning DataModule**: <https://lightning.ai/docs/pytorch/stable/data/datamodule.html> — stage semantics, setup/teardown contract
-- **Lightning Trainer methods**: <https://lightning.ai/docs/pytorch/stable/common/trainer.html> — which method triggers which stage
-- **W&B in tests**: tests set `logger=None` so nothing hits W&B. See [`docs/reference/wandb-integration.md`](wandb-integration.md) for runtime logger behavior.
+- [`tests/conftest.py`](../../tests/conftest.py) — the Hydra fixtures, including all preset overrides
+- [`tests/pipeline/conftest.py`](../../tests/pipeline/conftest.py) — pipeline-test fixtures (separate tree, separate fixtures)
+- [`tests/helpers/`](../../tests/helpers) — `RunIf`, `run_sh_command`, `package_available`
+- [`tests/test_eval.py::test_train_eval`](../../tests/test_eval.py) — canonical E2E template
+- [`Makefile`](../../Makefile) — `test`, `test-full`, and friends
+- [`pyproject.toml`](../../pyproject.toml) — registered markers + pytest config
+- [`.github/workflows/`](../../.github/workflows) — which CI job runs which markers
+- Lightning [DataModule](https://lightning.ai/docs/pytorch/stable/data/datamodule.html) and [Trainer](https://lightning.ai/docs/pytorch/stable/common/trainer.html) docs — stage semantics and the `fit/validate/test/predict` contract
+- [`docs/reference/wandb-integration.md`](wandb-integration.md) — tests disable the logger (`cfg.logger=None`); this covers the runtime behavior

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -1,0 +1,145 @@
+# Testing Primer
+
+> **Code version**: `1bfeff0` (2026-04-20, `main`)
+> **Scope**: what you need to read a test in this repo and write a new one that won't eat eight review comments. Not a complete testing philosophy — see `ml-test` skill for that.
+
+______________________________________________________________________
+
+## 1. Layout + invocation
+
+Tests mirror the source tree — `tests/` shadows `src/` and `pipeline/`. Locations roughly:
+
+- `tests/test_eval.py`, `tests/test_train.py` — end-to-end train/eval round-trips
+- `tests/test_configs.py` — Hydra config composition + env-var interpolation
+- `tests/test_instantiators.py`, `tests/test_datamodules.py` — unit-level checks of setup helpers
+- `tests/helpers/` — shared test utilities (`RunIf`, `package_available`, `run_sh_command`)
+
+Invocation:
+
+| Command                                        | What it runs                                                                       |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `make test`                                    | Quick tests — excludes `slow` and skips anything gated behind missing dependencies |
+| `make test-full`                               | Everything — includes `slow` and GPU-gated tests                                   |
+| `pytest -m "slow and gpu"`                     | Only the GPU end-to-end tests (what GPU CI runs)                                   |
+| `pytest -m "not slow"`                         | Same as `make test` under the hood                                                 |
+| `pytest tests/path/to/test_x.py::test_name -v` | One test, verbose                                                                  |
+
+Markers registered in `pyproject.toml` (must be applied via `@pytest.mark.<name>`):
+`slow`, `gpu`, `hypothesis`, `pipeline`, `benchmark`, `requires_vst`, `r2`, `docker_smoke`.
+
+Strict markers are on — unknown marker names fail collection, so new markers must be added to `pyproject.toml` first.
+
+______________________________________________________________________
+
+## 2. Fixtures (`tests/conftest.py`)
+
+Two canonical fixtures, both defined at `tests/conftest.py`. Use these rather than composing Hydra yourself.
+
+### `cfg_train`
+
+Per-function fixture wrapping `cfg_train_global`. Returns a `DictConfig` pre-composed from `configs/train.yaml` with test-friendly overrides already applied:
+
+- `trainer.max_epochs=1`, `trainer.max_steps=-1` (epoch-bounded, not step-bounded)
+- `trainer.limit_train_batches=0.01`, `trainer.limit_val_batches=0.1`, `trainer.limit_test_batches=0.1`
+- `trainer.accelerator="cpu"`, `trainer.devices=1`
+- `data.num_workers=0`, `data.pin_memory=False`
+- `logger=None` (no W&B/TB in tests)
+- `paths.output_dir` / `paths.log_dir` point at pytest's `tmp_path`
+
+If your test needs a different data module, model, or trainer config, override inside an `open_dict(cfg_train):` block before calling `train(cfg_train)`.
+
+### `cfg_eval`
+
+Per-function fixture wrapping `cfg_eval_global`. Same treatment, composed from `configs/eval.yaml`:
+
+- Same trainer defaults as `cfg_train` **except** `limit_val_batches` is **not** preset (only `limit_test_batches=0.1` is). See gotcha #3.
+- `ckpt_path="."` as a placeholder — set it to the real checkpoint inside your test
+- Defaults for `data`, `model`, `callbacks` come from `configs/eval.yaml` and **differ from** `cfg_train`'s defaults — if you want a train→eval round-trip, you must align them (gotcha #2)
+
+Both fixtures clear the global Hydra state on teardown via `GlobalHydra.instance().clear()`.
+
+______________________________________________________________________
+
+## 3. The train → eval e2e pattern
+
+Canonical template, lightly annotated. Use `tests/test_eval.py::test_train_eval` as the reference implementation when you write a new one.
+
+```python
+import os
+from pathlib import Path
+
+import pytest
+from hydra.core.hydra_config import HydraConfig
+from omegaconf import DictConfig, open_dict
+
+from src.eval import evaluate
+from src.train import train
+from tests.helpers.run_if import RunIf
+
+
+@pytest.mark.gpu
+@RunIf(min_gpus=1)
+@pytest.mark.slow
+def test_train_<what>(tmp_path: Path, cfg_train: DictConfig, cfg_eval: DictConfig) -> None:
+    assert str(tmp_path) == cfg_train.paths.output_dir == cfg_eval.paths.output_dir
+
+    # 1. Override cfg_train for this run
+    with open_dict(cfg_train):
+        cfg_train.trainer.accelerator = "gpu"
+        cfg_train.test = False                 # skip the post-train test phase if you don't need it
+
+    # 2. Train; assert the checkpoint landed
+    HydraConfig().set_config(cfg_train)
+    train_metric_dict, _ = train(cfg_train)
+    assert "last.ckpt" in os.listdir(tmp_path / "checkpoints")
+
+    # 3. Align cfg_eval with cfg_train so the checkpoint loads cleanly
+    with open_dict(cfg_eval):
+        cfg_eval.trainer.accelerator = "gpu"
+        cfg_eval.trainer.limit_val_batches = cfg_train.trainer.limit_val_batches  # parity (gotcha #3)
+        cfg_eval.data      = cfg_train.data                                        # ckpt's DataModule
+        cfg_eval.model     = cfg_train.model                                       # ckpt's LightningModule
+        cfg_eval.callbacks = cfg_train.callbacks                                   # matches train hooks
+        cfg_eval.ckpt_path = str(tmp_path / "checkpoints" / "last.ckpt")
+        cfg_eval.mode = "validate"             # or "test", or "predict"
+
+    # 4. Evaluate; assert metrics
+    HydraConfig().set_config(cfg_eval)
+    eval_metric_dict, _ = evaluate(cfg_eval)
+    assert eval_metric_dict["val/loss"] < float("inf")
+    # Optional parity check: train's in-fit val vs. standalone eval's val
+    assert abs(train_metric_dict["val/loss"].item() - eval_metric_dict["val/loss"].item()) < 0.001
+```
+
+The three-marker stack (`@pytest.mark.gpu`, `@RunIf(min_gpus=1)`, `@pytest.mark.slow`) is what makes GPU CI pick the test up and CPU-only `make test` skip it. Drop all three for CPU-only unit tests.
+
+______________________________________________________________________
+
+## 4. Gotchas
+
+1. **DataModule `setup(stage)` must cover every stage you invoke.** Lightning passes one of `{"fit", "validate", "test", "predict"}` depending on which Trainer method you call. A `setup()` that only handles `"fit"` will silently build the wrong dataloader (or none at all) for other stages. See Lightning's [DataModule docs](https://lightning.ai/docs/pytorch/stable/data/datamodule.html) and `src/data/ksin_datamodule.py` for the canonical three-branch pattern (`fit` → train, `{fit, validate}` → val, `{test, predict}` → test).
+
+2. **`cfg_eval.data/model/callbacks` default to different values than `cfg_train`'s.** `configs/eval.yaml` composes surge-oriented defaults; `configs/train.yaml` composes ksin defaults. If you want to round-trip a checkpoint produced by `train(cfg_train)`, align `cfg_eval.data`, `cfg_eval.model`, and `cfg_eval.callbacks` with `cfg_train`'s before loading the checkpoint — otherwise Lightning refuses to restore state into a differently-shaped LightningModule.
+
+3. **Pin `cfg_eval.trainer.limit_val_batches = cfg_train.trainer.limit_val_batches` for train→val parity checks.** The fixture presets `limit_val_batches=0.1` on `cfg_train` but **not** on `cfg_eval`. Without the pin, `train()`'s in-fit val loop runs on 10% of batches while `evaluate()` runs on 100%, and any parity assertion becomes noise.
+
+4. **Three-marker stack for GPU e2e tests.** `@pytest.mark.slow`, `@pytest.mark.gpu`, and `@RunIf(min_gpus=1)` are all needed:
+
+   - `slow` + `gpu` markers tell `make test` to skip the test locally and tell GPU CI to include it via `-m "slow and gpu"`
+   - `RunIf(min_gpus=1)` is a runtime guard that skips on hosts without a CUDA GPU (protects against mismatches between marker and environment)
+
+5. **`weights_only=False` when loading a checkpoint for eval.** PyTorch 2.6 tightened the default for `torch.load` to `weights_only=True`, which refuses to unpickle the Lightning checkpoint metadata. `src/eval.py` passes `weights_only=False` explicitly to `trainer.test/validate/predict(ckpt_path=...)` — any new standalone loader code needs the same flag.
+
+6. **If you add a new `mode=<x>` dispatch to `src/eval.py`, audit every affected DataModule's `setup()`.** `src/eval.py` dispatches on `cfg.mode` to `trainer.test/validate/predict`, each of which passes a different `stage` to `DataModule.setup()`. Adding a mode without verifying the DataModules handle its stage is how gotcha #1 bites.
+
+______________________________________________________________________
+
+## 5. Pointers
+
+- **Conftest**: [`tests/conftest.py`](../../tests/conftest.py) — source of `cfg_train` / `cfg_eval` fixtures, all preset overrides visible in one file
+- **Reference e2e test**: [`tests/test_eval.py::test_train_eval`](../../tests/test_eval.py) — cleanest example of the open_dict → train → ckpt → open_dict → evaluate pattern
+- **Markers config**: [`pyproject.toml`](../../pyproject.toml) `[tool.pytest.ini_options]` — source of truth for registered marker names
+- **GPU skipping helper**: [`tests/helpers/run_if.py`](../../tests/helpers/run_if.py) — ported from Lightning's own test harness
+- **Lightning DataModule**: <https://lightning.ai/docs/pytorch/stable/data/datamodule.html> — stage semantics, setup/teardown contract
+- **Lightning Trainer methods**: <https://lightning.ai/docs/pytorch/stable/common/trainer.html> — which method triggers which stage
+- **W&B in tests**: tests set `logger=None` so nothing hits W&B. See [`docs/reference/wandb-integration.md`](wandb-integration.md) for runtime logger behavior.

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -85,6 +85,7 @@ ______________________________________________________________________
 Reference implementation: [`tests/test_eval.py::test_train_eval`](../../tests/test_eval.py). The shape is four phases: override `cfg_train`, train + assert checkpoint, align `cfg_eval` with `cfg_train`, evaluate + assert metrics.
 
 ```python
+import math
 import os
 from pathlib import Path
 
@@ -126,7 +127,10 @@ def test_train_<what>(tmp_path: Path, cfg_train: DictConfig, cfg_eval: DictConfi
     # 4. Evaluate; assert metrics
     HydraConfig().set_config(cfg_eval)
     eval_metric_dict, _ = evaluate(cfg_eval)
-    assert eval_metric_dict["val/loss"] < float("inf")
+    # `math.isfinite` rejects +inf, -inf, and NaN. `< float("inf")` silently
+    # accepts -inf — safe for non-negative losses like MSE but a copy-paste
+    # hazard for losses that can go negative (log-likelihood, reward, ...).
+    assert math.isfinite(eval_metric_dict["val/loss"].item())
     # Optional parity check: train's in-fit val vs. standalone eval's val
     assert abs(train_metric_dict["val/loss"].item() - eval_metric_dict["val/loss"].item()) < 0.001
 ```


### PR DESCRIPTION
## Summary

Adds a small contributor-facing primer at `docs/reference/testing.md` covering the bare minimum someone needs to read a test in this repo and write a new one without eating eight review comments.

Linked from [`docs/getting-started.md §2f`](../blob/docs/testing-primer/docs/getting-started.md#2f-verify-the-installation) so contributors discover it immediately after verifying their install.

## What the primer covers

1. **Layout + invocation** — `tests/` tree, `make test` / `make test-full` / targeted `pytest -m "slow and gpu"`, registered markers
2. **Fixtures** — `cfg_train` and `cfg_eval` from `conftest.py`, what they pre-set, and the trap that `cfg_eval` doesn't preset `limit_val_batches` while `cfg_train` does
3. **The train→eval e2e pattern** — copy-paste template showing the four-step structure: override `cfg_train`, train + assert checkpoint, align `cfg_eval`, evaluate + assert metrics
4. **Six gotchas** distilled from recent review cycles:
   - DataModule `setup(stage)` must cover every stage (surfaced by [#636](https://github.com/tinaudio/synth-setter/pull/636))
   - `cfg_eval.data/model/callbacks` default to values that differ from `cfg_train`'s — must align for checkpoint round-trips
   - `limit_val_batches` parity (the PR #636 Copilot flag)
   - Three-marker GPU stack (`slow` + `gpu` + `@RunIf(min_gpus=1)`)
   - `weights_only=False` for PyTorch 2.6 checkpoint loads
   - `mode` → DataModule stage audit when extending `src/eval.py`
5. **Pointers** to conftest.py, `test_train_eval` as the reference template, Lightning docs, and `wandb-integration.md`

## Scope boundaries

Explicitly **out of scope** (kept out to stop the doc from rotting):
- Per-test explanations — tests are self-documenting
- ML-test theory — owned by the `ml-test` skill
- Marker philosophy beyond what pytest docs already cover
- Complete testing guide — target is ≤1 page, ~5 min read

Closes #650.

## Test plan

- [x] `make format` passes clean (mdformat reflowed tables on first pass; clean on second)
- [ ] Reviewer skims the primer and confirms it reads in ≤5 min
- [ ] Reviewer tries the canonical template against a scratch test and confirms it works without additional explanation