### PR TITLE
internal-fix(pipeline): replace launcher polling helper with sky.tail_logs(follow=True)

### DIFF
--- a/.github/workflows/test-skypilot-debug.yml
+++ b/.github/workflows/test-skypilot-debug.yml
@@ -350,7 +350,6 @@ jobs:
           CLUSTER_NAME: ${{ matrix.cluster_prefix }}-${{ matrix.cluster_suffix }}-${{ github.run_id }}
           CONFIG_PATH: ${{ matrix.config }}
           TEMPLATE: ${{ matrix.template }}
-          DEADLINE: ${{ env.JOB_DEADLINE_SECONDS }}
           LOG_PATH: /tmp/debug-pure-sky-${{ matrix.cluster_suffix }}.log
         run: |
           set -o pipefail
@@ -364,7 +363,6 @@ jobs:
             --config "$CONFIG_PATH" \
             --template "$TEMPLATE" \
             --cluster-name "$CLUSTER_NAME" \
-            --job-deadline-seconds "$DEADLINE" \
             2>&1 | tee "$LOG_PATH"
 
       - name: Run launcher (launcher-docker mode)
@@ -377,7 +375,6 @@ jobs:
           CLUSTER_NAME: ${{ matrix.cluster_prefix }}-${{ matrix.cluster_suffix }}-${{ github.run_id }}
           CONFIG_PATH: ${{ matrix.config }}
           TEMPLATE: ${{ matrix.template }}
-          DEADLINE: ${{ env.JOB_DEADLINE_SECONDS }}
           LOG_PATH: /tmp/debug-pure-sky-${{ matrix.cluster_suffix }}.log
         run: |
           set -o pipefail
@@ -388,7 +385,6 @@ jobs:
             -e CLUSTER_NAME \
             -e CONFIG_PATH \
             -e TEMPLATE \
-            -e DEADLINE \
             -e RCLONE_CONFIG_R2_TYPE=s3 \
             -e RCLONE_CONFIG_R2_PROVIDER=Cloudflare \
             -e RCLONE_CONFIG_R2_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
@@ -408,8 +404,7 @@ jobs:
               python -m pipeline.entrypoints.skypilot_launch_smoke \
                 --config "$CONFIG_PATH" \
                 --template "$TEMPLATE" \
-                --cluster-name "$CLUSTER_NAME" \
-                --job-deadline-seconds "$DEADLINE"
+                --cluster-name "$CLUSTER_NAME"
             ' \
             2>&1 | tee "$LOG_PATH"
 

--- a/configs/compute/runpod-debug-launcher-minimal-template.yaml
+++ b/configs/compute/runpod-debug-launcher-minimal-template.yaml
@@ -10,7 +10,7 @@
 # render flow."
 #
 # PASS = launcher's materialize_spec, task.update_envs, task.update_file_mounts,
-#        sky.launch + stream_and_get, _wait_for_job, sky.down all work on RunPod.
+#        sky.launch + stream_and_get, sky.tail_logs, sky.down all work on RunPod.
 # FAIL = the launcher itself has a bug, or the launcher's specific provisioning
 #        shape (cluster name pattern, mount upload, env injection) is what
 #        triggers RunPod failures the matrix's other variants don't see.

