### PR TITLE
fix(vst): reload plugin per render to eliminate every-other junk audio

### DIFF
--- a/docs/reference/audio-similarity-benchmarks.md
+++ b/docs/reference/audio-similarity-benchmarks.md
@@ -24,10 +24,11 @@ of the kind of regressions the chart is designed to surface:
 - **`librosa` / `pedalboard` upgrade** changing mel-spectrogram
   computation or VST host behavior, even with identical params.
 - **Regression in the renderer's determinism** in
-  `src/data/vst/render_params` — bug
-  [#489](https://github.com/tinaudio/synth-setter/issues/489) tracks the
-  every-other-render variance; if a future fix lands and then regresses,
-  that variance spikes here first.
+  `src/data/vst/core.py` § `render_params()` — bug
+  [#489](https://github.com/tinaudio/synth-setter/issues/489) was the
+  every-other-render variance, closed by
+  [#713](https://github.com/tinaudio/synth-setter/pull/713) via per-render
+  plugin reload; if that fix regresses, the variance spikes here first.
 - **Renderer perf regressions** — dB metrics may stay flat while
   `wall-clock-seconds-per-render` doubles.
 
@@ -43,7 +44,8 @@ safety net; the chart is the early warning.
 | `gh-pages` branch tree     | <https://github.com/tinaudio/synth-setter/tree/gh-pages>                       |
 | Workflow runs that publish | <https://github.com/tinaudio/synth-setter/actions/workflows/test-vst-slow.yml> |
 | Tracking issue             | [#703](https://github.com/tinaudio/synth-setter/issues/703)                    |
-| Underlying bug             | [#489](https://github.com/tinaudio/synth-setter/issues/489)                    |
+| Original bug               | [#489](https://github.com/tinaudio/synth-setter/issues/489) (closed)           |
+| Fix PR                     | [#713](https://github.com/tinaudio/synth-setter/pull/713)                      |
 
 The chart's left-hand legend lets you toggle individual metric series on
 and off; the dropdown at the top selects the dashboard ("bucket").
@@ -60,7 +62,9 @@ stages of `make_dataset` run with the same hardcoded
 `_HARDCODED_*_PARAMS` patch via `_patched_sample`, so all
 `2 × num_samples` renders use _identical_ inputs. The per-pair metrics
 plus an all-pairs cross-comparison expose every-other-render variance —
-this is the reproducer for [#489](https://github.com/tinaudio/synth-setter/issues/489).
+this was the reproducer for [#489](https://github.com/tinaudio/synth-setter/issues/489)
+and is now the regression guard against its fix in
+[#713](https://github.com/tinaudio/synth-setter/pull/713).
 
 Bucket name: `VST noise floor (1 preset N renders)`<br>
 JSON file (in workflow run): `vst-noise-floor-1-preset-n-renders.json`<br>
@@ -103,9 +107,10 @@ plus the two non-distance sentinels `num-samples` and
 | `wall-clock-seconds-per-render`       | `(stage1_t + stage2_t) / (2 × num_samples)`                                 | seconds     | yes                |
 
 The **`1 preset N renders`** bucket additionally emits five `all-pairs-*`
-series — these are the **#489 regression signal**, since the per-row
-metrics can stay flat while the all-pairs worst-case spikes (the bug
-manifests as junk on every-other render, not on every render):
+series — these are the **fix-regression signal for the #489
+every-other-render bug**, since the per-row metrics can stay flat
+while the all-pairs worst-case spikes (the bug manifested as junk on
+every-other render, not on every render):
 
 | Metric                                       | Computed by                                   | Unit        |
 | -------------------------------------------- | --------------------------------------------- | ----------- |

--- a/scripts/predict_vst_audio.py
+++ b/scripts/predict_vst_audio.py
@@ -12,7 +12,7 @@ from pedalboard.io import AudioFile
 from tqdm import tqdm, trange
 
 rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
-from src.data.vst import load_plugin, load_preset, param_specs, render_params
+from src.data.vst import param_specs, render_params
 from src.data.vst.param_spec import ParamSpec
 
 
@@ -127,11 +127,10 @@ def main(
     param_spec = param_specs[param_spec]
     os.makedirs(output_dir, exist_ok=True)
 
-    # 1. load and prepare the VST
-    plugin = load_plugin(plugin_path)
-    load_preset(plugin, preset_path)
+    # render_params loads the plugin (and applies preset_path) on every call,
+    # so no upfront load_plugin is needed here.
 
-    # 2. list the .pt files with accompanying indices (each file has name
+    # list the .pt files with accompanying indices (each file has name
     # pred-{index}.pt, and we want to sort by index)
     pred_dir = Path(pred_dir)
     pred_files = [f for f in pred_dir.glob("pred-*.pt") if f.is_file()]
@@ -167,9 +166,8 @@ def main(
             row_params_scaled = np.clip(row_params_scaled, 0, 1)
             synth_params, note_params = param_spec.decode(row_params_scaled)
 
-            load_preset(plugin, preset_path)
             pred_audio = render_params(
-                plugin,
+                plugin_path,
                 synth_params,
                 int(note_params["pitch"]),
                 velocity,
@@ -177,6 +175,7 @@ def main(
                 signal_duration_seconds,
                 sample_rate,
                 channels,
+                preset_path=preset_path,
             )
 
             out_target = os.path.join(sample_dir, "target.wav")
@@ -186,9 +185,8 @@ def main(
                 target_params_ = np.clip(target_params_, 0, 1)
                 target_synth_params, target_note_params = param_spec.decode(target_params_)
 
-                load_preset(plugin, preset_path)
                 new_target = render_params(
-                    plugin,
+                    plugin_path,
                     target_synth_params,
                     int(target_note_params["pitch"]),
                     velocity,
@@ -196,6 +194,7 @@ def main(
                     signal_duration_seconds,
                     sample_rate,
                     channels,
+                    preset_path=preset_path,
                 )
                 with AudioFile(out_target, "w", sample_rate, channels) as f:
                     f.write(new_target.T)

--- a/src/data/vst/core.py
+++ b/src/data/vst/core.py
@@ -46,13 +46,19 @@ def load_plugin(plugin_path: str) -> VST3Plugin:
     if sys.platform != "darwin":
         logger.info("Preparing plugin for preset load...")
         stop_event = threading.Event()
-        t = threading.Thread(target=_prepare_plugin, args=(stop_event,))
+        t = threading.Thread(target=_prepare_plugin, args=(stop_event,), daemon=True)
         t.start()
         try:
             p.show_editor(stop_event)
         finally:
             stop_event.set()
             t.join(timeout=_PREPARE_PLUGIN_JOIN_TIMEOUT_SECONDS)
+            if t.is_alive():
+                logger.warning(
+                    "Plugin preparation helper thread did not exit within {}s for {}",
+                    _PREPARE_PLUGIN_JOIN_TIMEOUT_SECONDS,
+                    plugin_path,
+                )
     return p
 
 

--- a/src/data/vst/core.py
+++ b/src/data/vst/core.py
@@ -1,6 +1,5 @@
 import sys
 import threading
-import time
 from typing import Optional, Tuple
 
 import mido
@@ -9,27 +8,8 @@ from loguru import logger
 from pedalboard import VST3Plugin
 from pedalboard.io import AudioFile
 
-# How long the helper thread waits before signalling ``show_editor`` to close.
-_PREPARE_PLUGIN_SLEEP_SECONDS = 0.5
-
-# Upper bound for how long load_plugin waits for the helper thread to exit
-# after signalling its stop event. The helper only sleeps for
-# ``_PREPARE_PLUGIN_SLEEP_SECONDS`` so 1.0s is a generous ceiling.
-_PREPARE_PLUGIN_JOIN_TIMEOUT_SECONDS = 1.0
-
-
-def _prepare_plugin(
-    stop_event: threading.Event,
-    sleep_time: float = _PREPARE_PLUGIN_SLEEP_SECONDS,
-) -> None:
-    """Sleep, then signal ``show_editor`` to close.
-
-    Used by :func:`load_plugin` to drive ``show_editor`` long enough that the
-    plugin completes initialisation, but no longer than necessary for batch
-    rendering throughput.
-    """
-    time.sleep(sleep_time)
-    stop_event.set()
+# How long the editor stays open before we signal it to close.
+_EDITOR_INIT_DELAY_SECONDS = 0.5
 
 
 def load_plugin(plugin_path: str) -> VST3Plugin:
@@ -45,20 +25,15 @@ def load_plugin(plugin_path: str) -> VST3Plugin:
     # audit on #714 for the empirical justification.
     if sys.platform != "darwin":
         logger.info("Preparing plugin for preset load...")
-        stop_event = threading.Event()
-        t = threading.Thread(target=_prepare_plugin, args=(stop_event,), daemon=True)
-        t.start()
+        close_editor = threading.Event()
+        timer = threading.Timer(_EDITOR_INIT_DELAY_SECONDS, close_editor.set)
+        timer.daemon = True
+        timer.start()
         try:
-            p.show_editor(stop_event)
+            p.show_editor(close_editor)
         finally:
-            stop_event.set()
-            t.join(timeout=_PREPARE_PLUGIN_JOIN_TIMEOUT_SECONDS)
-            if t.is_alive():
-                logger.warning(
-                    "Plugin preparation helper thread did not exit within {}s for {}",
-                    _PREPARE_PLUGIN_JOIN_TIMEOUT_SECONDS,
-                    plugin_path,
-                )
+            timer.cancel()
+            close_editor.set()  # defensive: ensure show_editor unblocks even if Timer fails
     return p
 
 

--- a/src/data/vst/core.py
+++ b/src/data/vst/core.py
@@ -1,8 +1,7 @@
-import _thread
 import sys
 import threading
 import time
-from typing import Callable, Optional, Tuple
+from typing import Optional, Tuple
 
 import mido
 import numpy as np
@@ -10,30 +9,27 @@ from loguru import logger
 from pedalboard import VST3Plugin
 from pedalboard.io import AudioFile
 
+# How long the helper thread waits before signalling ``show_editor`` to close.
+_PREPARE_PLUGIN_SLEEP_SECONDS = 0.5
 
-def _call_with_interrupt(fn: Callable, sleep_time: float = 2.0):
-    """Calls the function fn on the main thread, while another thread sends a KeyboardInterrupt
-    (SIGINT) to the main thread."""
-
-    def send_interrupt():
-        # Brief sleep so that fn starts before we send the interrupt
-        time.sleep(sleep_time)
-        _thread.interrupt_main()
-
-    # Create and start the thread that sends the interrupt
-    t = threading.Thread(target=send_interrupt)
-    t.start()
-
-    try:
-        fn()
-    except KeyboardInterrupt:
-        print("Interrupted main thread.")
-    finally:
-        t.join()
+# Upper bound for how long load_plugin waits for the helper thread to exit
+# after signalling its stop event. The helper only sleeps for
+# ``_PREPARE_PLUGIN_SLEEP_SECONDS`` so 1.0s is a generous ceiling.
+_PREPARE_PLUGIN_JOIN_TIMEOUT_SECONDS = 1.0
 
 
-def _prepare_plugin(plugin: VST3Plugin) -> None:
-    _call_with_interrupt(plugin.show_editor, sleep_time=2.0)
+def _prepare_plugin(
+    stop_event: threading.Event,
+    sleep_time: float = _PREPARE_PLUGIN_SLEEP_SECONDS,
+) -> None:
+    """Sleep, then signal ``show_editor`` to close.
+
+    Used by :func:`load_plugin` to drive ``show_editor`` long enough that the
+    plugin completes initialisation, but no longer than necessary for batch
+    rendering throughput.
+    """
+    time.sleep(sleep_time)
+    stop_event.set()
 
 
 def load_plugin(plugin_path: str) -> VST3Plugin:
@@ -49,8 +45,14 @@ def load_plugin(plugin_path: str) -> VST3Plugin:
     # audit on #714 for the empirical justification.
     if sys.platform != "darwin":
         logger.info("Preparing plugin for preset load...")
-        _prepare_plugin(p)
-        logger.info("Plugin ready")
+        stop_event = threading.Event()
+        t = threading.Thread(target=_prepare_plugin, args=(stop_event,))
+        t.start()
+        try:
+            p.show_editor(stop_event)
+        finally:
+            stop_event.set()
+            t.join(timeout=_PREPARE_PLUGIN_JOIN_TIMEOUT_SECONDS)
     return p
 
 
@@ -71,7 +73,7 @@ def write_wav(audio: np.ndarray, path: str, sample_rate: float, channels: int) -
 
 
 def render_params(
-    plugin: VST3Plugin,
+    plugin_path: str,
     params: dict[str, float],
     midi_note: int,
     velocity: int,
@@ -81,6 +83,12 @@ def render_params(
     channels: int,
     preset_path: Optional[str] = None,
 ) -> np.ndarray:
+    """Render a single audio sample by loading the plugin fresh per call.
+
+    Reloads the plugin on every call to work around stale-state bug #489. This incurs an extra
+    plugin-load per render; see #705 for the perf follow-up.
+    """
+    plugin = load_plugin(plugin_path)
     if preset_path is not None:
         load_preset(plugin, preset_path)
 

--- a/src/data/vst/generate_vst_dataset.py
+++ b/src/data/vst/generate_vst_dataset.py
@@ -10,12 +10,11 @@ import librosa
 import numpy as np
 import rootutils
 from loguru import logger
-from pedalboard import VST3Plugin
 from pyloudnorm import Meter
 from tqdm import trange
 
 rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
-from src.data.vst import load_plugin, param_specs, render_params  # noqa
+from src.data.vst import param_specs, render_params  # noqa
 from src.data.vst.param_spec import ParamSpec  # noqa
 
 
@@ -60,7 +59,7 @@ def make_spectrogram(audio: np.ndarray, sample_rate: float) -> np.ndarray:
 
 
 def generate_sample(
-    plugin: VST3Plugin,
+    plugin_path: str,
     velocity: int,
     signal_duration_seconds: float,
     sample_rate: float,
@@ -76,7 +75,7 @@ def generate_sample(
         logger.debug("sampling note")
 
         output = render_params(
-            plugin,
+            plugin_path,
             synth_params,
             note_params["pitch"],
             velocity,
@@ -242,15 +241,13 @@ def make_dataset(
     audio_dataset.attrs["channels"] = channels
     audio_dataset.attrs["min_loudness"] = min_loudness
 
-    plugin = load_plugin(plugin_path)
-
     sample_batch = []
     sample_batch_start = start_idx
 
     for i in trange(start_idx, num_samples):
         logger.info(f"Making sample {i}")
         sample = generate_sample(
-            plugin,
+            plugin_path,
             velocity=velocity,
             signal_duration_seconds=signal_duration_seconds,
             sample_rate=sample_rate,

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -18,6 +18,7 @@ import pytest
 
 from scripts.compute_audio_metrics import compute_mss, compute_rms, compute_sot, compute_wmfcc
 from src.data.vst import param_specs
+from src.data.vst.core import render_params
 from src.data.vst.generate_vst_dataset import make_dataset
 from src.data.vst.param_spec import ParamSpec
 
@@ -965,6 +966,63 @@ def test_make_dataset(tmp_path: Path) -> None:
         assert isinstance(synth, dict)
         assert isinstance(note, dict)
         assert note.keys() == {"pitch", "note_start_and_end"}
+
+
+@pytest.mark.slow
+@pytest.mark.requires_vst
+@skip_no_vst
+def test_show_editor_warmup_does_not_change_rendered_audio() -> None:
+    """``show_editor`` warm-up in ``load_plugin`` does not change rendered audio.
+
+    Empirical characterisation of ``load_plugin``'s ``show_editor`` warm-up.
+    Renders the same hardcoded patch N times each with the warm-up enabled
+    and disabled (by swapping ``VST3Plugin.show_editor`` to a no-op around
+    the second batch), then asserts every cross-path pair (with[i] vs no[j])
+    is within the same audio-similarity thresholds the round-trip tests use.
+
+    If this passes, the warm-up is not load-bearing for the per-render
+    reload path — it can be dropped without changing output. That matters
+    for #714 (macOS SIGTRAP from per-render ``show_editor`` accumulating
+    AppKit/CGS state in unbundled python).
+    """
+    from pedalboard import VST3Plugin
+
+    n_renders = 3
+    pitch = _HARDCODED_NOTE_PARAMS["pitch"]
+    note_window = _HARDCODED_NOTE_PARAMS["note_start_and_end"]
+    assert isinstance(pitch, int)
+    assert isinstance(note_window, tuple)
+
+    def _render_n(n: int) -> list[np.ndarray]:
+        return [
+            render_params(
+                _PLUGIN_PATH,
+                _HARDCODED_SYNTH_PARAMS,
+                pitch,
+                _VELOCITY,
+                note_window,
+                _DURATION,
+                _SAMPLE_RATE,
+                _CHANNELS,
+                preset_path=_PRESET_PATH,
+            )
+            for _ in range(n)
+        ]
+
+    with_editor = _render_n(n_renders)
+
+    original_show_editor = VST3Plugin.show_editor
+    VST3Plugin.show_editor = lambda self, *a, **kw: None
+    try:
+        no_editor = _render_n(n_renders)
+    finally:
+        VST3Plugin.show_editor = original_show_editor
+
+    for i, target in enumerate(with_editor):
+        for j, pred in enumerate(no_editor):
+            _assert_audio_metrics_within_thresholds(
+                target, pred, label=f"with-editor[{i}] vs no-editor[{j}]"
+            )
 
 
 # Unit tests for ``_emit_audio_similarity_benchmark_metrics`` — pure JSON

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -695,7 +695,6 @@ def _assert_round_trip_matches(
     )
 
 
-@pytest.mark.xfail(strict=True, reason="bug #489")
 @pytest.mark.slow
 @pytest.mark.requires_vst
 @skip_no_vst

--- a/tests/data/vst/test_preset_params.py
+++ b/tests/data/vst/test_preset_params.py
@@ -66,9 +66,8 @@ def test_render_params_sets_preset_dependent_param():
 
     # render_params now takes a plugin_path and loads its own VST3Plugin instance
     # per call (see src/data/vst/core.py docstring), so the caller cannot observe
-    # the post-call parameter state directly. Verify instead that the call returns
-    # finite, non-silent audio — proof that the preset-dependent param was set
-    # without raising KeyError.
+    # the post-call parameter state directly. Verify instead that the call does
+    # not raise KeyError and returns finite, non-silent audio.
     output = render_params(
         plugin_path=PLUGIN_PATH,
         params={"a_osc_1_sawtooth": 0.5},

--- a/tests/data/vst/test_preset_params.py
+++ b/tests/data/vst/test_preset_params.py
@@ -59,18 +59,19 @@ def test_preset_dependent_params_missing_without_flush():
 @requires_vst
 @skip_no_vst
 def test_render_params_sets_preset_dependent_param():
-    """render_params must successfully set preset-dependent params."""
-    from pedalboard import VST3Plugin
+    """render_params must successfully set preset-dependent params without raising."""
+    import numpy as np
 
     from src.data.vst.core import render_params
 
-    plugin = VST3Plugin(PLUGIN_PATH)
-    params = {"a_osc_1_sawtooth": 0.5}
-
-    # Should not raise KeyError
-    render_params(
-        plugin,
-        params=params,
+    # render_params now takes a plugin_path and loads its own VST3Plugin instance
+    # per call (see src/data/vst/core.py docstring), so the caller cannot observe
+    # the post-call parameter state directly. Verify instead that the call returns
+    # finite, non-silent audio — proof that the preset-dependent param was set
+    # without raising KeyError.
+    output = render_params(
+        plugin_path=PLUGIN_PATH,
+        params={"a_osc_1_sawtooth": 0.5},
         midi_note=60,
         velocity=100,
         note_start_and_end=(0.0, 0.5),
@@ -80,6 +81,5 @@ def test_render_params_sets_preset_dependent_param():
         preset_path=PRESET_PATH,
     )
 
-    assert plugin.parameters["a_osc_1_sawtooth"].raw_value == pytest.approx(  # type: ignore[attr-defined]
-        0.5, abs=0.01
-    )
+    assert np.isfinite(output).all()
+    assert np.abs(output).max() > 1e-4, "render produced silence"


### PR DESCRIPTION
## Summary

Reloads the VST3 plugin on every `render_params` call to fix the every-other-render junk audio bug ([#489](https://github.com/tinaudio/synth-setter/issues/489)). Per-render `VST3Plugin(plugin_path)` construction is what fixes the bug — proven empirically by reproducing #489 on a shared plugin instance and proving it does NOT reproduce on per-render-reload, with or without the editor warmup.

`load_plugin`'s editor warmup is restructured to use `threading.Timer` (cleaner than the previous Thread + sleep pattern) and remains gated to non-Darwin via the platform check landed in [#715](https://github.com/tinaudio/synth-setter/pull/715). On Darwin the warmup is skipped entirely to avoid the AppKit/CGS SIGTRAP ([#714](https://github.com/tinaudio/synth-setter/issues/714)) — proven safe by the preset-coverage audit also landed in #715.

Call sites in `generate_sample` / `make_dataset` / `scripts/predict_vst_audio.py` are updated to pass the plugin path through instead of pre-loading a `VST3Plugin` instance. The `xfail(strict=True)` decorator on `test_datasets_from_hardcoded_params_are_identical` is removed — the test now passes on its own.

## Out of scope (deferred)

Pulled from the bundled #702 set but **not** included here:
- The `surge_xt_interactive.py` script rewrite, its tests, and the user-facing docs.
- The `fixed_synth_params_list` / `fixed_note_params_list` deterministic-rendering kwargs.
- PEP 585 / PEP 604 annotation modernization.

## Verification (Linux, RTX 5060 Ti, headless wrapper)

- `make test` — 204 passed (non-slow, non-VST suite).
- VST suite (16/16 passed in 268s):
  - `test_datasets_from_hardcoded_params_are_identical` — **PASSES** (100s) — was xfail-strict on main, decorator removed in this PR.
  - `test_datasets_from_sampled_params_are_identical` — passes (57s).
  - `test_make_dataset` — passes (35s).
  - `test_show_editor_warmup_does_not_change_rendered_audio` (added in this PR, commit b134135) — passes (33s). Cross-path proof that show_editor isn't load-bearing for the per-render reload.
  - `test_preset_params.py` (3 tests) — pass.
  - `test_preset_coverage.py` (3 parametrized cases, landed via #715) — pass. Confirms the flush pattern is sufficient to commit Surge XT preset state without show_editor on Darwin.

## Performance

Per-render wall-clock (Linux, with editor warmup): ~8.6s/sample. The bug fix accepts this in exchange for correctness; #705 tracks the perf follow-up.

## Linked issues

Closes #489
Refs #705 · #714 · spotify/pedalboard#394