### PR TITLE
ci(test-skypilot-debug): add image-pull variant for second pod-boot probe

### DIFF
--- a/.github/workflows/test-skypilot-debug.yml
+++ b/.github/workflows/test-skypilot-debug.yml
@@ -1,6 +1,6 @@
 name: Test SkyPilot Debug
 
-# Permanent diagnostic matrix for the SkyPilot+RunPod path. Three canary
+# Permanent diagnostic matrix for the SkyPilot+RunPod path. Four canary
 # variants, each isolating one known failure class. None of these exercise
 # the production launcher or worker — they're standalone probes. When
 # test-dataset-generation (lands in a follow-up PR) regresses, dispatch
@@ -12,6 +12,15 @@ name: Test SkyPilot Debug
 #                    itself is fine; failure here means the regression
 #                    is in SkyPilot, RunPod's API, or the cluster
 #                    plumbing — not in our code.
+#
+#   image-pull       Image-availability canary. Same shape as `noop`
+#                    (provision a pod, run a one-line echo) but a
+#                    distinct slot in the matrix so a single RunPod
+#                    transient on `noop` doesn't look like a regression.
+#                    `noop` + `image-pull` together = two independent
+#                    pod boots per dispatch on the simplest possible
+#                    workload; both green = RunPod can reliably hand us
+#                    pods that have SSH + the dev-snapshot image ready.
 #
 #   rclone           rclone-process-exit canary
 #                    (`rclone copy <small file> r2:...`). Catches a
@@ -32,7 +41,7 @@ name: Test SkyPilot Debug
 #                    `os._exit(0)` workaround for.
 #
 # Triggers: workflow_dispatch only — RunPod pods are billable. Each
-# dispatch spends ~3 pods. Add a `push` trigger only temporarily when
+# dispatch spends ~4 pods. Add a `push` trigger only temporarily when
 # actively iterating on launcher / wrapper / template behavior.
 #
 # Required secrets:
@@ -72,6 +81,9 @@ jobs:
           - variant: noop
             template: configs/compute/runpod-debug-template.yaml
             cluster_suffix: noop
+          - variant: image-pull
+            template: configs/compute/runpod-debug-image-pull-template.yaml
+            cluster_suffix: image-pull
           - variant: rclone
             template: configs/compute/runpod-debug-rclone-template.yaml
             cluster_suffix: rclone

--- a/configs/compute/runpod-debug-image-pull-template.yaml
+++ b/configs/compute/runpod-debug-image-pull-template.yaml
@@ -1,0 +1,33 @@
+# SkyPilot task template for RunPod — DEBUG variant: image-pull canary.
+#
+# The minimum-meaningful workload: a pod is provisioned with the
+# dev-snapshot image, SkyPilot pulls the image, the container starts,
+# the run block prints a single "done" line. PASS = RunPod can hand us a
+# pod that has SSH + the image ready inside the SkyPilot SSH-readiness
+# timeout. FAIL = pod never came up to SSH-readiness (the failure mode we
+# saw on the test-dataset-generation smoke when production was failing
+# while the matrix's `noop` variant was green — this variant is a second
+# RunPod-orchestration probe per dispatch so a single transient doesn't
+# look like a regression).
+
+resources:
+  cloud: runpod
+  accelerators:
+    {
+      RTX3070:1,
+      RTX3080:1,
+      RTX3090:1,
+      RTXA4000:1,
+      RTX4000Ada:1,
+      A40:1,
+      RTX4090:1,
+    }
+  use_spot: false
+  disk_size: 50
+  image_id: docker:tinaudio/synth-setter:dev-snapshot
+
+setup: |
+  echo "synth-setter debug-image-pull worker ready (host: $(hostname))"
+
+run: |
+  echo "skypilot-debug image-pull job done (host: $(hostname), image online)"


### PR DESCRIPTION
## Summary

Adds a 4th variant (`image-pull`) to the `test-skypilot-debug` matrix that just provisions a RunPod pod, SkyPilot pulls the `dev-snapshot` image, the container starts, and the run block prints a single `done` line. Same shape as `noop` — but a distinct matrix slot so a single RunPod transient on `noop` doesn't look like a regression.

`noop` + `image-pull` together = two independent pod-boot probes per dispatch on the simplest possible workload. Useful concretely for triaging `test-dataset-generation` smoke failures with the shape `RuntimeError: Failed to SSH to <pod-ip> after timeout 600s, with Error: ConnectionRefusedError` (we hit several today): if both `noop` and `image-pull` are green when production is failing, the RunPod side is healthy and the failure is downstream of pod boot.

Files:

- `configs/compute/runpod-debug-image-pull-template.yaml` (new) — same `resources:` and `image_id` as the other debug templates; minimal `setup:` + `run:`.
- `.github/workflows/test-skypilot-debug.yml` — 4-variant matrix (was 3); docstring updated; "spends ~3 pods" → "~4 pods".

`Refs #534`.

## Test plan

- [ ] **Dispatch the matrix on this branch and confirm `image-pull` runs alongside the existing 3 variants** — Level 1, required by the `/pr-checkbox` skill for `workflow_dispatch` workflows. Will dispatch and link the green run here. Pod budget: ~4 RunPod pods per dispatch (vs ~3 today).
- [x] **YAML parses, matrix variants list resolves to `[noop, image-pull, rclone, pedalboard-load]`**:
  ```bash
  $ python3 -c "import yaml; y=yaml.safe_load(open('.github/workflows/test-skypilot-debug.yml')); print([m['variant'] for m in y['jobs']['debug']['strategy']['matrix']['include']])"
  ['noop', 'image-pull', 'rclone', 'pedalboard-load']
  ```