### PR TITLE
chore(lint): enable ANN001 in ruff with per-file/dir ignores

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: check-json
       - id: debug-statements
 
-  # ruff: linting (E/F/I/S/T/UP/W rules) and formatting for Python & Jupyter.
+  # ruff: linting (E/F/I/S/T/UP/W/ANN001 rules) and formatting for Python & Jupyter.
   # Config lives in pyproject.toml under [tool.ruff]. Legacy src/ files are
   # excluded via per-file-ignores there (see issue #25).
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ synth-setter: Synth inversion, sound matching and preset exploration tools
 ### Formatting & Linting (enforced by pre-commit)
 
 - **Ruff format** (line-length=99)
-- **Ruff** (rules: E, F, I, S, T, UP, W)
+- **Ruff** (rules: E, F, I, S, T, UP, W, ANN001)
 - Run `make format` before committing
 
 ### Commit Messages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,16 +43,17 @@ extend-exclude = []
 
 [tool.ruff.lint]
 # E=pycodestyle errors, F=pyflakes, I=isort, S=bandit security,
-# T=T10 (print) + T20 (debugger), UP=pyupgrade, W=pycodestyle warnings
-select = ["E", "F", "I", "S", "T", "UP", "W"]
+# T=T10 (print) + T20 (debugger), UP=pyupgrade, W=pycodestyle warnings,
+# ANN001=missing-type-function-argument
+select = ["E", "F", "I", "S", "T", "UP", "W", "ANN001"]
 # E501: line length handled by ruff-format, S101: allow assert in tests
 ignore = ["E501", "S101"]
 
 [tool.ruff.lint.per-file-ignores]
-"notebooks/**" = ["E702", "E722", "F841", "T201"]
+"notebooks/**" = ["E702", "E722", "F841", "T201", "ANN001"]
 "scripts/add_music2latent.py" = ["S605"]
-"scripts/compute_audio_metrics.py" = ["T201"]
-"scripts/get_dataset_stats.py" = ["E402", "T201"]
+"scripts/compute_audio_metrics.py" = ["T201", "ANN001"]
+"scripts/get_dataset_stats.py" = ["E402", "T201", "ANN001"]
 "scripts/make_sig_perf.py" = ["E402", "T201"]
 "scripts/model_from_wandb_repl.py" = ["E402"]
 "scripts/paramspec_to_table.py" = ["E402", "T201"]
@@ -65,17 +66,29 @@ ignore = ["E501", "S101"]
 # T201: click.echo used for CLI output.
 "scripts/r2_shard_report.py" = ["S603", "S607", "T201"]
 "scripts/reshard_data.py" = ["T201"]
-"scripts/subdir_funtime.py" = ["F841"]
+"scripts/rewrite_dataset_to_latest.py" = ["ANN001"]
+"scripts/subdir_funtime.py" = ["F841", "ANN001"]
 # S603/S607: rclone subprocess calls in R2 integration test fixtures.
 "tests/scripts/test_r2_shard_report.py" = ["S603", "S607"]
+# ANN001: pytest fixture-injected args left un-annotated on legacy callsites.
+"tests/scripts/test_surge_xt_interactive.py" = ["ANN001"]
+"tests/pipeline/test_schemas/test_config.py" = ["ANN001"]
+"tests/pipeline/test_schemas/test_prefix.py" = ["ANN001"]
+"tests/test_benchmarks.py" = ["ANN001"]
+"tests/test_configs.py" = ["ANN001"]
 "src/eval.py" = ["E402", "F841"]
+# ANN001: directory-wide ignore for legacy untyped function args under src/models/.
+# New code under src/models/ should still annotate; remove this entry once legacy
+# callsites are cleaned up.
+"src/models/**" = ["ANN001"]
 "src/models/components/transformer.py" = ["F841"]
 "src/models/components/vae.py" = ["E402", "T201"]
 "src/models/ksin_ff_module.py" = ["F821"]
 "src/models/surge_ff_module.py" = ["F821"]
 "src/train.py" = ["E402"]
 "src/utils/__init__.py" = ["F401"]
-"src/utils/callbacks.py" = ["F821", "T201"]
+"src/utils/callbacks.py" = ["F821", "T201", "ANN001"]
+"src/utils/math.py" = ["ANN001"]
 
 [tool.interrogate]
 verbose = 2


### PR DESCRIPTION
## Summary

Adds `ANN001` (missing-type-function-argument) to ruff's `select` list as a ratchet, matching the intent of #682 but silencing the existing legacy violations via **`[tool.ruff.lint.per-file-ignores]`** instead of per-line `# noqa: ANN001` markers.

This supersedes #682 — same goal, less source-tree noise. Any *new* missing-arg annotation outside the ignored set is still caught immediately.

## What changed

- `pyproject.toml` — `select` now includes `ANN001`; per-file-ignores extended:
  - `src/models/**` — directory-wide `ANN001` ignore (covers all 10 currently-violating modules under `src/models/`).
  - `notebooks/**` — `ANN001` added to the existing notebook ignore set.
  - 11 non-`src/models/` files get a file-wide `ANN001` entry (extends existing arrays where present, new entries otherwise):
    - `scripts/compute_audio_metrics.py`, `scripts/get_dataset_stats.py`, `scripts/rewrite_dataset_to_latest.py`, `scripts/subdir_funtime.py`
    - `src/utils/callbacks.py`, `src/utils/math.py`
    - `tests/pipeline/test_schemas/test_config.py`, `tests/pipeline/test_schemas/test_prefix.py`, `tests/scripts/test_surge_xt_interactive.py`, `tests/test_benchmarks.py`, `tests/test_configs.py`
- `CLAUDE.md` — rule list updated to `E, F, I, S, T, UP, W, ANN001`.
- `.pre-commit-config.yaml` — ruff comment updated to mention `ANN001`.

No `.py` source files are touched — zero `# noqa: ANN001` markers added anywhere.

## Note on `tests/scripts/test_surge_xt_interactive.py`

This file landed on `main` after #682 was opened (17 ANN001 violations from pytest fixture-injected args). It's included in the file-wide ignore set so the new ratchet doesn't fire on it.

## Verification

Run inside the worktree on commit `a32c170`:

```
$ uvx ruff check --select ANN001 --no-fix .
All checks passed!

$ uvx ruff check .
All checks passed!

$ uvx ruff format --check .
98 files already formatted

$ pre-commit run --all-files
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check docstring is first.................................................Passed
check yaml...............................................................Passed
detect private key.......................................................Passed
check that executables have shebangs.....................................Passed
don't commit to branch...................................................Passed
check toml...............................................................Passed
check for case conflicts.................................................Passed
check for added large files..............................................Passed
check json...............................................................Passed
debug statements (python)................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
pyright..................................................................Passed
Validate GitHub Workflows................................................Passed
Validate pyproject.toml..................................................Passed
docformatter.............................................................Passed
interrogate..............................................................Passed
prettier.................................................................Passed
shellcheck...............................................................Passed
mdformat.................................................................Passed
codespell................................................................Passed
nbstripout...............................................................Passed
```

Pyright passed — important since it's the most likely hook to surface ANN-adjacent issues that ruff was previously masking.

Refs #212

## Test plan

- [ ] CI ruff job passes on this branch.
- [ ] `pr-metadata-gate.yaml` passes (linked issue #212 has type=Task, label=code-health, milestone=code-health v1.0.0; traces to Phase #158 → Epic #114).
- [ ] Pre-commit run on the diff passes locally for any maintainer who pulls the branch.