### PR TITLE
docs: add comment-hygiene rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,15 @@ Conventional commits, enforced by gitlint (`.gitlint` config). Prefix matters fo
 - Use `structlog` for logging in pipeline code. Use Python's `logging` module elsewhere.
 - All `rclone` operations use `--checksum`.
 
+#### Comment Hygiene: Don't Bake Values Into Comments
+
+Comments that restate values, counts, or list contents go stale the moment the code changes. The code is the source of truth — name it, don't mirror it.
+
+- **Don't restate constant values.** Next to `num_samples = 6`, never write `# 6 samples (12 renders total)`. Reference the symbol (`each stage renders num_samples times`) or describe behavior without numbers.
+- **Don't bake in counts the code already reports.** `# 29 review comments triaged` or `# 5 metric series` belongs in a PR description (a snapshot in time), not in a docstring or inline comment that lives next to the data and will drift the next time someone adds an item. Prefer "the metric series listed below" or reference the data source.
+- **Don't enumerate list contents in prose.** Next to `THINGS = ["a", "b", "c"]`, never write `# three things: a, b, and c` — both the count and the contents will mismatch the list within a release. The list is the source of truth; a comment can name the *category*, not its contents.
+- Still write comments for: WHY a non-obvious choice was made, hidden invariants, workarounds (with bug ID), and surprising behavior.
+
 ### Testing
 
 - **pytest** with strict markers. Run `make test` for quick tests (excludes slow).


### PR DESCRIPTION
## Summary

- Adds a new "Comment Hygiene: Don't Bake Values Into Comments" subsection under `### Writing Code` in `CLAUDE.md`.
- Calls out three specific stale-fast patterns with concrete bad examples: restating constant values, baking in counts the code already reports, and enumerating list contents in prose.
- Explicitly preserves the existing good-comment categories (WHY, invariants, workarounds, surprises) so the new rule is not read as "no comments at all".

## Why

Future Claude sessions keep producing comments like `# 6 samples (12 renders total)` next to `num_samples = 6`, or `# three things: a, b, c` next to `THINGS = ["a", "b", "c"]`. Both go stale the moment the code changes. The new bullets give a clear rule (the code is the source of truth; comments name the category, not its contents) with examples concrete enough that future sessions can pattern-match against them.

## Scope

- Single file changed: `CLAUDE.md` (+9 lines).
- Existing comment-related bullets are not rewritten or moved; the new subsection is appended.
- No code or other docs touched.

## Test plan

- [ ] `make format` clean (verified locally)
- [ ] PR metadata gate passes (linked issue #710 has type=Task, label=documentation, milestone=documentation v1.0.0, parented under Phase #442 → Epic #351)

Refs #710