### PR TITLE
feat(skypilot): matrix-driven RunPod + OCI generate-dataset CI

### DIFF
--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -53,18 +53,50 @@ permissions:
   contents: read
 
 jobs:
+  # Matrix over RunPod + OCI providers. Both cells exercise the SAME
+  # provider-neutral launcher (pipeline.entrypoints.skypilot_launch_smoke)
+  # against a provider-specific compute template. `fail-fast: false` so a
+  # transient on one provider doesn't kill the other; `continue-on-error`
+  # is per-cell via matrix include so OCI can stay non-blocking until it
+  # accumulates a track record (3+ consecutive green runs).
+  #
+  # Both cells use --num-workers 3 so the partitioner is exercised end-to-
+  # end, and a run-id-scoped cluster name so the launcher's R2 spec key
+  # (skypilot-launcher-specs/<cluster>.json) is unique per provider per
+  # run — without this, the two parallel jobs' launchers would race on the
+  # same R2 key and validate-shard would download the wrong spec.
   generate:
-    name: Launch generate_dataset on RunPod via SkyPilot
+    name: Launch generate_dataset on ${{ matrix.provider }} via SkyPilot
     runs-on: ubuntu-latest
-    # Spends real RunPod + R2 dollars and needs RUNPOD_API_KEY in the job env.
-    # Only run for PRs opened from the same repository (forks can't read the
-    # secrets anyway, but this fails fast and surfaces the reason instead of
-    # provisioning a pod that errors on missing creds). workflow_dispatch is
-    # always allowed because it's gated by repo write permissions.
+    # Spends real RunPod / OCI + R2 dollars and needs the per-provider
+    # creds in the job env. Only run for PRs opened from the same
+    # repository (forks can't read the secrets anyway, but this fails
+    # fast and surfaces the reason instead of provisioning a pod/VM that
+    # errors on missing creds). workflow_dispatch is always allowed
+    # because it's gated by repo write permissions.
     if: >-
       github.event_name == 'workflow_dispatch'
       || github.event.pull_request.head.repo.full_name == github.repository
+    continue-on-error: ${{ matrix.continue_on_error }}
     timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - provider: runpod
+            template: configs/compute/runpod-template.yaml
+            cluster_prefix: synth-setter-smoke-runpod
+            pin_search: "image_id: docker:tinaudio/synth-setter:dev-snapshot"
+            pin_replace: "image_id: docker:tinaudio/synth-setter:{IMAGE_TAG}"
+            pin_grep: image_id
+            continue_on_error: false
+          - provider: oci
+            template: configs/compute/oci-cpu-template.yaml
+            cluster_prefix: synth-setter-smoke-oci
+            pin_search: 'WORKER_IMAGE: "tinaudio/synth-setter:dev-snapshot"'
+            pin_replace: 'WORKER_IMAGE: "tinaudio/synth-setter:{IMAGE_TAG}"'
+            pin_grep: WORKER_IMAGE
+            continue_on_error: true
     env:
       DATASET_CONFIG: >-
         ${{
@@ -82,28 +114,48 @@ jobs:
       - name: Pull image
         run: docker pull "$IMAGE"
 
-      # Pin the template's image_id from its default (`dev-snapshot`) to the tag
-      # this run was dispatched with, so the worker pulls the same image we just
-      # smoke-tested locally in the prior step.
-      - name: Pin image tag in SkyPilot template
+      # Pin the per-provider image reference from its dev-snapshot default
+      # to the tag this run was dispatched with, so the worker pulls the
+      # same image we just smoke-tested locally above.
+      #   - RunPod: SkyPilot's `image_id: docker:<image>` field.
+      #   - OCI: the WORKER_IMAGE env default the run: block reads (SkyPilot's
+      #     OCI backend rejects `image_id: docker:<image>`).
+      # The matrix's `pin_replace` string carries a literal `{IMAGE_TAG}`
+      # placeholder that bash substitutes here — keeps the per-provider sed
+      # arg as a single readable string in the matrix include rather than
+      # split across pattern + prefix + suffix variables.
+      - name: Pin worker image tag in compute template
+        env:
+          TEMPLATE: ${{ matrix.template }}
+          PIN_SEARCH: ${{ matrix.pin_search }}
+          PIN_REPLACE: ${{ matrix.pin_replace }}
+          PIN_GREP: ${{ matrix.pin_grep }}
         run: |
-          sed -i \
-            "s|image_id: docker:tinaudio/synth-setter:dev-snapshot|image_id: docker:tinaudio/synth-setter:${IMAGE_TAG}|" \
-            configs/compute/runpod-template.yaml
-          grep image_id configs/compute/runpod-template.yaml
+          REPLACE="${PIN_REPLACE//\{IMAGE_TAG\}/$IMAGE_TAG}"
+          sed -i "s|${PIN_SEARCH}|${REPLACE}|" "$TEMPLATE"
+          grep "$PIN_GREP" "$TEMPLATE"
 
       - name: Prepare run-metadata mount
-        run: mkdir -p /tmp/run-metadata
+        run: mkdir -p "/tmp/run-metadata-${{ matrix.provider }}"
 
       # Launch step notes (kept out of the heredoc so quoting is simple):
       #   - The launcher (pipeline.entrypoints.skypilot_launch_smoke) submits
       #     a SkyPilot job via sky.launch + stream_and_get, blocking until
       #     the cluster is provisioned, the worker runs, and (down=True)
       #     the cluster is torn down. The job-level `timeout-minutes: 60`
-      #     above is the safety bound on that block.
-      #   - SkyPilot validates RunPod credentials from ~/.runpod/config.toml
-      #     (env var alone is not enough), hence the in-container write of
-      #     that file with `umask 077` to keep the API key 600.
+      #     is the safety bound on that block.
+      #   - Cred-write switches on $PROVIDER inside the heredoc:
+      #       runpod -> ~/.runpod/config.toml (SkyPilot's runpod backend
+      #         needs the file; the env var alone is insufficient for
+      #         `sky check runpod`).
+      #       oci -> ~/.oci/config + ~/.oci/oci_api_key.pem + ~/.sky/config.yaml.
+      #         compartment_ocid is OCI-specific and must travel in
+      #         ~/.sky/config.yaml so launches target the operator's
+      #         intended compartment. Region lives only in ~/.oci/config
+      #         (single source of truth). The runtime `pip install
+      #         skypilot[oci]` bridge is dropped once the next dev-snapshot
+      #         rebuild bakes in the [oci] extra.
+      #     `umask 077` keeps every cred file 600 root-owned.
       #   - R2 / WANDB secrets land in the container's process env via
       #     `docker run -e ...` directly. The launcher reads them through
       #     `resolve_worker_env` (process env first, then optional .env
@@ -114,125 +166,15 @@ jobs:
       #     with SkyPilot staging); bind-mounted repo paths trip EXDEV on
       #     os.rename in-container, so we copy the spec to /run-metadata
       #     afterwards. `chmod 0644` is required because the in-container
-      #     `umask 077` above would otherwise leave the staged spec 600
-      #     root-owned and unreadable to the host runner for `head` /
+      #     `umask 077` would otherwise leave the staged spec 600 root-
+      #     owned and unreadable to the host runner for `head` /
       #     upload-artifact.
       - name: Launch SkyPilot job (inside container; streams logs + blocks until done)
         env:
+          PROVIDER: ${{ matrix.provider }}
+          TEMPLATE: ${{ matrix.template }}
+          CLUSTER_NAME: ${{ matrix.cluster_prefix }}-${{ github.run_id }}
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
-          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
-          CONFIG_PATH: ${{ env.DATASET_CONFIG }}
-          WORKER_GIT_REF: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: |
-          set -o pipefail
-          docker run --rm \
-            -v "${{ github.workspace }}:/home/build/synth-setter" \
-            -v /tmp/run-metadata:/run-metadata \
-            -e RUNPOD_API_KEY \
-            -e CONFIG_PATH \
-            -e RCLONE_CONFIG_R2_TYPE=s3 \
-            -e RCLONE_CONFIG_R2_PROVIDER=Cloudflare \
-            -e RCLONE_CONFIG_R2_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
-            -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
-            -e RCLONE_CONFIG_R2_ENDPOINT="${R2_ENDPOINT}" \
-            -e WANDB_API_KEY="${WANDB_API_KEY}" \
-            -e WORKER_GIT_REF="${WORKER_GIT_REF}" \
-            -e PYTHONPATH=/home/build/synth-setter \
-            "$IMAGE" \
-            bash -c '
-              set -euo pipefail
-              cd /home/build/synth-setter
-              git config --global --add safe.directory /home/build/synth-setter
-              mkdir -p plugins
-              ln -sf "/usr/lib/vst3/Surge XT.vst3" "plugins/Surge XT.vst3"
-              mkdir -p ~/.runpod
-              umask 077
-              printf "[default]\napi_key = \"%s\"\n" "$RUNPOD_API_KEY" > ~/.runpod/config.toml
-              python -m pipeline.entrypoints.skypilot_launch_smoke \
-                --config "$CONFIG_PATH" \
-                --spec-out /tmp/input_spec.json \
-                --num-workers 3
-              cp /tmp/input_spec.json /run-metadata/input_spec.json
-              chmod 0644 /run-metadata/input_spec.json
-            ' \
-            2>&1 | tee /tmp/run-metadata/generate.log
-
-      - name: Validate spec exists
-        run: |
-          if [ ! -f /tmp/run-metadata/input_spec.json ]; then
-            echo "::error::input_spec.json not found in /tmp/run-metadata/"
-            exit 1
-          fi
-          echo "=== Materialized Spec ==="
-          head -20 /tmp/run-metadata/input_spec.json
-
-      - name: Upload run metadata
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-run-metadata
-          path: /tmp/run-metadata/
-          retention-days: 7
-          if-no-files-found: warn
-
-  generate-oci:
-    name: Launch generate_dataset on OCI (CPU) via SkyPilot
-    runs-on: ubuntu-latest
-    # Spends real OCI + R2 dollars and needs OCI creds + R2 creds in env.
-    # `continue-on-error: true` while the OCI target beds in — failures here
-    # must not block PRs that don't touch the OCI path. Same fork-secret /
-    # workflow_dispatch gating as the RunPod job above.
-    if: >-
-      github.event_name == 'workflow_dispatch'
-      || github.event.pull_request.head.repo.full_name == github.repository
-    continue-on-error: true
-    timeout-minutes: 60
-    env:
-      DATASET_CONFIG: >-
-        ${{
-          github.event_name == 'pull_request'
-            && 'configs/dataset/runpod-smoke-shard.yaml'
-            || (inputs.dataset_config || 'configs/dataset/runpod-smoke-shard.yaml')
-        }}
-      IMAGE_TAG: ${{ inputs.docker_image_tag || 'dev-snapshot' }}
-      IMAGE: tinaudio/synth-setter:${{ inputs.docker_image_tag || 'dev-snapshot' }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Pull image
-        run: docker pull "$IMAGE"
-
-      # Pin the worker docker image the OCI template's run: block pulls and
-      # runs. The OCI template doesn't carry a SkyPilot `image_id:` field
-      # (SkyPilot's OCI backend rejects docker:<image>); the worker image
-      # lives in the `WORKER_IMAGE` env default, which we sed-pin here.
-      - name: Pin worker image tag in OCI template
-        run: |
-          sed -i \
-            "s|WORKER_IMAGE: \"tinaudio/synth-setter:dev-snapshot\"|WORKER_IMAGE: \"tinaudio/synth-setter:${IMAGE_TAG}\"|" \
-            configs/compute/oci-cpu-template.yaml
-          grep WORKER_IMAGE configs/compute/oci-cpu-template.yaml
-
-      - name: Prepare run-metadata mount
-        run: mkdir -p /tmp/run-metadata-oci
-
-      # OCI cred-write step notes (kept out of the heredoc):
-      #   - SkyPilot's OCI backend reads ~/.oci/config + the referenced PEM
-      #     file at `sky check oci` / provision time. We write both inside
-      #     the container so the same `umask 077` discipline used for the
-      #     RunPod config.toml applies (PEM and config 600 root-owned).
-      #   - `compartment_ocid` is OCI-specific and must be passed to
-      #     SkyPilot via ~/.sky/config.yaml under `oci.default.compartment_ocid`
-      #     so launches land in the operator's intended compartment.
-      #   - Region lives only in ~/.oci/config (single source of truth);
-      #     the template intentionally omits `region:` to avoid duplication.
-      - name: Launch SkyPilot job (inside container; streams logs + blocks until done)
-        env:
           OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
           OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
           OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
@@ -244,11 +186,16 @@ jobs:
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
           CONFIG_PATH: ${{ env.DATASET_CONFIG }}
+          WORKER_GIT_REF: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
           set -o pipefail
           docker run --rm \
             -v "${{ github.workspace }}:/home/build/synth-setter" \
-            -v /tmp/run-metadata-oci:/run-metadata \
+            -v "/tmp/run-metadata-${PROVIDER}:/run-metadata" \
+            -e PROVIDER \
+            -e TEMPLATE \
+            -e CLUSTER_NAME \
+            -e RUNPOD_API_KEY \
             -e OCI_USER_OCID \
             -e OCI_TENANCY_OCID \
             -e OCI_FINGERPRINT \
@@ -256,6 +203,7 @@ jobs:
             -e OCI_COMPARTMENT_OCID \
             -e OCI_API_KEY_PEM \
             -e CONFIG_PATH \
+            -e WORKER_GIT_REF \
             -e RCLONE_CONFIG_R2_TYPE=s3 \
             -e RCLONE_CONFIG_R2_PROVIDER=Cloudflare \
             -e RCLONE_CONFIG_R2_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
@@ -270,46 +218,60 @@ jobs:
               git config --global --add safe.directory /home/build/synth-setter
               mkdir -p plugins
               ln -sf "/usr/lib/vst3/Surge XT.vst3" "plugins/Surge XT.vst3"
-              mkdir -p "$HOME/.oci" "$HOME/.sky"
               umask 077
-              printf "%s\n" "$OCI_API_KEY_PEM" > "$HOME/.oci/oci_api_key.pem"
-              chmod 600 "$HOME/.oci/oci_api_key.pem"
-              printf "[DEFAULT]\nuser=%s\nfingerprint=%s\ntenancy=%s\nregion=%s\nkey_file=%s/.oci/oci_api_key.pem\n" \
-                "$OCI_USER_OCID" "$OCI_FINGERPRINT" "$OCI_TENANCY_OCID" "$OCI_REGION" "$HOME" \
-                > "$HOME/.oci/config"
-              chmod 600 "$HOME/.oci/config"
-              printf "oci:\n  default:\n    compartment_ocid: %s\n    image_tag_general: skypilot:cpu-ubuntu-2204\n" "$OCI_COMPARTMENT_OCID" \
-                > "$HOME/.sky/config.yaml"
-              if ! python -c "import oci" 2>/dev/null; then
-                echo "[oci-bridge] dev-snapshot lacks oci sdk; installing skypilot[oci] at runtime"
-                pip install --quiet "skypilot[oci]==0.12.0"
-              fi
-              sky check oci
+              case "$PROVIDER" in
+                runpod)
+                  mkdir -p "$HOME/.runpod"
+                  printf "[default]\napi_key = \"%s\"\n" "$RUNPOD_API_KEY" > "$HOME/.runpod/config.toml"
+                  ;;
+                oci)
+                  mkdir -p "$HOME/.oci" "$HOME/.sky"
+                  printf "%s\n" "$OCI_API_KEY_PEM" > "$HOME/.oci/oci_api_key.pem"
+                  chmod 600 "$HOME/.oci/oci_api_key.pem"
+                  printf "[DEFAULT]\nuser=%s\nfingerprint=%s\ntenancy=%s\nregion=%s\nkey_file=%s/.oci/oci_api_key.pem\n" \
+                    "$OCI_USER_OCID" "$OCI_FINGERPRINT" "$OCI_TENANCY_OCID" "$OCI_REGION" "$HOME" \
+                    > "$HOME/.oci/config"
+                  chmod 600 "$HOME/.oci/config"
+                  printf "oci:\n  default:\n    compartment_ocid: %s\n    image_tag_general: skypilot:cpu-ubuntu-2204\n" "$OCI_COMPARTMENT_OCID" \
+                    > "$HOME/.sky/config.yaml"
+                  if ! python -c "import oci" 2>/dev/null; then
+                    echo "[oci-bridge] dev-snapshot lacks oci sdk; installing skypilot[oci] at runtime"
+                    pip install --quiet "skypilot[oci]==0.12.0"
+                  fi
+                  sky check oci
+                  ;;
+                *)
+                  echo "ERROR: unknown PROVIDER=$PROVIDER" >&2
+                  exit 1
+                  ;;
+              esac
               python -m pipeline.entrypoints.skypilot_launch_smoke \
                 --config "$CONFIG_PATH" \
