### PR TITLE
feat(skypilot): add explicit dispatch flags + num_workers config option to launcher

### DIFF
--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -145,10 +145,12 @@ jobs:
   #     providers exercise the same launcher path.
   #   * `runpod` / `oci` — invoke the same provider-neutral launcher
   #     (`pipeline.entrypoints.skypilot_launch_smoke`) against the matching
-  #     `configs/compute/*-template.yaml`, with `--num-workers 3` so the
-  #     partitioner is exercised end-to-end. Cluster names include
-  #     `github.run_attempt` so re-running a failed job doesn't collide on the
-  #     launcher's R2 spec key.
+  #     `configs/compute/*-template.yaml`. Worker fan-out comes from
+  #     the dataset config's `num_workers` field
+  #     (`configs/dataset/runpod-smoke-shard.yaml`) so the partitioner is
+  #     exercised end-to-end. Cluster names include `github.run_attempt`
+  #     so re-running a failed job doesn't collide on the launcher's R2
+  #     spec key.
   generate:
     name: Run generate_dataset (${{ matrix.provider }})
     needs: setup
@@ -283,10 +285,12 @@ jobs:
       # the runner-local kind cluster (`sky local up` above) — which is
       # where the kind-loaded dev-snapshot image lives.
       #
-      # `--num-workers 1` overrides the dataset config's value (3) just for
-      # this row — the single-node kind cluster can't fit 3 concurrent
-      # worker pods of cpus=2+, mem=4+. See #843 for the deeper design
-      # discussion (multi-node kind, retry-on-pod-free).
+      # `num_workers` defaults from the dataset config
+      # (`configs/dataset/runpod-smoke-shard.yaml`), but this row passes
+      # `--num-workers 1` to override the config's value (3): the
+      # single-node kind cluster can't fit 3 concurrent worker pods of
+      # cpus=2+, mem=4+. See #843 for the deeper design discussion
+      # (multi-node kind, retry-on-pod-free).
       - name: Run launcher against local-template (skypilot-local row)
         if: ${{ matrix.provider == 'skypilot-local' }}
         env:
@@ -383,7 +387,6 @@ jobs:
                 --template "$TEMPLATE" \
                 --cluster-name "$CLUSTER_NAME" \
                 --worker-image-tag "$IMAGE_TAG" \
-                --num-workers 3 \
                 --spec-out /tmp/input_spec.json \
                 --tail
               cp /tmp/input_spec.json /run-metadata/input_spec.json

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -277,12 +277,16 @@ jobs:
       # workflow env to os.environ inside main() so upload_spec_to_r2's
       # rclone subprocess sees them.
       #
-      # `SKYPILOT_API_SERVER_ENDPOINT` is intentionally NOT exported here:
-      # the skypilot-local row is meant to exercise the SDK against the
-      # runner-local kind cluster (`sky local up` above), so dispatching to
-      # a remote API server would silently bypass the kind cluster and
-      # schedule pods on whatever Kubernetes context the remote server has
-      # — which won't have the dev-snapshot image kind-loaded into it.
+      # `--local` makes the launcher's local-vs-remote dispatch explicit
+      # (#841): it clears any inherited SKYPILOT_API_SERVER_ENDPOINT before
+      # any sky.* call so this row can't accidentally route remote and miss
+      # the runner-local kind cluster (`sky local up` above) — which is
+      # where the kind-loaded dev-snapshot image lives.
+      #
+      # `--num-workers 1` overrides the dataset config's value (3) just for
+      # this row — the single-node kind cluster can't fit 3 concurrent
+      # worker pods of cpus=2+, mem=4+. See #843 for the deeper design
+      # discussion (multi-node kind, retry-on-pod-free).
       - name: Run launcher against local-template (skypilot-local row)
         if: ${{ matrix.provider == 'skypilot-local' }}
         env:
@@ -296,17 +300,12 @@ jobs:
           PYTHONPATH: ${{ github.workspace }}
         run: |
           set -euo pipefail
