### PR TITLE
fix(testing): tighten test_eval finiteness assertions to math.isfinite

### DIFF
--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,3 +1,4 @@
+import math
 import os
 from pathlib import Path
 
@@ -52,8 +53,9 @@ def test_train_eval(tmp_path: Path, cfg_train: DictConfig, cfg_eval: DictConfig)
 
     # `ksin_ff_module.test_step` logs `test/loss` (MSE), not `test/acc`. Use loss for the sanity
     # bound and parity check — the train-time test phase and the standalone eval should produce
-    # identical `test/loss` on the same checkpoint and data.
-    assert test_metric_dict["test/loss"] < float("inf")
+    # identical `test/loss` on the same checkpoint and data. `math.isfinite` rejects `+inf`,
+    # `-inf`, and NaN; `< float("inf")` would silently accept `-inf`.
+    assert math.isfinite(test_metric_dict["test/loss"].item())
     assert (
         abs(train_metric_dict["test/loss"].item() - test_metric_dict["test/loss"].item()) < 0.001
     )
@@ -95,5 +97,5 @@ def test_train_validate(tmp_path: Path, cfg_train: DictConfig, cfg_eval: DictCon
     HydraConfig().set_config(cfg_eval)
     val_metric_dict, _ = evaluate(cfg_eval)
 
-    assert val_metric_dict["val/loss"] < float("inf")
+    assert math.isfinite(val_metric_dict["val/loss"].item())
     assert abs(train_metric_dict["val/loss"].item() - val_metric_dict["val/loss"].item()) < 0.001


### PR DESCRIPTION
## Summary

Swap both sanity-bound assertions in `tests/test_eval.py` from `< float("inf")` to `math.isfinite(...)`:

- Line 56 — `test_train_eval`'s `test/loss` check (introduced in [#641](https://github.com/tinaudio/synth-setter/pull/641))
- Line 98 — `test_train_validate`'s `val/loss` check (introduced in [#636](https://github.com/tinaudio/synth-setter/pull/636))

`< float("inf")` silently accepts `-inf`, so the assertion doesn't actually enforce "finite":
- `-inf < +inf` → `True` (slips through)
- `+inf < +inf` → `False` (caught)
- `NaN < +inf` → `False` (caught accidentally)

For the current MSE loss values this is moot (MSE is non-negative). But `docs/reference/testing.md` advertises these tests as the canonical E2E template, so a future copy-paste against a loss that can go negative (log-likelihood, reward, custom loss) would inherit the gap.

## Cherry-pick note

This fix was originally committed on the `test/test-train-validate` branch (which backs [#636](https://github.com/tinaudio/synth-setter/pull/636)) as `1965e22`, but pushed **after** #636 had already merged at `31aa1a4`. That commit is stranded on the post-merge branch and didn't reach main. This PR cherry-picks it onto a fresh branch off main to land it properly.

Closes #654. Refs [#636](https://github.com/tinaudio/synth-setter/pull/636), [#641](https://github.com/tinaudio/synth-setter/pull/641).

## Test plan

- [x] `make format` clean
- [x] GPU end-to-end: `pytest tests/test_eval.py::test_train_validate -m "slow and gpu" -v` PASSED in 465.65s on RTX 5060 Ti (verified before the cherry-pick, on the `test/test-train-validate` branch — same commit content)
- [ ] GPU end-to-end re-run on this branch's HEAD to confirm the cherry-pick didn't drift (run `pytest tests/test_eval.py::test_train_eval -v` and `pytest tests/test_eval.py::test_train_validate -v`)