### PR TITLE
build(deps): add skypilot[runpod]==0.12.0 to requirements-app.txt

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,10 +8,11 @@ tensorboard
 wandb
 
 # --------- pipeline --------- #
-click
+click<8.2
 numpy
 pydantic>=2
 pyyaml
+skypilot[runpod]==0.12.0
 structlog
 tenacity
 webdataset


### PR DESCRIPTION
## Summary

Adds `skypilot[runpod]==0.12.0` to `requirements-app.txt` so the SkyPilot RunPod backend is baked into images built from this file (notably `tinaudio/synth-setter:dev-snapshot`).

### Why

The Test Dataset Generation workflow (`.github/workflows/test-dataset-generation.yml`) drives `scripts/skypilot_launch_smoke.py`, which `import sky`s. The currently-published `dev-snapshot` image predates the SkyPilot integration on `feat/skypilot-runpod-smoke` and does not have `sky` installed, so the workflow fails with `ModuleNotFoundError: No module named 'sky'`. The workflow currently works around this with a `uv pip install` stopgap inside the container at job time.

Once `dev-snapshot` is rebuilt and republished from the current `Dockerfile` after this PR lands, `sky` will be importable from the image and the runtime install stopgap can be removed in a follow-up.

### What changed

- `requirements-app.txt`: added `skypilot[runpod]==0.12.0` in the `pipeline` group (alphabetical) and pinned the previously-bare `click` entry to `click<8.2` to dodge skypilot's `deepcopy(Sentinel)` crash that originally bit us on 0.7. The pin is harmless on 0.12 and matches what was carried on the feature branch.

No other lines touched. `make format` is clean.

## Test plan

- [ ] Test Dataset Generation workflow runs and passes after `dev-snapshot` is rebuilt with this change baked in
- [ ] Stopgap `uv pip install skypilot[runpod]` removed from `.github/workflows/test-dataset-generation.yml` in a follow-up PR after the image rebuild

Refs #534