### PR TITLE
docs: add terse-comments rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,8 +54,26 @@ Conventional commits, enforced by gitlint (`.gitlint` config). Prefix matters fo
 Comments that restate values, counts, or list contents go stale the moment the code changes. The code is the source of truth — name it, don't mirror it.
 
 - **Don't restate constant values.** Next to `num_samples = 6`, never write `# 6 samples (12 renders total)`. Reference the symbol (`each stage renders num_samples times`) or describe behavior without numbers.
+
 - **Don't bake in counts the code already reports.** `# 29 review comments triaged` or `# 5 metric series` belongs in a PR description (a snapshot in time), not in a docstring or inline comment that lives next to the data and will drift the next time someone adds an item. Prefer "the metric series listed below" or reference the data source.
+
 - **Don't enumerate list contents in prose.** Next to `THINGS = ["a", "b", "c"]`, never write `# three things: a, b, and c` — both the count and the contents will mismatch the list within a release. The list is the source of truth; a comment can name the *category*, not its contents.
+
+- **Keep comments terse — typically one short line.** Multi-sentence prose explanations inline are a smell. If a comment would need more than ~2 lines to be useful, that's a signal the context belongs in a GitHub issue, not in the source. Make the inline comment a one-line pointer to the issue.
+
+  ```python
+  # Bad — multi-sentence essay inline:
+  # We use os._exit(0) here instead of sys.exit(0) because SkyPilot's
+  # job runner wraps the process in a shell that doesn't propagate the
+  # exit code correctly when atexit handlers raise during interpreter
+  # shutdown — see the long investigation in the PR description.
+  os._exit(0)
+
+  # Good — one-line pointer to the issue with the full context:
+  # Workaround for atexit-during-shutdown hang — see #735.
+  os._exit(0)
+  ```
+
 - Still write comments for: WHY a non-obvious choice was made, hidden invariants, workarounds (with bug ID), and surprising behavior.
 
 #### No Comments Inside YAML `run:` Block-Scalars


### PR DESCRIPTION
## Summary

- Extend the existing **Comment Hygiene: Don't Bake Values Into Comments** subsection in `CLAUDE.md` with a fourth bullet: **comments should be terse — typically one short line**.
- If a comment would need more than ~2 lines to be useful, that's a signal the context belongs in a GitHub issue. The inline comment is then a one-line pointer to that issue (e.g., `# Workaround for atexit-during-shutdown hang — see #735`).
- Adds one before/after Python example, matching the style of the existing examples in CLAUDE.md.

## Why

The existing `### Writing Code` bullets and the **Don't Bake Values Into Comments** subsection say "default to writing no comments" and "don't restate values," but they don't explicitly cap *length* or describe what to do when significant context genuinely IS needed. Future sessions keep producing multi-sentence prose explanations inline. This bullet closes that gap and gives a concrete alternative (link to issue) so the rule isn't read as "no comments at all."

## Scope

- Single file changed: `CLAUDE.md` (+18 lines, including mdformat blank-line normalization on the existing bullets in the same list — required because the new bullet contains a fenced code block).
- The closing "Still write comments for: WHY / invariants / workarounds / surprises" bullet is preserved.
- No code, other docs, or tests touched.

## Test plan

- [x] `make format` clean (all pre-commit hooks pass: mdformat, prettier, codespell, etc.)
- [ ] PR metadata gate passes (linked issue #761 has type=Task, label=documentation, milestone=documentation v1.0.0, parented under Phase #442 → Epic #351)

Closes #761