### PR TITLE
test(data-pipeline): reproduce round-trip reproducibility failure for VST dataset generation

### DIFF
--- a/.github/workflows/test-expensive.yml
+++ b/.github/workflows/test-expensive.yml
@@ -6,15 +6,6 @@ name: Slow Tests
 # Triggered post-merge on main (and via manual dispatch).
 on:
   workflow_dispatch:
-    inputs:
-      publish_metrics:
-        # Opt-in escape hatch so a maintainer can bootstrap the gh-pages chart
-        # from a feature branch without merging to main first. The default is
-        # ``false`` so accidental dispatches don't pollute the benchmark
-        # history. Push-to-main always publishes regardless of this input.
-        description: "Push run metrics to gh-pages (creates the page on first run)"
-        type: boolean
-        default: false
   push:
     branches: [main]
     paths-ignore:
@@ -36,13 +27,6 @@ jobs:
     # GitHub-hosted label that fits — see `docs/reference/github-actions.md`
     # for the runner inventory. Don't downgrade without a CPU+memory probe.
     runs-on: ubuntu-latest-4core
-
-    # Job-level grant so only this job (not the rest of the workflow) can push to
-    # ``gh-pages`` for the benchmark history. The workflow-level default is
-    # ``contents: read``; the only step that needs write here is the
-    # ``Publish VST audio-similarity metrics`` step, gated to push-to-main.
-    permissions:
-      contents: write
 
     timeout-minutes: 90
 
@@ -111,37 +95,5 @@ jobs:
       - name: Run slow (non-GPU, non-MPS) tests
         env:
           HYDRA_FULL_ERROR: "1"
-          # Picked up by ``_emit_benchmark_metrics`` in
-          # ``tests/data/vst/test_generate_vst_dataset.py``. When set, the
-          # round-trip test appends summary audio-similarity metrics here for
-          # the publish step below. Unset locally → no-op.
-          BENCHMARK_OUTPUT_PATH: ${{ github.workspace }}/bench.json
         run: |
           pytest -vv -s -m "slow and not gpu and not mps"
