### PR TITLE
ci(ci-automation): run test-gpu.yml inside dev-snapshot Docker image

### DIFF
--- a/.github/workflows/test-gpu.yml
+++ b/.github/workflows/test-gpu.yml
@@ -1,9 +1,17 @@
 name: GPU Tests
 
-# Runs only @pytest.mark.gpu tests on a GPU runner.
-# Twice-weekly schedule (Mon + Thu) and manual dispatch.
+# Runs only @pytest.mark.gpu tests inside the project's
+# `tinaudio/synth-setter:dev-snapshot` Docker image so the torch (cu128)
+# build, Surge XT VST3, and headless X11 stack match production. Mirrors
+# the Docker-in-CI pattern used by `test-vst-slow.yml`. Twice-weekly
+# schedule (Mon + Thu) and manual dispatch.
 on:
   workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Docker image tag (e.g. dev-snapshot, dev-snapshot-<sha>)"
+        required: false
+        default: "dev-snapshot"
   schedule:
     - cron: "0 6 * * 1,4" # Mon + Thu 06:00 UTC
 
@@ -16,74 +24,66 @@ jobs:
 
     timeout-minutes: 120
 
+    env:
+      IMAGE: tinaudio/synth-setter:${{ inputs.image_tag || 'dev-snapshot' }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
+      - name: Pull image
+        run: docker pull "$IMAGE"
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: Install dependencies
-        # GitHub GPU runner ships NVIDIA driver 12080 (CUDA 12.8).
-        # torch >=2.7.0 requires CUDA 13.x — cap it via --constraint
-        # so CI stays compatible without changing requirements-torch.txt.
+      # Confirm the runner exposes a CUDA GPU to the container before the
+      # full pytest run; surfaces toolkit/driver issues with a clear error
+      # rather than a wall of skipped @RunIf(min_gpus=1) tests.
+      - name: Smoke-test GPU visibility inside container
         run: |
-          echo 'torch<2.7.0' > /tmp/torch-constraint.txt
-          uv pip install --system --constraint /tmp/torch-constraint.txt -r requirements.txt
-          uv pip install --system sh
-
-      # Install the Surge XT VST3 prebuilt .deb plus the headless X11 / dbus
-      # runtime stack needed by `scripts/run-linux-vst-headless.sh` (Xvfb,
-      # xsettingsd, openbox, dbus-x11, mesa, x11-utils). Mirrors the steps in
-      # `docker/ubuntu22_04/Dockerfile` (prebuilt-install + headless-runtime
-      # apt block, lines 184-218 and 289-306) and the symlink at line 316-317.
-      # The .deb installs the bundle at /usr/lib/vst3/Surge XT.vst3, which is
-      # then symlinked into the repo-relative `plugins/Surge XT.vst3` path
-      # that configs, CLI defaults, and tests assume.
-      - name: Install Surge XT VST3 + headless X11 stack
-        env:
-          SURGE_XT_VERSION: "1.3.4"
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            xvfb \
-            xauth \
-            dbus-x11 \
-            xsettingsd \
-            libgl1-mesa-dri \
-            mesa-utils \
-            openbox \
-            x11-utils \
-            x11-xserver-utils
-          deb="surge-xt-linux-x64-${SURGE_XT_VERSION}.deb"
-          curl -fsSL -o "/tmp/${deb}" \
-            "https://github.com/surge-synthesizer/releases-xt/releases/download/${SURGE_XT_VERSION}/${deb}"
-          sudo apt-get install -y --no-install-recommends "/tmp/${deb}"
-          rm "/tmp/${deb}"
-          test -d "/usr/lib/vst3/Surge XT.vst3"
-          mkdir -p plugins
-          ln -sfn "/usr/lib/vst3/Surge XT.vst3" "plugins/Surge XT.vst3"
+          docker run --rm --gpus all \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              nvidia-smi --query-gpu=name,memory.free --format=csv,noheader
+              python -c "import torch; assert torch.cuda.is_available(), \"CUDA not available in container\"; print(\"cuda:\", torch.cuda.is_available(), \"count:\", torch.cuda.device_count())"
+            '
 
       # Mirrors the headless plugin-load smoke check in
-      # `docker/ubuntu22_04/Dockerfile:312-314` — fails fast if the .deb
-      # install, X11 stack, or symlink is broken before the full pytest run.
+      # `docker/ubuntu22_04/Dockerfile:319-320` — fails fast if the plugin
+      # / image / mount layout is broken before the much-longer pytest run.
       - name: Smoke-test Surge XT plugin load
         run: |
-          ./scripts/run-linux-vst-headless.sh \
-            python -X faulthandler -c "from src.data.vst.core import load_plugin; load_plugin('plugins/Surge XT.vst3')"
+          docker run --rm \
+            -v ${{ github.workspace }}:/home/build/synth-setter \
+            -e PYTHONPATH=/home/build/synth-setter \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              git config --global --add safe.directory /home/build/synth-setter
+              scripts/run-linux-vst-headless.sh \
+                python -X faulthandler -c "from src.data.vst.core import load_plugin; load_plugin(\"/usr/lib/vst3/Surge XT.vst3\")"
+            '
 
-      - name: List dependencies
-        run: uv pip list --system
-
-      - name: Run GPU tests
-        env:
-          HYDRA_FULL_ERROR: "1"
+      # Mount the PR's tests + src into the container so we test THIS
+      # branch's code against the image's environment. The workspace mount
+      # shadows the in-image `plugins/Surge XT.vst3` symlink, so point
+      # SYNTH_SETTER_PLUGIN_PATH at the system VST3 path the image installs.
+      # `--gpus all` exposes the runner's CUDA device to the container; the
+      # dev-snapshot image's torch is built with cu128 wheels (see
+      # `configs/image/dev-snapshot.yaml`), matching the gpu-x64 runner's
+      # NVIDIA driver.
+      - name: Run GPU tests in Docker
         run: |
-          pytest -vv -s -m gpu
+          docker run --rm --gpus all \
+            -v ${{ github.workspace }}:/home/build/synth-setter \
+            -e PYTHONPATH=/home/build/synth-setter \
+            -e HYDRA_FULL_ERROR=1 \
+            -e "SYNTH_SETTER_PLUGIN_PATH=/usr/lib/vst3/Surge XT.vst3" \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              git config --global --add safe.directory /home/build/synth-setter
+              scripts/run-linux-vst-headless.sh \
+                pytest -vv -s -m gpu
+            '


### PR DESCRIPTION
## Summary

- Switches `.github/workflows/test-gpu.yml` from a bare-metal install (Python + uv + `torch<2.7.0` constraint + Surge XT `.deb` + apt headless X11 stack) to `docker pull` + `docker run --gpus all` against `tinaudio/synth-setter:dev-snapshot`, mirroring the proven pattern in `test-vst-slow.yml`.
- Drops ~80% of the workflow's setup steps — the dev-snapshot image already ships cu128 torch (matches the `gpu-x64` runner driver), Surge XT 1.3.4 at `/usr/lib/vst3/Surge XT.vst3`, and the headless X11/dbus stack.
- Adds a `workflow_dispatch` `image_tag` input (defaults to `dev-snapshot`) so a maintainer can pin a `dev-snapshot-<sha>` tag, plus a GPU-visibility smoke step (`nvidia-smi` + `torch.cuda.is_available()` inside the container) before the longer pytest run so toolkit/driver issues surface fast.
- Workspace is bind-mounted into `/home/build/synth-setter`; `SYNTH_SETTER_PLUGIN_PATH=/usr/lib/vst3/Surge XT.vst3` works around the in-image symlink getting shadowed by the mount; pytest is wrapped in `scripts/run-linux-vst-headless.sh` to match the existing setup.

Refs #787

## Test plan

- [ ] Manual `workflow_dispatch` of `GPU Tests` on this branch passes against the current `dev-snapshot` tag.
- [ ] GPU-visibility smoke step prints a non-empty `nvidia-smi` row and `cuda: True`.
- [ ] Surge XT plugin-load smoke step succeeds (proves the bind-mount + headless wrapper still work end-to-end).
- [ ] `pytest -vv -s -m gpu` finishes within the 120-minute timeout and is green.
- [ ] `Validate GitHub Workflows` pre-commit hook passes locally (already verified).

## Notes for reviewers

- Assumes `gpu-x64` has `nvidia-container-toolkit` so `--gpus all` works. If it does not, the GPU-visibility smoke step will fail fast and we'll roll back; this is intentional.
- Out of scope: `cpu-slow.yml` migration to Docker, GPU test cost/scheduling (tracked in #334).