### PR TITLE
test(surge-interactive): step 5 — TestPlayAudioQueueDrain (#844)

### DIFF
--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -467,7 +467,7 @@ class TestMidiListener:
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
         # ``daemon=True`` so a hung listener can't block pytest shutdown if the
-        # fixture-side ``drain_event`` assertion below fails before we set ``stop_event``.
+        # ``drain_event`` assertion below fails before we set ``stop_event``.
         listener_thread = threading.Thread(
             target=surge_xt_interactive.midi_listener,
             args=("fake-port", midi_queue, stop_event),

--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -466,17 +466,24 @@ class TestMidiListener:
 
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
+        # ``daemon=True`` so a hung listener can't block pytest shutdown if the
+        # fixture-side ``drain_event`` assertion below fails before we set ``stop_event``.
         listener_thread = threading.Thread(
             target=surge_xt_interactive.midi_listener,
             args=("fake-port", midi_queue, stop_event),
             kwargs={"port_opener": fake_port_opener},
+            daemon=True,
         )
         listener_thread.start()
-        # ``_FakeMidiPortHandle`` flips ``drain_event`` once the queued list is empty,
-        # so we know the listener has observed every message before we ask it to stop.
-        assert drain_event.wait(timeout=2.0), "listener did not drain fake messages"
-        stop_event.set()
-        listener_thread.join(timeout=2.0)
+        # Belt-and-suspenders: even though the thread is now daemonic, signal shutdown
+        # and join in a finally block so a failed drain assertion still cleans up.
+        try:
+            # ``_FakeMidiPortHandle`` flips ``drain_event`` once the queued list is empty,
+            # so we know the listener has observed every message before we ask it to stop.
+            assert drain_event.wait(timeout=2.0), "listener did not drain fake messages"
+        finally:
+            stop_event.set()
+            listener_thread.join(timeout=2.0)
         assert not listener_thread.is_alive(), "listener did not exit on stop_event"
 
         drained: list[tuple[list[int], float]] = []

--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -533,9 +533,7 @@ class TestMidiListener:
 
 
 class _FakeStream:
-    """Captures buffers written by ``play_audio``; serves as an ``AudioStream`` stand-in."""
-
-    default_output_device_name: str = "fake-device"
+    """Captures buffers written by ``play_audio``; an ``AudioStreamProtocol`` stand-in."""
 
     def __init__(self) -> None:
         self.writes: list[np.ndarray] = []
@@ -551,11 +549,26 @@ class _FakeStream:
 
 
 class _RecordingPlugin:
-    """Stand-in for a ``VST3Plugin`` that records the ``messages`` arg to ``process()``."""
+    """Stand-in for a ``VST3Plugin`` that records the ``messages`` arg to ``process()``.
 
-    def __init__(self, channels: int, buffer_size: int) -> None:
+    When ``stop_event`` and ``stop_after_n_calls`` are provided, the Nth ``process()``
+    invocation flips ``stop_event`` so ``play_audio`` exits its loop deterministically.
+    This replaces the late ``monkeypatch.setattr(plugin, "process", ...)`` re-bind that
+    earlier versions of ``TestPlayAudioQueueDrain`` used to drive shutdown.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        buffer_size: int,
+        *,
+        stop_event: threading.Event | None = None,
+        stop_after_n_calls: int = 1,
+    ) -> None:
         self._channels = channels
         self._buffer_size = buffer_size
+        self._stop_event = stop_event
+        self._stop_after_n_calls = stop_after_n_calls
         self.messages_per_call: list[list[tuple[list[int], float]]] = []
 
     def process(
@@ -569,108 +582,79 @@ class _RecordingPlugin:
     ) -> np.ndarray:
         assert reset is False
         self.messages_per_call.append(list(messages))
+        if (
+            self._stop_event is not None
+            and len(self.messages_per_call) >= self._stop_after_n_calls
+        ):
+            self._stop_event.set()
         return np.zeros((self._channels, self._buffer_size), dtype=np.float32)
 
 
 class TestPlayAudioQueueDrain:
     """``play_audio`` drains the MIDI queue into ``plugin.process`` once per buffer."""
 
-    def test_queued_events_are_forwarded_to_plugin_process(
-        self, surge_xt_interactive, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_queued_events_are_forwarded_to_plugin_process(self, surge_xt_interactive) -> None:
         """Tuples enqueued by the listener are drained and passed to ``plugin.process``."""
-        plugin = _RecordingPlugin(surge_xt_interactive.CHANNELS, surge_xt_interactive.BUFFER_SIZE)
+        stop_event = threading.Event()
+        plugin = _RecordingPlugin(
+            surge_xt_interactive.CHANNELS,
+            surge_xt_interactive.BUFFER_SIZE,
+            stop_event=stop_event,
+            stop_after_n_calls=1,
+        )
         stream = _FakeStream()
-
-        class _AudioStreamStub:
-            default_output_device_name = "fake-device"
-
-            def __new__(cls, **_kwargs: object) -> "_FakeStream":  # type: ignore[misc]
-                return stream
-
-        monkeypatch.setattr(surge_xt_interactive, "AudioStream", _AudioStreamStub)
 
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         midi_queue.put(([0x90, 0x3C, 0x40], 0.0))
         midi_queue.put(([0x80, 0x3C, 0x00], 0.0))
 
-        stop_event = threading.Event()
-
-        def _stop_after_first_buffer(*_args: object, **_kwargs: object) -> np.ndarray:
-            stop_event.set()
-            plugin.messages_per_call.append(list(_args[0]))  # type: ignore[arg-type]
-            return np.zeros(
-                (surge_xt_interactive.CHANNELS, surge_xt_interactive.BUFFER_SIZE),
-                dtype=np.float32,
-            )
-
-        monkeypatch.setattr(plugin, "process", _stop_after_first_buffer)
-        surge_xt_interactive.play_audio(plugin, stop_event, midi_queue)
+        surge_xt_interactive.play_audio(
+            plugin, stop_event, midi_queue, audio_stream_factory=lambda: stream
+        )
 
         assert plugin.messages_per_call == [[([0x90, 0x3C, 0x40], 0.0), ([0x80, 0x3C, 0x00], 0.0)]]
+        assert stop_event.is_set()
+        assert len(stream.writes) == 1
 
-    def test_none_queue_passes_empty_messages_list(
-        self, surge_xt_interactive, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_none_queue_passes_empty_messages_list(self, surge_xt_interactive) -> None:
         """When no MIDI port is configured, ``play_audio`` is invoked with ``midi_queue=None``."""
-        plugin = _RecordingPlugin(surge_xt_interactive.CHANNELS, surge_xt_interactive.BUFFER_SIZE)
+        stop_event = threading.Event()
+        plugin = _RecordingPlugin(
+            surge_xt_interactive.CHANNELS,
+            surge_xt_interactive.BUFFER_SIZE,
+            stop_event=stop_event,
+            stop_after_n_calls=1,
+        )
         stream = _FakeStream()
 
-        class _AudioStreamStub:
-            default_output_device_name = "fake-device"
-
-            def __new__(cls, **_kwargs: object) -> "_FakeStream":  # type: ignore[misc]
-                return stream
-
-        monkeypatch.setattr(surge_xt_interactive, "AudioStream", _AudioStreamStub)
-
-        stop_event = threading.Event()
-
-        def _stop_after_first_buffer(*_args: object, **_kwargs: object) -> np.ndarray:
-            stop_event.set()
-            plugin.messages_per_call.append(list(_args[0]))  # type: ignore[arg-type]
-            return np.zeros(
-                (surge_xt_interactive.CHANNELS, surge_xt_interactive.BUFFER_SIZE),
-                dtype=np.float32,
-            )
-
-        monkeypatch.setattr(plugin, "process", _stop_after_first_buffer)
-        surge_xt_interactive.play_audio(plugin, stop_event, None)
+        surge_xt_interactive.play_audio(
+            plugin, stop_event, None, audio_stream_factory=lambda: stream
+        )
 
         assert plugin.messages_per_call == [[]]
+        assert stop_event.is_set()
 
-    def test_drain_is_capped_at_max_midi_events_per_buffer(
-        self, surge_xt_interactive, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_drain_is_capped_at_max_midi_events_per_buffer(self, surge_xt_interactive) -> None:
         """A queue larger than ``_MAX_MIDI_EVENTS_PER_BUFFER`` drains in chunks across buffers,
         preventing one realtime callback from stretching to process the full backlog."""
         cap = surge_xt_interactive._MAX_MIDI_EVENTS_PER_BUFFER
-        plugin = _RecordingPlugin(surge_xt_interactive.CHANNELS, surge_xt_interactive.BUFFER_SIZE)
+        stop_event = threading.Event()
+        plugin = _RecordingPlugin(
+            surge_xt_interactive.CHANNELS,
+            surge_xt_interactive.BUFFER_SIZE,
+            stop_event=stop_event,
+            stop_after_n_calls=1,  # stop after the first buffer to assert the per-buffer cap
+        )
         stream = _FakeStream()
-
-        class _AudioStreamStub:
-            default_output_device_name = "fake-device"
-
-            def __new__(cls, **_kwargs: object) -> "_FakeStream":  # type: ignore[misc]
-                return stream
-
-        monkeypatch.setattr(surge_xt_interactive, "AudioStream", _AudioStreamStub)
 
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         # Enqueue cap + 5 events; first buffer should drain ``cap``, leaving 5 in the queue.
         for _ in range(cap + 5):
             midi_queue.put(([0x90, 0x3C, 0x40], 0.0))
 
-        stop_event = threading.Event()
-        # Stop after the first buffer so we can assert the per-buffer cap directly.
-        original_process = plugin.process
-
-        def _stop_after_first_buffer(*args: object, **kwargs: object) -> np.ndarray:
-            stop_event.set()
-            return original_process(*args, **kwargs)  # type: ignore[arg-type]
-
-        monkeypatch.setattr(plugin, "process", _stop_after_first_buffer)
-        surge_xt_interactive.play_audio(plugin, stop_event, midi_queue)
+        surge_xt_interactive.play_audio(
+            plugin, stop_event, midi_queue, audio_stream_factory=lambda: stream
+        )
 
         assert len(plugin.messages_per_call) == 1
         assert len(plugin.messages_per_call[0]) == cap

--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -435,9 +435,7 @@ class _FakeMidiPortHandle:
 class TestMidiListener:
     """``midi_listener`` filters mido messages by type and forwards them to a queue."""
 
-    def test_only_relevant_message_types_are_forwarded(
-        self, surge_xt_interactive, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_only_relevant_message_types_are_forwarded(self, surge_xt_interactive) -> None:
         """note_on/off, control_change, pitchwheel, aftertouch are queued; others are dropped."""
         forwarded = [
             _FakeMidiMessage("note_on", [0x90, 0x3C, 0x40]),
@@ -462,17 +460,16 @@ class TestMidiListener:
         ]
 
         drain_event = threading.Event()
-        monkeypatch.setattr(
-            surge_xt_interactive.mido,
-            "open_input",
-            lambda port_name: _FakeMidiPortHandle(all_messages, drain_event=drain_event),
-        )
+
+        def fake_port_opener(_port_name: str) -> _FakeMidiPortHandle:
+            return _FakeMidiPortHandle(all_messages, drain_event=drain_event)
 
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
         listener_thread = threading.Thread(
             target=surge_xt_interactive.midi_listener,
             args=("fake-port", midi_queue, stop_event),
+            kwargs={"port_opener": fake_port_opener},
         )
         listener_thread.start()
         # ``_FakeMidiPortHandle`` flips ``drain_event`` once the queued list is empty,
@@ -504,31 +501,25 @@ class TestMidiListener:
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
         stop_event.set()
-        # Drop in the idle port via a class-attribute swap so we don't reach the real
-        # mido backend (which would still try to enumerate hardware on import).
-        original_open_input = surge_xt_interactive.mido.open_input
-        surge_xt_interactive.mido.open_input = lambda _port: _IdlePort()
-        try:
-            surge_xt_interactive.midi_listener("fake-port", midi_queue, stop_event)
-        finally:
-            surge_xt_interactive.mido.open_input = original_open_input
+
+        surge_xt_interactive.midi_listener(
+            "fake-port", midi_queue, stop_event, port_opener=lambda _port: _IdlePort()
+        )
 
         assert midi_queue.empty()
 
-    def test_open_input_failure_logs_and_exits_thread(
-        self, surge_xt_interactive, monkeypatch: pytest.MonkeyPatch, caplog
-    ) -> None:
+    def test_open_input_failure_logs_and_exits_thread(self, surge_xt_interactive, caplog) -> None:
         """``midi_listener`` must not raise; failures are logged so the daemon exits cleanly."""
 
-        def _raise(_port_name: str) -> object:
+        def raising_port_opener(_port_name: str) -> object:
             raise OSError("device disconnected")
-
-        monkeypatch.setattr(surge_xt_interactive.mido, "open_input", _raise)
 
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
         with caplog.at_level("ERROR"):
-            surge_xt_interactive.midi_listener("fake-port", midi_queue, stop_event)
+            surge_xt_interactive.midi_listener(
+                "fake-port", midi_queue, stop_event, port_opener=raising_port_opener
+            )
 
         assert midi_queue.empty()
         assert any("MIDI listener thread aborted" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

Step 5 of [#844](https://github.com/tinaudio/synth-setter/issues/844). Stacked on top of [#852](https://github.com/tinaudio/synth-setter/pull/852) (step 4 — `TestMidiListener`).

Drops six monkeypatches in `TestPlayAudioQueueDrain` (3× `AudioStream` swap + 3× `plugin.process` re-bind). Two changes enable that:

1. **`_RecordingPlugin` gains `stop_event` + `stop_after_n_calls`** — its own `process()` method flips the event after the Nth call, so `play_audio` exits naturally. No more late-bound `monkeypatch.setattr(plugin, "process", _stop_after_first_buffer)` hack.
2. **`audio_stream_factory=lambda: stream`** is passed directly via the kwarg added in step 1. `_AudioStreamStub` (an inner class that existed only to expose `default_output_device_name` so the monkeypatch didn't break the production default factory) is gone.

`_FakeStream`'s `default_output_device_name` class attribute is also removed — it only existed to satisfy the stub class.

The new tests are strictly more state-based: every assertion checks observable state (`plugin.messages_per_call`, `stream.writes`, `stop_event.is_set()`) rather than mock spy state.

## Diff

```
tests/scripts/test_surge_xt_interactive.py | 134 +++++++++++++----------------
1 file changed, 59 insertions(+), 75 deletions(-)
```

## Test plan

- [x] `pytest tests/scripts/test_surge_xt_interactive.py::TestPlayAudioQueueDrain -v` — 3 passed
- [x] Full file `pytest tests/scripts/test_surge_xt_interactive.py -m "not slow"` — 63 passed
- [x] `make format` — clean
- [x] Audit: zero `monkeypatch` / `AudioStream =` references inside `TestPlayAudioQueueDrain`

## Note on base branch

This PR's base is `test/de-mock-surge-xt-interactive-step-4`, not `main`. After steps 1–4 land, GitHub will retarget to `main`.

Refs #844