### PR TITLE
ci(docker): rebuild dev-snapshot on merge to main instead of weekly cron

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -4,7 +4,7 @@ name: Docker Image Build and Push
 # tests against the pushed image.
 #
 # Triggers:
-# - Manual dispatch or weekly schedule: full build + push + smoke tests
+# - Manual dispatch or push to main: full build + push + smoke tests
 # - Pull request (Docker-related paths): build-only validation (no push)
 #
 # git_ref resolution:
@@ -27,9 +27,8 @@ on:
         description: "GitHub issue number for config metadata."
         required: false
         default: "311"
-  schedule:
-    # Weekly: Sunday 06:00 UTC
-    - cron: "0 6 * * 0"
+  push:
+    branches: [main]
   pull_request:
     paths:
       - "docker/**"
@@ -49,21 +48,21 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # pull_request: use PR head; dispatch: use input; schedule: main
+          # pull_request: use PR head; dispatch: use input; push: main
           ref: ${{ github.event.pull_request.head.sha || github.event.inputs.git_ref || 'main' }}
 
       # Emits three outputs:
       #   sha         — 40-char commit SHA, baked into the image
       #   is_main     — "true" when this build represents the main branch and
       #                 should advance the shared `dev-snapshot`/`latest` tags.
-      #                 Covers schedule runs, the common ref forms a user might
+      #                 Covers push-to-main runs, the common ref forms a user might
       #                 paste into the dispatch input (`main`, `refs/heads/main`,
       #                 `refs/remotes/origin/main`), and the case where the
       #                 resolved HEAD equals origin/main's HEAD (e.g., a literal
       #                 SHA dispatch that happens to be main).
       #   branch_slug — Docker-tag-safe branch name for the `dev-snapshot-<branch>`
       #                 floating tag, or empty when no meaningful branch applies
-      #                 (schedule run, any main ref form, a git_ref already
+      #                 (push-to-main run, any main ref form, a git_ref already
       #                 resolved to a SHA, or a git tag dispatch). Well-known
       #                 ref prefixes (`refs/heads/`, `refs/remotes/origin/`) are
       #                 stripped before slugging so the same branch produces the
@@ -89,7 +88,7 @@ jobs:
           echo "sha=${resolved_sha}" >> "$GITHUB_OUTPUT"
 
           is_main="false"
-          if [ "$EVENT_NAME" = "schedule" ]; then
+          if [ "$EVENT_NAME" = "push" ]; then
             is_main="true"
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             case "$DISPATCH_REF" in
@@ -199,7 +198,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ steps.config.outputs.image }}
-          # Floating tags `dev-snapshot` and `latest` are gated to schedule
+          # Floating tags `dev-snapshot` and `latest` are gated to push-to-main
           # runs or dispatches that explicitly target main. Dispatching with
           # git_ref pointed at a non-main ref must NOT overwrite either tag —
           # other workflows (test-skypilot-debug, test-dataset-generation)

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -48,8 +48,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          # pull_request: use PR head; dispatch: use input; push: main
-          ref: ${{ github.event.pull_request.head.sha || github.event.inputs.git_ref || 'main' }}
+          # pull_request: use PR head; dispatch: use input; push: triggering SHA.
+          # `github.sha` pins push runs to the commit that fired the workflow so
+          # back-to-back merges don't cause one run to build a later main commit
+          # (and skip the immutable dev-snapshot-<sha> tag for the triggering one).
+          ref: ${{ github.event.pull_request.head.sha || github.event.inputs.git_ref || github.sha }}
 
       # Emits three outputs:
       #   sha         — 40-char commit SHA, baked into the image

--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -56,13 +56,19 @@ jobs:
 
       # Emits three outputs:
       #   sha         — 40-char commit SHA, baked into the image
-      #   is_main     — "true" when this build represents the main branch and
-      #                 should advance the shared `dev-snapshot`/`latest` tags.
-      #                 Covers push-to-main runs, the common ref forms a user might
-      #                 paste into the dispatch input (`main`, `refs/heads/main`,
-      #                 `refs/remotes/origin/main`), and the case where the
-      #                 resolved HEAD equals origin/main's HEAD (e.g., a literal
-      #                 SHA dispatch that happens to be main).
+      #   is_main     — "true" when this build represents the *current* main
+      #                 HEAD and should advance the shared `dev-snapshot`/`latest`
+      #                 tags. Covers push-to-main runs whose triggering SHA still
+      #                 equals origin/main's HEAD, the common ref forms a user
+      #                 might paste into the dispatch input (`main`,
+      #                 `refs/heads/main`, `refs/remotes/origin/main`), and the
+      #                 case where the resolved HEAD equals origin/main's HEAD
+      #                 (e.g., a literal SHA dispatch that happens to be main).
+      #                 Push runs whose triggering SHA has been overtaken by a
+      #                 newer main commit (delayed/queued runs, manual re-runs
+      #                 of older pushes) fall through to `false` so they only
+      #                 publish the immutable `dev-snapshot-<sha>` tag and don't
+      #                 clobber the floating tags with an older commit.
       #   branch_slug — Docker-tag-safe branch name for the `dev-snapshot-<branch>`
       #                 floating tag, or empty when no meaningful branch applies
       #                 (push-to-main run, any main ref form, a git_ref already
@@ -91,19 +97,18 @@ jobs:
           echo "sha=${resolved_sha}" >> "$GITHUB_OUTPUT"
 
           is_main="false"
