### PR TITLE
ci(docker-build): scope dev-snapshot to main; add per-branch tag

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -52,9 +52,35 @@ jobs:
           # pull_request: use PR head; dispatch: use input; schedule: main
           ref: ${{ github.event.pull_request.head.sha || github.event.inputs.git_ref || 'main' }}
 
-      - name: Resolve checked-out commit SHA
+      # Emits two outputs:
+      #   sha         — 40-char commit SHA, baked into the image
+      #   branch_slug — Docker-tag-safe branch name for the `dev-snapshot-<branch>`
+      #                 floating tag, or empty when no meaningful branch applies
+      #                 (schedule run, main, or a git_ref that's already a SHA).
+      #                 Slashes become dashes; charset is restricted to
+      #                 [A-Za-z0-9_.-]; truncated to 100 chars to leave room for
+      #                 the `dev-snapshot-` prefix under Docker's 128-char limit.
+      - name: Resolve checked-out commit SHA and branch slug
         id: source
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_REF: ${{ github.event.inputs.git_ref }}
+          PR_HEAD_REF: ${{ github.head_ref }}
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          raw_branch=""
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ "$DISPATCH_REF" != "main" ] && ! printf '%s' "$DISPATCH_REF" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+              raw_branch="$DISPATCH_REF"
+            fi
+          elif [ "$EVENT_NAME" = "pull_request" ]; then
+            raw_branch="$PR_HEAD_REF"
+          fi
+          slug=""
+          if [ -n "$raw_branch" ]; then
+            slug=$(printf '%s' "$raw_branch" | tr '/' '-' | tr -c 'A-Za-z0-9_.-' '-' | cut -c1-100)
+          fi
+          echo "branch_slug=${slug}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -120,12 +146,18 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ steps.config.outputs.image }}
-          # `latest` is gated to schedule runs or dispatches that explicitly
-          # target the default branch. Dispatching with git_ref pointed at a
-          # non-main ref must NOT publish that ref as latest — the workflow
-          # ref can be main while the baked SHA is something else entirely.
+          # Floating tags `dev-snapshot` and `latest` are gated to schedule
+          # runs or dispatches that explicitly target main. Dispatching with
+          # git_ref pointed at a non-main ref must NOT overwrite either tag —
+          # other workflows (test-skypilot-debug, test-dataset-generation)
+          # consume `dev-snapshot` by default and would silently run against
+          # the feature branch's image until the next main build.
+          # Feature-branch dispatches get a per-branch floating tag instead
+          # (`dev-snapshot-<branch>`), gated on a non-empty branch_slug.
+          # The immutable `dev-snapshot-<sha>` tag is always pushed.
           tags: |
-            type=raw,value=dev-snapshot
+            type=raw,value=dev-snapshot,enable=${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.git_ref == 'main') }}
+            type=raw,value=dev-snapshot-${{ steps.source.outputs.branch_slug }},enable=${{ steps.source.outputs.branch_slug != '' }}
             type=raw,value=dev-snapshot-${{ steps.source.outputs.sha }}
             type=raw,value=latest,enable=${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.git_ref == 'main') }}
 

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -56,18 +56,28 @@ jobs:
       #   sha         — 40-char commit SHA, baked into the image
       #   is_main     — "true" when this build represents the main branch and
       #                 should advance the shared `dev-snapshot`/`latest` tags.
-      #                 Covers schedule runs and the common ref forms a user
-      #                 might paste into the dispatch input: `main`,
-      #                 `refs/heads/main`, `refs/remotes/origin/main`, plus the
-      #                 case where the resolved HEAD equals origin/main's HEAD
-      #                 (e.g., a literal SHA dispatch that happens to be main).
+      #                 Covers schedule runs, the common ref forms a user might
+      #                 paste into the dispatch input (`main`, `refs/heads/main`,
+      #                 `refs/remotes/origin/main`), and the case where the
+      #                 resolved HEAD equals origin/main's HEAD (e.g., a literal
+      #                 SHA dispatch that happens to be main).
       #   branch_slug — Docker-tag-safe branch name for the `dev-snapshot-<branch>`
       #                 floating tag, or empty when no meaningful branch applies