--- a/pipeline/entrypoints/skypilot_launch_smoke.py
+++ b/pipeline/entrypoints/skypilot_launch_smoke.py
@@ -1,9 +1,11 @@
 """Launch the smoke `generate_dataset` run on RunPod via SkyPilot.
 
 Materializes a `DatasetPipelineSpec` locally from the smoke config, ships the
-frozen spec into the worker via `task.update_file_mounts`, forwards the
-worker-side env from a `.env` file via `task.update_envs`, and launches
-an unmanaged SkyPilot task (`sky.launch`) that runs the existing container CLI.
+frozen spec to the worker via R2 (per #749 — RunPod backend rejects
+`task.update_file_mounts(...)` with a pubkey-overflow at pod-create time),
+forwards worker-side env from a `.env` file via `task.update_envs`, and
+launches an unmanaged SkyPilot task (`sky.launch`) that runs the existing
+container CLI. Logs stream live via `sky.tail_logs(..., follow=True)`.
 
 `sky.jobs.launch` (managed jobs) requires a cloud-storage backend for
 controller state, which RunPod doesn't provide; cluster-level launch is
@@ -19,13 +21,11 @@ from __future__ import annotations
 import os
 import subprocess
 import tempfile
-import time
 from pathlib import Path
 
 import click
 import sky
 from dotenv import dotenv_values
-from sky.exceptions import ClusterDoesNotExist, ClusterNotUpError
 
 from pipeline.schemas.config import dataset_config_id_from_path, load_dataset_config
 from pipeline.schemas.spec import DatasetPipelineSpec, materialize_spec
@@ -57,8 +57,9 @@ _WORKER_ENV_KEYS: tuple[str, ...] = (
     "WANDB_API_KEY",
 )
 
-_JOB_POLL_INTERVAL_SECONDS = 15
-_JOB_DEADLINE_SECONDS = 25 * 60  # bound the poll loop so a stuck job can't block CI forever
+# `sky.tail_logs(..., follow=True)` returns 0 on success, 100 if the worker
+# job ended in a non-SUCCEEDED terminal status (per sky/core.py docstring).
+_TAIL_LOGS_RC_SUCCESS = 0
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 DEFAULT_CONFIG = REPO_ROOT / "configs" / "dataset" / "runpod-smoke-shard.yaml"
@@ -187,25 +188,12 @@ def upload_spec_to_r2(spec: DatasetPipelineSpec, cluster_name: str) -> str:
         "$TMPDIR (avoids parallel-run collisions on a shared host)."
     ),
 )
-@click.option(
-    "--job-deadline-seconds",
-    type=int,
-    default=_JOB_DEADLINE_SECONDS,
-    show_default=True,
-    help=(
-        "Wall-clock cap on the job-status polling loop. The launcher fails fast if the "
-        "worker job has not reached a terminal status within this window — useful in "
-        "debug workflows where we want a stuck cluster to surface in seconds rather "
-        "than minutes."
-    ),
-)
 def main(
     config_path: Path,
     template_path: Path,
     env_file_path: Path,
     cluster_name: str | None,
     spec_out: Path | None,
-    job_deadline_seconds: int,
 ) -> None:
     """Launch the smoke `generate_dataset` run on RunPod via SkyPilot."""
     worker_env = resolve_worker_env(env_file_path)
@@ -232,9 +220,6 @@ def main(
     local_spec_path.write_text(spec.model_dump_json(indent=2), encoding="utf-8")
     click.echo(f"Materialized spec to {local_spec_path}")
 
-    # Upload the spec to R2 and pass the URI to the worker via env var. Worker
-    # downloads via load_spec_from_uri. Avoids `task.update_file_mounts(...)`
-    # which triggers SkyPilot's RunPod-backend pubkey-overflow bug (#749).
     spec_uri = upload_spec_to_r2(spec, resolved_cluster_name)
     click.echo(f"Spec uploaded to {spec_uri}")
     worker_env[_WORKER_SPEC_URI_ENV] = spec_uri
@@ -242,20 +227,10 @@ def main(
     task = sky.Task.from_yaml(str(template_path))
     task.update_envs(worker_env)
 
-    # `sky.launch` is async (returns a RequestId). `down=True` ensures cleanup; we set
-    # `idle_minutes_to_autostop=5` rather than 0 to leave a window between job-end and
-    # cluster-down for `_wait_for_job` to catch the terminal status — at idle=0 SkyPilot
-    # bumps to 1 min internally, which races our 15-second poll cadence and leaves the
-    # cluster vanished by the time we re-poll, surfacing as ClusterDoesNotExist.
-    # `stream_and_get` on the launch request blocks until provisioning + setup +
-    # job-submission completes; it returns `(job_id, handle)`. Non-managed launch
-    # (sky.launch, not sky.jobs.launch) — managed jobs require a separate cloud-storage
-    # backend for controller state, which RunPod doesn't provide.
-    #
-    # The inner finally drives teardown explicitly so the cluster always goes away on
-    # success, exception, or worker error — even if down=True or the autodown timer is
-    # silently dropped (observed on RunPod when setup runs cleanly but the job exits via
-    # a path that doesn't trigger the autodown scheduler).
+    # Non-managed launch (sky.launch, not sky.jobs.launch) — managed jobs require a separate
+    # cloud-storage backend for controller state, which RunPod doesn't provide. `down=True`
+    # ensures cleanup on launcher exit; `idle_minutes_to_autostop=5` is a backstop in case the
+    # launcher exits via an unexpected path that skips the explicit `sky.down` in `finally`.
     click.echo(f"Provisioning SkyPilot cluster: {resolved_cluster_name}")
     launch_request_id = sky.launch(
         task,
@@ -268,81 +243,17 @@ def main(
         raise click.ClickException(f"Launch yielded no job_id for cluster {resolved_cluster_name}")
     job_id: int = launch_result[0]
     try:
-        # `sky.tail_logs(..., follow=True)` hangs on RunPod waiting for an SSH-stream EOF
-        # that never arrives after the worker exits. Poll `sky.job_status` for a terminal
-        # JobStatus instead, then dump the buffered worker log non-following so a traceback
-        # still surfaces in CI.
-        click.echo(f"Polling job {job_id} on {resolved_cluster_name} for completion")
-        final_status = _wait_for_job(
-            resolved_cluster_name, job_id, deadline_seconds=job_deadline_seconds
-        )
-        click.echo(f"Job {job_id} reached terminal status: {final_status.name}")
-
-        if final_status != sky.JobStatus.SUCCEEDED:
+        click.echo(f"Streaming logs for job {job_id} on {resolved_cluster_name}")
+        rc = sky.tail_logs(cluster_name=resolved_cluster_name, job_id=job_id, follow=True)
+        click.echo(f"Job {job_id} log stream ended with rc={rc}")
+        if rc != _TAIL_LOGS_RC_SUCCESS:
             raise click.ClickException(
-                f"Worker job {job_id} ended with status {final_status.name}"
+                f"Worker job {job_id} ended in a non-SUCCEEDED status (tail_logs rc={rc})"
             )
     finally:
-        # Always dump the worker log before teardown so a worker traceback
-        # surfaces in CI even when the launcher exited via the deadline path.
-        try:
-            click.echo(f"--- Worker log (job {job_id}) ---")
-            sky.tail_logs(cluster_name=resolved_cluster_name, job_id=job_id, follow=False)
-            click.echo(f"--- End worker log (job {job_id}) ---")
-        except Exception as e:  # noqa: BLE001 — best-effort diagnostic
-            click.echo(f"Worker log dump failed: {e}")
-
         click.echo(f"Tearing down cluster: {resolved_cluster_name}")
         down_request_id = sky.down(resolved_cluster_name)
         sky.stream_and_get(down_request_id)
-
-
-def _wait_for_job(
-    cluster_name: str, job_id: int, deadline_seconds: int = _JOB_DEADLINE_SECONDS
-) -> sky.JobStatus:
-    """Poll `sky.job_status` until the given job reaches a terminal status, then return it.
-
-    Used in place of `sky.tail_logs(follow=True)` because the latter hangs on RunPod
-    waiting for an SSH-stream EOF that never arrives after the worker exits. Polls every
-    `_JOB_POLL_INTERVAL_SECONDS` seconds and times out after `deadline_seconds` so a
-    truly stuck worker can't block CI forever.
-
-    `sky.job_status` raises `sky.exceptions.ClusterNotUpError` when the cluster is still
-    in INIT (provisioning slow) or transitioning. That's a "not yet ready, keep polling"
-    signal — not a terminal failure — so swallow it as long as we're inside the deadline.
-    The caller's deadline still bounds total wait, so a cluster that genuinely never
-    transitions to UP fails on the deadline check below, not on the first job_status call.
-
-    `ClusterDoesNotExist` means the cluster was torn down between polls — typically by
-    SkyPilot's autostop timer firing after the worker job completed. With
-    `idle_minutes_to_autostop=5` on launch this should be rare, but raise a clean error
-    rather than letting the unhandled exception leak into CI logs.
-    """
-    deadline = time.monotonic() + deadline_seconds
-    while time.monotonic() < deadline:
-        try:
-            statuses = sky.stream_and_get(sky.job_status(cluster_name, [job_id])) or {}
-        except ClusterNotUpError as exc:
-            click.echo(f"  cluster not yet UP ({exc.cluster_status}); retrying")
-            time.sleep(_JOB_POLL_INTERVAL_SECONDS)
-            continue
-        except ClusterDoesNotExist as exc:
-            raise click.ClickException(
-                f"Cluster {cluster_name!r} vanished mid-poll ({exc}); job {job_id} terminal "
-                "status unknown. Likely autostop fired before the next poll caught the "
-                "transition — bump idle_minutes_to_autostop or shorten _JOB_POLL_INTERVAL_SECONDS."
-            ) from exc
-        status = statuses.get(job_id)
-        if status is None:
-            click.echo(f"  job {job_id} not yet visible; retrying")
-        else:
-            click.echo(f"  status={status.name}")
-            if status.is_terminal():
-                return status
-        time.sleep(_JOB_POLL_INTERVAL_SECONDS)
-    raise click.ClickException(
-        f"Job {job_id} did not reach a terminal status within {deadline_seconds} seconds"
-    )
 
 
 if __name__ == "__main__":

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch_smoke.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch_smoke.py
@@ -144,40 +144,30 @@ def mock_rclone_subprocess(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _succeeded_run(mock_sky: MagicMock) -> None:
-    """Configure `mock_sky` so the polled job reaches SUCCEEDED on first poll."""
-    import sky  # noqa: PLC0415 — real enum so JobStatus.is_terminal() works
+    """Configure `mock_sky` so launch + tail_logs + down all succeed.
 
