### PR TITLE
fix(pipeline): assert per-shard unlink mid-run; tighten run() docstring and stale docs

### DIFF
--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -80,9 +80,9 @@ cat configs/dataset/surge-simple-480k-10k.yaml
 
 # 2. Launch generation — creates spec, launches workers, exits
 # **Planned CLI** — the distributed pipeline CLI (`python -m pipeline generate/status/finalize`)
-# is not yet implemented. Currently only single-shard generation is available via:
+# is not yet implemented. Currently only single-worker sequential generation is available via:
 DATASET_CONFIG=configs/dataset/surge-simple-480k-10k.yaml python -m pipeline.entrypoints.generate_dataset
-# → Sequential multi-shard MVP. Loops over spec.shards on a single worker; distributed parallelism still tracked under #411.
+# → Sequential multi-shard MVP. Loops over spec.shards on a single worker; distributed parallelism still tracked under #407.
 # `generate_dataset` is the current MVP. It will be deprecated when
 # `generate-shards` lands on main (#411).
 

--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -80,8 +80,10 @@ cat configs/dataset/surge-simple-480k-10k.yaml
 
 # 2. Launch generation — creates spec, launches workers, exits
 # **Planned CLI** — the distributed pipeline CLI (`python -m pipeline generate/status/finalize`)
-# is not yet implemented. Currently only single-worker sequential generation is available via:
-DATASET_CONFIG=configs/dataset/surge-simple-480k-10k.yaml python -m pipeline.entrypoints.generate_dataset
+# is not yet implemented. Currently only single-worker sequential generation is available via
+# the in-tree entrypoint, which takes an already-materialized spec (config → spec materialization
+# is a separate step today; the planned `python -m pipeline generate` will handle both):
+scripts/docker_entrypoint.py generate_dataset --spec <path-or-r2-uri>
 # → Sequential multi-shard MVP. Loops over spec.shards on a single worker; distributed parallelism still tracked under #407.
 # `generate_dataset` is the current MVP. It will be deprecated when
 # `generate-shards` lands on main (#411).

--- a/pipeline/entrypoints/generate_dataset.py
+++ b/pipeline/entrypoints/generate_dataset.py
@@ -157,6 +157,11 @@ def run(spec: DatasetPipelineSpec) -> None:
             ``spec.renderer_version``, or if the render subprocess exits 0
             without writing the expected shard file (raised from
             ``_render_and_upload_shard``).
