### PR TITLE
deps(conda): pin torchaudio in environment.yaml to match conda torch ABI

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -31,6 +31,7 @@ dependencies:
   - python=3.10
   - pytorch>=2.0.0
   - torchvision>=0.15.0
+  - torchaudio>=2.0.0
   - lightning>=2.6.0
   - torchmetrics>=0.11.4
 

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -2,5 +2,6 @@
 # Install with an explicit index in Docker when targeting CUDA wheels.
 torch>=2.0.0
 torchvision>=0.15.0
+torchaudio>=2.0.0
 lightning>=2.6.0
 torchmetrics>=0.11.4


### PR DESCRIPTION
## Summary
- Add `torchaudio>=2.0.0` to `environment.yaml` so conda owns the resolution alongside `pytorch` / `torchvision`, keeping the whole torch stack on matching ABI versions.
- Symptom: `run_tests_conda` fails at import with `OSError: Could not load this library: .../torchaudio/lib/_torchaudio.abi3.so` because conda installs `pytorch 2.10` from `conda-forge` while pip pulls `torchaudio 2.11` from PyPI (transitively via `pesto-pitch>=2.0.1` -> `torchaudio>=2.0.2` in `requirements-app.txt`). Different minors -> ABI mismatch.

## Test plan
- [ ] `run_tests_conda` job passes on this PR
- [ ] `List dependencies` step shows `torchaudio` resolved from `conda-forge` (not `pypi_0`) at a version paired with `pytorch`

Closes #675