### PR TITLE
internal-feat(vst): add deterministic-render kwargs to make_dataset/generate_sample

### DIFF
--- a/src/data/vst/generate_vst_dataset.py
+++ b/src/data/vst/generate_vst_dataset.py
@@ -74,17 +74,23 @@ def generate_sample(
 
     When ``fixed_synth_params`` and/or ``fixed_note_params`` are supplied, they take
     precedence over the values drawn from ``param_spec.sample()`` for deterministic
-    rendering. Caveat: if ``fixed_synth_params`` produces audio below ``min_loudness``,
-    the loudness-retry loop will spin forever — the caller is responsible for providing
-    loudness-passing patches.
+    rendering. When BOTH are supplied, render inputs are fully fixed — the function
+    renders once and raises ``ValueError`` on loudness fail rather than retrying
+    against an unchanged input. When only one is supplied, the other is re-sampled
+    each retry and the loop remains meaningful.
     """
+    fully_fixed = fixed_synth_params is not None and fixed_note_params is not None
     while True:
-        logger.debug("sampling params")
-        sampled_synth, sampled_note = param_spec.sample()
-        synth_params = fixed_synth_params if fixed_synth_params is not None else sampled_synth
-        note_params = fixed_note_params if fixed_note_params is not None else sampled_note
-
-        logger.debug("sampling note")
+        if fixed_synth_params is None or fixed_note_params is None:
+            logger.debug("sampling params")
+            sampled_synth, sampled_note = param_spec.sample()
+            synth_params = (
+                fixed_synth_params if fixed_synth_params is not None else sampled_synth
+            )
+            note_params = fixed_note_params if fixed_note_params is not None else sampled_note
+        else:
+            synth_params = fixed_synth_params
+            note_params = fixed_note_params
 
         output = render_params(
             plugin_path,
@@ -102,6 +108,12 @@ def generate_sample(
         loudness = meter.integrated_loudness(output.T)
         logger.debug(f"loudness: {loudness}")
         if loudness < min_loudness:
+            if fully_fixed:
+                raise ValueError(
+                    f"fully-fixed render produced loudness {loudness:.2f} dB below "
+                    f"min_loudness {min_loudness:.2f} dB; retrying is futile because "
+                    f"render inputs are deterministic. Provide a louder patch."
+                )
             logger.debug("loudness too low, skipping")
             continue
 

--- a/src/data/vst/generate_vst_dataset.py
+++ b/src/data/vst/generate_vst_dataset.py
@@ -67,10 +67,22 @@ def generate_sample(
     min_loudness: float,
     param_spec: ParamSpec,
     preset_path: str,
+    fixed_synth_params: dict[str, float] | None = None,
+    fixed_note_params: dict[str, int | tuple[float, float]] | None = None,
 ) -> VSTDataSample:
+    """Render a single VST sample.
+
+    When ``fixed_synth_params`` and/or ``fixed_note_params`` are supplied, they take
+    precedence over the values drawn from ``param_spec.sample()`` for deterministic
+    rendering. Caveat: if ``fixed_synth_params`` produces audio below ``min_loudness``,
+    the loudness-retry loop will spin forever — the caller is responsible for providing
+    loudness-passing patches.
+    """
     while True:
         logger.debug("sampling params")
-        synth_params, note_params = param_spec.sample()
+        sampled_synth, sampled_note = param_spec.sample()
+        synth_params = fixed_synth_params if fixed_synth_params is not None else sampled_synth
+        note_params = fixed_note_params if fixed_note_params is not None else sampled_note
 
         logger.debug("sampling note")
 
@@ -222,6 +234,8 @@ def make_dataset(
     min_loudness: float,
     param_spec: ParamSpec,
     sample_batch_size: int,
+    fixed_synth_params_list: list[dict[str, float]] | None = None,
+    fixed_note_params_list: list[dict[str, int | tuple[float, float]]] | None = None,
 ) -> None:
 
     audio_dataset, mel_dataset, param_dataset, start_idx = (
@@ -235,6 +249,18 @@ def make_dataset(
         )
     )
 
+    expected_fixed_len = num_samples - start_idx
+    for name, lst in [
+        ("fixed_synth_params_list", fixed_synth_params_list),
+        ("fixed_note_params_list", fixed_note_params_list),
+    ]:
+        if lst is not None and len(lst) < expected_fixed_len:
+            raise ValueError(
+                f"{name} has length {len(lst)}, expected at least "
+                f"num_samples - start_idx = {expected_fixed_len} "
+                f"(num_samples={num_samples}, start_idx={start_idx})"
+            )
+
     audio_dataset.attrs["velocity"] = velocity
     audio_dataset.attrs["signal_duration_seconds"] = signal_duration_seconds
     audio_dataset.attrs["sample_rate"] = sample_rate
@@ -246,6 +272,7 @@ def make_dataset(
 
     for i in trange(start_idx, num_samples):
         logger.info(f"Making sample {i}")
+        fixed_idx = i - start_idx
         sample = generate_sample(
             plugin_path,
             velocity=velocity,
@@ -255,6 +282,16 @@ def make_dataset(
             min_loudness=min_loudness,
             param_spec=param_spec,
             preset_path=preset_path,
+            fixed_synth_params=(
+                fixed_synth_params_list[fixed_idx]
+                if fixed_synth_params_list is not None
+                else None
+            ),
+            fixed_note_params=(
+                fixed_note_params_list[fixed_idx]
+                if fixed_note_params_list is not None
+                else None
+            ),
         )
 
         sample_batch.append(sample)

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -1025,6 +1025,68 @@ def test_show_editor_warmup_does_not_change_rendered_audio() -> None:
             )
 
 
+def test_make_dataset_raises_when_fixed_params_list_is_too_short(
+    tmp_path: Path,
+) -> None:
+    """make_dataset rejects fixed_*_params_list shorter than num_samples - start_idx."""
+    spec = param_specs[_SPEC_NAME]
+    out = tmp_path / "should_not_write.h5"
+    with h5py.File(out, "a") as f:
+        with pytest.raises(ValueError, match="fixed_synth_params_list has length"):
+            make_dataset(
+                hdf5_file=f,
+                num_samples=3,
+                plugin_path=_PLUGIN_PATH,
+                preset_path=_PRESET_PATH,
+                sample_rate=_SAMPLE_RATE,
+                channels=_CHANNELS,
+                velocity=_VELOCITY,
+                signal_duration_seconds=_DURATION,
+                min_loudness=_MIN_LOUDNESS,
+                param_spec=spec,
+                sample_batch_size=3,
+                fixed_synth_params_list=[_HARDCODED_SYNTH_PARAMS],
+            )
+
+
+@pytest.mark.slow
+@pytest.mark.requires_vst
+@skip_no_vst
+def test_make_dataset_uses_fixed_params_lists_when_provided(
+    tmp_path: Path,
+) -> None:
+    """make_dataset writes the supplied fixed params verbatim, bypassing param_spec.sample()."""
+    spec = param_specs[_SPEC_NAME]
+    out = tmp_path / "fixed.h5"
+    num_samples = 3
+    with h5py.File(out, "a") as f:
+        make_dataset(
+            hdf5_file=f,
+            num_samples=num_samples,
+            plugin_path=_PLUGIN_PATH,
+            preset_path=_PRESET_PATH,
+            sample_rate=_SAMPLE_RATE,
+            channels=_CHANNELS,
+            velocity=_VELOCITY,
+            signal_duration_seconds=_DURATION,
+            min_loudness=_MIN_LOUDNESS,
+            param_spec=spec,
+            sample_batch_size=num_samples,
+            fixed_synth_params_list=[_HARDCODED_SYNTH_PARAMS] * num_samples,
+            fixed_note_params_list=[_HARDCODED_NOTE_PARAMS] * num_samples,
+        )
+
+    _, _, params = _assert_h5_structure_is_valid(out, spec, num_samples)
+    # ParamSpec.encode is annotated dict[str, float] on main but accepts the runtime
+    # note-param shape (pitch is int, note_start_and_end is a tuple); annotation gets
+    # corrected in a sibling PR.
+    expected = spec.encode(_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS)  # pyright: ignore[reportArgumentType]
+    for i in range(num_samples):
+        assert np.allclose(params[i], expected, atol=_ABSOLUTE_TOLERANCE), (
+            f"row {i} did not match fixed params"
+        )
+
+
 # Unit tests for ``_emit_audio_similarity_benchmark_metrics`` — pure JSON
 # serialization, no VST needed. Fast feedback while iterating on the
 # emission schema; complements the slow integration coverage above.


### PR DESCRIPTION
## Summary

Adds optional `fixed_synth_params` / `fixed_note_params` kwargs to `generate_sample` and `fixed_synth_params_list` / `fixed_note_params_list` kwargs to `make_dataset`, letting callers bypass `param_spec.sample()` and render a caller-supplied patch deterministically. Internal API only — no user-facing surface changes on this PR.

## Multi-act context (split of #702)

- Act 1 (#706): round-trip reproducibility tests + xfail-strict reproducer for #489
- Act 1.5 (#715): Darwin `show_editor` warmup workaround for #714
- Act 2 (#713): per-render plugin reload, fixes #489 (kwargs were explicitly deferred)
- **Act 3 (this PR): deterministic-render kwargs**
- Act 4 (future): wire up the `surge_xt_interactive.py` capture/replay flow that consumes these kwargs

## What changed

- `src/data/vst/generate_vst_dataset.py`:
  - `generate_sample` now accepts `fixed_synth_params: dict[str, float] | None` and `fixed_note_params: dict[str, int | tuple[float, float]] | None`. When supplied, they take precedence over `param_spec.sample()`. Docstring caveat added: caller-supplied patches must clear `min_loudness` or the loudness-retry loop will spin forever.
  - `make_dataset` now accepts `fixed_synth_params_list` / `fixed_note_params_list`, validates each list is at least `num_samples - start_idx` long, and indexes per-sample by `i - start_idx`.

- `tests/data/vst/test_generate_vst_dataset.py`:
  - `test_make_dataset_raises_when_fixed_params_list_is_too_short` — fast unit test, no VST needed; confirms the length validation fires before any rendering.
  - `test_make_dataset_uses_fixed_params_lists_when_provided` — slow + `requires_vst` test that drives `make_dataset` with hardcoded patches and asserts every written `param_array` row matches `spec.encode(_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS)`.

## Verification

- [x] `make format` — all pre-commit hooks pass.
- [x] Fast validation test alone — 1 passed in 0.89s.
- [x] `make test` — 205 passed, 3 warnings, 21.46s.
- [x] Slow VST kwargs-render test under headless wrapper — 1 passed in 15.68s.

## Unicode hygiene sweep

```
$ grep -rPn '[\x{FF00}-\x{FFEF}]' src/data/vst/ pipeline/ tests/data/vst/ configs/dataset/
(no matches)
```

The U+FF3F `plugin＿path` sighting noted in the #702 review is gone — landed via the per-render-reload rework in #713.

## Linked issues

Refs #702
Refs #719