### PR TITLE
test(testing): allow data.* path drift vs MODEL_BASELINE after #809

### DIFF
--- a/tests/test_compare_baseline_configs.py
+++ b/tests/test_compare_baseline_configs.py
@@ -309,6 +309,10 @@ ACCEPTED_DIFFS: tuple[str, ...] = (
     "logger.wandb.entity",  # env-derived (${oc.env:WANDB_ENTITY,null})
     "logger.wandb.log_model",  # changed `true` → "all" (artifact upload policy, not training)
     "logger.wandb.project",  # env-derived (${oc.env:WANDB_PROJECT,synth-setter})
+    # Cleared to `???` (mandatory override) in #809 — dataset locality, not a model knob.
+    "data.dataset_root",
+    "data.predict_file",
+    "data.stats_file",
 )
 
 


### PR DESCRIPTION
## Summary

- After PR #809 replaced the absolute cluster paths in `configs/data/*.yaml` with Hydra's `???` mandatory-override sentinel, `test_compare_baseline_configs` started failing on every parametrized case that resolves a Surge data config (8 surge-train cases + 18 predict cases). Failing run: https://github.com/tinaudio/synth-setter/actions/runs/25386601838/job/74451695250
- The `MODEL_BASELINE` ref (`v0.0.0`) still resolves the old hardcoded paths; the live tree resolves to `???`. Add `data.dataset_root`, `data.predict_file`, and `data.stats_file` to `ACCEPTED_DIFFS` so the equality assertion catches actual model-behavior drift instead of dataset-locality changes.
- Same rationale as the existing `logger.wandb.entity`/`logger.wandb.project` env-derived entries: these are caller-supplied per-machine inputs, not model knobs. A baseline bump would be the wrong fix — `MODEL_BASELINE` pins the published-results-relevant snapshot, and PR #809 didn't change training behavior.

Refs #816

## Test plan

- [x] No-network unit tests in `tests/test_compare_baseline_configs.py` pass (`uvenv/bin/python -m pytest tests/test_compare_baseline_configs.py::test_ref_compare_case_slug_renders_correctly tests/test_compare_baseline_configs.py::test_get_num_experiments tests/test_compare_baseline_configs.py::test_k_osc_train_cases tests/test_compare_baseline_configs.py::test_surge_train_cases tests/test_compare_baseline_configs.py::test_predict_cases tests/test_compare_baseline_configs.py::test_resolve_pair_rejects_empty_yaml tests/test_compare_baseline_configs.py::test_injected_host_name_propagates_into_resolved_hydra_config -v` → 7 passed)
- [x] Smoke check that `_assert_resolved_configs_equal` strips the new keys (`'???'` vs `/data/scratch/...` no longer raises) but still raises on a real `data.batch_size` divergence
- [ ] CI `run_slow_tests` job goes green for `test_surge_train_configs_are_equal` and `test_predict_configs_are_equal`