### PR TITLE
build(deps): add oci sdk as standalone dep in requirements-app.txt

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -10,6 +10,7 @@ wandb
 # --------- pipeline --------- #
 click<8.2
 numpy
+oci
 pydantic>=2
 pyyaml
 # Pin must stay in sync with the bare-runner install in


### PR DESCRIPTION
## Summary

- Adds `oci` as a standalone, top-level dep in `requirements-app.txt` (pipeline section, alphabetical between `numpy` and `pydantic`).
- `oci` is already pulled in transitively via `skypilot[runpod,oci]==0.12.0`. Adding it explicitly so consumers can import it without depending on the SkyPilot extra's resolution.
- Unpinned to defer to whatever SkyPilot resolves; pin can be added later if drift becomes a concern.

Refs #785

## Test plan

- [ ] CI: pre-commit / lint passes
- [ ] CI: `pip install -r requirements-app.txt` succeeds (existing build job covers this)
- [ ] `python -c "import oci"` works in a fresh venv after install