### PR TITLE
build(devcontainer): add tmux to devcontainer-tools image

### DIFF
--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -392,6 +392,7 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
       curl \
       jq \
+      tmux \
   && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -105,7 +105,8 @@ make docker-build-dev-snapshot \
   GIT_REF="$(git rev-parse HEAD)" \
   DOCKER_BUILD_FLAGS="--load"
 
-# devcontainer-tools — dev-base + gh, jq, Node.js, Claude Code, dev user
+# devcontainer-tools — dev-base + CLI tools, Node.js + Claude Code, dev user
+# (see the "devcontainer-tools" stage in docker/ubuntu22_04/Dockerfile)
 make docker-build-devcontainer-tools \
   GIT_REF="$(git rev-parse HEAD)" \
   DOCKER_BUILD_FLAGS="--load"
@@ -113,7 +114,8 @@ make docker-build-devcontainer-tools \
 
 The `devcontainer-tools` stage is a sibling of `dev-snapshot` — both stages
 build `FROM dev-base`, the shared parent that holds Surge XT, the venv, and
-the synth-setter source. `devcontainer-tools` adds CLI tooling (`gh`, `jq`),
+the synth-setter source. `devcontainer-tools` adds interactive CLI tooling
+(see the stage's `apt-get install` list and the GitHub CLI install block),
 Node.js + `@anthropic-ai/claude-code` installed system-wide, a non-root
 `dev` user, and a `/commandhistory` directory (owned by `dev`) that
 `.devcontainer/{cpu,gpu}/devcontainer.json` mounts as a named volume so bash


### PR DESCRIPTION
## Summary

- Adds `tmux` to the apt install list in the `devcontainer-tools` stage of `docker/ubuntu22_04/Dockerfile`, alongside the existing `curl` / `jq` / `gh` tools.
- Small dev-ergonomics improvement: provides a terminal multiplexer (multi-pane, detachable sessions) out of the box for shells inside the dev container.

Closes #837

## Test plan

- [ ] CI image build (`Build and Push Docker Image` workflow) succeeds for the `devcontainer-tools` stage.
- [ ] `tmux -V` resolves inside a container built from the `devcontainer-tools` target.