### PR TITLE
fix(ci): bump test-expensive runner to ubuntu-latest-4core

### DIFF
--- a/.github/workflows/test-expensive.yml
+++ b/.github/workflows/test-expensive.yml
@@ -19,7 +19,12 @@ permissions:
 
 jobs:
   run_slow_tests:
-    runs-on: ubuntu-latest
+    # Larger runner: the slow CPU suite runs PyTorch forward passes on the FFN
+    # smoke fixtures, and the standard 2-core/7 GB `ubuntu-latest` OOMs during
+    # those passes. `ubuntu-latest-4core` (4 vCPU / 16 GB) is the smallest
+    # GitHub-hosted label that fits — see `docs/reference/github-actions.md`
+    # for the runner inventory. Don't downgrade without a CPU+memory probe.
+    runs-on: ubuntu-latest-4core
 
     timeout-minutes: 90
 

--- a/docs/design/storage-provenance-spec.md
+++ b/docs/design/storage-provenance-spec.md
@@ -176,7 +176,7 @@ ______________________________________________________________________
 | --------------- | ------------------------ | --------------------- | ------------------------------- | ------------------- | ---------------------------------------------------------------- |
 | Tests           | `test.yml`               | push, PR, dispatch    | `ubuntu-latest`, `macos-latest` | —                   | —                                                                |
 | GPU Tests       | `test-gpu.yml`           | schedule, dispatch    | `gpu-x64`                       | —                   | —                                                                |
-| Slow Tests      | `test-expensive.yml`     | push (main), dispatch | `ubuntu-latest`                 | —                   | —                                                                |
+| Slow Tests      | `test-expensive.yml`     | push (main), dispatch | `ubuntu-latest-4core`           | —                   | —                                                                |
 | Data Generation | `dataset-generation.yml` | `workflow_call`       | `ubuntu-latest-4core`           | DockerHub           | `image_tag`, `config_path`, `artifact_name`                      |
 | Training        | TBD                      | `workflow_dispatch`   | TBD                             | R2, W&B, RunPod     | experiment, overrides                                            |
 | Evaluation      | TBD                      | `workflow_dispatch`   | TBD                             | R2, W&B             | `train_wandb_run_id`, `eval_config_id`                           |


### PR DESCRIPTION
## Summary

`.github/workflows/test-expensive.yml` ran the slow pytest lane on the standard `ubuntu-latest` runner (2 vCPU / 7 GB RAM). The PyTorch CPU forward passes that ship in [PR #674](https://github.com/tinaudio/synth-setter/pull/674) (`test_train_surge_xt[cpu]`, `test_train_eval_surge_xt[cpu]`) exceed that 7 GB ceiling and the runner OOMs. Since this lane is the post-merge gate for `[cpu]` accelerator coverage of slow tests, an OOM here means regressions land on main with no signal.

Bump `runs-on:` to `ubuntu-latest-4core` (4 vCPU / 16 GB) — the smallest GitHub-hosted label that fits the forward pass. Going wider buys nothing for this single-process CPU-bound workload.

This PR **only** changes the runner label. The pytest selector on this branch is still `-m "slow and not gpu"` (the `not mps` filter is delivered by [PR #674](https://github.com/tinaudio/synth-setter/pull/674) along with the `[mps]` parametrize that introduces the MPS marker). Once both PRs land, `Slow Tests` runs `-m "slow and not gpu and not mps"` on the larger runner.

## Why a separate PR

Surfaced during the review of #674 while documenting the test-expensive lane. The runner change is a one-line YAML tweak with its own merge story (CI billing increase, behavioural change in post-merge cadence) — better isolated than buried in a test-expansion PR.

## Test plan

- [ ] CI: `Slow Tests` workflow runs to completion on the merge commit (no OOM, no timeout).
- [ ] Workflow log shows `Runner Image:` resolving the new label and the expected vCPU/RAM.
- [ ] PR #674's `[cpu]` parametrize completes successfully on the next post-merge run after #674 lands.

Closes #698