### PR TITLE
ci(test-skypilot-debug): add 3 progressive variants for failure-boundary triage

### DIFF
--- a/.github/workflows/test-skypilot-debug.yml
+++ b/.github/workflows/test-skypilot-debug.yml
@@ -1,47 +1,62 @@
 name: Test SkyPilot Debug
 
-# Permanent diagnostic matrix for the SkyPilot+RunPod path. Four canary
-# variants, each isolating one known failure class. None of these exercise
-# the production launcher or worker — they're standalone probes. When
-# test-dataset-generation (lands in a follow-up PR) regresses, dispatch
-# this and read the green/red pattern to triage in ~10 minutes.
+# Permanent diagnostic matrix for the SkyPilot+RunPod path. Seven progressive
+# canary variants, each adding one piece of the production smoke's complexity.
+# None of these run the production launcher or worker — they're standalone
+# probes. Read the matrix's green/red pattern to identify where the production
+# smoke first breaks.
 #
-#   noop             SkyPilot/RunPod orchestration canary
-#                    (provision -> submit -> status-poll -> teardown,
-#                    no wrapper, no Python work). PASS = the platform
-#                    itself is fine; failure here means the regression
-#                    is in SkyPilot, RunPod's API, or the cluster
-#                    plumbing — not in our code.
+# Layer 1 — orchestration only (no wrapper, no Python, no mount):
 #
-#   image-pull       Image-availability canary. Same shape as `noop`
-#                    (provision a pod, run a one-line echo) but a
-#                    distinct slot in the matrix so a single RunPod
-#                    transient on `noop` doesn't look like a regression.
-#                    `noop` + `image-pull` together = two independent
-#                    pod boots per dispatch on the simplest possible
-#                    workload; both green = RunPod can reliably hand us
-#                    pods that have SSH + the dev-snapshot image ready.
+#   noop             Provision -> submit -> status-poll -> teardown.
+#                    PASS = the platform itself is fine; failure here
+#                    means the regression is in SkyPilot, RunPod's API,
+#                    or the cluster plumbing — not in our code.
 #
-#   rclone           rclone-process-exit canary
-#                    (`rclone copy <small file> r2:...`). Catches a
-#                    future image / network / rclone-version combo
-#                    where rclone hangs post-upload (the bug-#2 hang
-#                    shape from #735, currently believed gone — this
-#                    variant is the canary).
+#   image-pull       Same shape as `noop` but a distinct slot so a
+#                    single RunPod transient on `noop` doesn't look
+#                    like a regression. `noop` + `image-pull` together
+#                    = two independent pod boots per dispatch.
 #
-#   pedalboard-load  Python+pedalboard+X interpreter-shutdown canary
-#                    (`python -c "load Surge XT"` through the headless
-#                    wrapper). Closest-to-production worker shape
-#                    without rclone; collectively validates the three
-#                    wrapper-cleanup hardening commits (stdin-detach,
-#                    `wait`, `pkill -P $$`) by exercising them under
-#                    a long-lived Python interpreter. Also the canary
-#                    that tells us when bug-#3 (#735's interpreter
-#                    shutdown hang) becomes safe to revert the
-#                    `os._exit(0)` workaround for.
+# Layer 2 — add ONE production-relevant capability (in isolation):
+#
+#   spec-mount       Adds SkyPilot file_mounts (production uses this
+#                    via `task.update_file_mounts(...)` to ship the
+#                    materialized spec). PASS = mount upload during
+#                    provisioning works and the worker can read the
+#                    mounted file. FAIL = mount upload extends pod-boot
+#                    timing past SSH-readiness, OR mounts land in
+#                    unexpected paths/permissions on RunPod.
+#
+#   headless         Headless wrapper around an `echo` (Xvfb +
+#                    xsettingsd + openbox + dbus + cleanup trap).
+#                    PASS = the 3 wrapper hardening commits in #741
+#                    are working. FAIL = something in the wrapper's
+#                    child-process lifecycle is again holding the SSH
+#                    pipes open past the foreground command's exit
+#                    (#735 bug-#1).
+#
+#   rclone           `rclone copy <small file> r2:...` directly (no
+#                    wrapper). Catches `rclone copy` regressions on
+#                    RunPod's network — the bug-#2 hang shape from
+#                    #735.
+#
+# Layer 3 — combine two capabilities:
+#
+#   headless-rclone  Wrapper + rclone. If `headless` and `rclone` both
+#                    PASS but this FAILS, the failure is in their
+#                    interaction (rclone fds inheriting X-stack pipes,
+#                    dbus session seeing unexpected children, etc.).
+#
+#   pedalboard-load  Wrapper + Python interpreter (`python -c "load
+#                    Surge XT"`). Closest to production without rclone
+#                    — collectively validates the wrapper hardening
+#                    triplet under a long-lived Python interpreter.
+#                    Also the canary for #735's bug-#3 (interpreter
+#                    shutdown hang).
 #
 # Triggers: workflow_dispatch only — RunPod pods are billable. Each
