### PR TITLE
test(pipeline): fix platform-dependent args index in rank/world partition tests

### DIFF
--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -482,7 +482,11 @@ class TestRun:
 
         run(spec)
 
-        rendered_filenames = [Path(call[0][0][3]).name for call in mock_check_call.call_args_list]
+        rendered_filenames = []
+        for call in mock_check_call.call_args_list:
+            args = call[0][0]
+            output_file = args[_find_script_index(args) + 1]
+            rendered_filenames.append(Path(output_file).name)
         assert rendered_filenames == [spec.shards[0].filename, spec.shards[1].filename]
 
     @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")
@@ -502,7 +506,11 @@ class TestRun:
 
         run(spec)
 
-        rendered_filenames = [Path(call[0][0][3]).name for call in mock_check_call.call_args_list]
+        rendered_filenames = []
+        for call in mock_check_call.call_args_list:
+            args = call[0][0]
+            output_file = args[_find_script_index(args) + 1]
+            rendered_filenames.append(Path(output_file).name)
         assert rendered_filenames == [spec.shards[2].filename]
 
     @patch("pipeline.entrypoints.generate_dataset.subprocess.check_call")


### PR DESCRIPTION
## Summary

- Two partition tests in `tests/pipeline/test_entrypoints/test_generate_dataset.py` hard-coded `args[3]` as the rendered shard's output filename. That layout only holds when `args[0]` is `VST_HEADLESS_WRAPPER` (Linux). PR #766 made the wrapper Linux-only, shifting indices left by one on macOS, so `args[3]` became the `shard_size` string `"10000"`.
- Both tests now use the existing `_find_script_index(args) + 1` lookup, mirroring `test_run_with_three_shards_renders_each_shard`. No production code changes.

## Before / after

```python
# Before
rendered_filenames = [Path(call[0][0][3]).name for call in mock_check_call.call_args_list]

# After
rendered_filenames = []
for call in mock_check_call.call_args_list:
    args = call[0][0]
    output_file = args[_find_script_index(args) + 1]
    rendered_filenames.append(Path(output_file).name)
```

Closes #773

## Test plan

- [x] `tests/pipeline/test_entrypoints/test_generate_dataset.py::TestRun::test_rank_0_of_2_renders_only_first_half_of_shards` passes locally on Linux
- [x] `tests/pipeline/test_entrypoints/test_generate_dataset.py::TestRun::test_rank_1_of_2_renders_only_remaining_shard` passes locally on Linux
- [x] `make test` green (296 passed)
- [ ] macOS CI job green on this PR (real proof — Linux can't reproduce the macOS-specific symptom because `args[3]` IS the filename on Linux)