### PR TITLE
fix(ci): drop `passthrough` from remaining docker run invocations after #721

### DIFF
--- a/.github/workflows/dataset-generation.yml
+++ b/.github/workflows/dataset-generation.yml
@@ -42,8 +42,9 @@ jobs:
 
       # Bootstrap steps that can't run from inside the click entrypoint
       # (git safe.directory + plugin symlink depend on the bind mount + runner
-      # UID mismatch). Done via `passthrough` so we still exercise the real
-      # ENTRYPOINT (python click CLI) instead of `--entrypoint bash`.
+      # UID mismatch). The image has no ENTRYPOINT and CMD=/bin/bash (dropped
+      # in a3e5f87 so SkyPilot's RunPod backend can run `bash -c '<setup>'`),
+      # so trailing argv is the command — invoke `bash -c` directly.
       # CONFIG_PATH is passed as a positional arg to `bash -c`, not expanded
       # into the script text, to avoid quoting hazards if the workflow input
       # ever contains shell metacharacters.
@@ -57,15 +58,14 @@ jobs:
             -e CONFIG_PATH \
             -e PYTHONPATH=/home/build/synth-setter \
             tinaudio/synth-setter:${{ inputs.image_tag }} \
-            passthrough bash -c '
+            bash -c '
               set -euo pipefail
               cd /home/build/synth-setter
               git config --global --add safe.directory /home/build/synth-setter
               mkdir -p plugins
               ln -sf "/usr/lib/vst3/Surge XT.vst3" "plugins/Surge XT.vst3"
               # materialize_spec imports pedalboard (via param_specs) which
-              # needs a live X display — wrap the materialize invocation, not
-              # the whole container, so the click entrypoint stays X11-agnostic.
+              # needs a live X display.
               scripts/run-linux-vst-headless.sh \
                 python -m pipeline.ci.materialize_spec "$CONFIG_PATH" /run-metadata
             '
@@ -77,8 +77,8 @@ jobs:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         # Mount the PR's code into the container so we test THIS branch's code
-        # against the image's environment. Dispatch goes through the default
-        # ENTRYPOINT (python click CLI) — no `--entrypoint bash` override.
+        # against the image's environment. With ENTRYPOINT dropped, invoke the
+        # click CLI explicitly via `python /usr/local/bin/entrypoint.py`.
         run: |
           set -o pipefail
           docker run --rm \
@@ -92,7 +92,7 @@ jobs:
             -e WANDB_API_KEY="${WANDB_API_KEY}" \
             -e PYTHONPATH=/home/build/synth-setter \
             tinaudio/synth-setter:${{ inputs.image_tag }} \
-            generate_dataset --spec /run-metadata/input_spec.json \
+            python /usr/local/bin/entrypoint.py generate_dataset --spec /run-metadata/input_spec.json \
             2>&1 | tee /tmp/run-metadata/generate.log
 
       - name: Validate spec exists

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -91,9 +91,9 @@ jobs:
           echo "R2 prefix: ${R2_PREFIX}"
           echo "Shard file: ${SHARD_FILE}"
 
-          # Download shard from R2 via Docker (has rclone). The image's
-          # ENTRYPOINT is the python click CLI; `passthrough <cmd>` execs
-          # the trailing argv as PID 1.
+          # Download shard from R2 via Docker (has rclone). Image has no
+          # ENTRYPOINT (#721 dropped it for SkyPilot); CMD defaults to
+          # /bin/bash, so `docker run img <argv>` overrides CMD with that argv.
           mkdir -p /tmp/shard-download
           docker pull "$IMAGE"
           docker run --rm \
@@ -105,7 +105,7 @@ jobs:
             -e PYTHONPATH=/home/build/synth-setter \
             -v /tmp/shard-download:/download \
             "$IMAGE" \
-            passthrough rclone copy --checksum \
+            rclone copy --checksum \
               "r2:${R2_BUCKET}/${R2_PREFIX}${SHARD_FILE}" \
               /download/
 
@@ -120,6 +120,6 @@ jobs:
             -v "$(pwd)/input_spec.json:/spec/input_spec.json:ro" \
             -e PYTHONPATH=/home/build/synth-setter \
             "$IMAGE" \
-            passthrough python3 -m pipeline.ci.validate_shard \
+            python3 -m pipeline.ci.validate_shard \
               /spec/input_spec.json \
               "/download/${SHARD_FILE}"

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -81,7 +81,7 @@ jobs:
             -v ${{ github.workspace }}:/home/build/synth-setter \
             -e PYTHONPATH=/home/build/synth-setter \
             "$IMAGE" \
-            passthrough bash -c '
+            bash -c '
               set -euo pipefail
               cd /home/build/synth-setter
               git config --global --add safe.directory /home/build/synth-setter
@@ -91,10 +91,10 @@ jobs:
 
       - name: Run VST slow tests in Docker
         # Mount the PR's tests + src into the container so we test THIS
-        # branch's code against the image's environment. The image's
-        # ENTRYPOINT is the ``python click`` CLI; ``passthrough <argv>``
-        # execs the trailing argv as PID 1, same pattern as
-        # ``dataset-generation.yml``. The bench.json output goes to a host
+        # branch's code against the image's environment. Image has no
+        # ENTRYPOINT (#721 dropped it for SkyPilot); CMD defaults to
+        # /bin/bash, so `docker run img bash -c '...'` overrides CMD with
+        # the bash invocation. The bench.json output goes to a host
         # directory mounted at ``/bench`` so the publish step downstream
         # can pick it up.
         #
@@ -112,7 +112,7 @@ jobs:
             -e HYDRA_FULL_ERROR=1 \
             -e "SYNTH_SETTER_PLUGIN_PATH=/usr/lib/vst3/Surge XT.vst3" \
             "$IMAGE" \
-            passthrough bash -c '
+            bash -c '
               set -euo pipefail
               cd /home/build/synth-setter
               git config --global --add safe.directory /home/build/synth-setter


### PR DESCRIPTION
## Summary

- `dataset-generation.yml` and the `validate-shard` job in `test-dataset-generation.yml` were missed by #727 and still call `docker run img passthrough <argv>` against the rebuilt `dev-snapshot` image. Failing run: https://github.com/tinaudio/synth-setter/actions/runs/25236096530
- The image (rebuilt and republished as `dev-snapshot` at 2026-05-01 21:08 UTC from a `workflow_dispatch` of #721's branch) has no ENTRYPOINT and `CMD=["/bin/bash"]`, so docker exec's `passthrough` literally → `executable file not found in $PATH`.
- Drop `passthrough` from all remaining `docker run` invocations and invoke the click CLI explicitly via `python /usr/local/bin/entrypoint.py generate_dataset --spec …` (mirrors `configs/compute/runpod-template.yaml`).

`flush-investigation.yml` still uses `passthrough` but is slated for deletion, so it's left untouched.

Closes #726

## Test plan

- [ ] `Test Dataset Generation` (`workflow_dispatch` on this branch) reaches the in-container `materialize_spec` step without `exec: "passthrough"` failure.
- [ ] `generate-dataset` job in the same run executes `python /usr/local/bin/entrypoint.py generate_dataset --spec …` and produces a shard on R2.
- [ ] `validate-shard` job downloads the shard via `rclone copy` and runs `python3 -m pipeline.ci.validate_shard` without the `passthrough` error.