### PR TITLE
internal-feat(ci): mirror dev-snapshot image to OCIR for OCI workers

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -174,6 +174,74 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      # OCIR mirror: pushes the same dev-snapshot manifest under an OCI
+      # Container Registry tag so the OCI SkyPilot workflow
+      # (test-dataset-generation.yml's `oci` matrix cell) can pull
+      # in-region instead of cross-cloud from Docker Hub. Only the two
+      # tags that workflow consumes are mirrored — `dev-snapshot` (when
+      # main) and `dev-snapshot-<sha>`. `latest`, `dev-snapshot-<branch>`,
+      # and the devcontainer-tools target stay Docker Hub only.
+      #
+      # OCIR coordinates are derived rather than baked in:
+      #   - Region key: mapped from the existing OCI_REGION secret.
+      #   - Namespace: extracted from OCIR_USERNAME's leading
+      #     `<namespace>/...` component (OCIR docker-login convention).
+      # New secrets required for push: OCIR_USERNAME + OCIR_AUTH_TOKEN
+      # (OCI Auth Token, not the API signing key in OCI_API_KEY_PEM).
+      - name: Derive OCIR coordinates
+        id: ocir
+        if: github.event_name != 'pull_request'
+        env:
+          OCIR_USERNAME: ${{ secrets.OCIR_USERNAME }}
+          OCI_REGION: ${{ secrets.OCI_REGION }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OCIR_USERNAME:-}" ]; then
+            echo "::error::OCIR_USERNAME secret is empty — generate an OCI Auth Token and set OCIR_USERNAME (form: <namespace>/<oci-user>) and OCIR_AUTH_TOKEN before this workflow can push to OCIR." >&2
+            exit 1
+          fi
+          if [ -z "${OCI_REGION:-}" ]; then
+            echo "::error::OCI_REGION secret is empty — required to derive the OCIR registry host." >&2
+            exit 1
+          fi
+          ocir_namespace="${OCIR_USERNAME%%/*}"
+          if [ -z "${ocir_namespace}" ] || [ "${ocir_namespace}" = "${OCIR_USERNAME}" ]; then
+            echo "::error::OCIR_USERNAME='${OCIR_USERNAME}' must have form <namespace>/<oci-user>" >&2
+            exit 1
+          fi
+          case "${OCI_REGION}" in
+            us-ashburn-1)    region_key=iad ;;
+            us-phoenix-1)    region_key=phx ;;
+            eu-frankfurt-1)  region_key=fra ;;
+            eu-amsterdam-1)  region_key=ams ;;
+            uk-london-1)     region_key=lhr ;;
+            ap-tokyo-1)      region_key=nrt ;;
+            ap-mumbai-1)     region_key=bom ;;
+            ap-seoul-1)      region_key=icn ;;
+            ap-sydney-1)     region_key=syd ;;
+            ap-singapore-1)  region_key=sin ;;
+            ca-toronto-1)    region_key=yyz ;;
+            ca-montreal-1)   region_key=yul ;;
+            sa-saopaulo-1)   region_key=gru ;;
+            *)
+              echo "::error::OCI_REGION='${OCI_REGION}' has no region-key mapping in this workflow. Add it to the case statement above." >&2
+              exit 1
+              ;;
+          esac
+          ocir_host="${region_key}.ocir.io"
+          ocir_image="${ocir_host}/${ocir_namespace}/synth-setter"
+          echo "host=${ocir_host}" >> "$GITHUB_OUTPUT"
+          echo "image=${ocir_image}" >> "$GITHUB_OUTPUT"
+          echo "OCIR push target: ${ocir_image}"
+
+      - name: Log in to OCIR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ steps.ocir.outputs.host }}
+          username: ${{ secrets.OCIR_USERNAME }}
+          password: ${{ secrets.OCIR_AUTH_TOKEN }}
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -214,6 +282,20 @@ jobs:
             type=raw,value=dev-snapshot-${{ steps.source.outputs.sha }}
             type=raw,value=latest,enable=${{ steps.source.outputs.is_main == 'true' }}
 
