### PR TITLE
ci(test-dataset-generation): add provider chooser to workflow_dispatch

### DIFF
--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -23,6 +23,15 @@ on:
         description: "Docker image tag (e.g., dev-snapshot, dev-snapshot-<sha>)"
         required: false
         default: "dev-snapshot"
+      provider:
+        description: "Provider(s) to launch on (manual runs only; PR runs always exercise all)"
+        required: false
+        type: choice
+        default: all
+        options:
+          - all
+          - runpod
+          - oci
   pull_request:
     paths:
       - "src/data/vst/**"
@@ -60,8 +69,11 @@ jobs:
     # pod/VM that errors on missing creds. workflow_dispatch is gated by
     # repo write permissions.
     if: >-
-      github.event_name == 'workflow_dispatch'
-      || github.event.pull_request.head.repo.full_name == github.repository
+      (github.event_name == 'workflow_dispatch'
+       || github.event.pull_request.head.repo.full_name == github.repository)
+      && (github.event_name != 'workflow_dispatch'
+          || inputs.provider == 'all'
+          || inputs.provider == matrix.provider)
     continue-on-error: ${{ matrix.continue_on_error }}
     timeout-minutes: 60
     strategy:
@@ -256,7 +268,11 @@ jobs:
   validate-spec:
     name: Validate ${{ matrix.provider }} spec structure
     needs: generate
-    if: ${{ !cancelled() }}
+    if: >-
+      !cancelled()
+      && (github.event_name != 'workflow_dispatch'
+          || inputs.provider == 'all'
+          || inputs.provider == matrix.provider)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: ${{ matrix.continue_on_error }}
@@ -285,7 +301,11 @@ jobs:
   validate-shard:
     name: Validate ${{ matrix.provider }} shards
     needs: generate
-    if: ${{ !cancelled() }}
+    if: >-
+      !cancelled()
+      && (github.event_name != 'workflow_dispatch'
+          || inputs.provider == 'all'
+          || inputs.provider == matrix.provider)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     continue-on-error: ${{ matrix.continue_on_error }}


### PR DESCRIPTION
## Summary

- Adds a `provider` choice input (`all` | `runpod` | `oci`, default `all`) to `.github/workflows/test-dataset-generation.yml`'s `workflow_dispatch`, so a maintainer manually triggering the smoke pipeline can scope it to one provider while iterating on its template/secrets — without provisioning the other half of the matrix.
- The chooser is ANDed into the `if:` of `generate`, `validate-spec`, and `validate-shard`. PR-event runs are unchanged: `github.event_name != 'workflow_dispatch'` short-circuits the filter, and `inputs.provider` is empty on PR events anyway, so both providers continue to run on every PR.

## Why

After #777 collapsed RunPod + OCI into a single matrix, every manual dispatch provisions both a RunPod pod and an OCI VM. When iterating on one provider's template/secrets, the other cell is wasted billable capacity (and noise on the OCI cell which is still `continue-on-error: true`).

## Test plan

- [ ] Workflow dispatch with `provider=runpod` → only the `runpod` cell of `generate`, `validate-spec`, `validate-shard` runs; OCI cells skip.
- [ ] Workflow dispatch with `provider=oci` → only the `oci` cells run; RunPod cells skip.
- [ ] Workflow dispatch with `provider=all` (default) → both providers run, matching the pre-change behavior.
- [ ] PR-event run on this branch → both providers still run.

Refs #786