-          # `--num-workers 1` (vs. 3 on cloud rows): the kind cluster
-          # `sky local up` provisions has a single node — the GH runner —
-          # which can't fit 3 concurrent worker pods of cpus=2+, mem=4+. The
-          # cloud rows give each worker its own VM, so this row is the only
-          # shape with shared-cluster contention. See #843 for the deeper
-          # design discussion (multi-node kind, retry-on-pod-free).
           python -m pipeline.entrypoints.skypilot_launch_smoke \
             --config "$CONFIG_PATH" \
             --template configs/compute/local-template.yaml \
             --cluster-name "$CLUSTER_NAME" \
             --worker-image-tag "$IMAGE_TAG" \
+            --local \
             --num-workers 1 \
             --spec-out "/tmp/run-metadata-${{ matrix.provider }}/input_spec.json" \
             --tail \

--- a/configs/dataset/runpod-smoke-shard.yaml
+++ b/configs/dataset/runpod-smoke-shard.yaml
@@ -1,5 +1,5 @@
 # CI smoke-test config (test-dataset-generation workflow on PR).
-# num_shards matches --num-workers so each rank renders exactly one shard
+# num_shards matches num_workers so each rank renders exactly one shard
 # and the partitioner is actually exercised.
 param_spec: surge_simple
 plugin_path: plugins/Surge XT.vst3
@@ -7,6 +7,7 @@ output_format: hdf5
 sample_rate: 16000
 shard_size: 4
 num_shards: 3
+num_workers: 3
 base_seed: 42
 r2_bucket: intermediate-data
 

--- a/pipeline/entrypoints/skypilot_launch_smoke.py
+++ b/pipeline/entrypoints/skypilot_launch_smoke.py
@@ -203,6 +203,26 @@ def _detect_provider(template_path: Path) -> str:
     return provider
 
 
+_SKYPILOT_API_SERVER_ENV = "SKYPILOT_API_SERVER_ENDPOINT"
+
+
+def _apply_dispatch_mode(api_server: str | None, local: bool) -> None:
+    """Apply the launcher's explicit dispatch-mode selection to ``os.environ``.
+
+    Mutually exclusive — Click validates that, but assert again so a programmatic caller
+    can't bypass. ``--api-server`` exports ``SKYPILOT_API_SERVER_ENDPOINT`` so all
+    subsequent ``sky.*`` calls dispatch to the remote server. ``--local`` clears that env
+    var so an inherited value can't accidentally route remote (the failure mode #841
+    captures). Neither flag passed → leave the env untouched (backward-compat).
+    """
+    if api_server is not None and local:
+        raise click.ClickException("--api-server and --local are mutually exclusive")
+    if api_server is not None:
+        os.environ[_SKYPILOT_API_SERVER_ENV] = api_server
+    elif local:
+        os.environ.pop(_SKYPILOT_API_SERVER_ENV, None)
+
+
 def _run_cred_bootstrap(*, provider: str, env_file_path: Path | None = None) -> None:
     """Invoke `scripts/skypilot_write_provider_creds.sh` for `provider`.
 
@@ -217,9 +237,9 @@ def _run_cred_bootstrap(*, provider: str, env_file_path: Path | None = None) -> 
     (when provided) so a local-dev `.env` carrying provider creds bootstraps
     cleanly without manual `export`.
     """
-    if os.environ.get("SKYPILOT_API_SERVER_ENDPOINT"):
+    if os.environ.get(_SKYPILOT_API_SERVER_ENV):
         click.echo(
-            "SKYPILOT_API_SERVER_ENDPOINT is set; remote API server holds provider "
+            f"{_SKYPILOT_API_SERVER_ENV} is set; remote API server holds provider "
             "creds, skipping local cred bootstrap",
             err=True,
         )
@@ -369,6 +389,29 @@ def upload_spec_to_r2(spec: DatasetPipelineSpec, cluster_name: str) -> str:
         "are still torn down in `--no-tail` so SkyPilot state doesn't accumulate orphans."
     ),
 )