-    mock_sky.JobStatus = sky.JobStatus
+    `sky.tail_logs` returns an int rc directly (per sky/core.py:1232) — 0 means
+    the worker job ended in SUCCEEDED, anything else means it ended in a
+    non-SUCCEEDED terminal status.
+    """
     mock_sky.launch.return_value = "launch-req"
-    mock_sky.job_status.return_value = "job-status-req"
     mock_sky.down.return_value = "down-req"
 
     responses = {
         "launch-req": (1, MagicMock()),
-        "job-status-req": {1: sky.JobStatus.SUCCEEDED},
         "down-req": None,
     }
     mock_sky.stream_and_get.side_effect = lambda req: responses[req]
     mock_sky.tail_logs.return_value = 0
 
 
-def _failed_run(mock_sky: MagicMock, status: Any) -> None:
-    """Configure `mock_sky` so the polled job reaches the given terminal `status`."""
-    _succeeded_run(mock_sky)
-    responses = {
-        "launch-req": (1, MagicMock()),
-        "job-status-req": {1: status},
-        "down-req": None,
-    }
-    mock_sky.stream_and_get.side_effect = lambda req: responses[req]
-
-
 @pytest.fixture()
 def mock_sky(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     """Replace the launcher's module-level `sky` with a MagicMock pre-configured for success.
 
