### PR TITLE
build(skypilot): add worker bootstrap script (unused, awaiting dev-snapshot rebuild)

### DIFF
--- a/scripts/skypilot_worker_bootstrap.sh
+++ b/scripts/skypilot_worker_bootstrap.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SkyPilot worker bootstrap — shared by RunPod + OCI compute templates.
+# Caller (template) must set $WORKER_GIT_REF to the PR head SHA when
+# bypassing the dev-snapshot image-bake lag (PR CI), or leave it empty
+# to run the baked code as-is (operators).
+#
+# After bootstrap, exec scripts/skypilot_worker_run.sh which owns the
+# python invocation + #735 os._exit(0) workaround.
+set -euo pipefail
+cd /home/build/synth-setter
+if [[ -n "${WORKER_GIT_REF:-}" ]]; then
+  echo "Syncing worker checkout to git ref: $WORKER_GIT_REF"
+  if ! [[ "$WORKER_GIT_REF" =~ ^[0-9a-f]{7,40}$ ]]; then
+    echo "ERROR: WORKER_GIT_REF must be a 7-40 char hex git SHA, got: $WORKER_GIT_REF" >&2
+    exit 1
+  fi
+  git config --global --add safe.directory /home/build/synth-setter
+  git fetch --depth=1 origin -- "$WORKER_GIT_REF"
+  git checkout FETCH_HEAD
+  echo "Worker now at: $(git rev-parse HEAD)"
+fi
+exec bash scripts/skypilot_worker_run.sh

--- a/scripts/skypilot_worker_bootstrap.sh
+++ b/scripts/skypilot_worker_bootstrap.sh
@@ -7,16 +7,26 @@
 # After bootstrap, exec scripts/skypilot_worker_run.sh which owns the
 # python invocation + #735 os._exit(0) workaround.
 set -euo pipefail
-cd /home/build/synth-setter
+
+# Self-locate the synth-setter checkout from this script's path. Avoids
+# hardcoding /home/build/synth-setter in two places (here + Dockerfile WORKDIR);
+# if the image's WORKDIR ever moves, the script still works as long as it
+# lives at <repo-root>/scripts/.
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_DIR"
+
 if [[ -n "${WORKER_GIT_REF:-}" ]]; then
   echo "Syncing worker checkout to git ref: $WORKER_GIT_REF"
   if ! [[ "$WORKER_GIT_REF" =~ ^[0-9a-f]{7,40}$ ]]; then
     echo "ERROR: WORKER_GIT_REF must be a 7-40 char hex git SHA, got: $WORKER_GIT_REF" >&2
     exit 1
   fi
-  git config --global --add safe.directory /home/build/synth-setter
+  # Idempotent: only add safe.directory if not already present, so repeated
+  # worker starts on a long-lived host don't bloat ~/.gitconfig.
+  git config --global --get-all safe.directory | grep -qxF "$REPO_DIR" \
+    || git config --global --add safe.directory "$REPO_DIR"
   git fetch --depth=1 origin -- "$WORKER_GIT_REF"
   git checkout FETCH_HEAD
   echo "Worker now at: $(git rev-parse HEAD)"
 fi
-exec bash scripts/skypilot_worker_run.sh
+exec bash "$REPO_DIR/scripts/skypilot_worker_run.sh"


### PR DESCRIPTION
## Summary

Adds `scripts/skypilot_worker_bootstrap.sh` containing the `cd` + `WORKER_GIT_REF` fetch+checkout that's currently inlined at the top of both compute templates' `run:` blocks (`configs/compute/runpod-template.yaml` and `configs/compute/oci-cpu-template.yaml`). The script is **not called from anywhere in this PR** — the templates keep their inline bootstrap.

This is **Step 1 of 2** for #782.

## Why a no-op script PR?

The `dev-snapshot` Docker image (which all SkyPilot workers pull) is rebuilt post-merge by `.github/workflows/docker-build-validation.yml`. PRs that introduce new files under `scripts/` cannot reference those files from the templates' `run:` blocks during their own CI, because the worker invokes the template's bash from the not-yet-rebuilt image — the new file isn't on disk until `git checkout FETCH_HEAD` runs, and that line is what the bootstrap script is supposed to own.

Off-disk read mechanisms (`curl | bash`, `bash <(git show ...)`) were attempted in the source PR #777 (commits `c75f7c2`, `1acf114`) and rejected as either RCE-shape or clever-clever / non-obvious.

So the rollout is two PRs:

1. **This PR** — ship `scripts/skypilot_worker_bootstrap.sh` to `main` so the next `dev-snapshot` rebuild bakes it into the image. Templates unchanged.
2. **Follow-up PR** — swap each template's inline bootstrap for `bash /home/build/synth-setter/scripts/skypilot_worker_bootstrap.sh`. That PR will close #782.

## Why `internal-feat:`

Adds new tested code that's not yet user-facing — no template references the script in this PR. The follow-up PR will be `refactor:` (no version bump either).

## Background

- Source PR where the bootstrap extraction was deferred from: #777 (now merged as `adfd7ab`).
- Original review thread that asked for the extraction: PR #777 discussion `r3178483291` (B2 — code-health BLOCK).
- Issue: #782.

## After merge

Trigger the `dev-snapshot` rebuild explicitly (with maintainer approval) so the next time someone opens Step 2 the image already carries the script:

```
gh workflow run docker-build-validation.yml --ref main
```

Verify with:

```
docker pull tinaudio/synth-setter:dev-snapshot
docker run --rm tinaudio/synth-setter:dev-snapshot \
  ls -la /home/build/synth-setter/scripts/skypilot_worker_bootstrap.sh
```

## Test plan

- [x] `make format` — pre-commit (incl. shellcheck) passes
- [x] `make test` — all 296 quick tests pass
- [ ] CI `code-quality-pr` passes
- [ ] CI `pr-metadata-gate` passes (Refs #782; #782 is taxonomy-compliant: Task → Phase #71 → Epic #74, label `data-pipeline`, milestone `data-pipeline v1.0.0`)
- [ ] Note: `Test Dataset Generation` matrix is not triggered by this PR's `paths:` (no template / pipeline / workflow changes) — that's expected and correct. The script is dormant until Step 2.

Refs #782