+@click.option(
+    "--api-server",
+    "api_server",
+    type=str,
+    default=None,
+    help=(
+        "Dispatch to this remote SkyPilot API server URL. Sets SKYPILOT_API_SERVER_ENDPOINT in "
+        "the launcher's process env so all sky.* calls go to the remote server, and skips the "
+        "local cred bootstrap (the remote server holds provider creds). Mutually exclusive with "
+        "--local. When neither is passed the existing env var (if any) is honored."
+    ),
+)
+@click.option(
+    "--local",
+    "local",
+    is_flag=True,
+    default=False,
+    help=(
+        "Force local SDK dispatch. Clears SKYPILOT_API_SERVER_ENDPOINT from the launcher's "
+        "process env so an inherited value can't accidentally route remote (#841), and runs "
+        "the local cred bootstrap. Mutually exclusive with --api-server."
+    ),
+)
 def main(
     config_path: Path,
     template_path: Path,
@@ -378,8 +421,12 @@ def main(
     num_workers: int,
     worker_image_tag: str,
     tail: bool,
+    api_server: str | None,
+    local: bool,
 ) -> None:
     """Launch the smoke `generate_dataset` run via SkyPilot (RunPod or OCI per `--template`)."""
+    _apply_dispatch_mode(api_server=api_server, local=local)
+
     if num_workers < 1:
         raise click.ClickException(f"--num-workers must be >= 1, got {num_workers}")
 

--- a/pipeline/entrypoints/skypilot_launch_smoke.py
+++ b/pipeline/entrypoints/skypilot_launch_smoke.py
@@ -351,14 +351,14 @@ def upload_spec_to_r2(spec: DatasetPipelineSpec, cluster_name: str) -> str:
 @click.option(
     "--num-workers",
     type=int,
-    default=1,
-    show_default=True,
+    default=None,
     help=(
-        "Number of single-node SkyPilot clusters to fan out in parallel. RunPod's backend "
-        "does not support num_nodes>1, so we synthesize multi-worker partitioning by launching "
-        "N independent clusters and injecting SYNTH_SETTER_WORKER_RANK / SYNTH_SETTER_NUM_WORKERS per rank. Each cluster "
-        "downloads the same materialized spec and uses pipeline.partitioning.get_my_shards to "
-        "slice its share."
+        "Number of single-node SkyPilot clusters to fan out in parallel. Overrides the dataset "
+        "config's `num_workers` field; if neither is set, the schema default applies. RunPod's "
+        "backend does not support num_nodes>1, so we synthesize multi-worker partitioning by "
+        "launching N independent clusters and injecting SYNTH_SETTER_WORKER_RANK / "
+        "SYNTH_SETTER_NUM_WORKERS per rank. Each cluster downloads the same materialized spec "
+        "and uses pipeline.partitioning.get_my_shards to slice its share."
     ),
 )
 @click.option(
@@ -418,7 +418,7 @@ def main(
     env_file_path: Path,
     cluster_name: str | None,
     spec_out: Path | None,
-    num_workers: int,
+    num_workers: int | None,
     worker_image_tag: str,
     tail: bool,
     api_server: str | None,
@@ -427,7 +427,7 @@ def main(
     """Launch the smoke `generate_dataset` run via SkyPilot (RunPod or OCI per `--template`)."""
     _apply_dispatch_mode(api_server=api_server, local=local)
 
-    if num_workers < 1:
+    if num_workers is not None and num_workers < 1:
         raise click.ClickException(f"--num-workers must be >= 1, got {num_workers}")
 
     if not _DOCKER_TAG_RE.fullmatch(worker_image_tag):
@@ -461,6 +461,11 @@ def main(
     config = load_dataset_config(config_path)
     config_id = dataset_config_id_from_path(config_path)
     spec = materialize_spec(config, config_id)
+
+    # `--num-workers` (if passed) wins over the dataset config's `num_workers`. Schema
+    # default applies when neither is set. The launcher's run-time fan-out is the single
+    # source of truth for worker count from here on.
+    resolved_num_workers = num_workers if num_workers is not None else config.num_workers
 
     base_cluster_name = cluster_name or f"synth-setter-smoke-{config_id[:8]}"
 
@@ -505,8 +510,8 @@ def main(
     # workflows / CI dashboards that key off it; multi-worker uses -rN suffixes.
     cluster_names = (
         [base_cluster_name]
-        if num_workers == 1
-        else [f"{base_cluster_name}-r{i}" for i in range(num_workers)]
+        if resolved_num_workers == 1
+        else [f"{base_cluster_name}-r{i}" for i in range(resolved_num_workers)]
     )
 
     rcs = _run_workers(
@@ -518,11 +523,13 @@ def main(
     )
 
     failed = [
-        (cluster_names[i], rcs[i]) for i in range(num_workers) if rcs[i] != _TAIL_LOGS_RC_SUCCESS
+        (cluster_names[i], rcs[i])
+        for i in range(resolved_num_workers)
+        if rcs[i] != _TAIL_LOGS_RC_SUCCESS
     ]
     if failed:
         raise click.ClickException(
-            f"{len(failed)} of {num_workers} worker(s) failed: "
+            f"{len(failed)} of {resolved_num_workers} worker(s) failed: "
             + ", ".join(f"{name}(rc={rc})" for name, rc in failed)
         )
 

--- a/pipeline/entrypoints/skypilot_launch_smoke.py
+++ b/pipeline/entrypoints/skypilot_launch_smoke.py
@@ -209,16 +209,22 @@ _SKYPILOT_API_SERVER_ENV = "SKYPILOT_API_SERVER_ENDPOINT"
 def _apply_dispatch_mode(api_server: str | None, local: bool) -> None:
     """Apply the launcher's explicit dispatch-mode selection to ``os.environ``.
 
-    Mutually exclusive — Click validates that, but assert again so a programmatic caller
-    can't bypass. ``--api-server`` exports ``SKYPILOT_API_SERVER_ENDPOINT`` so all
-    subsequent ``sky.*`` calls dispatch to the remote server. ``--local`` clears that env
-    var so an inherited value can't accidentally route remote (the failure mode #841
-    captures). Neither flag passed → leave the env untouched (backward-compat).
+    This function is the sole enforcer of the ``--api-server`` / ``--local`` contract —
+    Click does not natively gate mutually-exclusive options, so the runtime check below
+    is what catches both CLI users and programmatic callers. ``--api-server`` exports
+    ``SKYPILOT_API_SERVER_ENDPOINT`` (after stripping surrounding whitespace; blank values
+    rejected) so all subsequent ``sky.*`` calls dispatch to the remote server.
+    ``--local`` clears that env var so an inherited value can't accidentally route
+    remote (the failure mode #841 captures). Neither flag passed → leave the env
+    untouched (backward-compat).
     """
     if api_server is not None and local:
         raise click.ClickException("--api-server and --local are mutually exclusive")
     if api_server is not None:
-        os.environ[_SKYPILOT_API_SERVER_ENV] = api_server
+        stripped = api_server.strip()
+        if not stripped:
+            raise click.ClickException("--api-server must be a non-empty URL")
+        os.environ[_SKYPILOT_API_SERVER_ENV] = stripped
     elif local:
         os.environ.pop(_SKYPILOT_API_SERVER_ENV, None)
 

--- a/pipeline/schemas/config.py
+++ b/pipeline/schemas/config.py
@@ -40,7 +40,7 @@ class DatasetConfig(BaseModel):
     min_loudness: float
     sample_batch_size: int
     # Number of single-node SkyPilot clusters the launcher fans out in parallel for this
-    # dataset. Default 1 matches the pre-config launcher default (#841); the launcher's
+    # dataset. Default 1 matches the pre-config launcher default; the launcher's
     # `--num-workers` overrides this when explicitly passed.
     num_workers: int = 1
 

--- a/pipeline/schemas/config.py
+++ b/pipeline/schemas/config.py
@@ -39,6 +39,10 @@ class DatasetConfig(BaseModel):
     signal_duration_seconds: float
     min_loudness: float
     sample_batch_size: int
+    # Number of single-node SkyPilot clusters the launcher fans out in parallel for this
+    # dataset. Default 1 matches the pre-config launcher default (#841); the launcher's
+    # `--num-workers` overrides this when explicitly passed.
+    num_workers: int = 1
 
     @field_validator("r2_bucket")
     @classmethod
@@ -75,6 +79,8 @@ class DatasetConfig(BaseModel):
             raise ValueError("signal_duration_seconds must be positive")
         if self.sample_batch_size <= 0:
             raise ValueError("sample_batch_size must be positive")
+        if self.num_workers < 1:
+            raise ValueError("num_workers must be >= 1")
         return self
 
 

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch_smoke.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch_smoke.py
@@ -1417,6 +1417,207 @@ class TestRunCredBootstrap:
 # ---------------------------------------------------------------------------
 
 
+class TestDispatchMode:
+    """`--api-server` / `--local` make the launcher's remote-vs-local dispatch explicit (#841).
+
+    Today's contract — "if SKYPILOT_API_SERVER_ENDPOINT is set in process env, dispatch remote;
+    else local SDK" — is preserved when neither flag is passed (backward-compat), but each call
+    site can now declare its intent via argv instead of via env-passthrough.
+    """
+
+    def test_local_flag_clears_inherited_api_server_endpoint(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`--local` clears an inherited SKYPILOT_API_SERVER_ENDPOINT so a stale env var can't
+        silently route this run to the remote server."""
+        monkeypatch.setenv("SKYPILOT_API_SERVER_ENDPOINT", "https://stale.example.com")
+
+        result = _invoke(
+            config_yaml, template_yaml, env_file, "--cluster-name", "smoke-job-1", "--local"
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "SKYPILOT_API_SERVER_ENDPOINT" not in os.environ
+
+    def test_api_server_flag_sets_endpoint_in_os_environ(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`--api-server <url>` exports the endpoint into os.environ before any sky.* call so the
+        SDK dispatches to the remote server."""
+        monkeypatch.delenv("SKYPILOT_API_SERVER_ENDPOINT", raising=False)
+
+        result = _invoke(
+            config_yaml,
+            template_yaml,
+            env_file,
+            "--cluster-name",
+            "smoke-job-1",
+            "--api-server",
+            "https://api.example.com",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert os.environ.get("SKYPILOT_API_SERVER_ENDPOINT") == "https://api.example.com"
+
+    def test_api_server_flag_skips_cred_bootstrap(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`--api-server <url>` causes `_run_cred_bootstrap` to short-circuit (remote server holds
+        creds) — no subprocess invocation."""
+        monkeypatch.delenv("SKYPILOT_API_SERVER_ENDPOINT", raising=False)
+
+        # Re-patch _run_cred_bootstrap to the real impl so the SKYPILOT_API_SERVER_ENDPOINT
+        # short-circuit is exercised end-to-end.
+        called: list[str] = []
+
+        def fake_run(args: list[str], **kwargs: Any) -> MagicMock:
+            called.append("invoked")
+            result = MagicMock()
+            result.stdout = ""
+            result.stderr = ""
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(
+            "pipeline.entrypoints.skypilot_launch_smoke._run_cred_bootstrap",
+            _real_run_cred_bootstrap,
+        )
+        monkeypatch.setattr("pipeline.entrypoints.skypilot_launch_smoke.subprocess.run", fake_run)
+
+        result = _invoke(
+            config_yaml,
+            template_yaml,
+            env_file,
+            "--cluster-name",
+            "smoke-job-1",
+            "--api-server",
+            "https://api.example.com",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert called == [], "cred bootstrap should be skipped when --api-server is set"
+
+    def test_local_flag_runs_cred_bootstrap_even_with_inherited_endpoint(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`--local` clears the inherited endpoint AND runs the cred bootstrap (the launcher host
+        needs creds on disk for local SDK dispatch)."""
+        monkeypatch.setenv("SKYPILOT_API_SERVER_ENDPOINT", "https://stale.example.com")
+        called: list[str] = []
+
+        def fake_run(args: list[str], **kwargs: Any) -> MagicMock:
+            called.append("invoked")
+            result = MagicMock()
+            result.stdout = ""
+            result.stderr = ""
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(
+            "pipeline.entrypoints.skypilot_launch_smoke._run_cred_bootstrap",
+            _real_run_cred_bootstrap,
+        )
+        monkeypatch.setattr("pipeline.entrypoints.skypilot_launch_smoke.subprocess.run", fake_run)
+
+        result = _invoke(
+            config_yaml, template_yaml, env_file, "--cluster-name", "smoke-job-1", "--local"
+        )
+
+        assert result.exit_code == 0, result.output
+        assert called == ["invoked"], "cred bootstrap must run under --local"
+
+    def test_both_flags_passed_is_rejected(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """`--api-server` and `--local` are mutually exclusive — a usage error before sky.* is
+        touched."""
+        result = _invoke(
+            config_yaml,
+            template_yaml,
+            env_file,
+            "--cluster-name",
+            "smoke-job-1",
+            "--api-server",
+            "https://api.example.com",
+            "--local",
+        )
+
+        assert result.exit_code != 0
+        assert "mutually exclusive" in result.output
+        mock_sky.launch.assert_not_called()
+
+    def test_neither_flag_preserves_inherited_endpoint(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Without --api-server / --local the launcher leaves SKYPILOT_API_SERVER_ENDPOINT alone —
+        backward-compat with workflows that already rely on env-var passthrough."""
+        monkeypatch.setenv("SKYPILOT_API_SERVER_ENDPOINT", "https://inherited.example.com")
+
+        result = _invoke(config_yaml, template_yaml, env_file, "--cluster-name", "smoke-job-1")
+
+        assert result.exit_code == 0, result.output
+        assert os.environ.get("SKYPILOT_API_SERVER_ENDPOINT") == "https://inherited.example.com"
+
+    def test_neither_flag_with_unset_endpoint_leaves_it_unset(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No flag and no inherited env var → still no env var (no surprise default)."""
+        monkeypatch.delenv("SKYPILOT_API_SERVER_ENDPOINT", raising=False)
+
+        result = _invoke(config_yaml, template_yaml, env_file, "--cluster-name", "smoke-job-1")
+
+        assert result.exit_code == 0, result.output
+        assert "SKYPILOT_API_SERVER_ENDPOINT" not in os.environ
+
+
 class TestWorkerEnvToOsEnvironBridge:
     """`main()` copies `RCLONE_CONFIG_R2_*` from the resolved worker_env into `os.environ` so
     `upload_spec_to_r2`'s `rclone copyto` subprocess inherits them.

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch_smoke.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch_smoke.py
@@ -1417,6 +1417,91 @@ class TestRunCredBootstrap:
 # ---------------------------------------------------------------------------
 
 
+class TestNumWorkersConfigPrecedence:
+    """`num_workers` resolution order: `--num-workers` CLI flag wins; else dataset config's
+    `num_workers` field; else schema default.
+
+    Drops the workflow's hardcoded `--num-workers 3` in favor of the dataset config field (#841) so
+    the same config produces the same fan-out across call sites.
+    """
+
+    def test_config_num_workers_drives_fan_out_when_cli_flag_omitted(
+        self,
+        tmp_path: Path,
+        fake_plugin: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """`num_workers: 3` in the dataset config drives a 3-cluster fan-out without any CLI
+        flag."""
+        config_dict = _make_config(fake_plugin)
+        config_dict["num_workers"] = 3
+        config_dict["num_shards"] = 3
+        config_dict["splits"] = {"train": 3, "val": 0, "test": 0}
+        config_path = tmp_path / "three-workers.yaml"
+        config_path.write_text(yaml.safe_dump(config_dict, sort_keys=False))
+
+        TestNumWorkersFanOut._setup_n_workers_mock(mock_sky, n=3)
+
+        result = _invoke(config_path, template_yaml, env_file, "--cluster-name", "smoke-job-1")
+
+        assert result.exit_code == 0, result.output
+        assert mock_sky.launch.call_count == 3
+
+    def test_cli_num_workers_overrides_config(
+        self,
+        tmp_path: Path,
+        fake_plugin: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """`--num-workers 2` overrides a config that says `num_workers: 5` — CLI wins so an
+        operator can override a config without editing it."""
+        config_dict = _make_config(fake_plugin)
+        config_dict["num_workers"] = 5
+        config_dict["num_shards"] = 5
+        config_dict["splits"] = {"train": 5, "val": 0, "test": 0}
+        config_path = tmp_path / "five-workers.yaml"
+        config_path.write_text(yaml.safe_dump(config_dict, sort_keys=False))
+
+        TestNumWorkersFanOut._setup_n_workers_mock(mock_sky, n=2)
+
+        result = _invoke(
+            config_path,
+            template_yaml,
+            env_file,
+            "--cluster-name",
+            "smoke-job-1",
+            "--num-workers",
+            "2",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert mock_sky.launch.call_count == 2
+
+    def test_default_when_neither_cli_nor_config_sets_num_workers(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """The fixture's config_yaml has no `num_workers`, and no `--num-workers` is passed — the
+        schema default (1) drives a single-cluster fan-out."""
+        result = _invoke(config_yaml, template_yaml, env_file, "--cluster-name", "smoke-job-1")
+
+        assert result.exit_code == 0, result.output
+        assert mock_sky.launch.call_count == 1
+
+
 class TestDispatchMode:
     """`--api-server` / `--local` make the launcher's remote-vs-local dispatch explicit (#841).
 

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch_smoke.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch_smoke.py
@@ -1421,8 +1421,8 @@ class TestNumWorkersConfigPrecedence:
     """`num_workers` resolution order: `--num-workers` CLI flag wins; else dataset config's
     `num_workers` field; else schema default.
 
-    Drops the workflow's hardcoded `--num-workers 3` in favor of the dataset config field (#841) so
-    the same config produces the same fan-out across call sites.
+    Drops the workflow's hardcoded `--num-workers 3` in favor of the dataset config field so the
+    same config produces the same fan-out across call sites.
     """
 
     def test_config_num_workers_drives_fan_out_when_cli_flag_omitted(
@@ -1557,6 +1557,60 @@ class TestDispatchMode:
 
         assert result.exit_code == 0, result.output
         assert os.environ.get("SKYPILOT_API_SERVER_ENDPOINT") == "https://api.example.com"
+
+    def test_api_server_flag_strips_surrounding_whitespace(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A non-empty URL with surrounding whitespace is stripped before being exported."""
+        monkeypatch.delenv("SKYPILOT_API_SERVER_ENDPOINT", raising=False)
+
+        result = _invoke(
+            config_yaml,
+            template_yaml,
+            env_file,
+            "--cluster-name",
+            "smoke-job-1",
+            "--api-server",
+            "  https://api.example.com  ",
+        )
+
+        assert result.exit_code == 0, result.output
+        assert os.environ.get("SKYPILOT_API_SERVER_ENDPOINT") == "https://api.example.com"
+
+    def test_api_server_flag_rejects_blank_value(
+        self,
+        config_yaml: Path,
+        template_yaml: Path,
+        env_file: Path,
+        patch_materialize_io: None,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A blank/whitespace-only value is rejected with a clear error rather than silently
+        setting an empty endpoint that makes downstream cred-bootstrap behavior confusing."""
+        monkeypatch.delenv("SKYPILOT_API_SERVER_ENDPOINT", raising=False)
+
+        result = _invoke(
+            config_yaml,
+            template_yaml,
+            env_file,
+            "--cluster-name",
+            "smoke-job-1",
+            "--api-server",
+            "   ",
+        )
+
+        assert result.exit_code != 0
+        assert "non-empty" in result.output.lower() or "blank" in result.output.lower()
+        assert "SKYPILOT_API_SERVER_ENDPOINT" not in os.environ
 
     def test_api_server_flag_skips_cred_bootstrap(
         self,

--- a/tests/pipeline/test_schemas/test_config.py
+++ b/tests/pipeline/test_schemas/test_config.py
@@ -119,6 +119,25 @@ class TestDatasetConfigValidation:
         with pytest.raises(ValidationError, match="r2_bucket must not be blank"):
             DatasetConfig(**valid_config_dict)
 
+    def test_dataset_config_num_workers_defaults_to_one(self, valid_config_dict):
+        """Omitting num_workers defaults to 1 — matches the launcher's pre-config default."""
+        valid_config_dict.pop("num_workers", None)
+        cfg = DatasetConfig(**valid_config_dict)
+        assert cfg.num_workers == 1
+
+    def test_dataset_config_num_workers_explicit_value_kept(self, valid_config_dict):
+        """An explicit num_workers value passes through unchanged."""
+        valid_config_dict["num_workers"] = 5
+        cfg = DatasetConfig(**valid_config_dict)
+        assert cfg.num_workers == 5
+
+    def test_dataset_config_rejects_zero_num_workers(self, valid_config_dict):
+        """num_workers < 1 raises ValidationError — caught before the launcher provisions
+        anything."""
+        valid_config_dict["num_workers"] = 0
+        with pytest.raises(ValidationError, match="num_workers must be >= 1"):
+            DatasetConfig(**valid_config_dict)
+
     def test_dataset_config_velocity_bounds(self, valid_config_dict):
         """Velocity outside [0, 127] raises; boundary values pass."""
         valid_config_dict["velocity"] = 200


### PR DESCRIPTION
> **Stacked on #840.** This PR's base branch is `feat/skypilot-cred-bootstrap-unify-v2`, the in-flight cred-bootstrap-unify branch, not `main`. After #840 merges, GitHub auto-rebases this onto main and the diff against main shrinks to just the changes here. Review #840 first; only the commits in this PR are new.

## Summary

Two design fixes called out while reviewing #840:

1. **Explicit local-vs-remote dispatch (Closes #841).** The launcher's "use remote SkyPilot API server vs. use local SDK" decision used to be implicit — controlled by whether `SKYPILOT_API_SERVER_ENDPOINT` was set in the launcher's process env. PR #840's commit `8eadbf8` worked around it for one workflow step by dropping the env-var passthrough; this PR makes the choice explicit:
   - `--api-server <url>` exports `SKYPILOT_API_SERVER_ENDPOINT` and skips the local cred bootstrap (remote server holds creds).
   - `--local` clears `SKYPILOT_API_SERVER_ENDPOINT` and runs the local cred bootstrap so an inherited stale value can't accidentally route remote.
   - Mutually exclusive (Click rejects both).
   - Default behavior (neither flag) preserves the existing env-var contract — backward-compat.

   The `skypilot-local` matrix row in `test-dataset-generation.yml` switches to `--local` (replaces the env-var-deletion workaround in #840).

2. **`num_workers` is now a dataset-config field.** Workflows used to hardcode `--num-workers 3` at every call site. The launcher now reads `num_workers` from the dataset config YAML; `--num-workers` CLI overrides; schema default is 1 (matches the launcher's pre-config default). `configs/dataset/runpod-smoke-shard.yaml` declares `num_workers: 3` once, and both call sites in `test-dataset-generation.yml` drop the hardcoded flag.

## Test plan

- [x] `pytest tests/pipeline/test_entrypoints/test_skypilot_launch_smoke.py tests/pipeline/test_schemas/test_config.py` (95 passed)
- [x] `make test` (502 passed, +13 vs the PR #840 baseline of 489)
- [ ] CI green on the `skypilot-local` matrix row (proves `--local` clears the inherited endpoint and the kind cluster receives the launcher's clusters)
- [ ] CI green on the `runpod` / `oci` rows (proves dropping `--num-workers 3` and reading from the config still produces 3-cluster fan-out)

## Design choices

- `num_workers` lives at the top level of `DatasetConfig` (next to `num_shards`, `shard_size`) — orchestration belongs at the same level as data sizing because they co-vary in CI configs (`num_shards == num_workers` so the partitioner is exercised). Open to moving it under a nested `pipeline:` section if there's a strong preference.
- Schema default is 1 (not 3) so existing configs that don't declare `num_workers` keep the launcher's pre-config single-cluster behavior. CI configs opt into multi-worker explicitly.
- `--api-server` accepts a URL value; `--local` is a flag (no value). Mirrors the SkyPilot SDK convention where the env var is a URL and "local SDK" is the implicit absence.

Closes #841