### PR TITLE
fix(ci): drop `passthrough` from docker run invocations after #721 dropped ENTRYPOINT

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -172,6 +172,11 @@ jobs:
           cache-from: type=registry,ref=tinaudio/synth-setter:buildcache
           cache-to: ""
 
+      # The image no longer sets an ENTRYPOINT (#721 dropped it for SkyPilot's
+      # RunPod backend, which prepends `bash -c '...'`); CMD defaults to
+      # /bin/bash, and `docker run img <argv>` overrides CMD with that argv.
+      # So we invoke pytest directly instead of going through the click CLI's
+      # `passthrough` subcommand.
       - name: Smoke test — container starts and Python imports work
         if: github.event_name != 'pull_request'
         env:
@@ -180,7 +185,7 @@ jobs:
           docker run --rm \
             -e PYTHONPATH=/home/build/synth-setter \
             "$SMOKE_IMAGE" \
-            passthrough pytest tests/docker/test_smoke.py::test_pedalboard_importable -v
+            pytest tests/docker/test_smoke.py::test_pedalboard_importable -v
 
       - name: Smoke test — VST loads under headless X11
         if: github.event_name != 'pull_request'
@@ -190,5 +195,5 @@ jobs:
           docker run --rm \
             -e PYTHONPATH=/home/build/synth-setter \
             "$SMOKE_IMAGE" \
-            passthrough scripts/run-linux-vst-headless.sh \
+            scripts/run-linux-vst-headless.sh \
               pytest tests/docker/test_smoke.py::test_surge_xt_loads -v

--- a/.github/workflows/spec-materialization.yml
+++ b/.github/workflows/spec-materialization.yml
@@ -36,10 +36,11 @@ jobs:
           CONFIG_PATH: ${{ inputs.config_path }}
         # Mount the PR's code into the container so we test THIS branch's code
         # against the image's environment (Surge XT, Python, pedalboard, etc.).
-        # Dispatch goes through the default ENTRYPOINT (python click CLI) via
-        # `passthrough` — no `--entrypoint bash` override. CONFIG_PATH is
-        # forwarded via -e so the inner script references it via $CONFIG_PATH
-        # instead of splicing a workflow input into the command text.
+        # Image has no ENTRYPOINT (#721 dropped it for SkyPilot); CMD defaults
+        # to /bin/bash, so `docker run img bash -c '...'` overrides CMD with
+        # the bash invocation. CONFIG_PATH is forwarded via -e so the inner
+        # script references it via $CONFIG_PATH instead of splicing a workflow
+        # input into the command text.
         run: |
           mkdir -p /tmp/spec-output
           docker run --rm \
@@ -53,7 +54,7 @@ jobs:
             -e CONFIG_PATH \
             -e PYTHONPATH=/home/build/synth-setter \
             tinaudio/synth-setter:${{ inputs.image_tag }} \
-            passthrough bash -c '
+            bash -c '
               set -euo pipefail
               cd /home/build/synth-setter
               # Runner UID != container UID; git refuses to run in untrusted dirs


### PR DESCRIPTION
## Summary

- Restore green smoke tests on `main` (failing run: [25178840823](https://github.com/tinaudio/synth-setter/actions/runs/25178840823/job/73818285292)) by dropping the `passthrough` prefix from docker run invocations in `docker-build-validation.yml` (both smoke steps) and `spec-materialization.yml`.
- #721 (commit 450cf0b) intentionally removed `ENTRYPOINT ["python", "/usr/local/bin/entrypoint.py"]` from `docker/ubuntu22_04/Dockerfile` to support SkyPilot's RunPod backend and switched `CMD` to `/bin/bash`. `passthrough` was a click subcommand of the now-absent ENTRYPOINT, so docker tried to exec the literal `passthrough` and failed with `executable file not found in $PATH`.
- With `CMD=/bin/bash` and no ENTRYPOINT, `docker run img <argv>` overrides CMD with `<argv>` directly, so the same commands run unchanged. Matches the canonical invocation already documented in `tests/docker/test_smoke.py`'s docstring.

## Out of scope

Three other workflows still use `passthrough` / click-CLI subcommands and will fail similarly on their next non-PR run. Tracked in #726, deferred to a follow-up PR to keep this fix narrowly scoped to the currently-red workflow:

- `.github/workflows/test-dataset-generation.yml`
- `.github/workflows/flush-investigation.yml`
- `.github/workflows/dataset-generation.yml`

## Test plan

- [ ] PR build (no smoke step) passes the docker build of `dev-snapshot` + `devcontainer-tools` targets.
- [ ] After merge, manually dispatch `Docker Image Build and Push` against `main` and confirm both smoke steps pass:
  - `Smoke test — container starts and Python imports work`
  - `Smoke test — VST loads under headless X11`
- [ ] Next workflow_call invocation of `Spec Materialization` runs the new bash command form successfully.

Refs #726