### PR TITLE
tests: mark surge_xt_interactive smoke test as requires_vst

### DIFF
--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -277,6 +277,7 @@ class TestLoadDatasetSynthParams:
         with pytest.raises((IndexError, ValueError)):
             surge_xt_interactive.load_dataset_synth_params(ref, param_spec_name=SURGE_SIMPLE)
 
+    @pytest.mark.requires_vst
     @pytest.mark.slow
     def test_loads_row_from_surge_xt_smoke_fixture(
         self,


### PR DESCRIPTION
## Summary

`cpu-slow.yml` (renamed from `test-expensive.yml` in #708) runs `pytest -m "slow and not gpu and not mps and not requires_vst"` on a bare `ubuntu-latest-4core` runner — VST tests now live in the Docker-based `test-vst-slow.yml`, so the X11 / Surge XT install steps were stripped.

`tests/scripts/test_surge_xt_interactive.py::TestLoadDatasetSynthParams::test_loads_row_from_surge_xt_smoke_fixture` (added in #723) was marked `@pytest.mark.slow` only, so the marker filter doesn't deselect it. Its `surge_xt_smoke_datasets` fixture (`tests/conftest.py:331`) shells out to `scripts/run-linux-vst-headless.sh`, which on the bare runner spawns Xvfb successfully but then fails the `xdpyinfo` probe (`x11-utils` isn't installed), exiting with the misleading message `Xvfb did not start`.

Failed run: https://github.com/tinaudio/synth-setter/actions/runs/25238068781/job/74008725889

This PR adds `@pytest.mark.requires_vst` to the test, mirroring the marker stack on `test_train_surge_xt` and `test_train_eval_surge_xt` (`tests/test_train.py:168,195`) which depend on the same fixture.

## Test plan

- [x] `pytest --collect-only -m "slow and not gpu and not mps and not requires_vst" tests/scripts/test_surge_xt_interactive.py` → test is deselected (matches `cpu-slow.yml` filter)
- [x] `pytest --collect-only -m "slow" tests/scripts/test_surge_xt_interactive.py` → test is still collected when `requires_vst` is allowed
- [x] `make format` passes (pre-commit hooks clean)
- [ ] CI: `cpu-slow.yml` run on this branch should no longer hit `Xvfb did not start` from this test

Fixes #717