### PR TITLE
build(devcontainer): add root_gpu variant with docker-in-docker + act

### DIFF
--- a/.devcontainer/root_gpu/devcontainer.json
+++ b/.devcontainer/root_gpu/devcontainer.json
@@ -1,0 +1,67 @@
+{
+  "name": "synth-setter (gpu)",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "context": "..",
+    "options": [
+      "--platform=linux/amd64"
+    ]
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/dhoeric/features/act:1": {}
+  },
+  "initializeCommand": "bash .devcontainer/initialize.sh",
+  "runArgs": [
+    "--gpus",
+    "all",
+    "--shm-size=16g",
+    "--env-file",
+    ".env"
+  ],
+  "containerEnv": {
+    "MODE": "idle"
+  },
+  "remoteUser": "${localEnv:DEVCONTAINER_USER:root}",
+  "updateRemoteUserUID": true,
+  "workspaceFolder": "/home/build/synth-setter",
+  "postCreateCommand": ".devcontainer/post-create.sh",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.debugpy",
+        "ms-python.vscode-python-envs",
+        "charliermarsh.ruff",
+        "ms-toolsai.jupyter",
+        "ms-toolsai.jupyter-keymap",
+        "ms-toolsai.jupyter-renderers",
+        "ms-toolsai.vscode-jupyter-cell-tags",
+        "ms-toolsai.vscode-jupyter-slideshow",
+        "redhat.vscode-yaml",
+        "kamilturek.vscode-pyproject-toml-snippets",
+        "ms-vscode.makefile-tools",
+        "jetmartin.bats",
+        "timonwong.shellcheck",
+        "lochbrunner.vscode-hdf5-viewer",
+        "adamviola.parquet-explorer",
+        "mechatroner.rainbow-csv",
+        "github.vscode-pull-request-github",
+        "github.vscode-github-actions",
+        "eamodio.gitlens",
+        "anthropic.claude-code"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/venv/main/bin/python",
+        "python.terminal.activateEnvironment": false,
+        "editor.formatOnSave": true,
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": [
+          "tests"
+        ]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a third devcontainer flavor at `.devcontainer/root_gpu/` for workflow / CI authoring. Mirrors the GPU variant (same Dockerfile, GPU `runArgs`, VS Code extensions, post-create) but:

- **Defaults `remoteUser` to `root`** (`${localEnv:DEVCONTAINER_USER:root}`) so the container starts as root unless overridden — matches how the worker images run in CI/cloud.
- **Adds `docker-in-docker` and `act` features** so you can run nested docker and exercise GitHub Actions locally with `act` from inside the container.
- **Drops the gpu variant's named `bashhistory` and `plugins` volume mounts and explicit `workspaceMount`** — uses devcontainer defaults to keep this a thin tools-on-top variant.

The existing `cpu/` and `gpu/` variants are unchanged.

## Test plan

- [ ] `Dev Containers: Reopen in Container` against `.devcontainer/root_gpu/devcontainer.json` succeeds and starts as root.
- [ ] `docker info` inside the container succeeds (docker-in-docker feature wired).
- [ ] `act --list` inside the container resolves a workflow from `.github/workflows/`.
- [ ] `nvidia-smi` inside the container reports GPUs (when launched on a GPU host).

Closes #812