### PR TITLE
feat(evaluation): apply model predictions to live Surge XT and record patches to dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,9 @@ Further reading (mostly for contributors and maintainers):
   storage provenance spec, SkyPilot integration, implementation plans
 - [`docs/reference/`](docs/reference/) — configuration reference, Docker,
   GitHub Actions, W&B integration
+- [`docs/guides/surge-xt-interactive.md`](docs/guides/surge-xt-interactive.md) —
+  human-in-the-loop tool for auditioning predicted Surge XT params and
+  capturing patches into a labeled dataset
 
 Run `make help` for available commands.
 

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -249,7 +249,7 @@ docs:
       - pattern: "scripts/surge_xt_interactive.py"
         covers: "CLI flags, interactive session lifecycle (audio + editor + keyboard threads, stop_event), p/q keybindings, recorded-patch HDF5 output, append-vs-fresh dataset semantics, PLAYBACK_SAMPLE_RATE / SAMPLE_RATE / BUFFER_SIZE / MAKE_DATASET_* constants"
       - pattern: "src/data/vst/core.py"
-        covers: "load_plugin warm-up timing (_PREPARE_PLUGIN_SLEEP_SECONDS), set_params, render_params per-sample reload rationale (silent-render workaround)"
+        covers: "load_plugin warm-up timing (_EDITOR_INIT_DELAY_SECONDS, non-Darwin only — macOS skips per #714), set_params, render_params per-sample reload rationale (silent-render workaround)"
         scope: "interactive"
       - pattern: "src/data/vst/generate_vst_dataset.py"
         covers: "fixed_synth_params_list / fixed_note_params_list optional path used to render captured patches; mel_spec shape (2,128,401), audio dtype float16"

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -242,6 +242,19 @@ docs:
         covers: "Packer template, packer variables (synth_setter_git_ref/torch_backend/python_version/vm_name), provisioner steps, brew packages, venv layout, VST3 path, smoke tests, .zshrc auto-activation, prebuilt image at registry-1.docker.io/tinaudio/synth-setter-macos, Docker Hub publishing workflow"
         scope: "tart"
 
+  # ── Surge XT interactive guide ──────────────────────────────────
+  - doc: docs/guides/surge-xt-interactive.md
+    description: Interactive Surge XT prediction audition and patch-recording guide
+    sources:
+      - pattern: "scripts/surge_xt_interactive.py"
+        covers: "CLI flags, interactive session lifecycle (audio + editor + keyboard threads, stop_event), p/q keybindings, recorded-patch HDF5 output, append-vs-fresh dataset semantics, PLAYBACK_SAMPLE_RATE / SAMPLE_RATE / BUFFER_SIZE / MAKE_DATASET_* constants"
+      - pattern: "src/data/vst/core.py"
+        covers: "load_plugin warm-up timing (_PREPARE_PLUGIN_SLEEP_SECONDS), set_params, render_params per-sample reload rationale (silent-render workaround)"
+        scope: "interactive"
+      - pattern: "src/data/vst/generate_vst_dataset.py"
+        covers: "fixed_synth_params_list / fixed_note_params_list optional path used to render captured patches; mel_spec shape (2,128,401), audio dtype float16"
+        scope: "interactive"
+
   # ── rclone reference (placeholder — doc does not exist yet) ─────
   # - doc: docs/reference/rclone.md
   #   description: rclone R2 operations reference

--- a/docs/guides/surge-xt-interactive.md
+++ b/docs/guides/surge-xt-interactive.md
@@ -221,13 +221,16 @@ python -c "import h5py; f = h5py.File('outputs/curated-patches.h5'); \
 These are accepted trade-offs, not bugs we plan to fix soon. Surface to
 your teammates so they aren't blindsided.
 
-- **0.5 s editor warm-up** — `_prepare_plugin` in `src/data/vst/core.py`
-  shows the editor for a fixed
-  [`_PREPARE_PLUGIN_SLEEP_SECONDS = 0.5`](../../src/data/vst/core.py)
-  to let the plugin populate its full parameter dict before we apply
-  params. On slow machines, parameter discovery may still be
-  incomplete; the visible symptom is a `KeyError` from
-  `set_params`. Workaround: bump the constant.
+- **0.5 s editor warm-up (non-Darwin only)** — `load_plugin` in
+  `src/data/vst/core.py` briefly opens the editor (gated by
+  [`_EDITOR_INIT_DELAY_SECONDS`](../../src/data/vst/core.py)) so the
+  plugin populates its full parameter dict before we apply params. On
+  slow machines parameter discovery may still be incomplete; the
+  visible symptom is a `KeyError` from `set_params`, and the workaround
+  is to bump the constant. On macOS the warmup is skipped entirely (see
+  the `#714` SIGTRAP comment in `core.py`); the post-load `process(...)`
+  flush in `render_params` is what commits Surge XT's preset state on
+  that platform.
 - **Plugin reloaded on every render in `make_dataset`** — `render_params`
   calls `load_plugin(plugin_path)` per sample
   ([`src/data/vst/core.py`](../../src/data/vst/core.py)). This is an
@@ -241,10 +244,13 @@ your teammates so they aren't blindsided.
   resamples params and re-renders until output integrated loudness
   exceeds `MAKE_DATASET_MIN_LOUDNESS = -50.0`
   ([`scripts/surge_xt_interactive.py`](../../scripts/surge_xt_interactive.py)).