-# dispatch spends ~4 pods. Add a `push` trigger only temporarily when
+# dispatch spends ~7 pods. Add a `push` trigger only temporarily when
 # actively iterating on launcher / wrapper / template behavior.
 #
 # Required secrets:
@@ -84,9 +99,18 @@ jobs:
           - variant: image-pull
             template: configs/compute/runpod-debug-image-pull-template.yaml
             cluster_suffix: image-pull
+          - variant: spec-mount
+            template: configs/compute/runpod-debug-spec-mount-template.yaml
+            cluster_suffix: spec-mount
+          - variant: headless
+            template: configs/compute/runpod-debug-headless-template.yaml
+            cluster_suffix: headless
           - variant: rclone
             template: configs/compute/runpod-debug-rclone-template.yaml
             cluster_suffix: rclone
+          - variant: headless-rclone
+            template: configs/compute/runpod-debug-headless-rclone-template.yaml
+            cluster_suffix: headless-rclone
           - variant: pedalboard-load
             template: configs/compute/runpod-debug-pedalboard-template.yaml
             cluster_suffix: pedalboard

--- a/configs/compute/runpod-debug-headless-rclone-template.yaml
+++ b/configs/compute/runpod-debug-headless-rclone-template.yaml
@@ -1,0 +1,44 @@
+# SkyPilot task template for RunPod — DEBUG variant: headless wrapper + rclone.
+#
+# Layer 4 in the progressive triage matrix: combines the `headless` and `rclone`
+# variants — invokes rclone *through* the headless wrapper. Tests interactions
+# between the X-stack child-process tree and rclone's post-upload cleanup. The
+# production smoke runs rclone from inside generate_dataset which runs inside
+# the headless wrapper; if `headless` and `rclone` both PASS but `headless-rclone`
+# FAILS, the failure is in their interaction (e.g. rclone leaving fds open that
+# inherit X-stack pipes, dbus session bus seeing unexpected children, etc.).
+
+resources:
+  cloud: runpod
+  accelerators:
+    {
+      RTX3070:1,
+      RTX3080:1,
+      RTX3090:1,
+      RTXA4000:1,
+      RTX4000Ada:1,
+      A40:1,
+      RTX4090:1,
+    }
+  use_spot: false
+  disk_size: 50
+  image_id: docker:tinaudio/synth-setter:dev-snapshot
+
+envs:
+  RCLONE_CONFIG_R2_TYPE: ""
+  RCLONE_CONFIG_R2_PROVIDER: ""
+  RCLONE_CONFIG_R2_ACCESS_KEY_ID: ""
+  RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ""
+  RCLONE_CONFIG_R2_ENDPOINT: ""
+  R2_BUCKET: ""
+  R2_DEBUG_PREFIX: ""
+
+setup: |
+  echo "synth-setter debug-headless-rclone worker ready (host: $(hostname))"
+
+run: |
+  echo "test from headless-rclone variant" > /tmp/headless-rclone-test.txt
+  bash scripts/run-linux-vst-headless.sh rclone copy --checksum \
+    /tmp/headless-rclone-test.txt \
+    "r2:${R2_BUCKET}/${R2_DEBUG_PREFIX}headless-rclone-test.txt"
+  echo "skypilot-debug headless-rclone job done (host: $(hostname))"

