### PR TITLE
build(devcontainer): add common-utils feature to CPU + GPU devcontainers

### DIFF
--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -7,6 +7,9 @@
       "--platform=linux/amd64"
     ]
   },
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {}
+  },
   "initializeCommand": "bash .devcontainer/initialize.sh",
   "runArgs": [
     "--env-file",

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -7,6 +7,9 @@
       "--platform=linux/amd64"
     ]
   },
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {}
+  },
   "initializeCommand": "bash .devcontainer/initialize.sh",
   "runArgs": [
     "--gpus",


### PR DESCRIPTION
## Summary

- Adds the [`common-utils`](https://github.com/devcontainers/features/tree/main/src/common-utils) devcontainer feature to both `.devcontainer/cpu/devcontainer.json` and `.devcontainer/gpu/devcontainer.json`:
  ```json
  {
    "features": {
      "ghcr.io/devcontainers/features/common-utils:2": {}
    }
  }
  ```

Closes #737

## Verification

Full evidence: see the [verification results comment](https://github.com/tinaudio/synth-setter/pull/738#issuecomment-4361071430).

- [x] OCI registry resolves `ghcr.io/devcontainers/features/common-utils:2` (Level 4 — manifest fetched, common-utils v2.5.7, digest `sha256:dbf431d…`).
- [x] CPU devcontainer config parses and feature dependency graph resolves under `@devcontainers/cli` 0.86.0 (Level 2).
- [x] GPU devcontainer config parses and feature dependency graph resolves under `@devcontainers/cli` 0.86.0 (Level 2). GPU `runArgs` preserved.
- [ ] Full `devcontainer build` of CPU and GPU images (Level 1 — SKIP: requires the private `tinaudio/synth-setter:devcontainer-tools` base image and a populated `.env` with R2/RunPod credentials; reproduction commands in the comment).
- [ ] Confirm `username: automatic` from common-utils does not collide with the existing `dev` user from `docker/ubuntu22_04/Dockerfile:412` (Level 1 adversarial — SKIP, blocked on the same prerequisite; mitigation snippet in the comment if a collision is observed).
