### PR TITLE
fix(vst): skip show_editor warmup on Darwin to avoid AppKit SIGTRAP

### DIFF
--- a/docs/design/eval-pipeline.md
+++ b/docs/design/eval-pipeline.md
@@ -1147,14 +1147,14 @@ and **eval artifacts** (audio files, prediction tensors — no W&B UI benefit).
 
 ## 11. Open Questions & Risks
 
-| #   | Question / Risk                                                                             | Impact                                              | Status                   |
-| --- | ------------------------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------ |
-| 1   | **VST plugin licensing on CI runners** — can we legally run Surge XT in GitHub Actions?     | E2E CI may need a stub or fixture-based approach    | Open                     |
-| 2   | **macOS pedalboard + Surge XT compatibility** — does the VST3 plugin load on Apple Silicon? | Blocks macOS render stage                           | Needs testing            |
-| 3   | **W&B artifact download speed** — best.ckpt may be 500MB+; W&B API is slower than rclone    | Mitigated by caching; accepted trade-off for W&B UI | Accepted                 |
-| 4   | **Metrics reproducibility across platforms** — float differences in spectral computations   | May cause CI flakiness with tight tolerances        | Use relative tolerances  |
-| 5   | **Xvfb availability in Docker base image** — may need to install in Dockerfile              | Low risk, well-documented                           | Resolved by Docker stage |
-| 6   | **rclone version skew** — different rclone versions on dev machines vs CI                   | Pin rclone version in Dockerfile and CI workflow    | Open                     |
+| #   | Question / Risk                                                                             | Impact                                              | Status                                                                                            |
+| --- | ------------------------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| 1   | **VST plugin licensing on CI runners** — can we legally run Surge XT in GitHub Actions?     | E2E CI may need a stub or fixture-based approach    | Open                                                                                              |
+| 2   | **macOS pedalboard + Surge XT compatibility** — does the VST3 plugin load on Apple Silicon? | Blocks macOS render stage                           | Partial — plugin loads; `show_editor` warmup skipped on Darwin (#714, see `src/data/vst/core.py`) |
+| 3   | **W&B artifact download speed** — best.ckpt may be 500MB+; W&B API is slower than rclone    | Mitigated by caching; accepted trade-off for W&B UI | Accepted                                                                                          |
+| 4   | **Metrics reproducibility across platforms** — float differences in spectral computations   | May cause CI flakiness with tight tolerances        | Use relative tolerances                                                                           |
+| 5   | **Xvfb availability in Docker base image** — may need to install in Dockerfile              | Low risk, well-documented                           | Resolved by Docker stage                                                                          |
+| 6   | **rclone version skew** — different rclone versions on dev machines vs CI                   | Pin rclone version in Dockerfile and CI workflow    | Open                                                                                              |
 
 ## 12. Out of Scope
 

--- a/src/data/vst/core.py
+++ b/src/data/vst/core.py
@@ -1,4 +1,5 @@
 import _thread
+import sys
 import threading
 import time
 from typing import Callable, Optional, Tuple
@@ -36,12 +37,20 @@ def _prepare_plugin(plugin: VST3Plugin) -> None:
 
 
 def load_plugin(plugin_path: str) -> VST3Plugin:
+    """Load a VST3 plugin (with a brief editor warmup on non-Darwin to populate its parameter
+    dict)."""
     logger.info(f"Loading plugin {plugin_path}")
     p = VST3Plugin(plugin_path)
     logger.info(f"Plugin {plugin_path} loaded")
-    logger.info("Preparing plugin for preset load...")
-    _prepare_plugin(p)
-    logger.info("Plugin ready")
+    # show_editor accumulates AppKit/CGS commit-handler state per call in
+    # unbundled python and triggers SIGTRAP after ~3-4 plugin reloads on
+    # Darwin (#714). The post-load process() flush in render_params is
+    # sufficient to commit Surge XT's preset state — see preset-coverage
+    # audit on #714 for the empirical justification.
+    if sys.platform != "darwin":
+        logger.info("Preparing plugin for preset load...")
+        _prepare_plugin(p)
+        logger.info("Plugin ready")
     return p
 
 

--- a/src/data/vst/core.py
+++ b/src/data/vst/core.py
@@ -37,8 +37,8 @@ def _prepare_plugin(plugin: VST3Plugin) -> None:
 
 
 def load_plugin(plugin_path: str) -> VST3Plugin:
-    """Load a VST3 plugin (with a brief editor warmup on non-Darwin to populate its parameter
-    dict)."""
+    """Load a VST3 plugin (with a brief editor warmup on non-Darwin — see comment below for
+    rationale)."""
     logger.info(f"Loading plugin {plugin_path}")
     p = VST3Plugin(plugin_path)
     logger.info(f"Plugin {plugin_path} loaded")

--- a/tests/data/vst/test_preset_coverage.py
+++ b/tests/data/vst/test_preset_coverage.py
@@ -14,6 +14,7 @@ Pattern compared:
 """
 
 import os
+import sys
 import threading
 import time
 from pathlib import Path
@@ -37,6 +38,10 @@ requires_vst = pytest.mark.requires_vst
 skip_no_vst = pytest.mark.skipif(
     not Path(_PLUGIN_PATH).exists(),
     reason=f"VST plugin not found at {_PLUGIN_PATH}",
+)
+skip_darwin = pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="show_editor SIGTRAPs on Darwin (#714) — the very crash this PR avoids",
 )
 
 
@@ -75,6 +80,7 @@ def _read_all_params(plugin: VST3Plugin) -> dict[str, float]:
 @pytest.mark.slow
 @requires_vst
 @skip_no_vst
+@skip_darwin
 def test_flush_pattern_matches_show_editor_pattern(preset_path: str) -> None:
     """Flush pattern in render_params is sufficient to commit Surge XT preset state."""
     p_no = VST3Plugin(_PLUGIN_PATH)

--- a/tests/data/vst/test_preset_coverage.py
+++ b/tests/data/vst/test_preset_coverage.py
@@ -72,6 +72,7 @@ def _read_all_params(plugin: VST3Plugin) -> dict[str, float]:
     "preset_path",
     sorted(p.as_posix() for p in _PRESET_DIR.glob("*.vstpreset")),
 )
+@pytest.mark.slow
 @requires_vst
 @skip_no_vst
 def test_flush_pattern_matches_show_editor_pattern(preset_path: str) -> None:

--- a/tests/data/vst/test_preset_coverage.py
+++ b/tests/data/vst/test_preset_coverage.py
@@ -1,0 +1,98 @@
+"""Preset-coverage audit: flush pattern vs. show_editor pattern produce the same params.
+
+Justifies skipping ``show_editor`` on Darwin (#714) where it accumulates AppKit
+commit-handler state and crashes the unbundled python process after a few
+plugin reloads. If this test ever finds a divergence — for any preset, any
+parameter, any pedalboard or Surge XT version — dropping ``show_editor`` would
+silently fall back to Surge defaults for the diverging parameter, which is
+exactly the failure mode this guard exists to prevent.
+
+Pattern compared:
+    A) ``VST3Plugin → load_preset → flush``  (the render_params path)
+    B) ``VST3Plugin → show_editor → load_preset → flush``  (the pedalboard #394
+       workaround order, kept on Linux)
+"""
+
+import os
+import threading
+import time
+from pathlib import Path
+
+import pytest
+from pedalboard import VST3Plugin
+
+_PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
+_PRESET_DIR = Path("presets")
+_SAMPLE_RATE = 44100.0
+_CHANNELS = 2
+_EDITOR_SLEEP_S = 0.5
+_FLUSH_DURATION_S = 32.0
+_FLUSH_BLOCK_SIZE = 2048
+
+# pedalboard.VST3Plugin.parameters is a dynamic C extension attribute that
+# pyright cannot resolve statically. All .parameters accesses below use
+# type: ignore[attr-defined] for this reason.
+
+requires_vst = pytest.mark.requires_vst
+skip_no_vst = pytest.mark.skipif(
+    not Path(_PLUGIN_PATH).exists(),
+    reason=f"VST plugin not found at {_PLUGIN_PATH}",
+)
+
+
+def _flush(plugin: VST3Plugin) -> None:
+    """Run a silent process()+reset() to commit pending preset state."""
+    plugin.process([], _FLUSH_DURATION_S, _SAMPLE_RATE, _CHANNELS, _FLUSH_BLOCK_SIZE, True)
+    plugin.reset()
+
+
+def _open_editor_briefly(plugin: VST3Plugin) -> None:
+    """Open and close the plugin editor (the spotify/pedalboard#394 workaround)."""
+    stop_event = threading.Event()
+
+    def _closer() -> None:
+        time.sleep(_EDITOR_SLEEP_S)
+        stop_event.set()
+
+    t = threading.Thread(target=_closer, daemon=True)
+    t.start()
+    plugin.show_editor(stop_event)
+    t.join(timeout=1.0)
+
+
+def _read_all_params(plugin: VST3Plugin) -> dict[str, float]:
+    """Snapshot every parameter's raw value into a name -> value mapping."""
+    return {
+        k: plugin.parameters[k].raw_value  # type: ignore[attr-defined]
+        for k in plugin.parameters.keys()  # type: ignore[attr-defined]
+    }
+
+
+@pytest.mark.parametrize(
+    "preset_path",
+    sorted(p.as_posix() for p in _PRESET_DIR.glob("*.vstpreset")),
+)
+@requires_vst
+@skip_no_vst
+def test_flush_pattern_matches_show_editor_pattern(preset_path: str) -> None:
+    """Flush pattern in render_params is sufficient to commit Surge XT preset state."""
+    p_no = VST3Plugin(_PLUGIN_PATH)
+    p_no.load_preset(preset_path)
+    _flush(p_no)
+    no_editor_state = _read_all_params(p_no)
+
+    p_we = VST3Plugin(_PLUGIN_PATH)
+    _open_editor_briefly(p_we)
+    p_we.load_preset(preset_path)
+    _flush(p_we)
+    with_editor_state = _read_all_params(p_we)
+
+    diffs = {
+        k: (with_editor_state.get(k), no_editor_state.get(k))
+        for k in set(with_editor_state) | set(no_editor_state)
+        if with_editor_state.get(k) != no_editor_state.get(k)
+    }
+    assert not diffs, (
+        f"flush pattern diverged from show_editor pattern for "
+        f"{len(diffs)} param(s): {dict(list(diffs.items())[:5])}..."
+    )


### PR DESCRIPTION
## Summary

`pedalboard.VST3Plugin.show_editor` accumulates AppKit/CGS commit-handler state per call in the unbundled python process on macOS. After ~3-4 calls the next invocation aborts with SIGTRAP, breaking any flow that reloads the plugin per render. This PR skips the editor warmup on Darwin only — Linux/Windows still keep `show_editor` as the established workaround for spotify/pedalboard#394.

The `process([], ...)` flush already in `render_params` is sufficient to commit Surge XT's preset state without `show_editor`. See the investigation comment on #714 for the full audit.

## Evidence

- **Cross-path equivalence** (on per-render-reload branch): 0 audio-sample differences with vs without `show_editor`.
- **Preset-coverage audit**: 3 presets, 770+ params each, 0 readback divergences between `(load_preset -> flush)` and `(show_editor -> load_preset -> flush)`.

A new `requires_vst` test (`tests/data/vst/test_preset_coverage.py`) parametrizes over every `.vstpreset` and asserts the two patterns produce identical readbacks. If a future preset / pedalboard release / Surge XT version diverges, the test fails loudly so the Darwin path doesn't silently fall back to Surge defaults.

## Verification

- [x] `make format` — all pre-commit hooks pass.
- [x] `make test` — 204 passed, 3 warnings, 21.11s.
- [x] `tests/data/vst/test_preset_coverage.py` (new) under headless wrapper — 3 passed in 33.24s (one per preset: `surge-base`, `surge-mini`, `surge-simple`); all show 0 readback divergences, confirming the audit hypothesis.
- [x] `tests/data/vst/test_preset_params.py` + `tests/data/vst/test_generate_vst_dataset.py` under headless wrapper — 11 passed, 1 xfailed (the round-trip xfail-strict test from #706 — expected, since this branch doesn't include per-render reload).

Linux behavior is unchanged: `show_editor` still runs because the warmup gates on `sys.platform != "darwin"`.

## Refs

Closes #714
Refs #713 #489 spotify/pedalboard#394