### PR TITLE
chore(skills): add /repo-review and /repo-review-full multi-skill PR review skills

### DIFF
--- a/.claude/skills/_shared/post_review.py
+++ b/.claude/skills/_shared/post_review.py
@@ -22,9 +22,8 @@ Input format on stdin:
     }
 
 The submitted review uses event=COMMENT so threads stay open (not approved or
-rejected). Designed for the workflow proven on PR #777: 45 comments in one
-review, three nearest-in-diff fallbacks for findings whose natural lines lay
-outside the diff hunks.
+rejected). Verified end-to-end on PR #777 — see that PR's description for the
+trace.
 """
 
 from __future__ import annotations
@@ -72,18 +71,6 @@ class AnchoredComment:
 HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
 
 
-def gh_api(args: list[str]) -> str:
-    """Run `gh api` and return stdout.
-
-    Surfaces stderr on failure.
-    """
-    result = subprocess.run(["gh", "api", *args], capture_output=True, text=True, check=False)
-    if result.returncode != 0:
-        sys.stderr.write(result.stderr)
-        sys.exit(result.returncode)
-    return result.stdout
-
-
 def fetch_diff(repo: str, pr_number: int) -> str:
     """Fetch the PR diff via gh — raw unified diff."""
     result = subprocess.run(
@@ -112,7 +99,9 @@ def parse_diff_hunks(diff_text: str) -> dict[str, list[Hunk]]:
 
     def flush() -> None:
         if current_path is not None and new_start is not None and new_line is not None:
-            hunks[current_path].append(Hunk(new_start, new_line - 1))
+            new_end = new_line - 1
+            if new_end >= new_start:
+                hunks[current_path].append(Hunk(new_start, new_end))
 
     for raw_line in diff_text.splitlines():
         if raw_line.startswith("+++ b/"):
@@ -139,8 +128,7 @@ def parse_diff_hunks(diff_text: str) -> dict[str, list[Hunk]]:
             new_line += 1
         # `-` lines: skip; only present in the old side.
 
-    if current_path is not None and new_start is not None and new_line is not None:
-        hunks[current_path].append(Hunk(new_start, new_line - 1))
+    flush()
 
     return hunks
 
@@ -199,7 +187,8 @@ def build_review_payload(
     if orphaned:
         body += "\n\n## Findings on files outside the diff\n\n"
         for finding in orphaned:
-            body += f"- `{finding.path}:{finding.line}` — {finding.body}\n"
+            indented = finding.body.replace("\n", "\n  ")
+            body += f"- `{finding.path}:{finding.line}` — {indented}\n"
     return {
         "body": body,
         "event": "COMMENT",

--- a/.claude/skills/_shared/post_review.py
+++ b/.claude/skills/_shared/post_review.py
@@ -1,0 +1,283 @@
+"""PR-comment-posting helper for the repo-review and repo-review-full skills.
+
+Reads a JSON review payload on stdin (list of findings), resolves each finding's
+anchor against the PR's diff hunks, falls back to the nearest in-hunk line with a
+cross-ref note when the natural line isn't anchorable, then submits one
+GitHub Pull Request review with every finding as an unresolved inline thread.
+
+Input format on stdin:
+
+    {
+      "pr_number": 777,
+      "repo": "tinaudio/synth-setter",
+      "review_body": "Top-level review summary (markdown).",
+      "findings": [
+        {
+          "path": "configs/compute/oci-cpu-template.yaml",
+          "line": 147,
+          "body": "**[code-health:block]** ..."
+        },
+        ...
+      ]
+    }
+
+The submitted review uses event=COMMENT so threads stay open (not approved or
+rejected). Designed for the workflow proven on PR #777: 45 comments in one
+review, three nearest-in-diff fallbacks for findings whose natural lines lay
+outside the diff hunks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Hunk:
+    """One unified-diff hunk's right-side line range, inclusive on both ends."""
+
+    new_start: int
+    new_end: int
+
+    def contains(self, line: int) -> bool:
+        """Return True if `line` is within this hunk's right-side range."""
+        return self.new_start <= line <= self.new_end
+
+
+@dataclass(frozen=True)
+class Finding:
+    """One review finding — a target file/line and a comment body."""
+
+    path: str
+    line: int
+    body: str
+
+
+@dataclass(frozen=True)
+class AnchoredComment:
+    """A finding resolved to a valid in-diff anchor; `rewritten` flags fallbacks."""
+
+    path: str
+    line: int
+    body: str
+    original_line: int
+    rewritten: bool
+
+
+HUNK_HEADER_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def gh_api(args: list[str]) -> str:
+    """Run `gh api` and return stdout.
+
+    Surfaces stderr on failure.
+    """
+    result = subprocess.run(["gh", "api", *args], capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        sys.exit(result.returncode)
+    return result.stdout
+
+
+def fetch_diff(repo: str, pr_number: int) -> str:
+    """Fetch the PR diff via gh — raw unified diff."""
+    result = subprocess.run(
+        ["gh", "pr", "diff", str(pr_number), "--repo", repo],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        sys.exit(result.returncode)
+    return result.stdout
+
+
+def parse_diff_hunks(diff_text: str) -> dict[str, list[Hunk]]:
+    """Parse a unified diff into {path: [Hunk, ...]} on the right (new) side.
+
+    The right-side range covers added (`+`) and unchanged (` `) lines — both are valid GitHub PR-
+    review-comment anchors. Only deleted (`-`) lines are skipped because they don't exist on the
+    new side.
+    """
+    hunks: dict[str, list[Hunk]] = {}
+    current_path: str | None = None
+    new_line: int | None = None
+    new_start: int | None = None
+
+    def flush() -> None:
+        if current_path is not None and new_start is not None and new_line is not None:
+            hunks[current_path].append(Hunk(new_start, new_line - 1))
+
+    for raw_line in diff_text.splitlines():
+        if raw_line.startswith("+++ b/"):
+            flush()
+            current_path = raw_line[len("+++ b/") :]
+            hunks.setdefault(current_path, [])
+            new_line = None
+            new_start = None
+            continue
+
+        match = HUNK_HEADER_RE.match(raw_line)
+        if match:
+            flush()
+            new_start = int(match.group(1))
+            new_line = new_start
+            continue
+
+        if current_path is None or new_line is None:
+            continue
+
+        if raw_line.startswith("+") and not raw_line.startswith("+++"):
+            new_line += 1
+        elif raw_line.startswith(" "):
+            new_line += 1
+        # `-` lines: skip; only present in the old side.
+
+    if current_path is not None and new_start is not None and new_line is not None:
+        hunks[current_path].append(Hunk(new_start, new_line - 1))
+
+    return hunks
+
+
+def nearest_in_hunk_line(line: int, hunks: list[Hunk]) -> int | None:
+    """Return the line in `hunks` closest to `line`, or None if `hunks` is empty."""
+    if not hunks:
+        return None
+    best: tuple[int, int] | None = None
+    for hunk in hunks:
+        if hunk.contains(line):
+            return line
+        candidates = (hunk.new_start, hunk.new_end)
+        for candidate in candidates:
+            distance = abs(candidate - line)
+            if best is None or distance < best[0]:
+                best = (distance, candidate)
+    return None if best is None else best[1]
+
+
+def anchor_finding(
+    finding: Finding, hunks_by_path: dict[str, list[Hunk]]
+) -> AnchoredComment | None:
+    """Pin a finding to a valid review-comment anchor; rewrite body on fallback.
+
+    Returns None if the path has no hunks at all (file not in diff) — caller can roll those into
+    the top-level review body.
+    """
+    hunks = hunks_by_path.get(finding.path, [])
+    target = nearest_in_hunk_line(finding.line, hunks)
+    if target is None:
+        return None
+    rewritten = target != finding.line
+    if rewritten:
+        prefix = (
+            f"*(anchored at line {target}; finding is on line {finding.line}, "
+            "outside the diff hunks)*\n\n"
+        )
+        body = prefix + finding.body
+    else:
+        body = finding.body
+    return AnchoredComment(
+        path=finding.path,
+        line=target,
+        body=body,
+        original_line=finding.line,
+        rewritten=rewritten,
+    )
+
+
+def build_review_payload(
+    review_body: str, anchored: list[AnchoredComment], orphaned: list[Finding]
+) -> dict[str, object]:
+    """Compose the JSON body for POST /repos/.../pulls/N/reviews."""
+    body = review_body
+    if orphaned:
+        body += "\n\n## Findings on files outside the diff\n\n"
+        for finding in orphaned:
+            body += f"- `{finding.path}:{finding.line}` — {finding.body}\n"
+    return {
+        "body": body,
+        "event": "COMMENT",
+        "comments": [
+            {"path": comment.path, "line": comment.line, "body": comment.body}
+            for comment in anchored
+        ],
+    }
+
+
+def submit_review(repo: str, pr_number: int, payload: dict[str, object]) -> dict:
+    """POST the review and return the parsed response."""
+    payload_json = json.dumps(payload)
+    result = subprocess.run(
+        [
+            "gh",
+            "api",
+            "-X",
+            "POST",
+            f"repos/{repo}/pulls/{pr_number}/reviews",
+            "--input",
+            "-",
+        ],
+        input=payload_json,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        sys.stderr.write(result.stderr)
+        sys.exit(result.returncode)
+    return json.loads(result.stdout)
+
+
+def main() -> int:
+    """CLI entry point — read JSON request on stdin, post or dry-run the review."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the resolved payload as JSON instead of submitting.",
+    )
+    args = parser.parse_args()
+
+    request = json.load(sys.stdin)
+    repo: str = request["repo"]
+    pr_number: int = int(request["pr_number"])
+    review_body: str = request.get("review_body", "")
+    findings = [Finding(**raw) for raw in request["findings"]]
+
+    diff_text = fetch_diff(repo, pr_number)
+    hunks_by_path = parse_diff_hunks(diff_text)
+
+    anchored: list[AnchoredComment] = []
+    orphaned: list[Finding] = []
+    for finding in findings:
+        result = anchor_finding(finding, hunks_by_path)
+        if result is None:
+            orphaned.append(finding)
+        else:
+            anchored.append(result)
+
+    payload = build_review_payload(review_body, anchored, orphaned)
+
+    sys.stderr.write(
+        f"Resolved {len(anchored)} inline anchor(s) "
+        f"({sum(1 for c in anchored if c.rewritten)} fell back to nearest-in-hunk); "
+        f"{len(orphaned)} finding(s) on files outside the diff rolled into review body.\n"
+    )
+
+    if args.dry_run:
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    response = submit_review(repo, pr_number, payload)
+    print(response.get("html_url", json.dumps(response)))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/repo-review-full/SKILL.md
+++ b/.claude/skills/repo-review-full/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: repo-review-full
+description: |
+  Full multi-skill PR review. Fans out parallel agents (code-health, shell-style,
+  gha-workflow-validator, synth-setter-project-standards, python-style,
+  tdd-refactor, plus tdd-implementation/ml-data-pipeline/ml-test when the diff
+  warrants) and posts every BLOCK/WARN as an individual unresolved inline PR
+  review comment. Reproduces the workflow demoed on PR #777. Requires the
+  tinaudio-synth-setter-skills plugin.
+---
+
+# repo-review-full — Multi-Skill Parallel PR Review
+
+You MUST complete every step in order.
+
+## Step 1: Resolve the PR
+
+Determine the PR number:
+
+- If invoked `/repo-review-full <N>`, use `<N>`.
+- Otherwise resolve via `gh pr view --json number`.
+
+Fetch metadata once:
+
+```bash
+gh pr view <N> --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \
+  --json number,headRefOid,baseRefOid,files,title,headRefName
+```
+
+If no PR exists for the current branch, stop and tell the user to push and open a PR first.
+
+## Step 2: Pick which skills to fan out to
+
+Read the file list from Step 1. Map file types → relevant skills:
+
+| File pattern | Skills that always run |
+|---|---|
+| Always | `code-health`, `synth-setter-project-standards` |
+| `*.py` | `python-style`, `tdd-implementation` |
+| `*.sh` or bash inside YAML `run:` blocks | `shell-style` |
+| `.github/workflows/*.{yml,yaml}` | `gha-workflow-validator` |
+| ML model / pipeline / training code under `src/` or `pipeline/` | `ml-data-pipeline`, `ml-test` |
+| Diff renames or moves files (anything with `R` in `git diff --name-status`) | `tdd-refactor` |
+
+Always run `code-health` and `synth-setter-project-standards`. Other skills opt in based on file extensions in the diff. Note which skills you selected; you'll launch one parallel agent per skill.
+
+## Step 3: Launch parallel review agents
+
+Launch one `general-purpose` Agent per selected skill. **All agents in a single message** so they run concurrently (Claude Code supports this — one message with N tool calls = N parallel agents).
+
+Each agent's prompt MUST include:
+
+- The PR number, repo, base SHA, head SHA.
+- The full file list (with per-file line counts is helpful but optional).
+- The exact skill to invoke: `Invoke the tinaudio-synth-setter-skills:<skill-name> skill via the Skill tool and apply its checklist to this PR's diff.`
+- The expected output shape (see below).
+
+Each agent returns a Markdown report with `BLOCK` and `WARN` sections. Each finding cites `<path>:<line>`. Agents work independently — they should not coordinate.
+
+### Per-agent output contract
+
+Each agent returns a Markdown block:
+
+````
+## <skill-name> review — PR #<N>
+
+### BLOCK findings
+1. **<path>:<line>** — <description>
+
+### WARN findings
+1. **<path>:<line>** — <description>
+
+### What looks good
+- ...
+````
+
+Aim each agent at a 1500-word ceiling so reports stay scannable. The orchestrator (you) can ask for tighter output if a skill's domain is small.
+
+## Step 4: Aggregate findings
+
+Once every parallel agent returns, parse each report's BLOCK and WARN findings. For each finding, build one entry in the post-review JSON. Prefix each comment body with `[<skill>:<severity>]` so reviewers can see which checklist surfaced it.
+
+Severity → severity tag:
+
+- `BLOCK` → `block`
+- `WARN` → `warn`
+
+Skill → tag (short form for comment body):
+
+| Plugin skill | Comment-body tag |
+|---|---|
+| `code-health` | `code-health` |
+| `shell-style` | `shell-style` |
+| `python-style` | `python-style` |
+| `gha-workflow-validator` | `gha` |
+| `synth-setter-project-standards` | `synth-setter` |
+| `tdd-implementation` | `tdd-impl` |
+| `tdd-refactor` | `tdd-refactor` |
+| `ml-data-pipeline` | `ml-pipeline` |
+| `ml-test` | `ml-test` |
+
+A finding becomes:
+
+```json
+{
+  "path": "<path>",
+  "line": <line>,
+  "body": "**[<short-tag>:<severity>]** <description>"
+}
+```
+
+Do NOT dedupe near-duplicate findings across skills (e.g. shell-style and synth-setter-project-standards both flagging a `[ ]` vs `[[ ]]` issue) — keep each skill's signal independent. Acceptable noise per the plan's out-of-scope list.
+
+## Step 5: Build the findings JSON
+
+Same shape `post_review.py` consumes:
+
+```json
+{
+  "pr_number": <N>,
+  "repo": "<owner>/<repo>",
+  "review_body": "Multi-skill review of PR #<N> — <K> parallel passes (<list of skills>). Every BLOCK/WARN posted below as an individual unresolved thread. Findings on files outside the diff are anchored to the line in the diff that *causes* the staleness or rolled into the review body.",
+  "findings": [ ... ]
+}
+```
+
+Write the JSON to a temp file:
+
+```bash
+cat > /tmp/repo-review-full-findings.json <<'JSON'
+... payload ...
+JSON
+```
+
+## Step 6: Submit the review
+
+```bash
+python3 .claude/skills/_shared/post_review.py < /tmp/repo-review-full-findings.json
+```
+
+Helper behavior matches `repo-review`:
+
+- Anchors each finding to its target line if that line falls inside a diff hunk.
+- Falls back to the nearest in-hunk line on the same file with a cross-ref note prepended to the body.
+- Rolls orphan findings (file outside the diff) into the review body under `## Findings on files outside the diff`.
+- Submits as `event=COMMENT`. Threads stay unresolved.
+
+Report the helper's `html_url` back to the user along with a one-line summary (`Posted N findings: B BLOCK + W WARN across K skills`).
+
+## Notes
+
+- This skill depends on the `tinaudio-synth-setter-skills` plugin being enabled. If a sub-skill invocation fails, surface the error — don't silently skip. Falling back to `repo-review` (MVP) is the user's call, not the skill's.
+- Each parallel agent is a *general-purpose* sub-agent that itself invokes a plugin skill via the Skill tool. The two-level structure is intentional: the parallel fan-out is the orchestrator's contribution; each plugin skill's authoritative checklist is the source of truth for its domain.
+- For the concrete invocation pattern (parallel Agent tool calls in a single message, expected per-agent prompt shape), see the example trace recorded in PR #777's review history — that's the workflow this skill packages.

--- a/.claude/skills/repo-review-full/SKILL.md
+++ b/.claude/skills/repo-review-full/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: repo-review-full
 description: |
-  Full multi-skill PR review. Fans out parallel agents (code-health, shell-style,
-  gha-workflow-validator, synth-setter-project-standards, python-style,
-  tdd-refactor, plus tdd-implementation/ml-data-pipeline/ml-test when the diff
-  warrants) and posts every BLOCK/WARN as an individual unresolved inline PR
-  review comment. Reproduces the workflow demoed on PR #777. Requires the
+  Full multi-skill PR review. Fans out one parallel agent per applicable plugin
+  checklist (selection rules in Step 2) and posts every BLOCK/WARN as an
+  individual unresolved inline PR review comment. Requires the
   tinaudio-synth-setter-skills plugin.
 ---
 

--- a/.claude/skills/repo-review/SKILL.md
+++ b/.claude/skills/repo-review/SKILL.md
@@ -49,7 +49,7 @@ BLOCK: <path>:<line> — [<category>] <description>
 WARN:  <path>:<line> — [<category>] <description>
 ```
 
-Categories: `comment-hygiene`, `yaml-bash`, `python`, `pipeline`, `commit-style`, `pr-link`, `stale-ref`, `secret-doc`.
+Categories: `comment-hygiene`, `yaml-bash`, `python`, `shell`, `pipeline`, `security`, `commit-style`, `pr-link`, `stale-ref`, `secret-doc`.
 
 ### The core checklist (sourced from CLAUDE.md)
 
@@ -59,18 +59,40 @@ Categories: `comment-hygiene`, `yaml-bash`, `python`, `pipeline`, `commit-style`
 - [comment-hygiene] No multi-paragraph essay-comments. If a comment runs more than ~2 lines, replace with a one-line pointer to a GitHub issue.
 - [yaml-bash] **No `#`-comments inside `run: |` or `setup: |` block-scalars** in `.github/workflows/*.{yml,yaml}` or `configs/compute/*.yaml`. Comments belong ABOVE the `run:` key, not inside the bash. This is a HARD project rule — flag every occurrence as BLOCK.
 
-**Python (CLAUDE.md "Writing Code")**
+**Python (CLAUDE.md "Writing Code" + plugin `python-style` BLOCK items)**
 
-- [python] All function signatures are type-annotated. No `Any` — use `Union`, `Optional`, or specific types.
-- [python] No bare `except:`. Always catch a specific exception class.
+- [python] All function signatures are type-annotated. No `Any` — use `Union`, `Optional`, or specific types. (PY8)
+- [python] No bare `except:`. Always catch a specific exception class. (PY2)
+- [python] No mutable default arguments (`def f(x: list = [])` is a footgun — defaults are shared across calls). Use `None` + initialize inside. (PY3)
+- [python] No `assert` for input validation or invariants — `python -O` strips them. Raise an explicit exception. (PY4)
+- [python] Use `with` statements for every file / socket / resource open. No bare `open(...)` without `with`. (PY13)
 - [python] Pydantic `BaseModel` with `strict=True` at trust boundaries (config parsing, JSON from R2, worker reports).
-- [python] `structlog` for logging in pipeline code; Python's `logging` module elsewhere — no `print()` in production code.
+- [python] `structlog` for logging in pipeline code; Python's `logging` module elsewhere.
+- [python] No `print()` statements in production code. CLI helpers + tests excepted (and exempted in `pyproject.toml` per-file-ignores). (P29)
 
-**Pipeline (CLAUDE.md "Pipeline-Specific Rules")**
+**Shell (plugin `shell-style` BLOCK items — applies to `.sh` files AND bash inside YAML `run:` / `setup:` block-scalars in `.github/workflows/*.{yml,yaml}` and `configs/compute/*.yaml`)**
 
-- [pipeline] All `rclone` operations include `--checksum`.
-- [pipeline] No writes to `data/shards/` outside `finalize` stage.
-- [pipeline] Workers only write under `metadata/workers/`.
+- [shell] `set -euo pipefail` at the top of every shell script and every YAML `run: |` / `setup: |` block-scalar. Inner `bash -c '...'` shells get their own `set -euo pipefail`. (SH1)
+- [shell] All variable expansions are double-quoted: `"${VAR}"` not `$VAR`. Exceptions: integers and `$?`. (SH2)
+- [shell] `[[ ]]` not `[ ]` for tests. Single-bracket is BLOCK. (SH3)
+- [shell] Return values of every command are checked — failure of `var=$(cmd)` or `mkdir`, `printf`, `cd` does not silently continue. With `set -e` this is automatic; without it the assignment-substitution variant must be split or wrapped. (SH8)
+- [shell] No `eval`. Refactor whatever needed `eval` into an array invocation or a function. (SH11)
+
+**Pipeline (CLAUDE.md "Pipeline-Specific Rules" + plugin invariants)**
+
+- [pipeline] All `rclone` operations include `--checksum`. (P13)
+- [pipeline] No writes to `data/shards/` outside `finalize` stage. (P12)
+- [pipeline] Workers only write under `metadata/workers/`. Finalize only writes to `data/`. (P11)
+- [pipeline] Shard IDs are logical (`shard-000042`), deterministic, infrastructure-independent. No `pod_id` / `host` / `runner_id` in shard names. (P14)
+- [pipeline] Specs are immutable after creation — no code path mutates a frozen spec in place. (P15)
+- [pipeline] `.valid` marker is written as the last step of shard lifecycle (commit point). Earlier writes leave shards in a partial state with no marker. (P16)
+- [pipeline] Array shapes match spec (sample rate, spectrogram bins, parameter count). dtypes are explicit — `float32` where expected, not `float64`. (P23, P24)
+
+**Security (plugin `synth-setter-project-standards` security block)**
+
+- [security] No credential leaks. API keys, tokens, OCIDs do not appear in code, logs, or error messages. Tracing-back-from-an-error to the secret value is also a leak. (P19)
+- [security] No command injection via subprocess. User-controlled input never gets interpolated into a shell command — pass argv arrays, never `shell=True` with concatenated strings. (P20)
+- [security] No unsafe deserialization. `pickle.loads` from untrusted sources is forbidden — use JSON / msgpack / protobuf for cross-trust-boundary data. (P21)
 
 **Commit style (CLAUDE.md "Commit Messages")**
 

--- a/.claude/skills/repo-review/SKILL.md
+++ b/.claude/skills/repo-review/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: repo-review
+description: |
+  Quick PR review using the repo's core checklist (CLAUDE.md hard rules).
+  Use when the tinaudio-synth-setter-skills plugin isn't available, or for a
+  fast sanity-check before opening for full review. Single agent, no plugin
+  dependency. Posts findings as individual unresolved inline PR review
+  comments via .claude/skills/_shared/post_review.py.
+---
+
+# repo-review — MVP PR Review
+
+You MUST complete every step in order.
+
+## Step 1: Resolve the PR
+
+Determine the PR number:
+
+- If the user invoked `/repo-review <N>`, use `<N>`.
+- Otherwise resolve via `gh pr view --json number` — runs against the current branch's PR.
+
+Fetch the PR's metadata once and remember it:
+
+```bash
+gh pr view <N> --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \
+  --json number,headRefOid,baseRefOid,files,title,headRefName
+```
+
+If there is no PR for the current branch, stop and tell the user to push and open a PR first.
+
+## Step 2: Read the diff
+
+Get the full unified diff:
+
+```bash
+gh pr diff <N> --repo <owner>/<repo>
+```
+
+Read every changed file at the head SHA (use the `Read` tool, not `cat`). Skim the PR description for context on intent.
+
+## Step 3: Apply the core checklist
+
+Evaluate ONLY the changed code. Skip items that don't apply to the diff (e.g. don't flag missing type annotations on a YAML-only PR).
+
+For each finding emit one line:
+
+```
+BLOCK: <path>:<line> — [<category>] <description>
+WARN:  <path>:<line> — [<category>] <description>
+```
+
+Categories: `comment-hygiene`, `yaml-bash`, `python`, `pipeline`, `commit-style`, `pr-link`, `stale-ref`, `secret-doc`.
+
+### The core checklist (sourced from CLAUDE.md)
+
+**Comment hygiene (CLAUDE.md "Comment Hygiene" + "No Comments Inside YAML run: Block-Scalars")**
+
+- [comment-hygiene] No comment restates a constant value, count, or list contents (`# 6 samples`, `# three things: a, b, c`).
+- [comment-hygiene] No multi-paragraph essay-comments. If a comment runs more than ~2 lines, replace with a one-line pointer to a GitHub issue.
+- [yaml-bash] **No `#`-comments inside `run: |` or `setup: |` block-scalars** in `.github/workflows/*.{yml,yaml}` or `configs/compute/*.yaml`. Comments belong ABOVE the `run:` key, not inside the bash. This is a HARD project rule — flag every occurrence as BLOCK.
+
+**Python (CLAUDE.md "Writing Code")**
+
+- [python] All function signatures are type-annotated. No `Any` — use `Union`, `Optional`, or specific types.
+- [python] No bare `except:`. Always catch a specific exception class.
+- [python] Pydantic `BaseModel` with `strict=True` at trust boundaries (config parsing, JSON from R2, worker reports).
+- [python] `structlog` for logging in pipeline code; Python's `logging` module elsewhere — no `print()` in production code.
+
+**Pipeline (CLAUDE.md "Pipeline-Specific Rules")**
+
+- [pipeline] All `rclone` operations include `--checksum`.
+- [pipeline] No writes to `data/shards/` outside `finalize` stage.
+- [pipeline] Workers only write under `metadata/workers/`.
+
+**Commit style (CLAUDE.md "Commit Messages")**
+
+- [commit-style] Every commit on this branch uses a conventional-commit prefix (`feat:`, `fix:`, `internal-feat:`, `internal-fix:`, `docs:`, `ci:`, `chore:`, `refactor:`, `test:`, `style:`, `build:`, `monitoring:`, `perf:`, `revert:`).
+- [commit-style] No commit carries a `Co-Authored-By:` trailer.
+- [commit-style] No commit / PR body contains a "Generated with Claude Code" attribution.
+- [commit-style] PR-level prefix matches the user-facing nature of the change (`feat:` for user-visible, `internal-feat:` for groundwork).
+
+**PR link (CLAUDE.md "PR & Issue References")**
+
+- [pr-link] PR body includes `Fixes #N`, `Closes #N`, `Refs #N`, or `Part of #N` linking to a taxonomy-compliant issue.
+- [pr-link] Use `Refs #N` (not `Fixes`/`Closes`) for partial fixes / workarounds.
+
+**Stale-reference audit (CLAUDE.md "Refactoring")**
+
+- [stale-ref] After any rename / move, references in *all* file types are updated: `.py`, `.yaml`, `.yml`, `.toml`, `.json`, `.md`, `.sh`, Dockerfile. Run a grep to verify; flag any survivors.
+- [stale-ref] If the PR renames a workflow artifact, every doc that names that artifact in a copy-paste command (`gh run download -n <name>`) is updated.
+
+**Secret/input documentation**
+
+- [secret-doc] Every secret the workflow reads (`secrets.X`) is enumerated in the workflow header comment AND in any operator-facing setup doc.
+- [secret-doc] Every `inputs.X` referenced in steps is declared in `workflow_dispatch.inputs`.
+
+End the listing with:
+
+```
+Summary: X BLOCK, Y WARN
+```
+
+If there are zero findings, output `PASS` and stop — do not post an empty review.
+
+## Step 4: Build the findings JSON
+
+Convert your BLOCK/WARN list to the JSON shape `post_review.py` consumes. Each finding becomes one inline comment with a `[repo-review:<severity>]` prefix.
+
+```json
+{
+  "pr_number": <N>,
+  "repo": "<owner>/<repo>",
+  "review_body": "Repo-review (MVP): <X> BLOCK, <Y> WARN. Inline core checklist from CLAUDE.md.",
+  "findings": [
+    {
+      "path": "<path>",
+      "line": <line>,
+      "body": "**[repo-review:block]** [<category>] <description>"
+    }
+  ]
+}
+```
+
+Write the JSON to a temp file (do NOT echo it inline — keep it readable):
+
+```bash
+cat > /tmp/repo-review-findings.json <<'JSON'
+... payload ...
+JSON
+```
+
+## Step 5: Submit the review
+
+```bash
+python3 .claude/skills/_shared/post_review.py < /tmp/repo-review-findings.json
+```
+
+The helper:
+
+- Fetches the PR diff and parses hunks.
+- Anchors each finding to its target line if that line falls inside a diff hunk.
+- Falls back to the nearest in-hunk line on the same file with a `*(anchored at line X; finding is on line Y, outside the diff hunks)*` cross-ref prepended to the body — preserves the original line number for the human reader.
+- Rolls findings on files entirely outside the diff into a `## Findings on files outside the diff` section in the review body.
+- Submits as `event=COMMENT` so threads stay unresolved without approving or rejecting.
+
+The helper prints the review's `html_url` on success. Report it back to the user.
+
+## Notes
+
+- Severity threshold: post everything (every BLOCK and every WARN). Tuning to top-N or by-category is a follow-up — see issue #778's "Out of scope" list.
+- Idempotency: re-running the skill on the same PR posts a fresh review with fresh comment threads (duplicates by design — easy to delete a whole review, fiddly to dedupe).
+- Drift: this checklist is sourced from CLAUDE.md verbatim. When CLAUDE.md changes, this SKILL.md should change in the same PR — that's the contract.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,8 +130,8 @@ The block-scalar should contain only commands. The reader who wants to know *why
 
 Two project-local skills package the review workflow:
 
-- **`/repo-review`** (MVP, default) — single agent, inline core checklist sourced from this CLAUDE.md (comment hygiene, no comments inside YAML `run:` block-scalars, type annotations, no bare `except`, `structlog` vs `logging`, `rclone --checksum`, conventional-commit prefixes, PR-issue link, stale-reference audit, secret/input doc parity). No plugin dependency — works on a fresh clone, in CI, for external contributors.
-- **`/repo-review-full`** (heavyweight) — fans out parallel agents (`code-health`, `synth-setter-project-standards` always; `python-style` + `tdd-implementation` for `*.py`; `shell-style` for bash; `gha-workflow-validator` for `.github/workflows/`; `ml-data-pipeline` + `ml-test` for ML code; `tdd-refactor` when files move/rename). Each agent invokes the corresponding `tinaudio-synth-setter-skills:*` plugin skill — requires the plugin enabled.
+- **`/repo-review`** (MVP, default) — single agent, inline core checklist sourced from this CLAUDE.md's hard rules. See `.claude/skills/repo-review/SKILL.md` for the authoritative checklist. No plugin dependency — works on a fresh clone, in CI, for external contributors.
+- **`/repo-review-full`** (heavyweight) — fans out one parallel agent per applicable plugin checklist. Selection rules live in `.claude/skills/repo-review-full/SKILL.md`. Requires the `tinaudio-synth-setter-skills` plugin.
 
 Both skills aggregate BLOCK/WARN findings, prefix each with `[<skill>:<severity>]`, and post every one as an individual unresolved inline review comment via `.claude/skills/_shared/post_review.py`. The helper anchors each finding to a line in the diff's hunks; findings whose natural line is outside the hunks fall back to the nearest in-hunk line on the same file with a cross-ref note in the body, and findings on files entirely outside the diff are rolled into the top-level review body.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,17 +128,24 @@ The block-scalar should contain only commands. The reader who wants to know *why
 
 ## Code Review
 
-When reviewing code or PRs, invoke these skills in order:
+Two project-local skills package the review workflow:
 
-1. `tdd-implementation` — TDD compliance checklist (16 items)
-2. `code-health` — code quality checklist (24 items)
-3. `ml-data-pipeline` — ML pipeline checklist (12 items)
-4. `synth-setter-project-standards` — project-specific checklist (30 items)
-5. `python-style` — Google Python Style Guide checklist (21 items)
-6. `shell-style` — Google Shell Style Guide checklist (19 items, `.sh` files only)
-7. `ml-test` — ML testing checklist (25 items, model/pipeline test code)
+- **`/repo-review`** (MVP, default) — single agent, inline core checklist sourced from this CLAUDE.md (comment hygiene, no comments inside YAML `run:` block-scalars, type annotations, no bare `except`, `structlog` vs `logging`, `rclone --checksum`, conventional-commit prefixes, PR-issue link, stale-reference audit, secret/input doc parity). No plugin dependency — works on a fresh clone, in CI, for external contributors.
+- **`/repo-review-full`** (heavyweight) — fans out parallel agents (`code-health`, `synth-setter-project-standards` always; `python-style` + `tdd-implementation` for `*.py`; `shell-style` for bash; `gha-workflow-validator` for `.github/workflows/`; `ml-data-pipeline` + `ml-test` for ML code; `tdd-refactor` when files move/rename). Each agent invokes the corresponding `tinaudio-synth-setter-skills:*` plugin skill — requires the plugin enabled.
 
-Review all changed code against every checklist. Prefix findings with BLOCK: (must fix) or WARN: (advisory). Skip style issues (Ruff handles formatting and linting).
+Both skills aggregate BLOCK/WARN findings, prefix each with `[<skill>:<severity>]`, and post every one as an individual unresolved inline review comment via `.claude/skills/_shared/post_review.py`. The helper anchors each finding to a line in the diff's hunks; findings whose natural line is outside the hunks fall back to the nearest in-hunk line on the same file with a cross-ref note in the body, and findings on files entirely outside the diff are rolled into the top-level review body.
+
+Canonical checklist reference (full content lives in the plugin):
+
+1. `tdd-implementation` — TDD compliance (16 items)
+2. `code-health` — code quality (24 items)
+3. `ml-data-pipeline` — ML pipeline (12 items)
+4. `synth-setter-project-standards` — project-specific (30 items)
+5. `python-style` — Google Python Style Guide (21 items)
+6. `shell-style` — Google Shell Style Guide (19 items, `.sh` files + bash inside YAML `run:` blocks)
+7. `ml-test` — ML testing (25 items, model/pipeline test code)
+
+Review all changed code against every applicable checklist. Skip style issues (Ruff handles formatting and linting).
 
 ## Refactoring
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,11 @@ ignore = ["E501", "S101"]
 # T201: click.echo used for CLI output.
 "scripts/r2_shard_report.py" = ["S603", "S607", "T201"]
 "scripts/reshard_data.py" = ["T201"]
+# .claude/skills/_shared/post_review.py: CLI helper that shells out to `gh` and
+# prints html_url on success. S603/S607 are the bandit warnings for subprocess
+# with a partial path — `gh` is on PATH by design (same pattern used by the
+# scripts/r2_shard_report.py exemption above).
+".claude/skills/_shared/post_review.py" = ["T201", "S603", "S607"]
 "scripts/subdir_funtime.py" = ["F841"]
 # S603/S607: rclone subprocess calls in R2 integration test fixtures.
 "tests/scripts/test_r2_shard_report.py" = ["S603", "S607"]


### PR DESCRIPTION
## Summary

- Adds **`/repo-review`** and **`/repo-review-full`** — two project-local skills under `.claude/skills/` that package the multi-skill PR review workflow demoed on #777 (45 inline findings posted in one review).
- Adds the shared **`.claude/skills/_shared/post_review.py`** helper: parses the PR diff, anchors each finding inside a hunk (with nearest-in-hunk fallback + cross-ref body for findings whose natural line is outside the hunks; orphan findings on files outside the diff roll into the review body), and submits one review with `event=COMMENT` so threads stay unresolved.
- Updates **CLAUDE.md** "Code Review" section to surface the new skills. The canonical 7-skill checklist list stays as the per-domain reference.

## Why two skills, not one with a fallback

- `/repo-review` (MVP, default) — single agent, inline core checklist sourced directly from CLAUDE.md. **No plugin dependency.** Works on a fresh clone, in CI, for external contributors. Drift is naturally bounded because the checklist is sourced from CLAUDE.md verbatim — when CLAUDE.md changes, this skill changes in the same PR.
- `/repo-review-full` (heavyweight) — parallel fan-out across the `tinaudio-synth-setter-skills` plugin checklists. Selects skills per file type: `code-health` + `synth-setter-project-standards` always; `python-style` + `tdd-implementation` for `*.py`; `shell-style` for bash; `gha-workflow-validator` for `.github/workflows/`; `ml-data-pipeline` + `ml-test` for ML code; `tdd-refactor` when files move/rename.

Two skills (rather than one with conditional fallback) means no detection logic, both are independently invocable, and the MVP smoke-tests the orchestration scaffolding without requiring the plugin be installed.

## Helper design

`post_review.py` reads a JSON request on stdin and either submits the review (default) or prints the resolved payload (`--dry-run`):

```json
{
  "pr_number": 777,
  "repo": "tinaudio/synth-setter",
  "review_body": "...",
  "findings": [
    {"path": "...", "line": 141, "body": "**[code-health:block]** ..."}
  ]
}
```

Anchoring rules (proven on #777):

| Case | Behavior |
|---|---|
| Finding's `line` is inside a diff hunk on `path` | Anchor exactly there. |
| Finding's `line` is outside hunks but `path` is in the diff | Anchor at the nearest in-hunk line on `path`; prepend `*(anchored at line X; finding is on line Y, outside the diff hunks)*` to the body. |
| `path` is not in the diff at all | Roll into the review-body section `## Findings on files outside the diff` with the original `path:line`. |

All comments submit as `event=COMMENT`. No approve / reject.

## Test plan

- [ ] **MVP smoke** — disable the `tinaudio-synth-setter-skills` plugin (or test in a fresh clone without it). Invoke `/repo-review <N>` against an existing PR with a small diff. Expect: single agent, inline core checklist applied, ≤15 findings posted, all anchors resolve.
- [ ] **Full smoke** — with the plugin enabled. Invoke `/repo-review-full <N>` on a PR with mixed file types (e.g. some Python + some YAML). Expect: 4–6 parallel agents, ≥30 findings posted across multiple skills, anchors resolve or fall back to nearest-in-diff with cross-ref.
- [ ] **Anchor-fallback** — already verified by `post_review.py --dry-run` against #777's diff: line 141 (in-hunk) anchors exactly; line 367 (outside) falls back to line 360; line 999 (way past EOF) falls back to last hunk line; orphan path rolls into review body.
- [ ] **Pre-commit** — `make format` passes on this branch (verified locally).

## Out of scope (deferred — see #778)

- Auto-trigger on PR push (`pull_request` workflow that calls `/repo-review-full`).
- Severity thresholds / cap-at-top-N / dedupe near-duplicate findings across skills.
- Idempotent re-run dedupe.
- Per-PR skill selection (`/repo-review-full --only shell-style,gha-validator`).

Refs #778
