### PR TITLE
fix(pipeline): skip VST_HEADLESS_WRAPPER on non-Linux in generate_dataset

### DIFF
--- a/pipeline/entrypoints/generate_dataset.py
+++ b/pipeline/entrypoints/generate_dataset.py
@@ -207,7 +207,8 @@ def _render_and_upload_shard(
     Unlinking after upload bounds local disk to one shard's HDF5 at a time — necessary for multi-
     shard runs on disk-constrained workers.
     """
-    args = [VST_HEADLESS_WRAPPER, *build_generate_args(spec, shard, work_dir)]
+    args = [VST_HEADLESS_WRAPPER] if sys.platform.startswith("linux") else []
+    args += build_generate_args(spec, shard, work_dir)
     logger.info(f"rendering shard {shard.shard_id} -> {shard.filename}")
     subprocess.check_call(args)  # noqa: S603 — args built from validated spec
     shard_path = work_dir / shard.filename

--- a/pipeline/entrypoints/generate_dataset.py
+++ b/pipeline/entrypoints/generate_dataset.py
@@ -207,7 +207,7 @@ def _render_and_upload_shard(
     Unlinking after upload bounds local disk to one shard's HDF5 at a time — necessary for multi-
     shard runs on disk-constrained workers.
     """
-    args = [VST_HEADLESS_WRAPPER] if sys.platform.startswith("linux") else []
+    args = [VST_HEADLESS_WRAPPER] if sys.platform == "linux" else []
     args += build_generate_args(spec, shard, work_dir)
     logger.info(f"rendering shard {shard.shard_id} -> {shard.filename}")
     subprocess.check_call(args)  # noqa: S603 — args built from validated spec

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -38,6 +38,19 @@ TEST_PLUGIN_VST3 = Path(__file__).resolve().parent.parent / "fixtures" / "TestPl
 TEST_PLUGIN_VERSION = "1.0.0-test"
 
 
+def _find_script_index(args: list[str]) -> int:
+    """Locate generate_vst_dataset.py in subprocess args, with a clear failure on miss.
+
+    The args layout depends on platform — `[wrapper, python, script, output, ...]` on Linux
+    versus `[python, script, output, ...]` elsewhere — so callers locate the script by name
+    rather than fixed index.
+    """
+    for i, a in enumerate(args):
+        if a.endswith("generate_vst_dataset.py"):
+            return i
+    raise AssertionError(f"generate_vst_dataset.py not found in subprocess args: {args}")
+
+
 def _materialize_shard(args: list[str]) -> int:
     """subprocess.check_call side effect that writes the expected shard file.
 
@@ -45,11 +58,7 @@ def _materialize_shard(args: list[str]) -> int:
     HDF5 to its output path. Tests that don't supply this side effect would trip the
     `shard_path.is_file()` check in `_render_and_upload_shard`.
     """
-    # Args layout depends on platform:
-    #   linux:     [wrapper, python, generate_vst_dataset.py, output_file, ...]
-    #   non-linux: [python, generate_vst_dataset.py, output_file, ...]
-    # Locate the script and read the output file from the next slot.
-    script_idx = next(i for i, a in enumerate(args) if a.endswith("generate_vst_dataset.py"))
+    script_idx = _find_script_index(args)
     output_file = Path(args[script_idx + 1])
     output_file.parent.mkdir(parents=True, exist_ok=True)
     output_file.write_bytes(b"")
@@ -190,7 +199,7 @@ class TestRun:
         run(spec)
 
         args = mock_check_call.call_args[0][0]
-        if sys.platform.startswith("linux"):
+        if sys.platform == "linux":
             assert args[0] == VST_HEADLESS_WRAPPER
             assert args[2] == "src/data/vst/generate_vst_dataset.py"
         else:
@@ -269,13 +278,7 @@ class TestRun:
         rendered_filenames = []
         for call in mock_check_call.call_args_list:
             args = call[0][0]
-            # Args layout depends on platform:
-            #   linux:     [wrapper, python, generate_vst_dataset.py, output_file, ...]
-            #   non-linux: [python, generate_vst_dataset.py, output_file, ...]
-            script_idx = next(
-                i for i, a in enumerate(args) if a.endswith("generate_vst_dataset.py")
-            )
-            output_file = args[script_idx + 1]
+            output_file = args[_find_script_index(args) + 1]
             rendered_filenames.append(Path(output_file).name)
         assert rendered_filenames == [s.filename for s in spec.shards]
 

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -14,6 +14,7 @@ recorded call args + ordering.
 from __future__ import annotations
 
 import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -44,8 +45,12 @@ def _materialize_shard(args: list[str]) -> int:
     HDF5 to its output path. Tests that don't supply this side effect would trip the
     `shard_path.is_file()` check in `_render_and_upload_shard`.
     """
-    # Args layout: [wrapper, python, generate_vst_dataset.py, output_file, ...].
-    output_file = Path(args[3])
+    # Args layout depends on platform:
+    #   linux:     [wrapper, python, generate_vst_dataset.py, output_file, ...]
+    #   non-linux: [python, generate_vst_dataset.py, output_file, ...]
+    # Locate the script and read the output file from the next slot.
+    script_idx = next(i for i, a in enumerate(args) if a.endswith("generate_vst_dataset.py"))
+    output_file = Path(args[script_idx + 1])
     output_file.parent.mkdir(parents=True, exist_ok=True)
     output_file.write_bytes(b"")
     return 0
@@ -162,7 +167,7 @@ class TestRun:
 
         mock_check_call.assert_called_once()
         args = mock_check_call.call_args[0][0]
-        # args = [VST_HEADLESS_WRAPPER, python, generate_vst_dataset.py, ...]
+        # args = [VST_HEADLESS_WRAPPER (linux only), python, generate_vst_dataset.py, ...]
         assert any("generate_vst_dataset.py" in a for a in args)
         assert str(spec.shard_size) in args
 
@@ -174,20 +179,23 @@ class TestRun:
         mock_check_call: MagicMock,
         spec: DatasetPipelineSpec,
     ) -> None:
-        """The VST subprocess is prefixed with scripts/run-linux-vst-headless.sh.
+        """The VST subprocess is prefixed with scripts/run-linux-vst-headless.sh on Linux.
 
         X11 bootstrap lives at the audio-rendering boundary (this subprocess) so the
         docker_entrypoint click CLI can stay X11-agnostic — idle and passthrough modes don't pay
-        the Xvfb startup cost.
+        the Xvfb startup cost. The wrapper is Linux-only (Xvfb is a Linux X11 server); on macOS and
+        other platforms the generator is invoked directly without a wrapper prefix.
         """
         mock_check_call.side_effect = _materialize_shard
         run(spec)
 
         args = mock_check_call.call_args[0][0]
-        assert args[0] == VST_HEADLESS_WRAPPER
-        # Wrapper prefixes the original generate_vst_dataset.py invocation,
-        # so the python interpreter + script must appear immediately after.
-        assert args[2] == "src/data/vst/generate_vst_dataset.py"
+        if sys.platform.startswith("linux"):
+            assert args[0] == VST_HEADLESS_WRAPPER
+            assert args[2] == "src/data/vst/generate_vst_dataset.py"
+        else:
+            assert VST_HEADLESS_WRAPPER not in args
+            assert args[1] == "src/data/vst/generate_vst_dataset.py"
 
     @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
     @patch("pipeline.entrypoints.generate_dataset._rclone_copy")
@@ -261,8 +269,13 @@ class TestRun:
         rendered_filenames = []
         for call in mock_check_call.call_args_list:
             args = call[0][0]
-            # Args layout: [wrapper, python, generate_vst_dataset.py, output_file, ...].
-            output_file = args[3]
+            # Args layout depends on platform:
+            #   linux:     [wrapper, python, generate_vst_dataset.py, output_file, ...]
+            #   non-linux: [python, generate_vst_dataset.py, output_file, ...]
+            script_idx = next(
+                i for i, a in enumerate(args) if a.endswith("generate_vst_dataset.py")
+            )
+            output_file = args[script_idx + 1]
             rendered_filenames.append(Path(output_file).name)
         assert rendered_filenames == [s.filename for s in spec.shards]
 


### PR DESCRIPTION
## Summary

`pipeline/entrypoints/generate_dataset.py:_render_and_upload_shard` unconditionally prepended `scripts/run-linux-vst-headless.sh` (Xvfb + xsettingsd + dbus bootstrap for VST3 headless rendering on Linux) to the shard-render subprocess args. The wrapper is Linux-only — Xvfb is a Linux X11 server — so `run(spec)` failed immediately on macOS and other non-Linux dev hosts.

This PR gates the wrapper on `sys.platform.startswith("linux")` at the call site, mirroring the existing pattern already used by `tests/conftest.py:surge_xt_smoke_datasets` and `tests/test_train.py`:

```python
args = [VST_HEADLESS_WRAPPER] if sys.platform.startswith("linux") else []
args += build_generate_args(spec, shard, work_dir)
```

The companion test `test_shard_generation_runs_under_headless_vst_wrapper` and the `_materialize_shard` helper are updated to handle both arg layouts (wrapper-prefixed on Linux, direct on non-Linux).

## Scope

In-scope: the one production call site in `_render_and_upload_shard` and its tests.

Out-of-scope: the other VST_HEADLESS_WRAPPER call sites (`tests/conftest.py:343`, `tests/test_train.py:259`) — both already gate correctly with `if sys.platform == "linux":`.

## Test plan

- [x] `pytest tests/pipeline/test_entrypoints/test_generate_dataset.py` — 20 passed (run on macOS, exercises the non-linux branch)
- [x] `pytest tests/pipeline/ -m "not slow and not requires_vst"` — 133 passed
- [x] `pre-commit run --files pipeline/entrypoints/generate_dataset.py tests/pipeline/test_entrypoints/test_generate_dataset.py` — all hooks pass (ruff, ruff-format, pyright, docformatter, interrogate, codespell)
- [ ] CI Linux job exercises the linux branch end-to-end via existing test coverage

Closes #765