### PR TITLE
ci(workflows): add Push To OCIR (mirror dev-snapshot to OCIR)

### DIFF
--- a/.github/workflows/push-to-ocir.yml
+++ b/.github/workflows/push-to-ocir.yml
@@ -4,14 +4,18 @@ name: Push To OCIR
 # workers can pull it in-region instead of cross-cloud. Pulls
 # tinaudio/synth-setter:dev-snapshot, retags for OCIR, pushes.
 #
-# Triggers on workflow_dispatch and pull_request — the PR trigger is
-# kept for end-to-end verification while the workflow is being validated;
-# remove it once the mirror is proven reliable (the dev-snapshot image is
-# multi-GB and PR-triggered pulls are expensive).
+# Required secrets:
+#   OCIR_REGION_KEY        — OCIR region key (e.g. iad, phx, fra); forms the
+#                            registry hostname <key>.ocir.io.
+#   OCIR_TENANCY_NAMESPACE — Object Storage namespace for the tenancy; the
+#                            second segment of the OCIR image path.
+#   OCIR_USERNAME          — full OCIR username, including any
+#                            <namespace>/ prefix the tenancy requires.
+#   OCIR_TOKEN             — OCI Auth Token with repos:push scope on the
+#                            target repository.
 
 on:
   workflow_dispatch:
-  pull_request:
 
 jobs:
   push-to-ocir:
@@ -22,10 +26,7 @@ jobs:
       contents: read
 
     steps:
-      # Fork PRs can't read repo secrets — gate auth/push steps so they no-op
-      # cleanly rather than failing with a misleading "denied" error.
       - name: Log in to OCIR
-        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.OCIR_REGION_KEY }}.ocir.io
@@ -33,12 +34,12 @@ jobs:
           password: ${{ secrets.OCIR_TOKEN }}
 
       - name: Pull dev-snapshot from Docker Hub, retag, push to OCIR
-        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           SOURCE_IMAGE: tinaudio/synth-setter:dev-snapshot
           OCIR_REGION_KEY: ${{ secrets.OCIR_REGION_KEY }}
           OCIR_TENANCY_NAMESPACE: ${{ secrets.OCIR_TENANCY_NAMESPACE }}
         run: |
+          set -euo pipefail
           docker pull "$SOURCE_IMAGE"
           target="${OCIR_REGION_KEY}.ocir.io/${OCIR_TENANCY_NAMESPACE}/synth-setter:dev-snapshot"
           docker tag "$SOURCE_IMAGE" "$target"

--- a/.github/workflows/push-to-ocir.yml
+++ b/.github/workflows/push-to-ocir.yml
@@ -1,0 +1,54 @@
+name: Push To OCIR
+
+# Smoke-test workflow that pushes a dummy image (`hello-world`, retagged) to
+# OCIR. Goal is to verify auth + push end-to-end against the configured OCIR
+# region/tenancy before committing to a real image-build pipeline against OCIR.
+# Triggers on workflow_dispatch and on pull_request so the smoke test runs as
+# a PR check.
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  push-to-ocir:
+    name: Push dummy image to OCIR
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      # PR head SHA is more useful than github.sha (the merge commit) for
+      # tracing the pushed tag back to the change that triggered it.
+      - name: Resolve commit SHA for image tag
+        id: source
+        env:
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_SHA: ${{ github.sha }}
+        run: |
+          sha="${PR_HEAD_SHA:-$GITHUB_SHA}"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+
+      # Fork PRs can't read repo secrets — gate auth/push steps so they no-op
+      # cleanly rather than failing with a misleading "denied" error.
+      - name: Log in to OCIR
+        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.OCIR_REGION }}.ocir.io
+          username: ${{ secrets.OCIR_TENANCY_NAMESPACE }}/${{ secrets.OCIR_USERNAME }}
+          password: ${{ secrets.OCIR_TOKEN }}
+
+      - name: Pull, retag, push hello-world
+        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          OCIR_REGION: ${{ secrets.OCIR_REGION }}
+          OCIR_TENANCY_NAMESPACE: ${{ secrets.OCIR_TENANCY_NAMESPACE }}
+          SHA: ${{ steps.source.outputs.sha }}
+        run: |
+          docker pull hello-world:latest
+          target="${OCIR_REGION}.ocir.io/${OCIR_TENANCY_NAMESPACE}/synth-setter-smoketest:${SHA}"
+          docker tag hello-world:latest "$target"
+          docker push "$target"
+          echo "Pushed $target"

