### PR TITLE
test(testing): xfail 7 docker_entrypoint error-path tests blocked by log_cli bug

### DIFF
--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -28,6 +28,20 @@ from pydantic import BaseModel
 REPO_ROOT = Path(__file__).resolve().parent.parent
 ENTRYPOINT_PATH = REPO_ROOT / "scripts" / "docker_entrypoint.py"
 
+# Tests that drive a click callback whose error path calls logger.error(...) crash inside
+# CliRunner.invoke()'s finally-block (.getvalue() on a closed BytesIOCopy) when pytest's
+# log_cli=True is set: _LiveLoggingStreamHandler.emit() suspends global capture mid-emit and
+# closes the BytesIOCopy that CliRunner.isolation() installed. Strict + raises=ValueError so
+# the markers are removed automatically by the real fix in #730.
+_XFAIL_CLI_RUNNER_LOG_CLI_BUG = pytest.mark.xfail(
+    reason=(
+        "CliRunner.invoke() finally-block .getvalue() on closed BytesIOCopy under "
+        "log_cli=True; tracked in #730."
+    ),
+    strict=True,
+    raises=ValueError,
+)
+
 
 def _load_entrypoint_module() -> ModuleType:
     """Import scripts/docker_entrypoint.py as a module for in-process testing."""
@@ -135,6 +149,7 @@ class TestIdle:
         assert result.exit_code == 0, result.output
         assert calls == [("sleep", ["sleep", "infinity"])]
 
+    @_XFAIL_CLI_RUNNER_LOG_CLI_BUG
     def test_idle_exec_failure_becomes_click_exception(
         self, runner: CliRunner, entrypoint: ModuleType
     ) -> None:
@@ -197,6 +212,7 @@ class TestPassthrough:
         assert result.exit_code == 0, result.output
         assert calls == [("rclone", ["rclone", "--checksum", "src", "dst"])]
 
+    @_XFAIL_CLI_RUNNER_LOG_CLI_BUG
     def test_passthrough_exec_failure_becomes_click_exception(
         self, runner: CliRunner, entrypoint: ModuleType
     ) -> None:
@@ -276,6 +292,7 @@ class TestGenerateDataset:
         result = runner.invoke(entrypoint.cli, ["generate_dataset", "--spec", str(missing)])
         assert result.exit_code == 2
 
+    @_XFAIL_CLI_RUNNER_LOG_CLI_BUG
     def test_malformed_json_spec_exits_nonzero_without_calling_run(
         self, runner: CliRunner, entrypoint: ModuleType, tmp_path: Path
     ) -> None:
@@ -290,6 +307,7 @@ class TestGenerateDataset:
 
         assert result.exit_code != 0
 
+    @_XFAIL_CLI_RUNNER_LOG_CLI_BUG
     def test_invalid_spec_shape_exits_nonzero_without_calling_run(
         self, runner: CliRunner, entrypoint: ModuleType, tmp_path: Path
     ) -> None:
@@ -304,6 +322,7 @@ class TestGenerateDataset:
 
         assert result.exit_code != 0
 
+    @_XFAIL_CLI_RUNNER_LOG_CLI_BUG
     def test_binary_spec_file_exits_nonzero_without_calling_run(
         self, runner: CliRunner, entrypoint: ModuleType, tmp_path: Path
     ) -> None:
@@ -336,6 +355,7 @@ class TestGenerateDataset:
 class TestRenderEval:
     """render_eval subcommand is a deliberate placeholder pointing at #410."""
 
+    @_XFAIL_CLI_RUNNER_LOG_CLI_BUG
     def test_render_eval_fails_loudly_with_issue_pointer(
         self, runner: CliRunner, entrypoint: ModuleType, tmp_path: Path
     ) -> None:
@@ -370,6 +390,7 @@ class TestRenderEval:
 class TestTrain:
     """Train subcommand is a deliberate placeholder pointing at #409."""
 
+    @_XFAIL_CLI_RUNNER_LOG_CLI_BUG
     def test_train_fails_loudly_with_issue_pointer(
         self, runner: CliRunner, entrypoint: ModuleType, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

Mark 7 error-path tests in `tests/test_docker_entrypoint.py` as `@pytest.mark.xfail(strict=True, raises=ValueError)` so CI is unblocked on branches that touch the test suite. The underlying click 8.3 + `log_cli=True` interaction is tracked in #730 and will be fixed in a follow-up PR (which will retire these markers automatically via `strict=True`).

## Why xfail and not skip / not delete

- The commands themselves work correctly — exit code, stderr, captured log are all right. Only `CliRunner.invoke()`'s finally-block is broken under `log_cli=True`.
- `strict=True` + `raises=ValueError` means: when the real fix lands, pytest fails with `XPASS(strict)` and forces the markers to be removed. No silent zombies.

Refs #730

## Test plan

- [x] Reproduce baseline failure on `main`:

  ```
  $ uvenv/bin/python -m pytest tests/test_docker_entrypoint.py -p no:xdist
  ...
  FAILED tests/test_docker_entrypoint.py::TestIdle::test_idle_exec_failure_becomes_click_exception - ValueError: I/O operation on closed file.
  FAILED tests/test_docker_entrypoint.py::TestPassthrough::test_passthrough_exec_failure_becomes_click_exception - ValueError: I/O operation on closed file.
  FAILED tests/test_docker_entrypoint.py::TestGenerateDataset::test_malformed_json_spec_exits_nonzero_without_calling_run - ValueError: I/O operation on closed file.
  FAILED tests/test_docker_entrypoint.py::TestGenerateDataset::test_invalid_spec_shape_exits_nonzero_without_calling_run - ValueError: I/O operation on closed file.
  FAILED tests/test_docker_entrypoint.py::TestGenerateDataset::test_binary_spec_file_exits_nonzero_without_calling_run - ValueError: I/O operation on closed file.
  FAILED tests/test_docker_entrypoint.py::TestRenderEval::test_render_eval_fails_loudly_with_issue_pointer - ValueError: I/O operation on closed file.
  FAILED tests/test_docker_entrypoint.py::TestTrain::test_train_fails_loudly_with_issue_pointer - ValueError: I/O operation on closed file.
  ========================= 7 failed, 11 passed in 0.52s =========================
  ```

- [x] After applying markers — `tests/test_docker_entrypoint.py` reports 11 passed, 7 xfailed, 0 xpassed:

  ```
  $ uvenv/bin/python -m pytest tests/test_docker_entrypoint.py -p no:xdist
  ======================== 11 passed, 7 xfailed in 0.46s =========================
  ```

- [x] Full non-slow suite — no regressions:

  ```
  $ uvenv/bin/python -m pytest -m 'not slow' -q
  ==== 223 passed, 5 skipped, 97 deselected, 7 xfailed, 2 warnings in 26.79s =====
  ```

- [x] `pre-commit run -a` clean (ruff, ruff format, pyright, etc. all green).