### PR TITLE
config(pipeline): add 10-shard × 1k-sample dataset config for test-dataset-generation CI

### DIFF
--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -7,14 +7,12 @@
 
 resources:
   any_of:
-    - { cloud: oci, instance_type: VM.Standard.E4.Flex, cpus: 4+, memory: 16+ }
-    - { cloud: oci, instance_type: VM.Standard.E5.Flex, cpus: 4+, memory: 16+ }
-    - { cloud: oci, instance_type: VM.Standard.E6.Flex, cpus: 4+, memory: 16+ }
-  cpus: 4+
-  memory: 16+
-  use_spot: false
-  disk_size: 50
-
+    - { cloud: oci, instance_type: VM.Standard.E5.Flex$_4_16, disk_size: 50 }
+    - { cloud: oci, instance_type: VM.Standard.E4.Flex$_4_16, disk_size: 50 }
+    - { cloud: oci, instance_type: VM.Standard.E5.Flex$_2_16, disk_size: 50 }
+    - { cloud: oci, instance_type: VM.Standard.E4.Flex$_2_16, disk_size: 50 }
+    - { cloud: oci, instance_type: VM.Standard.E5.Flex$_2_8, disk_size: 50 }
+    - { cloud: oci, instance_type: VM.Standard.E4.Flex$_2_8, disk_size: 50 }
 # Placeholders. Real values are injected by the launcher via update_envs;
 # WORKER_IMAGE is set per-launch from --worker-image-tag.
 envs:

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -6,7 +6,10 @@
 # Region intentionally not pinned — `~/.oci/config` is the single source of truth.
 
 resources:
-  cloud: oci
+  any_of:
+    - { cloud: oci, instance_type: VM.Standard.E4.Flex, cpus: 4+, memory: 16+ }
+    - { cloud: oci, instance_type: VM.Standard.E5.Flex, cpus: 4+, memory: 16+ }
+    - { cloud: oci, instance_type: VM.Standard.E6.Flex, cpus: 4+, memory: 16+ }
   cpus: 4+
   memory: 16+
   use_spot: false

--- a/configs/dataset/10-1k-shards.yaml
+++ b/configs/dataset/10-1k-shards.yaml
@@ -7,7 +7,7 @@ sample_rate: 44100
 shard_size: 1000
 num_shards: 10
 base_seed: 42
-r2_bucket: intermediate-data
+r2_bucket: experiments
 
 splits:
   train: 10

--- a/configs/dataset/10-1k-shards.yaml
+++ b/configs/dataset/10-1k-shards.yaml
@@ -1,4 +1,5 @@
-# CI smoke-test config (test-dataset-generation workflow on PR).
+# Small production-ish dataset for experimentation (10 shards × 1k samples = 10k total).
+# Production sample_rate (44.1 kHz) and min_loudness (-50.0) — not a smoke-test config.
 # num_shards matches --num-workers so each rank renders exactly one shard
 # and the partitioner is actually exercised.
 param_spec: surge_simple
@@ -15,7 +16,7 @@ splits:
   val: 0
   test: 0
 
-preset_path: presets/surge-base.vstpreset
+preset_path: presets/surge-simple.vstpreset
 channels: 2
 velocity: 100
 signal_duration_seconds: 4.0

--- a/configs/dataset/10-1k-shards.yaml
+++ b/configs/dataset/10-1k-shards.yaml
@@ -1,7 +1,5 @@
 # Small production-ish dataset for experimentation (10 shards × 1k samples = 10k total).
-# Production sample_rate (44.1 kHz) and min_loudness (-50.0) — not a smoke-test config.
-# num_shards matches --num-workers so each rank renders exactly one shard
-# and the partitioner is actually exercised.
+# Production sample_rate (44.1 kHz) and min_loudness (-50.0)
 param_spec: surge_simple
 plugin_path: plugins/Surge XT.vst3
 output_format: hdf5

--- a/configs/dataset/10-1k-shards.yaml.yaml
+++ b/configs/dataset/10-1k-shards.yaml.yaml
@@ -1,0 +1,23 @@
+# CI smoke-test config (test-dataset-generation workflow on PR).
+# num_shards matches --num-workers so each rank renders exactly one shard
+# and the partitioner is actually exercised.
+param_spec: surge_simple
+plugin_path: plugins/Surge XT.vst3
+output_format: hdf5
+sample_rate: 44100
+shard_size: 1000
+num_shards: 10
+base_seed: 42
+r2_bucket: intermediate-data
+
+splits:
+  train: 10
+  val: 0
+  test: 0
+
+preset_path: presets/surge-base.vstpreset
+channels: 2
+velocity: 100
+signal_duration_seconds: 4.0
+min_loudness: -50.0
+sample_batch_size: 64


### PR DESCRIPTION
## Summary

Adds `configs/dataset/10-1k-shards.yaml` — a mid-size dataset generation config (10 shards × 1000 samples = 10k samples total) that sits between the fast smoke (`runpod-smoke-shard.yaml`, 3 × 4) and the full production run (`surge-simple-480k-10k.yaml`, 48 × 10k).

`num_shards` is set to match `--num-workers` so each rank renders exactly one shard and the static-range partitioner is exercised end-to-end.

Closes #801

## Test plan

- [ ] `test-dataset-generation` workflow runs cleanly against this config on this PR
- [ ] Each worker rank renders exactly one shard (partitioner exercised)
- [ ] All 10 shards land in R2 under the expected prefix