### PR TITLE
internal-feat(pipeline): loop generate_dataset over spec.shards

### DIFF
--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -50,11 +50,11 @@ At research scale (500k–15M samples), the single-machine approach breaks down.
 
 ### Distributed Pipeline
 
-> **Implementation status:** Only single-shard generation is implemented today
-> (`pipeline/entrypoints/generate_dataset.py`). Multi-shard generation raises
-> `NotImplementedError`. The distributed pipeline described below is the design
-> target — the CLI, backends, reconciliation, and finalize stages are planned but
-> not yet built.
+> **Implementation status:** Single-machine sequential multi-shard generation is
+> implemented today (`pipeline/entrypoints/generate_dataset.py` loops over
+> `spec.shards`). The distributed/parallel pipeline described below — CLI,
+> backends, reconciliation, and finalize stages — is the design target and not
+> yet built.
 
 The distributed data pipeline solves this by splitting generation across N cloud workers on **[RunPod](https://www.runpod.io/)** (a GPU/CPU cloud marketplace offering cheap on-demand compute), each independently producing shards in parallel. Workers write shards to **[Cloudflare R2](https://developers.cloudflare.com/r2/)** (an S3-compatible object storage service with free egress), which serves as both the data store and the coordination layer. A separate finalize step downloads all shards, reshards them into train/val/test splits, computes normalization statistics, registers the dataset as a **[Weights & Biases](https://wandb.ai/)** (W&B) artifact, and uploads the final dataset.
 
@@ -82,8 +82,8 @@ cat configs/dataset/surge-simple-480k-10k.yaml
 # **Planned CLI** — the distributed pipeline CLI (`python -m pipeline generate/status/finalize`)
 # is not yet implemented. Currently only single-shard generation is available via:
 DATASET_CONFIG=configs/dataset/surge-simple-480k-10k.yaml python -m pipeline.entrypoints.generate_dataset
-# → Single-shard MVP. Multi-shard (num_shards > 1) raises NotImplementedError.
-# `generate_dataset` is the current single-shard MVP. It will be deprecated when
+# → Sequential multi-shard MVP. Loops over spec.shards on a single worker; distributed parallelism still tracked under #411.
+# `generate_dataset` is the current MVP. It will be deprecated when
 # `generate-shards` lands on main (#411).
 
 # --- Target state (distributed pipeline, not yet implemented) ---
@@ -1409,7 +1409,7 @@ pipeline/
 
   entrypoints/          # Pipeline entry points (implemented)
     __init__.py
-    generate_dataset.py # Single-shard dataset generation (MVP); deprecated when generate-shards lands (#411)
+    generate_dataset.py # Sequential multi-shard dataset generation (MVP); deprecated when generate-shards lands (#411)
 
   ci/                   # CI validation scripts (implemented)
     validate_shard.py   # Shard validation (valid HDF5, expected datasets, row count)

--- a/docs/design/storage-provenance-spec.md
+++ b/docs/design/storage-provenance-spec.md
@@ -44,7 +44,7 @@ ______________________________________________________________________
 
 ### 3a. Data Generation
 
-> **Implementation status:** The layout below is the target architecture. The current single-shard MVP uses a flat structure: spec and shard upload directly to `data/{config_id}/{run_id}/`.
+> **Implementation status:** The layout below is the target architecture. The current MVP uses a flat structure: spec and all shards upload directly to `data/{config_id}/{run_id}/`.
 
 ```
 data/{dataset_config_id}/{dataset_wandb_run_id}/

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -74,7 +74,7 @@ docs:
       - pattern: "configs/dataset/**"
         covers: "Dataset generation configs, shard counts, sample counts, synth params"
       - pattern: "pipeline/entrypoints/generate_dataset.py"
-        covers: "Dataset generation entrypoint, single-shard MVP, CLI interface"
+        covers: "Dataset generation entrypoint, sequential multi-shard MVP, CLI interface"
       - pattern: ".github/workflows/dataset-generation.yml"
         covers: "CI workflow steps, trigger conditions, artifact handling"
       - pattern: "pipeline/ci/**"

--- a/docs/reference/docker-spec.md
+++ b/docs/reference/docker-spec.md
@@ -31,7 +31,7 @@ inputs. All dataset-run configuration — including the R2 bucket
 (`DatasetPipelineSpec.r2_bucket`) — flows in through the materialized
 spec at `--spec`.
 
-> **Note:** `generate_dataset` is the current single-shard MVP. It will be deprecated when `generate-shards` lands on main ([#411](https://github.com/tinaudio/synth-setter/issues/411)).
+> **Note:** `generate_dataset` is the current MVP (sequential multi-shard, single-worker). It will be deprecated when `generate-shards` lands on main ([#411](https://github.com/tinaudio/synth-setter/issues/411)).
 
 ### Headless X11
 
@@ -127,8 +127,8 @@ subcommand (`generate_dataset`, `idle`, `passthrough`, …) is a positional
 arg; the pipeline spec — including the R2 bucket — is read from the JSON
 file passed via `--spec`. `input_spec.json` is written by the caller (the
 `pipeline.ci.materialize_spec` bootstrap step in CI) to a bind-mounted
-directory. Multi-shard generation (`num_shards > 1`) raises
-`NotImplementedError`.
+directory. Multi-shard generation runs sequentially on a single worker;
+distributed parallelism is tracked in [#407](https://github.com/tinaudio/synth-setter/issues/407).
 
 rclone's native env-var config synthesizes the `r2` remote in-memory from
 the 5 `RCLONE_CONFIG_R2_*` vars — no `rclone.conf` file is read or written.

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -211,7 +211,7 @@ docker run --rm synth-setter:dev-snapshot \
 
 ### `generate_dataset` — VST dataset generation
 
-Generates a VST dataset shard via `generate_vst_dataset.py` under
+Generates one or more VST dataset shards (looping over `spec.shards`) via `generate_vst_dataset.py` under
 headless X11 (Xvfb). The click entrypoint itself is X11-agnostic; the
 headless bootstrap (`scripts/run-linux-vst-headless.sh`) is applied
 inside `pipeline.entrypoints.generate_dataset.run()` at the

--- a/pipeline/entrypoints/generate_dataset.py
+++ b/pipeline/entrypoints/generate_dataset.py
@@ -176,13 +176,17 @@ def _render_and_upload_shard(
     logger.info(f"rendering shard {shard.shard_id} -> {shard.filename}")
     subprocess.check_call(args)  # noqa: S603 — args built from validated spec
     shard_path = work_dir / shard.filename
-    size = shard_path.stat().st_size if shard_path.exists() else 0
-    logger.info(f"shard rendered: {shard_path} ({size} bytes)")
+    # Catches a generator that exits 0 without writing output — surfaces a clear error
+    # at the rendering boundary rather than a downstream rclone "source not found".
+    if not shard_path.is_file():
+        raise RuntimeError(
+            f"generate_vst_dataset.py exited 0 but did not write expected shard file: {shard_path}"
+        )
+    logger.info(f"shard rendered: {shard_path} ({shard_path.stat().st_size} bytes)")
     _rclone_copy(str(shard_path), r2_dest_prefix)
     logger.info(f"shard uploaded: {shard.filename} -> {r2_dest_prefix}")
-    if shard_path.exists():
-        shard_path.unlink()
-        logger.info(f"shard removed locally: {shard_path}")
+    shard_path.unlink()
+    logger.info(f"shard removed locally: {shard_path}")
 
 
 if __name__ == "__main__":

--- a/pipeline/entrypoints/generate_dataset.py
+++ b/pipeline/entrypoints/generate_dataset.py
@@ -1,7 +1,8 @@
-"""Spec-driven single-shard generate_dataset runner.
+"""Spec-driven generate_dataset runner.
 
 Public API:
-    run(spec): Full flow — upload spec to R2, generate shard, upload shard to R2.
+    run(spec): Full flow — upload spec to R2 once, then loop over
+        ``spec.shards`` rendering and uploading each.
     build_generate_args(spec, shard, output_dir): Build CLI args for
         src/data/vst/generate_vst_dataset.py.
 
@@ -102,13 +103,13 @@ def build_generate_args(
 
 
 def run(spec: DatasetPipelineSpec) -> None:
-    """Materialized-spec driven run: upload spec to R2, generate shard, upload shard.
+    """Materialized-spec driven run: upload spec to R2 once, then render+upload each shard.
 
-    Single-shard only. Multi-shard generation is tracked in
-    https://github.com/tinaudio/synth-setter/issues/407 (``generate-shards``)
-    and requires the distributed pipeline. This entrypoint fails fast with
-    ``NotImplementedError`` on ``spec.num_shards > 1`` so callers don't
-    silently get a partial dataset.
+    Spec serialization, spec upload, and the renderer-version constraint check
+    happen once per run (pre-loop). Each shard is then rendered, uploaded, and
+    its local HDF5 file unlinked before moving on — so local disk usage is
+    bounded to one shard's worth at a time. Subprocess failures propagate
+    immediately (fail-fast); later shards are not attempted.
 
     HDF5-only. Other output formats (e.g. WebDataset) are not yet wired into
     the downstream generator.
@@ -117,19 +118,10 @@ def run(spec: DatasetPipelineSpec) -> None:
         spec: Pre-materialized DatasetPipelineSpec.
 
     Raises:
-        NotImplementedError: If ``spec.num_shards > 1`` (tracked in #407).
         ValueError: If ``spec.output_format != "hdf5"``.
+        RuntimeError: If the worker's plugin version disagrees with
+            ``spec.renderer_version``.
     """
-    # Single-shard fail-fast. The downstream generator, the shard-upload
-    # step, and build_generate_args all assume exactly one shard; see #407
-    # for the multi-shard rewrite.
-    if spec.num_shards > 1:
-        raise NotImplementedError(
-            f"num_shards > 1 not yet supported (got {spec.num_shards}). "
-            "Multi-shard generation is tracked in #407 "
-            "(https://github.com/tinaudio/synth-setter/issues/407)."
-        )
-
     if spec.output_format != "hdf5":
         raise ValueError(
             f"generate_vst_dataset.py only supports hdf5 output, got: {spec.output_format}"
@@ -165,17 +157,32 @@ def run(spec: DatasetPipelineSpec) -> None:
         _rclone_copy(str(spec_path), r2_dest_prefix)
         logger.info(f"spec uploaded -> {r2_dest_prefix}")
 
-        # Single-shard only: picks spec.shards[0] unconditionally. Guarded by
-        # the fail-fast check above; multi-shard support tracked in #407.
-        shard = spec.shards[0]
-        args = [VST_HEADLESS_WRAPPER, *build_generate_args(spec, shard, work_dir)]
-        logger.info(f"rendering shard {shard.shard_id} -> {shard.filename}")
-        subprocess.check_call(args)  # noqa: S603 — args built from validated spec
-        shard_path = work_dir / shard.filename
-        size = shard_path.stat().st_size if shard_path.exists() else 0
-        logger.info(f"shard rendered: {shard_path} ({size} bytes)")
-        _rclone_copy(str(shard_path), r2_dest_prefix)
-        logger.info(f"shard uploaded: {shard.filename} -> {r2_dest_prefix}")
+        for shard in spec.shards:
+            _render_and_upload_shard(spec, shard, work_dir, r2_dest_prefix)
+
+
+def _render_and_upload_shard(
+    spec: DatasetPipelineSpec,
+    shard: ShardSpec,
+    work_dir: Path,
+    r2_dest_prefix: str,
+) -> None:
+    """Render a single shard, upload it to R2, then unlink the local file.
+
+    Unlinking after upload bounds local disk to one shard's HDF5 at a time — necessary for multi-
+    shard runs on disk-constrained workers.
+    """
+    args = [VST_HEADLESS_WRAPPER, *build_generate_args(spec, shard, work_dir)]
+    logger.info(f"rendering shard {shard.shard_id} -> {shard.filename}")
+    subprocess.check_call(args)  # noqa: S603 — args built from validated spec
+    shard_path = work_dir / shard.filename
+    size = shard_path.stat().st_size if shard_path.exists() else 0
+    logger.info(f"shard rendered: {shard_path} ({size} bytes)")
+    _rclone_copy(str(shard_path), r2_dest_prefix)
+    logger.info(f"shard uploaded: {shard.filename} -> {r2_dest_prefix}")
+    if shard_path.exists():
+        shard_path.unlink()
+        logger.info(f"shard removed locally: {shard_path}")
 
 
 if __name__ == "__main__":

--- a/pipeline/schemas/spec.py
+++ b/pipeline/schemas/spec.py
@@ -89,6 +89,16 @@ class DatasetPipelineSpec(BaseModel):
             raise ValueError("r2_bucket must not be blank")
         return value
 
+    @field_validator("shards")
+    @classmethod
+    def _shards_must_not_be_empty(cls, value: tuple[ShardSpec, ...]) -> tuple[ShardSpec, ...]:
+        # DatasetConfig enforces num_shards > 0 at materialize time; this mirror catches
+        # specs loaded from external/hand-edited JSON where shards=[] would otherwise let
+        # generate_dataset.run() succeed as a silent no-op (uploads only the spec).
+        if not value:
+            raise ValueError("shards must not be empty")
+        return value
+
 
 def _get_git_sha() -> str:
     """Get the current git commit SHA."""

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -3,8 +3,9 @@
 The entrypoint's public surface is a single ``run(spec)`` function that:
   1. Serializes the spec to a tempfile.
   2. Uploads the spec to R2 at ``r2:{bucket}/{prefix}/input_spec.json``.
-  3. Shells out to ``generate_vst_dataset.py`` to produce the shard.
-  4. Uploads the shard to R2 at ``r2:{bucket}/{prefix}/``.
+  3. For each shard in ``spec.shards``, shells out to ``generate_vst_dataset.py``
+     to render it, uploads to R2 at ``r2:{bucket}/{prefix}/``, and unlinks the
+     local file.
 
 Tests monkeypatch ``_rclone_copy`` and ``subprocess.check_call`` and assert on
 recorded call args + ordering.

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -36,6 +36,20 @@ TEST_PLUGIN_VST3 = Path(__file__).resolve().parent.parent / "fixtures" / "TestPl
 TEST_PLUGIN_VERSION = "1.0.0-test"
 
 
+def _materialize_shard(args: list[str]) -> int:
+    """subprocess.check_call side effect that writes the expected shard file.
+
+    Mirrors the production contract: generate_vst_dataset.py exits 0 only after writing the
+    HDF5 to its output path. Tests that don't supply this side effect would trip the
+    `shard_path.is_file()` check in `_render_and_upload_shard`.
+    """
+    # Args layout: [wrapper, python, generate_vst_dataset.py, output_file, ...].
+    output_file = Path(args[3])
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_bytes(b"")
+    return 0
+
+
 def _base_spec_kwargs(tmp_path: Path, **overrides: object) -> dict[str, object]:
     """Return valid DatasetPipelineSpec kwargs for direct construction."""
     kwargs: dict[str, object] = {
@@ -102,6 +116,7 @@ class TestRun:
         spec: DatasetPipelineSpec,
     ) -> None:
         """Spec upload copies spec_path into the prefix directory (rclone preserves basename)."""
+        mock_check_call.side_effect = _materialize_shard
         run(spec)
 
         rclone_calls = mock_rclone.call_args_list
@@ -122,6 +137,7 @@ class TestRun:
         spec: DatasetPipelineSpec,
     ) -> None:
         """Spec is uploaded to R2 before the shard-generating subprocess runs."""
+        mock_check_call.side_effect = _materialize_shard
         manager = MagicMock()
         manager.attach_mock(mock_rclone, "rclone")
         manager.attach_mock(mock_check_call, "check_call")
@@ -140,6 +156,7 @@ class TestRun:
         spec: DatasetPipelineSpec,
     ) -> None:
         """subprocess.check_call invokes generate_vst_dataset.py with spec-derived args."""
+        mock_check_call.side_effect = _materialize_shard
         run(spec)
 
         mock_check_call.assert_called_once()
@@ -162,6 +179,7 @@ class TestRun:
         docker_entrypoint click CLI can stay X11-agnostic — idle and passthrough modes don't pay
         the Xvfb startup cost.
         """
+        mock_check_call.side_effect = _materialize_shard
         run(spec)
 
         args = mock_check_call.call_args[0][0]
@@ -179,6 +197,7 @@ class TestRun:
         spec: DatasetPipelineSpec,
     ) -> None:
         """Second rclone call uploads the shard to r2:{bucket}/{prefix}/."""
+        mock_check_call.side_effect = _materialize_shard
         run(spec)
 
         rclone_calls = mock_rclone.call_args_list
@@ -233,6 +252,7 @@ class TestRun:
     ) -> None:
         """Multi-shard run invokes generate_vst_dataset.py once per shard, in order."""
         spec = _multi_shard_spec(tmp_path, n=3)
+        mock_check_call.side_effect = _materialize_shard
 
         run(spec)
 
@@ -255,6 +275,7 @@ class TestRun:
     ) -> None:
         """Spec is uploaded once per run; remaining rclone calls are per-shard uploads."""
         spec = _multi_shard_spec(tmp_path, n=3)
+        mock_check_call.side_effect = _materialize_shard
 
         run(spec)
 
@@ -274,6 +295,7 @@ class TestRun:
     ) -> None:
         """Render and upload are interleaved per shard: render0, upload0, render1, upload1, ..."""
         spec = _multi_shard_spec(tmp_path, n=3)
+        mock_check_call.side_effect = _materialize_shard
         manager = MagicMock()
         manager.attach_mock(mock_rclone, "rclone")
         manager.attach_mock(mock_check_call, "check_call")
@@ -302,15 +324,6 @@ class TestRun:
     ) -> None:
         """Each shard's local HDF5 is unlinked after upload to bound disk to one shard."""
         spec = _multi_shard_spec(tmp_path, n=3)
-
-        # Render side effect: create the local shard file so the unlink call is real.
-        def _materialize_shard(args: list[str]) -> int:
-            # Args layout: [wrapper, python, generate_vst_dataset.py, output_file, ...].
-            output_file = Path(args[3])
-            output_file.parent.mkdir(parents=True, exist_ok=True)
-            output_file.write_bytes(b"")
-            return 0
-
         mock_check_call.side_effect = _materialize_shard
         # Track which paths existed at upload time, and which still exist after run().
         uploaded_paths: list[Path] = []
@@ -337,16 +350,45 @@ class TestRun:
     ) -> None:
         """Mid-loop subprocess failure raises immediately; later shards are not attempted."""
         spec = _multi_shard_spec(tmp_path, n=3)
-        mock_check_call.side_effect = [
-            None,
-            subprocess.CalledProcessError(1, "generate_vst_dataset.py"),
-            None,
-        ]
+        # First call materializes shard 0's file (so the existence check passes and the loop
+        # advances to shard 1); second call raises mid-loop; third call must never run.
+        call_count = 0
+
+        def _side_effect(args: list[str]) -> int:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                raise subprocess.CalledProcessError(1, "generate_vst_dataset.py")
+            return _materialize_shard(args)
+
+        mock_check_call.side_effect = _side_effect
 
         with pytest.raises(subprocess.CalledProcessError):
             run(spec)
 
         assert mock_check_call.call_count == 2
+
+    @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
+    @patch("pipeline.entrypoints.generate_dataset._rclone_copy")
+    def test_subprocess_exits_zero_without_writing_shard_raises(
+        self,
+        mock_rclone: MagicMock,
+        mock_check_call: MagicMock,
+        spec: DatasetPipelineSpec,
+    ) -> None:
+        """If the renderer exits 0 but never wrote the expected shard file, fail loudly.
+
+        Catches a generator bug at the rendering boundary instead of letting it surface as a less-
+        direct rclone "source not found" further down the pipeline.
+        """
+        # subprocess returns successfully but produces no file.
+        mock_check_call.return_value = 0
+
+        with pytest.raises(RuntimeError, match="did not write expected shard file"):
+            run(spec)
+
+        # Spec was uploaded (1 rclone call), but no shard upload was attempted.
+        assert mock_rclone.call_count == 1
 
     @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
     @patch("pipeline.entrypoints.generate_dataset._rclone_copy")

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -72,6 +72,19 @@ def spec(tmp_path: Path) -> DatasetPipelineSpec:
     return DatasetPipelineSpec(**_base_spec_kwargs(tmp_path))  # type: ignore[arg-type]
 
 
+def _multi_shard_spec(tmp_path: Path, n: int = 3) -> DatasetPipelineSpec:
+    """Return a DatasetPipelineSpec with ``n`` shards (deterministic filenames/seeds)."""
+    shards = tuple(
+        ShardSpec(shard_id=i, filename=f"shard-{i:06d}.h5", seed=42 + i) for i in range(n)
+    )
+    kwargs = _base_spec_kwargs(
+        tmp_path,
+        splits={"train": n, "val": 0, "test": 0},
+        shards=shards,
+    )
+    return DatasetPipelineSpec(**kwargs)  # type: ignore[arg-type]
+
+
 # ---------------------------------------------------------------------------
 # run — full flow orchestration
 # ---------------------------------------------------------------------------
@@ -202,21 +215,6 @@ class TestRun:
         with pytest.raises(subprocess.CalledProcessError):
             run(spec)
 
-    def test_num_shards_greater_than_one_raises(self, tmp_path: Path) -> None:
-        """num_shards > 1 raises NotImplementedError (multi-shard is orchestrator territory)."""
-        multi_shards = tuple(
-            ShardSpec(shard_id=i, filename=f"shard-{i:06d}.h5", seed=42 + i) for i in range(3)
-        )
-        kwargs = _base_spec_kwargs(
-            tmp_path,
-            splits={"train": 1, "val": 1, "test": 1},
-            shards=multi_shards,
-        )
-        spec = DatasetPipelineSpec(**kwargs)  # type: ignore[arg-type]
-
-        with pytest.raises(NotImplementedError, match="num_shards > 1"):
-            run(spec)
-
     def test_wds_output_format_raises(self, tmp_path: Path) -> None:
         """output_format 'wds' raises ValueError — generate_vst_dataset only supports hdf5."""
         kwargs = _base_spec_kwargs(tmp_path, output_format="wds")
@@ -224,6 +222,131 @@ class TestRun:
 
         with pytest.raises(ValueError, match="only supports hdf5"):
             run(spec)
+
+    @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
+    @patch("pipeline.entrypoints.generate_dataset._rclone_copy")
+    def test_run_with_three_shards_renders_each_shard(
+        self,
+        mock_rclone: MagicMock,
+        mock_check_call: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Multi-shard run invokes generate_vst_dataset.py once per shard, in order."""
+        spec = _multi_shard_spec(tmp_path, n=3)
+
+        run(spec)
+
+        assert mock_check_call.call_count == 3
+        rendered_filenames = []
+        for call in mock_check_call.call_args_list:
+            args = call[0][0]
+            # Args layout: [wrapper, python, generate_vst_dataset.py, output_file, ...].
+            output_file = args[3]
+            rendered_filenames.append(Path(output_file).name)
+        assert rendered_filenames == [s.filename for s in spec.shards]
+
+    @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
+    @patch("pipeline.entrypoints.generate_dataset._rclone_copy")
+    def test_spec_uploaded_exactly_once_for_multi_shard_run(
+        self,
+        mock_rclone: MagicMock,
+        mock_check_call: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Spec is uploaded once per run; remaining rclone calls are per-shard uploads."""
+        spec = _multi_shard_spec(tmp_path, n=3)
+
+        run(spec)
+
+        assert mock_rclone.call_count == 1 + 3
+        spec_uploads = [
+            call for call in mock_rclone.call_args_list if call[0][0].endswith(INPUT_SPEC_FILENAME)
+        ]
+        assert len(spec_uploads) == 1
+
+    @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
+    @patch("pipeline.entrypoints.generate_dataset._rclone_copy")
+    def test_each_shard_uploaded_after_its_render(
+        self,
+        mock_rclone: MagicMock,
+        mock_check_call: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Render and upload are interleaved per shard: render0, upload0, render1, upload1, ..."""
+        spec = _multi_shard_spec(tmp_path, n=3)
+        manager = MagicMock()
+        manager.attach_mock(mock_rclone, "rclone")
+        manager.attach_mock(mock_check_call, "check_call")
+
+        run(spec)
+
+        call_names = [c[0] for c in manager.mock_calls]
+        # First call is the spec upload; thereafter check_call/rclone alternate per shard.
+        assert call_names == [
+            "rclone",  # spec upload
+            "check_call",  # render shard 0
+            "rclone",  # upload shard 0
+            "check_call",  # render shard 1
+            "rclone",  # upload shard 1
+            "check_call",  # render shard 2
+            "rclone",  # upload shard 2
+        ]
+
+    @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
+    @patch("pipeline.entrypoints.generate_dataset._rclone_copy")
+    def test_local_shard_file_removed_after_upload(
+        self,
+        mock_rclone: MagicMock,
+        mock_check_call: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Each shard's local HDF5 is unlinked after upload to bound disk to one shard."""
+        spec = _multi_shard_spec(tmp_path, n=3)
+
+        # Render side effect: create the local shard file so the unlink call is real.
+        def _materialize_shard(args: list[str]) -> int:
+            # Args layout: [wrapper, python, generate_vst_dataset.py, output_file, ...].
+            output_file = Path(args[3])
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            output_file.write_bytes(b"")
+            return 0
+
+        mock_check_call.side_effect = _materialize_shard
+        # Track which paths existed at upload time, and which still exist after run().
+        uploaded_paths: list[Path] = []
+
+        def _record_upload(src: str, dest: str) -> None:
+            uploaded_paths.append(Path(src))
+
+        mock_rclone.side_effect = _record_upload
+
+        run(spec)
+
+        shard_uploads = [p for p in uploaded_paths if p.name != INPUT_SPEC_FILENAME]
+        assert len(shard_uploads) == 3
+        for shard_path in shard_uploads:
+            assert not shard_path.exists(), f"shard file still on disk after run: {shard_path}"
+
+    @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
+    @patch("pipeline.entrypoints.generate_dataset._rclone_copy")
+    def test_subprocess_failure_in_second_shard_propagates_immediately(
+        self,
+        mock_rclone: MagicMock,
+        mock_check_call: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """Mid-loop subprocess failure raises immediately; later shards are not attempted."""
+        spec = _multi_shard_spec(tmp_path, n=3)
+        mock_check_call.side_effect = [
+            None,
+            subprocess.CalledProcessError(1, "generate_vst_dataset.py"),
+            None,
+        ]
+
+        with pytest.raises(subprocess.CalledProcessError):
+            run(spec)
+
+        assert mock_check_call.call_count == 2
 
     @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
     @patch("pipeline.entrypoints.generate_dataset._rclone_copy")

--- a/tests/pipeline/test_schemas/test_spec.py
+++ b/tests/pipeline/test_schemas/test_spec.py
@@ -209,9 +209,46 @@ class TestDatasetPipelineSpec:
             "signal_duration_seconds": 4.0,
             "min_loudness": -55.0,
             "sample_batch_size": 32,
-            "shards": (),
+            "shards": (ShardSpec(shard_id=0, filename="shard-000000.h5", seed=42),),
         }
         with pytest.raises(ValidationError):
+            DatasetPipelineSpec(**kwargs)
+
+    def test_pipeline_spec_empty_shards_raises_validation_error(
+        self,
+        patch_materialize_io: Path,
+    ) -> None:
+        """Empty shards tuple raises ValidationError.
+
+        DatasetConfig enforces num_shards > 0 at materialize time; this mirror catches specs loaded
+        from external/hand-edited JSON where shards=[] would let generate_dataset.run() succeed as
+        a silent no-op (uploading only the spec, no shards).
+        """
+        kwargs: dict[str, Any] = {
+            "run_id": "test-run",
+            "r2_prefix": "data/test/test-run/",
+            "created_at": FIXED_NOW,
+            "code_version": "abc123",
+            "is_repo_dirty": False,
+            "param_spec": "surge_simple",
+            "renderer_version": "1.0.0",
+            "output_format": "hdf5",
+            "sample_rate": 16000,
+            "shard_size": 100,
+            "base_seed": 42,
+            "num_params": 92,
+            "r2_bucket": "intermediate-data",
+            "splits": SplitsConfig(train=1, val=0, test=0),
+            "plugin_path": str(patch_materialize_io),
+            "preset_path": "presets/test.vstpreset",
+            "channels": 2,
+            "velocity": 100,
+            "signal_duration_seconds": 4.0,
+            "min_loudness": -55.0,
+            "sample_batch_size": 32,
+            "shards": (),
+        }
+        with pytest.raises(ValidationError, match="shards must not be empty"):
             DatasetPipelineSpec(**kwargs)
 
     def test_direct_construction_with_nonexistent_plugin_path_succeeds(self) -> None:


### PR DESCRIPTION
## Summary
- Drop the `num_shards > 1` fail-fast guard in `generate_dataset.py`.
- Hoist spec serialize+upload and renderer-version check out of the per-shard loop (per-run, not per-shard).
- Loop over `spec.shards` for render → upload → local unlink. Per-shard local cleanup bounds disk to one shard's worth of HDF5 at a time.
- Update `run()` docstring; drop the single-shard wording and `#407` fail-fast paragraph.
- Preserves fail-fast subprocess semantics. No behavior change for single-shard runs.

## Out of scope (tracked separately)
- Seed plumbing — #364
- Skip-existing-shards / idempotency — #750
- Continue-on-error vs fail-fast — #751
- Xvfb amortization across shards — #752
- Per-shard progress / wall-clock logging — #753

Refs #407

## Test plan
- [x] New tests cover: 3-shard run renders each in order, spec uploaded once, render/upload interleaved, local file removed per shard, fail-fast on mid-loop subprocess error.
- [x] Single-shard tests unchanged and still pass.
- [x] `make format` clean.
- [x] `make test` green.