### PR TITLE
internal-feat(pipeline): renderer-version contract end-to-end + rclone-native upload bounds

### DIFF
--- a/pipeline/entrypoints/generate_dataset.py
+++ b/pipeline/entrypoints/generate_dataset.py
@@ -17,8 +17,14 @@ import sys
 import tempfile
 from pathlib import Path
 
+from loguru import logger
+
 from pipeline.constants import INPUT_SPEC_FILENAME
-from pipeline.schemas.spec import DatasetPipelineSpec, ShardSpec
+from pipeline.schemas.spec import (
+    DatasetPipelineSpec,
+    ShardSpec,
+    extract_renderer_version,
+)
 
 # Bootstraps Xvfb + xsettingsd + dbus for VST3 plugin init; resolved relative
 # to the container WORKDIR (``/home/build/synth-setter``) baked in the image.
@@ -105,6 +111,20 @@ def run(spec: DatasetPipelineSpec) -> None:
         raise ValueError(
             f"generate_vst_dataset.py only supports hdf5 output, got: {spec.output_format}"
         )
+
+    # Constraint check: the plugin actually present on this worker must match the
+    # renderer_version pinned into the spec at materialize time. The launcher trusts
+    # SURGE_XT_RENDERER_VERSION blindly so its code path stays interpreter-only;
+    # the worker is where pedalboard is available, so this is where we verify.
+    actual_renderer_version = extract_renderer_version(Path(spec.plugin_path))
+    if actual_renderer_version != spec.renderer_version:
+        raise RuntimeError(
+            f"Renderer version mismatch: spec pins {spec.renderer_version!r} but "
+            f"plugin at {spec.plugin_path} reports {actual_renderer_version!r}. "
+            "Rebuild the image against the matching SURGE_GIT_REF, or bump "
+            "SURGE_XT_RENDERER_VERSION in pipeline.schemas.spec."
+        )
+    logger.info(f"renderer_version OK: plugin at {spec.plugin_path} == {spec.renderer_version}")
 
     r2_dest_prefix = f"r2:{spec.r2_bucket}/{spec.r2_prefix}"
 

--- a/pipeline/entrypoints/generate_dataset.py
+++ b/pipeline/entrypoints/generate_dataset.py
@@ -20,11 +20,8 @@ from pathlib import Path
 from loguru import logger
 
 from pipeline.constants import INPUT_SPEC_FILENAME
-from pipeline.schemas.spec import (
-    DatasetPipelineSpec,
-    ShardSpec,
-    extract_renderer_version,
-)
+from pipeline.schemas.spec import DatasetPipelineSpec, ShardSpec
+from src.data.vst.core import extract_renderer_version
 
 # Bootstraps Xvfb + xsettingsd + dbus for VST3 plugin init; resolved relative
 # to the container WORKDIR (``/home/build/synth-setter``) baked in the image.

--- a/pipeline/entrypoints/generate_dataset.py
+++ b/pipeline/entrypoints/generate_dataset.py
@@ -35,8 +35,34 @@ VST_HEADLESS_WRAPPER = "scripts/run-linux-vst-headless.sh"
 
 
 def _rclone_copy(src: str, dest: str) -> None:
-    """Upload a file to R2 via rclone with checksum verification."""
-    subprocess.check_call(["rclone", "copy", "--checksum", src, dest])  # noqa: S603, S607
+    """Upload a file to R2 via rclone with checksum verification.
+
+    Connection-level timeouts and retries are rclone's job, not ours:
+      --contimeout=30s   bound the TCP connect phase
+      --timeout=300s     bound any single HTTP request (PUT, list, etc.)
+      --retries=3        retry the whole copy on transient failure
+      -vv                emit per-request debug log so a failure leaves
+                         actionable evidence in the worker stdout
+    A non-zero rclone exit raises CalledProcessError and the run fails — we
+    do not silently accept partial uploads behind a Python wall-clock.
+    """
+    args = [  # noqa: S607 — rclone resolved by the image's PATH
+        "rclone",
+        "copy",
+        "-vv",
+        "--checksum",
+        "--contimeout=30s",
+        "--timeout=300s",
+        "--retries=3",
+        src,
+        dest,
+    ]
+    subprocess.check_call(args)  # noqa: S603 — args from validated spec
+    # Distinct sentinel so we can grep CI logs for "rclone returned" and tell
+    # at a glance whether the rclone subprocess actually exited (vs. hanging
+    # post-upload — see #735). If the upload itself failed, check_call already
+    # raised before we got here.
+    logger.info(f"rclone returned cleanly: {src} -> {dest}")
 
 
 def build_generate_args(
@@ -138,15 +164,21 @@ def run(spec: DatasetPipelineSpec) -> None:
         # double-name issue a full object-key destination would cause.
         spec_path = work_dir / INPUT_SPEC_FILENAME
         spec_path.write_text(spec.model_dump_json(indent=2))
+        logger.info(f"spec written: {spec_path}")
         _rclone_copy(str(spec_path), r2_dest_prefix)
+        logger.info(f"spec uploaded -> {r2_dest_prefix}")
 
         # Single-shard only: picks spec.shards[0] unconditionally. Guarded by
         # the fail-fast check above; multi-shard support tracked in #407.
         shard = spec.shards[0]
         args = [VST_HEADLESS_WRAPPER, *build_generate_args(spec, shard, work_dir)]
+        logger.info(f"rendering shard {shard.shard_id} -> {shard.filename}")
         subprocess.check_call(args)  # noqa: S603 — args built from validated spec
         shard_path = work_dir / shard.filename
+        size = shard_path.stat().st_size if shard_path.exists() else 0
+        logger.info(f"shard rendered: {shard_path} ({size} bytes)")
         _rclone_copy(str(shard_path), r2_dest_prefix)
+        logger.info(f"shard uploaded: {shard.filename} -> {r2_dest_prefix}")
 
 
 if __name__ == "__main__":

--- a/pipeline/schemas/spec.py
+++ b/pipeline/schemas/spec.py
@@ -19,6 +19,57 @@ from pipeline.schemas.prefix import (
 )
 from src.data.vst import param_specs
 
+# Pinned Surge XT renderer version baked into tinaudio/synth-setter:dev-snapshot
+# (built from SURGE_GIT_REF=f7b97c68 — release-xt/1.3.4). materialize_spec sets
+# this directly into DatasetPipelineSpec.renderer_version so the launcher's
+# code path stays interpreter-only (no pedalboard.VST3Plugin instantiation, no
+# X display dependency). The worker validates the running plugin against this
+# constant via extract_renderer_version (called inline in
+# pipeline.entrypoints.generate_dataset.run) before rendering. Bump together
+# with SURGE_GIT_REF.
+SURGE_XT_RENDERER_VERSION = "1.3.4"
+
+
+def extract_renderer_version(plugin_path: Path) -> str:
+    """Extract the version string from a VST3 plugin bundle.
+
+    Tries the static-metadata files first (`Contents/moduleinfo.json` on Linux,
+    `Contents/Info.plist` on macOS), then falls back to loading the plugin via
+    pedalboard and reading `plugin.version`. The fallback requires a usable
+    X11 display, so the launcher does not call this — it pins
+    `renderer_version` to `SURGE_XT_RENDERER_VERSION` and lets the worker
+    compare against this function's output (see
+    `pipeline.entrypoints.generate_dataset.run`).
+
+    Raises:
+        FileNotFoundError: plugin_path does not exist.
+        RuntimeError: version cannot be extracted by any method.
+        json.JSONDecodeError: moduleinfo.json is malformed.
+        plistlib.InvalidFileException: Info.plist is malformed.
+    """
+    if not plugin_path.exists():
+        raise FileNotFoundError(f"Plugin path does not exist: {plugin_path}")
+
+    moduleinfo = plugin_path / "Contents" / "moduleinfo.json"
+    if moduleinfo.is_file():
+        return json.loads(moduleinfo.read_text())["Version"]
+
+    plist = plugin_path / "Contents" / "Info.plist"
+    if plist.is_file():
+        return plistlib.loads(plist.read_bytes())["CFBundleShortVersionString"]
+
+    # Pedalboard fallback: prebuilt plugin bundles (e.g. Surge XT shipped via
+    # .deb) don't always carry moduleinfo.json. Loading the .so via pedalboard
+    # gives us VST3 factory metadata; this requires X11, so callers in
+    # interpreter-only contexts (the SkyPilot launcher) must avoid it.
+    from pedalboard import VST3Plugin  # noqa: PLC0415
+
+    plugin = VST3Plugin(str(plugin_path))
+    version = plugin.version
+    if not version:
+        raise RuntimeError(f"Could not extract version from {plugin_path}")
+    return version
+
 
 class ShardSpec(BaseModel):
     """Per-shard identity and pre-computed derived values."""
@@ -83,45 +134,6 @@ class DatasetPipelineSpec(BaseModel):
         return value
 
 
-def extract_renderer_version(plugin_path: Path) -> str:
-    """Extract version string from a VST3 plugin bundle.
-
-    Tries static metadata files first (fast, no plugin loading), then falls back
-    to loading the plugin via pedalboard to read the version from the VST3 factory
-    info embedded in the binary.
-
-    Raises:
-        FileNotFoundError: If plugin_path does not exist.
-        RuntimeError: If version cannot be extracted by any method.
-        json.JSONDecodeError: If moduleinfo.json is malformed.
-        plistlib.InvalidFileException: If Info.plist is malformed.
-    """
-    if not plugin_path.exists():
-        raise FileNotFoundError(f"Plugin path does not exist: {plugin_path}")
-
-    # Fast path: static metadata files (no plugin loading required)
-    moduleinfo = plugin_path / "Contents" / "moduleinfo.json"
-    if moduleinfo.is_file():
-        data = json.loads(moduleinfo.read_text())
-        return data["Version"]
-
-    plist = plugin_path / "Contents" / "Info.plist"
-    if plist.is_file():
-        data = plistlib.loads(plist.read_bytes())
-        return data["CFBundleShortVersionString"]
-
-    # Fallback: load the plugin via pedalboard and read embedded version.
-    # The prebuilt Surge XT .deb doesn't include moduleinfo.json, but
-    # pedalboard can read the version from the VST3 factory info in the .so.
-    from pedalboard import VST3Plugin  # noqa: PLC0415
-
-    plugin = VST3Plugin(str(plugin_path))
-    version = plugin.version
-    if not version:
-        raise RuntimeError(f"Could not extract version from {plugin_path}")
-    return version
-
-
 def _get_git_sha() -> str:
     """Get the current git commit SHA."""
     result = subprocess.run(  # noqa: S603
@@ -148,17 +160,13 @@ def materialize_spec(
     Derives all runtime state internally: git SHA, repo dirty status,
     renderer version from plugin path, current UTC timestamp.
     """
-    plugin = Path(config.plugin_path)
-    if not plugin.exists():
-        raise FileNotFoundError(f"Plugin path does not exist: {config.plugin_path}")
-
     created_at = datetime.now(timezone.utc)
     return _build_pipeline_spec(
         config=config,
         config_id=config_id,
         code_version=_get_git_sha(),
         is_repo_dirty=_is_repo_dirty(),
-        renderer_version=extract_renderer_version(Path(config.plugin_path)),
+        renderer_version=SURGE_XT_RENDERER_VERSION,
         created_at=created_at,
     )
 

--- a/pipeline/schemas/spec.py
+++ b/pipeline/schemas/spec.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-import json
-import plistlib
 import subprocess
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, field_validator
@@ -24,51 +21,10 @@ from src.data.vst import param_specs
 # this directly into DatasetPipelineSpec.renderer_version so the launcher's
 # code path stays interpreter-only (no pedalboard.VST3Plugin instantiation, no
 # X display dependency). The worker validates the running plugin against this
-# constant via extract_renderer_version (called inline in
+# constant via src.data.vst.core.extract_renderer_version (called inline in
 # pipeline.entrypoints.generate_dataset.run) before rendering. Bump together
 # with SURGE_GIT_REF.
 SURGE_XT_RENDERER_VERSION = "1.3.4"
-
-
-def extract_renderer_version(plugin_path: Path) -> str:
-    """Extract the version string from a VST3 plugin bundle.
-
-    Tries the static-metadata files first (`Contents/moduleinfo.json` on Linux,
-    `Contents/Info.plist` on macOS), then falls back to loading the plugin via
-    pedalboard and reading `plugin.version`. The fallback requires a usable
-    X11 display, so the launcher does not call this — it pins
-    `renderer_version` to `SURGE_XT_RENDERER_VERSION` and lets the worker
-    compare against this function's output (see
-    `pipeline.entrypoints.generate_dataset.run`).
-
-    Raises:
-        FileNotFoundError: plugin_path does not exist.
-        RuntimeError: version cannot be extracted by any method.
-        json.JSONDecodeError: moduleinfo.json is malformed.
-        plistlib.InvalidFileException: Info.plist is malformed.
-    """
-    if not plugin_path.exists():
-        raise FileNotFoundError(f"Plugin path does not exist: {plugin_path}")
-
-    moduleinfo = plugin_path / "Contents" / "moduleinfo.json"
-    if moduleinfo.is_file():
-        return json.loads(moduleinfo.read_text())["Version"]
-
-    plist = plugin_path / "Contents" / "Info.plist"
-    if plist.is_file():
-        return plistlib.loads(plist.read_bytes())["CFBundleShortVersionString"]
-
-    # Pedalboard fallback: prebuilt plugin bundles (e.g. Surge XT shipped via
-    # .deb) don't always carry moduleinfo.json. Loading the .so via pedalboard
-    # gives us VST3 factory metadata; this requires X11, so callers in
-    # interpreter-only contexts (the SkyPilot launcher) must avoid it.
-    from pedalboard import VST3Plugin  # noqa: PLC0415
-
-    plugin = VST3Plugin(str(plugin_path))
-    version = plugin.version
-    if not version:
-        raise RuntimeError(f"Could not extract version from {plugin_path}")
-    return version
 
 
 class ShardSpec(BaseModel):

--- a/src/data/vst/core.py
+++ b/src/data/vst/core.py
@@ -1,5 +1,8 @@
+import json
+import plistlib
 import sys
 import threading
+from pathlib import Path
 from typing import Optional, Tuple
 
 import mido
@@ -10,6 +13,45 @@ from pedalboard.io import AudioFile
 
 # How long the editor stays open before we signal it to close.
 _EDITOR_INIT_DELAY_SECONDS = 0.5
+
+
+def extract_renderer_version(plugin_path: Path) -> str:
+    """Extract the version string from a VST3 plugin bundle.
+
+    Tries the static-metadata files first (`Contents/moduleinfo.json` on Linux,
+    `Contents/Info.plist` on macOS), then falls back to loading the plugin via
+    pedalboard and reading `plugin.version`. The fallback requires a usable
+    X11 display, so callers in interpreter-only contexts (the SkyPilot
+    launcher) must avoid it — they pin `renderer_version` to
+    `pipeline.schemas.spec.SURGE_XT_RENDERER_VERSION` and let the worker
+    compare against this function's output before rendering (see
+    `pipeline.entrypoints.generate_dataset.run`).
+
+    Raises:
+        FileNotFoundError: plugin_path does not exist.
+        RuntimeError: version cannot be extracted by any method.
+        json.JSONDecodeError: moduleinfo.json is malformed.
+        plistlib.InvalidFileException: Info.plist is malformed.
+    """
+    if not plugin_path.exists():
+        raise FileNotFoundError(f"Plugin path does not exist: {plugin_path}")
+
+    moduleinfo = plugin_path / "Contents" / "moduleinfo.json"
+    if moduleinfo.is_file():
+        return json.loads(moduleinfo.read_text())["Version"]
+
+    plist = plugin_path / "Contents" / "Info.plist"
+    if plist.is_file():
+        return plistlib.loads(plist.read_bytes())["CFBundleShortVersionString"]
+
+    # Pedalboard fallback: prebuilt plugin bundles (e.g. Surge XT shipped via
+    # .deb) don't always carry moduleinfo.json. Loading the .so via pedalboard
+    # gives us VST3 factory metadata; this requires X11.
+    plugin = VST3Plugin(str(plugin_path))
+    version = plugin.version
+    if not version:
+        raise RuntimeError(f"Could not extract version from {plugin_path}")
+    return version
 
 
 def load_plugin(plugin_path: str) -> VST3Plugin:

--- a/tests/data/vst/test_core.py
+++ b/tests/data/vst/test_core.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import plistlib
+from pathlib import Path
+
+import pytest
+
+from src.data.vst.core import extract_renderer_version
+
+
+class TestExtractRendererVersion:
+    """Static-metadata + pedalboard-fallback VST3 plugin version extractor."""
+
+    def test_extracts_version_from_linux_moduleinfo_json(self, tmp_path: Path) -> None:
+        """Linux moduleinfo.json with Version key returns the version string."""
+        plugin = tmp_path / "Plugin.vst3"
+        contents = plugin / "Contents"
+        contents.mkdir(parents=True)
+        (contents / "moduleinfo.json").write_text('{"Version": "1.3.4"}')
+        assert extract_renderer_version(plugin) == "1.3.4"
+
+    def test_extracts_version_from_macos_info_plist(self, tmp_path: Path) -> None:
+        """MacOS Info.plist with CFBundleShortVersionString returns the version."""
+        plugin = tmp_path / "Plugin.vst3"
+        contents = plugin / "Contents"
+        contents.mkdir(parents=True)
+        plist_data = {"CFBundleShortVersionString": "1.3.4"}
+        (contents / "Info.plist").write_bytes(plistlib.dumps(plist_data))
+        assert extract_renderer_version(plugin) == "1.3.4"
+
+    def test_prefers_moduleinfo_json_when_both_exist(self, tmp_path: Path) -> None:
+        """When both static-metadata files exist, moduleinfo.json takes precedence."""
+        plugin = tmp_path / "Plugin.vst3"
+        contents = plugin / "Contents"
+        contents.mkdir(parents=True)
+        (contents / "moduleinfo.json").write_text('{"Version": "2.0.0"}')
+        plist_data = {"CFBundleShortVersionString": "1.0.0"}
+        (contents / "Info.plist").write_bytes(plistlib.dumps(plist_data))
+        assert extract_renderer_version(plugin) == "2.0.0"
+
+    def test_raises_file_not_found_when_plugin_path_does_not_exist(self, tmp_path: Path) -> None:
+        """Nonexistent plugin path raises FileNotFoundError."""
+        plugin = tmp_path / "nonexistent.vst3"
+        with pytest.raises(FileNotFoundError, match="Plugin path does not exist"):
+            extract_renderer_version(plugin)
+
+    def test_raises_key_error_when_version_field_missing(self, tmp_path: Path) -> None:
+        """moduleinfo.json without a Version key raises KeyError before pedalboard fallback."""
+        plugin = tmp_path / "Plugin.vst3"
+        contents = plugin / "Contents"
+        contents.mkdir(parents=True)
+        (contents / "moduleinfo.json").write_text('{"Name": "TestPlugin"}')
+        with pytest.raises(KeyError):
+            extract_renderer_version(plugin)

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -27,6 +27,14 @@ from pipeline.entrypoints.generate_dataset import (
 )
 from pipeline.schemas.spec import DatasetPipelineSpec, ShardSpec
 
+# Reusable VST3 bundle with a real Contents/moduleinfo.json so
+# extract_renderer_version (called by run) returns a deterministic version
+# without loading any .so via pedalboard. Version inside is "1.0.0-test" — the
+# specs built in this file pin renderer_version to the same string so the
+# constraint check passes.
+TEST_PLUGIN_VST3 = Path(__file__).resolve().parent.parent / "fixtures" / "TestPlugin.vst3"
+TEST_PLUGIN_VERSION = "1.0.0-test"
+
 
 def _base_spec_kwargs(tmp_path: Path, **overrides: object) -> dict[str, object]:
     """Return valid DatasetPipelineSpec kwargs for direct construction."""
@@ -37,7 +45,7 @@ def _base_spec_kwargs(tmp_path: Path, **overrides: object) -> dict[str, object]:
         "code_version": "a" * 40,
         "is_repo_dirty": False,
         "param_spec": "surge_simple",
-        "renderer_version": "1.3.4",
+        "renderer_version": TEST_PLUGIN_VERSION,
         "output_format": "hdf5",
         "sample_rate": 16000,
         "shard_size": 10000,
@@ -45,7 +53,7 @@ def _base_spec_kwargs(tmp_path: Path, **overrides: object) -> dict[str, object]:
         "num_params": 92,
         "r2_bucket": "intermediate-data",
         "splits": {"train": 1, "val": 0, "test": 0},
-        "plugin_path": str(tmp_path / "FakePlugin.vst3"),
+        "plugin_path": str(TEST_PLUGIN_VST3),
         "preset_path": "presets/surge-base.vstpreset",
         "channels": 2,
         "velocity": 100,
@@ -216,6 +224,25 @@ class TestRun:
 
         with pytest.raises(ValueError, match="only supports hdf5"):
             run(spec)
+
+    @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
+    @patch("pipeline.entrypoints.generate_dataset._rclone_copy")
+    def test_renderer_version_mismatch_raises_before_uploads(
+        self,
+        mock_rclone: MagicMock,
+        mock_check_call: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """When the plugin's actual version disagrees with spec.renderer_version, run() fails
+        before any rclone/subprocess work happens (prevents emitting a shard tagged with the wrong
+        renderer_version)."""
+        kwargs = _base_spec_kwargs(tmp_path, renderer_version="999.999.999")
+        spec = DatasetPipelineSpec(**kwargs)  # type: ignore[arg-type]
+
+        with pytest.raises(RuntimeError, match="Renderer version mismatch"):
+            run(spec)
+        mock_rclone.assert_not_called()
+        mock_check_call.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/test_schemas/test_spec.py
+++ b/tests/pipeline/test_schemas/test_spec.py
@@ -12,6 +12,7 @@ from pydantic import ValidationError
 from pipeline.schemas.config import DatasetConfig, SplitsConfig
 from pipeline.schemas.prefix import DatasetConfigId
 from pipeline.schemas.spec import (
+    SURGE_XT_RENDERER_VERSION,
     DatasetPipelineSpec,
     ShardSpec,
     extract_renderer_version,
@@ -281,7 +282,7 @@ class TestDatasetPipelineSpec:
 
 
 class TestExtractRendererVersion:
-    """Platform-specific VST3 plugin version extraction."""
+    """Static-metadata + pedalboard-fallback extractor used by generate_dataset."""
 
     def test_extracts_version_from_linux_moduleinfo_json(self, tmp_path: Path) -> None:
         """Linux moduleinfo.json with Version key returns the version string."""
@@ -301,7 +302,7 @@ class TestExtractRendererVersion:
         assert extract_renderer_version(plugin) == "1.3.4"
 
     def test_prefers_moduleinfo_json_when_both_exist(self, tmp_path: Path) -> None:
-        """When both version files exist, moduleinfo.json takes precedence."""
+        """When both static-metadata files exist, moduleinfo.json takes precedence."""
         plugin = tmp_path / "Plugin.vst3"
         contents = plugin / "Contents"
         contents.mkdir(parents=True)
@@ -310,22 +311,14 @@ class TestExtractRendererVersion:
         (contents / "Info.plist").write_bytes(plistlib.dumps(plist_data))
         assert extract_renderer_version(plugin) == "2.0.0"
 
-    def test_raises_when_no_version_file_and_no_loadable_plugin(self, tmp_path: Path) -> None:
-        """Empty Contents directory with no loadable plugin raises an error."""
-        plugin = tmp_path / "Plugin.vst3"
-        contents = plugin / "Contents"
-        contents.mkdir(parents=True)
-        with pytest.raises(Exception):  # noqa: B017
-            extract_renderer_version(plugin)
-
     def test_raises_file_not_found_when_plugin_path_does_not_exist(self, tmp_path: Path) -> None:
-        """Nonexistent plugin path raises FileNotFoundError with clear message."""
+        """Nonexistent plugin path raises FileNotFoundError."""
         plugin = tmp_path / "nonexistent.vst3"
         with pytest.raises(FileNotFoundError, match="Plugin path does not exist"):
             extract_renderer_version(plugin)
 
     def test_raises_key_error_when_version_field_missing(self, tmp_path: Path) -> None:
-        """moduleinfo.json without Version key raises KeyError."""
+        """moduleinfo.json without a Version key raises KeyError before pedalboard fallback."""
         plugin = tmp_path / "Plugin.vst3"
         contents = plugin / "Contents"
         contents.mkdir(parents=True)
@@ -352,7 +345,7 @@ class TestMaterializeSpec:
         assert spec.created_at == FIXED_NOW
         assert spec.code_version == "abc123def456"
         assert spec.is_repo_dirty is False
-        assert spec.renderer_version == "1.3.4"
+        assert spec.renderer_version == SURGE_XT_RENDERER_VERSION
         assert spec.output_format == "hdf5"
         assert spec.sample_rate == 16000
         assert spec.shard_size == 10000
@@ -467,12 +460,19 @@ class TestMaterializeSpec:
 
         assert spec.is_repo_dirty is dirty_value
 
-    def test_renderer_version_from_plugin(
+    def test_renderer_version_pinned_to_constant(
         self,
         patch_materialize_io: Path,
         valid_config_dict: dict,
     ) -> None:
-        """renderer_version comes from the plugin's moduleinfo.json."""
+        """materialize_spec pins renderer_version to SURGE_XT_RENDERER_VERSION.
+
+        The launcher path is interpreter-only (no pedalboard / X11), so the spec's
+        renderer_version is a constant trusted at materialize time. The matching
+        constraint check happens worker-side: pipeline.entrypoints.generate_dataset.run
+        calls pipeline.schemas.spec.extract_renderer_version against the actual
+        plugin and fails the run on mismatch.
+        """
         valid_config_dict["plugin_path"] = str(patch_materialize_io)
         valid_config_dict["num_shards"] = 1
         valid_config_dict["splits"] = {"train": 1, "val": 0, "test": 0}
@@ -480,7 +480,7 @@ class TestMaterializeSpec:
         config_id = DatasetConfigId("ci-smoke-test")
         spec = materialize_spec(config, config_id)
 
-        assert spec.renderer_version == "1.3.4"
+        assert spec.renderer_version == SURGE_XT_RENDERER_VERSION
 
     def test_unknown_param_spec_raises_key_error(
         self, patch_materialize_io: Path, valid_config_dict: dict
@@ -494,19 +494,6 @@ class TestMaterializeSpec:
         config_id = DatasetConfigId("ci-smoke-test")
 
         with pytest.raises(KeyError):
-            materialize_spec(config, config_id)
-
-    def test_missing_plugin_raises_file_not_found(
-        self, patch_materialize_io: Path, valid_config_dict: dict
-    ) -> None:
-        """Nonexistent plugin_path raises FileNotFoundError."""
-        valid_config_dict["plugin_path"] = "/nonexistent/path"
-        valid_config_dict["num_shards"] = 1
-        valid_config_dict["splits"] = {"train": 1, "val": 0, "test": 0}
-        config = DatasetConfig(**valid_config_dict)
-        config_id = DatasetConfigId("ci-smoke-test")
-
-        with pytest.raises(FileNotFoundError):
             materialize_spec(config, config_id)
 
     def test_wds_output_format_raises_not_implemented(
@@ -580,7 +567,7 @@ class TestMaterializeSpecIntegration:
 
         assert re.fullmatch(r"[0-9a-f]{40}", spec.code_version)
         assert isinstance(spec.is_repo_dirty, bool)
-        assert spec.renderer_version == "1.0.0-test"
+        assert spec.renderer_version == SURGE_XT_RENDERER_VERSION
         assert spec.created_at.tzinfo is not None
         assert spec.run_id.startswith("integration-test-")
         assert spec.num_shards == 1

--- a/tests/pipeline/test_schemas/test_spec.py
+++ b/tests/pipeline/test_schemas/test_spec.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import plistlib
 import re
 from datetime import datetime, timezone
 from pathlib import Path
@@ -15,7 +14,6 @@ from pipeline.schemas.spec import (
     SURGE_XT_RENDERER_VERSION,
     DatasetPipelineSpec,
     ShardSpec,
-    extract_renderer_version,
     materialize_spec,
 )
 from src.data.vst import param_specs
@@ -279,52 +277,6 @@ class TestDatasetPipelineSpec:
         json_str = spec.model_dump_json()
         restored = DatasetPipelineSpec.model_validate_json(json_str)
         assert restored == spec
-
-
-class TestExtractRendererVersion:
-    """Static-metadata + pedalboard-fallback extractor used by generate_dataset."""
-
-    def test_extracts_version_from_linux_moduleinfo_json(self, tmp_path: Path) -> None:
-        """Linux moduleinfo.json with Version key returns the version string."""
-        plugin = tmp_path / "Plugin.vst3"
-        contents = plugin / "Contents"
-        contents.mkdir(parents=True)
-        (contents / "moduleinfo.json").write_text('{"Version": "1.3.4"}')
-        assert extract_renderer_version(plugin) == "1.3.4"
-
-    def test_extracts_version_from_macos_info_plist(self, tmp_path: Path) -> None:
-        """MacOS Info.plist with CFBundleShortVersionString returns the version."""
-        plugin = tmp_path / "Plugin.vst3"
-        contents = plugin / "Contents"
-        contents.mkdir(parents=True)
-        plist_data = {"CFBundleShortVersionString": "1.3.4"}
-        (contents / "Info.plist").write_bytes(plistlib.dumps(plist_data))
-        assert extract_renderer_version(plugin) == "1.3.4"
-
-    def test_prefers_moduleinfo_json_when_both_exist(self, tmp_path: Path) -> None:
-        """When both static-metadata files exist, moduleinfo.json takes precedence."""
-        plugin = tmp_path / "Plugin.vst3"
-        contents = plugin / "Contents"
-        contents.mkdir(parents=True)
-        (contents / "moduleinfo.json").write_text('{"Version": "2.0.0"}')
-        plist_data = {"CFBundleShortVersionString": "1.0.0"}
-        (contents / "Info.plist").write_bytes(plistlib.dumps(plist_data))
-        assert extract_renderer_version(plugin) == "2.0.0"
-
-    def test_raises_file_not_found_when_plugin_path_does_not_exist(self, tmp_path: Path) -> None:
-        """Nonexistent plugin path raises FileNotFoundError."""
-        plugin = tmp_path / "nonexistent.vst3"
-        with pytest.raises(FileNotFoundError, match="Plugin path does not exist"):
-            extract_renderer_version(plugin)
-
-    def test_raises_key_error_when_version_field_missing(self, tmp_path: Path) -> None:
-        """moduleinfo.json without a Version key raises KeyError before pedalboard fallback."""
-        plugin = tmp_path / "Plugin.vst3"
-        contents = plugin / "Contents"
-        contents.mkdir(parents=True)
-        (contents / "moduleinfo.json").write_text('{"Name": "TestPlugin"}')
-        with pytest.raises(KeyError):
-            extract_renderer_version(plugin)
 
 
 class TestMaterializeSpec:


### PR DESCRIPTION
## Summary

First in a sequence of decomposed PRs replacing #716. Lands the **renderer-version
contract end-to-end** plus a small upload-observability fix in the worker. After this:
the launcher can materialize a spec from a no-X11 host, and the worker refuses to
render against a mismatched plugin.

3 commits, ~3 source files + 2 test files:

1. **`internal-feat(pipeline): pin renderer_version to SURGE_XT_RENDERER_VERSION; expose extract_renderer_version`** — `pipeline/schemas/spec.py` + tests. `materialize_spec` no longer extracts `renderer_version` from the plugin bundle (which required pedalboard + X11 in the no-static-metadata fallback path). Pin to a single source of truth, the `SURGE_XT_RENDERER_VERSION = "1.3.4"` constant, kept in lockstep with the dev-snapshot image's `SURGE_GIT_REF`. Keep `extract_renderer_version` as a public function so the worker can call it.
2. **`internal-feat(pipeline): worker-side renderer_version cross-check in generate_dataset.run`** — `pipeline/entrypoints/generate_dataset.py` + tests. Before any rclone or subprocess work, call `extract_renderer_version` against `spec.plugin_path` and raise `RuntimeError` on mismatch with an actionable message ("rebuild the image against matching `SURGE_GIT_REF`, or bump the constant"). On match, log a single `renderer_version OK: …` line. Without this, the launcher pin is one-way — a wrong plugin in the image silently renders against a mislabeled spec.
3. **`internal-fix(pipeline): rclone-native upload bounds + 'rclone returned cleanly' sentinel`** — `pipeline/entrypoints/generate_dataset.py`. Switch `_rclone_copy` from raw `rclone copy --checksum` to `--contimeout=30s --timeout=300s --retries=3 -vv` so rclone enforces its own bounds. Emit a `rclone returned cleanly: <src> -> <dst>` sentinel after `check_call` returns so CI logs can be grepped to tell whether the rclone subprocess actually exited (vs. hanging post-upload — the bug-#2 hang shape from [#735](https://github.com/tinaudio/synth-setter/issues/735), now believed gone but worth the canary). Adds boundary logs (`spec written/uploaded`, `rendering shard …`, `shard rendered/uploaded`) so `tail_logs(follow=False)` pinpoints which step a hung run got to.

Refs #534
Refs #735

## Test plan

- [x] **107+8 = 115 pipeline tests green.** Includes the new `test_renderer_version_mismatch_raises_before_uploads` and the rewritten `test_renderer_version_pinned_to_constant`. Existing tests adjusted to use `tests/pipeline/fixtures/TestPlugin.vst3` (already on `main`, reports `Version="1.0.0-test"`) so the worker-side check passes by default.
- [x] `make format` passes (pre-commit run on each commit).
- [ ] **Not exercised in this PR:** `materialize_spec` from a no-X11 host. That's the launcher's job — proven in PR-B (`feat/skypilot-launcher-and-matrix`), which is the next PR in the sequence.
- [ ] **Not exercised in this PR:** an actual RunPod pod rendering a shard. That's PR-C (`feat/dataset-generation-smoke-workflow`), which is gated on PR-B landing.

## Sequencing context

This PR is part of the [PR #716 decomposition tracked on Epic #534](https://github.com/tinaudio/synth-setter/issues/534#issuecomment-4361944466). Merge order: #736 (merged) → **this PR** → PR-B (launcher + 3-variant matrix) → PR-C (production smoke workflow + `os._exit(0)` workaround) → #739 (docs) → close #716.