-    Tests that need a different behavior call `_failed_run(...)` (or override individual
-    knobs like `mock_sky.tail_logs.side_effect`) on top of this fixture.
+    Tests that need a different behavior tweak knobs on the returned mock (e.g. set
+    `mock_sky.tail_logs.return_value = 100` for a worker failure, or
+    `mock_sky.tail_logs.side_effect = ...` for a transport raise).
     """
     fake = MagicMock()
     monkeypatch.setattr("pipeline.entrypoints.skypilot_launch_smoke.sky", fake)
@@ -308,7 +298,7 @@ class TestMainCli:
         assert forwarded["RCLONE_CONFIG_R2_TYPE"] == "s3"
         assert forwarded["RCLONE_CONFIG_R2_ACCESS_KEY_ID"] == "process-env-key"
 
-    # --- Happy-path slices (split from the original monolithic test) ---------
+    # --- Happy-path slices ---------------------------------------------------
 
     def test_materialized_spec_round_trips_as_pipeline_spec(
         self,
@@ -401,9 +391,8 @@ class TestMainCli:
         local_spec_dir: Path,
         mock_sky: MagicMock,
     ) -> None:
-        """`sky.launch` keeps `down=True` for cleanup but uses a multi-minute autostop window — at
-        idle=0 SkyPilot tears down the cluster within ~1 min of the worker exiting, racing the
-        polling cadence and surfacing as ClusterDoesNotExist."""
+        """`sky.launch` keeps `down=True` for cleanup and an autostop window as a backstop in case
+        the explicit `sky.down` in `finally` is skipped by an unexpected exit path."""
         result = _invoke(config_yaml, template_yaml, env_file, "--cluster-name", "smoke-job-1")
         assert result.exit_code == 0, result.output
 
@@ -413,7 +402,7 @@ class TestMainCli:
         assert kwargs["idle_minutes_to_autostop"] >= 2
         assert kwargs["down"] is True
 
-    def test_tail_logs_invoked_with_follow_false(
+    def test_tail_logs_invoked_with_follow_true(
         self,
         config_yaml: Path,
         template_yaml: Path,
@@ -422,11 +411,12 @@ class TestMainCli:
         local_spec_dir: Path,
         mock_sky: MagicMock,
     ) -> None:
-        """`sky.tail_logs` is called once with follow=False (buffered post-completion dump)."""
+        """`sky.tail_logs` is called with follow=True — the launcher streams logs in real time
+        instead of polling job_status and dumping a buffered tail."""
         result = _invoke(config_yaml, template_yaml, env_file, "--cluster-name", "smoke-job-1")
         assert result.exit_code == 0, result.output
         mock_sky.tail_logs.assert_called_once_with(
-            cluster_name="smoke-job-1", job_id=1, follow=False
+            cluster_name="smoke-job-1", job_id=1, follow=True
         )
 
     def test_teardown_runs_on_success(
@@ -481,7 +471,7 @@ class TestMainCli:
         assert result.exit_code == 0, result.output
         assert explicit.is_file()
 
-    def test_worker_failed_status_fails_launcher(
+    def test_worker_failed_rc_fails_launcher(
         self,
         config_yaml: Path,
         template_yaml: Path,
@@ -490,95 +480,17 @@ class TestMainCli:
         local_spec_dir: Path,
         mock_sky: MagicMock,
     ) -> None:
-        """A worker job in a non-SUCCEEDED terminal status must fail the launcher."""
-        import sky  # noqa: PLC0415
-
-        _failed_run(mock_sky, sky.JobStatus.FAILED)
+        """A non-zero `tail_logs` rc means the worker job ended in a non-SUCCEEDED terminal status;
+        the launcher must surface that as a non-zero exit and still tear down the cluster."""
+        mock_sky.tail_logs.return_value = 100
 
         result = _invoke(config_yaml, template_yaml, env_file)
         assert result.exit_code != 0
-        assert "ended with status FAILED" in result.output
+        assert "non-SUCCEEDED" in result.output
+        assert "rc=100" in result.output
         mock_sky.down.assert_called_once()
 
     # --- Edge cases ----------------------------------------------------------
-
-    def test_deadline_timeout_raises(
-        self,
-        config_yaml: Path,
-        template_yaml: Path,
-        env_file: Path,
-        patch_materialize_io: None,
-        local_spec_dir: Path,
-        mock_sky: MagicMock,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """A job that never reaches a terminal status fails the launcher with a deadline error."""
-        import sky  # noqa: PLC0415
-
-        # Override only job_status to keep the polled status non-terminal forever.
-        responses = {
-            "launch-req": (1, MagicMock()),
-            "job-status-req": {1: sky.JobStatus.RUNNING},
-            "down-req": None,
-        }
-        mock_sky.stream_and_get.side_effect = lambda req: responses[req]
-
-        # Zero sleep between polls so the deadline-bounded loop completes synchronously.
-        monkeypatch.setattr(
-            "pipeline.entrypoints.skypilot_launch_smoke._JOB_POLL_INTERVAL_SECONDS", 0
-        )
-
-        result = _invoke(config_yaml, template_yaml, env_file, "--job-deadline-seconds", "0")
-        assert result.exit_code != 0
-        assert "did not reach a terminal status" in result.output
-        mock_sky.down.assert_called_once()
-
-    def test_cluster_not_up_error_is_swallowed_keeps_polling(
-        self,
-        config_yaml: Path,
-        template_yaml: Path,
-        env_file: Path,
-        patch_materialize_io: None,
-        local_spec_dir: Path,
-        mock_sky: MagicMock,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """`sky.job_status` raises ClusterNotUpError when the cluster is still INIT (provisioning
-        slow).
-
-        The launcher's poll loop must treat that as 'not yet ready, keep polling' instead of
-        crashing — otherwise a slow RunPod provisioning window fails the launcher even though the
-        cluster will reach UP eventually.
-        """
-        import sky  # noqa: PLC0415
-        from sky import ClusterStatus  # noqa: PLC0415
-        from sky.exceptions import ClusterNotUpError  # noqa: PLC0415
-
-        first_call = [True]
-
-        def stream_and_get(req: str) -> object:
-            if req == "launch-req":
-                return (1, MagicMock())
-            if req == "down-req":
-                return None
-            if req == "job-status-req":
-                if first_call[0]:
-                    first_call[0] = False
-                    raise ClusterNotUpError("provisioning", cluster_status=ClusterStatus.INIT)
-                return {1: sky.JobStatus.SUCCEEDED}
-            raise AssertionError(f"unexpected request: {req}")
-
-        mock_sky.stream_and_get.side_effect = stream_and_get
-        monkeypatch.setattr(
-            "pipeline.entrypoints.skypilot_launch_smoke._JOB_POLL_INTERVAL_SECONDS", 0
-        )
-
-        result = _invoke(config_yaml, template_yaml, env_file, "--cluster-name", "smoke-cnu")
-        assert result.exit_code == 0, result.output
-        assert "cluster not yet UP" in result.output
-        assert "retrying" in result.output
-        assert "status=SUCCEEDED" in result.output
-        mock_sky.down.assert_called_once()
 
     def test_launch_returning_none_job_id_aborts(
         self,
@@ -589,7 +501,7 @@ class TestMainCli:
         local_spec_dir: Path,
         mock_sky: MagicMock,
     ) -> None:
-        """If sky.launch yields no job_id the launcher aborts before polling/teardown."""
+        """If sky.launch yields no job_id the launcher aborts before tailing/teardown."""
         responses = {
             "launch-req": (None, MagicMock()),
         }
@@ -598,6 +510,8 @@ class TestMainCli:
         result = _invoke(config_yaml, template_yaml, env_file)
         assert result.exit_code != 0
         assert "no job_id" in result.output.lower()
+        mock_sky.tail_logs.assert_not_called()
+        mock_sky.down.assert_not_called()
 
     def test_teardown_runs_when_tail_logs_raises(
         self,
@@ -608,16 +522,12 @@ class TestMainCli:
         local_spec_dir: Path,
         mock_sky: MagicMock,
     ) -> None:
-        """A `sky.tail_logs` failure is observability-only — must not abort the launcher or skip
-        cluster teardown."""
+        """A `sky.tail_logs` transport error must not skip cluster teardown — the cluster always
+        comes down even if the log-stream side raised."""
         mock_sky.tail_logs.side_effect = RuntimeError("boom")
 
         result = _invoke(config_yaml, template_yaml, env_file)
-        # Worker job reached SUCCEEDED via the polling loop, so even though the worker-log
-        # dump in the finally raised, the launcher should still exit cleanly. The "boom"
-        # message is logged via click.echo as part of the diagnostic block.
-        assert result.exit_code == 0, result.output
-        assert "Worker log dump failed: boom" in result.output
+        assert result.exit_code != 0
         mock_sky.down.assert_called_once()
 
     def test_local_spec_persists_for_artifact_upload_even_on_launch_exception(
@@ -632,7 +542,6 @@ class TestMainCli:
     ) -> None:
         """If sky.launch raises after the launcher materialized + R2-uploaded the spec, the local
         spec file under LOCAL_SPEC_DIR is still around for downstream artifact upload."""
-        # Mock the rclone upload subprocess so this test doesn't need a real R2 endpoint.
         monkeypatch.setattr(
             "pipeline.entrypoints.skypilot_launch_smoke.subprocess.check_call",
             lambda args: None,


### PR DESCRIPTION
## Summary

- Drop `_wait_for_job` (~50 lines) and the `--job-deadline-seconds` CLI option from the SkyPilot RunPod launcher.
- Replace the polling block with one `sky.tail_logs(cluster_name=..., job_id=..., follow=True)` call. Per `sky/core.py:1232`, `tail_logs` returns int rc — 0 on SUCCEEDED, 100 on non-SUCCEEDED terminal — so the launcher just propagates that.
- Net: **185 lines deleted, 46 added** across launcher + tests + workflow.

## Why

The launcher's docstrings credited the original tail_logs hang on RunPod to a SkyPilot SSH-stream-EOF bug. The actual cause was the headless.sh wrapper leaking a child process that prevented Python from exiting on RunPod (fixed separately under `fix/headless-wrapper-drop-exec`). With that root cause addressed, the polling workaround is dead weight.

## Validation

- 17/17 launcher unit tests pass after rewrite (tests reframed: drop deadline/ClusterNotUpError-during-polling tests; flip tail_logs assertion from `follow=False` to `follow=True`; reframe failure path around tail_logs returning rc=100).
- 253/253 quick suite passes.
- The real validation is **`test-skypilot-debug.yml` against a real RunPod cluster** — if `tail_logs(follow=True)` does NOT hang now that the headless leak is fixed, the workaround was unnecessary all along. If it hangs, revert and reopen the original workaround.

## Test plan

- [ ] Unit tests pass in CI (`pytest tests/pipeline/test_entrypoints/test_skypilot_launch_smoke.py`)
- [ ] `test-skypilot-debug.yml` workflow run against this branch passes the `launcher` and `launcher-in-docker` matrix variants
- [ ] If the workflow hangs at the tail_logs step → revert this PR

Refs #758