### PR TITLE
tests: keep cpu-slow green — workers off in ddp_sim, requires_vst on surge_xt

### DIFF
--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -111,6 +111,17 @@ def test_train_ddp_sim(cfg_train: DictConfig) -> None:
         cfg_train.trainer.accelerator = "cpu"
         cfg_train.trainer.devices = 2
         cfg_train.trainer.strategy = "ddp_spawn"
+        # Workaround for #709: ddp_spawn rank processes start with torch's
+        # default `file_descriptor` sharing strategy, and their forked
+        # dataloader workers inherit it. On the GitHub-hosted
+        # `ubuntu-latest-4core` runner that strategy fails with
+        # `RuntimeError: unable to resize file ... Invalid argument (22)`
+        # because anonymous shm-backed fds can't be ftruncate'd in the
+        # runner sandbox. Setting num_workers=0 keeps dataloading inline in
+        # each rank process, sidestepping cross-process tensor shm entirely.
+        # This test exercises ddp_spawn coordination, not dataloader
+        # parallelism, so dropping workers does not weaken coverage.
+        cfg_train.data.num_workers = 0
     train(cfg_train)
 
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -165,6 +165,7 @@ def test_train_resume(tmp_path: Path, cfg_train: DictConfig) -> None:
     )
 
 
+@pytest.mark.requires_vst
 @pytest.mark.slow
 def test_train_surge_xt(cfg_surge_xt: DictConfig) -> None:
     """Run training of the Surge XT FFN model on the smoke test fixture.
@@ -191,6 +192,7 @@ def test_train_surge_xt(cfg_surge_xt: DictConfig) -> None:
         assert torch.isfinite(loss).all(), f"{key} is not finite: {loss}"
 
 
+@pytest.mark.requires_vst
 @pytest.mark.slow
 def test_train_eval_surge_xt(
     tmp_path: Path, cfg_surge_xt: DictConfig, cfg_surge_xt_eval: DictConfig


### PR DESCRIPTION
## Summary

Two fixes that together make the post-merge `cpu-slow` run green again.

### 1. `test_train_ddp_sim`: drop dataloader workers

`test_train_ddp_sim` had been failing every post-merge `cpu-slow` run on `main` with:

```
RuntimeError: unable to resize file <filename not specified> to the right size: Invalid argument (22)
```

raised inside `torch.multiprocessing.reductions.rebuild_storage_fd`.

Root cause: `ddp_spawn` rank processes start with torch's default `file_descriptor` sharing strategy, and their forked dataloader workers inherit it. On the GitHub-hosted `ubuntu-latest-4core` runner the anonymous shm-backed fds can't be `ftruncate`'d in the sandbox, so every dataloader worker handing a tensor back to its rank crashes.

Setting `cfg_train.data.num_workers = 0` for this test keeps dataloading inline in each rank process and sidesteps cross-process tensor shm entirely. The test exists to exercise `ddp_spawn` coordination, not dataloader parallelism, so dropping workers does not weaken coverage.

Setting the sharing strategy in the pytest parent process is not enough — `ddp_spawn` starts fresh interpreters that reset to the default — so the cleanest patch is at the dataloader config in this single test.

### 2. `test_train_surge_xt` / `test_train_eval_surge_xt`: mark `requires_vst`

After PR #708 added `not requires_vst` to the `cpu-slow` matrix, the workflow exposed two surge-xt smoke tests on `tests/test_train.py` that were marked `slow` but not `requires_vst`. They pull `surge_xt_smoke_datasets` (and so the headless VST host) transitively through `cfg_surge_xt`/`cfg_surge_xt_eval`, and the bare-metal `cpu-slow` runner has no Surge XT — both fail at setup with `Xvfb did not start`. See [the failing run on this branch](https://github.com/tinaudio/synth-setter/actions/runs/25144442363/job/73701108207).

Adding `@pytest.mark.requires_vst` to both tests deselects them in `cpu-slow` and keeps them eligible for the Docker-based VST workflows that have the plugin installed.

## Test plan

- [x] Reproduced the original `ddp_sim` failure locally on `main`: same `RuntimeError: unable to resize file ... Invalid argument (22)` shown in the linked CI runs.
- [x] Verified the `ddp_sim` fix passes locally: `pytest -vv -s tests/test_train.py::test_train_ddp_sim` → `1 passed in 14.65s`.
- [x] Verified the marker filter deselects both surge_xt tests locally: `pytest tests/test_train.py --collect-only -q -m "slow and not gpu and not mps and not requires_vst"` collects only `test_train_ddp_sim`.
- [ ] Confirm `cpu-slow` workflow goes green on this branch.

Closes #709