--- a/configs/compute/runpod-debug-headless-template.yaml
+++ b/configs/compute/runpod-debug-headless-template.yaml
@@ -1,0 +1,43 @@
+# SkyPilot task template for RunPod — DEBUG variant: headless wrapper canary.
+#
+# Layer 3 in the progressive triage matrix: builds on `noop` by invoking the
+# headless wrapper (`scripts/run-linux-vst-headless.sh`) around a no-op `echo`.
+# Tests the wrapper's full lifecycle on RunPod: Xvfb + xsettingsd + openbox +
+# dbus startup, the cleanup trap firing on `echo`'s exit, all child processes
+# reaped, the SSH command's pipes released, and SkyPilot's job-status reporter
+# observing SUCCEEDED.
+#
+# PASS = the 3 wrapper hardening commits in PR #741 are working as intended.
+# FAIL = something in the wrapper's child-process lifecycle is again holding
+# the SSH pipes open past the foreground command's exit (the original #735
+# bug-#1 hang shape).
+#
+# Pairs with `pedalboard-load` (wrapper + Python interpreter) and
+# `headless-rclone` (wrapper + rclone) to triangulate which workload shape
+# changes the result.
+#
+# `task.workdir = os.getcwd()` in test-skypilot-debug.yml syncs the GH-actions
+# checkout to the worker, so this exercises the in-repo wrapper as authored on
+# the dispatching branch — not the image-baked copy.
+
+resources:
+  cloud: runpod
+  accelerators:
+    {
+      RTX3070:1,
+      RTX3080:1,
+      RTX3090:1,
+      RTXA4000:1,
+      RTX4000Ada:1,
+      A40:1,
+      RTX4090:1,
+    }
+  use_spot: false
+  disk_size: 50
+  image_id: docker:tinaudio/synth-setter:dev-snapshot
+
+setup: |
+  echo "synth-setter debug-headless worker ready (host: $(hostname))"
+
+run: |
+  bash scripts/run-linux-vst-headless.sh echo "skypilot-debug headless job done (host: $(hostname))"

--- a/configs/compute/runpod-debug-spec-mount-template.yaml
+++ b/configs/compute/runpod-debug-spec-mount-template.yaml
@@ -1,0 +1,38 @@
+# SkyPilot task template for RunPod — DEBUG variant: spec-mount canary.
+#
+# Layer 3 in the progressive triage matrix: builds on `noop` / `image-pull` by
+# also exercising SkyPilot's `file_mounts` (which the production launcher uses
+# via `task.update_file_mounts(...)` to ship the materialized DatasetPipelineSpec
+# to the worker). PASS = file_mounts upload during provisioning works on RunPod
+# and the worker can read the mounted file. FAIL = something about the mount
+# upload extends pod-boot timing past the SSH-readiness window, OR mounts land
+# in unexpected paths / permissions on RunPod.
+#
+# Mounts an in-repo file (this template itself) so we don't need a fixture —
+# the worker just verifies the file is present and non-empty.
+
+resources:
+  cloud: runpod
+  accelerators:
+    {
+      RTX3070:1,
+      RTX3080:1,
+      RTX3090:1,
+      RTXA4000:1,
+      RTX4000Ada:1,
+      A40:1,
+      RTX4090:1,
+    }
+  use_spot: false
+  disk_size: 50
+  image_id: docker:tinaudio/synth-setter:dev-snapshot
+
+file_mounts:
+  /home/build/synth-setter/data/spec-mount-probe.txt: configs/compute/runpod-debug-spec-mount-template.yaml
+
+setup: |
+  echo "synth-setter debug-spec-mount worker ready (host: $(hostname))"
+
+run: |
+  echo "spec-mount probe: file size = $(wc -c < /home/build/synth-setter/data/spec-mount-probe.txt) bytes"
+  echo "skypilot-debug spec-mount job done (host: $(hostname))"


### PR DESCRIPTION
## Summary

