### PR TITLE
feat(ci): add push_image opt-in for workflow_dispatch in docker-build-validation

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -4,7 +4,9 @@ name: Docker Image Build and Push
 # tests against the pushed image.
 #
 # Triggers:
-# - Manual dispatch or weekly schedule: full build + push + smoke tests
+# - Weekly schedule: full build + push + smoke tests
+# - Manual dispatch: build-only by default; set `push_image: true` to push
+#   to Docker Hub and run smoke tests (works from any branch via `git_ref`)
 # - Pull request (Docker-related paths): build-only validation (no push)
 #
 # git_ref resolution:
@@ -27,6 +29,11 @@ on:
         description: "GitHub issue number for config metadata."
         required: false
         default: "311"
+      push_image:
+        description: "Push the built image to Docker Hub and run smoke tests. When false (default), the workflow only validates that the image builds. Works with any `git_ref` — set this to true to publish a dev-snapshot from a branch."
+        required: false
+        type: boolean
+        default: false
   schedule:
     # Weekly: Sunday 06:00 UTC
     - cron: "0 6 * * 0"
@@ -78,10 +85,11 @@ jobs:
             --issue-number '${{ github.event.pull_request.number || github.event.inputs.issue_number || 311 }}'
 
       - name: Log in to Docker Hub
-        # Only needed for push; PR runs are build-only validation. Gating
-        # this step prevents same-repo PRs from failing if DOCKERHUB_*
-        # secrets are temporarily unavailable, and matches the existing
-        # gate on the Verify Docker Hub push access step below.
+        # Only needed for push. Gated to (schedule) OR (workflow_dispatch
+        # with push_image=true). PR runs and build-only dispatches skip
+        # this to avoid failing if DOCKERHUB_* secrets are temporarily
+        # unavailable, and it matches the gate on the Verify Docker Hub
+        # push access step below.
         #
         # Note: fork PRs still can't build this Dockerfile even with the
         # gate in place, because the in-image `git fetch origin` resolves
@@ -89,7 +97,7 @@ jobs:
         # not the fork. A proper fork-PR build would need to fetch from
         # github.event.pull_request.head.repo.html_url; that's not
         # implemented here.
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.push_image)
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -99,7 +107,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Verify Docker Hub push access
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.push_image)
         env:
           DH_USER: ${{ secrets.DOCKERHUB_USERNAME }}
           DH_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -136,8 +144,8 @@ jobs:
           file: ${{ steps.config.outputs.dockerfile }}
           target: dev-snapshot
           platforms: ${{ steps.config.outputs.target_platform }}
-          push: ${{ github.event_name != 'pull_request' }}
-          load: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.push_image) }}
+          load: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.push_image) }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -149,7 +157,7 @@ jobs:
           # R2/W&B credentials flow in at runtime, not build time.
           secrets: ""
           cache-from: type=registry,ref=tinaudio/synth-setter:buildcache
-          cache-to: ${{ github.event_name != 'pull_request' && 'type=registry,ref=tinaudio/synth-setter:buildcache,mode=max' || '' }}
+          cache-to: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.push_image)) && 'type=registry,ref=tinaudio/synth-setter:buildcache,mode=max' || '' }}
 
       - name: Build and push devcontainer-tools image
         uses: docker/build-push-action@v6
@@ -158,7 +166,7 @@ jobs:
           file: ${{ steps.config.outputs.dockerfile }}
           target: devcontainer-tools
           platforms: ${{ steps.config.outputs.target_platform }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.push_image) }}
           tags: |
             ${{ steps.config.outputs.image }}:devcontainer-tools
             ${{ steps.config.outputs.image }}:devcontainer-tools-${{ steps.source.outputs.sha }}
@@ -173,7 +181,7 @@ jobs:
           cache-to: ""
 
       - name: Smoke test — container starts and Python imports work
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.push_image)
         env:
           SMOKE_IMAGE: ${{ steps.config.outputs.image }}:dev-snapshot-${{ steps.source.outputs.sha }}
         run: |
@@ -181,7 +189,7 @@ jobs:
             -c "pytest tests/docker/test_smoke.py::test_pedalboard_importable -v"
 
       - name: Smoke test — VST loads under headless X11
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.push_image)
         env:
           SMOKE_IMAGE: ${{ steps.config.outputs.image }}:dev-snapshot-${{ steps.source.outputs.sha }}
         run: |


### PR DESCRIPTION
## Summary

Adds a boolean `push_image` input on `workflow_dispatch` (default `false`) to the **Docker Image Build and Push** workflow (`.github/workflows/docker-build-validation.yml`). This lets operators dispatch a build-only validation run OR — by explicitly opting in — push the image to Docker Hub and run smoke tests from any branch via the existing `git_ref` input.

Before: every `workflow_dispatch` run unconditionally pushed to Docker Hub.
After: `workflow_dispatch` is build-only by default; push is gated on `inputs.push_image == true`.

## Changes

- Add `push_image: type=boolean, default=false` to `workflow_dispatch.inputs`.
- Replace the `github.event_name != 'pull_request'` gate on all push-related steps with `github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.push_image)`. Affects:
  - `Log in to Docker Hub`
  - `Verify Docker Hub push access`
  - `Build and push Docker image` — `push`, `load`, `cache-to`
  - `Build and push devcontainer-tools image` — `push`
  - Both `Smoke test …` steps
- Update the trigger-summary comment at the top of the file.

## Behavior matrix

| Event | `push_image` | Push + smoke tests? |
|---|---|---|
| `schedule` | n/a | yes (unchanged) |
| `pull_request` | n/a | no (unchanged) |
| `workflow_dispatch` | `false` (default) | **no (new default — was yes)** |
| `workflow_dispatch` | `true` | yes |

The `latest` tag gate is unchanged (`schedule` OR `workflow_dispatch` with `git_ref == 'main'`) — it still only applies when the image is actually pushed, since tags are only published when `push: true`.

## Breaking-ish note

This flips the default for `workflow_dispatch`: existing automation that dispatches this workflow expecting a push must now pass `push_image: true`. Scheduled and PR behavior is unchanged. Intentional per the issue — the ask was explicit opt-in.

## Validation

- `gha-workflow-validator`: 10 passed, 9 pre-existing warnings (unpinned action tags, no `permissions:` block, `secrets.DOCKERHUB_*` must be configured in repo), 0 failures.
- Semantic review: `if:` conditions match `on:` triggers; `cache-to` gated behind the same push condition (no registry login → no cache write); no Docker push+load conflicts.
- `make format` passes.

## Test plan

- [ ] Dispatch on `main` with `push_image=false` → build succeeds, no push, no smoke tests
- [ ] Dispatch on a branch with `push_image=true` → image pushed as `dev-snapshot-<sha>`, smoke tests run
- [ ] Open a PR touching `docker/**` → build-only validation (no push), same as before
- [ ] Next scheduled (Sunday 06:00 UTC) run → push + smoke tests, same as before

Closes #668