--- a/.github/workflows/push-to-ocir.yml
+++ b/.github/workflows/push-to-ocir.yml
@@ -37,7 +37,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.OCIR_REGION_KEY }}.ocir.io
-          username: ${{ secrets.OCIR_TENANCY_NAMESPACE }}/${{ secrets.OCIR_USERNAME }}
+          username: ${{ secrets.OCIR_USERNAME }}
           password: ${{ secrets.OCIR_TOKEN }}
 
       - name: Pull, retag, push hello-world

--- a/.github/workflows/push-to-ocir.yml
+++ b/.github/workflows/push-to-ocir.yml
@@ -36,19 +36,19 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
-          registry: ${{ secrets.OCIR_REGION }}.ocir.io
+          registry: ${{ secrets.OCIR_REGION_KEY }}.ocir.io
           username: ${{ secrets.OCIR_TENANCY_NAMESPACE }}/${{ secrets.OCIR_USERNAME }}
           password: ${{ secrets.OCIR_TOKEN }}
 
       - name: Pull, retag, push hello-world
         if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         env:
-          OCIR_REGION: ${{ secrets.OCIR_REGION }}
+          OCIR_REGION_KEY: ${{ secrets.OCIR_REGION_KEY }}
           OCIR_TENANCY_NAMESPACE: ${{ secrets.OCIR_TENANCY_NAMESPACE }}
           SHA: ${{ steps.source.outputs.sha }}
         run: |
           docker pull hello-world:latest
-          target="${OCIR_REGION}.ocir.io/${OCIR_TENANCY_NAMESPACE}/synth-setter-smoketest:${SHA}"
+          target="${OCIR_REGION_KEY}.ocir.io/${OCIR_TENANCY_NAMESPACE}/synth-setter-smoketest:${SHA}"
           docker tag hello-world:latest "$target"
           docker push "$target"
           echo "Pushed $target"

--- a/.github/workflows/push-to-ocir.yml
+++ b/.github/workflows/push-to-ocir.yml
@@ -4,13 +4,14 @@ name: Push To OCIR
 # workers can pull it in-region instead of cross-cloud. Pulls
 # tinaudio/synth-setter:dev-snapshot, retags for OCIR, pushes.
 #
-# Manual trigger only — the dev-snapshot image is multi-GB and not worth
-# pulling/pushing on every PR. Run after a fresh dev-snapshot build lands
-# (or wire as a `workflow_run` consumer of `Docker Image Build and Push`
-# once we want this to auto-mirror).
+# Triggers on workflow_dispatch and pull_request — the PR trigger is
+# kept for end-to-end verification while the workflow is being validated;
+# remove it once the mirror is proven reliable (the dev-snapshot image is
+# multi-GB and PR-triggered pulls are expensive).
 
 on:
   workflow_dispatch:
+  pull_request:
 
 jobs:
   push-to-ocir:
@@ -21,7 +22,10 @@ jobs:
       contents: read
 
     steps:
+      # Fork PRs can't read repo secrets — gate auth/push steps so they no-op
+      # cleanly rather than failing with a misleading "denied" error.
       - name: Log in to OCIR
+        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.OCIR_REGION_KEY }}.ocir.io
@@ -29,6 +33,7 @@ jobs:
           password: ${{ secrets.OCIR_TOKEN }}
 
       - name: Pull dev-snapshot from Docker Hub, retag, push to OCIR
+        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           SOURCE_IMAGE: tinaudio/synth-setter:dev-snapshot
           OCIR_REGION_KEY: ${{ secrets.OCIR_REGION_KEY }}

--- a/.github/workflows/push-to-ocir.yml
+++ b/.github/workflows/push-to-ocir.yml
@@ -1,54 +1,41 @@
 name: Push To OCIR
 
