### PR TITLE
feat(pipeline): bump run_id timestamp granularity from seconds to milliseconds

### DIFF
--- a/docs/design/data-pipeline-implementation-plan.md
+++ b/docs/design/data-pipeline-implementation-plan.md
@@ -124,7 +124,7 @@ min_loudness: -55.0
 sample_batch_size: 32
 ```
 
-**Run ID derivation:** `dataset_wandb_run_id = {dataset_config_id}-{YYYYMMDDTHHMMSSZ}` (e.g., `surge-simple-480k-10k-20260313T100000Z`). Maps to `run_id` in pipeline code.
+**Run ID derivation:** `dataset_wandb_run_id = {dataset_config_id}-{YYYYMMDDTHHMMSSsssZ}` (e.g., `surge-simple-480k-10k-20260313T100000500Z`). Maps to `run_id` in pipeline code. The `sss` suffix is a zero-padded 3-digit millisecond field.
 
 CLI (compute/storage are not in config):
 
@@ -285,7 +285,7 @@ Sub-issues: [#18](https://github.com/tinaudio/synth-setter/issues/18) (config-dr
   `splits` (sample counts, not shard counts), `stats`, `validation_summary`,
   `worker_architectures` (list of unique CPU archs), `shard_manifest: list[dict]`
   (per-shard `{shard_id, filename, content_hash}`), `input_spec_sha256`, `input_spec_path`.
-- Run ID format: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}` (see [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids)).
+- Run ID format: `{dataset_config_id}-{YYYYMMDDTHHMMSSsssZ}` (see [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids)).
   `dataset_config_id` is the config filename stem, which encodes runtime params for readability.
 - `materialize_spec(config: DatasetConfig, config_id: DatasetConfigId) -> DatasetPipelineSpec`.
   Derives all runtime state internally (git SHA, repo dirty status, pinned renderer version

--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -1228,7 +1228,7 @@ class DatasetPipelineSpec(BaseModel):
     """Frozen runtime specification materialized from DatasetConfig."""
     model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
 
-    run_id: DatasetRunId    # unique run ID: {config_id}-{YYYYMMDDTHHMMSSZ}
+    run_id: DatasetRunId    # unique run ID: {config_id}-{YYYYMMDDTHHMMSSsssZ}
     r2_prefix: R2Prefix     # R2 storage path: data/{config_id}/{run_id}/
     created_at: datetime    # UTC, timezone-aware
     code_version: str       # git commit SHA
@@ -1373,7 +1373,7 @@ On first `generate`:
 
 1. Load YAML, validate against Pydantic `DatasetConfig` (strict mode)
 2. Pin `renderer_version` to `SURGE_XT_RENDERER_VERSION` (the constant in `pipeline/schemas/spec.py`, kept in lockstep with the `dev-snapshot` image's `SURGE_GIT_REF`). The launcher path stays interpreter-only — the worker re-derives via `extract_renderer_version` (`Version` from `moduleinfo.json` on Linux, `CFBundleShortVersionString` from `Info.plist` on macOS, pedalboard fallback if neither is present) and refuses to render on mismatch.
-3. Derive `dataset_wandb_run_id`: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}`
+3. Derive `dataset_wandb_run_id`: `{dataset_config_id}-{YYYYMMDDTHHMMSSsssZ}` (millisecond precision)
 4. Materialize `DatasetPipelineSpec` — expand config into per-shard specs (seeds, filenames) and capture runtime state (git SHA, pinned renderer version, num_params)
 5. Upload spec + source config to R2
 6. Proceed with reconciliation
@@ -1462,7 +1462,7 @@ configs/
 | **Virtual dataset**        | HDF5 feature that creates a logical view over multiple files without copying data. Used by finalize to compose train/val/test splits from individual shards.                                                                                                                                                       |
 | **Input spec**             | JSON file (`input_spec.json`) defining the frozen input specification for a run — shard specs, seeds, shapes, splits, renderer version. Written once on first `generate`, never modified.                                                                                                                          |
 | **dataset_config_id**      | Stable identifier for a dataset configuration, derived from the config filename (without extension). Format: `{name}-{total_train_samples}-{shard_size}`. Example: `surge-simple-480k-10k`. See [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids).                                                 |
-| **dataset_wandb_run_id**   | Unique identifier for a pipeline execution. Format: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}`. Example: `surge-simple-480k-10k-20260312T143022Z`. See [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids).                                                                                            |
+| **dataset_wandb_run_id**   | Unique identifier for a pipeline execution. Format: `{dataset_config_id}-{YYYYMMDDTHHMMSSsssZ}` (millisecond precision). Example: `surge-simple-480k-10k-20260312T143022500Z`. See [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids).                                                              |
 | **Shard ID**               | Logical index for a shard (`shard-000042`). Deterministic, defined at run creation, independent of which worker computes it.                                                                                                                                                                                       |
 | **worker_id**              | Infrastructure identifier (e.g., RunPod's `RUNPOD_POD_ID`). Appears only in metadata, not in shard paths.                                                                                                                                                                                                          |
 | **Reconciliation**         | Comparing desired state (spec) against actual state (validated shards in R2) to determine what work remains.                                                                                                                                                                                                       |

--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -88,17 +88,17 @@ DATASET_CONFIG=configs/dataset/surge-simple-480k-10k.yaml python -m pipeline.ent
 
 # --- Target state (distributed pipeline, not yet implemented) ---
 # python -m pipeline generate --config configs/dataset/surge-simple-480k-10k.yaml --workers 10
-# → Created run surge-simple-480k-10k-20260313T100000Z
+# → Created run surge-simple-480k-10k-20260313T100000123Z
 # → Launched 10 workers for 48 shards
 # → Exiting. Run 'status' to check progress.
 #
-# python -m pipeline status --run-id surge-simple-480k-10k-20260313T100000Z
+# python -m pipeline status --run-id surge-simple-480k-10k-20260313T100000123Z
 # → Valid: 44/48  Missing: 2  Quarantined: 2
 #
-# python -m pipeline generate --run-id surge-simple-480k-10k-20260313T100000Z
+# python -m pipeline generate --run-id surge-simple-480k-10k-20260313T100000123Z
 # → 4 shards missing, launching 1 worker
 #
-# python -m pipeline finalize --run-id surge-simple-480k-10k-20260313T100000Z
+# python -m pipeline finalize --run-id surge-simple-480k-10k-20260313T100000123Z
 # → 48/48 valid. output_format: hdf5
 # → Resharding → train.h5, val.h5, test.h5  (or .tar shards if wds)
 # → Stats computed. Dataset registered in W&B as data-surge-simple-480k-10k.
@@ -111,8 +111,8 @@ Make targets are thin aliases for convenience:
 
 ```bash
 make generate ARGS="--config configs/dataset/surge-simple-480k-10k.yaml --workers 10"
-make status ARGS="--run-id surge-simple-480k-10k-20260313T100000Z"
-make finalize ARGS="--run-id surge-simple-480k-10k-20260313T100000Z"
+make status ARGS="--run-id surge-simple-480k-10k-20260313T100000123Z"
+make finalize ARGS="--run-id surge-simple-480k-10k-20260313T100000123Z"
 ```
 
 ## 3. Goals, Non-Goals & Design Principles
@@ -282,7 +282,7 @@ Each worker container runs with `MODE=generate-shards` — the entrypoint mode I
 > R2 root path follows [storage-provenance-spec.md §2](storage-provenance-spec.md#2-r2-bucket-layout). Pipeline-specific internal structure (workers/, lifecycle markers) is additive detail.
 
 ```
-data/{dataset_config_id}/{dataset_wandb_run_id}/   # e.g. data/surge-simple-480k-10k/surge-simple-480k-10k-20260312T143022Z/
+data/{dataset_config_id}/{dataset_wandb_run_id}/   # e.g. data/surge-simple-480k-10k/surge-simple-480k-10k-20260312T143022500Z/
   shards/                              # Written ONLY by finalize (promoted from staging)
     shard-000000.h5                    # Canonical finalized shards
     shard-000001.h5
@@ -572,9 +572,9 @@ Instead of tracking worker state or polling provider APIs, the pipeline determin
 `make status` runs the same reconciliation logic as `generate` but only prints the result. It checks for `.h5` + `.valid` marker existence — no data loading or re-validation. It does not query RunPod, check worker health, or monitor live tasks. The output is fully determined by storage contents — running it from any machine, at any time, produces the same result.
 
 ```
-$ python -m pipeline status --run-id surge-simple-480k-10k-20260313T100000Z
+$ python -m pipeline status --run-id surge-simple-480k-10k-20260313T100000123Z
 
-Run: surge-simple-480k-10k-20260313T100000Z
+Run: surge-simple-480k-10k-20260313T100000123Z
 Spec shards: 48
 Staged (valid):   44
 Missing:           2
@@ -1386,11 +1386,11 @@ On first `generate`:
 
 > ID conventions follow [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids).
 
-| Pipeline concept          | Storage spec concept                               | Example                                                              |
-| ------------------------- | -------------------------------------------------- | -------------------------------------------------------------------- |
-| Config filename (no ext)  | `dataset_config_id`                                | `surge-simple-480k-10k`                                              |
-| Config ID + ISO timestamp | `dataset_wandb_run_id`                             | `surge-simple-480k-10k-20260312T143022Z`                             |
-| R2 root path              | `data/{dataset_config_id}/{dataset_wandb_run_id}/` | `data/surge-simple-480k-10k/surge-simple-480k-10k-20260312T143022Z/` |
+| Pipeline concept          | Storage spec concept                               | Example                                                                 |
+| ------------------------- | -------------------------------------------------- | ----------------------------------------------------------------------- |
+| Config filename (no ext)  | `dataset_config_id`                                | `surge-simple-480k-10k`                                                 |
+| Config ID + ISO timestamp | `dataset_wandb_run_id`                             | `surge-simple-480k-10k-20260312T143022500Z`                             |
+| R2 root path              | `data/{dataset_config_id}/{dataset_wandb_run_id}/` | `data/surge-simple-480k-10k/surge-simple-480k-10k-20260312T143022500Z/` |
 
 Config filenames live in `configs/dataset/` and use the pattern `{name}-{total_train_samples}-{shard_size}.yaml`. The filename without extension is the `dataset_config_id`.
 

--- a/docs/design/eval-pipeline.md
+++ b/docs/design/eval-pipeline.md
@@ -99,22 +99,22 @@ cp .env.example .env
 make eval EXPERIMENT=surge/flow_simple
 # → Checkpoint auto-downloaded from W&B via ${wandb:...} resolver (cached after)
 # → Predictions, audio, and metrics written to
-#   logs/eval/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/
+#   logs/eval/flow_simple/flow_simple-20260315T091500250Z/surge_simple/surge_simple-20260320T160000750Z/
 
 # Or run stages individually:
 make predict EXPERIMENT=surge/flow_simple
 make render \
-  PRED_DIR=logs/eval/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/predictions/ \
-  OUTPUT_DIR=logs/eval/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/audio/
+  PRED_DIR=logs/eval/flow_simple/flow_simple-20260315T091500250Z/surge_simple/surge_simple-20260320T160000750Z/predictions/ \
+  OUTPUT_DIR=logs/eval/flow_simple/flow_simple-20260315T091500250Z/surge_simple/surge_simple-20260320T160000750Z/audio/
 make metrics \
-  AUDIO_DIR=logs/eval/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/audio/ \
-  OUTPUT_DIR=logs/eval/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/metrics/
+  AUDIO_DIR=logs/eval/flow_simple/flow_simple-20260315T091500250Z/surge_simple/surge_simple-20260320T160000750Z/audio/ \
+  OUTPUT_DIR=logs/eval/flow_simple/flow_simple-20260315T091500250Z/surge_simple/surge_simple-20260320T160000750Z/metrics/
 
 # 3. (Optional) Upload artifacts to R2
 make upload-eval
 # → rclone sync \
-#     logs/eval/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/ \
-#     r2:intermediate-data/eval/surge_simple/surge_simple-20260312T143022Z/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/ \
+#     logs/eval/flow_simple/flow_simple-20260315T091500250Z/surge_simple/surge_simple-20260320T160000750Z/ \
+#     r2:intermediate-data/eval/surge_simple/surge_simple-20260312T143022500Z/flow_simple/flow_simple-20260315T091500250Z/surge_simple/surge_simple-20260320T160000750Z/ \
 #     --checksum
 ```
 
@@ -227,7 +227,7 @@ The predict stage loads a trained model checkpoint via PyTorch Lightning's `Trai
 
 **Key behaviors:**
 
-- Dataset path resolved from `data.dataset_root` (default: `${paths.data_dir}/surge_simple/surge_simple-20260312T143022Z`, CLI override for cluster)
+- Dataset path resolved from `data.dataset_root` (default: `${paths.data_dir}/surge_simple/surge_simple-20260312T143022500Z`, CLI override for cluster)
 - If `data.r2_path` is explicitly set, `SurgeDataModule.prepare_data()` syncs from R2 before loading
 - Checkpoint path supports `${wandb:...}` resolver — auto-downloads from W&B artifacts to local cache
 - Output directory: `${paths.output_dir}/predictions` (see `configs/callbacks/prediction_writer.yaml`)
@@ -287,7 +287,7 @@ When `data.r2_path` is explicitly provided (via CLI override or experiment confi
 ```yaml
 # configs/data/surge_simple.yaml — no r2_path, no env vars for paths
 _target_: src.data.surge_datamodule.SurgeDataModule
-dataset_root: ${paths.data_dir}/surge_simple/surge_simple-20260312T143022Z  # {dataset_config_id}/{dataset_wandb_run_id}
+dataset_root: ${paths.data_dir}/surge_simple/surge_simple-20260312T143022500Z  # {dataset_config_id}/{dataset_wandb_run_id}
 # r2_path: deliberately absent — must be specified explicitly when needed
 batch_size: 128
 num_workers: 11
@@ -297,12 +297,12 @@ To use R2, pass it explicitly:
 
 ```bash
 # CLI override — explicit, visible, no hidden state
-python src/eval.py data.r2_path=r2:intermediate-data/data/surge_simple/surge_simple-20260312T143022Z/ ...
+python src/eval.py data.r2_path=r2:intermediate-data/data/surge_simple/surge_simple-20260312T143022500Z/ ...
 
 # Or in an experiment config that opts in
 # configs/experiment/surge/flow_simple.yaml
 data:
-  r2_path: r2:intermediate-data/data/surge_simple/surge_simple-20260312T143022Z/
+  r2_path: r2:intermediate-data/data/surge_simple/surge_simple-20260312T143022500Z/
 ```
 
 Behavior:
@@ -375,8 +375,8 @@ After metrics, optionally upload all eval outputs to R2:
 ```bash
 make upload-eval
 # rclone sync \
-#   logs/eval/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/ \
-#   r2:intermediate-data/eval/surge_simple/surge_simple-20260312T143022Z/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/ \
+#   logs/eval/flow_simple/flow_simple-20260315T091500250Z/surge_simple/surge_simple-20260320T160000750Z/ \
+#   r2:intermediate-data/eval/surge_simple/surge_simple-20260312T143022500Z/flow_simple/flow_simple-20260315T091500250Z/surge_simple/surge_simple-20260320T160000750Z/ \
 #   --checksum
 ```
 
@@ -386,13 +386,13 @@ Not automatic — explicit `make` target. Toggle via Hydra config or CLI flag.
 
 ```bash
 # All evals for a given training dataset generation run
-rclone ls r2:intermediate-data/eval/surge_simple/surge_simple-20260312T143022Z/
+rclone ls r2:intermediate-data/eval/surge_simple/surge_simple-20260312T143022500Z/
 
 # All evals of a specific training run
-rclone ls r2:intermediate-data/eval/surge_simple/surge_simple-20260312T143022Z/flow_simple/flow_simple-20260315T091500Z/
+rclone ls r2:intermediate-data/eval/surge_simple/surge_simple-20260312T143022500Z/flow_simple/flow_simple-20260315T091500250Z/
 
 # A specific eval run (fully qualified 6-segment path)
-rclone ls r2:intermediate-data/eval/surge_simple/surge_simple-20260312T143022Z/flow_simple/flow_simple-20260315T091500Z/surge_simple/surge_simple-20260320T160000Z/
+rclone ls r2:intermediate-data/eval/surge_simple/surge_simple-20260312T143022500Z/flow_simple/flow_simple-20260315T091500250Z/surge_simple/surge_simple-20260320T160000750Z/
 ```
 
 ### 6.4 W&B Eval Lineage
@@ -408,11 +408,11 @@ eval_run = wandb.init(
     job_type="evaluation",
     config={
         "dataset_config_id": "surge_simple",
-        "dataset_wandb_run_id": "surge_simple-20260312T143022Z",
+        "dataset_wandb_run_id": "surge_simple-20260312T143022500Z",
         "train_config_id": "flow_simple",
-        "train_wandb_run_id": "flow_simple-20260315T091500Z",
+        "train_wandb_run_id": "flow_simple-20260315T091500250Z",
         "eval_config_id": "surge_simple",
-        "eval_wandb_run_id": "surge_simple-20260320T160000Z",
+        "eval_wandb_run_id": "surge_simple-20260320T160000750Z",
         "github_sha": os.environ.get("GITHUB_SHA", "local"),
     },
 )
@@ -429,9 +429,9 @@ eval_artifact = wandb.Artifact(
     "eval-surge_simple", type="eval-results"
 )
 eval_artifact.add_reference(
-    "s3://intermediate-data/eval/surge_simple/surge_simple-20260312T143022Z/"
-    "flow_simple/flow_simple-20260315T091500Z/"
-    "surge_simple/surge_simple-20260320T160000Z/"
+    "s3://intermediate-data/eval/surge_simple/surge_simple-20260312T143022500Z/"
+    "flow_simple/flow_simple-20260315T091500250Z/"
+    "surge_simple/surge_simple-20260320T160000750Z/"
 )
 eval_run.log_artifact(eval_artifact)
 eval_run.finish()
@@ -440,7 +440,7 @@ eval_run.finish()
 This creates a lineage graph in W&B:
 
 ```
-data-surge_simple:v2 ──→ training run flow_simple-20260315T091500Z ──→ model-flow_simple:latest
+data-surge_simple:v2 ──→ training run flow_simple-20260315T091500250Z ──→ model-flow_simple:latest
                                                                                │
 data-surge_simple:v2 ──→ eval run (job_type=evaluation) ◄─────────────────────┘
                                   │
@@ -605,8 +605,8 @@ This section consolidates every configuration and environment behavior change in
 
 | Concern                      | Proposed mechanism                                                                                                                                                       | Where defined                                 | Portable? | Change from current                              |
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------- | --------- | ------------------------------------------------ |
-| **Dataset path**             | `dataset_root: ${paths.data_dir}/surge_simple/surge_simple-20260312T143022Z` (paths convention + run ID)                                                                 | `configs/data/surge_simple.yaml`              | Yes       | Hardcoded → paths convention + run ID            |
-| **Dataset path override**    | CLI: `data.dataset_root=/cluster/path/surge_simple-20260312T143022Z/`                                                                                                    | Command line                                  | Yes       | Implicit → explicit                              |
+| **Dataset path**             | `dataset_root: ${paths.data_dir}/surge_simple/surge_simple-20260312T143022500Z` (paths convention + run ID)                                                              | `configs/data/surge_simple.yaml`              | Yes       | Hardcoded → paths convention + run ID            |
+| **Dataset path override**    | CLI: `data.dataset_root=/cluster/path/surge_simple-20260312T143022500Z/`                                                                                                 | Command line                                  | Yes       | Implicit → explicit                              |
 | **Checkpoint resolution**    | `ckpt_path: ???` (base), pinned in experiment configs                                                                                                                    | `configs/eval.yaml` + `configs/experiment/`   | Yes       | Shell script → Hydra config                      |
 | **Checkpoint: ad-hoc**       | CLI: `ckpt_path=./local/best.ckpt`                                                                                                                                       | Command line                                  | No        | Same as today but without shell wrapper          |
 | **Checkpoint: reproducible** | `ckpt_path: ${wandb:tinaudio/synth-setter/model-flow_simple:latest}` in experiment config                                                                                | `configs/experiment/surge/flow_simple.yaml`   | Yes       | **New** — portable, pinned                       |
@@ -659,12 +659,12 @@ Cloud evaluation runs as `MODE=eval` (planned — [#410](https://github.com/tina
 
 **3. Dataset access (§6.3)**
 
-|                     | Current                    | Proposed                                                                                                      |
-| ------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| **Local data**      | Hardcoded path, must exist | `${paths.data_dir}/surge_simple/surge_simple-20260312T143022Z` ({config_id}/{wandb_run_id}), override via CLI |
-| **Remote data**     | Not supported              | `r2_path` opt-in triggers auto-download                                                                       |
-| **Risk eliminated** | —                          | "Data is on the cluster" — R2 makes it available everywhere                                                   |
-| **Trade-off**       | —                          | First download of a 100GB dataset takes time; cached after that                                               |
+|                     | Current                    | Proposed                                                                                                         |
+| ------------------- | -------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| **Local data**      | Hardcoded path, must exist | `${paths.data_dir}/surge_simple/surge_simple-20260312T143022500Z` ({config_id}/{wandb_run_id}), override via CLI |
+| **Remote data**     | Not supported              | `r2_path` opt-in triggers auto-download                                                                          |
+| **Risk eliminated** | —                          | "Data is on the cluster" — R2 makes it available everywhere                                                      |
+| **Trade-off**       | —                          | First download of a 100GB dataset takes time; cached after that                                                  |
 
 **4. Display handling (§7.1)**
 

--- a/docs/design/storage-provenance-spec.md
+++ b/docs/design/storage-provenance-spec.md
@@ -13,18 +13,18 @@ ______________________________________________________________________
 
 ## 1. IDs
 
-| ID                     | Construction                                                   | Source                             | Example                        |
-| ---------------------- | -------------------------------------------------------------- | ---------------------------------- | ------------------------------ |
-| `dataset_config_id`    | Config filename (stem)                                         | `configs/dataset/{id}.yaml`        | `diva-v1`                      |
-| `dataset_wandb_run_id` | Configurable, default `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}` | `wandb.init(id=...)`               | `diva-v1-20260312T143022Z`     |
-| `train_config_id`      | Config filename (stem)                                         | `configs/experiment/.../{id}.yaml` | `flow-simple`                  |
-| `train_wandb_run_id`   | Configurable, default `{train_config_id}-{YYYYMMDDTHHMMSSZ}`   | `wandb.init(id=...)`               | `flow-simple-20260315T091500Z` |
-| `eval_config_id`       | Eval dataset config filename (stem)                            | `configs/dataset/{id}.yaml`        | `nsynth-v1`                    |
-| `eval_wandb_run_id`    | Configurable, default `{eval_config_id}-{YYYYMMDDTHHMMSSZ}`    | `wandb.init(id=...)`               | `nsynth-v1-20260320T160000Z`   |
+| ID                     | Construction                                                      | Source                             | Example                           |
+| ---------------------- | ----------------------------------------------------------------- | ---------------------------------- | --------------------------------- |
+| `dataset_config_id`    | Config filename (stem)                                            | `configs/dataset/{id}.yaml`        | `diva-v1`                         |
+| `dataset_wandb_run_id` | Configurable, default `{dataset_config_id}-{YYYYMMDDTHHMMSSsssZ}` | `wandb.init(id=...)`               | `diva-v1-20260312T143022500Z`     |
+| `train_config_id`      | Config filename (stem)                                            | `configs/experiment/.../{id}.yaml` | `flow-simple`                     |
+| `train_wandb_run_id`   | Configurable, default `{train_config_id}-{YYYYMMDDTHHMMSSsssZ}`   | `wandb.init(id=...)`               | `flow-simple-20260315T091500250Z` |
+| `eval_config_id`       | Eval dataset config filename (stem)                               | `configs/dataset/{id}.yaml`        | `nsynth-v1`                       |
+| `eval_wandb_run_id`    | Configurable, default `{eval_config_id}-{YYYYMMDDTHHMMSSsssZ}`    | `wandb.init(id=...)`               | `nsynth-v1-20260320T160000750Z`   |
 
 - `*_config_id` = filename of the YAML config, without extension
 - `*_wandb_run_id` = the W&B run ID, set via `wandb.init(id=...)`. Default convention is `{*_config_id}-{timestamp}`, but the path format is agnostic to how the ID is generated.
-- Default timestamp format: `YYYYMMDDTHHMMSSZ` (seconds, UTC, filesystem-safe)
+- Default timestamp format: `YYYYMMDDTHHMMSSsssZ` (millisecond precision, UTC, filesystem-safe). The `sss` suffix is a zero-padded 3-digit millisecond field; it disambiguates run IDs minted within the same wall-clock second by concurrent launchers.
 - W&B run ID limit: 64 characters. Keep config filenames short.
 
 ______________________________________________________________________

--- a/docs/design/training-pipeline.md
+++ b/docs/design/training-pipeline.md
@@ -510,13 +510,13 @@ ______________________________________________________________________
 
 ## Appendix A: Glossary
 
-| Term                     | Definition                                                                                                                                                             |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`train_config_id`**    | Config filename stem for the training experiment. See [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids).                                               |
-| **`train_wandb_run_id`** | W&B run ID for a specific training run. Default format: `{train_config_id}-{YYYYMMDDTHHMMSSZ}`. See [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids). |
-| **durable checkpoint**   | A checkpoint persisted outside the training pod as a W&B model artifact.                                                                                               |
-| **promotion**            | Converting a trained model artifact into a GitHub Release / production alias. See [promotion-pipeline-reference.md](../reference/promotion-pipeline-reference.md).     |
-| **RunPod launcher**      | Thin script that creates one training pod — not a backend abstraction.                                                                                                 |
+| Term                     | Definition                                                                                                                                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`train_config_id`**    | Config filename stem for the training experiment. See [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids).                                                                          |
+| **`train_wandb_run_id`** | W&B run ID for a specific training run. Default format: `{train_config_id}-{YYYYMMDDTHHMMSSsssZ}` (millisecond precision). See [storage-provenance-spec.md §1](storage-provenance-spec.md#1-ids). |
+| **durable checkpoint**   | A checkpoint persisted outside the training pod as a W&B model artifact.                                                                                                                          |
+| **promotion**            | Converting a trained model artifact into a GitHub Release / production alias. See [promotion-pipeline-reference.md](../reference/promotion-pipeline-reference.md).                                |
+| **RunPod launcher**      | Thin script that creates one training pod — not a backend abstraction.                                                                                                                            |
 
 ## Appendix B: Current File Inventory
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -63,9 +63,9 @@ Project terminology for synth-setter. Grouped by domain.
 | Term                     | Definition                                                                                                                                                                                        |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **dataset_config_id**    | Stable identifier for a dataset configuration, derived from the config YAML filename stem. Example: `surge-simple-480k-10k`. See [storage-provenance-spec.md](design/storage-provenance-spec.md). |
-| **dataset_wandb_run_id** | Unique identifier for a pipeline execution. Format: `{dataset_config_id}-{YYYYMMDDTHHMMSSZ}`. Example: `surge-simple-480k-10k-20260312T143022Z`.                                                  |
+| **dataset_wandb_run_id** | Unique identifier for a pipeline execution. Format: `{dataset_config_id}-{YYYYMMDDTHHMMSSsssZ}` (millisecond precision). Example: `surge-simple-480k-10k-20260312T143022500Z`.                    |
 | **train_config_id**      | Config filename stem for a training experiment. Example: `flow-simple`.                                                                                                                           |
-| **train_wandb_run_id**   | W&B run ID for a specific training run. Format: `{train_config_id}-{YYYYMMDDTHHMMSSZ}`.                                                                                                           |
+| **train_wandb_run_id**   | W&B run ID for a specific training run. Format: `{train_config_id}-{YYYYMMDDTHHMMSSsssZ}` (millisecond precision).                                                                                |
 | **worker_id**            | Infrastructure identifier (e.g., RunPod's `RUNPOD_POD_ID`). Appears only in metadata, not in shard paths.                                                                                         |
 
 ## Infrastructure & Tools

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -189,20 +189,20 @@ Gaps are configuration inputs that design docs specify or that standard practice
 
 ### 5.1 Identity & Provenance
 
-| Input                          | Type   | What's Needed                                                               | Reference                   |
-| ------------------------------ | ------ | --------------------------------------------------------------------------- | --------------------------- |
-| `train_wandb_run_id`           | string | `{train_config_id}-{YYYYMMDDTHHMMSSZ}` — structured, reconstructible run ID | storage-provenance-spec §1  |
-| `dataset_config_id` linkage    | string | Explicit link from training config to consumed dataset                      | storage-provenance-spec §2  |
-| `dataset_wandb_run_id` linkage | string | Explicit link to specific dataset run version                               | storage-provenance-spec §2  |
-| `job_type`                     | string | Must be `"training"` in W&B config — currently empty                        | storage-provenance-spec §7  |
-| `github_sha` in `wandb.config` | string | Logged via `log_wandb_provenance()` but not in Hydra config                 | wandb-integration.md gap #3 |
+| Input                          | Type   | What's Needed                                                                  | Reference                   |
+| ------------------------------ | ------ | ------------------------------------------------------------------------------ | --------------------------- |
+| `train_wandb_run_id`           | string | `{train_config_id}-{YYYYMMDDTHHMMSSsssZ}` — structured, reconstructible run ID | storage-provenance-spec §1  |
+| `dataset_config_id` linkage    | string | Explicit link from training config to consumed dataset                         | storage-provenance-spec §2  |
+| `dataset_wandb_run_id` linkage | string | Explicit link to specific dataset run version                                  | storage-provenance-spec §2  |
+| `job_type`                     | string | Must be `"training"` in W&B config — currently empty                           | storage-provenance-spec §7  |
+| `github_sha` in `wandb.config` | string | Logged via `log_wandb_provenance()` but not in Hydra config                    | wandb-integration.md gap #3 |
 
 ### 5.2 W&B / Artifact Lineage
 
 | Input                        | Type   | What's Needed                                                    | Reference                   |
 | ---------------------------- | ------ | ---------------------------------------------------------------- | --------------------------- |
 | `logger.wandb.log_model`     | string | `"all"` — uploads every checkpoint immediately (crash-resilient) | training-pipeline.md §6.2   |
-| `logger.wandb.id`            | string | `{train_config_id}-{YYYYMMDDTHHMMSSZ}` instead of null/random    | wandb-integration.md gap #8 |
+| `logger.wandb.id`            | string | `{train_config_id}-{YYYYMMDDTHHMMSSsssZ}` instead of null/random | wandb-integration.md gap #8 |
 | `logger.wandb.job_type`      | string | `"training"` instead of empty                                    | storage-provenance-spec §7  |
 | `logger.wandb.resume`        | string | `"allow"` for W&B resume support                                 | training-pipeline.md §5.3   |
 | Dataset `run.use_artifact()` | code   | Lineage link to consumed dataset artifact                        | storage-provenance-spec §5  |

--- a/pipeline/schemas/prefix.py
+++ b/pipeline/schemas/prefix.py
@@ -16,7 +16,8 @@ def make_dataset_wandb_run_id(
 
     :param dataset_config_id: The dataset config identifier (e.g. filename stem).
     :param timestamp: Optional UTC datetime; defaults to now.
-    :returns: A string like ``<config_id>-<YYYYMMDD>T<HHMMSS>Z``.
+    :returns: A string like ``<config_id>-<YYYYMMDD>T<HHMMSSsss>Z`` where ``sss`` is
+        a zero-padded 3-digit millisecond field.
     """
     if timestamp is None:
         timestamp = datetime.now(timezone.utc)
@@ -25,7 +26,8 @@ def make_dataset_wandb_run_id(
     offset = timestamp.utcoffset()
     if offset is None or offset.total_seconds() != 0:
         raise ValueError("timestamp must be UTC")
-    formatted = timestamp.strftime("%Y%m%dT%H%M%SZ")
+    millis = timestamp.microsecond // 1000
+    formatted = timestamp.strftime("%Y%m%dT%H%M%S") + f"{millis:03d}Z"
     return DatasetRunId(f"{dataset_config_id}-{formatted}")
 
 

--- a/pipeline/schemas/spec.py
+++ b/pipeline/schemas/spec.py
@@ -42,7 +42,7 @@ class DatasetPipelineSpec(BaseModel):
 
     model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
 
-    run_id: DatasetRunId  # unique run ID: {config_id}-{YYYYMMDDTHHMMSSZ}
+    run_id: DatasetRunId  # unique run ID: {config_id}-{YYYYMMDDTHHMMSSsssZ}
     r2_prefix: R2Prefix  # R2 storage path: data/{config_id}/{run_id}/
     created_at: datetime  # UTC, timezone-aware materialization timestamp
     code_version: str  # git commit SHA at materialization time

--- a/tests/pipeline/test_schemas/test_prefix.py
+++ b/tests/pipeline/test_schemas/test_prefix.py
@@ -17,10 +17,24 @@ class TestMakeDatasetWandbRunId:
     """Tests for make_dataset_wandb_run_id."""
 
     def test_make_run_id_fixed_timestamp_format(self):
-        """Fixed UTC timestamp produces the expected run ID string."""
+        """Fixed UTC timestamp (microsecond=0) produces the expected run ID string."""
         ts = datetime(2026, 3, 13, 10, 0, 0, tzinfo=timezone.utc)
         result = make_dataset_wandb_run_id(DatasetConfigId("surge-simple-480k-10k"), timestamp=ts)
-        assert result == "surge-simple-480k-10k-20260313T100000Z"
+        assert result == "surge-simple-480k-10k-20260313T100000000Z"
+
+    def test_make_run_id_includes_millisecond_field(self):
+        """A timestamp with microseconds produces a 3-digit millisecond suffix."""
+        ts = datetime(2026, 5, 3, 13, 36, 33, 456789, tzinfo=timezone.utc)
+        result = make_dataset_wandb_run_id(DatasetConfigId("cfg"), timestamp=ts)
+        assert result == "cfg-20260503T133633456Z"
+
+    def test_make_run_id_milliseconds_disambiguate_within_same_second(self):
+        """Two timestamps within the same wall-clock second produce different IDs."""
+        ts1 = datetime(2026, 3, 13, 10, 0, 0, 100_000, tzinfo=timezone.utc)
+        ts2 = datetime(2026, 3, 13, 10, 0, 0, 900_000, tzinfo=timezone.utc)
+        id1 = make_dataset_wandb_run_id(DatasetConfigId("cfg"), timestamp=ts1)
+        id2 = make_dataset_wandb_run_id(DatasetConfigId("cfg"), timestamp=ts2)
+        assert id1 != id2
 
     @patch("pipeline.schemas.prefix.datetime")
     def test_make_run_id_default_timestamp_is_utc(self, mock_datetime):
@@ -29,7 +43,7 @@ class TestMakeDatasetWandbRunId:
         mock_datetime.side_effect = lambda *a, **kw: datetime(*a, **kw)
         result = make_dataset_wandb_run_id(DatasetConfigId("test-config"))
         mock_datetime.now.assert_called_once_with(timezone.utc)
-        assert result == "test-config-20260615T123045Z"
+        assert result == "test-config-20260615T123045000Z"
 
     def test_make_run_id_rejects_naive_timestamp(self):
         """Naive datetime (no tzinfo) raises ValueError."""
@@ -70,9 +84,9 @@ class TestMakeR2Prefix:
         """Prefix matches the expected data/<config_id>/<run_id>/ pattern."""
         result = make_r2_prefix(
             DatasetConfigId("surge-simple-480k-10k"),
-            DatasetRunId("surge-simple-480k-10k-20260313T100000Z"),
+            DatasetRunId("surge-simple-480k-10k-20260313T100000000Z"),
         )
-        assert result == "data/surge-simple-480k-10k/surge-simple-480k-10k-20260313T100000Z/"
+        assert result == "data/surge-simple-480k-10k/surge-simple-480k-10k-20260313T100000000Z/"
 
     def test_make_r2_prefix_trailing_slash(self):
         """Prefix always ends with a trailing slash."""

--- a/tests/pipeline/test_schemas/test_spec.py
+++ b/tests/pipeline/test_schemas/test_spec.py
@@ -330,7 +330,7 @@ class TestMaterializeSpec:
         config_id = DatasetConfigId("ci-smoke-test")
         spec = materialize_spec(config, config_id)
 
-        assert spec.run_id == "ci-smoke-test-20260328T120000Z"
+        assert spec.run_id == "ci-smoke-test-20260328T120000000Z"
         assert spec.created_at == FIXED_NOW
         assert spec.code_version == "abc123def456"
         assert spec.is_repo_dirty is False
@@ -395,7 +395,7 @@ class TestMaterializeSpec:
         config_id = DatasetConfigId("ci-smoke-test")
         spec = materialize_spec(config, config_id)
 
-        assert spec.run_id == "ci-smoke-test-20260328T120000Z"
+        assert spec.run_id == "ci-smoke-test-20260328T120000000Z"
 
     def test_created_at_is_utc_iso_format(
         self,


### PR DESCRIPTION
## Summary

Bump `dataset_wandb_run_id` timestamp granularity from seconds to milliseconds to eliminate run_id collisions when two `materialize_spec` calls land in the same wall-clock second.

Format change: `%Y%m%dT%H%M%SZ` → `%Y%m%dT%H%M%S` + 3-digit zero-padded milliseconds + `Z`.

Before / after example:

- Before: `runpod-smoke-shard-20260503T133633Z`
- After:  `runpod-smoke-shard-20260503T133633456Z`

The trailing `Z` is preserved. The new format is exactly 3 characters longer.

## Motivation

Concurrent launcher invocations (e.g. RunPod and OCI smoke jobs sharing the same R2 path, observed in #769) can mint identical run_ids within a single wall-clock second. Milliseconds eliminate the collision in practice for the GH-Actions / dev-laptop topology we run in.

## Backwards compatibility

No migration required. `run_id` is treated as an opaque string everywhere it's consumed — R2 prefix, W&B run id, `validate_spec`, finalize — so pre-existing run_ids continue to parse fine. The Pydantic spec model has no format validator on `run_id`.

## Scope

- `pipeline/schemas/prefix.py` — strftime change + docstring
- `pipeline/schemas/spec.py` — inline comment on `run_id` field
- `tests/pipeline/test_schemas/test_prefix.py` — update format assertions, add millisecond tests
- `tests/pipeline/test_schemas/test_spec.py` — update hardcoded run_id literals (microsecond=0 in fixed timestamp → `…000Z`)
- Docs: `docs/glossary.md`, `docs/design/storage-provenance-spec.md`, `docs/design/data-pipeline-implementation-plan.md`, `docs/reference/configuration-reference.md`, `docs/design/data-pipeline.md`

Closes #770

## Test plan

- [ ] `make test` green (full suite, 298 passed locally)
- [ ] `make_dataset_wandb_run_id` with a known datetime produces the expected 3-digit millisecond field
- [ ] Round-trip a `DatasetPipelineSpec` JSON and confirm `r2_prefix` ends with `T…sssZ/`
- [ ] Affected docs updated to the new format token (`YYYYMMDDTHHMMSSsssZ`)