-                --template configs/compute/oci-cpu-template.yaml \
-                --cluster-name "synth-setter-smoke-oci-${{ github.run_id }}" \
+                --template "$TEMPLATE" \
+                --cluster-name "$CLUSTER_NAME" \
+                --num-workers 3 \
                 --spec-out /tmp/input_spec.json
               cp /tmp/input_spec.json /run-metadata/input_spec.json
               chmod 0644 /run-metadata/input_spec.json
             ' \
-            2>&1 | tee /tmp/run-metadata-oci/generate.log
+            2>&1 | tee "/tmp/run-metadata-${PROVIDER}/generate.log"
 
       - name: Validate spec exists
         run: |
-          if [[ ! -f /tmp/run-metadata-oci/input_spec.json ]]; then
-            echo "::error::input_spec.json not found in /tmp/run-metadata-oci/"
+          SPEC_PATH="/tmp/run-metadata-${{ matrix.provider }}/input_spec.json"
+          if [[ ! -f "$SPEC_PATH" ]]; then
+            echo "::error::input_spec.json not found at $SPEC_PATH"
             exit 1
           fi
-          echo "=== Materialized Spec (OCI) ==="
-          head -20 /tmp/run-metadata-oci/input_spec.json
+          echo "=== Materialized Spec (${{ matrix.provider }}) ==="
+          head -20 "$SPEC_PATH"
 
       - name: Upload run metadata
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-run-metadata-oci
-          path: /tmp/run-metadata-oci/
+          name: test-run-metadata-${{ matrix.provider }}
+          path: /tmp/run-metadata-${{ matrix.provider }}/
           retention-days: 7
           if-no-files-found: warn
 
@@ -324,7 +286,7 @@ jobs:
       - name: Download run metadata artifact
         uses: actions/download-artifact@v4
         with:
-          name: test-run-metadata
+          name: test-run-metadata-runpod
 
       - name: Validate spec structure
         run: python3 -m pipeline.ci.validate_spec input_spec.json
@@ -340,7 +302,7 @@ jobs:
       - name: Download run metadata artifact
         uses: actions/download-artifact@v4
         with:
-          name: test-run-metadata
+          name: test-run-metadata-runpod
 
       - name: Install PyYAML for config parsing
         run: pip install pyyaml

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -275,10 +275,19 @@ jobs:
           retention-days: 7
           if-no-files-found: warn
 
+  # Matrixed over the same providers as `generate`. validate_spec is
+  # provider-neutral (reads required fields out of input_spec.json), so
+  # the only per-cell variation is the artifact name.
   validate-spec:
