### PR TITLE
monitoring: surge_xt_interactive Copilot nits + doc-drift cleanup

### DIFF
--- a/docs/design/eval-pipeline.md
+++ b/docs/design/eval-pipeline.md
@@ -211,6 +211,10 @@ The evaluation pipeline is a three-stage batch pipeline. Each stage is an indepe
 | Docker         | R2             | Xvfb (baked) | Baked in image      | CUDA | `make docker-eval` |
 | GitHub Actions | Repo fixture   | Xvfb         | Headless stub or CI | None | PR trigger         |
 
+### Consumers
+
+Interactive captured-patch evaluation: `scripts/surge_xt_interactive.py --checkpoint-path …` invokes the predict → render → metrics chain end-to-end via `eval_patches` (see [`docs/guides/surge-xt-interactive.md`](../guides/surge-xt-interactive.md)).
+
 ## 5. Stage Definitions
 
 ### 5.1 Predict

--- a/docs/guides/surge-xt-interactive.md
+++ b/docs/guides/surge-xt-interactive.md
@@ -80,8 +80,11 @@ python scripts/surge_xt_interactive.py \
 ```
 
 When `--session-recording-path` is set, the live audio stream is
-*replaced* by a fixed 10-second offline render: middle C held from
-2 s to 4 s, with the surrounding silence capturing any release tail.
+*replaced* by a fixed `SESSION_RECORDING_DURATION_SECONDS`-second offline
+render (currently 10): middle C held from
+`SESSION_RECORDING_NOTE_START_SECONDS` (2 s) to
+`SESSION_RECORDING_NOTE_END_SECONDS` (4 s), with the surrounding silence
+capturing any release tail.
 The render runs synchronously *before* the editor opens, so the WAV
 depends only on the initially-loaded plugin state (preset + `--pred`
 / `--dataset-ref` params) and the same inputs always produce the
@@ -104,12 +107,11 @@ raises `click.UsageError`.
 | `--param-spec-name`         | str                | `surge_xt`                     | Parameter spec name (key into `param_specs`) used to decode prediction/dataset rows applied to the plugin and to enumerate which synth params are captured when recording patches.                                                                                                                                                                                                                                                                                                                        |
 | `--output-dataset-dir-path` | path               | unset                          | Directory to create for the recorded patches. Must not already exist — `make_dataset` writes fixed-size HDF5 datasets without `maxshape` and cannot append to existing files. After the editor is closed, patches captured via the keyboard loop (press `p` to record, `q` to quit) are rendered through the plugin and written to `train.h5` inside this directory via `src.data.vst.generate_vst_dataset.make_dataset` (plus `val.h5`/`test.h5`/`predict.h5` siblings when `--checkpoint-path` is set). |
 | `--checkpoint-path`         | path               | unset                          | Optional checkpoint path to run standalone eval on after rendering captured patches. When set, triggers the `eval_patches` pipeline (`src/eval.py mode=predict` → `predict_vst_audio.py` → `compute_audio_metrics.py`); see [`docs/design/eval-pipeline.md`](../design/eval-pipeline.md) for the full pipeline and `_METRIC_COLUMNS` in the script for the metric series produced.                                                                                                                        |
-| `--session-recording-path`  | path               | unset                          | Optional WAV file to render a deterministic test clip to. When set, the script renders a fixed `SESSION_RECORDING_DURATION_SECONDS` (10 s) WAV containing middle C from `NOTE_START` (2 s) to `NOTE_END` (4 s) through the loaded plugin and exits the audio thread. No live device output. Output depends only on plugin state (preset + `--pred` / `--dataset-ref` params) — same inputs always produce the same WAV. No-op when not set.                                                               |
+| `--session-recording-path`  | path               | unset                          | Optional WAV file to render a deterministic test clip to. When set, the script renders a fixed `SESSION_RECORDING_DURATION_SECONDS` (10 s) WAV containing middle C from `SESSION_RECORDING_NOTE_START_SECONDS` (2 s) to `SESSION_RECORDING_NOTE_END_SECONDS` (4 s) through the loaded plugin and exits the audio thread. No live device output. Output depends only on plugin state (preset + `--pred` / `--dataset-ref` params) — same inputs always produce the same WAV. No-op when not set.           |
 
-Tip — the help strings above are quoted verbatim from the Click
-decorators in `scripts/surge_xt_interactive.py`. Run
-`python scripts/surge_xt_interactive.py --help` to confirm the current
-text.
+Tip — help strings above paraphrase the Click decorators in
+`scripts/surge_xt_interactive.py`. Run
+`python scripts/surge_xt_interactive.py --help` for the canonical text.
 
 ## The interactive session
 
@@ -158,9 +160,9 @@ to consume. Each file has these datasets:
 | `mel_spec`    | `(N, 2, 128, 401)`                              | `float32` | Mel spectrogram per channel. Compressed with Blosc2.                           |
 | `param_array` | `(N, P)`                                        | `float32` | Encoded params (`ParamSpec.encode` output) in `[0, 1]`. `P = len(param_spec)`. |
 
-Where `N = len(synth_patches)`, `sample_rate = 44100`, and
-`signal_duration_seconds = 4.0` (constants at the top of
-`scripts/surge_xt_interactive.py`).
+Where `N = len(synth_patches)`, `sample_rate = SAMPLE_RATE` (44100),
+and `signal_duration_seconds = MAKE_DATASET_SIGNAL_DURATION_SECONDS`
+(4.0); both at the top of `scripts/surge_xt_interactive.py`.
 
 The audio attached attrs on the `audio` dataset record the rendering
 config: `velocity`, `signal_duration_seconds`, `sample_rate`,

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -71,8 +71,9 @@ AUDIO_THREAD_DRAIN_TIMEOUT_SECONDS = 2
 
 # Deterministic recording clip when ``--session-recording-path`` is set.
 # The point is reproducibility: same plugin + preset + params -> same WAV.
-# A held middle-C note is rendered from ``NOTE_START`` to ``NOTE_END``,
-# inside a fixed-length window so any release tail is captured.
+# A held middle-C note is rendered from ``SESSION_RECORDING_NOTE_START_SECONDS``
+# to ``SESSION_RECORDING_NOTE_END_SECONDS``, inside a fixed-length window so any
+# release tail is captured.
 SESSION_RECORDING_DURATION_SECONDS = 10.0
 SESSION_RECORDING_MIDI_NOTE = 60  # middle C (C4)
 SESSION_RECORDING_VELOCITY = 100

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -139,9 +139,15 @@ def _validate_metrics_df(
             f"{metrics_path}: missing expected columns {sorted(missing_columns)}; "
             f"got {sorted(metrics_df.columns)}"
         )
-    numeric = metrics_df[sorted(expected.columns)].to_numpy()
+    expected_cols = sorted(expected.columns)
+    numeric = metrics_df[expected_cols].to_numpy()
     if not np.isfinite(numeric).all():
-        raise ValueError(f"{metrics_path} contains NaN/Inf:\n{metrics_df}")
+        bad_mask = ~np.isfinite(numeric).all(axis=1)
+        bad_rows = metrics_df.loc[bad_mask, expected_cols]
+        raise ValueError(
+            f"{metrics_path} contains NaN/Inf in {len(bad_rows)} of {len(metrics_df)} rows:\n"
+            f"{bad_rows}"
+        )
 
 
 @dataclass(frozen=True)
@@ -732,7 +738,7 @@ def eval_patches(
     "--checkpoint-path",
     type=click.Path(exists=True, dir_okay=False, path_type=Path),
     default=None,
-    help=("Optional checkpoint path to run standalone eval on after rendering captured patches. "),
+    help="Optional checkpoint path to run standalone eval on after rendering captured patches.",
 )
 @click.option(
     "--session-recording-path",


### PR DESCRIPTION
## Summary

Lands the two Copilot review nits that were missed when #835 was squash-merged. Cherry-pick of `3b488cf` (originally pushed to `feat/surge-mini-example` after the merge but never landed on `main`).

- `_validate_metrics_df`: on NaN/Inf, report only the offending rows (filtered to expected columns) instead of dumping the full metrics DataFrame. Keeps the `ValueError` message bounded for large `num_samples`.
- `--checkpoint-path` help: drop trailing space and redundant parens around the single string literal.

## Why this is a separate PR

The two nits arrived on PR #835 ~10 minutes before its squash merge and were not folded in. A post-merge automated reply chain on PR #835 incorrectly claimed they were "squash-merged as 146962a on main"; correction replies are being posted on those threads pointing at this PR.

## Test plan

- [x] `make test` — full suite passes locally.
- [x] `make format` — pre-commit clean.
- [ ] Verify `--help` no longer shows trailing whitespace on the `--checkpoint-path` line: `python scripts/surge_xt_interactive.py --help | grep -A1 checkpoint-path`.
- [ ] Manual: trigger the NaN-rows path on a synthetic `metrics.csv` with one bad row out of N and confirm the error names just that row (not the whole DataFrame).

## Doc-drift cleanup

Folded into this PR a single `docs:` commit addressing the doc-drift items the doc-drift hook flagged on this branch. They are scoped to the same files / surface area the Copilot-nit commit already touches, so bundling them avoids a separate one-commit PR for the same script and its guide.

- `docs/guides/surge-xt-interactive.md` CLI table: `NOTE_START` / `NOTE_END` -> the actual constants `SESSION_RECORDING_NOTE_START_SECONDS` / `SESSION_RECORDING_NOTE_END_SECONDS`.
- `scripts/surge_xt_interactive.py:74` script comment: same `NOTE_START` / `NOTE_END` drift, fixed to the full constant names. (Comment-only — no code-logic change.)
- Soften the "help strings above are quoted verbatim from the Click decorators" tip to "paraphrase" — several rows reorder/abbreviate; readers should run `--help` for the canonical text.
- Reference `SESSION_RECORDING_DURATION_SECONDS` / `*_NOTE_START_SECONDS` / `*_NOTE_END_SECONDS` by name on first mention in the quick-start prose (keeping the `(2 s)` / `(4 s)` / `(10)` parentheticals for readability).
- Name `SAMPLE_RATE` and `MAKE_DATASET_SIGNAL_DURATION_SECONDS` in the dataset-shape table prose instead of inlining the literal values.
- `docs/design/eval-pipeline.md`: add a `### Consumers` subsection at the end of §4 with a one-line back-reference to `scripts/surge_xt_interactive.py --checkpoint-path` / `eval_patches` as a consumer of the predict -> render -> metrics chain.

Refs #810