+      # OCIR mirror tag set: only the two tags consumed by the OCI SkyPilot
+      # workflow. Same `is_main` gate as Docker Hub for the floating
+      # `dev-snapshot` tag; the immutable `dev-snapshot-<sha>` always
+      # pushed. PR runs skip this step (no push, no OCIR login).
+      - name: Docker metadata (OCIR)
+        id: meta_ocir
+        if: github.event_name != 'pull_request'
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ steps.ocir.outputs.image }}
+          tags: |
+            type=raw,value=dev-snapshot,enable=${{ steps.source.outputs.is_main == 'true' }}
+            type=raw,value=dev-snapshot-${{ steps.source.outputs.sha }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -223,7 +305,13 @@ jobs:
           platforms: ${{ steps.config.outputs.target_platform }}
           push: ${{ github.event_name != 'pull_request' }}
           load: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          # Concatenated multi-registry tag list: buildx pushes one build
+          # under all listed names (Docker Hub + OCIR) in a single push,
+          # so the same digest lands at both. meta_ocir is empty on PR
+          # runs (the step is gated off); empty trailing lines are ignored.
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ steps.meta_ocir.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             BUILD_MODE=${{ steps.config.outputs.build_mode }}

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -75,11 +75,16 @@ jobs:
             pin_replace: "image_id: docker:tinaudio/synth-setter:{IMAGE_TAG}"
             oci_image_tag: ""
             continue_on_error: false
+          # OCI cell rewrites the worker image to OCIR (docker-build-validation.yml
+          # mirrors the same dev-snapshot tag set there) so the OCI VM pulls
+          # in-region instead of cross-cloud from Docker Hub. The {OCIR_PREFIX}
+          # placeholder is substituted at runtime in the "Pin worker image tag"
+          # step from the existing OCI_REGION + OCIR_USERNAME secrets.
           - provider: oci
             template: configs/compute/oci-cpu-template.yaml
             cluster_prefix: synth-setter-smoke-oci
             pin_search: 'WORKER_IMAGE: "tinaudio/synth-setter:dev-snapshot"'
-            pin_replace: 'WORKER_IMAGE: "tinaudio/synth-setter:{IMAGE_TAG}"'
+            pin_replace: 'WORKER_IMAGE: "{OCIR_PREFIX}/synth-setter:{IMAGE_TAG}"'
             oci_image_tag: skypilot:cpu-ubuntu-2204
             continue_on_error: true
     env:
@@ -99,18 +104,74 @@ jobs:
       - name: Pull image
         run: docker pull "${IMAGE}"
 
+      # OCI cell only: derive the OCIR registry prefix
+      # (`<region-key>.ocir.io/<namespace>`) from the existing OCI_REGION
+      # secret and the leading `<namespace>/...` component of OCIR_USERNAME.
+      # Substituted into matrix.pin_replace's {OCIR_PREFIX} placeholder
+      # in the next step. Region-key mapping kept in sync with
+      # docker-build-validation.yml's "Derive OCIR coordinates" step.
+      - name: Derive OCIR prefix
+        id: ocir_prefix
+        if: matrix.provider == 'oci'
+        env:
+          OCIR_USERNAME: ${{ secrets.OCIR_USERNAME }}
+          OCI_REGION: ${{ secrets.OCI_REGION }}
+        run: |
+          set -euo pipefail
+          if [ -z "${OCIR_USERNAME:-}" ]; then
+            echo "::error::OCIR_USERNAME secret is empty — required to extract the OCIR namespace." >&2
+            exit 1
+          fi
+          if [ -z "${OCI_REGION:-}" ]; then
+            echo "::error::OCI_REGION secret is empty — required to derive the OCIR registry host." >&2
+            exit 1
+          fi
+          ocir_namespace="${OCIR_USERNAME%%/*}"
+          if [ -z "${ocir_namespace}" ] || [ "${ocir_namespace}" = "${OCIR_USERNAME}" ]; then
+            echo "::error::OCIR_USERNAME='${OCIR_USERNAME}' must have form <namespace>/<oci-user>" >&2
+            exit 1
+          fi
+          case "${OCI_REGION}" in
+            us-ashburn-1)    region_key=iad ;;
+            us-phoenix-1)    region_key=phx ;;
+            eu-frankfurt-1)  region_key=fra ;;
+            eu-amsterdam-1)  region_key=ams ;;
+            uk-london-1)     region_key=lhr ;;
+            ap-tokyo-1)      region_key=nrt ;;
+            ap-mumbai-1)     region_key=bom ;;
+            ap-seoul-1)      region_key=icn ;;
+            ap-sydney-1)     region_key=syd ;;
+            ap-singapore-1)  region_key=sin ;;
+            ca-toronto-1)    region_key=yyz ;;
+            ca-montreal-1)   region_key=yul ;;
+            sa-saopaulo-1)   region_key=gru ;;
+            *)
+              echo "::error::OCI_REGION='${OCI_REGION}' has no region-key mapping (also update docker-build-validation.yml)." >&2
+              exit 1
+              ;;
+          esac
+          ocir_prefix="${region_key}.ocir.io/${ocir_namespace}"
+          echo "prefix=${ocir_prefix}" >> "$GITHUB_OUTPUT"
+          echo "OCIR prefix: ${ocir_prefix}"
+
       # Pin the per-provider image reference so the worker pulls the same
       # image we just smoke-tested locally above. Bash substitutes the