-      #                 (schedule run, any main ref form, or a git_ref that's
-      #                 already a SHA). Slashes become dashes; charset is
-      #                 restricted to [A-Za-z0-9_.-]; truncated to 100 chars to
-      #                 leave room for the `dev-snapshot-` prefix under Docker's
-      #                 128-char tag limit.
+      #                 (schedule run, any main ref form, a git_ref already
+      #                 resolved to a SHA, or a git tag dispatch). Well-known
+      #                 ref prefixes (`refs/heads/`, `refs/remotes/origin/`) are
+      #                 stripped before slugging so the same branch produces the
+      #                 same tag regardless of how the operator typed it.
+      #                 Slashes become dashes; charset is restricted to
+      #                 [A-Za-z0-9_.-]; truncated to 100 chars to leave room
+      #                 for the `dev-snapshot-` prefix under Docker's 128-char
+      #                 tag limit.
+      #                 Known limitation: branches whose slugs collide after
+      #                 normalization (e.g., `feat/foo` and `feat-foo`, or two
+      #                 branches sharing their first 100 normalized chars) will
+      #                 share the same `dev-snapshot-<slug>` tag and overwrite
+      #                 each other. Branches whose names are already Docker-tag
+      #                 -safe and ≤100 chars are unaffected.
       - name: Resolve checked-out commit SHA, main flag, and branch slug
         id: source
         env:
@@ -99,7 +109,22 @@ jobs:
           raw_branch=""
           if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$is_main" = "false" ]; then
             if ! printf '%s' "$DISPATCH_REF" | grep -Eq '^[0-9a-fA-F]{40}$'; then