-  When `fixed_synth_params` is set, the params don't change between
-  retries — so if the captured patch is near-silent, dataset
-  generation hangs on that row. Workaround: only press `p` while you
-  can hear the patch.
+  When `fixed_synth_params` is set (this script's path), the synth
+  params are held constant — only the note params are re-sampled per
+  retry — so a near-silent captured patch loops forever because the
+  note rarely fixes loudness. (When *both* synth and note params are
+  fully fixed, `generate_sample` raises `ValueError` instead of
+  retrying, but this script never reaches that branch.) Workaround:
+  only press `p` while you can hear the patch.
 - **Blocking keyboard input** — `keyboard_loop` uses
   `click.getchar()`, which only checks `stop_event` between
   keystrokes. After the editor closes, you may need to press one key

--- a/docs/guides/surge-xt-interactive.md
+++ b/docs/guides/surge-xt-interactive.md
@@ -72,7 +72,8 @@ python scripts/surge_xt_interactive.py \
 ```
 
 Render a deterministic test clip of the loaded patch to a WAV — useful
-for headless runs and reproducible audio diffs of model predictions:
+when no audio output device is available, and for reproducible audio
+diffs of model predictions:
 
 ```bash
 python scripts/surge_xt_interactive.py \
@@ -83,11 +84,13 @@ python scripts/surge_xt_interactive.py \
 When `--session-recording-path` is set, the live audio stream is
 *replaced* by a fixed 10-second offline render: middle C held from
 2 s to 4 s, with the surrounding silence capturing any release tail.
-Output depends only on plugin state (preset + `--pred` /
-`--dataset-ref` params), so the same inputs always produce the same
-WAV. The editor still runs and you can still snapshot patches.
-Combines freely with `--pred`, `--dataset-ref`, and
-`--output-dataset-path`.
+The render runs synchronously *before* the editor opens, so the WAV
+depends only on the initially-loaded plugin state (preset + `--pred`
+/ `--dataset-ref` params) and the same inputs always produce the
+same WAV. After the render completes, the editor still opens and you
+can still snapshot patches. No audio output device is required, but
+the editor still needs a display. Combines freely with `--pred`,
+`--dataset-ref`, and `--output-dataset-path`.
 
 `--pred` and `--dataset-ref` are mutually exclusive — passing both
 raises `click.UsageError`.
@@ -135,8 +138,10 @@ in parallel:
    - `q` — set `stop_event` and exit.
 
 Closing the editor window also sets `stop_event`, ending the audio
-thread and signalling the keyboard thread to exit. Snapshots are
-buffered in memory; nothing is written until the editor closes.
+thread. The keyboard thread checks that event only between
+`click.getchar()` calls, so it may not exit until another key is
+pressed. Snapshots are buffered in memory; nothing is written until
+the editor closes.
 
 ## Output dataset format
 

--- a/docs/guides/surge-xt-interactive.md
+++ b/docs/guides/surge-xt-interactive.md
@@ -1,0 +1,304 @@
+# Guide: Interactive Surge XT prediction & patch capture
+
+> **Status**: Stable
+> **Last Updated**: 2026-04-29
+> **Source**: [`scripts/surge_xt_interactive.py`](../../scripts/surge_xt_interactive.py)
+
+> Last refresh: `--session-recording-path` now renders a deterministic
+> 10-second middle-C clip (was: a tee of the live stream's first 20 s).
+
+______________________________________________________________________
+
+## What it is
+
+`scripts/surge_xt_interactive.py` opens the Surge XT VST3 editor with
+ML-predicted (or dataset-derived) parameters preloaded, streams real-time
+audio so you can audition and tweak the patch by ear, lets you snapshot
+patches by pressing `p`, and after the session renders those snapshots
+into a labeled HDF5 training dataset.
+
+It's a human-in-the-loop tool for producing high-quality (audio, params)
+training pairs that random sampling can't reach.
+
+## When to use it
+
+- Auditioning a model's predicted parameters as audio — does row 42 of
+  `pred-0.pt` actually sound like the target?
+- Capturing curated patches by ear, then rendering them with the same
+  pipeline the training data uses.
+- Producing labeled training pairs from human sound design — patches
+  that random sampling won't find but that the model needs to learn.
+
+## Prerequisites
+
+- Project Python env. `make install` plus `make install-surge-xt` covers
+  everything; see [getting-started](../getting-started.md) for the full
+  walkthrough.
+- Surge XT VST3 at a known path (default `plugins/Surge XT.vst3` —
+  satisfied by `make install-surge-xt`).
+- A base preset file (default `presets/surge-base.vstpreset`).
+- A working audio output device. The tool opens a real-time audio
+  stream via `pedalboard.io.AudioStream`; headless environments without
+  ALSA/PulseAudio cannot run it.
+- *Optional*: a prediction tensor (`pred-*.pt` from `src/eval.py`) or
+  an existing dataset (`*.h5`) to load parameters from.
+
+## Quick start
+
+Bare audition — open the editor on the base preset, no preloaded params:
+
+```bash
+python scripts/surge_xt_interactive.py
+```
+
+Audition a single prediction row (row index 0 inside `outputs/pred-0.pt`):
+
+```bash
+python scripts/surge_xt_interactive.py --pred outputs/pred-0.pt:0
+```
+
+Audition a row from an existing HDF5 dataset:
+
+```bash
+python scripts/surge_xt_interactive.py --dataset-ref outputs/test.h5:0
+```
+
+Record patches and render them into a fresh dataset:
+
+```bash
+python scripts/surge_xt_interactive.py \
+    --pred outputs/pred-0.pt:0 \
+    --output-dataset-path outputs/curated-patches.h5
+```
+
+Render a deterministic test clip of the loaded patch to a WAV — useful
+for headless runs and reproducible audio diffs of model predictions:
+
+```bash
+python scripts/surge_xt_interactive.py \
+    --pred outputs/pred-0.pt:0 \
+    --session-recording-path outputs/session.wav
+```
+
+When `--session-recording-path` is set, the live audio stream is
+*replaced* by a fixed 10-second offline render: middle C held from
+2 s to 4 s, with the surrounding silence capturing any release tail.
+Output depends only on plugin state (preset + `--pred` /
+`--dataset-ref` params), so the same inputs always produce the same
+WAV. The editor still runs and you can still snapshot patches.
+Combines freely with `--pred`, `--dataset-ref`, and
+`--output-dataset-path`.
+
+`--pred` and `--dataset-ref` are mutually exclusive — passing both
+raises `click.UsageError`.
+
+## CLI reference
+
+| Flag                       | Type               | Default                        | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| -------------------------- | ------------------ | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--plugin-path` / `-p`     | path               | `plugins/Surge XT.vst3`        | Path to VST3 plugin.                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| `--preset-path` / `-r`     | path               | `presets/surge-base.vstpreset` | Base preset to load before applying any `--pred` / `--dataset-ref` params.                                                                                                                                                                                                                                                                                                                                                                  |
+| `--pred`                   | `PATH:BATCH_IDX`   | unset                          | Prediction reference. When set, the predicted row is decoded and applied to the plugin before the editor opens. Example: `outputs/pred-0.pt:0`.                                                                                                                                                                                                                                                                                             |
+| `--dataset-ref`            | `PATH:DATASET_IDX` | unset                          | Dataset reference. When set, the dataset row is decoded and applied to the plugin before the editor opens. Example: `outputs/test.h5:0`.                                                                                                                                                                                                                                                                                                    |
+| `--param-spec-name`        | str                | `surge_xt`                     | Parameter spec name (key into `param_specs`) used to decode prediction/dataset rows applied to the plugin and to enumerate which synth params are captured when recording patches.                                                                                                                                                                                                                                                          |
+| `--output-dataset-path`    | path               | unset                          | HDF5 file to write recorded patches to. After the editor is closed, patches captured via the keyboard loop (press `p` to record, `q` to quit) are rendered through the plugin and written to this dataset via `src.data.vst.generate_vst_dataset.make_dataset`. Must not already exist — `make_dataset` writes fixed-size HDF5 datasets and cannot append.                                                                                  |
+| `--session-recording-path` | path               | unset                          | Optional WAV file to render a deterministic test clip to. When set, the script renders a fixed `SESSION_RECORDING_DURATION_SECONDS` (10 s) WAV containing middle C from `NOTE_START` (2 s) to `NOTE_END` (4 s) through the loaded plugin and exits the audio thread. No live device output. Output depends only on plugin state (preset + `--pred` / `--dataset-ref` params) — same inputs always produce the same WAV. No-op when not set. |
+
+Tip — the help strings above are quoted verbatim from the Click
+decorators in `scripts/surge_xt_interactive.py`. Run
+`python scripts/surge_xt_interactive.py --help` to confirm the current
+text.
+
+## The interactive session
+
+Once the plugin loads, the editor window opens and three things happen
+in parallel:
+
+1. **Audio thread** — silence is routed through Surge XT; the synth's
+   own oscillators produce sound. Two modes:
+   - Default (`play_audio`): writes plugin output to the default audio
+     output device via `pedalboard.io.AudioStream`, resampling on the fly
+     if `PLAYBACK_SAMPLE_RATE` differs from `SAMPLE_RATE`. You hear
+     whatever the current patch is doing.
+   - With `--session-recording-path` (`play_audio_recorded`): renders a
+     deterministic `SESSION_RECORDING_DURATION_SECONDS` (10 s) clip
+     (middle C from 2 s to 4 s) via a single `plugin.process(...)` call
+     and writes it to the given WAV file. No live device output. Returns
+     as soon as the offline render completes — the editor remains open
+     for patch capture.
+2. **Editor (main thread)** — the plugin's native GUI. Tweak knobs as
+   you would in any host.
+3. **Keyboard thread** — `keyboard_loop` reads keystrokes:
+   - `p` — record the current values of every parameter named in
+     `param_specs[--param-spec-name].synth_param_names` into an
+     in-memory list.
+   - `q` — set `stop_event` and exit.
+
+Closing the editor window also sets `stop_event`, ending the audio
+thread and signalling the keyboard thread to exit. Snapshots are
+buffered in memory; nothing is written until the editor closes.
+
+## Output dataset format
+
+When `--output-dataset-path` is set, the recorded patches are rendered
+through the plugin via
+[`make_dataset`](../../src/data/vst/generate_vst_dataset.py) and
+written to an HDF5 file with these datasets:
+
+| Dataset       | Shape                                           | Dtype     | Notes                                                                          |
+| ------------- | ----------------------------------------------- | --------- | ------------------------------------------------------------------------------ |
+| `audio`       | `(N, 2, sample_rate * signal_duration_seconds)` | `float16` | Stereo waveform. Compressed with Blosc2.                                       |
+| `mel_spec`    | `(N, 2, 128, 401)`                              | `float32` | Mel spectrogram per channel. Compressed with Blosc2.                           |
+| `param_array` | `(N, P)`                                        | `float32` | Encoded params (`ParamSpec.encode` output) in `[0, 1]`. `P = len(param_spec)`. |
+
+Where `N = len(synth_patches)`, `sample_rate = 44100`, and
+`signal_duration_seconds = 4.0` (constants at the top of
+`scripts/surge_xt_interactive.py`).
+
+The audio attached attrs on the `audio` dataset record the rendering
+config: `velocity`, `signal_duration_seconds`, `sample_rate`,
+`channels`, `min_loudness`.
+
+> **Use a fresh `--output-dataset-path` per session.** The current
+> implementation does not support appending to a finalized HDF5 file:
+> `make_dataset` creates fixed-size datasets (no `maxshape`), so
+> re-running with an existing file will either fail with a
+> `ValueError` from the fixed-params length check or fail on write
+> with an out-of-bounds index. If you need to combine multiple
+> sessions, write each one to its own file and concat downstream.
+
+> **Note params are still randomized.** Only `fixed_synth_params_list`
+> is passed to `make_dataset`; MIDI note, velocity, and timing remain
+> sampled from `param_spec`. The same captured patch produces multiple
+> rows with different note conditions if you record `p` more than once
+> (the synth params are identical; the note params will differ).
+
+## End-to-end workflow
+
+```
+                             ┌─────────────────────────┐
+  src/eval.py  ──pred-*.pt──▶│                         │
+                             │  surge_xt_interactive   │ ──┐
+  *.h5 dataset ──row N─────▶ │  (audition + capture)   │   │
+                             └─────────────────────────┘   │
+                                       │                   │
+                              ▼ user presses 'p'           │
+                            synth_patches: list[dict]      │
+                                       │                   │
+                                       ▼                   │
+                            make_dataset(                  │
+                                fixed_synth_params_list=…) │
+                                       │                   │
+                                       ▼                   │
+                            outputs/curated-patches.h5 ◀───┘
+                            (audio, mel_spec, param_array)
+                                       │
+                                       ▼
+                              downstream training
+```
+
+Worked example:
+
+```bash
+# 1. Generate predictions for some target audio (outside this guide).
+python -m src.eval +experiment=surge/eval ckpt_path=...
+
+# 2. Audition row 0 of the resulting predictions.
+python scripts/surge_xt_interactive.py --pred outputs/pred-0.pt:0
+
+# 3. When you find sounds you like, record them and produce a dataset.
+python scripts/surge_xt_interactive.py \
+    --pred outputs/pred-0.pt:0 \
+    --output-dataset-path outputs/curated-patches.h5
+
+# 4. Confirm the file:
+python -c "import h5py; f = h5py.File('outputs/curated-patches.h5'); \
+    print({k: f[k].shape for k in f})"
+```
+
+## Known limitations
+
+These are accepted trade-offs, not bugs we plan to fix soon. Surface to
+your teammates so they aren't blindsided.
+
+- **0.5 s editor warm-up** — `_prepare_plugin` in `src/data/vst/core.py`
+  shows the editor for a fixed
+  [`_PREPARE_PLUGIN_SLEEP_SECONDS = 0.5`](../../src/data/vst/core.py)
+  to let the plugin populate its full parameter dict before we apply
+  params. On slow machines, parameter discovery may still be
+  incomplete; the visible symptom is a `KeyError` from
+  `set_params`. Workaround: bump the constant.
+- **Plugin reloaded on every render in `make_dataset`** — `render_params`
+  calls `load_plugin(plugin_path)` per sample
+  ([`src/data/vst/core.py`](../../src/data/vst/core.py)). This is an
+  intentional workaround for a silent / repeated-render bug surfaced
+  during this branch's development; without per-call reloads, the
+  plugin retained stale state. The cost is ~7 s of plugin-load
+  overhead per sample, so capturing 100 patches at 4 s each takes
+  more than ten minutes. Acceptable for human-scale capture; do not
+  use this path for large pipeline runs.
+- **Loudness-retry loop has no iteration cap** — `generate_sample`
+  resamples params and re-renders until output integrated loudness
+  exceeds `MAKE_DATASET_MIN_LOUDNESS = -50.0`
+  ([`scripts/surge_xt_interactive.py`](../../scripts/surge_xt_interactive.py)).
+  When `fixed_synth_params` is set, the params don't change between
+  retries — so if the captured patch is near-silent, dataset
+  generation hangs on that row. Workaround: only press `p` while you
+  can hear the patch.
+- **Blocking keyboard input** — `keyboard_loop` uses
+  `click.getchar()`, which only checks `stop_event` between
+  keystrokes. After the editor closes, you may need to press one key
+  to let the script proceed to dataset rendering. Documented inline
+  in [`scripts/surge_xt_interactive.py`](../../scripts/surge_xt_interactive.py).
+- **No explicit lock on plugin parameters** — the audio thread reads
+  the plugin's parameter state to render the next buffer at the same
+  time the GUI thread may be writing it. `pedalboard` may handle this
+  internally, but the contract isn't documented upstream. In practice
+  this hasn't caused audible glitching, but a long session under load
+  could.
+- **No append support for `--output-dataset-path`** — see the warning
+  in *Output dataset format* above.
+
+## Troubleshooting
+
+**`AudioStream` fails to open / no audio device.** You're running
+headless or your default device is not configured. Use
+`--session-recording-path outputs/session.wav` —
+`play_audio_recorded` renders a deterministic 10-second middle-C clip
+of the loaded patch directly to a WAV via `pedalboard.io.AudioFile`,
+without ever opening an audio device. Enough to confirm the plugin
+loaded and the params applied without any live audio.
+
+**Sample-rate mismatch.** `play_audio` resamples on the fly via
+`StreamResampler` when `PLAYBACK_SAMPLE_RATE != SAMPLE_RATE`. If your
+device only supports 48 kHz, edit `PLAYBACK_SAMPLE_RATE = 48000` at
+the top of the script.
+
+**`KeyError` from `record_patch`.** A param name in the spec isn't in
+`plugin.parameters`. Likely causes: wrong `--param-spec-name` for the
+loaded plugin, or the preset put the plugin into a state where some
+params are hidden. Try `--param-spec-name surge_xt` against the
+default Surge XT preset to rule out config issues.
+
+**Prediction tensor shape mismatch.** `--pred` requires the second
+dim of the loaded tensor to match `param_specs[--param-spec-name]` row
+length. Print `pred_tensor.shape` and compare to
+`len(param_specs[name])`.
+
+**Dataset generation hangs after recording.** Likely the loudness
+retry loop on a near-silent patch; see *Known limitations*.
+
+**`ValueError: fixed_synth_params_list has length …`.** You re-ran
+with an existing `--output-dataset-path`. Use a fresh path; see the
+warning in *Output dataset format*.
+
+## Related
+
+- [`docs/design/eval-pipeline.md`](../design/eval-pipeline.md) —
+  where `pred-*.pt` files come from.
+- [`docs/glossary.md`](../glossary.md) — `param_spec`, VST, mel
+  spectrogram.
+- [`docs/design/data-pipeline.md`](../design/data-pipeline.md) —
+  downstream consumer of the produced HDF5.
+- [`docs/getting-started.md`](../getting-started.md) — env setup and
+  Surge XT install.

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -102,6 +102,8 @@ class PredictionRefType(click.ParamType):
             batch_idx = int(idx_str)
         except ValueError:
             self.fail(f"batch index must be an integer, got {idx_str!r}", param, ctx)
+        if batch_idx < 0:
+            self.fail(f"batch index must be non-negative, got {batch_idx}", param, ctx)
         return PredictionRef(path=Path(path_str), batch_idx=batch_idx)
 
 
@@ -127,6 +129,8 @@ class DatasetRefType(click.ParamType):
             batch_idx = int(idx_str)
         except ValueError:
             self.fail(f"batch index must be an integer, got {idx_str!r}", param, ctx)
+        if batch_idx < 0:
+            self.fail(f"dataset index must be non-negative, got {batch_idx}", param, ctx)
         return DatasetRef(path=Path(path_str), batch_idx=batch_idx)
 
 
@@ -257,10 +261,11 @@ def play_audio(plugin: VST3Plugin, stop_event: threading.Event) -> None:
     ) as stream:
         while not stop_event.is_set():
             synth_output = plugin(silence, SAMPLE_RATE, reset=False)
-            assert synth_output.shape == (CHANNELS, BUFFER_SIZE), (
-                f"expected synth output shape ({CHANNELS}, {BUFFER_SIZE}), "
-                f"got {synth_output.shape}"
-            )
+            if synth_output.shape != (CHANNELS, BUFFER_SIZE):
+                raise ValueError(
+                    f"expected synth output shape ({CHANNELS}, {BUFFER_SIZE}), "
+                    f"got {synth_output.shape}"
+                )
             if stream_resampler is not None:
                 stream.write(stream_resampler.process(synth_output), PLAYBACK_SAMPLE_RATE)
             else:
@@ -304,9 +309,10 @@ def play_audio_recorded(plugin: VST3Plugin, session_recording_path: Path) -> Non
         True,
     )
     expected_frames = int(SESSION_RECORDING_DURATION_SECONDS * SAMPLE_RATE)
-    assert output.shape == (CHANNELS, expected_frames), (
-        f"expected output shape ({CHANNELS}, {expected_frames}), got {output.shape}"
-    )
+    if output.shape != (CHANNELS, expected_frames):
+        raise ValueError(
+            f"expected output shape ({CHANNELS}, {expected_frames}), got {output.shape}"
+        )
     # AudioFile.write expects (frames, channels); plugin output is (channels, frames).
     with AudioFile(str(session_recording_path), "w", SAMPLE_RATE, CHANNELS) as f:
         f.write(output.T)
@@ -486,7 +492,9 @@ def main(
         set_params(plugin, synth_params)
 
     stop_event = threading.Event()
-    with ThreadPoolExecutor() as pool:
+    pool = ThreadPoolExecutor()
+    audio_timed_out = False
+    try:
         if session_recording_path is not None:
             audio_future = pool.submit(play_audio_recorded, plugin, session_recording_path)
         else:
@@ -499,17 +507,23 @@ def main(
             stop_event.set()
             # Surface any exception from the audio thread. Catch TimeoutError so
             # a slow stream-close on shutdown doesn't crash the script — log it
-            # and continue draining; cancel-style errors will resurface elsewhere.
+            # and skip the wait-for-completion in pool teardown to avoid hanging.
             try:
                 audio_future.result(timeout=AUDIO_THREAD_DRAIN_TIMEOUT_SECONDS)
             except TimeoutError:
+                audio_timed_out = True
                 logger.warning(
-                    "audio thread did not exit within %ss; continuing shutdown",
+                    "audio thread did not exit within %ss; cancelling pool and continuing shutdown",
                     AUDIO_THREAD_DRAIN_TIMEOUT_SECONDS,
                 )
         logger.info("Editor closed, waiting for keyboard thread to finish...")
         synth_patches = keyboard_future.result()
         logger.info("Recorded %d patches: %s", len(synth_patches), synth_patches)
+    finally:
+        # When the audio thread timed out, don't let pool teardown block waiting
+        # on it again — cancel pending work and return immediately. Otherwise
+        # wait for any remaining work to drain normally.
+        pool.shutdown(wait=not audio_timed_out, cancel_futures=audio_timed_out)
 
     if output_dataset_path is None:
         logger.info("No output dataset path provided, skipping dataset creation.")

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -491,14 +491,20 @@ def main(
         synth_params = load_prediction_synth_params(pred, param_spec_name)
         set_params(plugin, synth_params)
 
+    # Render the deterministic clip before opening the editor so the WAV depends
+    # only on the initially-loaded plugin state. Running it concurrently with
+    # show_editor would let the user twist knobs mid-render and break that
+    # guarantee.
+    if session_recording_path is not None:
+        play_audio_recorded(plugin, session_recording_path)
+
     stop_event = threading.Event()
     pool = ThreadPoolExecutor()
     audio_timed_out = False
     try:
-        if session_recording_path is not None:
-            audio_future = pool.submit(play_audio_recorded, plugin, session_recording_path)
-        else:
-            audio_future = pool.submit(play_audio, plugin, stop_event)
+        audio_future = (
+            pool.submit(play_audio, plugin, stop_event) if session_recording_path is None else None
+        )
         keyboard_future = pool.submit(keyboard_loop, plugin, stop_event, param_spec_name)
 
         try:
@@ -508,15 +514,20 @@ def main(
             # Surface any exception from the audio thread. Catch TimeoutError so
             # a slow stream-close on shutdown doesn't crash the script — log it
             # and skip the wait-for-completion in pool teardown to avoid hanging.
-            try:
-                audio_future.result(timeout=AUDIO_THREAD_DRAIN_TIMEOUT_SECONDS)
-            except TimeoutError:
-                audio_timed_out = True
-                logger.warning(
-                    "audio thread did not exit within %ss; cancelling pool and continuing shutdown",
-                    AUDIO_THREAD_DRAIN_TIMEOUT_SECONDS,
-                )
-        logger.info("Editor closed, waiting for keyboard thread to finish...")
+            if audio_future is not None:
+                try:
+                    audio_future.result(timeout=AUDIO_THREAD_DRAIN_TIMEOUT_SECONDS)
+                except TimeoutError:
+                    audio_timed_out = True
+                    logger.warning(
+                        "audio thread did not exit within %ss; "
+                        "cancelling pool and continuing shutdown",
+                        AUDIO_THREAD_DRAIN_TIMEOUT_SECONDS,
+                    )
+        logger.info(
+            "Editor closed; press any key in this terminal to finish "
+            "(captured patches will then be rendered)..."
+        )
         synth_patches = keyboard_future.result()
         logger.info("Recorded %d patches: %s", len(synth_patches), synth_patches)
     finally:

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -1,40 +1,537 @@
 """Interactive Surge XT preview with real-time audio streaming via pedalboard."""
 
+import logging
 import threading
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
 
-import click
-import numpy as np
-from pedalboard import VST3Plugin
-from pedalboard.io import AudioStream
+import rootutils
+
+rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
+
+import click  # noqa: E402
+import h5py  # noqa: E402
+import hdf5plugin  # noqa: F401, E402  side-effect: registers HDF5_PLUGIN_PATH for Blosc2 filters
+import numpy as np  # noqa: E402
+import torch  # noqa: E402
+from pedalboard import VST3Plugin  # noqa: E402
+from pedalboard.io import AudioFile, AudioStream, StreamResampler  # noqa: E402
+
+from src.data.vst import load_plugin, load_preset, param_specs  # noqa: E402
+from src.data.vst.core import make_midi_events, set_params  # noqa: E402
+from src.data.vst.generate_vst_dataset import make_dataset  # noqa: E402
+
+logger = logging.getLogger(__name__)
 
 CHANNELS = 2
 SAMPLE_RATE = 44100
 BUFFER_SIZE = 512
+MAKE_DATASET_VELOCITY = 100
+MAKE_DATASET_SIGNAL_DURATION_SECONDS = 4.0
+MAKE_DATASET_MIN_LOUDNESS = -50.0
+MAKE_DATASET_SAMPLE_BATCH_SIZE = 32
+
+# Real-time playback rate. Set this to whatever the default output device supports
+# if it differs from ``SAMPLE_RATE`` — ``play_audio`` will resample on the fly.
+# Resampling adds overhead, so it's optional and disabled by default.
+PLAYBACK_SAMPLE_RATE = SAMPLE_RATE
+
+# Maximum time to wait for the audio thread to drain after ``stop_event`` is set.
+AUDIO_THREAD_DRAIN_TIMEOUT_SECONDS = 2
+
+# Deterministic recording clip when ``--session-recording-path`` is set.
+# The point is reproducibility: same plugin + preset + params -> same WAV.
+# A held middle-C note is rendered from ``NOTE_START`` to ``NOTE_END``,
+# inside a fixed-length window so any release tail is captured.
+SESSION_RECORDING_DURATION_SECONDS = 10.0
+SESSION_RECORDING_MIDI_NOTE = 60  # middle C (C4)
+SESSION_RECORDING_VELOCITY = 100
+SESSION_RECORDING_NOTE_START_SECONDS = 2.0
+SESSION_RECORDING_NOTE_END_SECONDS = 4.0
+# Buffer size used for the offline ``plugin.process(...)`` render. Mirrors
+# the value used in ``src.data.vst.core.render_params``.
+_SESSION_RECORDING_BUFFER_SIZE = 2048
+
+# Plugin-flush parameters used by the post-load / pre-render flush pattern; see
+# ``_flush_plugin``. Mirror of the values used in ``src.data.vst.core.render_params``.
+_PLUGIN_FLUSH_DURATION_SECONDS = 32.0
+_PLUGIN_FLUSH_BUFFER_SIZE = 2048
+
+# Return signals for ``keyboard_loop`` actions — distinguishes "user requested
+# quit" from "action completed, keep listening".
+_KEEP_LOOPING = True
+_STOP_LOOPING = False
 
 
-def play_audio(plugin: VST3Plugin) -> None:
-    """Stream silence through Surge XT and write synthesized audio to the output device."""
+@dataclass(frozen=True)
+class PredictionRef:
+    """Identifier for a single predicted parameter row on disk."""
+
+    path: Path
+    batch_idx: int
+
+
+@dataclass(frozen=True)
+class DatasetRef:
+    """Identifier for a single dataset row on disk."""
+
+    path: Path
+    batch_idx: int
+
+
+class PredictionRefType(click.ParamType):
+    """Click parser for ``PATH:BATCH_IDX`` prediction references."""
+
+    name = "pred_ref"
+
+    def convert(
+        self,
+        value: str | PredictionRef,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> PredictionRef:
+        """Parse a ``PATH:BATCH_IDX`` string (or pass-through ``PredictionRef``) into a
+        ``PredictionRef``."""
+        if isinstance(value, PredictionRef):
+            return value
+        path_str, sep, idx_str = value.rpartition(":")
+        if not sep or not path_str or not idx_str:
+            self.fail(f"expected PATH:BATCH_IDX (e.g. 'pred-n.pt:n'), got {value!r}", param, ctx)
+        try:
+            batch_idx = int(idx_str)
+        except ValueError:
+            self.fail(f"batch index must be an integer, got {idx_str!r}", param, ctx)
+        return PredictionRef(path=Path(path_str), batch_idx=batch_idx)
+
+
+class DatasetRefType(click.ParamType):
+    """Click parser for ``PATH:DATASET_IDX`` dataset references."""
+
+    name = "dataset_ref"
+
+    def convert(
+        self,
+        value: str | DatasetRef,
+        param: click.Parameter | None,
+        ctx: click.Context | None,
+    ) -> DatasetRef:
+        """Parse a ``PATH:DATASET_IDX`` string (or pass-through ``DatasetRef``) into a
+        ``DatasetRef``."""
+        if isinstance(value, DatasetRef):
+            return value
+        path_str, sep, idx_str = value.rpartition(":")
+        if not sep or not path_str or not idx_str:
+            self.fail(f"expected PATH:DATASET_IDX (e.g. 'test.h5:0'), got {value!r}", param, ctx)
+        try:
+            batch_idx = int(idx_str)
+        except ValueError:
+            self.fail(f"batch index must be an integer, got {idx_str!r}", param, ctx)
+        return DatasetRef(path=Path(path_str), batch_idx=batch_idx)
+
+
+def _load_pred_tensor(pred_path: Path) -> torch.Tensor:
+    """Load a prediction tensor from disk (imperative shell — does I/O only).
+
+    :param pred_path: Path to a ``pred-*.pt`` file produced by ``predict_vst_audio.py``.
+    :returns: A float tensor of shape ``(batch_size, num_params)`` with values in
+        the model output range ``[-1, 1]`` (the inverse of the ``(x + 1) / 2``
+        scale used by ``predict_vst_audio.py``). Loaded with
+        ``weights_only=True`` since predictions are plain tensors.
+    """
+    return torch.load(pred_path, map_location="cpu", weights_only=True)
+
+
+def decode_prediction_row(
+    pred_tensor: torch.Tensor,
+    batch_idx: int,
+    param_spec_name: str,
+) -> dict[str, float]:
+    """Decode a single predicted row into raw VST synth params (functional core — pure transform).
+
+    :param pred_tensor: Float tensor of shape ``(batch_size, num_params)`` with
+        values in ``[-1, 1]`` (inverse of the ``(x + 1) / 2`` scale used by
+        ``predict_vst_audio.py``). Out-of-range values are clipped to ``[0, 1]``
+        after rescaling.
+    :param batch_idx: Row index within the prediction tensor to decode. Must be
+        in ``[0, batch_size)``.
+    :param param_spec_name: Parameter spec name (key into ``param_specs``) used
+        to decode the rescaled row into raw VST parameter values.
+    :returns: Dict mapping VST parameter name to its raw (decoded) value.
+    :raises IndexError: when ``batch_idx`` is out of range for ``pred_tensor``.
+    """
+    if batch_idx < 0 or batch_idx >= pred_tensor.shape[0]:
+        raise IndexError(f"batch_idx {batch_idx} out of range (batch size {pred_tensor.shape[0]})")
+
+    spec = param_specs[param_spec_name]
+    row = pred_tensor[batch_idx].detach().cpu().float().numpy()
+    row_scaled = np.clip((row + 1) / 2, 0, 1)
+    synth_params, _ = spec.decode(row_scaled)
+    return synth_params
+
+
+def load_dataset_synth_params(
+    ref: DatasetRef,
+    param_spec_name: str,
+) -> dict[str, float]:
+    """Load a single row from an h5 dataset's ``param_array`` and decode it into synth params.
+
+    Unlike prediction tensors, h5 dataset rows are already in encoded form
+    (output of :meth:`ParamSpec.encode`, values in ``[0, 1]``), so no
+    ``(x + 1) / 2`` rescaling is applied.
+
+    :param ref: Reference identifying the h5 file path and row to decode.
+    :param param_spec_name: Parameter spec name (key into ``param_specs``) used
+        to decode the row into raw VST parameter values.
+    :returns: Dict mapping VST parameter name to its raw (decoded) value.
+    """
+    spec = param_specs[param_spec_name]
+    with h5py.File(ref.path, "r") as f:
+        param_array = f["param_array"]
+        if not isinstance(param_array, h5py.Dataset):
+            raise TypeError(
+                f"expected h5py.Dataset for 'param_array', got {type(param_array).__name__}"
+            )
+        row = np.asarray(param_array[ref.batch_idx], dtype=np.float32)
+
+    synth_params, _ = spec.decode(row)
+    return synth_params
+
+
+def load_prediction_synth_params(
+    ref: PredictionRef,
+    param_spec_name: str,
+) -> dict[str, float]:
+    """Load a single predicted row from a pred-*.pt file and decode it into synth params.
+
+    Thin orchestrator: reads the prediction tensor from disk via
+    :func:`_load_pred_tensor` and decodes the requested row via
+    :func:`decode_prediction_row`.
+
+    :param ref: Reference identifying the file path and row to decode.
+    :param param_spec_name: Parameter spec name (key into ``param_specs``) used
+        to decode the rescaled row into raw VST parameter values.
+    :returns: Dict mapping VST parameter name to its raw (decoded) value. The
+        underlying tensor has shape ``(batch_size, num_params)`` and dtype
+        float, with values in ``[-1, 1]`` (the inverse of the ``(x + 1) / 2``
+        scale used by ``predict_vst_audio.py``).
+    :raises IndexError: when ``ref.batch_idx`` is out of range for the loaded tensor.
+    """
+    pred_tensor = _load_pred_tensor(ref.path)
+    return decode_prediction_row(pred_tensor, ref.batch_idx, param_spec_name)
+
+
+def _flush_plugin(plugin: VST3Plugin) -> None:
+    """Process an empty buffer and reset the plugin to flush internal state.
+
+    Mirrors the post-load / pre-render flush pattern in
+    ``src.data.vst.core.render_params``.
+    """
+    plugin.process(
+        [],
+        _PLUGIN_FLUSH_DURATION_SECONDS,
+        SAMPLE_RATE,
+        CHANNELS,
+        _PLUGIN_FLUSH_BUFFER_SIZE,
+        True,
+    )
+    plugin.reset()
+
+
+def play_audio(plugin: VST3Plugin, stop_event: threading.Event) -> None:
+    """Stream silence through Surge XT and write synthesized audio to the output device.
+
+    Runs until ``stop_event`` is set (typically by ``keyboard_loop``'s quit action or by
+    ``main`` after the plugin editor is closed). Resamples to ``PLAYBACK_SAMPLE_RATE`` if
+    it differs from ``SAMPLE_RATE`` so the output device gets a rate it supports.
+    """
     silence = np.zeros((CHANNELS, BUFFER_SIZE), dtype=np.float32)
+    needs_resample = SAMPLE_RATE != PLAYBACK_SAMPLE_RATE
+    stream_resampler = (
+        StreamResampler(SAMPLE_RATE, PLAYBACK_SAMPLE_RATE, CHANNELS) if needs_resample else None
+    )
     with AudioStream(
         output_device_name=AudioStream.default_output_device_name,
-        sample_rate=SAMPLE_RATE,
+        sample_rate=PLAYBACK_SAMPLE_RATE,
         buffer_size=BUFFER_SIZE,
     ) as stream:
-        while True:
+        while not stop_event.is_set():
             synth_output = plugin(silence, SAMPLE_RATE, reset=False)
-            stream.write(synth_output, SAMPLE_RATE)
+            assert synth_output.shape == (CHANNELS, BUFFER_SIZE), (
+                f"expected synth output shape ({CHANNELS}, {BUFFER_SIZE}), "
+                f"got {synth_output.shape}"
+            )
+            if stream_resampler is not None:
+                stream.write(stream_resampler.process(synth_output), PLAYBACK_SAMPLE_RATE)
+            else:
+                stream.write(synth_output, SAMPLE_RATE)
+
+
+def play_audio_recorded(plugin: VST3Plugin, session_recording_path: Path) -> None:
+    """Render a deterministic clip through ``plugin`` to ``session_recording_path``.
+
+    The clip is a fixed ``SESSION_RECORDING_DURATION_SECONDS`` window with a
+    held middle-C note from ``SESSION_RECORDING_NOTE_START_SECONDS`` to
+    ``SESSION_RECORDING_NOTE_END_SECONDS``; the surrounding silence captures
+    any release tail. The output depends only on the loaded plugin state
+    (preset + ``--pred`` / ``--dataset-ref`` params), so the same inputs
+    always produce the same WAV.
+
+    Headless alternative to :func:`play_audio` — uses
+    ``pedalboard.io.AudioFile`` instead of an ``AudioStream``, so it works in
+    environments without an audio output device.
+    """
+    midi_events = make_midi_events(
+        SESSION_RECORDING_MIDI_NOTE,
+        SESSION_RECORDING_VELOCITY,
+        SESSION_RECORDING_NOTE_START_SECONDS,
+        SESSION_RECORDING_NOTE_END_SECONDS,
+    )
+    logger.info(
+        "Rendering %.1fs deterministic clip (note %d, %.1f-%.1fs) to %s",
+        SESSION_RECORDING_DURATION_SECONDS,
+        SESSION_RECORDING_MIDI_NOTE,
+        SESSION_RECORDING_NOTE_START_SECONDS,
+        SESSION_RECORDING_NOTE_END_SECONDS,
+        session_recording_path,
+    )
+    output = plugin.process(
+        list(midi_events),
+        SESSION_RECORDING_DURATION_SECONDS,
+        SAMPLE_RATE,
+        CHANNELS,
+        _SESSION_RECORDING_BUFFER_SIZE,
+        True,
+    )
+    expected_frames = int(SESSION_RECORDING_DURATION_SECONDS * SAMPLE_RATE)
+    assert output.shape == (CHANNELS, expected_frames), (
+        f"expected output shape ({CHANNELS}, {expected_frames}), got {output.shape}"
+    )
+    # AudioFile.write expects (frames, channels); plugin output is (channels, frames).
+    with AudioFile(str(session_recording_path), "w", SAMPLE_RATE, CHANNELS) as f:
+        f.write(output.T)
+    logger.info("Recording wrote %d frames", expected_frames)
+
+
+def keyboard_loop(
+    plugin: VST3Plugin, stop_event: threading.Event, param_spec_name: str
+) -> list[dict[str, float]]:
+    """Read keystrokes and snapshot the live plugin params into a list of patches.
+
+    Keys:
+
+    - ``p`` — record the current values of every synth param in
+      ``param_specs[param_spec_name]`` as a patch dict.
+    - ``q`` — set ``stop_event`` and exit.
+
+    Also exits when ``stop_event`` is set externally (e.g. when the plugin editor is
+    closed). Returns the list of recorded patches.
+    """
+    spec = param_specs[param_spec_name]
+    synth_patches: list[dict[str, float]] = []
+
+    def quit_action() -> bool:
+        stop_event.set()
+        logger.info("Quitting...")
+        return _STOP_LOOPING
+
+    def record_patch() -> bool:
+        patch: dict[str, float] = {}
+        logger.info("Recording patch...")
+        for param_name in spec.synth_param_names:
+            if param_name not in plugin.parameters:  # pyright: ignore[reportAttributeAccessIssue]
+                raise KeyError(f"parameter {param_name!r} not found in plugin parameters")
+            patch[param_name] = plugin.parameters[param_name].raw_value  # pyright: ignore[reportAttributeAccessIssue]
+        synth_patches.append(patch)
+        logger.info("patch recorded: %s", synth_patches[-1])
+        return _KEEP_LOOPING
+
+    actions = {
+        "q": quit_action,
+        "p": record_patch,
+    }
+    # NOTE: ``click.getchar()`` blocks until a key is pressed, so this loop only
+    # checks ``stop_event`` between keystrokes. If the editor closes from another
+    # thread, the loop won't exit until the user presses any key. Acceptable for
+    # the typical editor-close-then-press-q flow; a sentinel-key approach would
+    # be needed for fully event-driven shutdown.
+    while not stop_event.is_set():
+        ch = click.getchar()
+        action = actions.get(ch)
+        if action is not None and action() == _STOP_LOOPING:
+            return synth_patches
+    return synth_patches
 
 
 @click.command()
 @click.option("--plugin-path", "-p", default="plugins/Surge XT.vst3", help="Path to VST3 plugin.")
-def main(plugin_path: str) -> None:
-    """Open Surge XT GUI with real-time audio streaming."""
-    plugin = VST3Plugin(plugin_path)
+@click.option(
+    "--pred",
+    type=PredictionRefType(),
+    default=None,
+    help=(
+        "Prediction reference as PATH:BATCH_IDX (e.g. 'outputs/pred-0.pt:0'). "
+        "When set, the predicted row is decoded and applied to the plugin "
+        "before the editor opens."
+    ),
+)
+@click.option(
+    "--dataset-ref",
+    type=DatasetRefType(),
+    default=None,
+    help=(
+        "Dataset reference as PATH:DATASET_IDX (e.g. 'outputs/test.h5:0'). "
+        "When set, the dataset row is decoded and applied to the plugin "
+        "before the editor opens."
+    ),
+)
+@click.option(
+    "--preset-path",
+    "-r",
+    type=str,
+    default="presets/surge-base.vstpreset",
+    help="Base preset to load before applying any --pred / --dataset-ref params.",
+)
+@click.option(
+    "--param-spec-name",
+    type=str,
+    default="surge_xt",
+    help=(
+        "Parameter spec name (key into ``param_specs``) used to decode prediction/dataset "
+        "rows applied to the plugin and to enumerate which synth params are captured when "
+        "recording patches."
+    ),
+)
+@click.option(
+    "--output-dataset-path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "HDF5 file to be created with the recorded patches. Must not already exist — "
+        "``make_dataset`` writes fixed-size HDF5 datasets without ``maxshape`` and cannot "
+        "append to existing files. After the editor is closed, patches captured via the "
+        "keyboard loop (press 'p' to record, 'q' to quit) are rendered through the plugin "
+        "and written to this file via ``src.data.vst.generate_vst_dataset.make_dataset``."
+    ),
+)
+@click.option(
+    "--session-recording-path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        f"Optional WAV file to render a deterministic "
+        f"{int(SESSION_RECORDING_DURATION_SECONDS)}s test clip to "
+        f"(middle C from {SESSION_RECORDING_NOTE_START_SECONDS:.1f}-"
+        f"{SESSION_RECORDING_NOTE_END_SECONDS:.1f}s). When set, replaces the live "
+        f"audio stream — output depends only on plugin state, so the same inputs "
+        f"always produce the same WAV. No-op when not set."
+    ),
+)
+def main(
+    plugin_path: str,
+    pred: PredictionRef | None,
+    dataset_ref: DatasetRef | None,
+    preset_path: str,
+    param_spec_name: str,
+    output_dataset_path: Path | None,
+    session_recording_path: Path | None,
+) -> None:
+    """Open Surge XT GUI with real-time audio streaming and record patches to an HDF5 dataset.
 
-    t = threading.Thread(target=play_audio, args=(plugin,), daemon=True)
-    t.start()
+    Flow:
 
-    plugin.show_editor()
+    1. Load the plugin and base preset.
+    2. If ``--pred`` or ``--dataset-ref`` is provided, decode the referenced row and apply
+       it to the plugin before the editor opens.
+    3. Open the plugin's GUI editor; in parallel, stream audio to the default output device
+       and run a keyboard loop (press ``p`` to snapshot the current synth params as a patch,
+       ``q`` to quit).
+    4. After the editor is closed, render every recorded patch through the plugin and append
+       the resulting samples to ``--output-dataset-path`` via ``make_dataset``.
+    """
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    if dataset_ref is not None and pred is not None:
+        raise click.UsageError(
+            "--pred and --dataset-ref are mutually exclusive; pass at most one."
+        )
+
+    # Fail fast — ``make_dataset`` writes fixed-size HDF5 datasets without
+    # ``maxshape`` and cannot append, so a pre-existing path would either
+    # silently overwrite (when re-creating datasets) or fail mid-render after
+    # patches have been captured. Better to reject up front.
+    if output_dataset_path is not None and output_dataset_path.exists():
+        raise click.UsageError(
+            f"--output-dataset-path {output_dataset_path} already exists; "
+            f"this script writes a new file (fixed-size HDF5 datasets cannot be "
+            f"appended to). Choose a path that does not exist yet."
+        )
+
+    plugin = load_plugin(plugin_path)
+    if not isinstance(plugin, VST3Plugin):
+        raise TypeError(f"expected VST3Plugin, got {type(plugin).__name__}")
+
+    load_preset(plugin, preset_path)
+
+    # Two flushes ensure the plugin's full parameter dict is populated and any
+    # transient state from preset load is cleared before applying user params.
+    _flush_plugin(plugin)
+    _flush_plugin(plugin)
+
+    if dataset_ref is not None:
+        synth_params = load_dataset_synth_params(dataset_ref, param_spec_name)
+        set_params(plugin, synth_params)
+    elif pred is not None:
+        synth_params = load_prediction_synth_params(pred, param_spec_name)
+        set_params(plugin, synth_params)
+
+    stop_event = threading.Event()
+    with ThreadPoolExecutor() as pool:
+        if session_recording_path is not None:
+            audio_future = pool.submit(play_audio_recorded, plugin, session_recording_path)
+        else:
+            audio_future = pool.submit(play_audio, plugin, stop_event)
+        keyboard_future = pool.submit(keyboard_loop, plugin, stop_event, param_spec_name)
+
+        try:
+            plugin.show_editor(stop_event)
+        finally:
+            stop_event.set()
+            # Surface any exception from the audio thread. Catch TimeoutError so
+            # a slow stream-close on shutdown doesn't crash the script — log it
+            # and continue draining; cancel-style errors will resurface elsewhere.
+            try:
+                audio_future.result(timeout=AUDIO_THREAD_DRAIN_TIMEOUT_SECONDS)
+            except TimeoutError:
+                logger.warning(
+                    "audio thread did not exit within %ss; continuing shutdown",
+                    AUDIO_THREAD_DRAIN_TIMEOUT_SECONDS,
+                )
+        logger.info("Editor closed, waiting for keyboard thread to finish...")
+        synth_patches = keyboard_future.result()
+        logger.info("Recorded %d patches: %s", len(synth_patches), synth_patches)
+
+    if output_dataset_path is None:
+        logger.info("No output dataset path provided, skipping dataset creation.")
+        return
+    if not synth_patches:
+        logger.info("No patches recorded, skipping dataset creation.")
+        return
+    with h5py.File(output_dataset_path, "w") as f:
+        make_dataset(
+            hdf5_file=f,
+            num_samples=len(synth_patches),
+            plugin_path=plugin_path,
+            preset_path=preset_path,
+            sample_rate=SAMPLE_RATE,
+            channels=CHANNELS,
+            velocity=MAKE_DATASET_VELOCITY,
+            signal_duration_seconds=MAKE_DATASET_SIGNAL_DURATION_SECONDS,
+            min_loudness=MAKE_DATASET_MIN_LOUDNESS,
+            param_spec=param_specs[param_spec_name],
+            sample_batch_size=MAKE_DATASET_SAMPLE_BATCH_SIZE,
+            fixed_synth_params_list=synth_patches,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -1,0 +1,356 @@
+"""Tests for scripts/surge_xt_interactive.py prediction decoding helpers."""
+
+import importlib
+from pathlib import Path
+
+import click
+import h5py
+import numpy as np
+import pytest
+import torch
+from pedalboard.io import AudioFile
+
+from src.data.vst import param_specs
+from src.data.vst.param_spec import ParamSpec
+
+SURGE_SIMPLE = "surge_simple"
+
+
+@pytest.fixture(scope="module")
+def surge_xt_interactive():
+    """Import the script module lazily so collection doesn't fail on heavy imports."""
+    return importlib.import_module("scripts.surge_xt_interactive")
+
+
+@pytest.fixture(scope="module")
+def simple_spec() -> ParamSpec:
+    """The ``surge_simple`` ParamSpec used by the prediction-decoding tests."""
+    return param_specs[SURGE_SIMPLE]
+
+
+@pytest.fixture(scope="module")
+def simple_spec_total_length(simple_spec: ParamSpec) -> int:
+    """Total encoded row length (synth + note params) for the simple spec."""
+    return simple_spec.synth_param_length + simple_spec.note_param_length
+
+
+@pytest.fixture
+def simple_pred_tensor(simple_spec_total_length: int) -> torch.Tensor:
+    """A 2-row prediction tensor sized for the surge_simple spec.
+
+    Row 0 cycles through ``[-1.0, 0.0, 1.0, 2.0]`` to exercise the
+    ``(-1..1) -> (0..1)`` rescaling and clipping (``2.0`` is clipped to ``1``).
+    Row 1 is all-zeros (decodes to mid-range values).
+    """
+    cycle = np.array([-1.0, 0.0, 1.0, 2.0], dtype=np.float32)
+    row_0 = np.tile(cycle, (simple_spec_total_length // 4) + 1)[:simple_spec_total_length]
+    row_1 = np.zeros(simple_spec_total_length, dtype=np.float32)
+    return torch.tensor(np.stack([row_0, row_1]), dtype=torch.float32)
+
+
+def _write_param_array_h5(path: Path, rows: np.ndarray) -> None:
+    """Write a 2D ``rows`` array to an h5 file under the ``param_array`` dataset."""
+    with h5py.File(path, "w") as f:
+        f.create_dataset("param_array", data=rows)
+
+
+class TestDecodePredictionRow:
+    """decode_prediction_row scales (-1..1) -> (0..1), clips, and decodes a row."""
+
+    def test_returns_expected_keys_and_finite_floats(
+        self,
+        surge_xt_interactive,
+        simple_pred_tensor: torch.Tensor,
+        simple_spec: ParamSpec,
+    ) -> None:
+        """Decoded row contains every synth-param key with finite float values."""
+        synth_params = surge_xt_interactive.decode_prediction_row(
+            simple_pred_tensor, batch_idx=0, param_spec_name=SURGE_SIMPLE
+        )
+
+        expected_keys = {p.name for p in simple_spec.synth_params}
+        assert set(synth_params.keys()) == expected_keys
+        for name, value in synth_params.items():
+            assert isinstance(value, float), f"{name} is {type(value).__name__}, expected float"
+            assert np.isfinite(value), f"{name} = {value} is not finite"
+
+    @pytest.mark.parametrize(
+        "param_name, expected",
+        [
+            # col 0 = -1.0 -> rescaled 0.0 -> attack at spec min (0.0)
+            ("a_amp_eg_attack", 0.0),
+            # col 1 =  0.0 -> rescaled 0.5 -> decay at spec midpoint
+            ("a_amp_eg_decay", 0.385),
+            # col 2 =  1.0 -> rescaled 1.0 -> release at spec max
+            ("a_amp_eg_release", 0.77),
+            # col 3 =  2.0 -> clipped to 1.0 -> sustain at spec max
+            ("a_amp_eg_sustain", 1.0),
+        ],
+    )
+    def test_clips_and_rescales_per_column(
+        self,
+        surge_xt_interactive,
+        simple_pred_tensor: torch.Tensor,
+        param_name: str,
+        expected: float,
+    ) -> None:
+        """Each column is rescaled from ``[-1, 1]`` to ``[0, 1]`` and clipped before decoding."""
+        synth_params = surge_xt_interactive.decode_prediction_row(
+            simple_pred_tensor, batch_idx=0, param_spec_name=SURGE_SIMPLE
+        )
+        assert synth_params[param_name] == pytest.approx(expected, abs=1e-6)
+
+    @pytest.mark.parametrize("bad_idx", [99, -1], ids=["above-range", "negative"])
+    def test_out_of_range_idx_raises(
+        self,
+        surge_xt_interactive,
+        simple_pred_tensor: torch.Tensor,
+        bad_idx: int,
+    ) -> None:
+        """``batch_idx`` outside ``[0, batch_size)`` raises ``IndexError``."""
+        with pytest.raises(IndexError):
+            surge_xt_interactive.decode_prediction_row(
+                simple_pred_tensor, batch_idx=bad_idx, param_spec_name=SURGE_SIMPLE
+            )
+
+
+class TestPredictionRefType:
+    """PredictionRefType parses ``PATH:BATCH_IDX`` into a PredictionRef."""
+
+    def test_parses_path_and_batch_idx(self, surge_xt_interactive) -> None:
+        """A ``PATH:BATCH_IDX`` string parses into a ``PredictionRef`` with matching fields."""
+        parser = surge_xt_interactive.PredictionRefType()
+
+        ref = parser.convert("outputs/pred-0.pt:42", None, None)
+
+        assert ref == surge_xt_interactive.PredictionRef(
+            path=Path("outputs/pred-0.pt"), batch_idx=42
+        )
+
+    def test_splits_on_last_colon(self, surge_xt_interactive) -> None:
+        """Absolute Windows-style paths still parse because rpartition uses the last ':'."""
+        parser = surge_xt_interactive.PredictionRefType()
+
+        ref = parser.convert(r"C:\models\pred-0.pt:7", None, None)
+
+        assert ref.path == Path(r"C:\models\pred-0.pt")
+        assert ref.batch_idx == 7
+
+    @pytest.mark.parametrize(
+        "value",
+        ["pred-0.pt", "pred-0.pt:not-an-int", ":42", "pred-0.pt:"],
+        ids=["missing-colon", "non-int-idx", "empty-path", "empty-idx"],
+    )
+    def test_rejects_invalid_uri(self, surge_xt_interactive, value: str) -> None:
+        """Malformed prediction references raise ``click.BadParameter``."""
+        parser = surge_xt_interactive.PredictionRefType()
+
+        with pytest.raises(click.BadParameter):
+            parser.convert(value, None, None)
+
+
+class TestDatasetRefType:
+    """DatasetRefType parses ``PATH:DATASET_IDX`` into a DatasetRef."""
+
+    def test_parses_path_and_batch_idx(self, surge_xt_interactive) -> None:
+        """A ``PATH:DATASET_IDX`` string parses into a ``DatasetRef`` with matching fields."""
+        parser = surge_xt_interactive.DatasetRefType()
+
+        ref = parser.convert("data/test.h5:3", None, None)
+
+        assert ref == surge_xt_interactive.DatasetRef(path=Path("data/test.h5"), batch_idx=3)
+
+    @pytest.mark.parametrize(
+        "value",
+        ["test.h5", "test.h5:not-an-int", ":0", "test.h5:"],
+        ids=["missing-colon", "non-int-idx", "empty-path", "empty-idx"],
+    )
+    def test_rejects_invalid_uri(self, surge_xt_interactive, value: str) -> None:
+        """Malformed dataset references raise ``click.BadParameter``."""
+        parser = surge_xt_interactive.DatasetRefType()
+
+        with pytest.raises(click.BadParameter):
+            parser.convert(value, None, None)
+
+
+class TestLoadPredictionSynthParams:
+    """load_prediction_synth_params reads a .pt file row and decodes it."""
+
+    def test_matches_decode_prediction_row_on_same_row(
+        self,
+        surge_xt_interactive,
+        simple_pred_tensor: torch.Tensor,
+        simple_spec: ParamSpec,
+        tmp_path: Path,
+    ) -> None:
+        """Loading from disk and in-memory ``decode_prediction_row`` produce identical outputs."""
+        pred_path = tmp_path / "pred-0.pt"
+        torch.save(simple_pred_tensor, pred_path)
+        ref = surge_xt_interactive.PredictionRef(path=pred_path, batch_idx=0)
+
+        loaded = surge_xt_interactive.load_prediction_synth_params(
+            ref, param_spec_name=SURGE_SIMPLE
+        )
+
+        direct = surge_xt_interactive.decode_prediction_row(
+            simple_pred_tensor, batch_idx=0, param_spec_name=SURGE_SIMPLE
+        )
+        expected_keys = {p.name for p in simple_spec.synth_params}
+        assert set(loaded.keys()) == expected_keys
+        assert loaded == direct
+
+
+class TestLoadDatasetSynthParams:
+    """load_dataset_synth_params reads an h5 ``param_array`` row and decodes it."""
+
+    def test_round_trip_returns_original_synth_params(
+        self,
+        surge_xt_interactive,
+        simple_spec: ParamSpec,
+        tmp_path: Path,
+    ) -> None:
+        """Encoding params, persisting to h5, and reloading recovers the original synth params."""
+        synth_param_dict, note_param_dict = simple_spec.sample()
+        encoded = simple_spec.encode(synth_param_dict, note_param_dict)
+        h5_path = tmp_path / "test.h5"
+        _write_param_array_h5(h5_path, encoded[None, :])
+        ref = surge_xt_interactive.DatasetRef(path=h5_path, batch_idx=0)
+
+        loaded = surge_xt_interactive.load_dataset_synth_params(ref, param_spec_name=SURGE_SIMPLE)
+
+        for name, value in synth_param_dict.items():
+            assert loaded[name] == pytest.approx(value, abs=1e-5)
+
+    def test_selects_correct_row(
+        self,
+        surge_xt_interactive,
+        simple_spec: ParamSpec,
+        tmp_path: Path,
+    ) -> None:
+        """``batch_idx`` selects the matching row from a multi-row ``param_array``."""
+        row_0_synth, row_0_note = simple_spec.sample()
+        row_1_synth, row_1_note = simple_spec.sample()
+        encoded = np.stack(
+            [
+                simple_spec.encode(row_0_synth, row_0_note),
+                simple_spec.encode(row_1_synth, row_1_note),
+            ]
+        )
+        h5_path = tmp_path / "test.h5"
+        _write_param_array_h5(h5_path, encoded)
+        ref = surge_xt_interactive.DatasetRef(path=h5_path, batch_idx=1)
+
+        loaded = surge_xt_interactive.load_dataset_synth_params(ref, param_spec_name=SURGE_SIMPLE)
+
+        for name, value in row_1_synth.items():
+            assert loaded[name] == pytest.approx(value, abs=1e-5)
+
+    def test_out_of_range_idx_raises(
+        self,
+        surge_xt_interactive,
+        simple_spec: ParamSpec,
+        tmp_path: Path,
+    ) -> None:
+        """A ``batch_idx`` past the end of ``param_array`` raises ``IndexError`` or
+        ``ValueError``."""
+        encoded = simple_spec.encode(*simple_spec.sample())
+        h5_path = tmp_path / "test.h5"
+        _write_param_array_h5(h5_path, encoded[None, :])
+        ref = surge_xt_interactive.DatasetRef(path=h5_path, batch_idx=99)
+
+        with pytest.raises((IndexError, ValueError)):
+            surge_xt_interactive.load_dataset_synth_params(ref, param_spec_name=SURGE_SIMPLE)
+
+    @pytest.mark.slow
+    def test_loads_row_from_surge_xt_smoke_fixture(
+        self,
+        surge_xt_interactive,
+        surge_xt_smoke_datasets: Path,
+    ) -> None:
+        """Loads row 0 from the real ``surge_xt_smoke_datasets`` test.h5 via the surge_xt spec."""
+        ref = surge_xt_interactive.DatasetRef(
+            path=surge_xt_smoke_datasets / "test.h5", batch_idx=0
+        )
+
+        loaded = surge_xt_interactive.load_dataset_synth_params(ref, param_spec_name="surge_xt")
+
+        expected_keys = {p.name for p in param_specs["surge_xt"].synth_params}
+        assert set(loaded.keys()) == expected_keys
+        for name, value in loaded.items():
+            assert isinstance(value, float), f"{name} is {type(value).__name__}, expected float"
+            assert np.isfinite(value), f"{name} = {value} is not finite"
+
+
+class _ConstantPlugin:
+    """Stand-in plugin with a ``.process(...)`` method that returns constant audio.
+
+    Duck-typed to satisfy ``play_audio_recorded``'s ``plugin.process(...)`` call —
+    avoids loading a real VST3, which is unavailable in headless test runs.
+    Stashes its last call's ``midi_messages`` argument for assertion in tests.
+    """
+
+    def __init__(self, sample_value: float) -> None:
+        self.sample_value = sample_value
+        self.process_call_count = 0
+        self.last_midi_messages: list | None = None
+
+    def process(
+        self,
+        midi_messages: list,
+        duration_seconds: float,
+        sample_rate: float,
+        num_channels: int,
+        buffer_size: int,
+        reset: bool,
+    ) -> np.ndarray:
+        """Return a constant-valued ``(num_channels, duration * sample_rate)`` buffer."""
+        del buffer_size, reset
+        self.process_call_count += 1
+        self.last_midi_messages = list(midi_messages)
+        frames = int(duration_seconds * sample_rate)
+        return np.full((num_channels, frames), self.sample_value, dtype=np.float32)
+
+
+class TestPlayAudioRecorded:
+    """play_audio_recorded renders a deterministic clip via a single plugin.process() call."""
+
+    def test_writes_exact_duration_frames(self, surge_xt_interactive, tmp_path: Path) -> None:
+        """The WAV's frame count is exactly ``DURATION * SAMPLE_RATE`` (one process call)."""
+        plugin = _ConstantPlugin(sample_value=0.25)
+        output_path = tmp_path / "session.wav"
+        expected_frames = int(
+            surge_xt_interactive.SESSION_RECORDING_DURATION_SECONDS
+            * surge_xt_interactive.SAMPLE_RATE
+        )
+
+        surge_xt_interactive.play_audio_recorded(plugin, output_path)
+
+        assert plugin.process_call_count == 1
+        assert output_path.is_file()
+        with AudioFile(str(output_path)) as f:
+            audio = f.read(f.frames)
+        assert audio.shape == (surge_xt_interactive.CHANNELS, expected_frames)
+        np.testing.assert_allclose(audio, plugin.sample_value, atol=1e-3)
+
+    def test_passes_expected_midi_events(self, surge_xt_interactive, tmp_path: Path) -> None:
+        """plugin.process is called with note_on/off middle-C events at NOTE_START/END."""
+        plugin = _ConstantPlugin(sample_value=0.0)
+
+        surge_xt_interactive.play_audio_recorded(plugin, tmp_path / "events.wav")
+
+        assert plugin.last_midi_messages is not None
+        assert len(plugin.last_midi_messages) == 2
+        (note_on_bytes, note_on_t), (note_off_bytes, note_off_t) = plugin.last_midi_messages
+
+        assert note_on_t == pytest.approx(
+            surge_xt_interactive.SESSION_RECORDING_NOTE_START_SECONDS
+        )
+        assert note_off_t == pytest.approx(surge_xt_interactive.SESSION_RECORDING_NOTE_END_SECONDS)
+
+        # MIDI wire format: status byte (high nibble = type), note, velocity.
+        # 0x90 = note_on (channel 0), 0x80 = note_off (channel 0).
+        assert note_on_bytes[0] & 0xF0 == 0x90
+        assert note_off_bytes[0] & 0xF0 == 0x80
+        assert note_on_bytes[1] == surge_xt_interactive.SESSION_RECORDING_MIDI_NOTE
+        assert note_off_bytes[1] == surge_xt_interactive.SESSION_RECORDING_MIDI_NOTE
+        assert note_on_bytes[2] == surge_xt_interactive.SESSION_RECORDING_VELOCITY

--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -148,6 +148,14 @@ class TestPredictionRefType:
         with pytest.raises(click.BadParameter):
             parser.convert(value, None, None)
 
+    def test_rejects_negative_batch_idx(self, surge_xt_interactive) -> None:
+        """Negative indices raise ``click.BadParameter`` to match ``decode_prediction_row``'s
+        contract — h5py-style negative indexing would otherwise silently select the last row."""
+        parser = surge_xt_interactive.PredictionRefType()
+
+        with pytest.raises(click.BadParameter):
+            parser.convert("pred-0.pt:-1", None, None)
+
 
 class TestDatasetRefType:
     """DatasetRefType parses ``PATH:DATASET_IDX`` into a DatasetRef."""
@@ -171,6 +179,14 @@ class TestDatasetRefType:
 
         with pytest.raises(click.BadParameter):
             parser.convert(value, None, None)
+
+    def test_rejects_negative_batch_idx(self, surge_xt_interactive) -> None:
+        """Negative indices raise ``click.BadParameter`` — h5py's ``param_array[-1]`` would
+        otherwise silently return the last row instead of failing."""
+        parser = surge_xt_interactive.DatasetRefType()
+
+        with pytest.raises(click.BadParameter):
+            parser.convert("test.h5:-1", None, None)
 
 
 class TestLoadPredictionSynthParams:


### PR DESCRIPTION
## Summary

Final sub-PR from #702. Replaces the 41-line `scripts/surge_xt_interactive.py` demo with a 537-line human-in-the-loop tool that:

- Loads predicted parameters (`--pred PATH:BATCH_IDX`) or dataset rows (`--dataset-ref PATH:DATASET_IDX`) and applies them to a live Surge XT plugin before opening the editor.
- Streams audio while the editor is open; the keyboard loop captures snapshots (`p` records the current synth params, `q` quits).
- Renders all recorded patches into a labeled HDF5 file (`--output-dataset-path`) via `make_dataset(..., fixed_synth_params_list=...)` (kwarg merged via PR #720).
- Replaces the old daemon-thread + `KeyboardInterrupt` shutdown with a `threading.Event` + `ThreadPoolExecutor`; audio-thread errors surface via `audio_future.result(timeout=2)` (refs #532).

Adds CPU-only unit tests (`tests/scripts/test_surge_xt_interactive.py`) for the row decoders and Click param-type parsers — no `requires_vst` marker, runs in the default suite. Adds a user guide at `docs/guides/surge-xt-interactive.md` plus README and `docs/doc-map.yaml` entries.

Runtime deps PR #713 (per-render plugin reload), PR #715 (Darwin warmup skip), PR #720 (deterministic-render kwargs) are all already merged on main, so this PR is a verbatim port of five files from #702 with no `src/` changes.

## Test plan

- [x] `make format` clean
- [x] `make test` green (229 passed, 3 warnings, 21.31s) — includes the new CPU-only tests
- [x] `python -m scripts.surge_xt_interactive --help` exits 0 and shows all six new flags (`--pred`, `--dataset-ref`, `--preset-path`, `--param-spec-name`, `--output-dataset-path`, `--session-recording-path`)
- [ ] Manual smoke (host with VST + audio device): launch with `--session-recording-path /tmp/test.wav` and confirm a 10s middle-C WAV is written

Closes #701
Refs #532
Part of #529