-          if [ "$EVENT_NAME" = "push" ]; then
-            is_main="true"
-          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             case "$DISPATCH_REF" in
               main|refs/heads/main|refs/remotes/origin/main)
                 is_main="true"
                 ;;
             esac
-            if [ "$is_main" = "false" ]; then
-              main_sha=$(git ls-remote origin refs/heads/main | awk '{print $1}')
-              if [ -n "$main_sha" ] && [ "$resolved_sha" = "$main_sha" ]; then
-                is_main="true"
-              fi
+          fi
+          if [ "$is_main" = "false" ] \
+              && { [ "$EVENT_NAME" = "push" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; }; then
+            main_sha=$(git ls-remote origin refs/heads/main | awk '{print $1}')
+            if [ -n "$main_sha" ] && [ "$resolved_sha" = "$main_sha" ]; then
+              is_main="true"
             fi
           fi
           echo "is_main=${is_main}" >> "$GITHUB_OUTPUT"

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -320,8 +320,8 @@ dev-snapshot image, pushes to Docker Hub, and runs smoke tests.
 
 1. Validates the image config (`configs/image/dev-snapshot.yaml` via Pydantic)
 2. Builds the image using Docker Buildx
-3. Pushes tagged images to Docker Hub (dispatch/schedule only)
-4. Runs smoke tests against the SHA-pinned tag (dispatch/schedule only)
+3. Pushes tagged images to Docker Hub (dispatch/push-to-main only)
+4. Runs smoke tests against the SHA-pinned tag (dispatch/push-to-main only)
 
 On **pull requests** (Docker-related paths only), the workflow runs steps 1–2
 as build validation — no push, no smoke tests.
@@ -340,7 +340,7 @@ If the YAML violates the schema, the workflow fails before any build starts.
 | `tinaudio/synth-setter:devcontainer-tools-<sha>` | No       | Immutable, pinnable from `.devcontainer/Dockerfile`                              |
 
 Both `latest` and `dev-snapshot` are gated to runs that represent the main
-branch — schedule runs, dispatches with `git_ref` in `{main, refs/heads/main, refs/remotes/origin/main}`, and dispatches with a 40-char SHA that resolves
+branch — push-to-main runs, dispatches with `git_ref` in `{main, refs/heads/main, refs/remotes/origin/main}`, and dispatches with a 40-char SHA that resolves
 to the current `origin/main` HEAD (so a deliberate "rebuild main at this
 exact commit" still advances the floating tags). Feature-branch dispatches
 publish to `dev-snapshot-<branch>` instead of overwriting `dev-snapshot`.


### PR DESCRIPTION
## Summary

- Replace the `schedule: cron: "0 6 * * 0"` trigger in `.github/workflows/docker-build-validation.yml` with `push: branches: [main]`, so every merge to `main` rebuilds and pushes the `dev-snapshot` Docker image (and the `latest` floating tag) immediately rather than waiting for the next Sunday rebuild.
- Updates the corresponding header trigger comment ("weekly schedule" -> "push to main"), the inline comments around the `is_main` resolver and the metadata-action `tags:` block ("schedule runs" -> "push-to-main runs"), and the resolver's `EVENT_NAME = "schedule"` branch -> `EVENT_NAME = "push"` so push-to-main builds advance the shared `dev-snapshot`/`latest` floating tags exactly as the schedule branch did.
- Pin the checkout `ref:` for `push` events to `github.sha` (instead of the literal `'main'` fallback) so two merges landing in quick succession each build the SHA that fired their own run; otherwise the first run could check out the second commit and never publish a `dev-snapshot-<sha>` tag for its trigger.
- `workflow_dispatch:` and the existing `pull_request:` paths trigger are untouched.

## Why

`dev-snapshot` lags `main` by up to a week today. Newly-added Python requirements (e.g. `skypilot[runpod,oci]==0.12.0` from #777) sit in `requirements-app.txt` but aren't baked into the published `tinaudio/synth-setter:dev-snapshot` image until the next Sunday rebuild. CI workflows have to paper over the gap with runtime `pip install` bridges:

- `.github/workflows/test-dataset-generation.yml` — `pip install skypilot[oci]` before launching the SkyPilot worker.
- `.github/workflows/test-skypilot-debug.yml` — same bridge.

Each bridge wastes a few minutes per run, masks "should already be in the image" drift, and grows whenever a new dep lands. Rebuilding on every push to main keeps the published image in lockstep with HEAD-of-main and lets a follow-up PR strip those bridges.

This PR intentionally does NOT remove the bridges — that's a separate follow-up that needs the new image to actually exist first.

## Verification

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/docker-build-validation.yml'))"` -> YAML OK; on triggers: `['workflow_dispatch', 'push', 'pull_request']`.
- `gha-workflow-validator` skill: 11 passed, 0 new failures or warnings introduced (path "failures" are git-ref strings extracted from comments, unrelated to this change).
- `make format` -> all pre-commit hooks pass.
- The first `pull_request` run of this PR exercises the build-only validation path (no push, identical to today's PR validation).
- Once merged, the first `push: main` run will exercise the full build + push + smoke-tests path that previously only ran on Sunday.

## Test plan

- [ ] CI green on this PR (build-only validation path on `pull_request`).
- [ ] After merge, the auto-triggered `push: main` run rebuilds + pushes `dev-snapshot` and `latest` tags successfully.
- [ ] Open the follow-up PR to strip the runtime `pip install skypilot[oci]` bridge from `test-dataset-generation.yml` and `test-skypilot-debug.yml`.

Part of #796
Refs #670