### PR TITLE
refactor(testing): scope live-logging detach fixture to the 7 failing tests

### DIFF
--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -31,9 +31,10 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 ENTRYPOINT_PATH = REPO_ROOT / "scripts" / "docker_entrypoint.py"
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def _detach_pytest_live_logging_handler() -> Iterator[None]:
-    """Detach pytest's live-logging handler around each CliRunner-driven test.
+    """Detach pytest's live-logging handler for tests that drive a CliRunner callback whose error
+    path calls ``logger.error(...)``.
 
     Why: when ``log_cli=True`` (project default), pytest installs
     ``_LiveLoggingStreamHandler`` on the root logger. Its ``emit()`` opens a
@@ -43,6 +44,10 @@ def _detach_pytest_live_logging_handler() -> Iterator[None]:
     under test then triggers ``CliRunner.invoke()``'s finally-block ``.getvalue()``
     on a closed buffer → ``ValueError: I/O operation on closed file``. Tracked
     in #730.
+
+    Opt-in via ``@pytest.mark.usefixtures("_detach_pytest_live_logging_handler")``
+    on tests that exercise that code path. Tests that don't drive ``logger.error``
+    inside ``CliRunner.invoke`` shouldn't pay the indirection cost.
     """
     root = logging.getLogger()
     detached = [
@@ -165,6 +170,7 @@ class TestIdle:
         assert result.exit_code == 0, result.output
         assert calls == [("sleep", ["sleep", "infinity"])]
 
+    @pytest.mark.usefixtures("_detach_pytest_live_logging_handler")
     def test_idle_exec_failure_becomes_click_exception(
         self, runner: CliRunner, entrypoint: ModuleType
     ) -> None:
@@ -227,6 +233,7 @@ class TestPassthrough:
         assert result.exit_code == 0, result.output
         assert calls == [("rclone", ["rclone", "--checksum", "src", "dst"])]
 
+    @pytest.mark.usefixtures("_detach_pytest_live_logging_handler")
     def test_passthrough_exec_failure_becomes_click_exception(
         self, runner: CliRunner, entrypoint: ModuleType
     ) -> None:
@@ -306,6 +313,7 @@ class TestGenerateDataset:
         result = runner.invoke(entrypoint.cli, ["generate_dataset", "--spec", str(missing)])
         assert result.exit_code == 2
 
+    @pytest.mark.usefixtures("_detach_pytest_live_logging_handler")
     def test_malformed_json_spec_exits_nonzero_without_calling_run(
         self, runner: CliRunner, entrypoint: ModuleType, tmp_path: Path
     ) -> None:
@@ -320,6 +328,7 @@ class TestGenerateDataset:
 
         assert result.exit_code != 0
 
+    @pytest.mark.usefixtures("_detach_pytest_live_logging_handler")
     def test_invalid_spec_shape_exits_nonzero_without_calling_run(
         self, runner: CliRunner, entrypoint: ModuleType, tmp_path: Path
     ) -> None:
@@ -334,6 +343,7 @@ class TestGenerateDataset:
 
         assert result.exit_code != 0
 
+    @pytest.mark.usefixtures("_detach_pytest_live_logging_handler")
     def test_binary_spec_file_exits_nonzero_without_calling_run(
         self, runner: CliRunner, entrypoint: ModuleType, tmp_path: Path
     ) -> None:
@@ -366,6 +376,7 @@ class TestGenerateDataset:
 class TestRenderEval:
     """render_eval subcommand is a deliberate placeholder pointing at #410."""
 
+    @pytest.mark.usefixtures("_detach_pytest_live_logging_handler")
     def test_render_eval_fails_loudly_with_issue_pointer(
         self, runner: CliRunner, entrypoint: ModuleType, tmp_path: Path
     ) -> None:
@@ -400,6 +411,7 @@ class TestRenderEval:
 class TestTrain:
     """Train subcommand is a deliberate placeholder pointing at #409."""
 
+    @pytest.mark.usefixtures("_detach_pytest_live_logging_handler")
     def test_train_fails_loudly_with_issue_pointer(
         self, runner: CliRunner, entrypoint: ModuleType, tmp_path: Path
     ) -> None:

--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import logging
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -27,6 +29,34 @@ from pydantic import BaseModel
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 ENTRYPOINT_PATH = REPO_ROOT / "scripts" / "docker_entrypoint.py"
+
+
+@pytest.fixture(autouse=True)
+def _detach_pytest_live_logging_handler() -> Iterator[None]:
+    """Detach pytest's live-logging handler around each CliRunner-driven test.
+
+    Why: when ``log_cli=True`` (project default), pytest installs
+    ``_LiveLoggingStreamHandler`` on the root logger. Its ``emit()`` opens a
+    ``global_and_fixture_disabled`` ctx that suspends pytest's global capture,
+    which closes the captured stream that ``CliRunner.isolation()`` puts on
+    ``sys.stdout``/``stderr``. A ``logger.error(...)`` inside the click callback
+    under test then triggers ``CliRunner.invoke()``'s finally-block ``.getvalue()``
+    on a closed buffer → ``ValueError: I/O operation on closed file``. Tracked
+    in #730.
+    """
+    root = logging.getLogger()
+    detached = [
+        (i, h)
+        for i, h in enumerate(root.handlers)
+        if type(h).__name__ == "_LiveLoggingStreamHandler"
+    ]
+    for _, h in detached:
+        root.removeHandler(h)
+    try:
+        yield
+    finally:
+        for i, h in sorted(detached):
+            root.handlers.insert(i, h)
 
 
 def _load_entrypoint_module() -> ModuleType:


### PR DESCRIPTION
## Summary

Follow-up to #732. Replace the autouse `_detach_pytest_live_logging_handler` fixture with an opt-in version, applied via `@pytest.mark.usefixtures(...)` only on the 7 error-path tests that actually exercise the broken code path (click callback whose error branch calls `logger.error(...)` while `CliRunner.invoke` is on the stack).

## Why

The 11 other tests in this file don't drive `logger.error` inside `CliRunner.invoke`, so they don't need the handler-detach indirection. Scoping the fixture makes the workaround surgical instead of file-wide.

Trade-off: any future test that adds a `logger.error` inside a `CliRunner.invoke` callback will hit the bug unless it opts in. Acceptable — failure mode is loud (`ValueError: I/O operation on closed file` with stack pointing here) and the docstring explains opt-in.

Refs #730 (kept open after #732 lands; the broader cause — pytest live-logging × click capture — still warrants an upstream fix).

## Test plan

- [x] Verify scoped fixture still cures the 7 failing tests on local (`click 8.3.1`):

  ```
  $ uvenv/bin/python -m pytest tests/test_docker_entrypoint.py -p no:xdist
  ============================== 18 passed in 0.34s ==============================
  ```

- [ ] CI Tests (Ubuntu/macOS/Conda) green — regression guard for removing autouse from the other 11 tests. Will verify after CI runs.
- [ ] Docker build job goes green for the 7 affected tests on this PR (workflow has to be dispatched manually since `tests/test_docker_entrypoint.py` isn't in `docker-build-validation.yml`'s pull_request paths). Will dispatch and verify after CI runs.