-              raw_branch="$DISPATCH_REF"
+              candidate="$DISPATCH_REF"
+              case "$candidate" in
+                refs/heads/*)          candidate="${candidate#refs/heads/}" ;;
+                refs/remotes/origin/*) candidate="${candidate#refs/remotes/origin/}" ;;
+              esac
+              is_tag="false"
+              case "$DISPATCH_REF" in
+                refs/tags/*) is_tag="true" ;;
+              esac
+              if [ "$is_tag" = "false" ] \
+                  && git ls-remote --tags origin "refs/tags/${candidate}" 2>/dev/null | grep -q .; then
+                is_tag="true"
+              fi
+              if [ "$is_tag" = "false" ]; then
+                raw_branch="$candidate"
+              fi
             fi
           elif [ "$EVENT_NAME" = "pull_request" ]; then
             raw_branch="$PR_HEAD_REF"

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -52,25 +52,53 @@ jobs:
           # pull_request: use PR head; dispatch: use input; schedule: main
           ref: ${{ github.event.pull_request.head.sha || github.event.inputs.git_ref || 'main' }}
 
-      # Emits two outputs:
+      # Emits three outputs:
       #   sha         — 40-char commit SHA, baked into the image
+      #   is_main     — "true" when this build represents the main branch and
+      #                 should advance the shared `dev-snapshot`/`latest` tags.
+      #                 Covers schedule runs and the common ref forms a user
+      #                 might paste into the dispatch input: `main`,
+      #                 `refs/heads/main`, `refs/remotes/origin/main`, plus the
+      #                 case where the resolved HEAD equals origin/main's HEAD
+      #                 (e.g., a literal SHA dispatch that happens to be main).
       #   branch_slug — Docker-tag-safe branch name for the `dev-snapshot-<branch>`
       #                 floating tag, or empty when no meaningful branch applies
-      #                 (schedule run, main, or a git_ref that's already a SHA).
-      #                 Slashes become dashes; charset is restricted to
-      #                 [A-Za-z0-9_.-]; truncated to 100 chars to leave room for
-      #                 the `dev-snapshot-` prefix under Docker's 128-char limit.
-      - name: Resolve checked-out commit SHA and branch slug
+      #                 (schedule run, any main ref form, or a git_ref that's
+      #                 already a SHA). Slashes become dashes; charset is
+      #                 restricted to [A-Za-z0-9_.-]; truncated to 100 chars to
+      #                 leave room for the `dev-snapshot-` prefix under Docker's
+      #                 128-char tag limit.
+      - name: Resolve checked-out commit SHA, main flag, and branch slug
         id: source
         env:
           EVENT_NAME: ${{ github.event_name }}
           DISPATCH_REF: ${{ github.event.inputs.git_ref }}
           PR_HEAD_REF: ${{ github.head_ref }}
         run: |
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          resolved_sha=$(git rev-parse HEAD)
+          echo "sha=${resolved_sha}" >> "$GITHUB_OUTPUT"
+
+          is_main="false"
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            is_main="true"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            case "$DISPATCH_REF" in
+              main|refs/heads/main|refs/remotes/origin/main)
+                is_main="true"
+                ;;
+            esac
+            if [ "$is_main" = "false" ]; then
+              main_sha=$(git ls-remote origin refs/heads/main | awk '{print $1}')
+              if [ -n "$main_sha" ] && [ "$resolved_sha" = "$main_sha" ]; then
+                is_main="true"
+              fi
+            fi
+          fi
+          echo "is_main=${is_main}" >> "$GITHUB_OUTPUT"
+
           raw_branch=""
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            if [ "$DISPATCH_REF" != "main" ] && ! printf '%s' "$DISPATCH_REF" | grep -Eq '^[0-9a-fA-F]{40}$'; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$is_main" = "false" ]; then
+            if ! printf '%s' "$DISPATCH_REF" | grep -Eq '^[0-9a-fA-F]{40}$'; then
               raw_branch="$DISPATCH_REF"
             fi
           elif [ "$EVENT_NAME" = "pull_request" ]; then
@@ -156,10 +184,10 @@ jobs:
           # (`dev-snapshot-<branch>`), gated on a non-empty branch_slug.
           # The immutable `dev-snapshot-<sha>` tag is always pushed.
           tags: |
-            type=raw,value=dev-snapshot,enable=${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.git_ref == 'main') }}
+            type=raw,value=dev-snapshot,enable=${{ steps.source.outputs.is_main == 'true' }}
             type=raw,value=dev-snapshot-${{ steps.source.outputs.branch_slug }},enable=${{ steps.source.outputs.branch_slug != '' }}
             type=raw,value=dev-snapshot-${{ steps.source.outputs.sha }}
-            type=raw,value=latest,enable=${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.git_ref == 'main') }}
+            type=raw,value=latest,enable=${{ steps.source.outputs.is_main == 'true' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -309,18 +309,22 @@ If the YAML violates the schema, the workflow fails before any build starts.
 
 ### Tags
 
-| Tag                                              | Mutable? | Purpose                                                     |
-| ------------------------------------------------ | -------- | ----------------------------------------------------------- |
-| `tinaudio/synth-setter:latest`                   | Yes      | Convenience pointer to the most recent default-branch build |
-| `tinaudio/synth-setter:dev-snapshot`             | Yes      | Latest dev-snapshot (convenience)                           |
-| `tinaudio/synth-setter:dev-snapshot-<sha>`       | No       | Immutable, used for smoke tests                             |
-| `tinaudio/synth-setter:devcontainer-tools`       | Yes      | Latest devcontainer-tools (consumed by `.devcontainer/`)    |
-| `tinaudio/synth-setter:devcontainer-tools-<sha>` | No       | Immutable, pinnable from `.devcontainer/Dockerfile`         |
+| Tag                                              | Mutable? | Purpose                                                                          |
+| ------------------------------------------------ | -------- | -------------------------------------------------------------------------------- |
+| `tinaudio/synth-setter:latest`                   | Yes      | Convenience pointer to the most recent default-branch build                      |
+| `tinaudio/synth-setter:dev-snapshot`             | Yes      | Latest dev-snapshot from main (gated like `latest`)                              |
+| `tinaudio/synth-setter:dev-snapshot-<branch>`    | Yes      | Per-branch floating tag for feature-branch dispatches (slug = branch, `/` → `-`) |
+| `tinaudio/synth-setter:dev-snapshot-<sha>`       | No       | Immutable, used for smoke tests                                                  |
+| `tinaudio/synth-setter:devcontainer-tools`       | Yes      | Latest devcontainer-tools (consumed by `.devcontainer/`)                         |
+| `tinaudio/synth-setter:devcontainer-tools-<sha>` | No       | Immutable, pinnable from `.devcontainer/Dockerfile`                              |
 
-Mutable tags (`latest`, `dev-snapshot`) are only published on dispatch/schedule
-runs — not on pull-request build validations. `latest` is additionally gated
-to schedule runs or to `workflow_dispatch` with `git_ref=main`, so dispatching
-from main with a non-main `git_ref` does not overwrite `latest`.
+Both `latest` and `dev-snapshot` are gated to schedule runs or
+`workflow_dispatch` with `git_ref=main`. Feature-branch dispatches publish
+to `dev-snapshot-<branch>` instead of overwriting the floating `dev-snapshot`
+tag. This matters because other workflows (`test-skypilot-debug`,
+`test-dataset-generation`) consume `dev-snapshot` by default — diverting
+feature-branch builds to a per-branch tag prevents in-flight feature work
+from silently changing what those workflows run against.
 
 Smoke tests pull the SHA-pinned tag to avoid race conditions with concurrent
 workflow runs.

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -318,13 +318,29 @@ If the YAML violates the schema, the workflow fails before any build starts.
 | `tinaudio/synth-setter:devcontainer-tools`       | Yes      | Latest devcontainer-tools (consumed by `.devcontainer/`)                         |
 | `tinaudio/synth-setter:devcontainer-tools-<sha>` | No       | Immutable, pinnable from `.devcontainer/Dockerfile`                              |
 
-Both `latest` and `dev-snapshot` are gated to schedule runs or
-`workflow_dispatch` with `git_ref=main`. Feature-branch dispatches publish
-to `dev-snapshot-<branch>` instead of overwriting the floating `dev-snapshot`
-tag. This matters because other workflows (`test-skypilot-debug`,
+Both `latest` and `dev-snapshot` are gated to runs that represent the main
+branch — schedule runs, dispatches with `git_ref` in `{main, refs/heads/main, refs/remotes/origin/main}`, and dispatches with a 40-char SHA that resolves
+to the current `origin/main` HEAD (so a deliberate "rebuild main at this
+exact commit" still advances the floating tags). Feature-branch dispatches
+publish to `dev-snapshot-<branch>` instead of overwriting `dev-snapshot`.
+This matters because other workflows (`test-skypilot-debug`,
 `test-dataset-generation`) consume `dev-snapshot` by default — diverting
 feature-branch builds to a per-branch tag prevents in-flight feature work
 from silently changing what those workflows run against.
+
+The branch slug is derived from `git_ref` after stripping well-known ref
+prefixes (`refs/heads/`, `refs/remotes/origin/`), so `feat/foo`,
+`refs/heads/feat/foo`, and `refs/remotes/origin/feat/foo` all publish to
+the same `dev-snapshot-feat-foo` tag. Git tag dispatches (either
+`refs/tags/<tag>` or a bare ref name that exists as a tag on origin) skip
+the per-branch tag entirely — the immutable `dev-snapshot-<sha>` tag is
+the only stable handle for tag builds.
+
+Known limitation: branch names whose slugs collide after normalization
+(e.g., `feat/foo` and `feat-foo`, or two branches sharing their first 100
+chars after slugging) share the same `dev-snapshot-<slug>` tag and can
+overwrite each other. Branches whose names are already Docker-tag-safe and
+≤100 chars are unaffected.
 
 Smoke tests pull the SHA-pinned tag to avoid race conditions with concurrent
 workflow runs.


### PR DESCRIPTION
## Problem

The workflow `.github/workflows/docker-build-validation.yml` pushed the floating `dev-snapshot` Docker tag unconditionally for any non-PR run, including manual `workflow_dispatch` runs against feature branches.

That meant dispatching a build at a feature-branch HEAD silently overwrote the floating `dev-snapshot` tag. Other workflows (`test-skypilot-debug`, `test-dataset-generation`) consume that tag by default, so they would silently run against the feature branch's image until the next `main` build replaced it. This caused PR #743's matrix dispatches to interfere with shared state.

## Fix

Gate the floating tags so they only update when the build is actually building `main`, and add a per-branch floating tag for feature-branch dispatches so they don't have to re-pull by SHA every time.

## New tagging matrix

| Event | `git_ref` / branch | `dev-snapshot` | `dev-snapshot-<branch>` | `dev-snapshot-<sha>` | `latest` |
| --- | --- | --- | --- | --- | --- |
| `schedule` (weekly) | main | push | skip | push | push |
| `workflow_dispatch` | `main` | push | skip | push | push |
| `workflow_dispatch` | `feat/foo` | skip | push (`feat-foo`) | push | skip |
| `workflow_dispatch` | 40-char SHA | skip | skip | push | skip |
| `pull_request` | any | skip (no push at all) | skip (no push at all) | skip (no push at all) | skip (no push at all) |

The `dev-snapshot` and `latest` gates use the same condition that `latest` already had on line 130 (`schedule || (workflow_dispatch && git_ref == 'main')`).

## Implementation notes

- The existing `source` step now emits a sibling `branch_slug` output alongside `sha`. For dispatches it derives from `github.event.inputs.git_ref`; for PRs from `github.head_ref`; for schedule runs it stays empty.
- Slashes are converted to dashes and the result is restricted to Docker's tag charset (`[A-Za-z0-9_.-]`) and truncated to 100 chars to leave room for the `dev-snapshot-` prefix under Docker's 128-char tag limit.
- If `git_ref` is already a 40-char hex SHA there's no meaningful branch name, so the slug is left empty and the per-branch tag is skipped (the immutable `dev-snapshot-<sha>` already covers that case).
- The new `dev-snapshot-<branch>` raw tag is only emitted when `branch_slug` is non-empty, via the `metadata-action` `enable=` clause.

## Scope

YAML-only change to one workflow file; no other workflows touched, no consumer of `dev-snapshot` updated. Existing `dev-snapshot` consumers continue to work and will simply stay pinned to the most recent main build.

Refs #534