Expands the `test-skypilot-debug` matrix from 4 to 7 variants. The new variants (`spec-mount`, `headless`, `headless-rclone`) bridge the gap between the simple orchestration probes (`noop`, `image-pull`) and the production-shape variants (`rclone`, `pedalboard-load`). After a dispatch, reading the green/red pattern lights up the boundary where the production smoke ([test-dataset-generation](https://github.com/tinaudio/synth-setter/blob/main/.github/workflows/test-dataset-generation.yml)) would first fail.

The structure is layered:

| Layer | Variant | What it adds | What a FAIL here means |
|---|---|---|---|
| 1 | `noop` | Provision/submit/status-poll/teardown only | SkyPilot or RunPod platform regression |
| 1 | `image-pull` | Same as noop, second probe slot | Pure RunPod transient |
| 2 | `spec-mount` (NEW) | SkyPilot `file_mounts` (production uses `task.update_file_mounts(...)` for the spec) | Mount upload extends pod-boot past SSH-readiness, or mount semantics on RunPod surprise us |
| 2 | `headless` (NEW) | Headless wrapper around an `echo` (Xvfb + xsettingsd + openbox + dbus + cleanup trap) | Wrapper hardening triplet (#741) regressed |
| 2 | `rclone` | `rclone copy <small file> r2:...` directly | rclone-on-RunPod regression (#735 bug-#2) |
| 3 | `headless-rclone` (NEW) | Wrapper + rclone | Interaction between X-stack and rclone (fd inheritance, dbus children, etc.) |
| 3 | `pedalboard-load` | Wrapper + Python interpreter | Long-lived Python+pedalboard+X path (#735 bug-#3) |

Spends ~7 RunPod pods per dispatch (was ~4), still `workflow_dispatch`-only.

### Why this shape

The production smoke ([#743](https://github.com/tinaudio/synth-setter/pull/743)) hit a string of "Failed to SSH to <pod-ip> after timeout 600s" failures earlier today while the existing 4-variant matrix was green. The failures looked like RunPod transients but we couldn't isolate which capability of the production smoke (file_mounts? the wrapper? the rclone path? the Python interpreter?) was the proximate trigger if any. The 3 new variants make that diagnosable in ~10 minutes per dispatch instead of "re-dispatch the whole production smoke and wait 25 minutes per attempt."

### Files

- `configs/compute/runpod-debug-spec-mount-template.yaml` (new)
- `configs/compute/runpod-debug-headless-template.yaml` (new)
- `configs/compute/runpod-debug-headless-rclone-template.yaml` (new)
- `.github/workflows/test-skypilot-debug.yml` — 7-variant matrix; docstring rewritten as the layered table

`Refs #534`. `Refs #735`.

## Test plan

- [ ] **7-variant matrix dispatched on this branch and all 7 turn green** — Level 1, REQUIRED by the `/pr-checkbox` skill for `workflow_dispatch` workflows. Will dispatch when this PR is opened. Pod budget: ~7 RunPod pods (vs 4 before).
- [x] **All 4 templates parse via `sky.Task.from_yaml`** *(Level 2 — invoked the actual SkyPilot parser, not just yaml.safe_load):*
  ```
  OK configs/compute/runpod-debug-spec-mount-template.yaml
  OK configs/compute/runpod-debug-headless-template.yaml
  OK configs/compute/runpod-debug-headless-rclone-template.yaml
  ```
- [x] **Matrix has 7 variants with unique cluster suffixes; all 7 templates exist on disk:**
  ```
  noop                  configs/compute/runpod-debug-template.yaml               ✓
  image-pull            configs/compute/runpod-debug-image-pull-template.yaml    ✓
  spec-mount            configs/compute/runpod-debug-spec-mount-template.yaml    ✓
  headless              configs/compute/runpod-debug-headless-template.yaml      ✓
  rclone                configs/compute/runpod-debug-rclone-template.yaml        ✓
  headless-rclone       configs/compute/runpod-debug-headless-rclone-template.yaml  ✓
  pedalboard-load       configs/compute/runpod-debug-pedalboard-template.yaml    ✓
  ```