-# Smoke-test workflow that pushes a dummy image (`hello-world`, retagged) to
-# OCIR. Goal is to verify auth + push end-to-end against the configured OCIR
-# region/tenancy before committing to a real image-build pipeline against OCIR.
-# Triggers on workflow_dispatch and on pull_request so the smoke test runs as
-# a PR check.
+# Mirrors the dev-snapshot Docker image from Docker Hub to OCIR so OCI
+# workers can pull it in-region instead of cross-cloud. Pulls
+# tinaudio/synth-setter:dev-snapshot, retags for OCIR, pushes.
+#
+# Manual trigger only — the dev-snapshot image is multi-GB and not worth
+# pulling/pushing on every PR. Run after a fresh dev-snapshot build lands
+# (or wire as a `workflow_run` consumer of `Docker Image Build and Push`
+# once we want this to auto-mirror).
 
 on:
   workflow_dispatch:
-  pull_request:
 
 jobs:
   push-to-ocir:
-    name: Push dummy image to OCIR
+    name: Mirror dev-snapshot to OCIR
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 30
     permissions:
       contents: read
 
     steps:
-      # PR head SHA is more useful than github.sha (the merge commit) for
-      # tracing the pushed tag back to the change that triggered it.
-      - name: Resolve commit SHA for image tag
-        id: source
-        env:
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          GITHUB_SHA: ${{ github.sha }}
-        run: |
-          sha="${PR_HEAD_SHA:-$GITHUB_SHA}"
-          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
-
-      # Fork PRs can't read repo secrets — gate auth/push steps so they no-op
-      # cleanly rather than failing with a misleading "denied" error.
       - name: Log in to OCIR
-        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.OCIR_REGION_KEY }}.ocir.io
           username: ${{ secrets.OCIR_USERNAME }}
           password: ${{ secrets.OCIR_TOKEN }}
 
-      - name: Pull, retag, push hello-world
-        if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+      - name: Pull dev-snapshot from Docker Hub, retag, push to OCIR
         env:
+          SOURCE_IMAGE: tinaudio/synth-setter:dev-snapshot
           OCIR_REGION_KEY: ${{ secrets.OCIR_REGION_KEY }}
           OCIR_TENANCY_NAMESPACE: ${{ secrets.OCIR_TENANCY_NAMESPACE }}
-          SHA: ${{ steps.source.outputs.sha }}
         run: |
-          docker pull hello-world:latest
-          target="${OCIR_REGION_KEY}.ocir.io/${OCIR_TENANCY_NAMESPACE}/synth-setter-smoketest:${SHA}"
-          docker tag hello-world:latest "$target"
+          docker pull "$SOURCE_IMAGE"
+          target="${OCIR_REGION_KEY}.ocir.io/${OCIR_TENANCY_NAMESPACE}/synth-setter:dev-snapshot"
+          docker tag "$SOURCE_IMAGE" "$target"
           docker push "$target"
           echo "Pushed $target"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/push-to-ocir.yml`, which pulls `tinaudio/synth-setter:dev-snapshot` from Docker Hub, retags it as `<region>.ocir.io/<tenancy_namespace>/synth-setter:dev-snapshot`, and pushes to OCIR.
- Goal: let OCI workers pull `dev-snapshot` in-region instead of cross-cloud from Docker Hub.
- Required secrets (enumerated in the workflow header): `OCIR_REGION_KEY`, `OCIR_TENANCY_NAMESPACE`, `OCIR_USERNAME`, `OCIR_TOKEN`.
- Out of scope: wiring `oci-cpu-template.yaml` to pull from OCIR, auto-mirroring after each `Docker Image Build and Push` run, multi-arch.

> ## Note on related work
> This PR overlaps with #790 / branch `internal-feat/docker-push-ocir`, which solves the same problem by adding dual Docker-Hub-and-OCIR push to `docker-build-validation.yml`. This PR takes the lighter alternative (independent mirror workflow). If you take this PR, the `internal-feat/docker-push-ocir` branch can be closed.

## Test plan

- [ ] Run `Push To OCIR` against this branch via `gh workflow run push-to-ocir.yml --ref ci/push-to-ocir-smoketest` and confirm `conclusion: success`.
- [ ] In OCI Console → Developer Services → Container Registry → configured region, confirm a `synth-setter` repo exists with a `dev-snapshot` tag.
- [ ] Pull from OCIR locally to confirm the mirrored manifest is valid: `docker pull <region>.ocir.io/<namespace>/synth-setter:dev-snapshot`.

Closes #794
Closes #790