-
-      - name: Publish VST audio-similarity metrics to benchmark history
-        # Push-to-main always publishes. Manual dispatch publishes only when
-        # the dispatcher explicitly sets ``publish_metrics=true`` — used to
-        # bootstrap the gh-pages chart from a feature branch before main has
-        # picked up the workflow. ``hashFiles`` skips cleanly if the test
-        # wrote nothing (e.g. it was deselected by markers or skipped because
-        # the VST plugin smoke check failed earlier in the job).
-        if: |
-          hashFiles('bench.json') != '' && (
-            (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-            (github.event_name == 'workflow_dispatch' && inputs.publish_metrics == true)
-          )
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: VST fixed-params replay
-          tool: customSmallerIsBetter
-          output-file-path: bench.json
-          gh-pages-branch: gh-pages
-          benchmark-data-dir-path: dev/bench
-          auto-push: true
-          alert-threshold: "150%"
-          comment-on-alert: true
-          # Warn-only initially. Flip to ``true`` once the noise floor of the
-          # five series is well-characterised and the alert threshold is tuned.
-          fail-on-alert: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-expensive.yml
+++ b/.github/workflows/test-expensive.yml
@@ -6,6 +6,15 @@ name: Slow Tests
 # Triggered post-merge on main (and via manual dispatch).
 on:
   workflow_dispatch:
+    inputs:
+      publish_metrics:
+        # Opt-in escape hatch so a maintainer can bootstrap the gh-pages chart
+        # from a feature branch without merging to main first. The default is
+        # ``false`` so accidental dispatches don't pollute the benchmark
+        # history. Push-to-main always publishes regardless of this input.
+        description: "Push run metrics to gh-pages (creates the page on first run)"
+        type: boolean
+        default: false
   push:
     branches: [main]
     paths-ignore:
@@ -111,11 +120,17 @@ jobs:
           pytest -vv -s -m "slow and not gpu and not mps"
 
       - name: Publish VST audio-similarity metrics to benchmark history
-        # Gated to push-to-main so PRs and manual dispatch from feature branches
-        # don't write to ``gh-pages``. ``hashFiles`` skips cleanly if the test
+        # Push-to-main always publishes. Manual dispatch publishes only when
+        # the dispatcher explicitly sets ``publish_metrics=true`` — used to
+        # bootstrap the gh-pages chart from a feature branch before main has
+        # picked up the workflow. ``hashFiles`` skips cleanly if the test
         # wrote nothing (e.g. it was deselected by markers or skipped because
         # the VST plugin smoke check failed earlier in the job).
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && hashFiles('bench.json') != ''
+        if: |
+          hashFiles('bench.json') != '' && (
+            (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+            (github.event_name == 'workflow_dispatch' && inputs.publish_metrics == true)
+          )
         uses: benchmark-action/github-action-benchmark@v1
         with:
           name: VST fixed-params replay

--- a/.github/workflows/test-expensive.yml
+++ b/.github/workflows/test-expensive.yml
@@ -28,6 +28,13 @@ jobs:
     # for the runner inventory. Don't downgrade without a CPU+memory probe.
     runs-on: ubuntu-latest-4core
 
+    # Job-level grant so only this job (not the rest of the workflow) can push to
+    # ``gh-pages`` for the benchmark history. The workflow-level default is
+    # ``contents: read``; the only step that needs write here is the
+    # ``Publish VST audio-similarity metrics`` step, gated to push-to-main.
+    permissions:
+      contents: write
+
     timeout-minutes: 90
 
     steps:
@@ -95,5 +102,31 @@ jobs:
       - name: Run slow (non-GPU, non-MPS) tests
         env:
           HYDRA_FULL_ERROR: "1"
+          # Picked up by ``_emit_benchmark_metrics`` in
+          # ``tests/data/vst/test_generate_vst_dataset.py``. When set, the
+          # round-trip test appends summary audio-similarity metrics here for
+          # the publish step below. Unset locally → no-op.
+          BENCHMARK_OUTPUT_PATH: ${{ github.workspace }}/bench.json
         run: |
           pytest -vv -s -m "slow and not gpu and not mps"
+
+      - name: Publish VST audio-similarity metrics to benchmark history
+        # Gated to push-to-main so PRs and manual dispatch from feature branches
+        # don't write to ``gh-pages``. ``hashFiles`` skips cleanly if the test
+        # wrote nothing (e.g. it was deselected by markers or skipped because
+        # the VST plugin smoke check failed earlier in the job).
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && hashFiles('bench.json') != ''
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: VST fixed-params replay
+          tool: customSmallerIsBetter
+          output-file-path: bench.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          alert-threshold: "150%"
+          comment-on-alert: true
+          # Warn-only initially. Flip to ``true`` once the noise floor of the
+          # five series is well-characterised and the alert threshold is tuned.
+          fail-on-alert: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -31,7 +31,10 @@ on:
         type: boolean
         default: false
   push:
-    branches: [main]
+    # ``test/vst-roundtrip-xfail-tests`` listed temporarily so we can bootstrap
+    # the ``gh-pages`` benchmark chart from this PR before merging to main.
+    # Revert to ``[main]`` once the chart exists.
+    branches: [main, test/vst-roundtrip-xfail-tests]
     paths:
       - "src/data/vst/**"
       - "tests/data/vst/**"
@@ -122,7 +125,7 @@ jobs:
         # cleanly when the previous step found no bench.json.
         if: |
           hashFiles('bench.json') != '' && (
-            (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+            (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test/vst-roundtrip-xfail-tests')) ||
             (github.event_name == 'workflow_dispatch' && inputs.publish_metrics == true)
           )
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -181,7 +181,7 @@ jobs:
             (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test/vst-roundtrip-xfail-tests')) ||
             (github.event_name == 'workflow_dispatch' && (inputs.publish_metrics == true || inputs.dummy_only == true))
           )
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:
           name: VST noise floor (1 preset N renders)
           tool: customSmallerIsBetter
@@ -207,7 +207,7 @@ jobs:
             (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test/vst-roundtrip-xfail-tests')) ||
             (github.event_name == 'workflow_dispatch' && (inputs.publish_metrics == true || inputs.dummy_only == true))
           )
-        uses: benchmark-action/github-action-benchmark@v1
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:
           name: VST noise floor (random preset replay)
           tool: customSmallerIsBetter

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -1,4 +1,5 @@
 name: VST Slow Tests
+# Re-trigger marker: 2026-04-29 (post-gh-pages-bootstrap). Safe to remove on the next edit.
 
 # Runs the slow VST audio-similarity tests in
 # ``tests/data/vst/test_generate_vst_dataset.py`` inside the

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -31,14 +31,6 @@ on:
         description: "Push run metrics to gh-pages (creates the page on first run)"
         type: boolean
         default: false
-      dummy_only:
-        # Fast iteration on the publish step. Skips the (slow) Docker test
-        # run entirely and writes a hardcoded ``bench.json`` so the publish
-        # step has data to push. Implies ``publish_metrics`` — flipping
-        # this on always publishes (the whole point is to debug publish).
-        description: "Skip slow tests; publish hardcoded dummy data only (debug-only)"
-        type: boolean
-        default: false
   push:
     # ``test/vst-roundtrip-xfail-tests`` listed temporarily so we can bootstrap
     # the ``gh-pages`` benchmark chart from this PR before merging to main.
@@ -77,15 +69,13 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Pull image
-        if: inputs.dummy_only != true
         run: docker pull "$IMAGE"
 
       # Mirrors the headless plugin-load smoke check in
       # ``docker/ubuntu22_04/Dockerfile:312-314`` (and the local-runner version
-      # in ``test-expensive.yml``) — fails fast if the plugin / image / mount
-      # layout is broken before the much-longer pytest run.
+      # in ``cpu-slow.yml``) — fails fast if the plugin / image / mount layout
+      # is broken before the much-longer pytest run.
       - name: Smoke-test Surge XT plugin load
-        if: inputs.dummy_only != true
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/home/build/synth-setter \
@@ -100,7 +90,6 @@ jobs:
             '
 
       - name: Run VST slow tests in Docker
-        if: inputs.dummy_only != true
         # Mount the PR's tests + src into the container so we test THIS
         # branch's code against the image's environment. The image's
         # ENTRYPOINT is the ``python click`` CLI; ``passthrough <argv>``
@@ -138,7 +127,7 @@ jobs:
         # publish steps expect it. Each prefix maps 1:1 to a chart bucket.
         # Skipped cleanly if a file is missing (test deselected, xfailed
         # before emit, etc).
-        if: always() && inputs.dummy_only != true
+        if: always()
         run: |
           for f in vst-noise-floor-1-preset-n-renders.json vst-noise-floor-random-preset-replay.json; do
             if [ -f "/tmp/bench/$f" ]; then
@@ -149,39 +138,17 @@ jobs:
             fi
           done
 
-      - name: Write hardcoded dummy bench JSON files (debug-only fast path)
-        # Bypasses the slow Docker test entirely. Lets a maintainer iterate
-        # on publish-step gating / config without waiting ~5 minutes per
-        # cycle. Schema mirrors what ``_assert_round_trip_matches`` writes
-        # for the two round-trip tests; values are fictitious but plausible.
-        if: inputs.dummy_only == true
-        run: |
-          for prefix in vst-noise-floor-1-preset-n-renders vst-noise-floor-random-preset-replay; do
-            cat > "${{ github.workspace }}/${prefix}.json" <<EOF
-          [
-            {"name": "${prefix}/multi-scale-spectral-loss-max",        "unit": "dB",          "value": 1.0},
-            {"name": "${prefix}/dtw-aligned-mfcc-distance-max",        "unit": "L1",          "value": 1.0},
-            {"name": "${prefix}/spectral-optimal-transport-max",       "unit": "Wasserstein", "value": 0.001},
-            {"name": "${prefix}/rms-envelope-cosine-distance-max",     "unit": "1-cos",       "value": 0.001},
-            {"name": "${prefix}/mel-spectrogram-mean-absolute-error",  "unit": "dB",          "value": 0.5},
-            {"name": "${prefix}/num-samples",                          "unit": "count",       "value": 6},
-            {"name": "${prefix}/wall-clock-seconds-per-render",        "unit": "seconds",     "value": 1.0}
-          ]
-          EOF
-            echo "dummy ${prefix}.json written"
-          done
-
       - name: Publish "1 preset N renders" metrics to benchmark history
         # Bucket 1: same hardcoded patch rendered ``num_samples`` times across
         # both stages, exposing the every-other-render variance described in
         # bug #489. See ``docs/reference/audio-similarity-benchmarks.md``.
         # Push-to-main always publishes; manual dispatch requires the
-        # ``publish_metrics`` or ``dummy_only`` opt-in. ``hashFiles`` skips
-        # the step cleanly if the file is missing.
+        # ``publish_metrics`` opt-in. ``hashFiles`` skips the step cleanly if
+        # the file is missing.
         if: |
           hashFiles('vst-noise-floor-1-preset-n-renders.json') != '' && (
             (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test/vst-roundtrip-xfail-tests')) ||
-            (github.event_name == 'workflow_dispatch' && (inputs.publish_metrics == true || inputs.dummy_only == true))
+            (github.event_name == 'workflow_dispatch' && inputs.publish_metrics == true)
           )
         uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:
@@ -207,7 +174,7 @@ jobs:
         if: |
           hashFiles('vst-noise-floor-random-preset-replay.json') != '' && (
             (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test/vst-roundtrip-xfail-tests')) ||
-            (github.event_name == 'workflow_dispatch' && (inputs.publish_metrics == true || inputs.dummy_only == true))
+            (github.event_name == 'workflow_dispatch' && inputs.publish_metrics == true)
           )
         uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -31,6 +31,14 @@ on:
         description: "Push run metrics to gh-pages (creates the page on first run)"
         type: boolean
         default: false
+      dummy_only:
+        # Fast iteration on the publish step. Skips the (slow) Docker test
+        # run entirely and writes a hardcoded ``bench.json`` so the publish
+        # step has data to push. Implies ``publish_metrics`` — flipping
+        # this on always publishes (the whole point is to debug publish).
+        description: "Skip slow tests; publish hardcoded dummy data only (debug-only)"
+        type: boolean
+        default: false
   push:
     # ``test/vst-roundtrip-xfail-tests`` listed temporarily so we can bootstrap
     # the ``gh-pages`` benchmark chart from this PR before merging to main.
@@ -69,9 +77,30 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Pull image
+        if: inputs.dummy_only != true
         run: docker pull "$IMAGE"
 
+      # Mirrors the headless plugin-load smoke check in
+      # ``docker/ubuntu22_04/Dockerfile:312-314`` (and the local-runner version
+      # in ``test-expensive.yml``) — fails fast if the plugin / image / mount
+      # layout is broken before the much-longer pytest run.
+      - name: Smoke-test Surge XT plugin load
+        if: inputs.dummy_only != true
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/home/build/synth-setter \
+            -e PYTHONPATH=/home/build/synth-setter \
+            "$IMAGE" \
+            passthrough bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              git config --global --add safe.directory /home/build/synth-setter
+              scripts/run-linux-vst-headless.sh \
+                python -X faulthandler -c "from src.data.vst.core import load_plugin; load_plugin(\"/usr/lib/vst3/Surge XT.vst3\")"
+            '
+
       - name: Run VST slow tests in Docker
+        if: inputs.dummy_only != true
         # Mount the PR's tests + src into the container so we test THIS
         # branch's code against the image's environment. The image's
         # ENTRYPOINT is the ``python click`` CLI; ``passthrough <argv>``
@@ -92,13 +121,12 @@ jobs:
             -e PYTHONPATH=/home/build/synth-setter \
             -e BENCHMARK_OUTPUT_PATH=/bench/bench.json \
             -e HYDRA_FULL_ERROR=1 \
+            -e "SYNTH_SETTER_PLUGIN_PATH=/usr/lib/vst3/Surge XT.vst3" \
             "$IMAGE" \
             passthrough bash -c '
               set -euo pipefail
               cd /home/build/synth-setter
               git config --global --add safe.directory /home/build/synth-setter
-              mkdir -p plugins
-              ln -sf "/usr/lib/vst3/Surge XT.vst3" "plugins/Surge XT.vst3"
               scripts/run-linux-vst-headless.sh \
                 pytest -vv -s tests/data/vst/test_generate_vst_dataset.py
             '
@@ -109,7 +137,7 @@ jobs:
         # out of the host-mounted volume to where the action expects it.
         # Skipped cleanly if the test wrote nothing (e.g. all xfail tests
         # produced XFAIL before reaching the emit, or VST tests deselected).
-        if: always()
+        if: always() && inputs.dummy_only != true
         run: |
           if [ -f /tmp/bench/bench.json ]; then
             cp /tmp/bench/bench.json "${{ github.workspace }}/bench.json"
@@ -117,6 +145,25 @@ jobs:
           else
             echo "no bench.json written by test run — publish step will be skipped"
           fi
+
+      - name: Write hardcoded dummy bench.json (debug-only fast path)
+        # Bypasses the slow Docker test entirely. Lets a maintainer iterate
+        # on the publish-step gating / config without waiting ~5 minutes
+        # per cycle. Schema mirrors what ``_assert_round_trip_matches``
+        # writes for ``test_datasets_from_hardcoded_params_are_identical``;
+        # values are fictitious but plausible.
+        if: inputs.dummy_only == true
+        run: |
+          cat > "${{ github.workspace }}/bench.json" <<'EOF'
+          [
+            {"name": "vst-fixed-replay/mss-max",          "unit": "dB",    "value": 1.0},
+            {"name": "vst-fixed-replay/wmfcc-max",        "unit": "L1",    "value": 1.0},
+            {"name": "vst-fixed-replay/sot-max",          "unit": "W",     "value": 0.001},
+            {"name": "vst-fixed-replay/rms-distance-max", "unit": "1-cos", "value": 0.001},
+            {"name": "vst-fixed-replay/mel-mean-abs",     "unit": "dB",    "value": 0.5}
+          ]
+          EOF
+          echo "dummy bench.json written (size: $(wc -c < "${{ github.workspace }}/bench.json") bytes)"
 
       - name: Publish VST audio-similarity metrics to benchmark history
         # Push-to-main always publishes. Manual dispatch publishes only
@@ -127,7 +174,7 @@ jobs:
         if: |
           hashFiles('bench.json') != '' && (
             (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test/vst-roundtrip-xfail-tests')) ||
-            (github.event_name == 'workflow_dispatch' && inputs.publish_metrics == true)
+            (github.event_name == 'workflow_dispatch' && (inputs.publish_metrics == true || inputs.dummy_only == true))
           )
         uses: benchmark-action/github-action-benchmark@v1
         with:
@@ -136,12 +183,6 @@ jobs:
           output-file-path: bench.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
-          # ``gh-pages`` doesn't exist yet on first bootstrap. Without this,
-          # the action fails at ``git fetch ... gh-pages:gh-pages`` with
-          # "couldn't find remote ref gh-pages" instead of creating it.
-          # Safe to keep on after bootstrap — the action falls back to fetch
-          # when the local checkout doesn't have the branch yet.
-          skip-fetch-gh-pages: true
           auto-push: true
           alert-threshold: "150%"
           comment-on-alert: true

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -119,7 +119,7 @@ jobs:
             -v ${{ github.workspace }}:/home/build/synth-setter \
             -v /tmp/bench:/bench \
             -e PYTHONPATH=/home/build/synth-setter \
-            -e BENCHMARK_OUTPUT_PATH=/bench/bench.json \
+            -e BENCHMARK_OUTPUT_DIR=/bench \
             -e HYDRA_FULL_ERROR=1 \
             -e "SYNTH_SETTER_PLUGIN_PATH=/usr/lib/vst3/Surge XT.vst3" \
             "$IMAGE" \
@@ -131,56 +131,61 @@ jobs:
                 pytest -vv -s tests/data/vst/test_generate_vst_dataset.py
             '
 
-      - name: Surface bench.json on the runner
-        # ``benchmark-action/github-action-benchmark`` reads the file from
-        # the runner workspace, not from inside the container — copy it
-        # out of the host-mounted volume to where the action expects it.
-        # Skipped cleanly if the test wrote nothing (e.g. all xfail tests
-        # produced XFAIL before reaching the emit, or VST tests deselected).
+      - name: Surface per-bucket bench JSON files on the runner
+        # ``benchmark-action/github-action-benchmark`` reads its input from
+        # the runner workspace, not from inside the container — copy each
+        # ``<prefix>.json`` out of the host-mounted volume to where the
+        # publish steps expect it. Each prefix maps 1:1 to a chart bucket.
+        # Skipped cleanly if a file is missing (test deselected, xfailed
+        # before emit, etc).
         if: always() && inputs.dummy_only != true
         run: |
-          if [ -f /tmp/bench/bench.json ]; then
-            cp /tmp/bench/bench.json "${{ github.workspace }}/bench.json"
-            echo "bench.json captured (size: $(wc -c < bench.json) bytes)"
-          else
-            echo "no bench.json written by test run — publish step will be skipped"
-          fi
+          for f in vst-noise-floor-1-preset-n-renders.json vst-noise-floor-random-preset-replay.json; do
+            if [ -f "/tmp/bench/$f" ]; then
+              cp "/tmp/bench/$f" "${{ github.workspace }}/$f"
+              echo "$f captured (size: $(wc -c < "${{ github.workspace }}/$f") bytes)"
+            else
+              echo "no $f written by test run — corresponding publish step will be skipped"
+            fi
+          done
 
-      - name: Write hardcoded dummy bench.json (debug-only fast path)
+      - name: Write hardcoded dummy bench JSON files (debug-only fast path)
         # Bypasses the slow Docker test entirely. Lets a maintainer iterate
-        # on the publish-step gating / config without waiting ~5 minutes
-        # per cycle. Schema mirrors what ``_assert_round_trip_matches``
-        # writes for ``test_datasets_from_hardcoded_params_are_identical``;
-        # values are fictitious but plausible.
+        # on publish-step gating / config without waiting ~5 minutes per
+        # cycle. Schema mirrors what ``_assert_round_trip_matches`` writes
+        # for the two round-trip tests; values are fictitious but plausible.
         if: inputs.dummy_only == true
         run: |
-          cat > "${{ github.workspace }}/bench.json" <<'EOF'
+          for prefix in vst-noise-floor-1-preset-n-renders vst-noise-floor-random-preset-replay; do
+            cat > "${{ github.workspace }}/${prefix}.json" <<EOF
           [
-            {"name": "vst-fixed-replay/mss-max",          "unit": "dB",    "value": 1.0},
-            {"name": "vst-fixed-replay/wmfcc-max",        "unit": "L1",    "value": 1.0},
-            {"name": "vst-fixed-replay/sot-max",          "unit": "W",     "value": 0.001},
-            {"name": "vst-fixed-replay/rms-distance-max", "unit": "1-cos", "value": 0.001},
-            {"name": "vst-fixed-replay/mel-mean-abs",     "unit": "dB",    "value": 0.5}
+            {"name": "${prefix}/multi-scale-spectral-loss-max",        "unit": "dB",          "value": 1.0},
+            {"name": "${prefix}/dtw-aligned-mfcc-distance-max",        "unit": "L1",          "value": 1.0},
+            {"name": "${prefix}/spectral-optimal-transport-max",       "unit": "Wasserstein", "value": 0.001},
+            {"name": "${prefix}/rms-envelope-cosine-distance-max",     "unit": "1-cos",       "value": 0.001},
+            {"name": "${prefix}/mel-spectrogram-mean-absolute-error",  "unit": "dB",          "value": 0.5}
           ]
           EOF
-          echo "dummy bench.json written (size: $(wc -c < "${{ github.workspace }}/bench.json") bytes)"
+            echo "dummy ${prefix}.json written"
+          done
 
-      - name: Publish VST audio-similarity metrics to benchmark history
-        # Push-to-main always publishes. Manual dispatch publishes only
-        # when the dispatcher explicitly sets ``publish_metrics=true``,
-        # used to bootstrap the gh-pages chart from a feature branch
-        # before main has picked up the workflow. ``hashFiles`` skips
-        # cleanly when the previous step found no bench.json.
+      - name: Publish "1 preset N renders" metrics to benchmark history
+        # Bucket 1: same hardcoded patch rendered ``num_samples`` times across
+        # both stages, exposing the every-other-render variance described in
+        # bug #489. See ``docs/reference/audio-similarity-benchmarks.md``.
+        # Push-to-main always publishes; manual dispatch requires the
+        # ``publish_metrics`` or ``dummy_only`` opt-in. ``hashFiles`` skips
+        # the step cleanly if the file is missing.
         if: |
-          hashFiles('bench.json') != '' && (
+          hashFiles('vst-noise-floor-1-preset-n-renders.json') != '' && (
             (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test/vst-roundtrip-xfail-tests')) ||
             (github.event_name == 'workflow_dispatch' && (inputs.publish_metrics == true || inputs.dummy_only == true))
           )
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: VST noise floor
+          name: VST noise floor (1 preset N renders)
           tool: customSmallerIsBetter
-          output-file-path: bench.json
+          output-file-path: vst-noise-floor-1-preset-n-renders.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
           auto-push: true
@@ -189,5 +194,28 @@ jobs:
           # Warn-only initially. Flip to ``true`` once the noise floor of
           # the five series is well-characterised and the alert threshold
           # is tuned.
+          fail-on-alert: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish "random preset replay" metrics to benchmark history
+        # Bucket 2: random Stage-1 candidates replayed in Stage 2. Per-row
+        # only (no all-pairs), so it tracks the API-level round-trip
+        # invariant rather than the every-other-render bug. See
+        # ``docs/reference/audio-similarity-benchmarks.md``.
+        if: |
+          hashFiles('vst-noise-floor-random-preset-replay.json') != '' && (
+            (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test/vst-roundtrip-xfail-tests')) ||
+            (github.event_name == 'workflow_dispatch' && (inputs.publish_metrics == true || inputs.dummy_only == true))
+          )
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: VST noise floor (random preset replay)
+          tool: customSmallerIsBetter
+          output-file-path: vst-noise-floor-random-preset-replay.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          alert-threshold: "150%"
+          comment-on-alert: true
           fail-on-alert: false
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -135,6 +135,12 @@ jobs:
           output-file-path: bench.json
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
+          # ``gh-pages`` doesn't exist yet on first bootstrap. Without this,
+          # the action fails at ``git fetch ... gh-pages:gh-pages`` with
+          # "couldn't find remote ref gh-pages" instead of creating it.
+          # Safe to keep on after bootstrap — the action falls back to fetch
+          # when the local checkout doesn't have the branch yet.
+          skip-fetch-gh-pages: true
           auto-push: true
           alert-threshold: "150%"
           comment-on-alert: true

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -178,7 +178,7 @@ jobs:
           )
         uses: benchmark-action/github-action-benchmark@v1
         with:
-          name: VST fixed-params replay
+          name: VST noise floor
           tool: customSmallerIsBetter
           output-file-path: bench.json
           gh-pages-branch: gh-pages

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -163,7 +163,9 @@ jobs:
             {"name": "${prefix}/dtw-aligned-mfcc-distance-max",        "unit": "L1",          "value": 1.0},
             {"name": "${prefix}/spectral-optimal-transport-max",       "unit": "Wasserstein", "value": 0.001},
             {"name": "${prefix}/rms-envelope-cosine-distance-max",     "unit": "1-cos",       "value": 0.001},
-            {"name": "${prefix}/mel-spectrogram-mean-absolute-error",  "unit": "dB",          "value": 0.5}
+            {"name": "${prefix}/mel-spectrogram-mean-absolute-error",  "unit": "dB",          "value": 0.5},
+            {"name": "${prefix}/num-samples",                          "unit": "count",       "value": 6},
+            {"name": "${prefix}/wall-clock-seconds-per-render",        "unit": "seconds",     "value": 1.0}
           ]
           EOF
             echo "dummy ${prefix}.json written"

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -1,0 +1,142 @@
+name: VST Slow Tests
+
+# Runs the slow VST audio-similarity tests in
+# ``tests/data/vst/test_generate_vst_dataset.py`` inside the
+# ``tinaudio/synth-setter:dev-snapshot`` Docker image so the headless X11
+# stack the renderer needs is the same one used by ``dataset-generation.yml``
+# (proven working in CI). Bare ``ubuntu-latest`` runners hit "Timeout
+# waiting for Xvfb to start" intermittently — see the failing run at
+# https://github.com/tinaudio/synth-setter/actions/runs/25026506440 — which
+# is why this lives in its own Docker-only workflow rather than as another
+# step in ``test-expensive.yml``.
+#
+# Also publishes per-run audio-similarity metrics to the ``gh-pages``
+# benchmark chart (Issue #703) on push-to-main, or on dispatch when the
+# operator opts in via ``publish_metrics=true``.
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Docker image tag (e.g. dev-snapshot, dev-snapshot-<sha>)"
+        required: false
+        default: "dev-snapshot"
+      publish_metrics:
+        # Opt-in escape hatch so a maintainer can bootstrap the gh-pages
+        # chart from a feature branch without merging to main first. The
+        # default is ``false`` so accidental dispatches don't pollute the
+        # benchmark history. Push-to-main always publishes regardless of
+        # this input.
+        description: "Push run metrics to gh-pages (creates the page on first run)"
+        type: boolean
+        default: false
+  push:
+    branches: [main]
+    paths:
+      - "src/data/vst/**"
+      - "tests/data/vst/**"
+      - "scripts/compute_audio_metrics.py"
+      - ".github/workflows/test-vst-slow.yml"
+      - "requirements*.txt"
+
+concurrency:
+  group: test-vst-slow-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  run_vst_slow_tests:
+    name: VST slow tests (Docker)
+    runs-on: ubuntu-latest-4core
+    timeout-minutes: 60
+
+    # Job-level grant so only this job can push to ``gh-pages`` for the
+    # benchmark history. Workflow-level default is ``contents: read``.
+    permissions:
+      contents: write
+
+    env:
+      IMAGE: tinaudio/synth-setter:${{ inputs.image_tag || 'dev-snapshot' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Pull image
+        run: docker pull "$IMAGE"
+
+      - name: Run VST slow tests in Docker
+        # Mount the PR's tests + src into the container so we test THIS
+        # branch's code against the image's environment. The image's
+        # ENTRYPOINT is the ``python click`` CLI; ``passthrough <argv>``
+        # execs the trailing argv as PID 1, same pattern as
+        # ``dataset-generation.yml``. The bench.json output goes to a host
+        # directory mounted at ``/bench`` so the publish step downstream
+        # can pick it up.
+        #
+        # ``run-linux-vst-headless.sh`` wraps pytest because pedalboard
+        # imports load the VST host which needs a live X display, so the
+        # headless wrapper has to apply at the pytest level (not the
+        # entire container).
+        run: |
+          mkdir -p /tmp/bench
+          docker run --rm \
+            -v ${{ github.workspace }}:/home/build/synth-setter \
+            -v /tmp/bench:/bench \
+            -e PYTHONPATH=/home/build/synth-setter \
+            -e BENCHMARK_OUTPUT_PATH=/bench/bench.json \
+            -e HYDRA_FULL_ERROR=1 \
+            "$IMAGE" \
+            passthrough bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              git config --global --add safe.directory /home/build/synth-setter
+              mkdir -p plugins
+              ln -sf "/usr/lib/vst3/Surge XT.vst3" "plugins/Surge XT.vst3"
+              scripts/run-linux-vst-headless.sh \
+                pytest -vv -s tests/data/vst/test_generate_vst_dataset.py
+            '
+
+      - name: Surface bench.json on the runner
+        # ``benchmark-action/github-action-benchmark`` reads the file from
+        # the runner workspace, not from inside the container — copy it
+        # out of the host-mounted volume to where the action expects it.
+        # Skipped cleanly if the test wrote nothing (e.g. all xfail tests
+        # produced XFAIL before reaching the emit, or VST tests deselected).
+        if: always()
+        run: |
+          if [ -f /tmp/bench/bench.json ]; then
+            cp /tmp/bench/bench.json "${{ github.workspace }}/bench.json"
+            echo "bench.json captured (size: $(wc -c < bench.json) bytes)"
+          else
+            echo "no bench.json written by test run — publish step will be skipped"
+          fi
+
+      - name: Publish VST audio-similarity metrics to benchmark history
+        # Push-to-main always publishes. Manual dispatch publishes only
+        # when the dispatcher explicitly sets ``publish_metrics=true``,
+        # used to bootstrap the gh-pages chart from a feature branch
+        # before main has picked up the workflow. ``hashFiles`` skips
+        # cleanly when the previous step found no bench.json.
+        if: |
+          hashFiles('bench.json') != '' && (
+            (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+            (github.event_name == 'workflow_dispatch' && inputs.publish_metrics == true)
+          )
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: VST fixed-params replay
+          tool: customSmallerIsBetter
+          output-file-path: bench.json
+          gh-pages-branch: gh-pages
+          benchmark-data-dir-path: dev/bench
+          auto-push: true
+          alert-threshold: "150%"
+          comment-on-alert: true
+          # Warn-only initially. Flip to ``true`` once the noise floor of
+          # the five series is well-characterised and the alert threshold
+          # is tuned.
+          fail-on-alert: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/reference/audio-similarity-benchmarks.md
+++ b/docs/reference/audio-similarity-benchmarks.md
@@ -1,0 +1,201 @@
+# Audio similarity benchmarks
+
+Reference for the per-run audio-similarity metrics published by
+[`.github/workflows/test-vst-slow.yml`](../../.github/workflows/test-vst-slow.yml)
+to the `gh-pages` chart at
+**<https://tinaudio.github.io/synth-setter/dev/bench/>**.
+
+## Purpose
+
+The slow VST tests in
+[`tests/data/vst/test_generate_vst_dataset.py`](../../tests/data/vst/test_generate_vst_dataset.py)
+exercise `make_dataset` round-trips and assert that two independent renders
+of the same parameters land within phase-robust tolerances. Per-run
+metric values typically come in well below the assertion thresholds, so
+the assertions only catch _gross_ regressions (silence, wrong patch).
+
+The benchmark dashboards plot the per-run values as a time series so
+subtler drift becomes visible long before any threshold trips. Examples
+of the kind of regressions the chart is designed to surface:
+
+- **Surge XT version bump** in the `dev-snapshot` Docker image (the `.deb`
+  install in `docker/ubuntu22_04/Dockerfile`) that quietly shifts the
+  metric distribution.
+- **`librosa` / `pedalboard` upgrade** changing mel-spectrogram
+  computation or VST host behavior, even with identical params.
+- **Regression in the per-render plugin reload** in
+  `src/data/vst/render_params` — this is the workaround for
+  [#489](https://github.com/tinaudio/synth-setter/issues/489), and if it
+  ever stops doing what it should, the every-other-render variance
+  spikes.
+- **Renderer perf regressions** — dB metrics may stay flat while
+  `wall-clock-seconds-per-render` doubles.
+
+The hard caps in `tests/data/vst/test_generate_vst_dataset.py` are the
+safety net; the chart is the early warning.
+
+## Where to find the dashboards
+
+| Dashboard                  | URL                                                                            |
+| -------------------------- | ------------------------------------------------------------------------------ |
+| Live charts (both buckets) | <https://tinaudio.github.io/synth-setter/dev/bench/>                           |
+| Raw data file              | <https://github.com/tinaudio/synth-setter/blob/gh-pages/dev/bench/data.js>     |
+| `gh-pages` branch tree     | <https://github.com/tinaudio/synth-setter/tree/gh-pages>                       |
+| Workflow runs that publish | <https://github.com/tinaudio/synth-setter/actions/workflows/test-vst-slow.yml> |
+| Tracking issue             | [#703](https://github.com/tinaudio/synth-setter/issues/703)                    |
+| Underlying bug             | [#489](https://github.com/tinaudio/synth-setter/issues/489)                    |
+
+The chart's left-hand legend lets you toggle individual metric series on
+and off; the dropdown at the top selects the dashboard ("bucket").
+
+## Two dashboards
+
+The workflow publishes two independent dashboards, each representing a
+different question.
+
+### `VST noise floor (1 preset N renders)`
+
+Sourced from `test_datasets_from_hardcoded_params_are_identical`. Both
+stages of `make_dataset` run with the same hardcoded
+`_HARDCODED_*_PARAMS` patch via `_patched_sample`, so all
+`2 × num_samples` renders use _identical_ inputs. The per-pair metrics
+plus an all-pairs cross-comparison expose every-other-render variance —
+this is the reproducer for [#489](https://github.com/tinaudio/synth-setter/issues/489).
+
+Bucket name: `VST noise floor (1 preset N renders)`<br>
+JSON file (in workflow run): `vst-noise-floor-1-preset-n-renders.json`<br>
+Metric name prefix: `vst-noise-floor-1-preset-n-renders/`
+
+This is the most _sensitive_ noise-floor view — every render should
+match every other render perfectly, so any drift shows up quickly.
+
+### `VST noise floor (random preset replay)`
+
+Sourced from `test_datasets_from_sampled_params_are_identical`. Stage 1
+samples `num_samples` random patches; Stage 2 replays them via
+`_patched_sample`. Each row uses _different_ params, so the metrics
+compare matched pairs (`expected[i]` vs `actual[i]`) — there's no
+all-pairs cross-comparison here because cross-row pairs naturally
+differ.
+
+Bucket name: `VST noise floor (random preset replay)`<br>
+JSON file (in workflow run): `vst-noise-floor-random-preset-replay.json`<br>
+Metric name prefix: `vst-noise-floor-random-preset-replay/`
+
+This view is _broader_ in patch coverage but noisier between runs (each
+run picks a different random sample), so trend signal is lower per
+point but covers more of the patch space than the hardcoded fixture.
+
+## Metric series
+
+Both buckets emit the same six series:
+
+| Metric                                | Computed by                                                                 | Unit        | Smaller-is-better? |
+| ------------------------------------- | --------------------------------------------------------------------------- | ----------- | ------------------ |
+| `multi-scale-spectral-loss-max`       | `compute_mss` (`scripts/compute_audio_metrics.py`) — multi-scale log-mel L1 | dB          | yes                |
+| `dtw-aligned-mfcc-distance-max`       | `compute_wmfcc` — DTW-aligned MFCC L1 distance                              | L1          | yes                |
+| `spectral-optimal-transport-max`      | `compute_sot` — Wasserstein on STFT magnitudes                              | Wasserstein | yes                |
+| `rms-envelope-cosine-distance-max`    | `1 - compute_rms` — RMS envelope cosine distance                            | 1-cos       | yes                |
+| `mel-spectrogram-mean-absolute-error` | mean abs diff on stored mel arrays                                          | dB          | yes                |
+| `num-samples`                         | static fixture size (input parameter)                                       | count       | n/a (sentinel)     |
+| `wall-clock-seconds-per-render`       | `(stage1_t + stage2_t) / (2 × num_samples)`                                 | seconds     | yes                |
+
+Distance metrics are emitted as **max-over-samples** (worst-case
+per-pair) for distance-style series — that's what `_assert_round_trip_matches`
+reports — and `1 - min(rms_cos)` for the RMS series so that all entries
+read smaller-is-better (required by the `customSmallerIsBetter` schema).
+`num-samples` is a static input parameter; emitting it as a series makes
+fixture-size regressions visible alongside the metric drift it would
+silently cause.
+`wall-clock-seconds-per-render` includes the loudness-loop retries on
+Stage 1 of the random-replay test, so it's a real-throughput number
+rather than a render-only one.
+
+## Thresholds + alerting
+
+The publish step has `alert-threshold: "150%"` and `fail-on-alert: false` — so an alert posts a comment on the offending commit if a
+metric exceeds 1.5× the rolling baseline, but doesn't block CI. Once
+the noise floor is well-characterized, flip `fail-on-alert: true` to
+gate merges.
+
+## Workflow wiring
+
+```
+tests/data/vst/test_generate_vst_dataset.py
+   |
+   |  _emit_benchmark_metrics(..., bench_filename="<prefix>.json")
+   |  writes to $BENCHMARK_OUTPUT_DIR/<prefix>.json (per-test)
+   v
+docker run -v /tmp/bench:/bench -e BENCHMARK_OUTPUT_DIR=/bench ...
+   |
+   |  Surface step: cp /tmp/bench/<prefix>.json -> ${{ workspace }}/<prefix>.json
+   v
+benchmark-action/github-action-benchmark@v1   (one publish step per bucket)
+   |
+   |  fetch + commit + push gh-pages
+   v
+gh-pages branch  →  GitHub Pages  →  https://tinaudio.github.io/synth-setter/dev/bench/
+```
+
+## Operations
+
+### Bootstrapping the chart on a new repo
+
+`benchmark-action/github-action-benchmark@v1` can't create the
+`gh-pages` branch on its own. Push an empty orphan branch first:
+
+```bash
+cd /tmp
+git clone --depth 1 https://github.com/tinaudio/synth-setter.git ghpages-bootstrap
+cd ghpages-bootstrap
+git checkout --orphan gh-pages
+git rm -rf .
+echo "# Benchmark history" > README.md
+git add README.md
+git -c user.email="<your-noreply>@users.noreply.github.com" commit -m "Initial gh-pages bootstrap"
+git push origin gh-pages
+```
+
+Then enable Pages: **Settings → Pages → Source = "Deploy from a
+branch", branch = `gh-pages`, folder = `/ (root)`**. The chart will
+populate on the next workflow run that publishes.
+
+### Publishing from a feature branch (pre-merge)
+
+The workflow's `workflow_dispatch` accepts a `publish_metrics` boolean.
+However, `gh workflow run --ref <feature-branch>` returns 404 because
+the gh CLI looks up the workflow file on the default branch first, and
+the standard PAT doesn't have permission for the REST `dispatches`
+endpoint. So pre-merge bootstrapping uses a temporary `push:` trigger
+on the feature branch + a relaxed publish-step `if:` condition; revert
+both once the chart exists.
+
+### Adding a new benchmark dashboard
+
+To add a third bucket (e.g. `VST noise floor (sustained note)`):
+
+1. Add a test that calls `_assert_round_trip_matches(..., benchmark_name_prefix="vst-noise-floor-sustained-note")`.
+2. Add a Surface step entry that copies
+   `vst-noise-floor-sustained-note.json` out of the volume.
+3. Add a third publish step that reads that file with a matching
+   `name:`.
+
+The two existing dashboards share `benchmark-data-dir-path: dev/bench`
+so they all write to the same `data.js`; the chart UI just adds a new
+selectable bucket.
+
+### Pruning old data
+
+`window.BENCHMARK_DATA.entries` in
+[`gh-pages/dev/bench/data.js`](https://github.com/tinaudio/synth-setter/blob/gh-pages/dev/bench/data.js)
+is plain JS — surgical edits work. Three levels of cleanup:
+
+- **Per-entry**: edit `data.js` to splice out specific runs (anomalous
+  bootstrap data, runs from before a threshold change), commit,
+  force-push to `gh-pages`.
+- **Per-bucket reset**: replace `data.js` with a stub that has an empty
+  `entries: {}` object, force-push.
+- **Nuke**: delete the `gh-pages` branch and re-bootstrap.
+
+The action also accepts `max-items-in-chart: <N>` for automatic pruning
+once the chart exceeds N points — useful long-term.

--- a/docs/reference/audio-similarity-benchmarks.md
+++ b/docs/reference/audio-similarity-benchmarks.md
@@ -88,8 +88,9 @@ point but covers more of the patch space than the hardcoded fixture.
 
 ## Metric series
 
-Both buckets emit the same seven series (five distance metrics plus
-two non-distance sentinels — `num-samples` and `wall-clock-seconds-per-render`):
+Both buckets emit the per-row "round-trip" series (five distance metrics
+plus the two non-distance sentinels `num-samples` and
+`wall-clock-seconds-per-render`):
 
 | Metric                                | Computed by                                                                 | Unit        | Smaller-is-better? |
 | ------------------------------------- | --------------------------------------------------------------------------- | ----------- | ------------------ |
@@ -101,13 +102,26 @@ two non-distance sentinels — `num-samples` and `wall-clock-seconds-per-render`
 | `num-samples`                         | static fixture size (input parameter)                                       | count       | n/a (sentinel)     |
 | `wall-clock-seconds-per-render`       | `(stage1_t + stage2_t) / (2 × num_samples)`                                 | seconds     | yes                |
 
+The **`1 preset N renders`** bucket additionally emits five `all-pairs-*`
+series — these are the **#489 regression signal**, since the per-row
+metrics can stay flat while the all-pairs worst-case spikes (the bug
+manifests as junk on every-other render, not on every render):
+
+| Metric                                       | Computed by                                   | Unit        |
+| -------------------------------------------- | --------------------------------------------- | ----------- |
+| `all-pairs-multi-scale-spectral-loss-max`    | worst-case `compute_mss` across all pairs     | dB          |
+| `all-pairs-dtw-aligned-mfcc-distance-max`    | worst-case `compute_wmfcc` across all pairs   | L1          |
+| `all-pairs-spectral-optimal-transport-max`   | worst-case `compute_sot` across all pairs     | Wasserstein |
+| `all-pairs-rms-envelope-cosine-distance-max` | worst-case `1 - compute_rms` across all pairs | 1-cos       |
+| `all-pairs-pair-count`                       | `n × (n − 1) / 2` for `n = 2 × num_samples`   | count       |
+
 Distance metrics are emitted as **max-over-samples** (worst-case
-per-pair) for distance-style series — that's what `_assert_round_trip_matches`
-reports — and `1 - min(rms_cos)` for the RMS series so that all entries
-read smaller-is-better (required by the `customSmallerIsBetter` schema).
-`num-samples` is a static input parameter; emitting it as a series makes
-fixture-size regressions visible alongside the metric drift it would
-silently cause.
+per-pair) for the round-trip series and **max-over-pairs** for the
+all-pairs series, with `1 - min(rms_cos)` so all entries read
+smaller-is-better (required by the `customSmallerIsBetter` schema).
+`num-samples` and `all-pairs-pair-count` are static given the test's
+fixture size; emitting them as series makes accidental fixture changes
+visible alongside the metric drift they would silently cause.
 `wall-clock-seconds-per-render` includes the loudness-loop retries on
 Stage 1 of the random-replay test, so it's a real-throughput number
 rather than a render-only one.

--- a/docs/reference/audio-similarity-benchmarks.md
+++ b/docs/reference/audio-similarity-benchmarks.md
@@ -23,11 +23,11 @@ of the kind of regressions the chart is designed to surface:
   metric distribution.
 - **`librosa` / `pedalboard` upgrade** changing mel-spectrogram
   computation or VST host behavior, even with identical params.
-- **Regression in the per-render plugin reload** in
-  `src/data/vst/render_params` — this is the workaround for
-  [#489](https://github.com/tinaudio/synth-setter/issues/489), and if it
-  ever stops doing what it should, the every-other-render variance
-  spikes.
+- **Regression in the renderer's determinism** in
+  `src/data/vst/render_params` — bug
+  [#489](https://github.com/tinaudio/synth-setter/issues/489) tracks the
+  every-other-render variance; if a future fix lands and then regresses,
+  that variance spikes here first.
 - **Renderer perf regressions** — dB metrics may stay flat while
   `wall-clock-seconds-per-render` doubles.
 

--- a/docs/reference/audio-similarity-benchmarks.md
+++ b/docs/reference/audio-similarity-benchmarks.md
@@ -88,7 +88,8 @@ point but covers more of the patch space than the hardcoded fixture.
 
 ## Metric series
 
-Both buckets emit the same six series:
+Both buckets emit the same seven series (five distance metrics plus
+two non-distance sentinels — `num-samples` and `wall-clock-seconds-per-render`):
 
 | Metric                                | Computed by                                                                 | Unit        | Smaller-is-better? |
 | ------------------------------------- | --------------------------------------------------------------------------- | ----------- | ------------------ |

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -494,27 +494,31 @@ def _assert_round_trip_matches(
         _emit_benchmark_metrics(
             [
                 {
-                    "name": f"{benchmark_name_prefix}/mss-max",
+                    "name": f"{benchmark_name_prefix}/multi-scale-spectral-loss-max",
                     "unit": "dB",
                     "value": max(mss_values),
                 },
                 {
-                    "name": f"{benchmark_name_prefix}/wmfcc-max",
+                    "name": f"{benchmark_name_prefix}/dtw-aligned-mfcc-distance-max",
                     "unit": "L1",
                     "value": max(wmfcc_values),
                 },
                 {
-                    "name": f"{benchmark_name_prefix}/sot-max",
-                    "unit": "W",
+                    "name": f"{benchmark_name_prefix}/spectral-optimal-transport-max",
+                    "unit": "Wasserstein",
                     "value": max(sot_values),
                 },
                 {
-                    "name": f"{benchmark_name_prefix}/rms-distance-max",
+                    "name": (
+                        f"{benchmark_name_prefix}/rms-envelope-cosine-distance-max"
+                    ),
                     "unit": "1-cos",
                     "value": 1.0 - min(rms_cos_values),
                 },
                 {
-                    "name": f"{benchmark_name_prefix}/mel-mean-abs",
+                    "name": (
+                        f"{benchmark_name_prefix}/mel-spectrogram-mean-absolute-error"
+                    ),
                     "unit": "dB",
                     "value": mel_dist,
                 },
@@ -623,7 +627,7 @@ def test_datasets_from_hardcoded_params_are_identical(
         expected_params=expected_params,
         expected_synth_patches=[_HARDCODED_SYNTH_PARAMS] * num_samples,
         expected_note_patches=[_HARDCODED_NOTE_PARAMS] * num_samples,
-        benchmark_name_prefix="vst-fixed-replay",
+        benchmark_name_prefix="vst-noise-floor",
         spec=spec,
         num_samples=num_samples,
     )

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -360,17 +361,25 @@ def _assert_audio_metrics_within_thresholds(
     return mss, wmfcc, sot, rms_cos
 
 
-def _emit_benchmark_metrics(entries: list[dict[str, float | str]]) -> None:
-    """Append metrics to ``BENCHMARK_OUTPUT_PATH`` for github-action-benchmark.
+def _emit_benchmark_metrics(
+    entries: list[dict[str, float | str]], bench_filename: str
+) -> None:
+    """Append metrics to ``$BENCHMARK_OUTPUT_DIR/<bench_filename>`` for the trend chart.
 
-    No-op when the env var is unset (e.g. local pytest runs). The on-disk format
-    is the ``customSmallerIsBetter`` schema:
+    No-op when the env var is unset (e.g. local pytest runs). One file per
+    benchmark "bucket" because ``benchmark-action/github-action-benchmark@v1``
+    keys all entries from a single file under one chart page; multiple charts
+    require multiple publish steps reading distinct files. See
+    ``docs/reference/audio-similarity-benchmarks.md`` for the wiring.
+
+    The on-disk format is the ``customSmallerIsBetter`` schema:
     https://github.com/benchmark-action/github-action-benchmark#examples
     """
-    out_path = os.environ.get("BENCHMARK_OUTPUT_PATH")
-    if not out_path:
+    out_dir = os.environ.get("BENCHMARK_OUTPUT_DIR")
+    if not out_dir:
         return
-    out = Path(out_path)
+    out = Path(out_dir) / bench_filename
+    out.parent.mkdir(parents=True, exist_ok=True)
     existing = json.loads(out.read_text()) if out.exists() else []
     out.write_text(json.dumps(existing + entries, indent=2))
 
@@ -443,6 +452,7 @@ def _assert_round_trip_matches(
     spec: ParamSpec,
     num_samples: int,
     benchmark_name_prefix: str | None = None,
+    total_render_seconds: float | None = None,
 ) -> None:
     """Assert a Stage-2 dataset reproduces a Stage-1 dataset within phase-robust tolerances.
 
@@ -491,38 +501,60 @@ def _assert_round_trip_matches(
     if benchmark_name_prefix is not None:
         # Max-over-samples for distance-style metrics; ``1 - min(rms_cos)`` keeps
         # all entries smaller=better, which the customSmallerIsBetter schema requires.
+        # Each prefix gets its own JSON file so the publish step can post each
+        # bucket to a different chart page.
+        bench_entries: list[dict[str, float | str]] = [
+            {
+                "name": f"{benchmark_name_prefix}/multi-scale-spectral-loss-max",
+                "unit": "dB",
+                "value": max(mss_values),
+            },
+            {
+                "name": f"{benchmark_name_prefix}/dtw-aligned-mfcc-distance-max",
+                "unit": "L1",
+                "value": max(wmfcc_values),
+            },
+            {
+                "name": f"{benchmark_name_prefix}/spectral-optimal-transport-max",
+                "unit": "Wasserstein",
+                "value": max(sot_values),
+            },
+            {
+                "name": f"{benchmark_name_prefix}/rms-envelope-cosine-distance-max",
+                "unit": "1-cos",
+                "value": 1.0 - min(rms_cos_values),
+            },
+            {
+                "name": f"{benchmark_name_prefix}/mel-spectrogram-mean-absolute-error",
+                "unit": "dB",
+                "value": mel_dist,
+            },
+            {
+                # Static input parameter, but emitting it as a series keeps it
+                # visible alongside the other metrics — useful to verify the
+                # workflow ran the configured fixture size and to spot
+                # accidental num_samples regressions.
+                "name": f"{benchmark_name_prefix}/num-samples",
+                "unit": "count",
+                "value": num_samples,
+            },
+        ]
+        if total_render_seconds is not None:
+            # Wall-clock time of both stages divided by total renders
+            # (= 2 × num_samples, since each stage renders num_samples). Captures
+            # render-loop perf drift (Surge XT version bumps, pedalboard updates,
+            # plugin reload changes). Includes loudness-loop retries on Stage 1
+            # so it's a real-throughput number, not a render-only number.
+            bench_entries.append(
+                {
+                    "name": f"{benchmark_name_prefix}/wall-clock-seconds-per-render",
+                    "unit": "seconds",
+                    "value": total_render_seconds / (2 * num_samples),
+                },
+            )
         _emit_benchmark_metrics(
-            [
-                {
-                    "name": f"{benchmark_name_prefix}/multi-scale-spectral-loss-max",
-                    "unit": "dB",
-                    "value": max(mss_values),
-                },
-                {
-                    "name": f"{benchmark_name_prefix}/dtw-aligned-mfcc-distance-max",
-                    "unit": "L1",
-                    "value": max(wmfcc_values),
-                },
-                {
-                    "name": f"{benchmark_name_prefix}/spectral-optimal-transport-max",
-                    "unit": "Wasserstein",
-                    "value": max(sot_values),
-                },
-                {
-                    "name": (
-                        f"{benchmark_name_prefix}/rms-envelope-cosine-distance-max"
-                    ),
-                    "unit": "1-cos",
-                    "value": 1.0 - min(rms_cos_values),
-                },
-                {
-                    "name": (
-                        f"{benchmark_name_prefix}/mel-spectrogram-mean-absolute-error"
-                    ),
-                    "unit": "dB",
-                    "value": mel_dist,
-                },
-            ]
+            entries=bench_entries,
+            bench_filename=f"{benchmark_name_prefix}.json",
         )
 
     for i in range(num_samples):
@@ -573,6 +605,7 @@ def test_datasets_from_hardcoded_params_are_identical(
     replay = [(_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS)] * num_samples
 
     expected_dataset = tmp_path / "expected.h5"
+    t0 = time.perf_counter()
     with (
         h5py.File(expected_dataset, "a") as f,
         _patched_sample(spec, replay),
@@ -590,12 +623,14 @@ def test_datasets_from_hardcoded_params_are_identical(
             param_spec=spec,
             sample_batch_size=num_samples,
         )
+    stage1_seconds = time.perf_counter() - t0
 
     expected_audio, expected_mel, expected_params = _assert_h5_structure_is_valid(
         expected_dataset, spec, num_samples
     )
 
     got_dataset = tmp_path / "replayed.h5"
+    t0 = time.perf_counter()
     with (
         h5py.File(got_dataset, "a") as f,
         _patched_sample(spec, replay),
@@ -613,6 +648,7 @@ def test_datasets_from_hardcoded_params_are_identical(
             param_spec=spec,
             sample_batch_size=num_samples,
         )
+    stage2_seconds = time.perf_counter() - t0
 
     actual_audio, actual_mel, actual_params = _assert_h5_structure_is_valid(
         got_dataset, spec, num_samples
@@ -627,7 +663,11 @@ def test_datasets_from_hardcoded_params_are_identical(
         expected_params=expected_params,
         expected_synth_patches=[_HARDCODED_SYNTH_PARAMS] * num_samples,
         expected_note_patches=[_HARDCODED_NOTE_PARAMS] * num_samples,
-        benchmark_name_prefix="vst-noise-floor",
+        # Each prefix is also the bench JSON filename — workflow's publish step
+        # reads ``vst-noise-floor-1-preset-n-renders.json``. See
+        # ``docs/reference/audio-similarity-benchmarks.md``.
+        benchmark_name_prefix="vst-noise-floor-1-preset-n-renders",
+        total_render_seconds=stage1_seconds + stage2_seconds,
         spec=spec,
         num_samples=num_samples,
     )
@@ -675,6 +715,7 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
 
     # Stage 1: random-sampled "candidates" dataset (loudness-filtered).
     expected_dataset = tmp_path / "candidates.h5"
+    t0 = time.perf_counter()
     with h5py.File(expected_dataset, "a") as expected_file:
         make_dataset(
             hdf5_file=expected_file,
@@ -689,6 +730,7 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
             param_spec=spec,
             sample_batch_size=_NUM_SAMPLES,
         )
+    stage1_seconds = time.perf_counter() - t0
 
     expected_audio, expected_mel, expected_params = _assert_h5_structure_is_valid(
         expected_dataset, spec, _NUM_SAMPLES
@@ -719,6 +761,7 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
     # Stage 2: replay the candidates via ``_patched_sample`` and verify reproducibility.
     got_dataset = tmp_path / "replayed.h5"
     replay = list(zip(synth_patches, note_patches, strict=True))
+    t0 = time.perf_counter()
     with (
         h5py.File(got_dataset, "a") as f,
         _patched_sample(spec, replay),
@@ -736,6 +779,7 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
             param_spec=spec,
             sample_batch_size=_NUM_SAMPLES,
         )
+    stage2_seconds = time.perf_counter() - t0
 
     actual_audio, actual_mel, actual_params = _assert_h5_structure_is_valid(
         got_dataset, spec, _NUM_SAMPLES
@@ -752,6 +796,11 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
         expected_note_patches=note_patches,
         spec=spec,
         num_samples=_NUM_SAMPLES,
+        # Each prefix is also the bench JSON filename — workflow's publish step
+        # reads ``vst-noise-floor-random-preset-replay.json``. See
+        # ``docs/reference/audio-similarity-benchmarks.md``.
+        benchmark_name_prefix="vst-noise-floor-random-preset-replay",
+        total_render_seconds=stage1_seconds + stage2_seconds,
     )
 
 

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -6,6 +6,7 @@ import os
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import dataclass
 from pathlib import Path
 from unittest.mock import patch
 
@@ -362,6 +363,150 @@ def _assert_audio_metrics_within_thresholds(
     return mss, wmfcc, sot, rms_cos
 
 
+@dataclass(frozen=True)
+class RoundTripMetrics:
+    """Per-pair (``expected[i]`` vs ``actual[i]``) audio-similarity summary.
+
+    Computed by ``_assert_round_trip_matches`` over ``num_samples`` matched
+    rows. Values are worst-case across rows for distance-style metrics
+    (max for MSS / wMFCC / SOT, min for RMS cosine), and a global mean for
+    the mel diff.
+    """
+
+    mss_max: float
+    wmfcc_max: float
+    sot_max: float
+    rms_cos_min: float
+    mel_mean_abs: float
+    num_samples: int
+
+
+@dataclass(frozen=True)
+class AllPairsMetrics:
+    """Worst-case across all (i, j) pairs in a single audio array.
+
+    Computed by ``_assert_all_pairs_audio_metrics_within_thresholds``.
+    Use this when every row is a render of the *same* params — the
+    worst-pair signal is the #489 fingerprint (every-other-render variance)
+    and is the right thing to track on the trend chart for that bucket.
+    """
+
+    mss_max: float
+    wmfcc_max: float
+    sot_max: float
+    rms_cos_min: float
+    pair_count: int
+
+
+def _emit_audio_similarity_benchmark_metrics(
+    prefix: str,
+    round_trip: RoundTripMetrics | None = None,
+    all_pairs: AllPairsMetrics | None = None,
+    total_render_seconds: float | None = None,
+) -> None:
+    """Convert metric structs into bench entries and write them under ``prefix``.
+
+    Caller supplies whichever structs are meaningful for the bucket:
+
+    - ``round_trip`` for buckets where each row uses different params; the
+      meaningful comparison is per-pair ``expected[i]`` vs ``actual[i]``.
+      Series prefix: ``<prefix>/`` (no extra qualifier).
+    - ``all_pairs`` for buckets where every row uses identical params; the
+      meaningful comparison is the worst-case across the union of renders
+      (the #489 reproducer signal). Series prefix: ``<prefix>/all-pairs-``.
+    - ``total_render_seconds`` adds a ``wall-clock-seconds-per-render``
+      entry derived from ``round_trip.num_samples`` (so it's only emitted
+      when ``round_trip`` is also supplied).
+
+    No-op when ``$BENCHMARK_OUTPUT_DIR`` is unset (local pytest runs).
+    """
+    entries: list[dict[str, float | str]] = []
+    if round_trip is not None:
+        entries.extend(
+            [
+                {
+                    "name": f"{prefix}/multi-scale-spectral-loss-max",
+                    "unit": "dB",
+                    "value": round_trip.mss_max,
+                },
+                {
+                    "name": f"{prefix}/dtw-aligned-mfcc-distance-max",
+                    "unit": "L1",
+                    "value": round_trip.wmfcc_max,
+                },
+                {
+                    "name": f"{prefix}/spectral-optimal-transport-max",
+                    "unit": "Wasserstein",
+                    "value": round_trip.sot_max,
+                },
+                {
+                    "name": f"{prefix}/rms-envelope-cosine-distance-max",
+                    "unit": "1-cos",
+                    "value": 1.0 - round_trip.rms_cos_min,
+                },
+                {
+                    "name": f"{prefix}/mel-spectrogram-mean-absolute-error",
+                    "unit": "dB",
+                    "value": round_trip.mel_mean_abs,
+                },
+                {
+                    # Static input parameter; emitting it as a series surfaces
+                    # accidental fixture-size regressions alongside the metric
+                    # drift they would silently cause.
+                    "name": f"{prefix}/num-samples",
+                    "unit": "count",
+                    "value": round_trip.num_samples,
+                },
+            ]
+        )
+        if total_render_seconds is not None:
+            # Wall-clock time of both stages divided by total renders
+            # (= 2 × num_samples, since each stage renders num_samples).
+            # Captures renderer perf drift even when audio metrics stay flat.
+            # Includes loudness-loop retries on Stage 1 of the random-replay
+            # test, so it's a real-throughput number not a render-only one.
+            entries.append(
+                {
+                    "name": f"{prefix}/wall-clock-seconds-per-render",
+                    "unit": "seconds",
+                    "value": total_render_seconds / (2 * round_trip.num_samples),
+                }
+            )
+    if all_pairs is not None:
+        entries.extend(
+            [
+                {
+                    "name": f"{prefix}/all-pairs-multi-scale-spectral-loss-max",
+                    "unit": "dB",
+                    "value": all_pairs.mss_max,
+                },
+                {
+                    "name": f"{prefix}/all-pairs-dtw-aligned-mfcc-distance-max",
+                    "unit": "L1",
+                    "value": all_pairs.wmfcc_max,
+                },
+                {
+                    "name": f"{prefix}/all-pairs-spectral-optimal-transport-max",
+                    "unit": "Wasserstein",
+                    "value": all_pairs.sot_max,
+                },
+                {
+                    "name": f"{prefix}/all-pairs-rms-envelope-cosine-distance-max",
+                    "unit": "1-cos",
+                    "value": 1.0 - all_pairs.rms_cos_min,
+                },
+                {
+                    "name": f"{prefix}/all-pairs-pair-count",
+                    "unit": "count",
+                    "value": all_pairs.pair_count,
+                },
+            ]
+        )
+    if not entries:
+        return
+    _emit_benchmark_metrics(entries=entries, bench_filename=f"{prefix}.json")
+
+
 def _emit_benchmark_metrics(
     entries: list[dict[str, float | str]], bench_filename: str
 ) -> None:
@@ -395,7 +540,7 @@ def _emit_benchmark_metrics(
 
 def _assert_all_pairs_audio_metrics_within_thresholds(
     audio: np.ndarray, label_prefix: str
-) -> None:
+) -> AllPairsMetrics:
     """For every (i, j) pair with i < j in ``audio``, assert metrics within thresholds.
 
     Use this when every row is expected to be a render of the *same* params — every pair should be
@@ -403,6 +548,9 @@ def _assert_all_pairs_audio_metrics_within_thresholds(
     the worst measurement so a single failure surfaces the most-divergent rendering rather than the
     first iteration to trip a threshold. Identifies the (i, j) that produced each worst measurement
     to make debugging easy.
+
+    Returns an ``AllPairsMetrics`` summarising the worst-case observations so callers can pass it
+    to ``_emit_audio_similarity_benchmark_metrics`` without recomputing.
     """
     n = audio.shape[0]
     pair_count = n * (n - 1) // 2
@@ -447,6 +595,13 @@ def _assert_all_pairs_audio_metrics_within_thresholds(
         f"{label_prefix}: worst rms cosine={worst_rms_cos[0]:.4f} at pair "
         f"{worst_rms_cos[1:]} below {_RMS_MIN_COSINE}"
     )
+    return AllPairsMetrics(
+        mss_max=float(worst_mss[0]),
+        wmfcc_max=float(worst_wmfcc[0]),
+        sot_max=float(worst_sot[0]),
+        rms_cos_min=float(worst_rms_cos[0]),
+        pair_count=pair_count,
+    )
 
 
 def _assert_round_trip_matches(
@@ -460,9 +615,7 @@ def _assert_round_trip_matches(
     expected_note_patches: list[dict[str, int | tuple[float, float]]],
     spec: ParamSpec,
     num_samples: int,
-    benchmark_name_prefix: str | None = None,
-    total_render_seconds: float | None = None,
-) -> None:
+) -> RoundTripMetrics:
     """Assert a Stage-2 dataset reproduces a Stage-1 dataset within phase-robust tolerances.
 
     Five checks: ``param_array`` exact equality, per-row phase-robust audio metrics
@@ -476,9 +629,9 @@ def _assert_round_trip_matches(
     lists. For tests that replay a single fixed patch across all rows, callers should
     pass the patch repeated ``num_samples`` times.
 
-    ``benchmark_name_prefix`` (optional): when set and ``BENCHMARK_OUTPUT_DIR`` is
-    defined, the helper emits the worst-case per-pair metrics + mel diff under that
-    prefix for github-action-benchmark trend tracking. See ``_emit_benchmark_metrics``.
+    Returns a ``RoundTripMetrics`` summarising the per-row worst-case observations so
+    callers can pass it to ``_emit_audio_similarity_benchmark_metrics`` without
+    recomputing.
     """
     np.testing.assert_allclose(
         actual_params,
@@ -507,65 +660,6 @@ def _assert_round_trip_matches(
         f"mel mean abs diff {mel_dist:.4f} exceeds {_MEL_MEAN_ABS_MAX}"
     )
 
-    if benchmark_name_prefix is not None:
-        # Max-over-samples for distance-style metrics; ``1 - min(rms_cos)`` keeps
-        # all entries smaller=better, which the customSmallerIsBetter schema requires.
-        # Each prefix gets its own JSON file so the publish step can post each
-        # bucket to a different chart page.
-        bench_entries: list[dict[str, float | str]] = [
-            {
-                "name": f"{benchmark_name_prefix}/multi-scale-spectral-loss-max",
-                "unit": "dB",
-                "value": max(mss_values),
-            },
-            {
-                "name": f"{benchmark_name_prefix}/dtw-aligned-mfcc-distance-max",
-                "unit": "L1",
-                "value": max(wmfcc_values),
-            },
-            {
-                "name": f"{benchmark_name_prefix}/spectral-optimal-transport-max",
-                "unit": "Wasserstein",
-                "value": max(sot_values),
-            },
-            {
-                "name": f"{benchmark_name_prefix}/rms-envelope-cosine-distance-max",
-                "unit": "1-cos",
-                "value": 1.0 - min(rms_cos_values),
-            },
-            {
-                "name": f"{benchmark_name_prefix}/mel-spectrogram-mean-absolute-error",
-                "unit": "dB",
-                "value": mel_dist,
-            },
-            {
-                # Static input parameter, but emitting it as a series keeps it
-                # visible alongside the other metrics — useful to verify the
-                # workflow ran the configured fixture size and to spot
-                # accidental num_samples regressions.
-                "name": f"{benchmark_name_prefix}/num-samples",
-                "unit": "count",
-                "value": num_samples,
-            },
-        ]
-        if total_render_seconds is not None:
-            # Wall-clock time of both stages divided by total renders
-            # (= 2 × num_samples, since each stage renders num_samples). Captures
-            # render-loop perf drift (Surge XT version bumps, pedalboard updates,
-            # plugin reload changes). Includes loudness-loop retries on Stage 1
-            # so it's a real-throughput number, not a render-only number.
-            bench_entries.append(
-                {
-                    "name": f"{benchmark_name_prefix}/wall-clock-seconds-per-render",
-                    "unit": "seconds",
-                    "value": total_render_seconds / (2 * num_samples),
-                },
-            )
-        _emit_benchmark_metrics(
-            entries=bench_entries,
-            bench_filename=f"{benchmark_name_prefix}.json",
-        )
-
     for i in range(num_samples):
         decoded_synth_params, decoded_note_params = spec.decode(actual_params[i])
         assert isinstance(decoded_synth_params, dict)
@@ -590,6 +684,16 @@ def _assert_round_trip_matches(
         start, end = decoded_note_params["note_start_and_end"]
         assert isinstance(start, np.floating)
         assert isinstance(end, np.floating)
+
+    return RoundTripMetrics(
+        mss_max=max(mss_values),
+        wmfcc_max=max(wmfcc_values),
+        sot_max=max(sot_values),
+        rms_cos_min=min(rms_cos_values),
+        mel_mean_abs=mel_dist,
+        num_samples=num_samples,
+    )
+
 
 @pytest.mark.xfail(strict=True, reason="bug #489")
 @pytest.mark.slow
@@ -665,7 +769,7 @@ def test_datasets_from_hardcoded_params_are_identical(
         got_dataset, spec, num_samples
     )
 
-    _assert_round_trip_matches(
+    round_trip_metrics = _assert_round_trip_matches(
         actual_audio=actual_audio,
         actual_mel=actual_mel,
         actual_params=actual_params,
@@ -674,21 +778,29 @@ def test_datasets_from_hardcoded_params_are_identical(
         expected_params=expected_params,
         expected_synth_patches=[_HARDCODED_SYNTH_PARAMS] * num_samples,
         expected_note_patches=[_HARDCODED_NOTE_PARAMS] * num_samples,
-        # Each prefix is also the bench JSON filename — workflow's publish step
-        # reads ``vst-noise-floor-1-preset-n-renders.json``. See
-        # ``docs/reference/audio-similarity-benchmarks.md``.
-        benchmark_name_prefix="vst-noise-floor-1-preset-n-renders",
-        total_render_seconds=stage1_seconds + stage2_seconds,
         spec=spec,
         num_samples=num_samples,
     )
 
     # Every render in expected ∪ actual uses identical params, so every pair across
     # the union should be perceptually identical. Asserts on the worst-case pair to
-    # surface the most-divergent rendering (e.g. an every-other-render glitch).
-    _assert_all_pairs_audio_metrics_within_thresholds(
+    # surface the most-divergent rendering (e.g. an every-other-render glitch). This is
+    # the #489 fingerprint, so the trend chart for this bucket tracks all-pairs metrics
+    # (the per-row round_trip metrics are emitted alongside for context, not as the
+    # primary regression signal).
+    all_pairs_metrics = _assert_all_pairs_audio_metrics_within_thresholds(
         np.concatenate([expected_audio, actual_audio], axis=0),
         label_prefix="hardcoded all-pairs",
+    )
+
+    # Bench filename is the prefix; workflow's publish step reads
+    # ``vst-noise-floor-1-preset-n-renders.json``. See
+    # ``docs/reference/audio-similarity-benchmarks.md``.
+    _emit_audio_similarity_benchmark_metrics(
+        prefix="vst-noise-floor-1-preset-n-renders",
+        round_trip=round_trip_metrics,
+        all_pairs=all_pairs_metrics,
+        total_render_seconds=stage1_seconds + stage2_seconds,
     )
 
 
@@ -796,7 +908,7 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
         got_dataset, spec, _NUM_SAMPLES
     )
 
-    _assert_round_trip_matches(
+    round_trip_metrics = _assert_round_trip_matches(
         actual_audio=actual_audio,
         actual_mel=actual_mel,
         actual_params=actual_params,
@@ -807,10 +919,16 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
         expected_note_patches=note_patches,
         spec=spec,
         num_samples=_NUM_SAMPLES,
-        # Each prefix is also the bench JSON filename — workflow's publish step
-        # reads ``vst-noise-floor-random-preset-replay.json``. See
-        # ``docs/reference/audio-similarity-benchmarks.md``.
-        benchmark_name_prefix="vst-noise-floor-random-preset-replay",
+    )
+
+    # Each row uses different random params, so cross-row pairs differ legitimately —
+    # no all-pairs check applies here. Per-row round-trip metrics are the right
+    # regression signal for this bucket. Bench filename is the prefix; workflow's
+    # publish step reads ``vst-noise-floor-random-preset-replay.json``. See
+    # ``docs/reference/audio-similarity-benchmarks.md``.
+    _emit_audio_similarity_benchmark_metrics(
+        prefix="vst-noise-floor-random-preset-replay",
+        round_trip=round_trip_metrics,
         total_render_seconds=stage1_seconds + stage2_seconds,
     )
 
@@ -845,3 +963,134 @@ def test_make_dataset(tmp_path: Path) -> None:
         assert isinstance(synth, dict)
         assert isinstance(note, dict)
         assert note.keys() == {"pitch", "note_start_and_end"}
+
+
+# Unit tests for ``_emit_audio_similarity_benchmark_metrics`` — pure JSON
+# serialization, no VST needed. Fast feedback while iterating on the
+# emission schema; complements the slow integration coverage above.
+
+
+def test_emit_benchmark_skips_when_env_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No-op when ``BENCHMARK_OUTPUT_DIR`` isn't set (local pytest runs)."""
+    monkeypatch.delenv("BENCHMARK_OUTPUT_DIR", raising=False)
+    _emit_audio_similarity_benchmark_metrics(
+        prefix="x",
+        round_trip=RoundTripMetrics(
+            mss_max=1.0, wmfcc_max=1.0, sot_max=0.001,
+            rms_cos_min=0.99, mel_mean_abs=0.5, num_samples=4,
+        ),
+    )
+    assert list(tmp_path.iterdir()) == []  # nothing written
+
+
+def test_emit_benchmark_round_trip_only_writes_expected_schema(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Per-pair-only emission (sampled bucket): seven entries, no all-pairs.
+
+    Includes ``wall-clock-seconds-per-render`` because ``total_render_seconds``
+    is supplied. ``rms-envelope-cosine-distance`` is reported as ``1 - rms_cos_min``
+    so the schema reads smaller-is-better.
+    """
+    monkeypatch.setenv("BENCHMARK_OUTPUT_DIR", str(tmp_path))
+    _emit_audio_similarity_benchmark_metrics(
+        prefix="bucket-a",
+        round_trip=RoundTripMetrics(
+            mss_max=2.5, wmfcc_max=3.5, sot_max=0.02,
+            rms_cos_min=0.97, mel_mean_abs=1.5, num_samples=4,
+        ),
+        total_render_seconds=8.0,  # 8 / (2 × 4) = 1.0 s/render
+    )
+    out = tmp_path / "bucket-a.json"
+    assert out.exists()
+    entries = json.loads(out.read_text())
+    by_name = {e["name"]: e for e in entries}
+    assert by_name["bucket-a/multi-scale-spectral-loss-max"]["value"] == 2.5
+    assert by_name["bucket-a/dtw-aligned-mfcc-distance-max"]["value"] == 3.5
+    assert by_name["bucket-a/spectral-optimal-transport-max"]["value"] == 0.02
+    assert (
+        by_name["bucket-a/rms-envelope-cosine-distance-max"]["value"]
+        == pytest.approx(1.0 - 0.97)
+    )
+    assert by_name["bucket-a/mel-spectrogram-mean-absolute-error"]["value"] == 1.5
+    assert by_name["bucket-a/num-samples"]["value"] == 4
+    assert by_name["bucket-a/wall-clock-seconds-per-render"]["value"] == 1.0
+    # Units are spelled out, not abbreviated.
+    assert by_name["bucket-a/spectral-optimal-transport-max"]["unit"] == "Wasserstein"
+    # No all-pairs entries when only round_trip is supplied.
+    assert not any("all-pairs" in name for name in by_name)
+
+
+def test_emit_benchmark_all_pairs_only_skips_round_trip_series(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All-pairs-only emission: five entries, none of the round-trip series."""
+    monkeypatch.setenv("BENCHMARK_OUTPUT_DIR", str(tmp_path))
+    _emit_audio_similarity_benchmark_metrics(
+        prefix="bucket-b",
+        all_pairs=AllPairsMetrics(
+            mss_max=4.0, wmfcc_max=6.0, sot_max=0.03,
+            rms_cos_min=0.95, pair_count=66,
+        ),
+    )
+    entries = json.loads((tmp_path / "bucket-b.json").read_text())
+    by_name = {e["name"]: e for e in entries}
+    assert by_name["bucket-b/all-pairs-multi-scale-spectral-loss-max"]["value"] == 4.0
+    assert (
+        by_name["bucket-b/all-pairs-rms-envelope-cosine-distance-max"]["value"]
+        == pytest.approx(1.0 - 0.95)
+    )
+    assert by_name["bucket-b/all-pairs-pair-count"]["value"] == 66
+    # No round-trip entries when only all_pairs is supplied.
+    assert "bucket-b/multi-scale-spectral-loss-max" not in by_name
+    assert "bucket-b/num-samples" not in by_name
+
+
+def test_emit_benchmark_both_structs_writes_both_namespaces(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Hardcoded bucket emits both per-row and all-pairs (the latter is the #489 signal)."""
+    monkeypatch.setenv("BENCHMARK_OUTPUT_DIR", str(tmp_path))
+    _emit_audio_similarity_benchmark_metrics(
+        prefix="bucket-c",
+        round_trip=RoundTripMetrics(
+            mss_max=1.0, wmfcc_max=1.0, sot_max=0.001,
+            rms_cos_min=0.99, mel_mean_abs=0.5, num_samples=6,
+        ),
+        all_pairs=AllPairsMetrics(
+            mss_max=4.0, wmfcc_max=6.0, sot_max=0.03,
+            rms_cos_min=0.95, pair_count=66,
+        ),
+    )
+    entries = json.loads((tmp_path / "bucket-c.json").read_text())
+    names = {e["name"] for e in entries}
+    # Both namespaces present.
+    assert "bucket-c/multi-scale-spectral-loss-max" in names
+    assert "bucket-c/all-pairs-multi-scale-spectral-loss-max" in names
+
+
+def test_emit_benchmark_no_args_writes_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both structs None ⇒ no file written, no error."""
+    monkeypatch.setenv("BENCHMARK_OUTPUT_DIR", str(tmp_path))
+    _emit_audio_similarity_benchmark_metrics(prefix="bucket-d")
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_emit_benchmark_appends_to_existing_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Subsequent emissions for the same prefix accumulate in the same file."""
+    monkeypatch.setenv("BENCHMARK_OUTPUT_DIR", str(tmp_path))
+    rt = RoundTripMetrics(
+        mss_max=1.0, wmfcc_max=1.0, sot_max=0.001,
+        rms_cos_min=0.99, mel_mean_abs=0.5, num_samples=2,
+    )
+    _emit_audio_similarity_benchmark_metrics(prefix="bucket-e", round_trip=rt)
+    _emit_audio_similarity_benchmark_metrics(prefix="bucket-e", round_trip=rt)
+    entries = json.loads((tmp_path / "bucket-e.json").read_text())
+    # Six round-trip entries per call (no render-seconds), twice = 12 total.
+    assert len(entries) == 12

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -35,10 +35,10 @@ _ABSOLUTE_TOLERANCE = 1e-7
 _RELATIVE_TOLERANCE = 1e-9
 
 # Phase-robust audio similarity thresholds for replayed-params vs. candidates.
-# Two independent renders of identical params differ at the sample level (Surge XT's
-# oscillator phase init is nondeterministic across the per-call plugin reloads in
-# ``render_params``), but should remain perceptually close. Tune downward if the
-# metrics consistently come in tighter than these caps.
+# Two independent renders of identical params differ at the sample level on main
+# (issue #489 — Surge XT's oscillator phase init is nondeterministic across renders),
+# but should remain perceptually close. Tune downward if the metrics consistently come
+# in tighter than these caps.
 _MSS_MAX = 10.0           # multi-scale log-mel L1 distance (dB)
 _WMFCC_MAX = 18.0         # DTW-aligned MFCC L1 distance
 _SOT_MAX = 0.15          # spectral optimal transport (Wasserstein on STFT mags)
@@ -67,11 +67,10 @@ skip_no_vst = pytest.mark.skipif(
 
 # Known-good loudness-passing patch captured from a prior random-sampled run
 # (sample 4 of a 5-sample candidates dataset for the surge_xt spec). Used by
-# ``test_make_dataset_replays_via_param_spec_sample_mock_with_hardcoded_params``
-# to drive both stages with a fixed, single-sample param set rather than
-# random sampling. If the spec changes (keys added/removed), this dict must
-# be regenerated; values can be edited freely as long as the resulting render
-# clears ``_MIN_LOUDNESS``.
+# ``test_datasets_from_hardcoded_params_are_identical`` to drive both stages
+# with a fixed, single-sample param set rather than random sampling. If the
+# spec changes (keys added/removed), this dict must be regenerated; values
+# can be edited freely as long as the resulting render clears ``_MIN_LOUDNESS``.
 _HARDCODED_SYNTH_PARAMS: dict[str, float] = {
     "a_amp_eg_attack": 0.6115446960926056,
     "a_amp_eg_decay": 0.7035384780168533,
@@ -283,16 +282,18 @@ def _assert_h5_structure_is_valid(
         assert audio.attrs["min_loudness"] == _MIN_LOUDNESS
 
         audio_arr = audio[...].astype(np.float32)
+        mel_arr = mel[...]
+        params_arr = params[...]
         assert np.isfinite(audio_arr).all()
-        assert np.isfinite(mel[...]).all()
-        assert np.isfinite(params[...]).all()
+        assert np.isfinite(mel_arr).all()
+        assert np.isfinite(params_arr).all()
 
         peak = np.abs(audio_arr).reshape(num_samples, -1).max(axis=1)
         assert (peak > _AUDIO_PEAK_SILENCE_FLOOR).all(), (
             f"silent clips: peaks={peak.tolist()}"
         )
 
-        return audio_arr, mel[...], params[...]
+        return audio_arr, mel_arr, params_arr
 
 
 @contextmanager
@@ -380,7 +381,15 @@ def _emit_benchmark_metrics(
         return
     out = Path(out_dir) / bench_filename
     out.parent.mkdir(parents=True, exist_ok=True)
-    existing = json.loads(out.read_text()) if out.exists() else []
+    if out.exists():
+        try:
+            existing = json.loads(out.read_text())
+        except json.JSONDecodeError:
+            # Truncated file from a previous interrupted run — start fresh.
+            log.warning("benchmark file %s contains invalid JSON; resetting", out)
+            existing = []
+    else:
+        existing = []
     out.write_text(json.dumps(existing + entries, indent=2))
 
 
@@ -459,9 +468,9 @@ def _assert_round_trip_matches(
     Five checks: ``param_array`` exact equality, per-row phase-robust audio metrics
     (MSS / wMFCC / SOT / RMS-envelope cosine), mel mean-abs-diff, per-row decoded-params
     equality vs. the expected patches, and decoded shape/type sanity. Element-wise audio
-    equality is *not* a property of the system: ``render_params`` reloads Surge XT per
-    call (work-around for the silent-output bug, commits 086d80f / 9ff7f16), and each
-    reload yields a different oscillator phase init.
+    equality is *not* a property of the system: Surge XT's oscillator phase init is
+    nondeterministic across renders of identical params (issue #489), so two renders are
+    phase-shifted variants of the same waveform.
 
     ``expected_synth_patches`` / ``expected_note_patches`` are length-``num_samples``
     lists. For tests that replay a single fixed patch across all rows, callers should
@@ -591,11 +600,13 @@ def test_datasets_from_hardcoded_params_are_identical(
 ) -> None:
     """make_dataset round-trips a single hardcoded param set when ``param_spec.sample`` is patched.
 
-    Variant of ``test_make_dataset_replays_via_param_spec_sample_mock`` that removes
+    Variant of ``test_datasets_from_sampled_params_are_identical`` that removes
     the random Stage 1 entirely. Both stages patch ``param_spec.sample`` to return the
     same hardcoded ``(_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS)`` tuple, so the
     test pins reproducibility on a fixed, version-controlled patch rather than a
-    random candidate. ``num_samples=1``: a single render per stage, total two renders.
+    random candidate. ``num_samples=6`` (12 renders total across both stages) so the
+    all-pairs check has enough pairs to surface every-other-render variance — bug #489
+    only shows up across multiple renders, single-pair checks miss it.
 
     The hardcoded values are a known-good loudness-passing capture from a prior
     surge_xt run; if the spec changes, they must be regenerated.
@@ -705,10 +716,10 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
       tolerance — params are deterministic.
     - Per-row audio matches within phase-robust perceptual metrics (MSS,
       wMFCC, SOT, RMS-envelope cosine). Element-wise equality is *not* a
-      property of the system: ``render_params`` reloads Surge XT per call to
-      work around the silent-output bug (commits 086d80f, 9ff7f16), and each
-      reload yields a different oscillator phase init, so the two renders of
-      the same params are phase-shifted variants of the same waveform.
+      property of the system: Surge XT's oscillator phase init is
+      nondeterministic across renders of identical params (issue #489), so
+      the two renders of the same params are phase-shifted variants of the
+      same waveform.
     - Mel spec matches within mean absolute log-power error.
     """
     spec = param_specs[_SPEC_NAME]

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -476,7 +476,7 @@ def _assert_round_trip_matches(
     lists. For tests that replay a single fixed patch across all rows, callers should
     pass the patch repeated ``num_samples`` times.
 
-    ``benchmark_name_prefix`` (optional): when set and ``BENCHMARK_OUTPUT_PATH`` is
+    ``benchmark_name_prefix`` (optional): when set and ``BENCHMARK_OUTPUT_DIR`` is
     defined, the helper emits the worst-case per-pair metrics + mel diff under that
     prefix for github-action-benchmark trend tracking. See ``_emit_benchmark_metrics``.
     """

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -1,0 +1,636 @@
+"""Basic e2e test for src/data/vst/generate_vst_dataset.py — verifies HDF5 output."""
+
+import logging
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+import h5py
+import hdf5plugin  # noqa: F401  side-effect: registers Blosc2 filter for h5py reads
+_ = hdf5plugin  # keep type checkers from flagging the side-effect import
+import numpy as np
+import pytest
+
+from scripts.compute_audio_metrics import compute_mss, compute_rms, compute_sot, compute_wmfcc
+from src.data.vst import param_specs
+from src.data.vst.generate_vst_dataset import make_dataset
+from src.data.vst.param_spec import ParamSpec
+
+log = logging.getLogger(__name__)
+
+_PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
+_PRESET_PATH = "presets/surge-base.vstpreset"
+_NUM_SAMPLES = 5
+_SAMPLE_RATE = 44100.0
+_CHANNELS = 2
+_DURATION = 4.0
+_VELOCITY = 100
+_MIN_LOUDNESS = -55.0
+_SPEC_NAME = "surge_xt"
+_ABSOLUTE_TOLERANCE = 1e-7
+_RELATIVE_TOLERANCE = 1e-9
+
+# Phase-robust audio similarity thresholds for replayed-params vs. candidates.
+# Two independent renders of identical params differ at the sample level (Surge XT's
+# oscillator phase init is nondeterministic across the per-call plugin reloads in
+# ``render_params``), but should remain perceptually close. Tune downward if the
+# metrics consistently come in tighter than these caps.
+_MSS_MAX = 10.0           # multi-scale log-mel L1 distance (dB)
+_WMFCC_MAX = 18.0         # DTW-aligned MFCC L1 distance
+_SOT_MAX = 0.15          # spectral optimal transport (Wasserstein on STFT mags)
+_RMS_MIN_COSINE = 0.8   # RMS envelope cosine similarity (1.0 = identical)
+_MEL_MEAN_ABS_MAX = 5.0  # mean abs diff on stored mel_spec (log-power dB)
+
+# Peak amplitude floor below which a clip is treated as silent.
+_AUDIO_PEAK_SILENCE_FLOOR = 1e-4
+
+# Per-sample mel shape `(channels, n_mels, n_frames)` hardcoded by the writer.
+# Derivation: channels=2 literal in writer; n_mels=128 from librosa kwarg;
+# n_frames = _DURATION * 100 + 1 (hop_length = sample_rate/100 → 100 fps + librosa's
+# trailing frame). If _CHANNELS, _DURATION, librosa kwargs, or the writer literal
+# change, update this constant.
+# Pointers:
+#   - `create_datasets_and_get_start_idx()` in `src/data/vst/generate_vst_dataset.py`
+#     (the literal `(num_samples, 2, 128, 401)` passed to `create_dataset`)
+#   - `make_spectrogram()` in `src/data/vst/generate_vst_dataset.py`
+#   - `_SURGE_MEL_SHAPE` in `tests/conftest.py` — mirror, keep in sync.
+_PER_SAMPLE_MEL_SHAPE = (2, 128, 401)
+
+skip_no_vst = pytest.mark.skipif(
+    not Path(_PLUGIN_PATH).exists(),
+    reason=f"VST plugin not found at {_PLUGIN_PATH}",
+)
+
+# Known-good loudness-passing patch captured from a prior random-sampled run
+# (sample 4 of a 5-sample candidates dataset for the surge_xt spec). Used by
+# ``test_make_dataset_replays_via_param_spec_sample_mock_with_hardcoded_params``
+# to drive both stages with a fixed, single-sample param set rather than
+# random sampling. If the spec changes (keys added/removed), this dict must
+# be regenerated; values can be edited freely as long as the resulting render
+# clears ``_MIN_LOUDNESS``.
+_HARDCODED_SYNTH_PARAMS: dict[str, float] = {
+    "a_amp_eg_attack": 0.6115446960926056,
+    "a_amp_eg_decay": 0.7035384780168533,
+    "a_amp_eg_sustain": 0.8458655476570129,
+    "a_amp_eg_release": 0.7526835530996323,
+    "a_amp_eg_envelope_mode": 0.75,
+    "a_filter_eg_attack": 0.6334269267320634,
+    "a_filter_eg_decay": 0.498066001534462,
+    "a_filter_eg_sustain": 0.20409274101257324,
+    "a_filter_eg_release": 0.2183585774898529,
+    "a_filter_eg_envelope_mode": 0.75,
+    "a_feedback": 0.5,
+    "a_filter_balance": 0.5,
+    "a_filter_configuration": 0.7125,
+    "a_highpass": 0.8109021186828613,
+    "a_filter_1_cutoff": 0.18654786050319672,
+    "a_filter_1_feg_mod_amount": 0.6178140640258789,
+    "a_filter_1_resonance": 0.9254387617111206,
+    "a_filter_1_type": 0.6955,
+    "a_filter_2_cutoff": 0.222905233502388,
+    "a_filter_2_feg_mod_amount": 0.5447665452957153,
+    "a_filter_2_resonance": 0.4141045808792114,
+    "a_filter_2_type": 0.2455,
+    "a_waveshaper_drive": 0.5353075826990605,
+    "a_waveshaper_type": 0.1,
+    "a_osc_1_mute": 0.2505,
+    "a_osc_1_octave": 0.5005,
+    "a_osc_1_pitch": 0.27579981088638306,
+    "a_osc_1_route": 0.874,
+    "a_osc_1_sawtooth": 0.8939391374588013,
+    "a_osc_1_width": 0.7921043634414673,
+    "a_osc_1_sync": 0.008044014684855938,
+    "a_osc_1_unison_detune": 0.2343703955411911,
+    "a_osc_1_unison_voices": 0.0195,
+    "a_osc_1_volume": 0.22278083860874176,
+    "a_osc_1_pulse": 0.6516783237457275,
+    "a_osc_1_triangle": 0.24101869761943817,
+    "a_osc_2_mute": 0.2505,
+    "a_osc_2_octave": 0.5,
+    "a_osc_2_pitch": 0.5,
+    "a_osc_2_route": 0.1265,
+    "a_osc_2_sawtooth": 0.7841401696205139,
+    "a_osc_2_width": 0.651004433631897,
+    "a_osc_2_sync": 0.8729211688041687,
+    "a_osc_2_unison_detune": 0.9950850605964661,
+    "a_osc_2_unison_voices": 0.0195,
+    "a_osc_2_volume": 0.8628856539726257,
+    "a_osc_2_pulse": 0.5585712194442749,
+    "a_osc_2_triangle": 0.7885411381721497,
+    "a_osc_3_mute": 0.2505,
+    "a_osc_3_octave": 0.5,
+    "a_osc_3_pitch": 0.8914749622344971,
+    "a_osc_3_route": 0.874,
+    "a_osc_3_sawtooth": 0.8178988695144653,
+    "a_osc_3_width": 0.25304195284843445,
+    "a_osc_3_sync": 0.32539647817611694,
+    "a_osc_3_unison_detune": 0.5072322487831116,
+    "a_osc_3_unison_voices": 0.0195,
+    "a_osc_3_volume": 0.9149643778800964,
+    "a_osc_3_pulse": 0.03317605331540108,
+    "a_osc_3_triangle": 0.02597862109541893,
+    "a_osc_drift": 0.9930819272994995,
+    "a_fm_depth": 0.21858084201812744,
+    "a_fm_routing": 0.9155,
+    "a_lfo_1_amplitude": 0.0,
+    "a_lfo_1_attack": 0.0022514958889223637,
+    "a_lfo_1_decay": 0.2558778440952301,
+    "a_lfo_1_deform": 0.31317904591560364,
+    "a_lfo_1_hold": 0.5517071908712388,
+    "a_lfo_1_phase": 0.6524000763893127,
+    "a_lfo_1_rate": 0.45813828706741333,
+    "a_lfo_1_release": 0.5639569038152695,
+    "a_lfo_1_sustain": 0.7934410572052002,
+    "a_lfo_1_type": 0.5549999999999999,
+    "a_lfo_2_amplitude": 0.0,
+    "a_lfo_2_attack": 0.2449902430176735,
+    "a_lfo_2_decay": 0.004002517010085285,
+    "a_lfo_2_deform": 0.6100139021873474,
+    "a_lfo_2_hold": 0.1760928821563721,
+    "a_lfo_2_phase": 0.7932401299476624,
+    "a_lfo_2_rate": 0.09311769902706146,
+    "a_lfo_2_release": 0.490568408370018,
+    "a_lfo_2_sustain": 0.04693538323044777,
+    "a_lfo_2_type": 0.5549999999999999,
+    "a_lfo_3_amplitude": 0.0,
+    "a_lfo_3_attack": 0.4771536821126938,
+    "a_lfo_3_decay": 0.22750570356845856,
+    "a_lfo_3_deform": 0.5475855469703674,
+    "a_lfo_3_hold": 0.2858144730329514,
+    "a_lfo_3_phase": 0.4254957139492035,
+    "a_lfo_3_rate": 0.870485246181488,
+    "a_lfo_3_release": 0.597478711605072,
+    "a_lfo_3_sustain": 0.8878445029258728,
+    "a_lfo_3_type": 0.3355,
+    "a_lfo_4_amplitude": 0.011512083001434803,
+    "a_lfo_4_attack": 0.2023567634820938,
+    "a_lfo_4_decay": 0.7672159743309022,
+    "a_lfo_4_deform": 0.22317861020565033,
+    "a_lfo_4_hold": 0.2421818467974663,
+    "a_lfo_4_phase": 0.17402644455432892,
+    "a_lfo_4_rate": 0.32441940903663635,
+    "a_lfo_4_release": 0.09115911923348904,
+    "a_lfo_4_sustain": 0.8703923225402832,
+    "a_lfo_4_type": 0.0305,
+    "a_lfo_5_amplitude": 0.0,
+    "a_lfo_5_attack": 0.7430108767747879,
+    "a_lfo_5_decay": 0.70498992562294,
+    "a_lfo_5_deform": 0.3357408046722412,
+    "a_lfo_5_hold": 0.4660577839612961,
+    "a_lfo_5_phase": 0.14568571746349335,
+    "a_lfo_5_rate": 0.1889970600605011,
+    "a_lfo_5_release": 0.19390373915433884,
+    "a_lfo_5_sustain": 0.1149880513548851,
+    "a_lfo_5_type": 0.0305,
+    "a_lfo_6_amplitude": 0.0,
+    "a_lfo_6_attack": 0.27028446555137636,
+    "a_lfo_6_decay": 0.31658956825733187,
+    "a_lfo_6_deform": 0.20451003313064575,
+    "a_lfo_6_hold": 0.3530474078655243,
+    "a_lfo_6_release": 0.5311448252201081,
+    "a_lfo_6_sustain": 0.9014169573783875,
+    "a_noise_color": 0.06865139305591583,
+    "a_noise_mute": 0.2505,
+    "a_noise_route": 0.5005,
+    "a_noise_volume": 0.25137007236480713,
+    "a_pan": 0.5,
+    "a_ring_modulation_1x2_mute": 0.7505,
+    "a_ring_modulation_1x2_route": 0.1265,
+    "a_ring_modulation_1x2_volume": 0.05965404957532883,
+    "a_ring_modulation_2x3_mute": 0.7505,
+    "a_ring_modulation_2x3_route": 0.1265,
+    "a_ring_modulation_2x3_volume": 0.39768943190574646,
+    "a_vca_gain": 0.5358291573184729,
+    "a_width": 0.793622612953186,
+    "fx_a1_delay_time": 0.2910090684890747,
+    "fx_a1_modulation_rate": 0.28712332248687744,
+    "fx_a1_modulation_depth": 0.6283016800880432,
+    "fx_a1_delay_feedback": 0.18823447823524475,
+    "fx_a1_eq_low_cut": 0.5102251768112183,
+    "fx_a1_eq_high_cut": 0.07518906146287918,
+    "fx_a1_output_mix": 0.0,
+    "fx_a1_output_width": 0.5458093285560608,
+    "fx_a2_delay_time_left": 0.673,
+    "fx_a2_delay_time_right": 0.3225,
+    "fx_a2_feedback_eq_feedback": 0.09261893033981324,
+    "fx_a2_feedback_eq_crossfeed": 0.33431210517883303,
+    "fx_a2_feedback_eq_low_cut": 0.7649092674255371,
+    "fx_a2_feedback_eq_high_cut": 0.445017546415329,
+    "fx_a2_modulation_rate": 0.8504968881607056,
+    "fx_a2_modulation_depth": 0.5354740619659424,
+    "fx_a2_input_channel": 0.9212818741798401,
+    "fx_a2_output_mix": 0.0,
+    "fx_a2_output_width": 0.9808350205421448,
+    "fx_a3_pre_delay_pre_delay": 0.2418496161699295,
+    "fx_a3_reverb_room_size": 0.6668235659599304,
+    "fx_a3_reverb_decay_time": 0.9710032939910889,
+    "fx_a3_reverb_diffusion": 0.2893294394016266,
+    "fx_a3_reverb_buildup": 0.799410879611969,
+    "fx_a3_reverb_modulation": 0.7270567417144775,
+    "fx_a3_eq_lf_damping": 0.9389781951904297,
+    "fx_a3_eq_hf_damping": 0.398930162191391,
+    "fx_a3_output_width": 0.7004019618034363,
+    "fx_a3_output_mix": 0.0,
+}
+
+_HARDCODED_NOTE_PARAMS: dict[str, int | tuple[float, float]] = {
+    "pitch": 64,
+    "note_start_and_end": (0.77033705, 2.2995389),
+}
+
+
+def _assert_h5_structure_is_valid(
+    out: Path, spec, num_samples: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Open ``out`` and assert dataset keys, shapes, dtypes, attrs, and finiteness.
+
+    Returns materialized (audio, mel_spec, param_array) numpy arrays so callers can perform per-row
+    decode checks without re-opening the file. Shared by the round-trip and random-sampling e2e
+    tests.
+    """
+    expected_audio_shape = (num_samples, _CHANNELS, int(_SAMPLE_RATE * _DURATION))
+    expected_mel_shape = (num_samples, *_PER_SAMPLE_MEL_SHAPE)
+
+    with h5py.File(out, "r") as f:
+        for name in ("audio", "mel_spec", "param_array"):
+            assert name in f, f"missing dataset {name!r}"
+
+        audio = f["audio"]
+        mel = f["mel_spec"]
+        params = f["param_array"]
+        assert isinstance(audio, h5py.Dataset)
+        assert isinstance(mel, h5py.Dataset)
+        assert isinstance(params, h5py.Dataset)
+
+        assert audio.shape == expected_audio_shape
+        assert mel.shape == expected_mel_shape
+        assert params.shape == (num_samples, len(spec))
+        assert params.shape[1] == spec.synth_param_length + spec.note_param_length
+        assert spec.note_param_length == 3  # pitch (1) + note_start_and_end (2)
+
+        assert audio.dtype == np.float16
+        assert mel.dtype == np.float32
+        assert params.dtype == np.float32
+
+        assert audio.attrs["velocity"] == _VELOCITY
+        assert audio.attrs["sample_rate"] == _SAMPLE_RATE
+        assert audio.attrs["channels"] == _CHANNELS
+        assert audio.attrs["signal_duration_seconds"] == _DURATION
+        assert audio.attrs["min_loudness"] == _MIN_LOUDNESS
+
+        audio_arr = audio[...].astype(np.float32)
+        assert np.isfinite(audio_arr).all()
+        assert np.isfinite(mel[...]).all()
+        assert np.isfinite(params[...]).all()
+
+        peak = np.abs(audio_arr).reshape(num_samples, -1).max(axis=1)
+        assert (peak > _AUDIO_PEAK_SILENCE_FLOOR).all(), (
+            f"silent clips: peaks={peak.tolist()}"
+        )
+
+        return audio_arr, mel[...], params[...]
+
+
+@contextmanager
+def _patched_sample(
+    spec: ParamSpec,
+    replay: list[tuple[dict[str, float], dict[str, int | tuple[float, float]]]],
+) -> Iterator[None]:
+    """Patch ``spec.sample`` with a deterministic replay over the lifetime of the block.
+
+    Each call to the patched ``sample`` yields the next ``(synth, note)`` tuple from
+    ``replay``. If the loudness ``while True`` loop in ``generate_sample`` retries (an
+    unexpected extra call), ``next(replay_iter)`` raises ``StopIteration`` which
+    surfaces as a test failure rather than a silent desync. On exit, asserts the
+    total pull count equals ``len(replay)``.
+    """
+    replay_iter = iter(replay)
+    pull_count = [0]
+
+    def fake_sample() -> tuple[dict[str, float], dict[str, int | tuple[float, float]]]:
+        pull_count[0] += 1
+        return next(replay_iter)
+
+    with patch.object(spec, "sample", side_effect=fake_sample):
+        yield
+
+    assert pull_count[0] == len(replay), (
+        f"expected exactly {len(replay)} param_spec.sample calls; got {pull_count[0]} "
+        "(loudness loop retried — replay may have desynced)"
+    )
+
+
+def _assert_round_trip_matches(
+    actual_audio: np.ndarray,
+    actual_mel: np.ndarray,
+    actual_params: np.ndarray,
+    expected_audio: np.ndarray,
+    expected_mel: np.ndarray,
+    expected_params: np.ndarray,
+    expected_synth_patches: list[dict[str, float]],
+    expected_note_patches: list[dict[str, int | tuple[float, float]]],
+    spec: ParamSpec,
+    num_samples: int,
+) -> None:
+    """Assert a Stage-2 dataset reproduces a Stage-1 dataset within phase-robust tolerances.
+
+    Five checks: ``param_array`` exact equality, per-row phase-robust audio metrics
+    (MSS / wMFCC / SOT / RMS-envelope cosine), mel mean-abs-diff, per-row decoded-params
+    equality vs. the expected patches, and decoded shape/type sanity. Element-wise audio
+    equality is *not* a property of the system: ``render_params`` reloads Surge XT per
+    call (work-around for the silent-output bug, commits 086d80f / 9ff7f16), and each
+    reload yields a different oscillator phase init.
+
+    ``expected_synth_patches`` / ``expected_note_patches`` are length-``num_samples``
+    lists. For tests that replay a single fixed patch across all rows, callers should
+    pass the patch repeated ``num_samples`` times.
+    """
+    np.testing.assert_allclose(
+        actual_params,
+        expected_params,
+        rtol=_RELATIVE_TOLERANCE,
+        atol=_ABSOLUTE_TOLERANCE,
+        err_msg="param_array row-for-row mismatch",
+    )
+
+    for i in range(num_samples):
+        target = expected_audio[i]
+        pred = actual_audio[i]
+        mss = compute_mss(target, pred)
+        wmfcc = compute_wmfcc(target, pred)
+        sot = compute_sot(target, pred)
+        rms_cos = compute_rms(target, pred)
+        log.info(
+            "sample %d audio metrics: mss=%.4f wmfcc=%.4f sot=%.4f rms_cos=%.4f",
+            i,
+            mss,
+            wmfcc,
+            sot,
+            rms_cos,
+        )
+        assert mss < _MSS_MAX, f"sample {i}: mss={mss:.4f} exceeds {_MSS_MAX}"
+        assert wmfcc < _WMFCC_MAX, f"sample {i}: wmfcc={wmfcc:.4f} exceeds {_WMFCC_MAX}"
+        assert sot < _SOT_MAX, f"sample {i}: sot={sot:.4f} exceeds {_SOT_MAX}"
+        assert rms_cos > _RMS_MIN_COSINE, (
+            f"sample {i}: rms cosine similarity {rms_cos:.4f} below {_RMS_MIN_COSINE}"
+        )
+
+    mel_dist = float(np.mean(np.abs(actual_mel - expected_mel)))
+    log.info("mel mean abs diff: %.4f (max=%.4f)", mel_dist, _MEL_MEAN_ABS_MAX)
+    assert mel_dist < _MEL_MEAN_ABS_MAX, (
+        f"mel mean abs diff {mel_dist:.4f} exceeds {_MEL_MEAN_ABS_MAX}"
+    )
+
+    for i in range(num_samples):
+        decoded_synth_params, decoded_note_params = spec.decode(actual_params[i])
+        assert isinstance(decoded_synth_params, dict)
+        assert decoded_synth_params == pytest.approx(
+            expected_synth_patches[i], rel=_RELATIVE_TOLERANCE, abs=_ABSOLUTE_TOLERANCE
+        ), (
+            f"sample {i}: decoded synth params {decoded_synth_params} do not match input "
+            f"{expected_synth_patches[i]} within tolerances "
+            f"(abs={_ABSOLUTE_TOLERANCE}, rel={_RELATIVE_TOLERANCE})"
+        )
+        assert decoded_note_params == pytest.approx(
+            expected_note_patches[i], rel=_RELATIVE_TOLERANCE, abs=_ABSOLUTE_TOLERANCE
+        ), (
+            f"sample {i}: decoded note params {decoded_note_params} do not match input "
+            f"{expected_note_patches[i]} within tolerances "
+            f"(abs={_ABSOLUTE_TOLERANCE}, rel={_RELATIVE_TOLERANCE})"
+        )
+        assert isinstance(decoded_note_params, dict)
+        assert decoded_note_params.keys() == {"pitch", "note_start_and_end"}
+        assert isinstance(decoded_note_params["pitch"], int)
+        assert isinstance(decoded_note_params["note_start_and_end"], tuple)
+        start, end = decoded_note_params["note_start_and_end"]
+        assert isinstance(start, np.floating)
+        assert isinstance(end, np.floating)
+
+@pytest.mark.xfail(strict=True, reason="bug #489")
+@pytest.mark.slow
+@pytest.mark.requires_vst
+@skip_no_vst
+def test_make_dataset_replays_via_param_spec_sample_mock_with_hardcoded_params(
+    tmp_path: Path,
+) -> None:
+    """make_dataset round-trips a single hardcoded param set when ``param_spec.sample`` is patched.
+
+    Variant of ``test_make_dataset_replays_via_param_spec_sample_mock`` that removes
+    the random Stage 1 entirely. Both stages patch ``param_spec.sample`` to return the
+    same hardcoded ``(_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS)`` tuple, so the
+    test pins reproducibility on a fixed, version-controlled patch rather than a
+    random candidate. ``num_samples=1``: a single render per stage, total two renders.
+
+    The hardcoded values are a known-good loudness-passing capture from a prior
+    surge_xt run; if the spec changes, they must be regenerated.
+    """
+    spec = param_specs[_SPEC_NAME]
+    num_samples = 8
+    replay = [(_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS)] * num_samples
+
+    expected_dataset = tmp_path / "expected.h5"
+    with (
+        h5py.File(expected_dataset, "a") as f,
+        _patched_sample(spec, replay),
+    ):
+        make_dataset(
+            hdf5_file=f,
+            num_samples=num_samples,
+            plugin_path=_PLUGIN_PATH,
+            preset_path=_PRESET_PATH,
+            sample_rate=_SAMPLE_RATE,
+            channels=_CHANNELS,
+            velocity=_VELOCITY,
+            signal_duration_seconds=_DURATION,
+            min_loudness=_MIN_LOUDNESS,
+            param_spec=spec,
+            sample_batch_size=num_samples,
+        )
+
+    expected_audio, expected_mel, expected_params = _assert_h5_structure_is_valid(
+        expected_dataset, spec, num_samples
+    )
+
+    got_dataset = tmp_path / "replayed.h5"
+    with (
+        h5py.File(got_dataset, "a") as f,
+        _patched_sample(spec, replay),
+    ):
+        make_dataset(
+            hdf5_file=f,
+            num_samples=num_samples,
+            plugin_path=_PLUGIN_PATH,
+            preset_path=_PRESET_PATH,
+            sample_rate=_SAMPLE_RATE,
+            channels=_CHANNELS,
+            velocity=_VELOCITY,
+            signal_duration_seconds=_DURATION,
+            min_loudness=_MIN_LOUDNESS,
+            param_spec=spec,
+            sample_batch_size=num_samples,
+        )
+
+    actual_audio, actual_mel, actual_params = _assert_h5_structure_is_valid(
+        got_dataset, spec, num_samples
+    )
+
+    _assert_round_trip_matches(
+        actual_audio=actual_audio,
+        actual_mel=actual_mel,
+        actual_params=actual_params,
+        expected_audio=expected_audio,
+        expected_mel=expected_mel,
+        expected_params=expected_params,
+        expected_synth_patches=[_HARDCODED_SYNTH_PARAMS] * num_samples,
+        expected_note_patches=[_HARDCODED_NOTE_PARAMS] * num_samples,
+        spec=spec,
+        num_samples=num_samples,
+    )
+
+@pytest.mark.xfail(strict=True, reason="bug #489")
+@pytest.mark.slow
+@pytest.mark.requires_vst
+@skip_no_vst
+def test_make_dataset_replays_via_param_spec_sample_mock(tmp_path: Path) -> None:
+    """make_dataset reproduces a previous dataset row-for-row when params are replayed.
+
+    Two-stage e2e test:
+
+    1. Build a "candidates" dataset by calling ``make_dataset`` with the natural
+       random source. ``generate_sample`` samples params via ``param_spec.sample()``
+       and rejects renders below ``_MIN_LOUDNESS`` in a ``while True`` loop, so each
+       surviving row is guaranteed to be loud enough to pass the loudness gate.
+    2. Decode the candidate ``param_array`` rows back into ``synth_patches`` /
+       ``note_patches`` and replay them in Stage 2 by patching ``param_spec.sample``
+       (via ``_patched_sample``) to yield the candidate tuples in order. Because the
+       params are guaranteed-loud (step 1), this run can't infinite-loop on the
+       loudness gate.
+
+    Assertions:
+
+    - ``param_array`` matches the candidates exactly within float32 numeric
+      tolerance — params are deterministic.
+    - Per-row audio matches within phase-robust perceptual metrics (MSS,
+      wMFCC, SOT, RMS-envelope cosine). Element-wise equality is *not* a
+      property of the system: ``render_params`` reloads Surge XT per call to
+      work around the silent-output bug (commits 086d80f, 9ff7f16), and each
+      reload yields a different oscillator phase init, so the two renders of
+      the same params are phase-shifted variants of the same waveform.
+    - Mel spec matches within mean absolute log-power error.
+    """
+    spec = param_specs[_SPEC_NAME]
+
+    # Stage 1: random-sampled "candidates" dataset (loudness-filtered).
+    expected_dataset = tmp_path / "candidates.h5"
+    with h5py.File(expected_dataset, "a") as expected_file:
+        make_dataset(
+            hdf5_file=expected_file,
+            num_samples=_NUM_SAMPLES,
+            plugin_path=_PLUGIN_PATH,
+            preset_path=_PRESET_PATH,
+            sample_rate=_SAMPLE_RATE,
+            channels=_CHANNELS,
+            velocity=_VELOCITY,
+            signal_duration_seconds=_DURATION,
+            min_loudness=_MIN_LOUDNESS,
+            param_spec=spec,
+            sample_batch_size=_NUM_SAMPLES,
+        )
+
+    expected_audio, expected_mel, expected_params = _assert_h5_structure_is_valid(
+        expected_dataset, spec, _NUM_SAMPLES
+    )
+
+    log.info(
+        "spec %s synth_len=%d note_len=%d",
+        spec.names,
+        spec.synth_param_length,
+        spec.note_param_length,
+    )
+
+    # Decode the candidate rows back into synth/note params dicts. These are the
+    # inputs for the second ``make_dataset`` run — guaranteed past the loudness
+    # gate by construction (the candidate render survived stage 1).
+    synth_patches: list[dict[str, float]] = []
+    note_patches: list[dict[str, int | tuple[float, float]]] = []
+    for i in range(_NUM_SAMPLES):
+        decoded_synth_params, decoded_note_params = spec.decode(expected_params[i])
+        synth_patches.append(decoded_synth_params)
+        # ParamSpec.decode is annotated dict[str, float] on main but actually returns
+        # dict[str, int | tuple[float, float]] at runtime (pitch is int, note_start_and_end
+        # is a tuple). Annotation gets corrected in a sibling PR.
+        note_patches.append(decoded_note_params)  # pyright: ignore[reportArgumentType]
+    log.info("synth_patches: %s", synth_patches)
+    log.info("note_patches: %s", note_patches)
+
+    # Stage 2: replay the candidates via ``_patched_sample`` and verify reproducibility.
+    got_dataset = tmp_path / "replayed.h5"
+    replay = list(zip(synth_patches, note_patches, strict=True))
+    with (
+        h5py.File(got_dataset, "a") as f,
+        _patched_sample(spec, replay),
+    ):
+        make_dataset(
+            hdf5_file=f,
+            num_samples=_NUM_SAMPLES,
+            plugin_path=_PLUGIN_PATH,
+            preset_path=_PRESET_PATH,
+            sample_rate=_SAMPLE_RATE,
+            channels=_CHANNELS,
+            velocity=_VELOCITY,
+            signal_duration_seconds=_DURATION,
+            min_loudness=_MIN_LOUDNESS,
+            param_spec=spec,
+            sample_batch_size=_NUM_SAMPLES,
+        )
+
+    actual_audio, actual_mel, actual_params = _assert_h5_structure_is_valid(
+        got_dataset, spec, _NUM_SAMPLES
+    )
+
+    _assert_round_trip_matches(
+        actual_audio=actual_audio,
+        actual_mel=actual_mel,
+        actual_params=actual_params,
+        expected_audio=expected_audio,
+        expected_mel=expected_mel,
+        expected_params=expected_params,
+        expected_synth_patches=synth_patches,
+        expected_note_patches=note_patches,
+        spec=spec,
+        num_samples=_NUM_SAMPLES,
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.requires_vst
+@skip_no_vst
+def test_make_dataset_with_random_sampling_produces_valid_h5(tmp_path: Path) -> None:
+    """make_dataset with the natural random source writes a valid h5."""
+    out = tmp_path / "random.h5"
+    spec = param_specs[_SPEC_NAME]
+
+    with h5py.File(out, "a") as f:
+        make_dataset(
+            hdf5_file=f,
+            num_samples=_NUM_SAMPLES,
+            plugin_path=_PLUGIN_PATH,
+            preset_path=_PRESET_PATH,
+            sample_rate=_SAMPLE_RATE,
+            channels=_CHANNELS,
+            velocity=_VELOCITY,
+            signal_duration_seconds=_DURATION,
+            min_loudness=_MIN_LOUDNESS,
+            param_spec=spec,
+            sample_batch_size=_NUM_SAMPLES,
+        )
+
+    _, _, params = _assert_h5_structure_is_valid(out, spec, _NUM_SAMPLES)
+
+    decoded_rows = [spec.decode(params[i]) for i in range(_NUM_SAMPLES)]
+    for synth, note in decoded_rows:
+        assert isinstance(synth, dict)
+        assert isinstance(note, dict)
+        assert note.keys() == {"pitch", "note_start_and_end"}

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -637,7 +637,6 @@ def test_datasets_from_hardcoded_params_are_identical(
     )
 
 
-@pytest.mark.xfail(strict=True, reason="bug #489")
 @pytest.mark.slow
 @pytest.mark.requires_vst
 @skip_no_vst

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -1,5 +1,6 @@
 """Basic e2e test for src/data/vst/generate_vst_dataset.py — verifies HDF5 output."""
 
+import json
 import logging
 import os
 from collections.abc import Iterator
@@ -322,6 +323,114 @@ def _patched_sample(
     )
 
 
+def _audio_metrics(
+    target: np.ndarray, pred: np.ndarray
+) -> tuple[float, float, float, float]:
+    """Compute (mss, wmfcc, sot, rms_cos) for one (target, pred) audio pair."""
+    return (
+        compute_mss(target, pred),
+        compute_wmfcc(target, pred),
+        compute_sot(target, pred),
+        compute_rms(target, pred),
+    )
+
+
+def _assert_audio_metrics_within_thresholds(
+    target: np.ndarray, pred: np.ndarray, label: str
+) -> tuple[float, float, float, float]:
+    """Assert phase-robust audio metrics for one pair are within the module thresholds.
+
+    Returns the four metric values so callers can accumulate them for trend reporting.
+    """
+    mss, wmfcc, sot, rms_cos = _audio_metrics(target, pred)
+    log.info(
+        "%s audio metrics: mss=%.4f wmfcc=%.4f sot=%.4f rms_cos=%.4f",
+        label,
+        mss,
+        wmfcc,
+        sot,
+        rms_cos,
+    )
+    assert mss < _MSS_MAX, f"{label}: mss={mss:.4f} exceeds {_MSS_MAX}"
+    assert wmfcc < _WMFCC_MAX, f"{label}: wmfcc={wmfcc:.4f} exceeds {_WMFCC_MAX}"
+    assert sot < _SOT_MAX, f"{label}: sot={sot:.4f} exceeds {_SOT_MAX}"
+    assert rms_cos > _RMS_MIN_COSINE, (
+        f"{label}: rms cosine similarity {rms_cos:.4f} below {_RMS_MIN_COSINE}"
+    )
+    return mss, wmfcc, sot, rms_cos
+
+
+def _emit_benchmark_metrics(entries: list[dict[str, float | str]]) -> None:
+    """Append metrics to ``BENCHMARK_OUTPUT_PATH`` for github-action-benchmark.
+
+    No-op when the env var is unset (e.g. local pytest runs). The on-disk format
+    is the ``customSmallerIsBetter`` schema:
+    https://github.com/benchmark-action/github-action-benchmark#examples
+    """
+    out_path = os.environ.get("BENCHMARK_OUTPUT_PATH")
+    if not out_path:
+        return
+    out = Path(out_path)
+    existing = json.loads(out.read_text()) if out.exists() else []
+    out.write_text(json.dumps(existing + entries, indent=2))
+
+
+def _assert_all_pairs_audio_metrics_within_thresholds(
+    audio: np.ndarray, label_prefix: str
+) -> None:
+    """For every (i, j) pair with i < j in ``audio``, assert metrics within thresholds.
+
+    Use this when every row is expected to be a render of the *same* params — every pair should be
+    perceptually identical, and the worst pair across the run is the interesting datum. Asserts on
+    the worst measurement so a single failure surfaces the most-divergent rendering rather than the
+    first iteration to trip a threshold. Identifies the (i, j) that produced each worst measurement
+    to make debugging easy.
+    """
+    n = audio.shape[0]
+    pair_count = n * (n - 1) // 2
+    worst_mss = (-1.0, -1, -1)
+    worst_wmfcc = (-1.0, -1, -1)
+    worst_sot = (-1.0, -1, -1)
+    worst_rms_cos = (1.0 + 1e-9, -1, -1)  # min target — start above 1.0
+    for i in range(n):
+        for j in range(i + 1, n):
+            mss, wmfcc, sot, rms_cos = _audio_metrics(audio[i], audio[j])
+            if mss > worst_mss[0]:
+                worst_mss = (mss, i, j)
+            if wmfcc > worst_wmfcc[0]:
+                worst_wmfcc = (wmfcc, i, j)
+            if sot > worst_sot[0]:
+                worst_sot = (sot, i, j)
+            if rms_cos < worst_rms_cos[0]:
+                worst_rms_cos = (rms_cos, i, j)
+    log.info(
+        "%s worst-pair over %d pairs: mss=%.4f@(%d,%d) wmfcc=%.4f@(%d,%d) "
+        "sot=%.4f@(%d,%d) rms_cos=%.4f@(%d,%d)",
+        label_prefix,
+        pair_count,
+        *worst_mss,
+        *worst_wmfcc,
+        *worst_sot,
+        *worst_rms_cos,
+    )
+    assert worst_mss[0] < _MSS_MAX, (
+        f"{label_prefix}: worst mss={worst_mss[0]:.4f} at pair {worst_mss[1:]} "
+        f"exceeds {_MSS_MAX}"
+    )
+    assert worst_wmfcc[0] < _WMFCC_MAX, (
+        f"{label_prefix}: worst wmfcc={worst_wmfcc[0]:.4f} at pair {worst_wmfcc[1:]} "
+        f"exceeds {_WMFCC_MAX}"
+    )
+    assert worst_sot[0] < _SOT_MAX, (
+        f"{label_prefix}: worst sot={worst_sot[0]:.4f} at pair {worst_sot[1:]} "
+        f"exceeds {_SOT_MAX}"
+    )
+    assert worst_rms_cos[0] > _RMS_MIN_COSINE, (
+        f"{label_prefix}: worst rms cosine={worst_rms_cos[0]:.4f} at pair "
+        f"{worst_rms_cos[1:]} below {_RMS_MIN_COSINE}"
+    )
+
+
 def _assert_round_trip_matches(
     actual_audio: np.ndarray,
     actual_mel: np.ndarray,
@@ -333,6 +442,7 @@ def _assert_round_trip_matches(
     expected_note_patches: list[dict[str, int | tuple[float, float]]],
     spec: ParamSpec,
     num_samples: int,
+    benchmark_name_prefix: str | None = None,
 ) -> None:
     """Assert a Stage-2 dataset reproduces a Stage-1 dataset within phase-robust tolerances.
 
@@ -346,6 +456,10 @@ def _assert_round_trip_matches(
     ``expected_synth_patches`` / ``expected_note_patches`` are length-``num_samples``
     lists. For tests that replay a single fixed patch across all rows, callers should
     pass the patch repeated ``num_samples`` times.
+
+    ``benchmark_name_prefix`` (optional): when set and ``BENCHMARK_OUTPUT_PATH`` is
+    defined, the helper emits the worst-case per-pair metrics + mel diff under that
+    prefix for github-action-benchmark trend tracking. See ``_emit_benchmark_metrics``.
     """
     np.testing.assert_allclose(
         actual_params,
@@ -355,33 +469,57 @@ def _assert_round_trip_matches(
         err_msg="param_array row-for-row mismatch",
     )
 
+    mss_values: list[float] = []
+    wmfcc_values: list[float] = []
+    sot_values: list[float] = []
+    rms_cos_values: list[float] = []
     for i in range(num_samples):
-        target = expected_audio[i]
-        pred = actual_audio[i]
-        mss = compute_mss(target, pred)
-        wmfcc = compute_wmfcc(target, pred)
-        sot = compute_sot(target, pred)
-        rms_cos = compute_rms(target, pred)
-        log.info(
-            "sample %d audio metrics: mss=%.4f wmfcc=%.4f sot=%.4f rms_cos=%.4f",
-            i,
-            mss,
-            wmfcc,
-            sot,
-            rms_cos,
+        mss, wmfcc, sot, rms_cos = _assert_audio_metrics_within_thresholds(
+            expected_audio[i], actual_audio[i], label=f"sample {i}"
         )
-        assert mss < _MSS_MAX, f"sample {i}: mss={mss:.4f} exceeds {_MSS_MAX}"
-        assert wmfcc < _WMFCC_MAX, f"sample {i}: wmfcc={wmfcc:.4f} exceeds {_WMFCC_MAX}"
-        assert sot < _SOT_MAX, f"sample {i}: sot={sot:.4f} exceeds {_SOT_MAX}"
-        assert rms_cos > _RMS_MIN_COSINE, (
-            f"sample {i}: rms cosine similarity {rms_cos:.4f} below {_RMS_MIN_COSINE}"
-        )
+        mss_values.append(float(mss))
+        wmfcc_values.append(float(wmfcc))
+        sot_values.append(float(sot))
+        rms_cos_values.append(float(rms_cos))
 
     mel_dist = float(np.mean(np.abs(actual_mel - expected_mel)))
     log.info("mel mean abs diff: %.4f (max=%.4f)", mel_dist, _MEL_MEAN_ABS_MAX)
     assert mel_dist < _MEL_MEAN_ABS_MAX, (
         f"mel mean abs diff {mel_dist:.4f} exceeds {_MEL_MEAN_ABS_MAX}"
     )
+
+    if benchmark_name_prefix is not None:
+        # Max-over-samples for distance-style metrics; ``1 - min(rms_cos)`` keeps
+        # all entries smaller=better, which the customSmallerIsBetter schema requires.
+        _emit_benchmark_metrics(
+            [
+                {
+                    "name": f"{benchmark_name_prefix}/mss-max",
+                    "unit": "dB",
+                    "value": max(mss_values),
+                },
+                {
+                    "name": f"{benchmark_name_prefix}/wmfcc-max",
+                    "unit": "L1",
+                    "value": max(wmfcc_values),
+                },
+                {
+                    "name": f"{benchmark_name_prefix}/sot-max",
+                    "unit": "W",
+                    "value": max(sot_values),
+                },
+                {
+                    "name": f"{benchmark_name_prefix}/rms-distance-max",
+                    "unit": "1-cos",
+                    "value": 1.0 - min(rms_cos_values),
+                },
+                {
+                    "name": f"{benchmark_name_prefix}/mel-mean-abs",
+                    "unit": "dB",
+                    "value": mel_dist,
+                },
+            ]
+        )
 
     for i in range(num_samples):
         decoded_synth_params, decoded_note_params = spec.decode(actual_params[i])
@@ -412,7 +550,7 @@ def _assert_round_trip_matches(
 @pytest.mark.slow
 @pytest.mark.requires_vst
 @skip_no_vst
-def test_make_dataset_replays_via_param_spec_sample_mock_with_hardcoded_params(
+def test_datasets_from_hardcoded_params_are_identical(
     tmp_path: Path,
 ) -> None:
     """make_dataset round-trips a single hardcoded param set when ``param_spec.sample`` is patched.
@@ -427,7 +565,7 @@ def test_make_dataset_replays_via_param_spec_sample_mock_with_hardcoded_params(
     surge_xt run; if the spec changes, they must be regenerated.
     """
     spec = param_specs[_SPEC_NAME]
-    num_samples = 8
+    num_samples = 6
     replay = [(_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS)] * num_samples
 
     expected_dataset = tmp_path / "expected.h5"
@@ -485,15 +623,25 @@ def test_make_dataset_replays_via_param_spec_sample_mock_with_hardcoded_params(
         expected_params=expected_params,
         expected_synth_patches=[_HARDCODED_SYNTH_PARAMS] * num_samples,
         expected_note_patches=[_HARDCODED_NOTE_PARAMS] * num_samples,
+        benchmark_name_prefix="vst-fixed-replay",
         spec=spec,
         num_samples=num_samples,
     )
+
+    # Every render in expected ∪ actual uses identical params, so every pair across
+    # the union should be perceptually identical. Asserts on the worst-case pair to
+    # surface the most-divergent rendering (e.g. an every-other-render glitch).
+    _assert_all_pairs_audio_metrics_within_thresholds(
+        np.concatenate([expected_audio, actual_audio], axis=0),
+        label_prefix="hardcoded all-pairs",
+    )
+
 
 @pytest.mark.xfail(strict=True, reason="bug #489")
 @pytest.mark.slow
 @pytest.mark.requires_vst
 @skip_no_vst
-def test_make_dataset_replays_via_param_spec_sample_mock(tmp_path: Path) -> None:
+def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
     """make_dataset reproduces a previous dataset row-for-row when params are replayed.
 
     Two-stage e2e test:
@@ -607,7 +755,7 @@ def test_make_dataset_replays_via_param_spec_sample_mock(tmp_path: Path) -> None
 @pytest.mark.slow
 @pytest.mark.requires_vst
 @skip_no_vst
-def test_make_dataset_with_random_sampling_produces_valid_h5(tmp_path: Path) -> None:
+def test_make_dataset(tmp_path: Path) -> None:
     """make_dataset with the natural random source writes a valid h5."""
     out = tmp_path / "random.h5"
     spec = param_specs[_SPEC_NAME]

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -704,13 +704,16 @@ def test_datasets_from_hardcoded_params_are_identical(
 ) -> None:
     """make_dataset round-trips a single hardcoded param set when ``param_spec.sample`` is patched.
 
-    Variant of ``test_datasets_from_sampled_params_are_identical`` that removes
-    the random Stage 1 entirely. Both stages patch ``param_spec.sample`` to return the
-    same hardcoded ``(_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS)`` tuple, so the
-    test pins reproducibility on a fixed, version-controlled patch rather than a
-    random candidate. ``num_samples=6`` (12 renders total across both stages) so the
-    all-pairs check has enough pairs to surface every-other-render variance — bug #489
-    only shows up across multiple renders, single-pair checks miss it.
+    Both stages of ``make_dataset`` patch ``param_spec.sample`` to return the same
+    hardcoded ``(_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS)`` tuple, so every
+    one of the ``2 × num_samples`` renders uses identical inputs. This pins
+    reproducibility on a fixed, version-controlled patch — no random sampling, no
+    Stage-1-then-decode — and the rendered audio across rows should be perceptually
+    identical on every pair.
+
+    ``num_samples=6`` (12 renders total) so the all-pairs check has enough pairs to
+    surface every-other-render variance — bug #489 only shows up across multiple
+    renders, single-pair checks miss it.
 
     The hardcoded values are a known-good loudness-passing capture from a prior
     surge_xt run; if the spec changes, they must be regenerated.


### PR DESCRIPTION
## Summary

Adds round-trip reproducibility tests for `make_dataset` plus shared validation infrastructure. One of the three tests is marked `@pytest.mark.xfail(strict=True, reason="bug #489")` because it fails reliably on main: Surge XT's oscillator phase init is nondeterministic across renders of identical params, and the test's all-pairs check exceeds the perceptual-similarity thresholds. When #489 is fixed, the strict flag will surface that as a CI failure so the test gets reclassified.

## What the tests exercise

- **`test_datasets_from_hardcoded_params_are_identical`** *(xfail on main — bug #489 reproducer)* — drives both stages of `make_dataset` with the same hardcoded `_HARDCODED_*_PARAMS` patch via `_patched_sample` (patches `param_spec.sample`), so all 12 renders (6 expected + 6 actual) use *identical* params. Asserts (a) per-pair `expected[i]` vs `actual[i]` audio metrics within thresholds, AND (b) all-pairs worst-case across the union of 12 renders. The all-pairs check is what makes this test a real #489 reproducer — single-pair tests miss the every-other-render junk because they never compare two stage-2 renders against each other.
- **`test_datasets_from_sampled_params_are_identical`** *(passes on main)* — random Stage 1, decoded candidates replayed in Stage 2 via `_patched_sample`. Per-row metric check only (no all-pairs — each row uses different random params), and per-row metrics pass within thresholds on main, so this test is not an #489 reproducer and is not xfail.
- **`test_make_dataset`** *(passes on main)* — single-stage smoke that validates the h5 structure of a normal random-sampled run.

## Why xfail strict=True is justified — empirical evidence on main

Ran `test_datasets_from_hardcoded_params_are_identical` (num_samples=6 → 12 renders, 66 all-pairs) against `origin/main` HEAD with the test file pinned to PR #706's contents:

> main = [`0d055b3`](https://github.com/tinaudio/synth-setter/commit/0d055b35ac85932c7584d67e57087c7432b35476)

### All-pairs worst-case (the assertion that catches #489)

| Metric  | main `0d055b3` worst @ pair | Threshold | Result |
|---------|-----------------------------|-----------|--------|
| MSS     | **21.39** @ (8, 11)         | 10.0      | FAIL — strict xfail correctly produces XFAIL |
| wMFCC   | 17.25 @ (0, 9)              | 18.0      | PASS (barely) |
| SOT     | **0.293** @ (5, 10)         | 0.15      | FAIL |
| RMS cos | 0.886 @ (5, 10)             | min 0.8   | PASS |

Pair (8, 11) on main = `actual[2]` vs `actual[5]` — two replays of the *same* hardcoded params during Stage 2 producing mss=21.39, ~6× the worst per-pair value of 3.66 in the same run. That's the every-other-render junk that #489 describes.

### Per-pair (`expected[i]` vs `actual[i]`) — passes cleanly on main

These are within thresholds on main — which is why an earlier version of this PR (without the all-pairs check) was wrongly claiming xfail and erroneously XPASS-ing. The all-pairs check is what changed the empirical answer and made strict-xfail an honest contract.

## What this PR ships

- New `tests/data/vst/test_generate_vst_dataset.py` (entirely new file — main `0d055b3` has no `test_generate_vst_dataset.py`).
- Helpers: `_patched_sample` (context manager that drives `param_spec.sample` from a deterministic replay list), `_assert_round_trip_matches` (param + per-row + mel + decoded-params checks), `_assert_audio_metrics_within_thresholds` (one-pair metric assertion), `_assert_all_pairs_audio_metrics_within_thresholds` (worst-case-across-all-pairs assertion).
- Hardcoded loudness-passing patch constants (`_HARDCODED_SYNTH_PARAMS`, `_HARDCODED_NOTE_PARAMS`).
- `xfail(strict=True)` decorator on `test_datasets_from_hardcoded_params_are_identical`.
- New `.github/workflows/test-vst-slow.yml` Docker-based CI workflow that runs the slow VST tests in the project's `dev-snapshot` image and publishes per-run audio-similarity metrics to a `gh-pages` benchmark dashboard.

No production-code changes.

## Test plan

- [x] `make format` clean
- [x] `pytest --collect-only` shows all 3 tests
- [x] On main `0d055b3`: hardcoded test FAILS at `worst mss=21.3918 at pair (8, 11) exceeds 10.0` → strict-xfail correctly produces `XFAIL` (not `XPASS`)

Refs #489
