### PR TITLE
test(surge-interactive): step 4 — TestMidiListener (#844)

### DIFF
--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -467,7 +467,7 @@ class TestMidiListener:
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
         # ``daemon=True`` so a hung listener can't block pytest shutdown if the
-        # fixture-side ``drain_event`` assertion below fails before we set ``stop_event``.
+        # ``drain_event`` assertion below fails before we set ``stop_event``.
         listener_thread = threading.Thread(
             target=surge_xt_interactive.midi_listener,
             args=("fake-port", midi_queue, stop_event),

--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -466,17 +466,24 @@ class TestMidiListener:
 
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
+        # ``daemon=True`` so a hung listener can't block pytest shutdown if the
+        # fixture-side ``drain_event`` assertion below fails before we set ``stop_event``.
         listener_thread = threading.Thread(
             target=surge_xt_interactive.midi_listener,
             args=("fake-port", midi_queue, stop_event),
             kwargs={"port_opener": fake_port_opener},
+            daemon=True,
         )
         listener_thread.start()
-        # ``_FakeMidiPortHandle`` flips ``drain_event`` once the queued list is empty,
-        # so we know the listener has observed every message before we ask it to stop.
-        assert drain_event.wait(timeout=2.0), "listener did not drain fake messages"
-        stop_event.set()
-        listener_thread.join(timeout=2.0)
+        # Belt-and-suspenders: even though the thread is now daemonic, signal shutdown
+        # and join in a finally block so a failed drain assertion still cleans up.
+        try:
+            # ``_FakeMidiPortHandle`` flips ``drain_event`` once the queued list is empty,
+            # so we know the listener has observed every message before we ask it to stop.
+            assert drain_event.wait(timeout=2.0), "listener did not drain fake messages"
+        finally:
+            stop_event.set()
+            listener_thread.join(timeout=2.0)
         assert not listener_thread.is_alive(), "listener did not exit on stop_event"
 
         drained: list[tuple[list[int], float]] = []

--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -435,9 +435,7 @@ class _FakeMidiPortHandle:
 class TestMidiListener:
     """``midi_listener`` filters mido messages by type and forwards them to a queue."""
 
-    def test_only_relevant_message_types_are_forwarded(
-        self, surge_xt_interactive, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_only_relevant_message_types_are_forwarded(self, surge_xt_interactive) -> None:
         """note_on/off, control_change, pitchwheel, aftertouch are queued; others are dropped."""
         forwarded = [
             _FakeMidiMessage("note_on", [0x90, 0x3C, 0x40]),
@@ -462,17 +460,16 @@ class TestMidiListener:
         ]
 
         drain_event = threading.Event()
-        monkeypatch.setattr(
-            surge_xt_interactive.mido,
-            "open_input",
-            lambda port_name: _FakeMidiPortHandle(all_messages, drain_event=drain_event),
-        )
+
+        def fake_port_opener(_port_name: str) -> _FakeMidiPortHandle:
+            return _FakeMidiPortHandle(all_messages, drain_event=drain_event)
 
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
         listener_thread = threading.Thread(
             target=surge_xt_interactive.midi_listener,
             args=("fake-port", midi_queue, stop_event),
+            kwargs={"port_opener": fake_port_opener},
         )
         listener_thread.start()
         # ``_FakeMidiPortHandle`` flips ``drain_event`` once the queued list is empty,
@@ -504,31 +501,25 @@ class TestMidiListener:
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
         stop_event.set()
-        # Drop in the idle port via a class-attribute swap so we don't reach the real
-        # mido backend (which would still try to enumerate hardware on import).
-        original_open_input = surge_xt_interactive.mido.open_input
-        surge_xt_interactive.mido.open_input = lambda _port: _IdlePort()
-        try:
-            surge_xt_interactive.midi_listener("fake-port", midi_queue, stop_event)
-        finally:
-            surge_xt_interactive.mido.open_input = original_open_input
+
+        surge_xt_interactive.midi_listener(
+            "fake-port", midi_queue, stop_event, port_opener=lambda _port: _IdlePort()
+        )
 
         assert midi_queue.empty()
 
-    def test_open_input_failure_logs_and_exits_thread(
-        self, surge_xt_interactive, monkeypatch: pytest.MonkeyPatch, caplog
-    ) -> None:
+    def test_open_input_failure_logs_and_exits_thread(self, surge_xt_interactive, caplog) -> None:
         """``midi_listener`` must not raise; failures are logged so the daemon exits cleanly."""
 
-        def _raise(_port_name: str) -> object:
+        def raising_port_opener(_port_name: str) -> object:
             raise OSError("device disconnected")
-
-        monkeypatch.setattr(surge_xt_interactive.mido, "open_input", _raise)
 
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
         with caplog.at_level("ERROR"):
-            surge_xt_interactive.midi_listener("fake-port", midi_queue, stop_event)
+            surge_xt_interactive.midi_listener(
+                "fake-port", midi_queue, stop_event, port_opener=raising_port_opener
+            )
 
         assert midi_queue.empty()
         assert any("MIDI listener thread aborted" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

Step 4 of [#844](https://github.com/tinaudio/synth-setter/issues/844). Stacked on top of [#851](https://github.com/tinaudio/synth-setter/pull/851) (step 3 — `TestMaybeEvalCapturedPatches`).

Drops every patch of `surge_xt_interactive.mido.open_input` in `TestMidiListener` and replaces it with direct injection of a callable through the `port_opener` kwarg added in step 1.

The middle test was the worst offender — it manually swapped `surge_xt_interactive.mido.open_input` with a try/finally restore (a hand-rolled `monkeypatch` in disguise). With the seam, that's just `port_opener=lambda _port: _IdlePort()` passed as a keyword arg.

## Diff

```
tests/scripts/test_surge_xt_interactive.py | 37 +++++++++++-------------------
1 file changed, 14 insertions(+), 23 deletions(-)
```

## Test plan

- [x] `pytest tests/scripts/test_surge_xt_interactive.py::TestMidiListener -v` — 3 passed
- [x] Full file `pytest tests/scripts/test_surge_xt_interactive.py -m "not slow"` — 63 passed, 4 deselected
- [x] `make format` — clean
- [x] Audit: zero `monkeypatch.setattr` / `pytest.MonkeyPatch` / manual `mido.open_input =` references inside `TestMidiListener`

## Note on base branch

This PR's base is `test/de-mock-surge-xt-interactive-step-3`, not `main`. After steps 1–3 land, GitHub will retarget this PR to `main` and the diff will collapse to step 4 only.

Refs #844