### PR TITLE
refactor(pipeline): drop OCI bridge + collapse provider matrix

### DIFF
--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -59,21 +59,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Compute the provider matrix at runtime. GH rejects `matrix.<x>` inside a
-  # job-level `if:`, so gating moves into this job's script and downstream
-  # jobs consume `generate_matrix` / `validate_matrix` via `fromJSON()`.
+  # Compute the provider list at runtime. Provider-specific values
+  # (template, cluster prefix, OCI image tag) are derived from the provider
+  # name in the consuming jobs via expressions, so the only thing this job
+  # has to publish is the JSON array.
   #
   # Policy:
   #   * pull_request (same repo) → OCI only
   #   * pull_request (fork)      → empty (forks can't read secrets)
   #   * workflow_dispatch        → respect `inputs.provider` (all|runpod|oci)
+  #
+  # Empty array → downstream matrices skip naturally; no `has_jobs` flag.
   setup:
-    name: Compute provider matrix
+    name: Compute provider list
     runs-on: ubuntu-latest
     outputs:
-      generate_matrix: ${{ steps.matrix.outputs.generate_matrix }}
-      validate_matrix: ${{ steps.matrix.outputs.validate_matrix }}
-      has_jobs: ${{ steps.matrix.outputs.has_jobs }}
+      providers: ${{ steps.matrix.outputs.providers }}
     steps:
       - id: matrix
         env:
@@ -83,53 +84,19 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-
-          providers=()
-          if [[ "${EVENT_NAME}" == "pull_request" ]]; then
-            if [[ "${PR_HEAD_REPO}" == "${REPO}" ]]; then
-              providers=("oci")
-            fi
+          if [[ "${EVENT_NAME}" == "pull_request" && "${PR_HEAD_REPO}" == "${REPO}" ]]; then
+            providers='["oci"]'
           elif [[ "${EVENT_NAME}" == "workflow_dispatch" ]]; then
             case "${PROVIDER_INPUT}" in
-              runpod) providers=("runpod") ;;
-              oci)    providers=("oci") ;;
-              *)      providers=("runpod" "oci") ;;
+              runpod) providers='["runpod"]' ;;
+              oci)    providers='["oci"]' ;;
+              *)      providers='["runpod","oci"]' ;;
             esac
