### PR TITLE
fix(scripts): drop exec from run-linux-vst-headless.sh's dbus-run-session call

### DIFF
--- a/scripts/run-linux-vst-headless.sh
+++ b/scripts/run-linux-vst-headless.sh
@@ -88,5 +88,13 @@ XSETTINGS_PID=$!
 openbox-session >"$TMP_DIR/openbox.log" 2>&1 &
 OPENBOX_PID=$!
 
-# Run the actual command inside a D-Bus session
-exec dbus-run-session -- "$@"
+# Run the actual command inside a D-Bus session.
+#
+# Do NOT use `exec` here. With `exec`, the wrapper bash is replaced by
+# dbus-run-session, the `trap cleanup EXIT` above never fires, and
+# Xvfb / xsettingsd / openbox keep running after the wrapped command
+# exits. On RunPod, SkyPilot's job-status reporter never sees the SSH
+# session's process tree go quiet — the job stays in RUNNING forever
+# even after the worker uploads its artifacts. Bisected via the
+# test-skypilot-debug matrix; see #735 for the full evidence.
+dbus-run-session -- "$@"


### PR DESCRIPTION
## Summary
- One-line behavioral fix to `scripts/run-linux-vst-headless.sh`: the
  wrapper used `exec dbus-run-session ...` which replaces the bash
  process and prevents the `trap cleanup EXIT` from firing. X-stack
  daemons leaked, blocking SkyPilot's job-status reporter on RunPod.
- Diagnosis bisected via the `test-skypilot-debug` workflow on PR #716.

## Test plan
- [ ] CI passes (no test changes; this is a tiny shell behavioral fix).
- [ ] After merge, `test-dataset-generation.yaml` end-to-end succeeds
      (worker uploads spec + shard, SkyPilot registers SUCCEEDED, cluster
      tears down) — currently being validated on PR #716.

Fixes #735
