### PR TITLE
feat(monitoring): enable W&B logger by default in many_loggers compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ set -a && source .env && set +a
 
 > **Experiment tracking:** the default training run logs to W&B + CSV +
 > TensorBoard. Run `wandb login` (or set `WANDB_API_KEY`) before your first
-> training run, or drop W&B from the default compose by uncommenting `- wandb`
-> in `configs/logger/many_loggers.yaml`. See
+> training run, or drop W&B from the default compose by commenting out (or
+> removing) `- wandb` in `configs/logger/many_loggers.yaml`. See
 > [getting-started §4c](docs/getting-started.md#4c-weights--biases-wb) for
 > the full configuration workflow.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ under the GPL-3.0 license.
 
 - **Flow matching and baseline models** for synthesizer parameter estimation
 - **Distributed data pipeline** for VST audio dataset generation with cloud support
-- **W&B integration** (opt-in) for experiment tracking and model checkpointing — fresh installs log to CSV + TensorBoard; pass `logger=wandb` to enable W&B
+- **W&B integration** for experiment tracking and model checkpointing — fresh installs log to W&B + CSV + TensorBoard by default; pass `logger=csv` or edit `configs/logger/many_loggers.yaml` to drop W&B
 - **Docker support** for reproducible training and generation environments
 - **Hydra configs** for flexible experiment management
 
@@ -76,11 +76,12 @@ make install-surge-xt
 set -a && source .env && set +a
 ```
 
-> **Experiment tracking:** the default training run logs to CSV + TensorBoard
-> (no external account needed). W&B is **opt-in** — run training with
-> `logger=wandb` after `wandb login` (or setting `WANDB_API_KEY`). See
+> **Experiment tracking:** the default training run logs to W&B + CSV +
+> TensorBoard. Run `wandb login` (or set `WANDB_API_KEY`) before your first
+> training run, or drop W&B from the default compose by uncommenting `- wandb`
+> in `configs/logger/many_loggers.yaml`. See
 > [getting-started §4c](docs/getting-started.md#4c-weights--biases-wb) for
-> the full enable/disable workflow.
+> the full configuration workflow.
 
 > **Already have Surge XT installed system-wide?** Skip `make install-surge-xt`
 > and symlink it manually:

--- a/configs/logger/many_loggers.yaml
+++ b/configs/logger/many_loggers.yaml
@@ -6,4 +6,4 @@ defaults:
   # - mlflow
   # - neptune
   - tensorboard
-  # - wandb
+  - wandb

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -170,6 +170,9 @@ docs:
         covers: "Host-side initializeCommand — refuses pointer-file `.git` (worktree/submodule/--separate-git-dir), ensures .env exists"
       - pattern: ".devcontainer/post-create.sh"
         covers: "First-run setup — git safety, pre-commit install, root-to-dev privilege drop"
+      - pattern: "configs/logger/many_loggers.yaml"
+        covers: "Default logger compose — referenced in §4c for enable/disable workflow"
+        scope: "wandb-config"
 
   # ── GitHub taxonomy ─────────────────────────────────────────────
   - doc: docs/design/github-taxonomy.md

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -50,6 +50,8 @@ docs:
     sources:
       - pattern: "configs/logger/wandb.yaml"
         covers: "Entity, project, log_model setting, offline mode"
+      - pattern: "configs/logger/many_loggers.yaml"
+        covers: "Default logger compose — which loggers are enabled out of the box"
       - pattern: "src/train.py"
         covers: "WandbLogger instantiation, trainer integration, run lifecycle"
       - pattern: "src/eval.py"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -178,9 +178,9 @@ with decreasing loss values.
 - Hydra composes the config from `configs/train.yaml` + the experiment override
 - Lightning sets up the data module, model, callbacks, and trainer
 - Checkpoints are saved under `logs/{task_name}/{experiment_name}/{run_name}-{timestamp}/checkpoints/` (for this command: `logs/train/kosc/ffn_mse-<timestamp>/checkpoints/`)
-- Metrics are logged locally to CSV + TensorBoard by default. If you opt into
-  W&B (see [section 4c](#4c-weights--biases-wb)), metrics also go to your W&B
-  dashboard
+- Metrics are logged to W&B + CSV + TensorBoard by default. W&B requires
+  `wandb login` (or `WANDB_API_KEY`) — see [section 4c](#4c-weights--biases-wb)
+  for credentials, or to drop W&B from the default compose
 
 ### 3b. Available k-osc experiments
 
@@ -295,17 +295,14 @@ You should see top-level directories like `data/`, `train/`, and `eval/`.
 
 ### 4c. Weights & Biases (W&B)
 
-**W&B is opt-in.** [Weights & Biases](https://wandb.ai/) provides experiment
-tracking, metric logging, and model checkpoint storage. The default training
-logger (`configs/logger/many_loggers.yaml`) composes CSV + TensorBoard, so
-`python src/train.py ...` works out of the box with no W&B account and no
-`wandb login` prompt. The integration is handled through Lightning's
-`WandbLogger` -- there are no direct `wandb.init()` calls in the codebase.
+**W&B is enabled by default.** [Weights & Biases](https://wandb.ai/) provides
+experiment tracking, metric logging, and model checkpoint storage. The default
+training logger (`configs/logger/many_loggers.yaml`) composes W&B + CSV +
+TensorBoard, so fresh runs log to all three. The integration is handled
+through Lightning's `WandbLogger` -- there are no direct `wandb.init()` calls
+in the codebase.
 
-**Disabled (default):** do nothing. Fresh runs log to CSV + TensorBoard only.
-No W&B account is required.
-
-**Enabled — per-run override (recommended):**
+**Enabled (default):** authenticate once before your first training run.
 
 1. Create an account at [wandb.ai](https://wandb.ai/).
 
@@ -321,19 +318,23 @@ No W&B account is required.
    WANDB_API_KEY=<your-api-key>
    ```
 
-4. Pass `logger=wandb` on the command line:
+4. Run training as usual — metrics flow to W&B + CSV + TensorBoard:
 
    ```bash
-   python src/train.py experiment=kosc/ffn_mse logger=wandb
+   python src/train.py experiment=kosc/ffn_mse
    ```
 
-   This replaces the default logger composition with W&B only. To log to
-   **both** CSV/TensorBoard **and** W&B, uncomment the `- wandb` line in
-   `configs/logger/many_loggers.yaml`.
+**Disabled — drop W&B from the default compose:** comment out `- wandb` in
+`configs/logger/many_loggers.yaml`, or override per run with `logger=csv`
+or `logger=tensorboard`:
 
-**Enabled — as the default:** edit `configs/logger/many_loggers.yaml` and
-uncomment `- wandb`, or change the `logger:` default in `configs/train.yaml`
-to `wandb`.
+```bash
+python src/train.py experiment=kosc/ffn_mse logger=csv
+```
+
+Without `wandb login` (or `WANDB_API_KEY`), the W&B logger will prompt for
+credentials at training start. If you don't want a W&B account, drop W&B
+from the compose as shown above.
 
 **Optional entity / project overrides:**
 
@@ -401,8 +402,8 @@ python src/train.py experiment=kosc/ffn_mse model.optimizer.lr=1e-4
 # Use CPU trainer instead of GPU
 python src/train.py experiment=kosc/ffn_mse trainer=cpu
 
-# Enable W&B logging (opt-in; default logger is CSV + TensorBoard)
-python src/train.py experiment=kosc/ffn_mse logger=wandb
+# Override default logger compose (default is W&B + CSV + TensorBoard)
+python src/train.py experiment=kosc/ffn_mse logger=csv
 
 # Limit training steps
 python src/train.py experiment=kosc/ffn_mse trainer.max_steps=10000

--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -23,9 +23,9 @@ ______________________________________________________________________
 
 | Concern           | How it works                                                                                             | File                               |
 | ----------------- | -------------------------------------------------------------------------------------------------------- | ---------------------------------- |
-| W&B run creation  | `WandbLogger` instantiated by Hydra — opt-in via `logger=wandb` (the default `many_loggers` is CSV + TB) | `configs/logger/wandb.yaml`        |
+| W&B run creation  | `WandbLogger` instantiated by Hydra — included in the default `many_loggers` compose (W&B + CSV + TB)    | `configs/logger/wandb.yaml`        |
 | Entity / project  | Env-var driven: `entity: ${oc.env:WANDB_ENTITY,null}`, `project: "${oc.env:WANDB_PROJECT,synth-setter}"` | `configs/logger/wandb.yaml:10,13`  |
-| Default compose   | `many_loggers` composes `csv + tensorboard` (W&B excluded by default)                                    | `configs/logger/many_loggers.yaml` |
+| Default compose   | `many_loggers` composes `csv + tensorboard + wandb` (W&B enabled by default)                             | `configs/logger/many_loggers.yaml` |
 | Run ID            | `null` (W&B auto-generates)                                                                              | `configs/logger/wandb.yaml:8`      |
 | Checkpoint upload | `log_model: "all"`                                                                                       | `configs/logger/wandb.yaml:11`     |
 | Code saving       | `wandb.Settings(code_dir=".")`                                                                           | `configs/logger/wandb.yaml:17-19`  |
@@ -95,9 +95,9 @@ Logged via `self.log()` in each LightningModule:
 Image-producing callbacks route figures through `_log_figure` in
 `src/utils/callbacks.py`, which dispatches to `WandbLogger.log_image` and/or
 `TensorBoardLogger.experiment.add_figure` depending on the attached loggers.
-Under the default `many_loggers` composition (CSV + TB), plots land in
-TensorBoard; with `logger=wandb` they go to W&B; with both attached they go
-to both.
+Under the default `many_loggers` composition (W&B + CSV + TB), plots land in
+both W&B and TensorBoard; with `logger=tensorboard` they go to TensorBoard
+only; with `logger=wandb` they go to W&B only.
 
 | Callback                           | Logged key                       | Trigger                                         | Symbol                                                               |
 | ---------------------------------- | -------------------------------- | ----------------------------------------------- | -------------------------------------------------------------------- |

--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -1,6 +1,6 @@
 # W&B Integration Reference
 
-> **Code version**: `0b55a9e` (2026-04-20, `feat/wandb-optional-by-default`)
+> **Code version**: `1970388` (2026-04-25, `feat/wandb-default-logger`)
 > **PyTorch**: see `requirements.txt` · **Lightning**: see `requirements.txt`
 > **Tracking**: #252, #263
 


### PR DESCRIPTION
## Summary

- Re-enable W&B in the default `many_loggers` compose so fresh installs log to W&B + CSV + TensorBoard out of the box. Reverses the opt-in switch from #612.
- Run `wandb login` (or set `WANDB_API_KEY`) before training; users who don't want W&B can comment out the `- wandb` line in `configs/logger/many_loggers.yaml` or override per run with `logger=csv` / `logger=tensorboard`.
- Doc updates produced via `/doc-drift`: README, getting-started §4c, wandb-integration reference, and `docs/doc-map.yaml` (added `many_loggers.yaml` so future default-compose changes are caught).

## Test plan

- [ ] CI: pre-commit (mdformat, prettier, codespell) passes — verified locally
- [ ] CI: `pytest tests/test_configs.py tests/test_callbacks.py tests/test_logging_utils.py` passes — verified locally (21 passed)
- [ ] CI: `pr-metadata-gate.yaml` passes (linked issue #676 has type=Task, label=monitoring, milestone=monitoring v1.0.0, parent=Phase #257)
- [ ] Reviewer: confirm wandb-by-default is the desired team default (this reverses #612)
- [ ] Reviewer: docs read coherently — fresh-install user knows they need `wandb login` before first run

Closes #676.