### PR TITLE
fix(testing): detach pytest live-logging handler around CliRunner tests

### DIFF
--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import logging
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -27,6 +29,34 @@ from pydantic import BaseModel
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 ENTRYPOINT_PATH = REPO_ROOT / "scripts" / "docker_entrypoint.py"
+
+
+@pytest.fixture(autouse=True)
+def _detach_pytest_live_logging_handler() -> Iterator[None]:
+    """Detach pytest's live-logging handler around each CliRunner-driven test.
+
+    Why: when ``log_cli=True`` (project default), pytest installs
+    ``_LiveLoggingStreamHandler`` on the root logger. Its ``emit()`` opens a
+    ``global_and_fixture_disabled`` ctx that suspends pytest's global capture,
+    which closes the captured stream that ``CliRunner.isolation()`` puts on
+    ``sys.stdout``/``stderr``. A ``logger.error(...)`` inside the click callback
+    under test then triggers ``CliRunner.invoke()``'s finally-block ``.getvalue()``
+    on a closed buffer → ``ValueError: I/O operation on closed file``. Tracked
+    in #730.
+    """
+    root = logging.getLogger()
+    detached = [
+        (i, h)
+        for i, h in enumerate(root.handlers)
+        if type(h).__name__ == "_LiveLoggingStreamHandler"
+    ]
+    for _, h in detached:
+        root.removeHandler(h)
+    try:
+        yield
+    finally:
+        for i, h in sorted(detached):
+            root.handlers.insert(i, h)
 
 
 def _load_entrypoint_module() -> ModuleType:


### PR DESCRIPTION
## Summary

Detach pytest's `_LiveLoggingStreamHandler` from the root logger around each test in `tests/test_docker_entrypoint.py` so `CliRunner.invoke()` no longer crashes with `ValueError: I/O operation on closed file` when a click callback under test calls `logger.error(...)`.

## Why this is the right fix

The handler's `emit()` opens a `global_and_fixture_disabled` context that suspends pytest's global capture, which closes the captured stream `CliRunner.isolation()` installs on `sys.stdout`/`stderr`. A `logger.error(...)` inside a click callback then makes `CliRunner.invoke()`'s `finally`-block `.getvalue()` raise on a closed buffer.

The bug is not click-version-specific — it reproduces with `click==8.1.8 + pytest==9.0.3` inside the Docker build (see [run 25184695371, job 73838810585](https://github.com/tinaudio/synth-setter/actions/runs/25184695371/job/73838810585)) and with `click==8.3.1` on local macOS. It does not reproduce on GitHub-hosted Ubuntu/macOS runners with the same pinned versions, so the trigger is environmental (likely capture-mode / xdist-worker interaction), but the cause is the live-logging handler in all cases.

The fixture detaches the handler before the test and reattaches it after. `caplog` and pytest's per-test "Captured log call" output use different handlers and are unaffected — log visibility on test failure is preserved.

Refs #730

## Test plan

- [x] Reproduce baseline failure on `main` (local, `click 8.3.1`):

  ```
  $ uvenv/bin/python -m pytest tests/test_docker_entrypoint.py -p no:xdist
  ...
  ========================= 7 failed, 11 passed in 0.52s =========================
  ```

- [x] Tests pass with the fixture applied — 18 passed, no `xfailed`/`failed`:

  ```
  $ uvenv/bin/python -m pytest tests/test_docker_entrypoint.py -p no:xdist
  ============================== 18 passed in 0.42s ==============================
  ```

- [x] Full non-slow suite — no regressions, count went 223 → 230 passed (the 7 previously-failing tests now pass):

  ```
  $ uvenv/bin/python -m pytest -m 'not slow' -q
  ========== 230 passed, 5 skipped, 97 deselected, 2 warnings in 26.21s ==========
  ```

- [ ] CI Docker job goes green for these 7 tests on this PR — was failing on main with `click==8.1.8` (run 25184695371). Will verify after CI runs.
- [ ] Ubuntu/macOS/Conda CI legs stay green (regression guard for the `_LiveLoggingStreamHandler` detachment). Will verify after CI runs.
- [x] `pre-commit run -a` clean (ruff, ruff format, pyright, etc.).