+        subprocess.CalledProcessError: Propagated unchanged from any
+            non-zero exit of either the per-shard ``generate_vst_dataset.py``
+            render subprocess or any ``rclone copy`` call (spec upload or
+            per-shard shard upload). Fail-fast — later shards are not
+            attempted.
     """
     if spec.output_format != "hdf5":
         raise ValueError(

--- a/pipeline/entrypoints/generate_dataset.py
+++ b/pipeline/entrypoints/generate_dataset.py
@@ -155,7 +155,9 @@ def run(spec: DatasetPipelineSpec) -> None:
     Raises:
         ValueError: If ``spec.output_format != "hdf5"``.
         RuntimeError: If the worker's plugin version disagrees with
-            ``spec.renderer_version``.
+            ``spec.renderer_version``, or if the render subprocess exits 0
+            without writing the expected shard file (raised from
+            ``_render_and_upload_shard``).
     """
     if spec.output_format != "hdf5":
         raise ValueError(

--- a/pipeline/entrypoints/generate_dataset.py
+++ b/pipeline/entrypoints/generate_dataset.py
@@ -2,7 +2,6 @@
 
 Public API:
     load_spec_from_uri(uri): Parse a DatasetPipelineSpec from a local path or r2:// URI.
-    run(spec): Full flow — upload spec to R2, generate shard, upload shard to R2.
     run(spec): Full flow — upload spec to R2 once, then loop over
         ``spec.shards`` rendering and uploading each.
     build_generate_args(spec, shard, output_dir): Build CLI args for

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -317,29 +317,43 @@ class TestRun:
 
     @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
     @patch("pipeline.entrypoints.generate_dataset._rclone_copy")
-    def test_local_shard_file_removed_after_upload(
+    def test_previous_shard_unlinked_before_next_render(
         self,
         mock_rclone: MagicMock,
         mock_check_call: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Each shard's local HDF5 is unlinked after upload to bound disk to one shard."""
+        """Each shard's local HDF5 is unlinked before the next render starts.
+
+        Asserted as an in-loop invariant (not post-run) — the run wraps everything in
+        ``tempfile.TemporaryDirectory()`` so a post-run existence check would pass
+        regardless of whether unlink ran. This bounds local disk to one shard's worth
+        at a time.
+        """
         spec = _multi_shard_spec(tmp_path, n=3)
-        mock_check_call.side_effect = _materialize_shard
-        # Track which paths existed at upload time, and which still exist after run().
-        uploaded_paths: list[Path] = []
+        rendered_paths: list[Path] = []
 
-        def _record_upload(src: str, dest: str) -> None:
-            uploaded_paths.append(Path(src))
+        def _render_side_effect(args: list[str]) -> int:
+            # Args layout: [wrapper, python, generate_vst_dataset.py, output_file, ...].
+            output_file = Path(args[3])
+            output_file.parent.mkdir(parents=True, exist_ok=True)
+            output_file.write_bytes(b"")
+            # Before rendering shard i (i >= 1), shard i-1 must already be gone.
+            if rendered_paths:
+                previous = rendered_paths[-1]
+                assert not previous.exists(), (
+                    f"previous shard {previous.name} still on disk when "
+                    f"rendering {output_file.name}"
+                )
+            rendered_paths.append(output_file)
+            return 0
 
-        mock_rclone.side_effect = _record_upload
+        mock_check_call.side_effect = _render_side_effect
 
         run(spec)
 
-        shard_uploads = [p for p in uploaded_paths if p.name != INPUT_SPEC_FILENAME]
-        assert len(shard_uploads) == 3
-        for shard_path in shard_uploads:
-            assert not shard_path.exists(), f"shard file still on disk after run: {shard_path}"
+        # Sanity: the side effect must have fired once per shard.
+        assert len(rendered_paths) == 3
 
     @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
     @patch("pipeline.entrypoints.generate_dataset._rclone_copy")

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -317,28 +317,47 @@ class TestRun:
 
     @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
     @patch("pipeline.entrypoints.generate_dataset._rclone_copy")
-    def test_previous_shard_unlinked_before_next_render(
+    def test_each_shard_unlinked_after_its_upload(
         self,
         mock_rclone: MagicMock,
         mock_check_call: MagicMock,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Each shard's local HDF5 is unlinked before the next render starts.
+        """Every shard's local HDF5 — including the final one — is unlinked after upload.
 
-        Asserted as an in-loop invariant (not post-run) — the run wraps everything in
-        ``tempfile.TemporaryDirectory()`` so a post-run existence check would pass
-        regardless of whether unlink ran. This bounds local disk to one shard's worth
-        at a time.
+        Two complementary assertions, because a single check misses a corner:
+          * In-loop: before rendering shard i (i >= 1), shard i-1 is already gone. Catches
+            mid-loop regressions but cannot see the final shard's unlink (no follow-up render).
+          * Post-run: every rendered shard path is gone after ``run()`` returns. Catches a
+            regression on the last shard's unlink. Requires patching
+            ``tempfile.TemporaryDirectory`` so the work dir persists past ``run()`` —
+            otherwise the tmpdir cleanup would erase evidence regardless of whether
+            ``unlink()`` ran.
         """
         spec = _multi_shard_spec(tmp_path, n=3)
         rendered_paths: list[Path] = []
+
+        persisted_work_dir = tmp_path / "persisted-work-dir"
+        persisted_work_dir.mkdir()
+
+        class _PersistentTempDir:
+            def __enter__(self) -> str:
+                return str(persisted_work_dir)
+
+            def __exit__(self, *_: object) -> None:
+                return None
+
+        monkeypatch.setattr(
+            "pipeline.entrypoints.generate_dataset.tempfile.TemporaryDirectory",
+            lambda: _PersistentTempDir(),
+        )
 
         def _render_side_effect(args: list[str]) -> int:
             # Args layout: [wrapper, python, generate_vst_dataset.py, output_file, ...].
             output_file = Path(args[3])
             output_file.parent.mkdir(parents=True, exist_ok=True)
             output_file.write_bytes(b"")
-            # Before rendering shard i (i >= 1), shard i-1 must already be gone.
             if rendered_paths:
                 previous = rendered_paths[-1]
                 assert not previous.exists(), (
@@ -352,8 +371,11 @@ class TestRun:
 
         run(spec)
 
-        # Sanity: the side effect must have fired once per shard.
         assert len(rendered_paths) == 3
+        for shard_path in rendered_paths:
+            assert not shard_path.exists(), (
+                f"shard {shard_path.name} still on disk after run() returned"
+            )
 
     @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
     @patch("pipeline.entrypoints.generate_dataset._rclone_copy")


### PR DESCRIPTION
## Summary

Three small correctness/cleanup fixes to the multi-shard `generate_dataset` loop landed in #755:

- **Test was vacuous.** `test_local_shard_file_removed_after_upload` asserted `not shard_path.exists()` AFTER `run()` returned, but `run()` wraps everything in `tempfile.TemporaryDirectory()` so the work_dir gets destroyed on exit regardless of whether per-shard `unlink()` actually ran. The test passed even with `unlink()` removed. Replaced with `test_previous_shard_unlinked_before_next_render`, which uses the `subprocess.check_call` side effect to assert the i-1 shard is gone *before* rendering shard i. Verified non-vacuous: temporarily removing `unlink()` from `generate_dataset.py` makes the new test fail with `AssertionError: previous shard shard-000000.h5 still on disk when rendering shard-000001.h5`.
- **`run()` docstring incomplete.** `Raises:` listed `RuntimeError` only for renderer-version mismatch. `_render_and_upload_shard` (added in #755) also raises `RuntimeError` when the render subprocess exits 0 without writing the expected output file. Docstring now covers both modes.
- **`docs/design/data-pipeline.md` stale.** Line 83 still said "Currently only single-shard generation is available" — inconsistent with the multi-shard MVP comment directly below it. Same block referenced `#411` for parallelism work, but `#411` is the *deprecation* task; the parallelism / generate-shards port is `#407`. Fixed (kept `#411` on the line below where it correctly refers to deprecation).
- **Bonus doc-drift cleanup** caught in review of this PR (commit `859c0de`):
  - `docs/design/data-pipeline.md` showed `python -m pipeline.entrypoints.generate_dataset` as the runnable command, but that module's `__main__` block now raises `SystemExit` pointing at `scripts/docker_entrypoint.py generate_dataset --spec <path>`. Updated.
  - `pipeline/entrypoints/generate_dataset.py` module docstring listed `run(spec)` twice in the Public API block — once with stale single-shard wording and once with the current multi-shard description. Dropped the stale duplicate.

## Why a separate PR

#755 was squash-merged ~30s before three Copilot review comments landed; the fix commit was orphaned on the now-merged branch. This PR is a clean cherry-pick + extra cleanup so the fixes can land on `main`.

Replies linking the original review threads:
- https://github.com/tinaudio/synth-setter/pull/755#discussion_r3176003535
- https://github.com/tinaudio/synth-setter/pull/755#discussion_r3176003645
- https://github.com/tinaudio/synth-setter/pull/755#discussion_r3176003715

Refs #407

## Test plan
- [x] `make format` clean
- [x] `make test` green (255 passed)
- [x] New test verified non-vacuous by removing `unlink()` and confirming it fails with the expected message