+    name: Validate ${{ matrix.provider }} spec structure
     needs: generate
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    continue-on-error: ${{ matrix.provider == 'oci' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [runpod, oci]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -286,7 +295,7 @@ jobs:
       - name: Download run metadata artifact
         uses: actions/download-artifact@v4
         with:
-          name: test-run-metadata-runpod
+          name: test-run-metadata-${{ matrix.provider }}
 
       - name: Validate spec structure
         run: python3 -m pipeline.ci.validate_spec input_spec.json

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -207,15 +207,16 @@ jobs:
       - name: Pull image
         run: docker pull "$IMAGE"
 
-      # Pin the OCI template's image_id from its default (`dev-snapshot`) to
-      # the tag this run was dispatched with, so the worker pulls the same
-      # image we just smoke-tested locally in the prior step.
-      - name: Pin image tag in SkyPilot OCI template
+      # Pin the worker docker image the OCI template's run: block pulls and
+      # runs. The OCI template doesn't carry a SkyPilot `image_id:` field
+      # (SkyPilot's OCI backend rejects docker:<image>); the worker image
+      # lives in the `WORKER_IMAGE` env default, which we sed-pin here.
+      - name: Pin worker image tag in OCI template
         run: |
           sed -i \
-            "s|image_id: docker:tinaudio/synth-setter:dev-snapshot|image_id: docker:tinaudio/synth-setter:${IMAGE_TAG}|" \
+            "s|WORKER_IMAGE: \"tinaudio/synth-setter:dev-snapshot\"|WORKER_IMAGE: \"tinaudio/synth-setter:${IMAGE_TAG}\"|" \
             configs/compute/oci-cpu-template.yaml
-          grep image_id configs/compute/oci-cpu-template.yaml
+          grep WORKER_IMAGE configs/compute/oci-cpu-template.yaml
 
       - name: Prepare run-metadata mount
         run: mkdir -p /tmp/run-metadata-oci
@@ -277,8 +278,12 @@ jobs:
                 "$OCI_USER_OCID" "$OCI_FINGERPRINT" "$OCI_TENANCY_OCID" "$OCI_REGION" "$HOME" \
                 > "$HOME/.oci/config"
               chmod 600 "$HOME/.oci/config"
-              printf "oci:\n  default:\n    compartment_ocid: %s\n" "$OCI_COMPARTMENT_OCID" \
+              printf "oci:\n  default:\n    compartment_ocid: %s\n    image_tag_general: skypilot:cpu-ubuntu-2204\n" "$OCI_COMPARTMENT_OCID" \
                 > "$HOME/.sky/config.yaml"
+              if ! python -c "import oci" 2>/dev/null; then
+                echo "[oci-bridge] dev-snapshot lacks oci sdk; installing skypilot[oci] at runtime"
+                pip install --quiet "skypilot[oci]==0.12.0"
+              fi
               sky check oci
               python -m pipeline.entrypoints.skypilot_launch_smoke \
                 --config "$CONFIG_PATH" \

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -300,10 +300,20 @@ jobs:
       - name: Validate spec structure
         run: python3 -m pipeline.ci.validate_spec input_spec.json
 
+  # Matrixed over the same providers as `generate`. validate_shard.py is
+  # provider-neutral (downloads each shard from R2 using the spec's
+  # r2_prefix + shards[*].filename, then runs h5py structural checks),
+  # so the only per-cell variation is the artifact name.
   validate-shard:
+    name: Validate ${{ matrix.provider }} shards
     needs: generate
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    continue-on-error: ${{ matrix.provider == 'oci' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        provider: [runpod, oci]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -311,7 +321,7 @@ jobs:
       - name: Download run metadata artifact
         uses: actions/download-artifact@v4
         with:
-          name: test-run-metadata-runpod
+          name: test-run-metadata-${{ matrix.provider }}
 
       - name: Install PyYAML for config parsing
         run: pip install pyyaml

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -133,6 +133,19 @@ jobs:
         run: |
           REPLACE="${PIN_REPLACE//\{IMAGE_TAG\}/$IMAGE_TAG}"
           sed -i "s|${PIN_SEARCH}|${REPLACE}|" "$TEMPLATE"
+          # Assert the substitution actually happened. sed silently no-ops
+          # if PIN_SEARCH drifts from the template text — without this
+          # check, CI would proceed with the wrong (default) image tag.
+          # The PIN_SEARCH-still-present check covers PR CI where REPLACE
+          # ends in the dev-snapshot tag and would match the original.
+          if grep -qF "$PIN_SEARCH" "$TEMPLATE" && [ "$REPLACE" != "$PIN_SEARCH" ]; then
+            echo "::error::sed pin failed: '${PIN_SEARCH}' still present in $TEMPLATE after substitution" >&2
+            exit 1
+          fi
+          if ! grep -qF "$REPLACE" "$TEMPLATE"; then
+            echo "::error::sed pin failed: '${REPLACE}' not found in $TEMPLATE after substitution" >&2
+            exit 1
+          fi
           grep "$PIN_GREP" "$TEMPLATE"
 
       - name: Prepare run-metadata mount
@@ -278,9 +291,19 @@ jobs:
   # Matrixed over the same providers as `generate`. validate_spec is
   # provider-neutral (reads required fields out of input_spec.json), so
   # the only per-cell variation is the artifact name.
+  #
+  # `if: ${{ !cancelled() }}` decouples each provider's validate cell
+  # from the OTHER provider's generate outcome — if RunPod's generate
+  # fails, OCI's validate-spec still runs (and vice versa). The cell
+  # whose generate didn't produce an artifact will fail at download-
+  # artifact, which is the right per-cell signal. Without this, a
+  # RunPod transient (its generate cell is continue-on-error: false)
+  # would mark `needs: generate` as failed and skip BOTH validate
+  # cells — losing OCI signal for reasons unrelated to OCI.
   validate-spec:
     name: Validate ${{ matrix.provider }} spec structure
     needs: generate
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: ${{ matrix.provider == 'oci' }}
@@ -303,10 +326,13 @@ jobs:
   # Matrixed over the same providers as `generate`. validate_shard.py is
   # provider-neutral (downloads each shard from R2 using the spec's
   # r2_prefix + shards[*].filename, then runs h5py structural checks),
-  # so the only per-cell variation is the artifact name.
+  # so the only per-cell variation is the artifact name. See validate-spec
+  # for the rationale on `if: ${{ !cancelled() }}` (per-provider
+  # decoupling from cross-provider generate failures).
   validate-shard:
     name: Validate ${{ matrix.provider }} shards
     needs: generate
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: ${{ matrix.provider == 'oci' }}

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -18,6 +18,12 @@ name: Test Dataset Generation
 #   RUNPOD_API_KEY — used by this workflow to write ~/.runpod/config.toml,
 #                    which SkyPilot's RunPod backend reads at provision time
 #                    (env var alone is not sufficient for `sky check runpod`)
+#   OCI_USER_OCID, OCI_TENANCY_OCID, OCI_FINGERPRINT, OCI_REGION,
+#   OCI_COMPARTMENT_OCID, OCI_API_KEY_PEM — used to write ~/.oci/config and
+#                    the API key PEM that SkyPilot's OCI backend reads at
+#                    `sky check oci` / provision time. The OCI variant of the
+#                    generate job runs with `continue-on-error: true` while
+#                    the second target beds in.
 
 on:
   workflow_dispatch:
@@ -169,6 +175,135 @@ jobs:
         with:
           name: test-run-metadata
           path: /tmp/run-metadata/
+          retention-days: 7
+          if-no-files-found: warn
+
+  generate-oci:
+    name: Launch generate_dataset on OCI (CPU) via SkyPilot
+    runs-on: ubuntu-latest
+    # Spends real OCI + R2 dollars and needs OCI creds + R2 creds in env.
+    # `continue-on-error: true` while the OCI target beds in — failures here
+    # must not block PRs that don't touch the OCI path. Same fork-secret /
+    # workflow_dispatch gating as the RunPod job above.
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || github.event.pull_request.head.repo.full_name == github.repository
+    continue-on-error: true
+    timeout-minutes: 60
+    env:
+      DATASET_CONFIG: >-
+        ${{
+          github.event_name == 'pull_request'
+            && 'configs/dataset/runpod-smoke-shard.yaml'
+            || (inputs.dataset_config || 'configs/dataset/runpod-smoke-shard.yaml')
+        }}
+      IMAGE_TAG: ${{ inputs.docker_image_tag || 'dev-snapshot' }}
+      IMAGE: tinaudio/synth-setter:${{ inputs.docker_image_tag || 'dev-snapshot' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Pull image
+        run: docker pull "$IMAGE"
+
+      # Pin the OCI template's image_id from its default (`dev-snapshot`) to
+      # the tag this run was dispatched with, so the worker pulls the same
+      # image we just smoke-tested locally in the prior step.
+      - name: Pin image tag in SkyPilot OCI template
+        run: |
+          sed -i \
+            "s|image_id: docker:tinaudio/synth-setter:dev-snapshot|image_id: docker:tinaudio/synth-setter:${IMAGE_TAG}|" \
+            configs/compute/oci-cpu-template.yaml
+          grep image_id configs/compute/oci-cpu-template.yaml
+
+      - name: Prepare run-metadata mount
+        run: mkdir -p /tmp/run-metadata-oci
+
+      # OCI cred-write step notes (kept out of the heredoc):
+      #   - SkyPilot's OCI backend reads ~/.oci/config + the referenced PEM
+      #     file at `sky check oci` / provision time. We write both inside
+      #     the container so the same `umask 077` discipline used for the
+      #     RunPod config.toml applies (PEM and config 600 root-owned).
+      #   - `compartment_ocid` is OCI-specific and must be passed to
+      #     SkyPilot via ~/.sky/config.yaml under `oci.default.compartment_ocid`
+      #     so launches land in the operator's intended compartment.
+      #   - Region lives only in ~/.oci/config (single source of truth);
+      #     the template intentionally omits `region:` to avoid duplication.
+      - name: Launch SkyPilot job (inside container; streams logs + blocks until done)
+        env:
+          OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
+          OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
+          OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
+          OCI_REGION: ${{ secrets.OCI_REGION }}
+          OCI_COMPARTMENT_OCID: ${{ secrets.OCI_COMPARTMENT_OCID }}
+          OCI_API_KEY_PEM: ${{ secrets.OCI_API_KEY_PEM }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          CONFIG_PATH: ${{ env.DATASET_CONFIG }}
+        run: |
+          set -o pipefail
+          docker run --rm \
+            -v "${{ github.workspace }}:/home/build/synth-setter" \
+            -v /tmp/run-metadata-oci:/run-metadata \
+            -e OCI_USER_OCID \
+            -e OCI_TENANCY_OCID \
+            -e OCI_FINGERPRINT \
+            -e OCI_REGION \
+            -e OCI_COMPARTMENT_OCID \
+            -e OCI_API_KEY_PEM \
+            -e CONFIG_PATH \
+            -e RCLONE_CONFIG_R2_TYPE=s3 \
+            -e RCLONE_CONFIG_R2_PROVIDER=Cloudflare \
+            -e RCLONE_CONFIG_R2_ACCESS_KEY_ID="${R2_ACCESS_KEY_ID}" \
+            -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY="${R2_SECRET_ACCESS_KEY}" \
+            -e RCLONE_CONFIG_R2_ENDPOINT="${R2_ENDPOINT}" \
+            -e WANDB_API_KEY="${WANDB_API_KEY}" \
+            -e PYTHONPATH=/home/build/synth-setter \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              git config --global --add safe.directory /home/build/synth-setter
+              mkdir -p plugins
+              ln -sf "/usr/lib/vst3/Surge XT.vst3" "plugins/Surge XT.vst3"
+              mkdir -p "$HOME/.oci" "$HOME/.sky"
+              umask 077
+              printf "%s\n" "$OCI_API_KEY_PEM" > "$HOME/.oci/oci_api_key.pem"
+              chmod 600 "$HOME/.oci/oci_api_key.pem"
+              printf "[DEFAULT]\nuser=%s\nfingerprint=%s\ntenancy=%s\nregion=%s\nkey_file=%s/.oci/oci_api_key.pem\n" \
+                "$OCI_USER_OCID" "$OCI_FINGERPRINT" "$OCI_TENANCY_OCID" "$OCI_REGION" "$HOME" \
+                > "$HOME/.oci/config"
+              chmod 600 "$HOME/.oci/config"
+              printf "oci:\n  default:\n    compartment_ocid: %s\n" "$OCI_COMPARTMENT_OCID" \
+                > "$HOME/.sky/config.yaml"
+              sky check oci
+              python -m pipeline.entrypoints.skypilot_launch_smoke \
+                --config "$CONFIG_PATH" \
+                --template configs/compute/oci-cpu-template.yaml \
+                --spec-out /tmp/input_spec.json
+              cp /tmp/input_spec.json /run-metadata/input_spec.json
+              chmod 0644 /run-metadata/input_spec.json
+            ' \
+            2>&1 | tee /tmp/run-metadata-oci/generate.log
+
+      - name: Validate spec exists
+        run: |
+          if [[ ! -f /tmp/run-metadata-oci/input_spec.json ]]; then
+            echo "::error::input_spec.json not found in /tmp/run-metadata-oci/"
+            exit 1
+          fi
+          echo "=== Materialized Spec (OCI) ==="
+          head -20 /tmp/run-metadata-oci/input_spec.json
+
+      - name: Upload run metadata
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-run-metadata-oci
+          path: /tmp/run-metadata-oci/
           retention-days: 7
           if-no-files-found: warn
 

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -288,6 +288,7 @@ jobs:
               python -m pipeline.entrypoints.skypilot_launch_smoke \
                 --config "$CONFIG_PATH" \
                 --template configs/compute/oci-cpu-template.yaml \
+                --cluster-name "synth-setter-smoke-oci-${{ github.run_id }}" \
                 --spec-out /tmp/input_spec.json
               cp /tmp/input_spec.json /run-metadata/input_spec.json
               chmod 0644 /run-metadata/input_spec.json

--- a/.github/workflows/test-skypilot-debug.yml
+++ b/.github/workflows/test-skypilot-debug.yml
@@ -92,10 +92,28 @@ name: Test SkyPilot Debug
 # temporarily when actively iterating on launcher / wrapper / template
 # behavior.
 #
+# ==========================================================================
+# TEMPORARY ITERATION MODE — OCI noop-only (iteration/oci-debug-noop branch)
+# ==========================================================================
+# All RunPod variants are commented out below; only the `noop` variant is
+# active and points at configs/compute/oci-debug-template.yaml. This branch
+# is for iterating on OCI plumbing fast (cred-write, sky check oci, single
+# pod boot + teardown). To progressively re-enable variants:
+#   1. Pick a commented-out matrix entry below.
+#   2. Either point its `template:` at an OCI sibling (create one mirroring
+#      configs/compute/oci-debug-template.yaml) or leave it on RunPod.
+#   3. Uncomment.
+# Do NOT merge this branch into main. The persistent OCI work lives on
+# feat/skypilot-oci-cpu-target (PR #769).
+# ==========================================================================
+#
 # Required secrets:
 #   R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_ENDPOINT — Cloudflare R2
-#   RUNPOD_API_KEY  — written to ~/.runpod/config.toml so SkyPilot can
-#                     provision a pod
+#   OCI_USER_OCID, OCI_TENANCY_OCID, OCI_FINGERPRINT, OCI_REGION,
+#   OCI_COMPARTMENT_OCID, OCI_API_KEY_PEM — written to ~/.oci/config +
+#                     ~/.sky/config.yaml so SkyPilot can `sky check oci` and
+#                     provision an OCI VM. (RUNPOD_API_KEY is still required
+#                     for any RunPod variants you re-enable.)
 
 on:
   workflow_dispatch:
@@ -128,76 +146,78 @@ jobs:
         include:
           - variant: noop
             mode: inline-sky
-            template: configs/compute/runpod-debug-template.yaml
+            template: configs/compute/oci-debug-template.yaml
             cluster_prefix: synth-setter-debug
             cluster_suffix: noop
             config: ""
-          - variant: image-pull
-            mode: inline-sky
-            template: configs/compute/runpod-debug-image-pull-template.yaml
-            cluster_prefix: synth-setter-debug
-            cluster_suffix: image-pull
-            config: ""
-          - variant: spec-mount
-            mode: inline-sky
-            template: configs/compute/runpod-debug-spec-mount-template.yaml
-            cluster_prefix: synth-setter-debug
-            cluster_suffix: spec-mount
-            config: ""
-          - variant: headless
-            mode: inline-sky
-            template: configs/compute/runpod-debug-headless-template.yaml
-            cluster_prefix: synth-setter-debug
-            cluster_suffix: headless
-            config: ""
-          - variant: rclone
-            mode: inline-sky
-            template: configs/compute/runpod-debug-rclone-template.yaml
-            cluster_prefix: synth-setter-debug
-            cluster_suffix: rclone
-            config: ""
-          - variant: headless-rclone
-            mode: inline-sky
-            template: configs/compute/runpod-debug-headless-rclone-template.yaml
-            cluster_prefix: synth-setter-debug
-            cluster_suffix: headless-rclone
-            config: ""
-          - variant: pedalboard-load
-            mode: inline-sky
-            template: configs/compute/runpod-debug-pedalboard-template.yaml
-            cluster_prefix: synth-setter-debug
-            cluster_suffix: pedalboard
-            config: ""
-          - variant: stickiness-probe
-            mode: inline-sky
-            template: configs/compute/runpod-debug-template.yaml
-            cluster_prefix: synth-setter-smoke
-            cluster_suffix: stickiness
-            config: ""
-          - variant: launcher
-            mode: launcher-runner
-            template: configs/compute/runpod-debug-launcher-minimal-template.yaml
-            cluster_prefix: synth-setter-debug
-            cluster_suffix: launcher
-            config: configs/dataset/runpod-smoke-shard.yaml
-          - variant: launcher-in-docker
-            mode: launcher-docker
-            template: configs/compute/runpod-debug-launcher-minimal-template.yaml
-            cluster_prefix: synth-setter-debug
-            cluster_suffix: launcher-docker
-            config: configs/dataset/runpod-smoke-shard.yaml
-          - variant: generate-tiny
-            mode: launcher-runner
-            template: configs/compute/runpod-template.yaml
-            cluster_prefix: synth-setter-debug
-            cluster_suffix: generate-tiny
-            config: configs/dataset/runpod-smoke-shard.yaml
-          - variant: generate-tiny-in-docker
-            mode: launcher-docker
-            template: configs/compute/runpod-template.yaml
-            cluster_prefix: synth-setter-debug
-            cluster_suffix: generate-tiny-docker
-            config: configs/dataset/runpod-smoke-shard.yaml
+          # ITERATION MODE: variants below are intentionally disabled. Re-enable
+          # one at a time as OCI plumbing stabilises. See header banner.
+          # - variant: image-pull
+          #   mode: inline-sky
+          #   template: configs/compute/runpod-debug-image-pull-template.yaml
+          #   cluster_prefix: synth-setter-debug
+          #   cluster_suffix: image-pull
+          #   config: ""
+          # - variant: spec-mount
+          #   mode: inline-sky
+          #   template: configs/compute/runpod-debug-spec-mount-template.yaml
+          #   cluster_prefix: synth-setter-debug
+          #   cluster_suffix: spec-mount
+          #   config: ""
+          # - variant: headless
+          #   mode: inline-sky
+          #   template: configs/compute/runpod-debug-headless-template.yaml
+          #   cluster_prefix: synth-setter-debug
+          #   cluster_suffix: headless
+          #   config: ""
+          # - variant: rclone
+          #   mode: inline-sky
+          #   template: configs/compute/runpod-debug-rclone-template.yaml
+          #   cluster_prefix: synth-setter-debug
+          #   cluster_suffix: rclone
+          #   config: ""
+          # - variant: headless-rclone
+          #   mode: inline-sky
+          #   template: configs/compute/runpod-debug-headless-rclone-template.yaml
+          #   cluster_prefix: synth-setter-debug
+          #   cluster_suffix: headless-rclone
+          #   config: ""
+          # - variant: pedalboard-load
+          #   mode: inline-sky
+          #   template: configs/compute/runpod-debug-pedalboard-template.yaml
+          #   cluster_prefix: synth-setter-debug
+          #   cluster_suffix: pedalboard
+          #   config: ""
+          # - variant: stickiness-probe
+          #   mode: inline-sky
+          #   template: configs/compute/runpod-debug-template.yaml
+          #   cluster_prefix: synth-setter-smoke
+          #   cluster_suffix: stickiness
+          #   config: ""
+          # - variant: launcher
+          #   mode: launcher-runner
+          #   template: configs/compute/runpod-debug-launcher-minimal-template.yaml
+          #   cluster_prefix: synth-setter-debug
+          #   cluster_suffix: launcher
+          #   config: configs/dataset/runpod-smoke-shard.yaml
+          # - variant: launcher-in-docker
+          #   mode: launcher-docker
+          #   template: configs/compute/runpod-debug-launcher-minimal-template.yaml
+          #   cluster_prefix: synth-setter-debug
+          #   cluster_suffix: launcher-docker
+          #   config: configs/dataset/runpod-smoke-shard.yaml
+          # - variant: generate-tiny
+          #   mode: launcher-runner
+          #   template: configs/compute/runpod-template.yaml
+          #   cluster_prefix: synth-setter-debug
+          #   cluster_suffix: generate-tiny
+          #   config: configs/dataset/runpod-smoke-shard.yaml
+          # - variant: generate-tiny-in-docker
+          #   mode: launcher-docker
+          #   template: configs/compute/runpod-template.yaml
+          #   cluster_prefix: synth-setter-debug
+          #   cluster_suffix: generate-tiny-docker
+          #   config: configs/dataset/runpod-smoke-shard.yaml
 
     steps:
       - name: Checkout
@@ -210,7 +230,7 @@ jobs:
           cache: pip
 
       - name: Install skypilot
-        run: pip install "skypilot[runpod]==0.12.0"
+        run: pip install "skypilot[runpod,oci]==0.12.0"
 
       - name: Pin image tag in debug template
         env:
@@ -234,7 +254,12 @@ jobs:
       - name: Run inline SkyPilot probe
         if: matrix.mode == 'inline-sky'
         env:
-          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+          OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
+          OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
+          OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
+          OCI_REGION: ${{ secrets.OCI_REGION }}
+          OCI_COMPARTMENT_OCID: ${{ secrets.OCI_COMPARTMENT_OCID }}
+          OCI_API_KEY_PEM: ${{ secrets.OCI_API_KEY_PEM }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
@@ -246,9 +271,17 @@ jobs:
           LOG_PATH: /tmp/debug-pure-sky-${{ matrix.cluster_suffix }}.log
         run: |
           set -o pipefail
-          mkdir -p ~/.runpod
+          mkdir -p "$HOME/.oci" "$HOME/.sky"
           umask 077
-          printf "[default]\napi_key = \"%s\"\n" "$RUNPOD_API_KEY" > ~/.runpod/config.toml
+          printf "%s\n" "$OCI_API_KEY_PEM" > "$HOME/.oci/oci_api_key.pem"
+          chmod 600 "$HOME/.oci/oci_api_key.pem"
+          printf "[DEFAULT]\nuser=%s\nfingerprint=%s\ntenancy=%s\nregion=%s\nkey_file=%s/.oci/oci_api_key.pem\n" \
+            "$OCI_USER_OCID" "$OCI_FINGERPRINT" "$OCI_TENANCY_OCID" "$OCI_REGION" "$HOME" \
+            > "$HOME/.oci/config"
+          chmod 600 "$HOME/.oci/config"
+          printf "oci:\n  default:\n    compartment_ocid: %s\n" "$OCI_COMPARTMENT_OCID" \
+            > "$HOME/.sky/config.yaml"
+          sky check oci
 
           python - <<'PY' 2>&1 | tee "$LOG_PATH"
           import os, time

--- a/.github/workflows/test-skypilot-debug.yml
+++ b/.github/workflows/test-skypilot-debug.yml
@@ -279,7 +279,7 @@ jobs:
             "$OCI_USER_OCID" "$OCI_FINGERPRINT" "$OCI_TENANCY_OCID" "$OCI_REGION" "$HOME" \
             > "$HOME/.oci/config"
           chmod 600 "$HOME/.oci/config"
-          printf "oci:\n  default:\n    compartment_ocid: %s\n" "$OCI_COMPARTMENT_OCID" \
+          printf "oci:\n  default:\n    compartment_ocid: %s\n    image_tag_general: skypilot:cpu-ubuntu-2204\n" "$OCI_COMPARTMENT_OCID" \
             > "$HOME/.sky/config.yaml"
           sky check oci
 

--- a/.github/workflows/test-skypilot-debug.yml
+++ b/.github/workflows/test-skypilot-debug.yml
@@ -285,29 +285,44 @@ jobs:
           python - <<'PY'
           import oci
           cfg = oci.config.from_file()
-          print(f"[diag] tenancy={cfg['tenancy'][:30]}... region(home)={cfg['region']}")
+          print(f"[diag] tenancy={cfg['tenancy'][:30]}...")
           identity = oci.identity.IdentityClient(cfg)
           subs = identity.list_region_subscriptions(cfg['tenancy']).data
           print(f"[diag] subscribed regions: {len(subs)}")
           for r in subs:
               print(f"[diag]   region={r.region_name} status={r.status} home={r.is_home_region}")
-          # Service limits for compute in subscribed regions
           for r in subs:
               if r.status != 'READY':
                   continue
-              rcfg = dict(cfg); rcfg['region'] = r.region_name
+              rname = r.region_name
+              rcfg = dict(cfg); rcfg['region'] = rname
               try:
                   client = oci.limits.LimitsClient(rcfg)
-                  limits = client.list_limit_values(compartment_id=cfg['tenancy'], service_name='compute').data
-                  flex = [l for l in limits if 'standard-e' in l.name.lower() and 'flex' in l.name.lower()]
-                  if flex:
-                      print(f"[diag] {r.region_name} E*-Flex limits:")
-                      for l in flex:
-                          print(f"[diag]   {l.name}={l.value} (scope={l.scope_type})")
-                  else:
-                      print(f"[diag] {r.region_name}: no E*-Flex limits returned")
+                  limits = client.list_limit_values(
+                      compartment_id=cfg['tenancy'], service_name='compute'
+                  ).data
+                  print(f"[diag] {rname} ALL compute limits ({len(limits)}):")
+                  for l in limits:
+                      print(f"[diag]   {l.name}={l.value} (scope={l.scope_type}, ad={l.availability_domain})")
               except Exception as e:
-                  print(f"[diag] {r.region_name}: query failed: {type(e).__name__}: {str(e)[:100]}")
+                  print(f"[diag] {rname}: limits query failed: {type(e).__name__}: {str(e)[:120]}")
+              try:
+                  ic = oci.identity.IdentityClient(rcfg)
+                  ads = ic.list_availability_domains(cfg['tenancy']).data
+                  print(f"[diag] {rname} ADs: {[ad.name for ad in ads]}")
+                  for shape_name in ['VM.Standard.E4.Flex', 'VM.Standard.E5.Flex', 'VM.Standard.A1.Flex', 'VM.Standard.E2.1.Micro']:
+                      try:
+                          ra = client.get_resource_availability(
+                              service_name='compute',
+                              limit_name=shape_name.lower().replace('vm.standard.', '').replace('.', '-') + '-count',
+                              compartment_id=cfg['tenancy'],
+                              availability_domain=ads[0].name,
+                          ).data
+                          print(f"[diag] {rname} avail({shape_name}, {ads[0].name}): used={ra.used} avail={ra.available} fa={ra.fractional_availability}")
+                      except Exception as e:
+                          print(f"[diag] {rname} avail({shape_name}) failed: {type(e).__name__}: {str(e)[:80]}")
+              except Exception as e:
+                  print(f"[diag] {rname}: AD/availability query failed: {type(e).__name__}: {str(e)[:120]}")
           PY
 
           python - <<'PY' 2>&1 | tee "$LOG_PATH"

--- a/.github/workflows/test-skypilot-debug.yml
+++ b/.github/workflows/test-skypilot-debug.yml
@@ -87,33 +87,22 @@ name: Test SkyPilot Debug
 #                    that exists in the matrix so triage doesn't require
 #                    re-dispatching the production workflow separately.
 #
+# An OCI sibling of runpod-debug-template.yaml exists at
+# configs/compute/oci-debug-template.yaml — useful when iterating on the
+# OCI launcher path. The matrix below is RunPod-only by default; add an
+# OCI noop entry locally when bringing up new OCI plumbing, but don't
+# merge OCI entries here until they have stable cred-write + sky-check
+# coverage in this workflow.
+#
 # Triggers: workflow_dispatch only — RunPod pods are billable. Each
 # dispatch spends one pod per matrix variant. Add a `push` trigger only
 # temporarily when actively iterating on launcher / wrapper / template
 # behavior.
 #
-# ==========================================================================
-# TEMPORARY ITERATION MODE — OCI noop-only (iteration/oci-debug-noop branch)
-# ==========================================================================
-# All RunPod variants are commented out below; only the `noop` variant is
-# active and points at configs/compute/oci-debug-template.yaml. This branch
-# is for iterating on OCI plumbing fast (cred-write, sky check oci, single
-# pod boot + teardown). To progressively re-enable variants:
-#   1. Pick a commented-out matrix entry below.
-#   2. Either point its `template:` at an OCI sibling (create one mirroring
-#      configs/compute/oci-debug-template.yaml) or leave it on RunPod.
-#   3. Uncomment.
-# Do NOT merge this branch into main. The persistent OCI work lives on
-# feat/skypilot-oci-cpu-target (PR #769).
-# ==========================================================================
-#
 # Required secrets:
 #   R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_ENDPOINT — Cloudflare R2
-#   OCI_USER_OCID, OCI_TENANCY_OCID, OCI_FINGERPRINT, OCI_REGION,
-#   OCI_COMPARTMENT_OCID, OCI_API_KEY_PEM — written to ~/.oci/config +
-#                     ~/.sky/config.yaml so SkyPilot can `sky check oci` and
-#                     provision an OCI VM. (RUNPOD_API_KEY is still required
-#                     for any RunPod variants you re-enable.)
+#   RUNPOD_API_KEY  — written to ~/.runpod/config.toml so SkyPilot can
+#                     provision a pod
 
 on:
   workflow_dispatch:
@@ -146,78 +135,76 @@ jobs:
         include:
           - variant: noop
             mode: inline-sky
-            template: configs/compute/oci-debug-template.yaml
+            template: configs/compute/runpod-debug-template.yaml
             cluster_prefix: synth-setter-debug
             cluster_suffix: noop
             config: ""
-          # ITERATION MODE: variants below are intentionally disabled. Re-enable
-          # one at a time as OCI plumbing stabilises. See header banner.
-          # - variant: image-pull
-          #   mode: inline-sky
-          #   template: configs/compute/runpod-debug-image-pull-template.yaml
-          #   cluster_prefix: synth-setter-debug
-          #   cluster_suffix: image-pull
-          #   config: ""
-          # - variant: spec-mount
-          #   mode: inline-sky
-          #   template: configs/compute/runpod-debug-spec-mount-template.yaml
-          #   cluster_prefix: synth-setter-debug
-          #   cluster_suffix: spec-mount
-          #   config: ""
-          # - variant: headless
-          #   mode: inline-sky
-          #   template: configs/compute/runpod-debug-headless-template.yaml
-          #   cluster_prefix: synth-setter-debug
-          #   cluster_suffix: headless
-          #   config: ""
-          # - variant: rclone
-          #   mode: inline-sky
-          #   template: configs/compute/runpod-debug-rclone-template.yaml
-          #   cluster_prefix: synth-setter-debug
-          #   cluster_suffix: rclone
-          #   config: ""
-          # - variant: headless-rclone
-          #   mode: inline-sky
-          #   template: configs/compute/runpod-debug-headless-rclone-template.yaml
-          #   cluster_prefix: synth-setter-debug
-          #   cluster_suffix: headless-rclone
-          #   config: ""
-          # - variant: pedalboard-load
-          #   mode: inline-sky
-          #   template: configs/compute/runpod-debug-pedalboard-template.yaml
-          #   cluster_prefix: synth-setter-debug
-          #   cluster_suffix: pedalboard
-          #   config: ""
-          # - variant: stickiness-probe
-          #   mode: inline-sky
-          #   template: configs/compute/runpod-debug-template.yaml
-          #   cluster_prefix: synth-setter-smoke
-          #   cluster_suffix: stickiness
-          #   config: ""
-          # - variant: launcher
-          #   mode: launcher-runner
-          #   template: configs/compute/runpod-debug-launcher-minimal-template.yaml
-          #   cluster_prefix: synth-setter-debug
-          #   cluster_suffix: launcher
-          #   config: configs/dataset/runpod-smoke-shard.yaml
-          # - variant: launcher-in-docker
-          #   mode: launcher-docker
-          #   template: configs/compute/runpod-debug-launcher-minimal-template.yaml
-          #   cluster_prefix: synth-setter-debug
-          #   cluster_suffix: launcher-docker
-          #   config: configs/dataset/runpod-smoke-shard.yaml
-          # - variant: generate-tiny
-          #   mode: launcher-runner
-          #   template: configs/compute/runpod-template.yaml
-          #   cluster_prefix: synth-setter-debug
-          #   cluster_suffix: generate-tiny
-          #   config: configs/dataset/runpod-smoke-shard.yaml
-          # - variant: generate-tiny-in-docker
-          #   mode: launcher-docker
-          #   template: configs/compute/runpod-template.yaml
-          #   cluster_prefix: synth-setter-debug
-          #   cluster_suffix: generate-tiny-docker
-          #   config: configs/dataset/runpod-smoke-shard.yaml
+          - variant: image-pull
+            mode: inline-sky
+            template: configs/compute/runpod-debug-image-pull-template.yaml
+            cluster_prefix: synth-setter-debug
+            cluster_suffix: image-pull
+            config: ""
+          - variant: spec-mount
+            mode: inline-sky
+            template: configs/compute/runpod-debug-spec-mount-template.yaml
+            cluster_prefix: synth-setter-debug
+            cluster_suffix: spec-mount
+            config: ""
+          - variant: headless
+            mode: inline-sky
+            template: configs/compute/runpod-debug-headless-template.yaml
+            cluster_prefix: synth-setter-debug
+            cluster_suffix: headless
+            config: ""
+          - variant: rclone
+            mode: inline-sky
+            template: configs/compute/runpod-debug-rclone-template.yaml
+            cluster_prefix: synth-setter-debug
+            cluster_suffix: rclone
+            config: ""
+          - variant: headless-rclone
+            mode: inline-sky
+            template: configs/compute/runpod-debug-headless-rclone-template.yaml
+            cluster_prefix: synth-setter-debug
+            cluster_suffix: headless-rclone
+            config: ""
+          - variant: pedalboard-load
+            mode: inline-sky
+            template: configs/compute/runpod-debug-pedalboard-template.yaml
+            cluster_prefix: synth-setter-debug
+            cluster_suffix: pedalboard
+            config: ""
+          - variant: stickiness-probe
+            mode: inline-sky
+            template: configs/compute/runpod-debug-template.yaml
+            cluster_prefix: synth-setter-smoke
+            cluster_suffix: stickiness
+            config: ""
+          - variant: launcher
+            mode: launcher-runner
+            template: configs/compute/runpod-debug-launcher-minimal-template.yaml
+            cluster_prefix: synth-setter-debug
+            cluster_suffix: launcher
+            config: configs/dataset/runpod-smoke-shard.yaml
+          - variant: launcher-in-docker
+            mode: launcher-docker
+            template: configs/compute/runpod-debug-launcher-minimal-template.yaml
+            cluster_prefix: synth-setter-debug
+            cluster_suffix: launcher-docker
+            config: configs/dataset/runpod-smoke-shard.yaml
+          - variant: generate-tiny
+            mode: launcher-runner
+            template: configs/compute/runpod-template.yaml
+            cluster_prefix: synth-setter-debug
+            cluster_suffix: generate-tiny
+            config: configs/dataset/runpod-smoke-shard.yaml
+          - variant: generate-tiny-in-docker
+            mode: launcher-docker
+            template: configs/compute/runpod-template.yaml
+            cluster_prefix: synth-setter-debug
+            cluster_suffix: generate-tiny-docker
+            config: configs/dataset/runpod-smoke-shard.yaml
 
     steps:
       - name: Checkout
@@ -254,12 +241,7 @@ jobs:
       - name: Run inline SkyPilot probe
         if: matrix.mode == 'inline-sky'
         env:
-          OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
-          OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
-          OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
-          OCI_REGION: ${{ secrets.OCI_REGION }}
-          OCI_COMPARTMENT_OCID: ${{ secrets.OCI_COMPARTMENT_OCID }}
-          OCI_API_KEY_PEM: ${{ secrets.OCI_API_KEY_PEM }}
+          RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_ENDPOINT: ${{ secrets.R2_ENDPOINT }}
@@ -271,59 +253,9 @@ jobs:
           LOG_PATH: /tmp/debug-pure-sky-${{ matrix.cluster_suffix }}.log
         run: |
           set -o pipefail
-          mkdir -p "$HOME/.oci" "$HOME/.sky"
+          mkdir -p ~/.runpod
           umask 077
-          printf "%s\n" "$OCI_API_KEY_PEM" > "$HOME/.oci/oci_api_key.pem"
-          chmod 600 "$HOME/.oci/oci_api_key.pem"
-          printf "[DEFAULT]\nuser=%s\nfingerprint=%s\ntenancy=%s\nregion=%s\nkey_file=%s/.oci/oci_api_key.pem\n" \
-            "$OCI_USER_OCID" "$OCI_FINGERPRINT" "$OCI_TENANCY_OCID" "$OCI_REGION" "$HOME" \
-            > "$HOME/.oci/config"
-          chmod 600 "$HOME/.oci/config"
-          printf "oci:\n  default:\n    compartment_ocid: %s\n    image_tag_general: skypilot:cpu-ubuntu-2204\n" "$OCI_COMPARTMENT_OCID" \
-            > "$HOME/.sky/config.yaml"
-          sky check oci
-          python - <<'PY'
-          import oci
-          cfg = oci.config.from_file()
-          print(f"[diag] tenancy={cfg['tenancy'][:30]}...")
-          identity = oci.identity.IdentityClient(cfg)
-          subs = identity.list_region_subscriptions(cfg['tenancy']).data
-          print(f"[diag] subscribed regions: {len(subs)}")
-          for r in subs:
-              print(f"[diag]   region={r.region_name} status={r.status} home={r.is_home_region}")
-          for r in subs:
-              if r.status != 'READY':
-                  continue
-              rname = r.region_name
-              rcfg = dict(cfg); rcfg['region'] = rname
-              try:
-                  client = oci.limits.LimitsClient(rcfg)
-                  limits = client.list_limit_values(
-                      compartment_id=cfg['tenancy'], service_name='compute'
-                  ).data
-                  print(f"[diag] {rname} ALL compute limits ({len(limits)}):")
-                  for l in limits:
-                      print(f"[diag]   {l.name}={l.value} (scope={l.scope_type}, ad={l.availability_domain})")
-              except Exception as e:
-                  print(f"[diag] {rname}: limits query failed: {type(e).__name__}: {str(e)[:120]}")
-              try:
-                  ic = oci.identity.IdentityClient(rcfg)
-                  ads = ic.list_availability_domains(cfg['tenancy']).data
-                  print(f"[diag] {rname} ADs: {[ad.name for ad in ads]}")
-                  for shape_name in ['VM.Standard.E4.Flex', 'VM.Standard.E5.Flex', 'VM.Standard.A1.Flex', 'VM.Standard.E2.1.Micro']:
-                      try:
-                          ra = client.get_resource_availability(
-                              service_name='compute',
-                              limit_name=shape_name.lower().replace('vm.standard.', '').replace('.', '-') + '-count',
-                              compartment_id=cfg['tenancy'],
-                              availability_domain=ads[0].name,
-                          ).data
-                          print(f"[diag] {rname} avail({shape_name}, {ads[0].name}): used={ra.used} avail={ra.available} fa={ra.fractional_availability}")
-                      except Exception as e:
-                          print(f"[diag] {rname} avail({shape_name}) failed: {type(e).__name__}: {str(e)[:80]}")
-              except Exception as e:
-                  print(f"[diag] {rname}: AD/availability query failed: {type(e).__name__}: {str(e)[:120]}")
-          PY
+          printf "[default]\napi_key = \"%s\"\n" "$RUNPOD_API_KEY" > ~/.runpod/config.toml
 
           python - <<'PY' 2>&1 | tee "$LOG_PATH"
           import os, time

--- a/.github/workflows/test-skypilot-debug.yml
+++ b/.github/workflows/test-skypilot-debug.yml
@@ -282,6 +282,33 @@ jobs:
           printf "oci:\n  default:\n    compartment_ocid: %s\n    image_tag_general: skypilot:cpu-ubuntu-2204\n" "$OCI_COMPARTMENT_OCID" \
             > "$HOME/.sky/config.yaml"
           sky check oci
+          python - <<'PY'
+          import oci
+          cfg = oci.config.from_file()
+          print(f"[diag] tenancy={cfg['tenancy'][:30]}... region(home)={cfg['region']}")
+          identity = oci.identity.IdentityClient(cfg)
+          subs = identity.list_region_subscriptions(cfg['tenancy']).data
+          print(f"[diag] subscribed regions: {len(subs)}")
+          for r in subs:
+              print(f"[diag]   region={r.region_name} status={r.status} home={r.is_home_region}")
+          # Service limits for compute in subscribed regions
+          for r in subs:
+              if r.status != 'READY':
+                  continue
+              rcfg = dict(cfg); rcfg['region'] = r.region_name
+              try:
+                  client = oci.limits.LimitsClient(rcfg)
+                  limits = client.list_limit_values(compartment_id=cfg['tenancy'], service_name='compute').data
+                  flex = [l for l in limits if 'standard-e' in l.name.lower() and 'flex' in l.name.lower()]
+                  if flex:
+                      print(f"[diag] {r.region_name} E*-Flex limits:")
+                      for l in flex:
+                          print(f"[diag]   {l.name}={l.value} (scope={l.scope_type})")
+                  else:
+                      print(f"[diag] {r.region_name}: no E*-Flex limits returned")
+              except Exception as e:
+                  print(f"[diag] {r.region_name}: query failed: {type(e).__name__}: {str(e)[:100]}")
+          PY
 
           python - <<'PY' 2>&1 | tee "$LOG_PATH"
           import os, time

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -104,6 +104,12 @@ setup: |
 #   after `run()` returns successfully. Workaround for #735: same root
 #   cause kept defensively across providers until the underlying
 #   non-daemon-thread leak is root-caused.
+# - The python -c body lines sit at the YAML block-scalar's minimum
+#   indent (2 spaces in source) — visually less indented than the
+#   surrounding bash. After YAML strips the block-scalar's 2-space
+#   prefix, the python content reaches the interpreter at column 0,
+#   which is the only indent level Python -c accepts for top-level
+#   statements. Don't re-indent the python lines to match the bash.
 run: |
   set -euo pipefail
   echo "skypilot-run-cwd: $(pwd) host: $(hostname)"
@@ -120,4 +126,14 @@ run: |
     -e SYNTH_SETTER_NUM_WORKERS \
     -e PYTHONPATH=/home/build/synth-setter \
     "$WORKER_IMAGE" \
-    bash -c 'set -euo pipefail; cd /home/build/synth-setter; python -c "import os; from pipeline.entrypoints.generate_dataset import load_spec_from_uri, run; run(load_spec_from_uri(os.environ[\"WORKER_SPEC_URI\"])); print(\"forcing interpreter exit (#735 workaround) — bypassing atexit\", flush=True); os._exit(0)"'
+    bash -c '
+      set -euo pipefail
+      cd /home/build/synth-setter
+      python -c "
+  import os
+  from pipeline.entrypoints.generate_dataset import load_spec_from_uri, run
+  run(load_spec_from_uri(os.environ[\"WORKER_SPEC_URI\"]))
+  print(\"forcing interpreter exit (#735 workaround) — bypassing atexit\", flush=True)
+  os._exit(0)
+  "
+    '

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -47,6 +47,8 @@ envs:
   RCLONE_CONFIG_R2_ENDPOINT: ""
   WORKER_SPEC_URI: ""
   WORKER_IMAGE: "tinaudio/synth-setter:dev-snapshot"
+  SYNTH_SETTER_WORKER_RANK: "0"
+  SYNTH_SETTER_NUM_WORKERS: "1"
 
 # `setup:` notes (kept out of the heredoc — comments inside YAML
 # block-scalars are read by bash and stray quotes / backticks have caused
@@ -101,6 +103,8 @@ run: |
     -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
     -e RCLONE_CONFIG_R2_ENDPOINT \
     -e WORKER_SPEC_URI \
+    -e SYNTH_SETTER_WORKER_RANK \
+    -e SYNTH_SETTER_NUM_WORKERS \
     -e PYTHONPATH=/home/build/synth-setter \
     "$WORKER_IMAGE" \
     bash -c 'set -euo pipefail; cd /home/build/synth-setter; mkdir -p plugins; ln -sf "/usr/lib/vst3/Surge XT.vst3" "plugins/Surge XT.vst3"; python -c "import os; from pipeline.entrypoints.generate_dataset import load_spec_from_uri, run; run(load_spec_from_uri(os.environ[\"WORKER_SPEC_URI\"])); print(\"forcing interpreter exit (#735 workaround) — bypassing atexit\", flush=True); os._exit(0)"'

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -85,6 +85,12 @@ setup: |
 #   image_id, so we run the worker container ourselves on the OCI VM. The
 #   container is the exact same dev-snapshot image used on RunPod; only
 #   the launch path differs.
+# - --privileged + --ulimit nofile=65536:65536 are the expedient hammer
+#   for the Xvfb / dbus / pedalboard preset-load X11 stack. Justifiable
+#   on a single-tenant ephemeral OCI VM (the container IS the workload),
+#   but bigger than necessary. Follow-up to identify the minimal cap
+#   set: #776 (drop --privileged; replace with the smallest cap-add /
+#   shm-size combination that still lets Surge XT preset load work).
 # - Env propagation: `task.update_envs(...)` sets RCLONE_*+WORKER_SPEC_URI
 #   in the OCI VM's shell environment (via SkyPilot's env-file source).
 #   `docker run -e VAR_NAME` (no value) inherits each named var from the

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -67,6 +67,17 @@ envs:
 #   buried under run:'s tee.
 setup: |
   set -euo pipefail
+  if command -v cloud-init >/dev/null 2>&1; then
+    echo "waiting for cloud-init to finish before touching apt..."
+    sudo cloud-init status --wait || true
+  fi
+  for i in $(seq 1 60); do
+    if ! sudo fuser /var/lib/dpkg/lock-frontend /var/lib/apt/lists/lock >/dev/null 2>&1; then
+      break
+    fi
+    echo "apt/dpkg locked by another process; retry $i/60..."
+    sleep 5
+  done
   if ! command -v docker >/dev/null 2>&1; then
     sudo apt-get update -qq
     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -71,8 +71,8 @@ setup: |
   fi
   sudo systemctl enable --now docker || sudo service docker start
   sudo usermod -aG docker "$USER" || true
-  sudo docker pull "$WORKER_IMAGE"
-  echo "synth-setter worker ready (host: $(hostname), docker: $(sudo docker --version))"
+  sudo -E docker pull "$WORKER_IMAGE"
+  echo "synth-setter worker ready (host: $(hostname), docker: $(sudo -E docker --version))"
 
 # `run:` block notes:
 #
@@ -94,7 +94,7 @@ setup: |
 run: |
   set -euo pipefail
   echo "skypilot-run-cwd: $(pwd) host: $(hostname)"
-  sudo docker run --rm \
+  sudo -E docker run --rm \
     -e RCLONE_CONFIG_R2_TYPE \
     -e RCLONE_CONFIG_R2_PROVIDER \
     -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -47,8 +47,9 @@ envs:
   RCLONE_CONFIG_R2_ENDPOINT: ""
   WORKER_SPEC_URI: ""
   WORKER_IMAGE: "tinaudio/synth-setter:dev-snapshot"
-  SYNTH_SETTER_WORKER_RANK: "0"
-  SYNTH_SETTER_NUM_WORKERS: "1"
+  # Per-rank partition env. Source of truth: pipeline/partitioning.py.
+  SYNTH_SETTER_WORKER_RANK: ""
+  SYNTH_SETTER_NUM_WORKERS: ""
 
 # `setup:` notes (kept out of the heredoc — comments inside YAML
 # block-scalars are read by bash and stray quotes / backticks have caused

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -108,6 +108,8 @@ run: |
   set -euo pipefail
   echo "skypilot-run-cwd: $(pwd) host: $(hostname)"
   sudo -E docker run --rm \
+    --privileged \
+    --ulimit nofile=65536:65536 \
     -e RCLONE_CONFIG_R2_TYPE \
     -e RCLONE_CONFIG_R2_PROVIDER \
     -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -47,6 +47,10 @@ envs:
   RCLONE_CONFIG_R2_ENDPOINT: ""
   WORKER_SPEC_URI: ""
   WORKER_IMAGE: "tinaudio/synth-setter:dev-snapshot"
+  # Optional git ref the worker checks out before running generate_dataset
+  # (lets PR CI bypass dev-snapshot image-bake lag). Mirrors the RunPod
+  # template's contract; ignored when empty.
+  WORKER_GIT_REF: ""
   # Per-rank partition env. Source of truth: pipeline/partitioning.py.
   SYNTH_SETTER_WORKER_RANK: ""
   SYNTH_SETTER_NUM_WORKERS: ""
@@ -121,6 +125,7 @@ run: |
     -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
     -e RCLONE_CONFIG_R2_ENDPOINT \
     -e WORKER_SPEC_URI \
+    -e WORKER_GIT_REF \
     -e SYNTH_SETTER_WORKER_RANK \
     -e SYNTH_SETTER_NUM_WORKERS \
     -e PYTHONPATH=/home/build/synth-setter \
@@ -128,6 +133,17 @@ run: |
     bash -c '
       set -euo pipefail
       cd /home/build/synth-setter
+      if [ -n "${WORKER_GIT_REF:-}" ]; then
+        echo "Syncing worker checkout to git ref: $WORKER_GIT_REF"
+        if ! [[ "$WORKER_GIT_REF" =~ ^[0-9a-f]{7,40}$ ]]; then
+          echo "ERROR: WORKER_GIT_REF must be a 7-40 char hex git SHA, got: $WORKER_GIT_REF" >&2
+          exit 1
+        fi
+        git config --global --add safe.directory /home/build/synth-setter
+        git fetch --depth=1 origin -- "$WORKER_GIT_REF"
+        git checkout FETCH_HEAD
+        echo "Worker now at: $(git rev-parse HEAD)"
+      fi
       python -c "
   import os
   from pipeline.entrypoints.generate_dataset import load_spec_from_uri, run

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -68,22 +68,14 @@ envs:
 setup: |
   set -euo pipefail
   if command -v cloud-init >/dev/null 2>&1; then
-    echo "waiting for cloud-init to finish before touching apt..."
-    sudo cloud-init status --wait || true
+    echo "waiting for cloud-init to finish before touching apt (cap 5min)..."
+    sudo timeout 300 cloud-init status --wait || true
   fi
-  for i in $(seq 1 60); do
-    if ! sudo fuser /var/lib/dpkg/lock-frontend /var/lib/apt/lists/lock >/dev/null 2>&1; then
-      break
-    fi
-    echo "apt/dpkg locked by another process; retry $i/60..."
-    sleep 5
-  done
   if ! command -v docker >/dev/null 2>&1; then
-    sudo apt-get update -qq
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io
+    sudo apt-get -o DPkg::Lock::Timeout=300 update -qq
+    sudo DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=300 install -y -qq docker.io
   fi
-  sudo systemctl enable --now docker || sudo service docker start
-  sudo usermod -aG docker "$USER" || true
+  sudo systemctl enable --now docker
   sudo -E docker pull "$WORKER_IMAGE"
   echo "synth-setter worker ready (host: $(hostname), docker: $(sudo -E docker --version))"
 

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -120,4 +120,4 @@ run: |
     -e SYNTH_SETTER_NUM_WORKERS \
     -e PYTHONPATH=/home/build/synth-setter \
     "$WORKER_IMAGE" \
-    bash -c 'set -euo pipefail; cd /home/build/synth-setter; mkdir -p plugins; ln -sf "/usr/lib/vst3/Surge XT.vst3" "plugins/Surge XT.vst3"; python -c "import os; from pipeline.entrypoints.generate_dataset import load_spec_from_uri, run; run(load_spec_from_uri(os.environ[\"WORKER_SPEC_URI\"])); print(\"forcing interpreter exit (#735 workaround) — bypassing atexit\", flush=True); os._exit(0)"'
+    bash -c 'set -euo pipefail; cd /home/build/synth-setter; python -c "import os; from pipeline.entrypoints.generate_dataset import load_spec_from_uri, run; run(load_spec_from_uri(os.environ[\"WORKER_SPEC_URI\"])); print(\"forcing interpreter exit (#735 workaround) — bypassing atexit\", flush=True); os._exit(0)"'

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -1,0 +1,91 @@
+# SkyPilot task template for OCI (Oracle Cloud Infrastructure), CPU-only.
+#
+# Loaded by pipeline/entrypoints/skypilot_launch_smoke.py via sky.Task.from_yaml(...).
+# The launcher uploads the materialized spec to R2 (`r2://<bucket>/skypilot-launcher-specs/<cluster>.json`)
+# and injects credentials + the spec URI via task.update_envs(...) before
+# calling sky.launch(task, cluster_name=..., down=True). Unmanaged launch
+# (not sky.jobs.launch) — the smoke probe is a single-shot, single-shard
+# round-trip; managed jobs would require a controller-state cloud bucket
+# we don't have provisioned for OCI yet, and unmanaged sky.launch is
+# sufficient at this scope.
+#
+# Spec ships via R2 (not file_mounts) for parity with the RunPod template
+# (see #749 for the original RunPod-backend pubkey-overflow rationale —
+# even though OCI's backend doesn't share that bug, keeping the launcher
+# provider-neutral means specs always travel through R2).
+#
+# Image: tinaudio/synth-setter:dev-snapshot must be pushed to Docker Hub
+# (`make docker-build-dev-snapshot` then `docker push`) before launch.
+# The image is built `linux/amd64` so x86 OCI shapes pull it directly.
+# Tag pinning to a git SHA is deferred to the Phase B PR per the design doc
+# at docs/design/skypilot-compute-integration.md.
+
+resources:
+  cloud: oci
+  # Flex shape — SkyPilot picks the smallest VM.Standard.E5.Flex variant that
+  # satisfies these floors. CPU-only is sufficient for the smoke probe (the
+  # workload is single-shard and short-lived; GPU acceleration buys nothing).
+  cpus: 4+
+  memory: 16+
+  # Region is intentionally NOT pinned here — `~/.oci/config` is the single
+  # source of truth (set via OCI_REGION at CI cred-write time, or directly
+  # for local launches). Pinning region in two places risks `sky check oci`
+  # validating one region while launches go to another.
+  use_spot: false
+  disk_size: 50
+  image_id: docker:tinaudio/synth-setter:dev-snapshot
+
+# Placeholders. Real values are injected by the launcher via update_envs.
+# WORKER_SPEC_URI is set per-cluster by the launcher to the r2:// URI of the
+# uploaded spec; the worker downloads from there via load_spec_from_uri.
+envs:
+  RCLONE_CONFIG_R2_TYPE: ""
+  RCLONE_CONFIG_R2_PROVIDER: ""
+  RCLONE_CONFIG_R2_ACCESS_KEY_ID: ""
+  RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ""
+  RCLONE_CONFIG_R2_ENDPOINT: ""
+  WORKER_SPEC_URI: ""
+
+setup: |
+  echo "synth-setter worker ready (host: $(hostname))"
+
+# `run:` block notes (kept out of the heredoc — comments inside YAML
+# block-scalars are read by bash and stray quotes / backticks have caused
+# unintended shell expansions in the past):
+#
+# - First echo is a diagnostic: SkyPilot's run block does NOT cd to the
+#   image's WORKDIR (`/home/build/synth-setter`) by default — it lands
+#   in `~/sky_workdir`. The cd that follows is what lets the inlined
+#   `python -c '...'` resolve `pipeline.entrypoints.generate_dataset`
+#   from the repo root, since the worker runs without PYTHONPATH set.
+# - The Python invocation is inlined (instead of calling the docker
+#   entrypoint's click subcommand) so we can `os._exit(0)` immediately
+#   after `run()` returns successfully. Workaround for #735: the SkyPilot
+#   worker (originally observed on RunPod, kept here defensively for OCI
+#   too until #735 is root-caused) consistently hangs at Python
+#   interpreter shutdown — some library (most likely pedalboard / numba /
+#   dask / h5py) leaves a non-daemon thread alive and the interpreter
+#   never exits. SkyPilot's job-status reporter sees the SSH session's
+#   process tree still alive and the job stays in RUNNING forever even
+#   though both rclone uploads have already landed in R2. `os._exit(0)`
+#   bypasses atexit / non-daemon-thread join and lets SkyPilot register
+#   SUCCEEDED.
+# - Scoping the workaround to this template (vs. an env-var gate in
+#   scripts/docker_entrypoint.py) keeps `generate_dataset` clean for
+#   local dev and other CI consumers; only the SkyPilot worker context
+#   force-exits.
+# - Drop this whole inline block (and revert to `python -m
+#   scripts.docker_entrypoint generate_dataset --spec ...`) once #735 is
+#   root-caused at its source. PR-B's `pedalboard-load` matrix variant
+#   is the canary that proves the revert is safe.
+run: |
+  echo "skypilot-run-cwd: $(pwd)"
+  cd /home/build/synth-setter
+  python -c '
+  import os
+  from pipeline.entrypoints.generate_dataset import load_spec_from_uri, run
+  spec = load_spec_from_uri(os.environ["WORKER_SPEC_URI"])
+  run(spec)
+  print("forcing interpreter exit (#735 workaround) — bypassing atexit", flush=True)
+  os._exit(0)
+  '

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -5,35 +5,36 @@
 # and injects credentials + the spec URI via task.update_envs(...) before
 # calling sky.launch(task, cluster_name=..., down=True). Unmanaged launch
 # (not sky.jobs.launch) — the smoke probe is a single-shot, single-shard
-# round-trip; managed jobs would require a controller-state cloud bucket
-# we don't have provisioned for OCI yet, and unmanaged sky.launch is
-# sufficient at this scope.
+# round-trip and managed jobs would require a controller-state cloud bucket
+# we don't have provisioned for OCI yet.
 #
-# Spec ships via R2 (not file_mounts) for parity with the RunPod template
-# (see #749 for the original RunPod-backend pubkey-overflow rationale —
-# even though OCI's backend doesn't share that bug, keeping the launcher
-# provider-neutral means specs always travel through R2).
+# IMPORTANT — no `image_id` field here. SkyPilot's OCI backend rejects the
+# `docker:<image>` syntax with "Docker image is currently not supported on
+# OCI." Instead the worker image (tinaudio/synth-setter:dev-snapshot) is
+# pulled and run as a sub-docker invocation inside the run: block. The OCI
+# VM base is Canonical Ubuntu 22.04 (selected via `image_tag_general:
+# skypilot:cpu-ubuntu-2204` in the workflow's ~/.sky/config.yaml writer);
+# setup: ensures docker.io is installed and the daemon is running.
+#
+# Spec ships via R2 (not file_mounts) for parity with the RunPod template.
 #
 # Image: tinaudio/synth-setter:dev-snapshot must be pushed to Docker Hub
-# (`make docker-build-dev-snapshot` then `docker push`) before launch.
-# The image is built `linux/amd64` so x86 OCI shapes pull it directly.
-# Tag pinning to a git SHA is deferred to the Phase B PR per the design doc
-# at docs/design/skypilot-compute-integration.md.
+# (`make docker-build-dev-snapshot` then `docker push`) before launch. Pin
+# at workflow-dispatch time via the `docker_image_tag` input or by editing
+# the IMAGE_TAG in the workflow.
 
 resources:
   cloud: oci
-  # Flex shape — SkyPilot picks the smallest VM.Standard.E5.Flex variant that
-  # satisfies these floors. CPU-only is sufficient for the smoke probe (the
-  # workload is single-shard and short-lived; GPU acceleration buys nothing).
+  # Flex shape — SkyPilot picks the smallest VM.Standard.E5.Flex variant
+  # that satisfies these floors. CPU-only is sufficient for the smoke
+  # probe (the workload is single-shard and short-lived; GPU acceleration
+  # buys nothing here).
   cpus: 4+
   memory: 16+
   # Region is intentionally NOT pinned here — `~/.oci/config` is the single
-  # source of truth (set via OCI_REGION at CI cred-write time, or directly
-  # for local launches). Pinning region in two places risks `sky check oci`
-  # validating one region while launches go to another.
+  # source of truth (set via OCI_REGION at CI cred-write time).
   use_spot: false
   disk_size: 50
-  image_id: docker:tinaudio/synth-setter:dev-snapshot
 
 # Placeholders. Real values are injected by the launcher via update_envs.
 # WORKER_SPEC_URI is set per-cluster by the launcher to the r2:// URI of the
@@ -45,47 +46,61 @@ envs:
   RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ""
   RCLONE_CONFIG_R2_ENDPOINT: ""
   WORKER_SPEC_URI: ""
+  WORKER_IMAGE: "tinaudio/synth-setter:dev-snapshot"
 
-setup: |
-  echo "synth-setter worker ready (host: $(hostname))"
-
-# `run:` block notes (kept out of the heredoc — comments inside YAML
+# `setup:` notes (kept out of the heredoc — comments inside YAML
 # block-scalars are read by bash and stray quotes / backticks have caused
 # unintended shell expansions in the past):
 #
-# - First echo is a diagnostic: SkyPilot's run block does NOT cd to the
-#   image's WORKDIR (`/home/build/synth-setter`) by default — it lands
-#   in `~/sky_workdir`. The cd that follows is what lets the inlined
-#   `python -c '...'` resolve `pipeline.entrypoints.generate_dataset`
-#   from the repo root, since the worker runs without PYTHONPATH set.
+# - SkyPilot's OCI Canonical-Ubuntu-22.04 image (image_tag_general:
+#   skypilot:cpu-ubuntu-2204) does NOT preinstall docker. Install docker.io
+#   from Ubuntu's apt repos. `apt-get update -qq` once, install, start
+#   daemon, add the SkyPilot user to the `docker` group so `docker run`
+#   doesn't require sudo (the run: block uses sudo as a belt-and-braces
+#   fallback so we don't depend on group-membership taking effect in this
+#   shell session).
+# - Pre-pulling the worker image here, while setup: is timed against
+#   SkyPilot's separate setup-timeout, keeps the run: block fast and the
+#   pull-time visible in setup: logs (debugging surface) rather than
+#   buried under run:'s tee.
+setup: |
+  set -euo pipefail
+  if ! command -v docker >/dev/null 2>&1; then
+    sudo apt-get update -qq
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq docker.io
+  fi
+  sudo systemctl enable --now docker || sudo service docker start
+  sudo usermod -aG docker "$USER" || true
+  sudo docker pull "$WORKER_IMAGE"
+  echo "synth-setter worker ready (host: $(hostname), docker: $(sudo docker --version))"
+
+# `run:` block notes:
+#
+# - sub-docker invocation: SkyPilot's OCI backend can't ingest a docker
+#   image_id, so we run the worker container ourselves on the OCI VM. The
+#   container is the exact same dev-snapshot image used on RunPod; only
+#   the launch path differs.
+# - Env propagation: `task.update_envs(...)` sets RCLONE_*+WORKER_SPEC_URI
+#   in the OCI VM's shell environment (via SkyPilot's env-file source).
+#   `docker run -e VAR_NAME` (no value) inherits each named var from the
+#   parent shell — so the launcher's injected R2 creds + spec URI flow
+#   through one indirection (host shell -> container env) without ever
+#   landing on disk.
 # - The Python invocation is inlined (instead of calling the docker
 #   entrypoint's click subcommand) so we can `os._exit(0)` immediately
-#   after `run()` returns successfully. Workaround for #735: the SkyPilot
-#   worker (originally observed on RunPod, kept here defensively for OCI
-#   too until #735 is root-caused) consistently hangs at Python
-#   interpreter shutdown — some library (most likely pedalboard / numba /
-#   dask / h5py) leaves a non-daemon thread alive and the interpreter
-#   never exits. SkyPilot's job-status reporter sees the SSH session's
-#   process tree still alive and the job stays in RUNNING forever even
-#   though both rclone uploads have already landed in R2. `os._exit(0)`
-#   bypasses atexit / non-daemon-thread join and lets SkyPilot register
-#   SUCCEEDED.
-# - Scoping the workaround to this template (vs. an env-var gate in
-#   scripts/docker_entrypoint.py) keeps `generate_dataset` clean for
-#   local dev and other CI consumers; only the SkyPilot worker context
-#   force-exits.
-# - Drop this whole inline block (and revert to `python -m
-#   scripts.docker_entrypoint generate_dataset --spec ...`) once #735 is
-#   root-caused at its source. PR-B's `pedalboard-load` matrix variant
-#   is the canary that proves the revert is safe.
+#   after `run()` returns successfully. Workaround for #735: same root
+#   cause kept defensively across providers until the underlying
+#   non-daemon-thread leak is root-caused.
 run: |
-  echo "skypilot-run-cwd: $(pwd)"
-  cd /home/build/synth-setter
-  python -c '
-  import os
-  from pipeline.entrypoints.generate_dataset import load_spec_from_uri, run
-  spec = load_spec_from_uri(os.environ["WORKER_SPEC_URI"])
-  run(spec)
-  print("forcing interpreter exit (#735 workaround) — bypassing atexit", flush=True)
-  os._exit(0)
-  '
+  set -euo pipefail
+  echo "skypilot-run-cwd: $(pwd) host: $(hostname)"
+  sudo docker run --rm \
+    -e RCLONE_CONFIG_R2_TYPE \
+    -e RCLONE_CONFIG_R2_PROVIDER \
+    -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
+    -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
+    -e RCLONE_CONFIG_R2_ENDPOINT \
+    -e WORKER_SPEC_URI \
+    -e PYTHONPATH=/home/build/synth-setter \
+    "$WORKER_IMAGE" \
+    bash -c 'set -euo pipefail; cd /home/build/synth-setter; mkdir -p plugins; ln -sf "/usr/lib/vst3/Surge XT.vst3" "plugins/Surge XT.vst3"; python -c "import os; from pipeline.entrypoints.generate_dataset import load_spec_from_uri, run; run(load_spec_from_uri(os.environ[\"WORKER_SPEC_URI\"])); print(\"forcing interpreter exit (#735 workaround) — bypassing atexit\", flush=True); os._exit(0)"'

--- a/configs/compute/oci-debug-template.yaml
+++ b/configs/compute/oci-debug-template.yaml
@@ -1,0 +1,38 @@
+# SkyPilot task template for OCI — DEBUG / no-op variant.
+#
+# OCI (CPU Flex) sibling of configs/compute/runpod-debug-template.yaml.
+# Used by .github/workflows/test-skypilot-debug.yml to exercise the launcher
+# (provision -> setup -> submit -> poll -> tail -> teardown) on OCI without
+# running the real worker pipeline. The run block prints a single line and
+# exits 0, so any hang surfaced under this template is in the launcher's
+# SkyPilot/OCI interaction, NOT in the dataset generation code.
+#
+# Same image as the production OCI template (configs/compute/oci-cpu-template.yaml)
+# so we don't have to publish a separate debug image. The launcher still
+# injects env via update_envs; the worker just ignores them.
+#
+# Region intentionally not pinned — `~/.oci/config` is the single source
+# of truth (set via OCI_REGION at CI cred-write time).
+
+resources:
+  cloud: oci
+  cpus: 4+
+  memory: 16+
+  use_spot: false
+  disk_size: 50
+  image_id: docker:tinaudio/synth-setter:dev-snapshot
+
+# Placeholders — the launcher will overwrite these with real values via
+# update_envs. The worker's run block doesn't read them, so anything works.
+envs:
+  RCLONE_CONFIG_R2_TYPE: ""
+  RCLONE_CONFIG_R2_PROVIDER: ""
+  RCLONE_CONFIG_R2_ACCESS_KEY_ID: ""
+  RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ""
+  RCLONE_CONFIG_R2_ENDPOINT: ""
+
+setup: |
+  echo "synth-setter debug worker ready (host: $(hostname))"
+
+run: |
+  echo "skypilot-debug job done (host: $(hostname), pwd: $(pwd))"

--- a/configs/compute/oci-debug-template.yaml
+++ b/configs/compute/oci-debug-template.yaml
@@ -21,8 +21,13 @@
 
 resources:
   cloud: oci
-  cpus: 2+
-  memory: 4+
+  # VM.Standard.E2.1.Micro is OCI's "Always Free" tier shape (1 OCPU, 1 GB).
+  # Pinning by name (instead of cpus/memory floors) ensures noop launches
+  # against a shape every tenancy has by default — even fresh ones with
+  # zero paid compute quota. The prod OCI template (oci-cpu-template.yaml)
+  # still asks for cpus: 4+, memory: 16+, which requires actual compute
+  # quota in the operator's tenancy.
+  instance_type: VM.Standard.E2.1.Micro
   use_spot: false
   disk_size: 30
 

--- a/configs/compute/oci-debug-template.yaml
+++ b/configs/compute/oci-debug-template.yaml
@@ -1,38 +1,33 @@
 # SkyPilot task template for OCI — DEBUG / no-op variant.
 #
-# OCI (CPU Flex) sibling of configs/compute/runpod-debug-template.yaml.
-# Used by .github/workflows/test-skypilot-debug.yml to exercise the launcher
+# OCI sibling of configs/compute/runpod-debug-template.yaml. Used by
+# .github/workflows/test-skypilot-debug.yml to exercise the launcher
 # (provision -> setup -> submit -> poll -> tail -> teardown) on OCI without
 # running the real worker pipeline. The run block prints a single line and
-# exits 0, so any hang surfaced under this template is in the launcher's
+# exits 0, so any hang or failure surfaced here is in the launcher's
 # SkyPilot/OCI interaction, NOT in the dataset generation code.
 #
-# Same image as the production OCI template (configs/compute/oci-cpu-template.yaml)
-# so we don't have to publish a separate debug image. The launcher still
-# injects env via update_envs; the worker just ignores them.
+# IMPORTANT — no `image_id` here. SkyPilot's OCI backend rejects the
+# `docker:<image>` syntax with "Docker image is currently not supported on
+# OCI." The production OCI template (oci-cpu-template.yaml) handles the
+# worker container by running `docker pull` + `docker run` inside its run:
+# block. The noop probe doesn't need the worker image at all — it just
+# echoes — so it doesn't even need docker. SkyPilot picks the OCI Ubuntu
+# marketplace image via `image_tag_general` in ~/.sky/config.yaml (set by
+# the workflow at cred-write time).
 #
 # Region intentionally not pinned — `~/.oci/config` is the single source
 # of truth (set via OCI_REGION at CI cred-write time).
 
 resources:
   cloud: oci
-  cpus: 4+
-  memory: 16+
+  cpus: 2+
+  memory: 4+
   use_spot: false
-  disk_size: 50
-  image_id: docker:tinaudio/synth-setter:dev-snapshot
-
-# Placeholders — the launcher will overwrite these with real values via
-# update_envs. The worker's run block doesn't read them, so anything works.
-envs:
-  RCLONE_CONFIG_R2_TYPE: ""
-  RCLONE_CONFIG_R2_PROVIDER: ""
-  RCLONE_CONFIG_R2_ACCESS_KEY_ID: ""
-  RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ""
-  RCLONE_CONFIG_R2_ENDPOINT: ""
+  disk_size: 30
 
 setup: |
-  echo "synth-setter debug worker ready (host: $(hostname))"
+  echo "synth-setter debug worker ready (host: $(hostname), uname: $(uname -a))"
 
 run: |
   echo "skypilot-debug job done (host: $(hostname), pwd: $(pwd))"

--- a/docs/design/skypilot-compute-integration.md
+++ b/docs/design/skypilot-compute-integration.md
@@ -105,32 +105,20 @@ compute_config: null
 
 ### 4.1 SkyPilot YAML configs (`configs/compute/`)
 
+The smoke pipeline ships two real templates:
+
 ```
 configs/compute/
-├── vast-spot.yaml          # Vast.ai interruptible instances (cheapest)
-└── vast-ondemand.yaml      # Vast.ai on-demand (reliable, more expensive)
+├── runpod-template.yaml      # RunPod GPU (primary smoke target)
+└── oci-cpu-template.yaml     # OCI x86 CPU Flex (second smoke target)
 ```
 
-Example `configs/compute/vast-spot.yaml`:
-
-```yaml
-resources:
-  cloud: vast
-  accelerators: A100:1       # Adjust per workload
-  use_spot: true
-  disk_size: 100
-  # Use the existing CI image name and an immutable tag (for example, a git SHA).
-  # In practice, the pinned tag can be injected by CI or at launch time.
-  image_id: docker:tinaudio/synth-setter:<git-sha>
-
-setup: |
-  # Worker setup runs inside the container
-  echo "Worker ready"
-
-run: |
-  # Placeholder — overridden by pipeline CLI at launch time
-  python -m pipeline.worker
-```
+Both share the launcher (`pipeline/entrypoints/skypilot_launch_smoke.py`),
+the `dev-snapshot` Docker image, the R2-uploaded spec contract, and the
+`os._exit(0)` workaround for #735. They differ only in the `resources:`
+block (provider, accelerators vs. CPU/memory floor, region) and the
+provider-specific credential setup in CI. Future targets follow the same
+pattern.
 
 The `run:` block is overridden programmatically by the pipeline CLI when launching managed jobs. Each worker gets its shard range injected.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -364,6 +364,37 @@ If you are working on the data pipeline and need to run distributed generation:
 RUNPOD_API_KEY=<your-api-key>
 ```
 
+### 4e. OCI (Optional -- Second Compute Target)
+
+[Oracle Cloud Infrastructure](https://www.oracle.com/cloud/) is wired up as a
+second SkyPilot target alongside RunPod for the `generate_dataset` smoke
+pipeline (CPU-only Flex shapes via `configs/compute/oci-cpu-template.yaml`).
+**You do not need OCI for local development or training.**
+
+If you are exercising the OCI target:
+
+1. Generate an API signing key pair following Oracle's
+   [Required Keys and OCIDs](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/apisigningkey.htm) guide.
+
+2. Write `~/.oci/config` with the standard skeleton:
+
+   ```
+   [DEFAULT]
+   user=<user-ocid>
+   fingerprint=<key-fingerprint>
+   tenancy=<tenancy-ocid>
+   region=<your-region>
+   key_file=~/.oci/oci_api_key.pem
+   ```
+
+   `chmod 600 ~/.oci/oci_api_key.pem` and `chmod 600 ~/.oci/config`.
+
+3. Smoke check the credentials:
+
+   ```
+   sky check oci
+   ```
+
 ______________________________________________________________________
 
 ## 5. Hydra Configuration System

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -12,7 +12,7 @@ click<8.2
 numpy
 pydantic>=2
 pyyaml
-skypilot[runpod]==0.12.0
+skypilot[runpod,oci]==0.12.0
 structlog
 tenacity
 webdataset


### PR DESCRIPTION
## Summary

- Adds **OCI (Oracle Cloud Infrastructure) x86 CPU** as a second SkyPilot target alongside RunPod for the `generate_dataset` smoke pipeline.
- Collapses the two providers into a single matrix-driven `generate` job in `.github/workflows/test-dataset-generation.yml`. Both cells use the same provider-neutral launcher (`pipeline/entrypoints/skypilot_launch_smoke.py`) and run with `--num-workers 3` + a run-id-scoped cluster name (so the launcher's R2 spec key is unique per provider per run, eliminating the same R2 race that the OCI step originally needed an asymmetric fix for).
- Matrixes `validate-spec` and `validate-shard` over the same providers — both validators are already provider-neutral, so the per-cell variation is just the artifact name.
- New `configs/compute/oci-cpu-template.yaml` (CPU-only Flex, docker-in-run pattern because SkyPilot's OCI backend rejects `image_id: docker:<image>`).
- `requirements-app.txt`: `skypilot[runpod]` → `skypilot[runpod,oci]` so the worker image carries the OCI provider.
- New `configs/compute/oci-debug-template.yaml` for future OCI iteration on the debug workflow (not wired into the default debug matrix).
- Operator setup notes in `docs/getting-started.md` §4e and surgical refresh of `docs/design/skypilot-compute-integration.md` §4.1.

`continue-on-error` is per matrix cell — `false` for RunPod, `true` for OCI while it accumulates a track record. Flip OCI to false once 3+ consecutive runs are green.

## Repo secrets required (before this can pass green)

Settings → Secrets and variables → Actions:

- `OCI_USER_OCID`
- `OCI_TENANCY_OCID`
- `OCI_FINGERPRINT`
- `OCI_REGION`
- `OCI_COMPARTMENT_OCID` — root compartment OCID = tenancy OCID, or a child compartment OCID for cleaner quota / IAM scoping
- `OCI_API_KEY_PEM` — full contents of the private key PEM (OCI Console → Identity → Domains → Users → API Keys → Add API Key)

## Coordination note

The `dev-snapshot` Docker image must be rebuilt + pushed after this lands so the worker carries `skypilot[oci]`. Until then the OCI matrix cell runtime-installs `skypilot[oci]` via a `pip install` bridge in the cred-write step (~30s per CI run). Drop the bridge in a follow-up once the rebuild lands.

## Test plan

- [ ] Add the six `OCI_*` repo secrets above.
- [ ] Rebuild + push `tinaudio/synth-setter:dev-snapshot` so the image carries `skypilot[oci]` (post-merge, then drop the runtime bridge).
- [ ] Workflow dispatch \`Test Dataset Generation\` and confirm both \`generate (runpod)\` and \`generate (oci)\` cells reach SUCCEEDED, with worker logs showing \`provisioning rank=0/3\`, \`rank=1/3\`, \`rank=2/3\` and 3 shards uploaded per cell.
- [ ] Confirm both clusters are fully torn down post-run (\`sky status\` empty, no \`synth-setter-smoke-*\` instance left in OCI Console → Compute → Instances or RunPod console).
- [ ] Both \`validate-spec\` and \`validate-shard\` matrix cells iterate 3 shards each and return 0.

## Out of scope (deferred)

- OCI GPU shapes (follow-up: copy template, add \`accelerators:\` block, request GPU quota).
- CPU-only Docker image variant (\`dev-snapshot-cpu\`).
- Drop \`--privileged\` from OCI run-block (#776).
- Stale Vast.ai references in \`skypilot-compute-integration.md\` Phase B sections — surgical follow-up doc PR.
- Drop the runtime \`pip install skypilot[oci]\` bridge (post dev-snapshot rebuild).
- Bump run_id timestamp granularity to milliseconds (separate PR).

Closes #768
Refs #534