### PR TITLE
chore(config): clear stale absolute data paths in configs/data/*.yaml

### DIFF
--- a/configs/data/fsd.yaml
+++ b/configs/data/fsd.yaml
@@ -4,4 +4,4 @@ batch_size: 32
 num_workers: 4
 segment_length_seconds: 4.0
 shuffle: true
-stats_file: /data/scratch/acw585/surge/stats.npz
+stats_file: ???

--- a/configs/data/nsynth.yaml
+++ b/configs/data/nsynth.yaml
@@ -4,4 +4,4 @@ batch_size: 32
 num_workers: 4
 segment_length_seconds: 4.0
 shuffle: true
-stats_file: /data/scratch/acw585/surge/stats.npz
+stats_file: ???

--- a/configs/data/surge.yaml
+++ b/configs/data/surge.yaml
@@ -1,7 +1,7 @@
 _target_: src.data.surge_datamodule.SurgeDataModule
-dataset_root: /data/scratch/acw585/surge/
+dataset_root: ???
 use_saved_mean_and_variance: true
 batch_size: 128
 ot: true
 num_workers: 11
-predict_file: /data/scratch/acw585/surge/shard-205.h5
+predict_file: ???

--- a/configs/data/surge_debug.yaml
+++ b/configs/data/surge_debug.yaml
@@ -1,8 +1,8 @@
 _target_: src.data.surge_datamodule.SurgeDataModule
-dataset_root: /data/scratch/acw585/surge-mini/
+dataset_root: ???
 use_saved_mean_and_variance: true
 batch_size: 128
 ot: true
 num_workers: 11
-predict_file: /data/scratch/acw585/surge-mini/shard-1.h5
+predict_file: ???
 repeat_first_batch: true

--- a/configs/data/surge_mini.yaml
+++ b/configs/data/surge_mini.yaml
@@ -1,7 +1,7 @@
 _target_: src.data.surge_datamodule.SurgeDataModule
-dataset_root: /data/scratch/acw585/surge-mini/
+dataset_root: ???
 use_saved_mean_and_variance: true
 batch_size: 128
 ot: true
 num_workers: 11
-predict_file: /data/scratch/acw585/surge-mini/shard-201.h5
+predict_file: ???

--- a/configs/data/surge_simple.yaml
+++ b/configs/data/surge_simple.yaml
@@ -1,7 +1,7 @@
 _target_: src.data.surge_datamodule.SurgeDataModule
-dataset_root: /data/scratch/acw585/surge-simple/
+dataset_root: ???
 use_saved_mean_and_variance: true
 batch_size: 128
 ot: true
 num_workers: 11
-predict_file: /data/scratch/acw585/surge-simple/shard-205.h5
+predict_file: ???

--- a/docs/design/eval-pipeline.md
+++ b/docs/design/eval-pipeline.md
@@ -47,15 +47,15 @@ Topline goal: Run the full evaluation pipeline — predict, render, metrics — 
 
 This pipeline works end-to-end today but is tightly coupled to a university HPC cluster:
 
-| Coupling             | Where                                                | Impact                                           |
-| -------------------- | ---------------------------------------------------- | ------------------------------------------------ |
-| Hardcoded paths      | `configs/data/surge*.yaml` → `/data/scratch/acw585/` | Cannot run on any other machine                  |
-| SGE directives       | `jobs/predict/*.sh` → `#$ -l gpu=1`                  | 19 near-identical scripts, one per model variant |
-| Module system        | `module load gcc`, `module load hdf5-parallel`       | Not available outside HPC                        |
-| Conda env            | `mamba activate perm`                                | Specific to cluster user's env                   |
-| Apptainer container  | `apptainer exec --nv ...`                            | Not available on Mac/Linux dev machines          |
-| Checkpoint retrieval | `scripts/get-ckpt-from-wandb.sh` (W&B download)      | Fragile, no R2 option                            |
-| Data locality        | Datasets assumed at fixed cluster paths              | No remote download capability                    |
+| Coupling              | Where                                                                  | Impact                                                                                                    |
+| --------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| Mandatory `???` paths | `configs/data/surge*.yaml` use `???` for `dataset_root`/`predict_file` | Caller must supply paths per-machine; `${paths.data_dir}/{config_id}/{run_id}` convention not yet adopted |
+| SGE directives        | `jobs/predict/*.sh` → `#$ -l gpu=1`                                    | 19 near-identical scripts, one per model variant                                                          |
+| Module system         | `module load gcc`, `module load hdf5-parallel`                         | Not available outside HPC                                                                                 |
+| Conda env             | `mamba activate perm`                                                  | Specific to cluster user's env                                                                            |
+| Apptainer container   | `apptainer exec --nv ...`                                              | Not available on Mac/Linux dev machines                                                                   |
+| Checkpoint retrieval  | `scripts/get-ckpt-from-wandb.sh` (W&B download)                        | Fragile, no R2 option                                                                                     |
+| Data locality         | Datasets assumed at fixed cluster paths                                | No remote download capability                                                                             |
 
 Separately, the data pipeline (#74) already uses R2 as the source of truth for generated datasets. Extending R2 to the eval workflow — auto-downloading datasets and uploading eval artifacts — and using W&B for checkpoint storage closes the loop so the full workflow (generate → train → eval) can run from any machine with an internet connection.
 
@@ -585,21 +585,21 @@ This section consolidates every configuration and environment behavior change in
 
 #### Current behavior (as-is)
 
-| Concern                   | Current mechanism                                                   | Where defined                              | Portable? | Problem                                           |
-| ------------------------- | ------------------------------------------------------------------- | ------------------------------------------ | --------- | ------------------------------------------------- |
-| **Dataset path**          | Hardcoded `/data/scratch/acw585/surge_simple/`                      | `configs/data/surge_simple.yaml`           | No        | Only works on university cluster                  |
-| **Checkpoint resolution** | `get-ckpt-from-wandb.sh` searches local `logs/train/` by W&B run ID | `jobs/predict/*.sh` (19 scripts)           | No        | Requires training logs on same machine            |
-| **Checkpoint path**       | `ckpt_path: ???` in eval, resolved by shell script to local path    | `configs/eval.yaml` + shell                | No        | Local filesystem dependency                       |
-| **R2 dataset access**     | Not supported                                                       | —                                          | —         | Must manually copy data to machine                |
-| **Checkpoint access**     | `get-ckpt-from-wandb.sh` (local filesystem search by W&B run ID)    | `jobs/predict/*.sh`                        | No        | Only works on the machine where training happened |
-| **Checkpoint upload**     | W&B `log_model: "all"` — uploads every checkpoint immediately       | `configs/logger/wandb.yaml`                | Yes       | —                                                 |
-| **Credentials**           | No `.env` pattern for R2                                            | —                                          | —         | No standardized credential management             |
-| **Display handling**      | `renderscript.sh` assumes Linux + Xvfb                              | `renderscript.sh`                          | No        | Fails on macOS (no Xvfb needed), no auto-detect   |
-| **Log directory**         | `${paths.root_dir}/logs/` via `PROJECT_ROOT`                        | `configs/paths/default.yaml`               | Yes       | Already works                                     |
-| **Predict output**        | `${paths.output_dir}/predictions`                                   | `configs/callbacks/prediction_writer.yaml` | Yes       | Already works                                     |
-| **W&B entity**            | Hardcoded `entity: "benhayes"`                                      | `configs/logger/wandb.yaml`                | No        | Wrong for other users                             |
-| **SGE scripts**           | 19 near-identical scripts, one per model                            | `jobs/predict/*.sh`                        | No        | Copy-paste errors, cluster-only                   |
-| **Eval CLI**              | Raw `python src/eval.py ...` with many args                         | Shell scripts                              | No        | No `make` targets, hard to discover               |
+| Concern                   | Current mechanism                                                                      | Where defined                              | Portable? | Problem                                                     |
+| ------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------ | --------- | ----------------------------------------------------------- |
+| **Dataset path**          | `???` (Hydra mandatory override) — caller must pass `data.dataset_root=...` on the CLI | `configs/data/surge_simple.yaml`           | No        | Per-machine; `${paths.data_dir}` convention not yet adopted |
+| **Checkpoint resolution** | `get-ckpt-from-wandb.sh` searches local `logs/train/` by W&B run ID                    | `jobs/predict/*.sh` (19 scripts)           | No        | Requires training logs on same machine                      |
+| **Checkpoint path**       | `ckpt_path: ???` in eval, resolved by shell script to local path                       | `configs/eval.yaml` + shell                | No        | Local filesystem dependency                                 |
+| **R2 dataset access**     | Not supported                                                                          | —                                          | —         | Must manually copy data to machine                          |
+| **Checkpoint access**     | `get-ckpt-from-wandb.sh` (local filesystem search by W&B run ID)                       | `jobs/predict/*.sh`                        | No        | Only works on the machine where training happened           |
+| **Checkpoint upload**     | W&B `log_model: "all"` — uploads every checkpoint immediately                          | `configs/logger/wandb.yaml`                | Yes       | —                                                           |
+| **Credentials**           | No `.env` pattern for R2                                                               | —                                          | —         | No standardized credential management                       |
+| **Display handling**      | `renderscript.sh` assumes Linux + Xvfb                                                 | `renderscript.sh`                          | No        | Fails on macOS (no Xvfb needed), no auto-detect             |
+| **Log directory**         | `${paths.root_dir}/logs/` via `PROJECT_ROOT`                                           | `configs/paths/default.yaml`               | Yes       | Already works                                               |
+| **Predict output**        | `${paths.output_dir}/predictions`                                                      | `configs/callbacks/prediction_writer.yaml` | Yes       | Already works                                               |
+| **W&B entity**            | Hardcoded `entity: "benhayes"`                                                         | `configs/logger/wandb.yaml`                | No        | Wrong for other users                                       |
+| **SGE scripts**           | 19 near-identical scripts, one per model                                               | `jobs/predict/*.sh`                        | No        | Copy-paste errors, cluster-only                             |
+| **Eval CLI**              | Raw `python src/eval.py ...` with many args                                            | Shell scripts                              | No        | No `make` targets, hard to discover                         |
 
 #### Proposed behavior (to-be)
 
@@ -1184,20 +1184,22 @@ and **eval artifacts** (audio files, prediction tensors — no W&B UI benefit).
 
 ### Eval Scripts
 
-| File                               | Lines    | Purpose                                     | Cluster coupling                               |
-| ---------------------------------- | -------- | ------------------------------------------- | ---------------------------------------------- |
-| `src/eval.py`                      | 121      | Hydra entry point for predict/test/validate | Hardcoded paths in data configs                |
-| `scripts/predict_vst_audio.py`     | 232      | VST rendering from predicted parameters     | Plugin path defaults                           |
-| `renderscript.sh`                  | 59       | Xvfb wrapper for headless rendering         | Assumes Linux, no macOS support                |
-| `scripts/compute_audio_metrics.py` | 323      | Parallel metric computation                 | None (already portable)                        |
-| `jobs/predict/*.sh`                | 19 files | SGE job scripts, one per model (deprecated) | SGE directives, hardcoded paths, `module load` |
+| File                               | Lines    | Purpose                                     | Cluster coupling                                                          |
+| ---------------------------------- | -------- | ------------------------------------------- | ------------------------------------------------------------------------- |
+| `src/eval.py`                      | 121      | Hydra entry point for predict/test/validate | Data configs require explicit `dataset_root`/`predict_file` (no defaults) |
+| `scripts/predict_vst_audio.py`     | 232      | VST rendering from predicted parameters     | Plugin path defaults                                                      |
+| `renderscript.sh`                  | 59       | Xvfb wrapper for headless rendering         | Assumes Linux, no macOS support                                           |
+| `scripts/compute_audio_metrics.py` | 323      | Parallel metric computation                 | None (already portable)                                                   |
+| `jobs/predict/*.sh`                | 19 files | SGE job scripts, one per model (deprecated) | SGE directives, hardcoded paths, `module load`                            |
 
 ### Data Configs
 
-| File                             | Hardcoded path                       |
-| -------------------------------- | ------------------------------------ |
-| `configs/data/surge_simple.yaml` | `/data/scratch/acw585/surge_simple/` |
-| `configs/data/surge_mini.yaml`   | `/data/scratch/acw585/surge-mini/`   |
+| File                             | Default `dataset_root`           |
+| -------------------------------- | -------------------------------- |
+| `configs/data/surge_simple.yaml` | `???` (Hydra mandatory override) |
+| `configs/data/surge_mini.yaml`   | `???` (Hydra mandatory override) |
+
+The original cluster paths (`/data/scratch/acw585/...`) are preserved in git history.
 
 ### Audio Dir Manifests
 

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -210,11 +210,11 @@ Gaps are configuration inputs that design docs specify or that standard practice
 
 ### 5.3 Data Portability
 
-| Input               | Type   | What's Needed                                                                    | Reference                 |
-| ------------------- | ------ | -------------------------------------------------------------------------------- | ------------------------- |
-| `data.dataset_root` | string | Remove hardcoded `/data/scratch/...` paths; use env-based or `${paths.data_dir}` | training-pipeline.md §1   |
-| `data.r2_path`      | string | Optional R2 URI for remote dataset sync before training                          | training-pipeline.md §6.1 |
-| `data.stats_file`   | string | Remove hardcoded paths in nsynth/fsd configs                                     | training-pipeline.md §1   |
+| Input               | Type   | What's Needed                                                                                                 | Reference                 |
+| ------------------- | ------ | ------------------------------------------------------------------------------------------------------------- | ------------------------- |
+| `data.dataset_root` | string | Hardcoded paths removed (now `???`); migrate to `${paths.data_dir}` convention still open                     | training-pipeline.md §1   |
+| `data.r2_path`      | string | Optional R2 URI for remote dataset sync before training                                                       | training-pipeline.md §6.1 |
+| `data.stats_file`   | string | Hardcoded paths removed (now `???` in `nsynth.yaml`/`fsd.yaml`); replace with run-id-aware default still open | training-pipeline.md §1   |
 
 ### 5.4 Hardware & Compute
 


### PR DESCRIPTION
## Summary

Replace hard-coded absolute filesystem paths in six Hydra data configs with Hydra's mandatory-override sentinel (`???`):

- `configs/data/fsd.yaml` — `stats_file`
- `configs/data/nsynth.yaml` — `stats_file`
- `configs/data/surge.yaml` — `dataset_root`, `predict_file`
- `configs/data/surge_debug.yaml` — `dataset_root`, `predict_file`
- `configs/data/surge_mini.yaml` — `dataset_root`, `predict_file`
- `configs/data/surge_simple.yaml` — `dataset_root`, `predict_file`

The previous defaults (`/data/scratch/acw585/...`) pointed at one operator's home directory on a long-decommissioned shared cluster. Any run that forgot to override these on the CLI silently inherited an unreachable filesystem path — usually surfacing later as an opaque `FileNotFoundError` or worse, a bad `stats_file` lookup deep into training.

With `???`, Hydra raises `MissingMandatoryValue` immediately at config-resolve time, naming the missing field. Loud-fail beats silent-misuse.

## Why now

Caught while preparing the run-monitoring + eval-on-captured-audio work; want training/eval configs to fail loudly when these paths are missing rather than quietly resolve to a non-existent default.

## Test plan

- [ ] `python -c "from hydra import compose, initialize; ..."` resolving `data=surge_simple` without `+data.dataset_root=...` raises `MissingMandatoryValue`.
- [ ] An actual training launch with `data=surge_simple data.dataset_root=$LOCAL_PATH data.predict_file=$LOCAL_PATH/shard.h5` continues to work.
- [ ] Pre-commit (yaml hooks) passes.

Closes #808