### PR TITLE
refactor(configs): standardize VST plugin path via Hydra paths group

### DIFF
--- a/configs/paths/default.yaml
+++ b/configs/paths/default.yaml
@@ -16,3 +16,7 @@ output_dir: ${hydra:runtime.output_dir}
 
 # path to working directory
 work_dir: ${hydra:runtime.cwd}
+
+# path to VST3 plugin bundle
+# override via SYNTH_SETTER_PLUGIN_PATH env var
+vst_plugin_path: ${oc.env:SYNTH_SETTER_PLUGIN_PATH,plugins/Surge XT.vst3}

--- a/docs/design/eval-pipeline.md
+++ b/docs/design/eval-pipeline.md
@@ -249,7 +249,7 @@ The render stage loads each predicted parameter tensor, decodes it using the `Pa
 - `renderscript.sh` wraps `predict_vst_audio.py` with display server management
 - On macOS: uses native display, no wrapper needed — `make render` calls the Python script directly
 - On headless Linux: launches Xvfb, sets `DISPLAY`, runs script, kills Xvfb
-- Plugin path default: `plugins/Surge XT.vst3` (overridable via `--plugin_path`)
+- `--plugin_path` is required (no default); `load_plugin` raises `FileNotFoundError` if the path does not exist. The Hydra paths group exposes the same value as `paths.vst_plugin_path`, sourced from `SYNTH_SETTER_PLUGIN_PATH` with fallback `plugins/Surge XT.vst3`.
 - Preset path default: `presets/surge-base.vstpreset` (overridable via `--preset_path`)
 - Parameters are denormalized from `[-1, 1]` → `[0, 1]` before decoding
 

--- a/scripts/predict_vst_audio.py
+++ b/scripts/predict_vst_audio.py
@@ -100,7 +100,7 @@ def params_to_csv(
 @click.command()
 @click.argument("pred_dir", type=str)
 @click.argument("output_dir", type=str)
-@click.option("--plugin_path", "-p", type=str, default="plugins/Surge XT.vst3")
+@click.option("--plugin_path", "-p", type=str, required=True)
 @click.option("--preset_path", "-r", type=str, default="presets/surge-base.vstpreset")
 @click.option("--sample_rate", "-s", type=float, default=44100.0)
 @click.option("--channels", "-c", type=int, default=2)
@@ -113,7 +113,7 @@ def params_to_csv(
 def main(
     pred_dir: str,
     output_dir: str,
-    plugin_path: str = "plugins/Surge XT.vst3",
+    plugin_path: str,
     preset_path: str = "presets/surge-base.vstpreset",
     sample_rate: float = 44100.0,
     channels: int = 2,

--- a/src/data/vst/core.py
+++ b/src/data/vst/core.py
@@ -1,6 +1,7 @@
 import _thread
 import threading
 import time
+from pathlib import Path
 from typing import Callable, Optional, Tuple
 
 import mido
@@ -36,6 +37,8 @@ def _prepare_plugin(plugin: VST3Plugin) -> None:
 
 
 def load_plugin(plugin_path: str) -> VST3Plugin:
+    if not Path(plugin_path).exists():
+        raise FileNotFoundError(f"VST3 plugin not found at {plugin_path}")
     logger.info(f"Loading plugin {plugin_path}")
     p = VST3Plugin(plugin_path)
     logger.info(f"Plugin {plugin_path} loaded")

--- a/src/data/vst/generate_vst_dataset.py
+++ b/src/data/vst/generate_vst_dataset.py
@@ -285,7 +285,7 @@ def make_dataset(
 @click.command()
 @click.argument("data_file", type=str, required=True)
 @click.argument("num_samples", type=int, required=True)
-@click.option("--plugin_path", "-p", type=str, default="plugins/Surge XT.vst3")
+@click.option("--plugin_path", "-p", type=str, required=True)
 @click.option("--preset_path", "-r", type=str, default="presets/surge-base.vstpreset")
 @click.option("--sample_rate", "-s", type=float, default=44100.0)
 @click.option("--channels", "-c", type=int, default=2)
@@ -297,7 +297,7 @@ def make_dataset(
 def main(
     data_file: str,
     num_samples: int,
-    plugin_path: str = "plugins/Surge XT.vst3",
+    plugin_path: str,
     preset_path: str = "presets/surge-base.vstpreset",
     sample_rate: float = 44100.0,
     channels: int = 2,

--- a/tests/data/vst/test_load_plugin_validation.py
+++ b/tests/data/vst/test_load_plugin_validation.py
@@ -1,0 +1,10 @@
+import pytest
+
+from src.data.vst.core import load_plugin
+
+
+def test_load_plugin_missing_file_raises_filenotfound(tmp_path):
+    """load_plugin must raise FileNotFoundError when the plugin path does not exist."""
+    missing = tmp_path / "does-not-exist.vst3"
+    with pytest.raises(FileNotFoundError, match=str(missing)):
+        load_plugin(str(missing))


### PR DESCRIPTION
## Summary

- Add `vst_plugin_path` to `configs/paths/default.yaml`, sourced from `SYNTH_SETTER_PLUGIN_PATH` with fallback to `plugins/Surge XT.vst3`. Single source of truth for Hydra-driven code; env-var name matches what `tests/data/vst/test_preset_params.py` already uses.
- Validate path existence in `load_plugin` (`src/data/vst/core.py`) and raise `FileNotFoundError` with a clear message before the path reaches `pedalboard.VST3Plugin`.
- Make `--plugin_path` a required Click flag in `src/data/vst/generate_vst_dataset.py` and `scripts/predict_vst_audio.py` — CLI invocations must pass it explicitly rather than silently falling back to a hardcoded default.
- Add `tests/data/vst/test_load_plugin_validation.py` regression test for the new validation (no VST required).

Closes #692

## Test plan

- [x] `pytest tests/data/vst/test_load_plugin_validation.py -v` — passes.
- [x] Hydra fallback resolves: `unset SYNTH_SETTER_PLUGIN_PATH` → `cfg.paths.vst_plugin_path == "plugins/Surge XT.vst3"`.
- [x] Hydra env override resolves: `SYNTH_SETTER_PLUGIN_PATH=/tmp/custom.vst3` → `cfg.paths.vst_plugin_path == "/tmp/custom.vst3"`.
- [x] `python -m src.data.vst.generate_vst_dataset /tmp/dummy.h5 1` exits 2 with `Error: Missing option '--plugin_path' / '-p'`.
- [x] `python scripts/predict_vst_audio.py /tmp/preds /tmp/out` exits 2 with `Error: Missing option '--plugin_path' / '-p'`.
- [x] `make format` clean (pre-commit incl. ruff/pyright/interrogate).