### PR TITLE
fix(ci): pin pyright to 1.1.408

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -32,7 +32,7 @@ pedalboard
 POT
 pre-commit
 pyloudnorm
-pyright
+pyright==1.1.408
 pytest
 pytest-benchmark
 pytest-xdist


### PR DESCRIPTION
## Summary

- Pin `pyright==1.1.408` in `requirements-app.txt` to restore the `code-quality-main.yaml` workflow on main.
- Pyright 1.1.409 (auto-installed because pyright was unpinned) tightened `reportPrivateImportUsage` and now flags torch's top-level re-exports as private.

Refs #690

## Why this broke

Last successful main run: [run 24732763098](https://github.com/tinaudio/synth-setter/actions/runs/24732763098) (2026-04-21, `pyright==1.1.408`, `torch==2.11.0`)
First failing main run: [run 24943602999](https://github.com/tinaudio/synth-setter/actions/runs/24943602999) (2026-04-25, `pyright==1.1.409`, `torch==2.11.0`)

`torch` did not change. Only `pyright` moved.

## Error sample (from [run 24943602999](https://github.com/tinaudio/synth-setter/actions/runs/24943602999/job/73041109049))

```
src/models/components/embed_pool.py:9:16  - error: "zeros" is not exported from module "torch" (reportPrivateImportUsage)
src/models/components/embed_pool.py:10:22 - error: "arange" is not exported from module "torch" (reportPrivateImportUsage)
src/models/components/embed_pool.py:10:53 - error: "float32" is not exported from module "torch" (reportPrivateImportUsage)
src/models/components/embed_pool.py:11:22 - error: "exp" is not exported from module "torch" (reportPrivateImportUsage)
src/models/components/sinkhorn.py:18:15  - error: "zeros" is not exported from module "torch" (reportPrivateImportUsage)
src/models/components/sinkhorn.py:30:27  - error: "logsumexp" is not exported from module "torch" (reportPrivateImportUsage)
src/models/components/sinkhorn.py:46:19  - error: "cdist" is not exported from module "torch" (reportPrivateImportUsage)
src/models/components/sinkhorn.py:104:19 - error: "einsum" is not exported from module "torch" (reportPrivateImportUsage)
src/models/components/loss.py:16:19  - error: "cdist" is not exported from module "torch" (reportPrivateImportUsage)
src/models/components/loss.py:20:30  - error: "mean" is not exported from module "torch" (reportPrivateImportUsage)
src/data/audio_datamodule.py:126:23 - error: "from_numpy" is not exported from module "torch" (reportPrivateImportUsage)
src/utils/math.py:5:18  - error: "div" is not exported from module "torch" (reportPrivateImportUsage)
src/utils/math.py:5:58  - error: "remainder" is not exported from module "torch" (reportPrivateImportUsage)
... 25+ similar errors across 6 files
```

## Why this happens

Pyright 1.1.409 tightened `reportPrivateImportUsage`. PyTorch's `torch/__init__.pyi` re-exports many top-level functions and dtypes (`zeros`, `arange`, `float32`, `cdist`, `logsumexp`, `einsum`, `from_numpy`, `div`, `remainder`, `sin`, `cos`, `exp`, `mean`, `argsort`, `gather`, `empty`, `int64`) without the explicit `from x import y as y` form pyright now requires. The new pyright treats them as private and flags every `torch.<symbol>` call site.

These are not real bugs — they're a stub-quality artifact in the upstream torch type stubs.

## Why pinning fixes it

Pinning `pyright==1.1.408` in `requirements-app.txt` reverts to the exact version that was passing on 2026-04-21. CI installs are reproducible again, and any future pyright bump becomes an intentional, reviewable change instead of an unannounced break on main.

## Alternatives considered

- Disable `reportPrivateImportUsage` in `pyrightconfig.json` — works but silences the check globally, including for any non-torch case where it might be real.
- Rewrite call sites with `from torch import zeros, arange, ...` — invasive and treats a stub-quality issue as if it were our problem.

Pinning is the smallest reversible change. We can revisit when the upstream torch stubs catch up or pyright relaxes the check.

## Test plan

- [ ] CI `code-quality` job passes on this PR (pyright 1.1.408 reinstated)
- [ ] No other dependency versions change
