### PR TITLE
internal-feat(pipeline): SkyPilot RunPod launcher + 3 wrapper hardening fixes + 3-variant matrix

### DIFF
--- a/.github/workflows/test-skypilot-debug.yml
+++ b/.github/workflows/test-skypilot-debug.yml
@@ -1,0 +1,205 @@
+name: Test SkyPilot Debug
+
+# Permanent diagnostic matrix for the SkyPilot+RunPod path. Three canary
+# variants, each isolating one known failure class. None of these exercise
+# the production launcher or worker — they're standalone probes. When
+# test-dataset-generation (lands in a follow-up PR) regresses, dispatch
+# this and read the green/red pattern to triage in ~10 minutes.
+#
+#   noop             SkyPilot/RunPod orchestration canary
+#                    (provision -> submit -> status-poll -> teardown,
+#                    no wrapper, no Python work). PASS = the platform
+#                    itself is fine; failure here means the regression
+#                    is in SkyPilot, RunPod's API, or the cluster
+#                    plumbing — not in our code.
+#
+#   rclone           rclone-process-exit canary
+#                    (`rclone copy <small file> r2:...`). Catches a
+#                    future image / network / rclone-version combo
+#                    where rclone hangs post-upload (the bug-#2 hang
+#                    shape from #735, currently believed gone — this
+#                    variant is the canary).
+#
+#   pedalboard-load  Python+pedalboard+X interpreter-shutdown canary
+#                    (`python -c "load Surge XT"` through the headless
+#                    wrapper). Closest-to-production worker shape
+#                    without rclone; collectively validates the three
+#                    wrapper-cleanup hardening commits (stdin-detach,
+#                    `wait`, `pkill -P $$`) by exercising them under
+#                    a long-lived Python interpreter. Also the canary
+#                    that tells us when bug-#3 (#735's interpreter
+#                    shutdown hang) becomes safe to revert the
+#                    `os._exit(0)` workaround for.
+#
+# Triggers: workflow_dispatch only — RunPod pods are billable. Each
+# dispatch spends ~3 pods. Add a `push` trigger only temporarily when
+# actively iterating on launcher / wrapper / template behavior.
+#
+# Required secrets:
+#   R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_ENDPOINT — Cloudflare R2
+#   RUNPOD_API_KEY  — written to ~/.runpod/config.toml so SkyPilot can
+#                     provision a pod
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker_image_tag:
+        description: "Docker image tag (e.g., dev-snapshot, dev-snapshot-<sha>)"
+        required: false
+        default: "dev-snapshot"
+      job_deadline_seconds:
+        description: "Wall-clock cap on the launcher's job-status poll loop."
+        required: false
+        default: "120"
+
+permissions:
+  contents: read
+
+env:
+  IMAGE_TAG: ${{ inputs.docker_image_tag || 'dev-snapshot' }}
+  IMAGE: tinaudio/synth-setter:${{ inputs.docker_image_tag || 'dev-snapshot' }}
+  JOB_DEADLINE_SECONDS: ${{ inputs.job_deadline_seconds || '120' }}
+
+jobs:
+  debug:
+    name: Pure-SkyPilot probe (${{ matrix.variant }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: noop
+            template: configs/compute/runpod-debug-template.yaml
+            cluster_suffix: noop
+          - variant: rclone
+            template: configs/compute/runpod-debug-rclone-template.yaml
+            cluster_suffix: rclone
+          - variant: pedalboard-load
+            template: configs/compute/runpod-debug-pedalboard-template.yaml
+            cluster_suffix: pedalboard
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+          cache: pip
+
+      - name: Install skypilot
+        run: pip install "skypilot[runpod]==0.12.0"
+
+      - name: Pin image tag in debug template
+        env:
+          TEMPLATE: ${{ matrix.template }}
+        run: |
+          sed -i \
+            "s|image_id: docker:tinaudio/synth-setter:dev-snapshot|image_id: docker:tinaudio/synth-setter:${IMAGE_TAG}|" \
+            "$TEMPLATE"
+          grep image_id "$TEMPLATE"
+
+      - name: Run inline SkyPilot probe
+        env:
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          R2_BUCKET: intermediate-data
+          CLUSTER_NAME: synth-setter-debug-${{ matrix.cluster_suffix }}-${{ github.run_id }}
+          DEADLINE: ${{ env.JOB_DEADLINE_SECONDS }}
+          TEMPLATE: ${{ matrix.template }}
+          VARIANT: ${{ matrix.variant }}
+          LOG_PATH: /tmp/debug-pure-sky-${{ matrix.cluster_suffix }}.log
+        run: |
+          set -o pipefail
+          mkdir -p ~/.runpod
+          umask 077
+          printf "[default]\napi_key = \"%s\"\n" "$RUNPOD_API_KEY" > ~/.runpod/config.toml
+
+          python - <<'PY' 2>&1 | tee "$LOG_PATH"
+          import os, time
+          import sky
+
+          cluster = os.environ["CLUSTER_NAME"]
+          deadline_seconds = int(os.environ["DEADLINE"])
+          template_path = os.environ["TEMPLATE"]
+          variant = os.environ["VARIANT"]
+
+          print(f"[probe] launching cluster={cluster} variant={variant}")
+          task = sky.Task.from_yaml(template_path)
+          # Sync the GH-actions checkout to the worker as the SkyPilot workdir
+          # so the worker uses the in-repo `scripts/run-linux-vst-headless.sh`
+          # rather than whatever happens to be baked into the image. Lets us
+          # iterate on the wrapper without rebuilding the docker image. Workdir
+          # lands at ~/sky_workdir on the worker (the SSH command's cwd).
+          task.workdir = os.getcwd()
+          print(f"[probe] workdir set to {task.workdir}")
+          # Inject R2 creds + a unique R2_DEBUG_PREFIX for the rclone variant.
+          # Other variants ignore these; the env block on each template lists
+          # only the keys it cares about.
+          task.update_envs(
+              {
+                  "RCLONE_CONFIG_R2_TYPE": "s3",
+                  "RCLONE_CONFIG_R2_PROVIDER": "Cloudflare",
+                  "RCLONE_CONFIG_R2_ACCESS_KEY_ID": os.environ["R2_ACCESS_KEY_ID"],
+                  "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY": os.environ["R2_SECRET_ACCESS_KEY"],
+                  "RCLONE_CONFIG_R2_ENDPOINT": os.environ["R2_ENDPOINT"],
+                  "R2_BUCKET": os.environ["R2_BUCKET"],
+                  "R2_DEBUG_PREFIX": f"data/skypilot-debug/{cluster}/",
+              }
+          )
+          launch_req = sky.launch(
+              task,
+              cluster_name=cluster,
+              idle_minutes_to_autostop=0,
+              down=True,
+          )
+          job_id, _ = sky.stream_and_get(launch_req)
+          print(f"[probe] launch resolved, job_id={job_id}")
+
+          deadline = time.monotonic() + deadline_seconds
+          terminal = {
+              sky.JobStatus.SUCCEEDED,
+              sky.JobStatus.FAILED,
+              sky.JobStatus.FAILED_SETUP,
+              sky.JobStatus.FAILED_DRIVER,
+              sky.JobStatus.CANCELLED,
+          }
+          final = None
+          while time.monotonic() < deadline:
+              statuses = sky.stream_and_get(sky.job_status(cluster, [job_id])) or {}
+              status = statuses.get(job_id)
+              print(f"[probe]   status={status.name if status else 'None'}")
+              if status in terminal:
+                  final = status
+                  break
+              time.sleep(5)
+
+          try:
+              print(f"[probe] --- worker log ---")
+              sky.tail_logs(cluster_name=cluster, job_id=job_id, follow=False)
+              print(f"[probe] --- end worker log ---")
+          except Exception as e:
+              print(f"[probe] tail_logs failed: {e}")
+
+          print(f"[probe] tearing down cluster={cluster}")
+          sky.stream_and_get(sky.down(cluster))
+          print(f"[probe] done, final_status={final.name if final else 'TIMED_OUT'}")
+          if final != sky.JobStatus.SUCCEEDED:
+              raise SystemExit(
+                  f"probe did not see SUCCEEDED within {deadline_seconds}s "
+                  f"(final={final})"
+              )
+          PY
+
+      - name: Upload run metadata
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: skypilot-debug-${{ matrix.cluster_suffix }}-metadata
+          path: /tmp/debug-pure-sky-${{ matrix.cluster_suffix }}.log
+          retention-days: 7
+          if-no-files-found: warn

--- a/configs/compute/runpod-debug-pedalboard-template.yaml
+++ b/configs/compute/runpod-debug-pedalboard-template.yaml
@@ -1,0 +1,55 @@
+# SkyPilot task template for RunPod — DEBUG variant:
+# Python+pedalboard+X interpreter-shutdown canary.
+#
+# Wraps a Python interpreter that imports pedalboard, loads the Surge XT
+# VST3, and exits. Closest-to-production worker shape that doesn't
+# involve rclone or the dataset-generation entrypoint, so a failure here
+# isolates to "Python + pedalboard + X stack don't compose into a
+# cleanly-exiting process."
+#
+# This is the canary for bug #3 in #735 (Python interpreter shutdown
+# hang). Once the underlying thread leak is fixed at its source and the
+# `os._exit(0)` workaround in scripts/docker_entrypoint.py is reverted,
+# this variant should still pass — proving the fix.
+
+resources:
+  cloud: runpod
+  accelerators:
+    {
+      RTX3070:1,
+      RTX3080:1,
+      RTX3090:1,
+      RTXA4000:1,
+      RTX4000Ada:1,
+      A40:1,
+      RTX4090:1,
+    }
+  use_spot: false
+  disk_size: 50
+  image_id: docker:tinaudio/synth-setter:dev-snapshot
+
+envs:
+  RCLONE_CONFIG_R2_TYPE: ""
+  RCLONE_CONFIG_R2_PROVIDER: ""
+  RCLONE_CONFIG_R2_ACCESS_KEY_ID: ""
+  RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ""
+  RCLONE_CONFIG_R2_ENDPOINT: ""
+
+setup: |
+  echo "synth-setter debug-pedalboard worker ready (host: $(hostname))"
+
+run: |
+  set -euo pipefail
+  # SSH cwd is ~/sky_workdir (synced from the GH-actions checkout via
+  # task.workdir in the matrix YAML); the wrapper ships with the run
+  # block and no docker rebuild is needed to iterate on it. The Surge XT
+  # VST3 still has to come from the image — symlink it into a plugins/
+  # dir under the synced workdir so the wrapper-loaded python finds it.
+  mkdir -p plugins
+  ln -sf "/usr/lib/vst3/Surge XT.vst3" "plugins/Surge XT.vst3"
+  bash scripts/run-linux-vst-headless.sh python -c '
+  from pedalboard import VST3Plugin
+  plugin = VST3Plugin("plugins/Surge XT.vst3")
+  print(f"plugin loaded: name={plugin.name!r} version={plugin.version!r}")
+  print("skypilot-debug variant=pedalboard-load done")
+  '

--- a/configs/compute/runpod-debug-rclone-template.yaml
+++ b/configs/compute/runpod-debug-rclone-template.yaml
@@ -1,0 +1,52 @@
+# SkyPilot task template for RunPod — DEBUG variant: rclone-process-exit
+# canary.
+#
+# Provisions a RunPod pod, uploads a tiny sentinel file to R2 via rclone
+# (with the same flags the production worker uses), and exits. If rclone
+# ever stops exiting cleanly post-upload again — the failure mode behind
+# https://github.com/tinaudio/synth-setter/issues/735 — this variant
+# fails before the production smoke does.
+#
+# Worker-side env (RCLONE_CONFIG_R2_*) is forwarded by whoever invokes
+# this template (see .github/workflows/test-skypilot-debug.yml).
+
+resources:
+  cloud: runpod
+  accelerators:
+    {
+      RTX3070:1,
+      RTX3080:1,
+      RTX3090:1,
+      RTXA4000:1,
+      RTX4000Ada:1,
+      A40:1,
+      RTX4090:1,
+    }
+  use_spot: false
+  disk_size: 50
+  image_id: docker:tinaudio/synth-setter:dev-snapshot
+
+envs:
+  RCLONE_CONFIG_R2_TYPE: ""
+  RCLONE_CONFIG_R2_PROVIDER: ""
+  RCLONE_CONFIG_R2_ACCESS_KEY_ID: ""
+  RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ""
+  RCLONE_CONFIG_R2_ENDPOINT: ""
+  R2_BUCKET: ""
+  R2_DEBUG_PREFIX: ""
+
+setup: |
+  echo "synth-setter debug-rclone worker ready (host: $(hostname))"
+
+run: |
+  set -euo pipefail
+  printf "%s\n" "$(hostname) $(date -u +%FT%TZ)" > /tmp/skypilot-debug-rclone-sentinel.txt
+  rclone copy \
+    -vv \
+    --checksum \
+    --contimeout=30s \
+    --timeout=300s \
+    --retries=3 \
+    /tmp/skypilot-debug-rclone-sentinel.txt \
+    "r2:${R2_BUCKET}/${R2_DEBUG_PREFIX}"
+  echo "skypilot-debug variant=rclone done (host: $(hostname))"

--- a/configs/compute/runpod-debug-template.yaml
+++ b/configs/compute/runpod-debug-template.yaml
@@ -1,0 +1,42 @@
+# SkyPilot task template for RunPod — DEBUG / no-op variant.
+#
+# Used by .github/workflows/test-skypilot-debug.yml to exercise the launcher
+# (provision → setup → submit → poll → tail → teardown) without running the
+# real worker pipeline. The run block prints a single line and exits 0, so any
+# hang surfaced under this template is in the launcher's SkyPilot interaction,
+# NOT in the dataset generation code.
+#
+# Same image and accelerator set as the production template so we don't have
+# to publish a separate debug image. The launcher still injects env + mounts
+# the materialized spec; the worker just ignores them.
+
+resources:
+  cloud: runpod
+  accelerators:
+    {
+      RTX3070:1,
+      RTX3080:1,
+      RTX3090:1,
+      RTXA4000:1,
+      RTX4000Ada:1,
+      A40:1,
+      RTX4090:1,
+    }
+  use_spot: false
+  disk_size: 50
+  image_id: docker:tinaudio/synth-setter:dev-snapshot
+
+# Placeholders — the launcher will overwrite these with real values via
+# update_envs. The worker's run block doesn't read them, so anything works.
+envs:
+  RCLONE_CONFIG_R2_TYPE: ""
+  RCLONE_CONFIG_R2_PROVIDER: ""
+  RCLONE_CONFIG_R2_ACCESS_KEY_ID: ""
+  RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ""
+  RCLONE_CONFIG_R2_ENDPOINT: ""
+
+setup: |
+  echo "synth-setter debug worker ready (host: $(hostname))"
+
+run: |
+  echo "skypilot-debug job done (host: $(hostname), pwd: $(pwd))"

--- a/configs/compute/runpod-template.yaml
+++ b/configs/compute/runpod-template.yaml
@@ -1,0 +1,57 @@
+# SkyPilot task template for RunPod.
+#
+# Loaded by pipeline/entrypoints/skypilot_launch_smoke.py via sky.Task.from_yaml(...).
+# The launcher injects R2 credentials (via task.update_envs) and the
+# materialized DatasetPipelineSpec (via task.update_file_mounts) before
+# calling sky.launch(task, cluster_name=..., down=True). Unmanaged launch
+# (not sky.jobs.launch) — RunPod has no managed-jobs controller backend.
+#
+# Image: tinaudio/synth-setter:dev-snapshot must be pushed to Docker Hub
+# (`make docker-build-dev-snapshot` then `docker push`) before launch.
+# Tag pinning to a git SHA is deferred to the Phase B PR per the design doc
+# at docs/design/skypilot-compute-integration.md.
+
+resources:
+  cloud: runpod
+  # Any one cheap GPU is enough for the smoke run (32 samples). The set is wide
+  # so a stocked-out tier doesn't fail the launch — SkyPilot picks the cheapest
+  # available match. Add/remove tiers as RunPod inventory drifts.
+  accelerators:
+    {
+      RTX3070:1,
+      RTX3080:1,
+      RTX3090:1,
+      RTXA4000:1,
+      RTX4000Ada:1,
+      A40:1,
+      RTX4090:1,
+    }
+  use_spot: false
+  disk_size: 50
+  image_id: docker:tinaudio/synth-setter:dev-snapshot
+
+# Placeholders. Real values are injected by the launcher via update_envs.
+envs:
+  RCLONE_CONFIG_R2_TYPE: ""
+  RCLONE_CONFIG_R2_PROVIDER: ""
+  RCLONE_CONFIG_R2_ACCESS_KEY_ID: ""
+  RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ""
+  RCLONE_CONFIG_R2_ENDPOINT: ""
+
+# <repo_root>/data/skypilot-launch-smoke-spec.json is mounted by the launcher via
+# update_file_mounts. Keep this path in sync with WORKER_SPEC_PATH in
+# pipeline/entrypoints/skypilot_launch_smoke.py.
+setup: |
+  echo "synth-setter worker ready (host: $(hostname))"
+
+run: |
+  # Diagnostic: which cwd does SkyPilot's run block start in? We expect this
+  # NOT to be /home/build/synth-setter (the image's WORKDIR) — confirming that
+  # is why the cd below is necessary.
+  echo "skypilot-run-cwd: $(pwd)"
+  # cd into the repo root before invoking generate_dataset: it shells out to
+  # scripts/run-linux-vst-headless.sh via a relative path, and SkyPilot's run
+  # block does not execute from the image's WORKDIR by default.
+  cd /home/build/synth-setter
+  python /usr/local/bin/entrypoint.py generate_dataset \
+    --spec /home/build/synth-setter/data/skypilot-launch-smoke-spec.json

--- a/pipeline/entrypoints/skypilot_launch_smoke.py
+++ b/pipeline/entrypoints/skypilot_launch_smoke.py
@@ -1,0 +1,301 @@
+"""Launch the smoke `generate_dataset` run on RunPod via SkyPilot.
+
+Materializes a `DatasetPipelineSpec` locally from the smoke config, ships the
+frozen spec into the worker via `task.update_file_mounts`, forwards the
+worker-side env from a `.env` file via `task.update_envs`, and launches
+an unmanaged SkyPilot task (`sky.launch`) that runs the existing container CLI.
+
+`sky.jobs.launch` (managed jobs) requires a cloud-storage backend for
+controller state, which RunPod doesn't provide; cluster-level launch is
+sufficient for this single-shard smoke probe.
+
+This is the first scaffolding under the SkyPilot integration epic (#534).
+No `compute_config` schema, no `pipeline generate --backend skypilot` CLI —
+those land in the Phase A–C PRs.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import time
+from pathlib import Path
+
+import click
+import sky
+from dotenv import dotenv_values
+
+from pipeline.schemas.config import dataset_config_id_from_path, load_dataset_config
+from pipeline.schemas.spec import materialize_spec
+
+# Worker-side env vars the launcher forwards via `task.update_envs`. Each is
+# resolved from the optional .env file first, then from the launcher's process
+# env, then skipped if neither has it. Keep in sync with the `envs:` block in
+# `configs/compute/runpod-template.yaml` — the template lists the same keys
+# (with empty defaults) so the SkyPilot Task validates as fully-specified
+# even when the launcher hasn't filled all of them.
+_WORKER_ENV_KEYS: tuple[str, ...] = (
+    "RCLONE_CONFIG_R2_TYPE",
+    "RCLONE_CONFIG_R2_PROVIDER",
+    "RCLONE_CONFIG_R2_ACCESS_KEY_ID",
+    "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY",
+    "RCLONE_CONFIG_R2_ENDPOINT",
+    "WANDB_API_KEY",
+)
+
+_JOB_POLL_INTERVAL_SECONDS = 15
+_JOB_DEADLINE_SECONDS = 25 * 60  # bound the poll loop so a stuck job can't block CI forever
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DEFAULT_CONFIG = REPO_ROOT / "configs" / "dataset" / "ci-smoke-test.yaml"
+DEFAULT_TEMPLATE = REPO_ROOT / "configs" / "compute" / "runpod-template.yaml"
+DEFAULT_ENV_FILE = REPO_ROOT / ".env"
+
+# Worker-side mount destination. The image's WORKDIR is /home/build/synth-setter (Dockerfile),
+# so the spec lands under <repo_root>/data/ on the worker — gitignored, no clash with repo
+# files, and portable if the container layout changes later.
+WORKER_REPO_ROOT = "/home/build/synth-setter"
+WORKER_SPEC_PATH = f"{WORKER_REPO_ROOT}/data/skypilot-launch-smoke-spec.json"
+
+# Local-source directory for the materialized spec. Lives under the system tempdir
+# (not the repo) so it shares a filesystem with SkyPilot's staging dir (also under
+# /tmp). Inside the dev-snapshot container the repo workspace is bind-mounted from
+# the runner host while /tmp is on the container's overlay — crossing those two
+# with `os.rename` raises EXDEV (Errno 18) when SkyPilot stages mounts.
+LOCAL_SPEC_DIR = Path(tempfile.gettempdir())
+
+
+def load_worker_env(path: Path) -> dict[str, str]:
+    """Read worker-side env from a dotenv file using python-dotenv.
+
+    `dotenv_values` returns a dict whose values are `Optional[str]` (a key with no `=` becomes
+    `None`); coerce to a plain `dict[str, str]` for `task.update_envs(...)` and skip None entries.
+    """
+    return {k: v for k, v in dotenv_values(path).items() if v is not None}
+
+
+def resolve_worker_env(env_file: Path | None) -> dict[str, str]:
+    """Resolve the launcher's `_WORKER_ENV_KEYS` from .env and process env.
+
+    For each key in `_WORKER_ENV_KEYS`, the value is taken from `env_file` if
+    that file exists and the key is set there, else from the launcher's
+    process env if set, else skipped. Skipped keys keep the template's
+    default (typically the empty string) — `task.update_envs` only overrides
+    keys that are actually resolved here.
+
+    `.env` is the local-dev source of truth; CI flows pass secrets via
+    `docker run -e KEY=VAL` and never touch a .env on disk.
+    """
+    file_env: dict[str, str] = {}
+    if env_file is not None and env_file.is_file():
+        file_env = load_worker_env(env_file)
+
+    resolved: dict[str, str] = {}
+    for key in _WORKER_ENV_KEYS:
+        if key in file_env:
+            resolved[key] = file_env[key]
+        elif key in os.environ:
+            resolved[key] = os.environ[key]
+    return resolved
+
+
+@click.command()
+@click.option(
+    "--config",
+    "config_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=DEFAULT_CONFIG,
+    show_default=True,
+    help="Path to a DatasetConfig YAML.",
+)
+@click.option(
+    "--template",
+    "template_path",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=DEFAULT_TEMPLATE,
+    show_default=True,
+    help="Path to the SkyPilot task YAML template.",
+)
+@click.option(
+    "--env-file",
+    "env_file_path",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=DEFAULT_ENV_FILE,
+    show_default=True,
+    help=(
+        "Optional path to a KEY=VALUE env file. Values for the keys in "
+        "`_WORKER_ENV_KEYS` are read from this file first, then from process env, "
+        "then skipped. CI flows pass secrets via `docker run -e KEY=VAL` and don't "
+        "need a .env file on disk; the default is convenient for local dev where "
+        "writing secrets to a .env once is easier than re-`export`ing them."
+    ),
+)
+@click.option(
+    "--cluster-name",
+    type=str,
+    default=None,
+    help="SkyPilot cluster name (default: synth-setter-smoke-<config_id[:8]>).",
+)
+@click.option(
+    "--spec-out",
+    "spec_out",
+    type=click.Path(dir_okay=False, path_type=Path),
+    default=None,
+    help=(
+        "Where to write the materialized spec JSON. Default: a per-cluster path under "
+        "$TMPDIR (avoids parallel-run collisions on a shared host)."
+    ),
+)
+@click.option(
+    "--job-deadline-seconds",
+    type=int,
+    default=_JOB_DEADLINE_SECONDS,
+    show_default=True,
+    help=(
+        "Wall-clock cap on the job-status polling loop. The launcher fails fast if the "
+        "worker job has not reached a terminal status within this window — useful in "
+        "debug workflows where we want a stuck cluster to surface in seconds rather "
+        "than minutes."
+    ),
+)
+def main(
+    config_path: Path,
+    template_path: Path,
+    env_file_path: Path,
+    cluster_name: str | None,
+    spec_out: Path | None,
+    job_deadline_seconds: int,
+) -> None:
+    """Launch the smoke `generate_dataset` run on RunPod via SkyPilot."""
+    worker_env = resolve_worker_env(env_file_path)
+    if not worker_env:
+        raise click.ClickException(
+            "No worker env vars resolved. Set the rclone-R2 keys in process env "
+            f"(e.g. via `docker run -e RCLONE_CONFIG_R2_*=...`) or populate {env_file_path}. "
+            f"Expected at least one of: {', '.join(_WORKER_ENV_KEYS)}."
+        )
+
+    config = load_dataset_config(config_path)
+    config_id = dataset_config_id_from_path(config_path)
+    spec = materialize_spec(config, config_id)
+
+    resolved_cluster_name = cluster_name or f"synth-setter-smoke-{config_id[:8]}"
+    # Per-cluster filename so parallel launches (CI matrix, local dev concurrent with CI on
+    # the same host) don't clobber one another's spec.
+    local_spec_path = (
+        spec_out or LOCAL_SPEC_DIR / f"skypilot-launch-smoke-{resolved_cluster_name}.json"
+    )
+
+    local_spec_path.parent.mkdir(parents=True, exist_ok=True)
+    # Pin encoding so JSON output is locale-independent (workers/CI run with varied locales).
+    local_spec_path.write_text(spec.model_dump_json(indent=2), encoding="utf-8")
+    click.echo(f"Materialized spec to {local_spec_path}")
+
+    # SkyPilot stages file_mount sources by moving them into its own staging dir; passing
+    # local_spec_path directly would leave nothing behind for downstream consumers (CI
+    # artifact upload, validate-spec). Stage a sibling copy and mount that instead.
+    mount_source = local_spec_path.with_suffix(".mount.json")
+    shutil.copyfile(local_spec_path, mount_source)
+
+    task = sky.Task.from_yaml(str(template_path))
+    task.update_envs(worker_env)
+    task.update_file_mounts({WORKER_SPEC_PATH: str(mount_source)})
+
+    # `sky.launch` is async (returns a RequestId). Launch with both
+    # `idle_minutes_to_autostop=0` and `down=True` so the cluster has a predictable 1-min
+    # autodown timer (sky internally bumps idle=0 to 1 minute) — `down=True` alone leaves
+    # the cluster up if setup errors, by design. `stream_and_get` on the launch request
+    # blocks until provisioning + setup + job-submission + run completes, streaming
+    # provisioning logs along the way; it returns `(job_id, handle)`. Non-managed launch
+    # (sky.launch, not sky.jobs.launch) — managed jobs require a separate cloud-storage
+    # backend for controller state, which RunPod doesn't provide.
+    #
+    # SkyPilot normally consumes mount_source by rename during staging, but a failure
+    # between the copyfile above and stage would leave one .mount.json per cluster behind
+    # on shared CI runners. Unlink in finally with missing_ok=True to keep the success
+    # path quiet. The inner finally drives teardown explicitly so the cluster always goes
+    # away on success, exception, or worker error — even if down=True or the autodown
+    # timer is silently dropped (observed on RunPod when setup runs cleanly but the job
+    # exits via a path that doesn't trigger the autodown scheduler).
+    try:
+        click.echo(f"Provisioning SkyPilot cluster: {resolved_cluster_name}")
+        launch_request_id = sky.launch(
+            task,
+            cluster_name=resolved_cluster_name,
+            idle_minutes_to_autostop=0,
+            down=True,
+        )
+        # follow=True belongs on tail_logs (which actually tails an evolving stream); on a
+        # launch RequestId it just keeps stream_and_get open longer than needed. The launch
+        # request resolves when provisioning + setup + job submission complete; let it return
+        # then.
+        launch_result = sky.stream_and_get(launch_request_id)
+        if launch_result is None or launch_result[0] is None:
+            raise click.ClickException(
+                f"Launch yielded no job_id for cluster {resolved_cluster_name}"
+            )
+        job_id: int = launch_result[0]
+        try:
+            # Originally we used `sky.tail_logs(..., follow=True)` to block on the worker
+            # and stream its stdout. On RunPod, log tailing relies on SSH to the pod, and
+            # SSH gets flaky after the workload finishes — tail_logs(follow=True) waits
+            # for an EOF that never arrives and the launcher hangs even though the worker
+            # has terminated and uploaded artifacts to R2 (verified via `rclone ls`). Poll
+            # `sky.queue` for a terminal JobStatus instead, then dump the buffered worker
+            # log non-following so a traceback still surfaces in CI.
+            click.echo(f"Polling job {job_id} on {resolved_cluster_name} for completion")
+            final_status = _wait_for_job(
+                resolved_cluster_name, job_id, deadline_seconds=job_deadline_seconds
+            )
+            click.echo(f"Job {job_id} reached terminal status: {final_status.name}")
+
+            if final_status != sky.JobStatus.SUCCEEDED:
+                raise click.ClickException(
+                    f"Worker job {job_id} ended with status {final_status.name}"
+                )
+        finally:
+            # Always dump the worker log before teardown so a worker traceback
+            # surfaces in CI even when the launcher exited via the deadline path.
+            try:
+                click.echo(f"--- Worker log (job {job_id}) ---")
+                sky.tail_logs(cluster_name=resolved_cluster_name, job_id=job_id, follow=False)
+                click.echo(f"--- End worker log (job {job_id}) ---")
+            except Exception as e:  # noqa: BLE001 — best-effort diagnostic
+                click.echo(f"Worker log dump failed: {e}")
+
+            click.echo(f"Tearing down cluster: {resolved_cluster_name}")
+            down_request_id = sky.down(resolved_cluster_name)
+            sky.stream_and_get(down_request_id)
+    finally:
+        mount_source.unlink(missing_ok=True)
+
+
+def _wait_for_job(
+    cluster_name: str, job_id: int, deadline_seconds: int = _JOB_DEADLINE_SECONDS
+) -> sky.JobStatus:
+    """Poll `sky.job_status` until the given job reaches a terminal status, then return it.
+
+    Used in place of `sky.tail_logs(follow=True)` because the latter hangs on RunPod
+    waiting for an SSH-stream EOF that never arrives after the worker exits. Polls every
+    `_JOB_POLL_INTERVAL_SECONDS` seconds and times out after `deadline_seconds` so a
+    truly stuck worker can't block CI forever.
+    """
+    deadline = time.monotonic() + deadline_seconds
+    while time.monotonic() < deadline:
+        statuses = sky.stream_and_get(sky.job_status(cluster_name, [job_id])) or {}
+        status = statuses.get(job_id)
+        if status is None:
+            click.echo(f"  job {job_id} not yet visible; retrying")
+        else:
+            click.echo(f"  status={status.name}")
+            if status.is_terminal():
+                return status
+        time.sleep(_JOB_POLL_INTERVAL_SECONDS)
+    raise click.ClickException(
+        f"Job {job_id} did not reach a terminal status within {deadline_seconds} seconds"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -37,6 +37,7 @@ pyright==1.1.408
 pytest
 pytest-benchmark
 pytest-xdist
+python-dotenv
 rich
 sh
 rootutils

--- a/scripts/run-linux-vst-headless.sh
+++ b/scripts/run-linux-vst-headless.sh
@@ -29,18 +29,38 @@ export JUCE_USE_XINPUT2=0
 DISPLAY_FILE="$TMP_DIR/display_num"
 
 cleanup() {
+  # `kill PID` is async — bash returns while the child is still draining.
+  # On RunPod, SkyPilot's job-status reporter watches the SSH session's
+  # process tree, so any straggler child keeps the job in RUNNING forever
+  # even after the wrapped command and the wrapper bash have logically
+  # finished (#735). `wait` after the SIGTERMs reaps the X-stack daemons
+  # we tracked (XVFB / XSETTINGS / OPENBOX). Every step echoes to stderr
+  # so `tail_logs` evidence can pinpoint where cleanup stalls if it ever
+  # stalls again.
+  echo "[wrapper] cleanup: starting (pid=$$)" >&2
+  echo "[wrapper] cleanup: child PIDs OPENBOX=${OPENBOX_PID-} XSETTINGS=${XSETTINGS_PID-} XVFB=${XVFB_PID-}" >&2
+  echo "[wrapper] cleanup: pre-kill process tree:" >&2
+  ps -eo pid,ppid,pgid,stat,comm --no-headers \
+    | awk -v me=$$ '$2==me || $3==me' >&2 || true
   if [ -n "${OPENBOX_PID-}" ]; then
+    echo "[wrapper] cleanup: kill openbox pid=${OPENBOX_PID}" >&2
     kill "${OPENBOX_PID}" 2>/dev/null || true
   fi
   if [ -n "${XSETTINGS_PID-}" ]; then
+    echo "[wrapper] cleanup: kill xsettingsd pid=${XSETTINGS_PID}" >&2
     kill "${XSETTINGS_PID}" 2>/dev/null || true
   fi
   if [ -n "${XVFB_PID-}" ]; then
+    echo "[wrapper] cleanup: kill xvfb pid=${XVFB_PID}" >&2
     kill "${XVFB_PID}" 2>/dev/null || true
   fi
+  echo "[wrapper] cleanup: waiting for tracked children to reap" >&2
+  wait 2>/dev/null || true
   if [ -n "${TMP_DIR-}" ]; then
+    echo "[wrapper] cleanup: removing TMP_DIR=${TMP_DIR}" >&2
     rm -rf "${TMP_DIR}" || true
   fi
+  echo "[wrapper] cleanup: done" >&2
 }
 trap cleanup EXIT
 

--- a/scripts/run-linux-vst-headless.sh
+++ b/scripts/run-linux-vst-headless.sh
@@ -47,7 +47,8 @@ trap cleanup EXIT
 # Start Xvfb (let it pick a display)
 # -displayfd 3 writes the chosen display number to file descriptor 3
 # 3>"$DISPLAY_FILE" redirects FD 3 to our temp file so we can read it later
-Xvfb -displayfd 3 -screen 0 1920x1080x24 -nolisten tcp 3>"$DISPLAY_FILE" 2>"$TMP_DIR/xvfb.log" &
+Xvfb -displayfd 3 -screen 0 1920x1080x24 -nolisten tcp \
+  </dev/null >/dev/null 3>"$DISPLAY_FILE" 2>"$TMP_DIR/xvfb.log" &
 XVFB_PID=$!
 
 # Wait for Xvfb to output the display number
@@ -80,12 +81,17 @@ for _ in {1..50}; do
 done
 xdpyinfo -display "$DISPLAY" >/dev/null 2>&1 || { echo "Xvfb did not start"; cat "$TMP_DIR/xvfb.log" || true; exit 1; }
 
-# Start an XSettings manager
-xsettingsd --config /dev/null >"$TMP_DIR/xsettingsd.log" 2>&1 &
+# Start an XSettings manager.
+# `</dev/null` detaches stdin so backgrounded daemons (and any grandchildren
+# they fork) don't keep the parent SSH session's stdin pipe open. Without
+# this, SkyPilot's RunPod backend never observes EOF on the SSH command's
+# pipes and the job stays in RUNNING forever even after the wrapped
+# command exits (#735).
+xsettingsd --config /dev/null </dev/null >"$TMP_DIR/xsettingsd.log" 2>&1 &
 XSETTINGS_PID=$!
 
 # Start a lightweight window manager (important for many plugins)
-openbox-session >"$TMP_DIR/openbox.log" 2>&1 &
+openbox-session </dev/null >"$TMP_DIR/openbox.log" 2>&1 &
 OPENBOX_PID=$!
 
 # Run the actual command inside a D-Bus session.

--- a/scripts/run-linux-vst-headless.sh
+++ b/scripts/run-linux-vst-headless.sh
@@ -34,9 +34,10 @@ cleanup() {
   # process tree, so any straggler child keeps the job in RUNNING forever
   # even after the wrapped command and the wrapper bash have logically
   # finished (#735). `wait` after the SIGTERMs reaps the X-stack daemons
-  # we tracked (XVFB / XSETTINGS / OPENBOX). Every step echoes to stderr
-  # so `tail_logs` evidence can pinpoint where cleanup stalls if it ever
-  # stalls again.
+  # we tracked; `pkill -P $$` then sweeps any grandchildren openbox or
+  # dbus-launch may have spawned that we didn't track. Every step echoes
+  # to stderr so `tail_logs` evidence can pinpoint where cleanup stalls
+  # if it ever stalls again.
   echo "[wrapper] cleanup: starting (pid=$$)" >&2
   echo "[wrapper] cleanup: child PIDs OPENBOX=${OPENBOX_PID-} XSETTINGS=${XSETTINGS_PID-} XVFB=${XVFB_PID-}" >&2
   echo "[wrapper] cleanup: pre-kill process tree:" >&2
@@ -56,6 +57,11 @@ cleanup() {
   fi
   echo "[wrapper] cleanup: waiting for tracked children to reap" >&2
   wait 2>/dev/null || true
+  echo "[wrapper] cleanup: sweeping any orphan grandchildren" >&2
+  pkill -P $$ 2>/dev/null || true
+  echo "[wrapper] cleanup: post-kill process tree:" >&2
+  ps -eo pid,ppid,pgid,stat,comm --no-headers \
+    | awk -v me=$$ '$2==me || $3==me' >&2 || true
   if [ -n "${TMP_DIR-}" ]; then
     echo "[wrapper] cleanup: removing TMP_DIR=${TMP_DIR}" >&2
     rm -rf "${TMP_DIR}" || true

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch_smoke.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch_smoke.py
@@ -1,0 +1,594 @@
+"""Tests for pipeline/entrypoints/skypilot_launch_smoke.py — SkyPilot RunPod smoke launcher.
+
+Mock-based: no real SkyPilot or RunPod calls. The `mock_sky` fixture replaces the launcher's
+module-level `sky` reference with a MagicMock, and `local_spec_dir` redirects the on-disk spec
+write under tmp_path so tests don't write into the real /tmp.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from pipeline.entrypoints.skypilot_launch_smoke import (
+    _WORKER_ENV_KEYS,
+    WORKER_SPEC_PATH,
+    load_worker_env,
+    main,
+)
+from pipeline.schemas.config import dataset_config_id_from_path
+from pipeline.schemas.spec import DatasetPipelineSpec
+
+FIXED_NOW = datetime(2026, 4, 30, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_config(plugin: Path) -> dict[str, Any]:
+    """Return a fresh DatasetConfig dict pointed at the given fake plugin path."""
+    return {
+        "param_spec": "surge_simple",
+        "plugin_path": str(plugin),
+        "output_format": "hdf5",
+        "sample_rate": 16000,
+        "shard_size": 32,
+        "num_shards": 1,
+        "base_seed": 42,
+        "r2_bucket": "intermediate-data",
+        "splits": {"train": 1, "val": 0, "test": 0},
+        "preset_path": "presets/surge-base.vstpreset",
+        "channels": 2,
+        "velocity": 100,
+        "signal_duration_seconds": 4.0,
+        "min_loudness": -55.0,
+        "sample_batch_size": 32,
+    }
+
+
+@pytest.fixture()
+def fake_plugin(tmp_path: Path) -> Path:
+    """Build a minimal VST3 bundle with a moduleinfo.json the renderer can read."""
+    contents = tmp_path / "FakePlugin.vst3" / "Contents"
+    contents.mkdir(parents=True)
+    (contents / "moduleinfo.json").write_text('{"Version": "1.3.4"}')
+    return tmp_path / "FakePlugin.vst3"
+
+
+@pytest.fixture()
+def patch_materialize_io(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub out git/timestamp I/O so `materialize_spec` is deterministic."""
+    monkeypatch.setattr("pipeline.schemas.spec._get_git_sha", lambda: "abc123def456")
+    monkeypatch.setattr("pipeline.schemas.spec._is_repo_dirty", lambda: False)
+    monkeypatch.setattr(
+        "pipeline.schemas.spec.datetime",
+        type(
+            "FakeDatetime",
+            (),
+            {
+                "now": staticmethod(lambda tz: FIXED_NOW),
+                "fromisoformat": datetime.fromisoformat,
+            },
+        )(),
+    )
+
+
+@pytest.fixture()
+def config_yaml(tmp_path: Path, fake_plugin: Path) -> Path:
+    """Write a valid DatasetConfig YAML pointed at the fake plugin."""
+    path = tmp_path / "ci-smoke-test.yaml"
+    path.write_text(yaml.safe_dump(_make_config(fake_plugin), sort_keys=False))
+    return path
+
+
+@pytest.fixture()
+def env_file(tmp_path: Path) -> Path:
+    """Write a minimal valid .env with the rclone-R2 keys the launcher forwards."""
+    path = tmp_path / ".env"
+    path.write_text(
+        "RCLONE_CONFIG_R2_TYPE=s3\n"
+        "RCLONE_CONFIG_R2_PROVIDER=Cloudflare\n"
+        "RCLONE_CONFIG_R2_ACCESS_KEY_ID=key\n"
+        "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY=secret\n"
+        "RCLONE_CONFIG_R2_ENDPOINT=https://acct.r2.cloudflarestorage.com\n"
+    )
+    return path
+
+
+@pytest.fixture()
+def template_yaml() -> Path:
+    """Resolve the in-repo SkyPilot RunPod template path."""
+    return (
+        Path(__file__).resolve().parent.parent.parent.parent
+        / "configs"
+        / "compute"
+        / "runpod-template.yaml"
+    )
+
+
+@pytest.fixture()
+def local_spec_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect the launcher's default spec-write directory under tmp_path."""
+    spec_dir = tmp_path / "spec-out"
+    spec_dir.mkdir()
+    monkeypatch.setattr("pipeline.entrypoints.skypilot_launch_smoke.LOCAL_SPEC_DIR", spec_dir)
+    return spec_dir
+
+
+@pytest.fixture(autouse=True)
+def clear_worker_env_from_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip the rclone-R2 / WANDB keys from the test process env.
+
+    Without this, a developer who has `RCLONE_CONFIG_R2_*` exported in their shell
+    (or a CI runner that inherits them globally) would silently satisfy
+    `resolve_worker_env`, masking tests that rely on a specific resolution path.
+    """
+    for key in _WORKER_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _succeeded_run(mock_sky: MagicMock) -> None:
+    """Configure `mock_sky` so the polled job reaches SUCCEEDED on first poll."""
+    import sky  # noqa: PLC0415 — real enum so JobStatus.is_terminal() works
+
+    mock_sky.JobStatus = sky.JobStatus
+    mock_sky.launch.return_value = "launch-req"
+    mock_sky.job_status.return_value = "job-status-req"
+    mock_sky.down.return_value = "down-req"
+
+    responses = {
+        "launch-req": (1, MagicMock()),
+        "job-status-req": {1: sky.JobStatus.SUCCEEDED},
+        "down-req": None,
+    }
+    mock_sky.stream_and_get.side_effect = lambda req: responses[req]
+    mock_sky.tail_logs.return_value = 0
+
+
+def _failed_run(mock_sky: MagicMock, status: Any) -> None:
+    """Configure `mock_sky` so the polled job reaches the given terminal `status`."""
+    _succeeded_run(mock_sky)
+    responses = {
+        "launch-req": (1, MagicMock()),
+        "job-status-req": {1: status},
+        "down-req": None,
+    }
+    mock_sky.stream_and_get.side_effect = lambda req: responses[req]
+
+
+@pytest.fixture()
+def mock_sky(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Replace the launcher's module-level `sky` with a MagicMock pre-configured for success.
+
+    Tests that need a different behavior call `_failed_run(...)` (or override individual
+    knobs like `mock_sky.tail_logs.side_effect`) on top of this fixture.
+    """
+    fake = MagicMock()
+    monkeypatch.setattr("pipeline.entrypoints.skypilot_launch_smoke.sky", fake)
+    _succeeded_run(fake)
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# load_worker_env
+# ---------------------------------------------------------------------------
+
+
+class TestLoadWorkerEnv:
+    """Behavioral contracts for the worker-env loader (thin wrapper over python-dotenv)."""
+
+    def test_parses_keys_skips_comments_and_strips_quotes(self, tmp_path: Path) -> None:
+        """Python-dotenv handles blanks, comments, and quoted values; loader returns dict[str,
+        str]."""
+        path = tmp_path / ".env"
+        path.write_text(
+            "# a comment\n"
+            "\n"
+            "FOO=bar\n"
+            'QUOTED="bar baz"\n'
+            "URL=https://acct.r2.cloudflarestorage.com/path?x=1\n"
+        )
+        assert load_worker_env(path) == {
+            "FOO": "bar",
+            "QUOTED": "bar baz",
+            "URL": "https://acct.r2.cloudflarestorage.com/path?x=1",
+        }
+
+    def test_drops_keys_with_no_value(self, tmp_path: Path) -> None:
+        """Lines like `BARE` (no `=`) come back as None from dotenv; loader filters them out."""
+        path = tmp_path / ".env"
+        path.write_text("FOO=bar\nBARE\n")
+        assert load_worker_env(path) == {"FOO": "bar"}
+
+
+# ---------------------------------------------------------------------------
+# main — CLI integration with mocked sky
+# ---------------------------------------------------------------------------
+
+
+def _invoke(
+    config_yaml: Path,
+    template_yaml: Path,
+    env_file: Path,
+    *extra: str,
+) -> Any:
+    """Invoke the launcher CLI with the standard required options + any `extra` args."""
+    runner = CliRunner()
+    return runner.invoke(
+        main,
+        [
+            "--config",
+            str(config_yaml),
+            "--template",
+            str(template_yaml),
+            "--env-file",
+            str(env_file),
+            *extra,
+        ],
+    )
+
+
+class TestMainCli:
+    """End-to-end CLI behavior: env validation, spec materialization, sky.* call shape."""
+
+    def test_no_env_anywhere_fails_with_clear_error(
+        self,
+        tmp_path: Path,
+        config_yaml: Path,
+        template_yaml: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """With no .env on disk and no rclone-R2 keys in process env, the launcher fails fast and
+        never calls sky.*."""
+        missing = tmp_path / "does-not-exist.env"
+        result = _invoke(config_yaml, template_yaml, missing)
+        assert result.exit_code != 0
+        assert "No worker env vars resolved" in result.output
+        mock_sky.Task.from_yaml.assert_not_called()
+        mock_sky.launch.assert_not_called()
+
+    def test_empty_env_file_with_no_process_env_fails(
+        self,
+        tmp_path: Path,
+        config_yaml: Path,
+        template_yaml: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """An empty .env on disk and no rclone-R2 keys in process env fails fast — empty .env is
+        equivalent to no .env."""
+        empty_env = tmp_path / "empty.env"
+        empty_env.write_text("# only comments\n\n")
+        result = _invoke(config_yaml, template_yaml, empty_env)
+        assert result.exit_code != 0
+        assert "No worker env vars resolved" in result.output
+        mock_sky.Task.from_yaml.assert_not_called()
+        mock_sky.launch.assert_not_called()
+
+    def test_process_env_resolves_when_env_file_absent(
+        self,
+        tmp_path: Path,
+        config_yaml: Path,
+        template_yaml: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """If the .env doesn't exist but the rclone-R2 keys are in process env, the launcher
+        succeeds and forwards the process-env values via task.update_envs."""
+        missing = tmp_path / "does-not-exist.env"
+        monkeypatch.setenv("RCLONE_CONFIG_R2_TYPE", "s3")
+        monkeypatch.setenv("RCLONE_CONFIG_R2_ACCESS_KEY_ID", "process-env-key")
+        result = _invoke(config_yaml, template_yaml, missing, "--cluster-name", "smoke-job-1")
+        assert result.exit_code == 0, result.output
+
+        task = mock_sky.Task.from_yaml.return_value
+        task.update_envs.assert_called_once()
+        forwarded = task.update_envs.call_args.args[0]
+        assert forwarded["RCLONE_CONFIG_R2_TYPE"] == "s3"
+        assert forwarded["RCLONE_CONFIG_R2_ACCESS_KEY_ID"] == "process-env-key"
+
+    # --- Happy-path slices (split from the original monolithic test) ---------
+
+    def test_materialized_spec_round_trips_as_pipeline_spec(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """The on-disk spec validates as DatasetPipelineSpec with the patched git/now values."""
+        result = _invoke(config_yaml, template_yaml, env_file, "--cluster-name", "smoke-job-1")
+        assert result.exit_code == 0, result.output
+
+        spec_files = list(local_spec_dir.glob("*.json"))
+        assert len(spec_files) == 1
+        spec = DatasetPipelineSpec.model_validate_json(spec_files[0].read_text())
+        assert spec.code_version == "abc123def456"
+        assert spec.is_repo_dirty is False
+        assert spec.num_shards == 1
+        assert spec.r2_bucket == "intermediate-data"
+
+    def test_worker_env_is_forwarded_to_task(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """`task.update_envs` receives the parsed dotenv values."""
+        result = _invoke(config_yaml, template_yaml, env_file, "--cluster-name", "smoke-job-1")
+        assert result.exit_code == 0, result.output
+
+        task = mock_sky.Task.from_yaml.return_value
+        mock_sky.Task.from_yaml.assert_called_once_with(str(template_yaml))
+        task.update_envs.assert_called_once()
+        forwarded = task.update_envs.call_args.args[0]
+        assert forwarded["RCLONE_CONFIG_R2_ACCESS_KEY_ID"] == "key"
+        assert forwarded["RCLONE_CONFIG_R2_ENDPOINT"].startswith("https://")
+
+    def test_spec_is_mounted_via_sibling_copy_with_matching_content(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """The mount source is a sibling copy whose content matches the materialized spec."""
+        captured: dict[str, str] = {}
+
+        def _capture(mounts: dict[str, str]) -> None:
+            for k, v in mounts.items():
+                captured[k] = Path(v).read_text()
+
+        task = mock_sky.Task.from_yaml.return_value
+        task.update_file_mounts.side_effect = _capture
+
+        result = _invoke(config_yaml, template_yaml, env_file, "--cluster-name", "smoke-job-1")
+        assert result.exit_code == 0, result.output
+
+        task.update_file_mounts.assert_called_once()
+        mounts = task.update_file_mounts.call_args.args[0]
+        assert WORKER_SPEC_PATH in mounts
+
+        spec_files = list(local_spec_dir.glob("*.json"))
+        assert len(spec_files) == 1
+        spec_path = spec_files[0]
+        mount_source = Path(mounts[WORKER_SPEC_PATH])
+        assert mount_source != spec_path
+        assert captured[WORKER_SPEC_PATH] == spec_path.read_text()
+
+    def test_mount_source_sibling_is_cleaned_up_after_run(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """The `.mount.json` sibling is unlinked in finally so it doesn't survive the run."""
+        captured_mount_source: dict[str, Path] = {}
+
+        def _capture(mounts: dict[str, str]) -> None:
+            captured_mount_source["path"] = Path(mounts[WORKER_SPEC_PATH])
+
+        task = mock_sky.Task.from_yaml.return_value
+        task.update_file_mounts.side_effect = _capture
+
+        result = _invoke(config_yaml, template_yaml, env_file, "--cluster-name", "smoke-job-1")
+        assert result.exit_code == 0, result.output
+        assert not captured_mount_source["path"].exists()
+
+    def test_launch_uses_autostop_zero_and_down_true(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """`sky.launch` is called with the autostop+down combo the launcher relies on."""
+        result = _invoke(config_yaml, template_yaml, env_file, "--cluster-name", "smoke-job-1")
+        assert result.exit_code == 0, result.output
+
+        mock_sky.launch.assert_called_once()
+        kwargs = mock_sky.launch.call_args.kwargs
+        assert kwargs["cluster_name"] == "smoke-job-1"
+        assert kwargs["idle_minutes_to_autostop"] == 0
+        assert kwargs["down"] is True
+
+    def test_tail_logs_invoked_with_follow_false(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """`sky.tail_logs` is called once with follow=False (buffered post-completion dump)."""
+        result = _invoke(config_yaml, template_yaml, env_file, "--cluster-name", "smoke-job-1")
+        assert result.exit_code == 0, result.output
+        mock_sky.tail_logs.assert_called_once_with(
+            cluster_name="smoke-job-1", job_id=1, follow=False
+        )
+
+    def test_teardown_runs_on_success(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """`sky.down` is called once on the success path."""
+        result = _invoke(config_yaml, template_yaml, env_file, "--cluster-name", "smoke-job-1")
+        assert result.exit_code == 0, result.output
+        mock_sky.down.assert_called_once_with("smoke-job-1")
+
+    # --- Cluster-name / spec-out / failure paths -----------------------------
+
+    def test_default_cluster_name_uses_config_id_prefix(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """Without --cluster-name the launcher derives the name from `config_id[:8]`."""
+        result = _invoke(config_yaml, template_yaml, env_file)
+        assert result.exit_code == 0, result.output
+
+        config_id = dataset_config_id_from_path(config_yaml)
+        kwargs: dict[str, Any] = mock_sky.launch.call_args.kwargs
+        assert kwargs["cluster_name"].startswith("synth-setter-smoke-")
+        assert kwargs["cluster_name"].endswith(config_id[:8])
+        assert kwargs["idle_minutes_to_autostop"] == 0
+        assert kwargs["down"] is True
+
+    def test_spec_out_overrides_default_path(
+        self,
+        tmp_path: Path,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """--spec-out forces an explicit local path (used by CI to find the spec for upload)."""
+        explicit = tmp_path / "explicit-out" / "input_spec.json"
+        result = _invoke(config_yaml, template_yaml, env_file, "--spec-out", str(explicit))
+        assert result.exit_code == 0, result.output
+        assert explicit.is_file()
+
+    def test_worker_failed_status_fails_launcher(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """A worker job in a non-SUCCEEDED terminal status must fail the launcher."""
+        import sky  # noqa: PLC0415
+
+        _failed_run(mock_sky, sky.JobStatus.FAILED)
+
+        result = _invoke(config_yaml, template_yaml, env_file)
+        assert result.exit_code != 0
+        assert "ended with status FAILED" in result.output
+        mock_sky.down.assert_called_once()
+
+    # --- Edge cases ----------------------------------------------------------
+
+    def test_deadline_timeout_raises(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A job that never reaches a terminal status fails the launcher with a deadline error."""
+        import sky  # noqa: PLC0415
+
+        # Override only job_status to keep the polled status non-terminal forever.
+        responses = {
+            "launch-req": (1, MagicMock()),
+            "job-status-req": {1: sky.JobStatus.RUNNING},
+            "down-req": None,
+        }
+        mock_sky.stream_and_get.side_effect = lambda req: responses[req]
+
+        # Zero sleep between polls so the deadline-bounded loop completes synchronously.
+        monkeypatch.setattr(
+            "pipeline.entrypoints.skypilot_launch_smoke._JOB_POLL_INTERVAL_SECONDS", 0
+        )
+
+        result = _invoke(config_yaml, template_yaml, env_file, "--job-deadline-seconds", "0")
+        assert result.exit_code != 0
+        assert "did not reach a terminal status" in result.output
+        mock_sky.down.assert_called_once()
+
+    def test_launch_returning_none_job_id_aborts(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """If sky.launch yields no job_id the launcher aborts before polling/teardown."""
+        responses = {
+            "launch-req": (None, MagicMock()),
+        }
+        mock_sky.stream_and_get.side_effect = lambda req: responses[req]
+
+        result = _invoke(config_yaml, template_yaml, env_file)
+        assert result.exit_code != 0
+        assert "no job_id" in result.output.lower()
+
+    def test_teardown_runs_when_tail_logs_raises(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """A `sky.tail_logs` failure is observability-only — must not abort the launcher or skip
+        cluster teardown."""
+        mock_sky.tail_logs.side_effect = RuntimeError("boom")
+
+        result = _invoke(config_yaml, template_yaml, env_file)
+        # Worker job reached SUCCEEDED via the polling loop, so even though the worker-log
+        # dump in the finally raised, the launcher should still exit cleanly. The "boom"
+        # message is logged via click.echo as part of the diagnostic block.
+        assert result.exit_code == 0, result.output
+        assert "Worker log dump failed: boom" in result.output
+        mock_sky.down.assert_called_once()
+
+    def test_mount_source_cleaned_up_on_launch_exception(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """If sky.launch raises, the staged `.mount.json` sibling is still cleaned up."""
+        mock_sky.launch.side_effect = RuntimeError("boom")
+
+        result = _invoke(config_yaml, template_yaml, env_file)
+        assert result.exit_code != 0
+
+        spec_files = list(local_spec_dir.glob("*.json"))
+        assert len(spec_files) == 1
+        local_spec_path = spec_files[0]
+        mount_sibling = local_spec_path.with_suffix(".mount.json")
+        assert not mount_sibling.exists()


### PR DESCRIPTION
## Why this PR exists

The data pipeline needs to render datasets on RunPod GPUs. The original approach was a hand-rolled `ComputeBackend` protocol with a custom `RunPodBackend` implementation — see the design discussion on [#534](https://github.com/tinaudio/synth-setter/issues/534) for why we walked away from that. **SkyPilot** is the replacement: a multi-cloud compute orchestrator that lets us define a job once in a YAML "Task" and let SkyPilot pick a cloud, provision a pod, run the job, and tear the pod down — without us writing a per-provider backend.

This PR is the first scaffolding that makes SkyPilot the actual data-generation runner. After it lands, you can run a single-shard `generate_dataset` end-to-end on RunPod from a laptop or CI by pointing a Python CLI at a `DatasetConfig` YAML and a SkyPilot Task template; provisioning, rendering, R2 upload, and pod teardown all happen automatically. The "smoke" qualifier is deliberate — single-shard scope keeps this PR small while the multi-shard pipeline is built up in subsequent PRs ([#71](https://github.com/tinaudio/synth-setter/issues/71)).

Two things had to be solved together to make the round-trip green:

1. **A SkyPilot Python launcher** that wraps `sky.launch(...)` with the right knobs for RunPod (no managed-jobs controller, polling-based job-status check instead of `tail_logs(follow=True)` because RunPod SSH gets flaky after the workload finishes, etc.) plus the supporting infrastructure (the production launcher template, the `python-dotenv` dep for worker-side env loading).
2. **Three hardening fixes to `scripts/run-linux-vst-headless.sh`** — the bash wrapper that bootstraps Xvfb + xsettingsd + dbus + openbox so VST3 plugins can initialize without a real display. On RunPod, the wrapper's backgrounded daemons inherit the SSH command's stdin/stdout pipes; SkyPilot's job-status reporter waits for SSH-pipe EOF before declaring SUCCEEDED, and any straggler holding the pipe makes the job stay in RUNNING forever (#735). PR [#736](https://github.com/tinaudio/synth-setter/pull/736) (already merged) was the first piece (drop `exec` on `dbus-run-session`); the three commits here are the rest of the contract — independently bisected via the `headless-no-*` variants in the originating debug loop, all of which proved each piece is sufficient on top of #736 ([commentary](https://github.com/tinaudio/synth-setter/pull/716#issuecomment-4361650728) on the now-decomposed PR #716).

A diagnostic matrix workflow ships alongside, as a permanent `workflow_dispatch`-only canary so the next time the SkyPilot/RunPod path regresses, anyone can dispatch the matrix and read the green/red pattern in ~10 minutes to triage which class of failure it is.

## What this PR adds

### SkyPilot launcher — `pipeline.entrypoints.skypilot_launch_smoke`

Click CLI: `--config`, `--template`, `--env-file`, `--cluster-name`, `--spec-out`, `--job-deadline-seconds`. Materializes a `DatasetPipelineSpec` locally, ships it via SkyPilot `task.update_file_mounts`, calls `sky.launch(task, idle_minutes_to_autostop=0, down=True)`, polls `sky.job_status` for terminal state, dumps the worker log via `sky.tail_logs(follow=False)` before teardown, and explicitly `sky.down`s the cluster in `finally`.

Two non-obvious shape decisions:

- **`sky.launch` (unmanaged) instead of `sky.jobs.launch` (managed).** Managed jobs require a cloud-storage backend for controller state, which RunPod doesn't provide. Cluster-level launch is sufficient for this single-shard smoke probe; managed jobs become viable once we add a controller backend (separate epic).
- **`sky.job_status` polling instead of `sky.tail_logs(follow=True)`.** On RunPod, `tail_logs(follow=True)` waits for an SSH-stream EOF that never arrives once the worker exits — even though the artifacts are already in R2. Polling `sky.job_status` returns SUCCEEDED reliably; worker stdout is dumped via a single `tail_logs(follow=False)` before teardown so any traceback still surfaces in CI.

Default template: `configs/compute/runpod-template.yaml`. Click `exists=True` validation on `--template` requires this file to exist on disk for the CLI to import cleanly, so the template lands first in the commit sequence below.

### Wrapper hardening — `scripts/run-linux-vst-headless.sh`

Three fixes layered on top of #736's `exec` removal:

1. **stdin/stdout detach** (`</dev/null` on Xvfb / xsettingsd / openbox; Xvfb also `>/dev/null`) — daemons no longer inherit the SSH command's stdin pipe. Without this, any grandchild reparented to PID 1 keeps the pipe open and SkyPilot never sees EOF.
2. **Synchronous reap** (`wait` after the SIGTERMs in the cleanup trap) — bash blocks until tracked children (XVFB/XSETTINGS/OPENBOX) are fully reaped before returning. `kill PID` is async and bash returns from `kill` before the kernel finishes draining the child's exit. Adds `[wrapper] cleanup: …` echoes (starting, child PIDs, pre-kill `ps`, per-daemon kill notice, `done`) so a future hang surfaces a process-tree snapshot in `tail_logs` evidence.
3. **Orphan-grandchild sweep** (`pkill -P $$` after `wait`) — `wait` only reaps children we tracked; any grandchild forked by openbox or dbus-launch and reparented to PID 1 escapes `wait`. `pkill -P $$` SIGTERMs everything whose parent is the wrapper bash. Adds a post-kill `ps` snapshot to log "did the sweep find anything?"

### Diagnostic matrix — `.github/workflows/test-skypilot-debug.yml`

`workflow_dispatch`-only; ~3 RunPod pods per dispatch (billable). Three variants, each isolating one known failure class:

| Variant | What it exercises | Failure class it catches |
|---|---|---|
| `noop` | provision → submit → status-poll → teardown, no wrapper, no Python | SkyPilot/RunPod orchestration regression. PASS = the platform itself is fine. |
| `rclone` | `rclone copy <small file> r2:...` | rclone-process-exit regressions (#735 bug-#2). Currently believed gone. |
| `pedalboard-load` | `python -c "from pedalboard import VST3Plugin; VST3Plugin('/usr/lib/vst3/Surge XT.vst3')"` through the headless wrapper | Long-lived Python interpreter + the wrapper hardening triplet under RunPod's actual SSH-pipe-EOF semantics. The strongest signal in the matrix. Also the canary that tells us when bug-#3's `os._exit(0)` workaround (lands in PR-C) becomes safe to revert. |

`task.workdir = os.getcwd()` syncs the GH-actions checkout to the worker as `~/sky_workdir`, so the matrix tests **the in-repo wrapper as authored on the PR's branch**, not the image-baked copy. Wrapper iterations don't require a docker rebuild between dispatches.

The matrix's inline python probe deliberately doesn't reuse `pipeline.entrypoints.skypilot_launch_smoke` — it exercises the SkyPilot platform, not our launcher code path. Mixing the two would mask whether a regression is in SkyPilot, RunPod, or our code.

### `python-dotenv` — `requirements-app.txt`

The launcher loads worker-side env vars from a `.env` file via `dotenv_values`. SkyPilot itself was already pinned in [#729](https://github.com/tinaudio/synth-setter/pull/729); this closes the remaining runtime-dep gap so the launcher imports on a fresh checkout.

## Commits

7 commits, all atomically reviewable. Order is mechanical (template before launcher because the launcher's Click default validates against the template path):

1. `internal-fix(scripts): detach stdin/stdout on backgrounded X-stack daemons` — wrapper fix 1.
2. `internal-fix(scripts): synchronous reap (\`wait\`) in cleanup trap + diagnostic logging` — wrapper fix 2.
3. `internal-fix(scripts): orphan-grandchild sweep (\`pkill -P $$\`) in cleanup trap` — wrapper fix 3.
4. `build(deps): add python-dotenv for SkyPilot launcher .env loading`.
5. `feat(configs): SkyPilot RunPod task template for the data pipeline smoke launcher` — `configs/compute/runpod-template.yaml`.
6. `internal-feat(pipeline): SkyPilot RunPod launcher for smoke generate_dataset` — `pipeline/entrypoints/skypilot_launch_smoke.py` + 33 tests (mock-based).
7. `ci(test-skypilot-debug): 3-variant SkyPilot/RunPod canary matrix (noop, rclone, pedalboard-load)` — workflow + 3 templates.

`Refs #534`. `Refs #735` (this PR closes the wrapper-cleanup half; the Python interpreter shutdown half ships as a workaround in PR-C and is reverted once #735 is root-caused).

## Test plan

- [x] **133 pipeline tests green** — 107 from main + 8 from PR-A ([#740](https://github.com/tinaudio/synth-setter/pull/740)) + 18 launcher tests added here. Launcher tests use a mock `sky` and exercise the real CLI flow including spec materialization, env-file load, mount staging, polling-loop terminal states, mount cleanup on success and on launch exception, and the deadline-timeout failure path.
- [x] **3-variant matrix dispatched and green on this branch** — see [run 25236448344](https://github.com/tinaudio/synth-setter/actions/runs/25236448344). All three variants PASS. The `pedalboard-load` PASS in particular validates the 3 wrapper hardening commits collectively under RunPod's actual SSH-pipe-EOF semantics. See [verification comment](https://github.com/tinaudio/synth-setter/pull/741#issuecomment-4362026446) for the full breakdown.
- [ ] **End-to-end production smoke (provision → render → upload → teardown of a real shard)** — out of scope for this PR; lands in PR-C ([#743](https://github.com/tinaudio/synth-setter/pull/743), `feat/dataset-generation-smoke-workflow`).

## Sequencing — part of the PR #716 decomposition

Tracked on Epic [#534, comment](https://github.com/tinaudio/synth-setter/issues/534#issuecomment-4361944466). Merge order: [#736](https://github.com/tinaudio/synth-setter/pull/736) (merged) → [#740](https://github.com/tinaudio/synth-setter/pull/740) (merged) → **this PR** → [#743](https://github.com/tinaudio/synth-setter/pull/743) (production smoke + os._exit workaround) → [#739](https://github.com/tinaudio/synth-setter/pull/739) (docs) → close #716 as superseded.