-      # literal `{IMAGE_TAG}` placeholder in matrix.pin_replace at runtime.
+      # literal `{IMAGE_TAG}` placeholder in matrix.pin_replace at runtime;
+      # for the OCI cell, `{OCIR_PREFIX}` is also substituted (from the
+      # prior "Derive OCIR prefix" step). Other providers' pin_replace
+      # contains neither `{OCIR_PREFIX}` nor an empty OCIR_PREFIX env, so
+      # the second substitution is a no-op there.
       - name: Pin worker image tag in compute template
         env:
           IMAGE_TAG: ${{ env.IMAGE_TAG }}
           TEMPLATE: ${{ matrix.template }}
           PIN_SEARCH: ${{ matrix.pin_search }}
           PIN_REPLACE: ${{ matrix.pin_replace }}
+          OCIR_PREFIX: ${{ steps.ocir_prefix.outputs.prefix }}
         run: |
           set -euo pipefail
           REPLACE="${PIN_REPLACE//\{IMAGE_TAG\}/${IMAGE_TAG}}"
+          REPLACE="${REPLACE//\{OCIR_PREFIX\}/${OCIR_PREFIX}}"
           PIN_COUNT=$(grep -cF "${PIN_SEARCH}" "${TEMPLATE}" || true)
           if [[ "${PIN_COUNT}" != "1" ]]; then
             echo "::error::expected exactly 1 occurrence of PIN_SEARCH in ${TEMPLATE}, found ${PIN_COUNT}" >&2


### PR DESCRIPTION
## Summary

- Adds an OCIR mirror push to `docker-build-validation.yml` alongside the existing Docker Hub push, so the OCI SkyPilot workflow can pull `dev-snapshot` in-region instead of cross-cloud.
- Mirrors only the two tags the OCI cell consumes (`dev-snapshot` + `dev-snapshot-<sha>`); Docker Hub stays canonical for everything else (devcontainer-tools, RunPod, validate-shard runners, local dev, the buildcache).
- Rewrites `WORKER_IMAGE` to the OCIR path in `test-dataset-generation.yml`'s OCI matrix cell via a new `{OCIR_PREFIX}` placeholder substituted in the existing pin step.
- `oci-cpu-template.yaml`'s default stays Docker Hub so manual dispatchers without OCIR auth still work.

## Design notes

- **No tenant identifiers in the repo.** OCIR coordinates are derived at runtime from existing state: region key mapped from `OCI_REGION`, namespace extracted from `OCIR_USERNAME`'s leading `<namespace>/...` component. The region-key `case` mapping covers the 13 most common OCI regions; unknown regions fail with an explicit error pointing at the workflow line to update.
- **Single buildx push.** `docker/build-push-action@v6` accepts a multi-line `tags:` input — buildx publishes the same digest under both registry names in one push, so divergence between Docker Hub and OCIR is impossible without re-tagging.
- **PR runs unchanged.** Both new OCIR steps (`Derive OCIR coordinates`, `Log in to OCIR`, `Docker metadata (OCIR)`) are gated on `github.event_name != 'pull_request'`, matching the existing Docker Hub push gate. PR build-only validation never touches OCIR.

## Required new secrets

Push runs (workflow_dispatch / schedule) will fail at the OCIR derive/login steps until these are set:

- `OCIR_USERNAME` — `<namespace>/<oci-user>` form (federated users prepend `oracleidentitycloudservice/`).
- `OCIR_AUTH_TOKEN` — OCI Auth Token generated in the OCI Console (Console → User Settings → Auth Tokens). **NOT** the API signing key in `OCI_API_KEY_PEM`.

OCIR repo is assumed public (anonymous pull from the OCI VM, no `docker login` in `oci-cpu-template.yaml`'s setup block).

## Test plan

- [ ] After secrets are added, dispatch `Docker Image Build and Push` and confirm the run logs show `Login Succeeded` for both Docker Hub and `<region>.ocir.io`.
- [ ] Confirm buildx pushes the manifest under both `tinaudio/synth-setter:dev-snapshot-<sha>` AND `<region>.ocir.io/<namespace>/synth-setter:dev-snapshot-<sha>` in the build step output.
- [ ] Anonymous pull from OCIR succeeds: `docker pull <region>.ocir.io/<namespace>/synth-setter:dev-snapshot-<sha>` from any machine without OCIR creds.
- [ ] Dispatch `Test Dataset Generation` and confirm:
  - The OCI cell's `Derive OCIR prefix` step emits the expected `<region>.ocir.io/<namespace>` value.
  - The `Pin worker image tag` step rewrites `WORKER_IMAGE` to the OCIR path (visible via the trailing `grep -F`).
  - The OCI VM's `setup:` block's `docker pull` succeeds against OCIR (visible in `sky logs`).
- [ ] Confirm the RunPod matrix cell still passes unchanged (no OCIR exposure).
- [ ] Manual follow-up (token-scope blocker): add #790 to the synth-setter project board and set Priority (P2 / nice-to-have once OCI cell is blocking).

Refs #790