-          fi
-
-          runpod_entry='{"provider":"runpod","template":"configs/compute/runpod-template.yaml","cluster_prefix":"synth-setter-smoke-runpod","oci_image_tag":""}'
-          oci_entry='{"provider":"oci","template":"configs/compute/oci-cpu-template.yaml","cluster_prefix":"synth-setter-smoke-oci","oci_image_tag":"skypilot:cpu-ubuntu-2204"}'
-
-          gen_entries=()
-          val_entries=()
-          if (( ${#providers[@]} > 0 )); then
-            for p in "${providers[@]}"; do
-              case "${p}" in
-                runpod) gen_entries+=("${runpod_entry}") ;;
-                oci)    gen_entries+=("${oci_entry}") ;;
-              esac
-              val_entries+=("\"${p}\"")
-            done
-          fi
-
-          gen_json="[$(IFS=,; echo "${gen_entries[*]:-}")]"
-          val_json="[$(IFS=,; echo "${val_entries[*]:-}")]"
-
-          if (( ${#providers[@]} > 0 )); then
-            has_jobs=true
           else
-            has_jobs=false
+            providers='[]'
           fi
-
-          {
-            echo "generate_matrix=${gen_json}"
-            echo "validate_matrix=${val_json}"
-            echo "has_jobs=${has_jobs}"
-          } >> "${GITHUB_OUTPUT}"
-
-          echo "providers: ${providers[*]:-<none>}"
-          echo "generate_matrix: ${gen_json}"
-          echo "validate_matrix: ${val_json}"
+          echo "providers=${providers}" >> "${GITHUB_OUTPUT}"
+          echo "providers: ${providers}"
 
   # Matrix over the providers selected by `setup`. Each cell exercises the
   # same provider-neutral launcher (pipeline.entrypoints.skypilot_launch_smoke)
@@ -140,13 +107,12 @@ jobs:
   generate:
     name: Launch generate_dataset on ${{ matrix.provider }} via SkyPilot
     needs: setup
-    if: needs.setup.outputs.has_jobs == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJSON(needs.setup.outputs.generate_matrix) }}
+        provider: ${{ fromJSON(needs.setup.outputs.providers) }}
     env:
       DATASET_CONFIG: >-
         ${{
@@ -171,15 +137,13 @@ jobs:
       # timeout-minutes: 60 is the safety bound. Cred-write is delegated to
       # scripts/skypilot_write_provider_creds.sh (umask 077; mode 600 on
       # every cred file). R2/W&B secrets land in container env via -e flags
-      # (no .env on disk). The runtime `pip install skypilot[oci]` bridge
-      # stays in until dev-snapshot rebuilds against the requirements bump
-      # in this PR; follow-up PR removes it.
+      # (no .env on disk).
       - name: Launch SkyPilot job (inside container; streams logs + blocks until done)
         env:
           PROVIDER: ${{ matrix.provider }}
-          TEMPLATE: ${{ matrix.template }}
-          CLUSTER_NAME: ${{ matrix.cluster_prefix }}-${{ github.run_id }}-${{ github.run_attempt }}
-          OCI_IMAGE_TAG: ${{ matrix.oci_image_tag }}
+          TEMPLATE: configs/compute/${{ matrix.provider == 'oci' && 'oci-cpu' || matrix.provider }}-template.yaml
+          CLUSTER_NAME: synth-setter-smoke-${{ matrix.provider }}-${{ github.run_id }}-${{ github.run_attempt }}
+          OCI_IMAGE_TAG: ${{ matrix.provider == 'oci' && 'skypilot:cpu-ubuntu-2204' || '' }}
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
           OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
           OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
@@ -228,10 +192,6 @@ jobs:
               ln -sf "/usr/lib/vst3/Surge XT.vst3" "plugins/Surge XT.vst3"
               bash scripts/skypilot_write_provider_creds.sh
               if [[ "$PROVIDER" == "oci" ]]; then
-                if ! python -c "import oci" 2>/dev/null; then
-                  echo "[oci-bridge] dev-snapshot lacks oci sdk; installing skypilot[oci] at runtime"
-                  pip install --quiet "skypilot[oci]==0.12.0" || { echo "::error::oci bridge install failed" >&2; exit 1; }
-                fi
                 sky check oci
               fi
               python -m pipeline.entrypoints.skypilot_launch_smoke \
@@ -273,13 +233,13 @@ jobs:
   validate-spec:
     name: Validate ${{ matrix.provider }} spec structure
     needs: [setup, generate]
-    if: needs.setup.outputs.has_jobs == 'true' && !cancelled()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
       fail-fast: false
       matrix:
-        provider: ${{ fromJSON(needs.setup.outputs.validate_matrix) }}
+        provider: ${{ fromJSON(needs.setup.outputs.providers) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -297,13 +257,13 @@ jobs:
   validate-shard:
     name: Validate ${{ matrix.provider }} shards
     needs: [setup, generate]
-    if: needs.setup.outputs.has_jobs == 'true' && !cancelled()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
-        provider: ${{ fromJSON(needs.setup.outputs.validate_matrix) }}
+        provider: ${{ fromJSON(needs.setup.outputs.providers) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/pipeline/entrypoints/skypilot_launch_smoke.py
+++ b/pipeline/entrypoints/skypilot_launch_smoke.py
@@ -296,22 +296,13 @@ def _override_image_id(task: sky.Task, worker_image: str) -> None:
     a sub-docker invocation inside the YAML's run: block and consumes WORKER_IMAGE from env, so
     OCI Resources are left untouched here.
     """
-    # Lazy-import: the RunPod CI cell runs this launcher inside a dev-snapshot
-    # image that doesn't always carry `skypilot[oci]` extras (the OCI matrix
-    # cell pip-installs the bridge at runtime, RunPod doesn't). Importing at
-    # module level would break the RunPod cell on those images.
-    try:
-        from sky.clouds import OCI as SkyOCI
-
-        oci_cls: type | None = SkyOCI
-    except ImportError:
-        oci_cls = None
+    from sky.clouds import OCI
 
     docker_ref = f"docker:{worker_image}"
     new_resources: list[sky.Resources] = []
     mutated = False
     for res in task.resources:
-        if oci_cls is not None and isinstance(res.cloud, oci_cls):
+        if isinstance(res.cloud, OCI):
             new_resources.append(res)
             continue
         new_resources.append(res.copy(image_id=docker_ref))

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -12,8 +12,7 @@ click<8.2
 numpy
 pydantic>=2
 pyyaml
-# skypilot pin must stay in sync with the runtime bridge in
-# .github/workflows/test-dataset-generation.yml and the install in
+# Pin must stay in sync with the bare-runner install in
 # .github/workflows/test-skypilot-debug.yml.
 skypilot[runpod,oci]==0.12.0
 structlog

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch_smoke.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch_smoke.py
@@ -961,20 +961,3 @@ class TestOverrideImageId:
 
         oci_res.copy.assert_not_called()
         task.set_resources.assert_not_called()
-
-    def test_does_not_crash_when_oci_extras_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """When `skypilot[oci]` extras aren't installed (e.g. RunPod-only dev-snapshot images), the
-        lazy `from sky.clouds import OCI` raises ImportError; the function falls back to treating
-        every Resource as non-OCI and still mutates them."""
-        import sky.clouds
-
-        monkeypatch.delattr(sky.clouds, "OCI", raising=False)
-
-        runpod_cloud = MagicMock(name="RunPodCloud")
-        res = self._make_resource(runpod_cloud)
-        task = self._make_task([res])
-
-        _override_image_id(task, "tinaudio/synth-setter:test-tag")
-
-        res.copy.assert_called_once_with(image_id="docker:tinaudio/synth-setter:test-tag")
-        task.set_resources.assert_called_once()


### PR DESCRIPTION
## Summary

Follow-up to #791 / #792. `skypilot[runpod,oci]==0.12.0` ships in `dev-snapshot`
via `requirements-app.txt` (the umbrella `requirements.txt` includes it; the
Dockerfile installs `requirements.txt`), and #797 made the image rebuild on
every merge to main — so the runtime "bridge" workarounds in
`test-dataset-generation.yml` + `skypilot_launch_smoke.py` are dead weight.
While in there, the dynamic-matrix `setup` script is collapsed: with
`oci_image_tag` no longer riding along, the matrix only needs the provider
name (template / cluster prefix / OCI image tag derive cleanly from
`matrix.provider` via expressions in the consuming step).

### Removed (lazy-load cleanup)

- `if [[ "$PROVIDER" == "oci" ]] ... pip install skypilot[oci]==0.12.0 ... fi`
  block inside the launch step in `test-dataset-generation.yml`. `sky check oci`
  remains as a fast-fail probe of the cred file.
- `try/except ImportError` around `from sky.clouds import OCI` in
  `_override_image_id` — now a direct import inside the function.
- `test_does_not_crash_when_oci_extras_missing` — the OCI-resource-untouched
  guarantee is still covered by `test_oci_resource_left_untouched`.
- "Pin must stay in sync with the runtime bridge" comment in
  `requirements-app.txt`.

### Simplified (matrix collapse)

- `setup` job's ~60-line bash script → ~15 lines, with one output
  (`providers`) instead of three (`generate_matrix`, `validate_matrix`,
  `has_jobs`).
- `generate.matrix.include` (4-field per provider) → `provider:` (single
  axis); `TEMPLATE`, `CLUSTER_NAME`, `OCI_IMAGE_TAG` become expressions on
  `matrix.provider`.
- `validate-spec` / `validate-shard` consume the same `providers` array.
- `has_jobs` flag and its three `if:` gates dropped (empty `fromJSON('[]')`
  skips a matrix job natively); validate jobs keep `if: !cancelled()` for
  per-provider decoupling.

Net diff: 4 files, +28 / -95 lines.

### Out of scope

- Bare-runner `pip install skypilot[runpod,oci]` in `test-skypilot-debug.yml`
  line 216 — runs outside docker for `inline-sky` / `launcher-runner` modes;
  not a lazy load.
- The 12-entry `include:` matrix in `test-skypilot-debug.yml` — its
  verbosity doubles as canary-layer documentation.

## Test plan

- [x] `make format` / pre-commit hooks green (ruff, ruff-format, pyright,
      docformatter, prettier, codespell, GHA workflow validator)
- [x] `python -c "import ast; ast.parse(open('pipeline/entrypoints/skypilot_launch_smoke.py').read())"` and the test file
- [x] YAML round-trips: `yaml.safe_load(...)` produces 4 jobs (`setup`,
      `generate`, `validate-spec`, `validate-shard`)
- [x] `pyright pipeline/entrypoints/skypilot_launch_smoke.py tests/...` clean
      (against a venv with `requirements-app.txt`)
- [ ] CI `Code Quality PR` green
- [ ] CI `Test Dataset Generation` (this PR) green — same-repo PR runs OCI-only
      by policy; bridge step **must be absent** from the rendered job log
- [ ] `workflow_dispatch` with `provider=runpod` — `OCI_IMAGE_TAG` resolves to
      `''`, `TEMPLATE` to `configs/compute/runpod-template.yaml`
- [ ] `workflow_dispatch` with `provider=oci` — `OCI_IMAGE_TAG` resolves to
      `skypilot:cpu-ubuntu-2204`, `TEMPLATE` to
      `configs/compute/oci-cpu-template.yaml`
- [ ] `workflow_dispatch` with `provider=all` — both providers run; shard
      validation downloads all materialized shards from R2

Closes #800.