### PR TITLE
test(surge-interactive): step 6 — extract pure helpers (#844)

### DIFF
--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -713,7 +713,8 @@ def _build_predict_vst_audio_argv(
     """Build the argv list for ``scripts/predict_vst_audio.py`` rendering.
 
     On Linux the VST headless wrapper is prepended so the subprocess inherits a Xvfb display.
-    Pure function — does not touch ``audio_dir`` or invoke ``predict_vst_audio.py``.
+    No subprocess execution and no writes; the only side effects are reading ``sys.platform``
+    and an existence check on ``_VST_HEADLESS_WRAPPER`` when running on Linux.
 
     :raises FileNotFoundError: on Linux when ``_VST_HEADLESS_WRAPPER`` is absent.
     """
@@ -744,7 +745,7 @@ def _validate_rendered_audio_dir(audio_dir: Path, num_samples: int) -> None:
 
     Each ``sample_{i}`` directory must contain the four expected artifacts (``target.wav``,
     ``pred.wav``, ``spec.png``, ``params.csv``) and the rendered WAVs must not be silent.
-    Pure function — only reads from ``audio_dir``.
+    Read-only with respect to ``audio_dir`` — no writes and no subprocess execution.
 
     :raises FileNotFoundError: if a sample directory is missing or any artifact is absent.
     :raises ValueError: if a rendered WAV's peak amplitude is below ``SILENCE_PEAK_THRESHOLD``.
@@ -785,8 +786,8 @@ def _render_predicted_audio(
     """Render audio for the predicted patches and validate per-sample outputs.
 
     Thin orchestrator over :func:`_build_predict_vst_audio_argv` (argv construction) and
-    :func:`_validate_rendered_audio_dir` (post-render checks); both are pure functions
-    independently testable without a ``subprocess_runner``.
+    :func:`_validate_rendered_audio_dir` (post-render checks); neither helper invokes a
+    subprocess, so both are independently testable without a ``subprocess_runner``.
 
     ``param_spec_name`` and ``preset_path`` must match the values used to capture the patches —
     otherwise ``predict_vst_audio.py`` would fall back to its own defaults (``surge_xt`` /

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -749,15 +749,18 @@ def _validate_rendered_audio_dir(audio_dir: Path, num_samples: int) -> None:
     :raises FileNotFoundError: if a sample directory is missing or any artifact is absent.
     :raises ValueError: if a rendered WAV's peak amplitude is below ``SILENCE_PEAK_THRESHOLD``.
     """
-    sample_dirs = sorted(d for d in audio_dir.iterdir() if d.is_dir())
-    actual_sample_names = [d.name for d in sample_dirs]
-    expected_sample_names = [f"sample_{i}" for i in range(num_samples)]
+    # Compare as sets so num_samples >= 10 doesn't trip on lexical ordering
+    # (``sample_10`` sorts before ``sample_2`` in a plain ``sorted()``).
+    expected_sample_names = {f"sample_{i}" for i in range(num_samples)}
+    actual_sample_names = {d.name for d in audio_dir.iterdir() if d.is_dir()}
     if actual_sample_names != expected_sample_names:
+        missing = sorted(expected_sample_names - actual_sample_names)
+        extra = sorted(actual_sample_names - expected_sample_names)
         raise FileNotFoundError(
-            f"unexpected sample directories in {audio_dir}: "
-            f"got {actual_sample_names}, expected {expected_sample_names}"
+            f"unexpected sample directories in {audio_dir}: missing={missing}, extra={extra}"
         )
-    for sample_dir in sample_dirs:
+    for i in range(num_samples):
+        sample_dir = audio_dir / f"sample_{i}"
         for fname in ("target.wav", "pred.wav", "spec.png", "params.csv"):
             artifact_path = sample_dir / fname
             if not artifact_path.is_file():

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -704,26 +704,18 @@ def _validate_predictions(predictions_output_dir: Path, num_samples: int) -> Non
             raise ValueError(f"{pred_path} contains NaN/Inf")
 
 
-def _render_predicted_audio(
+def _build_predict_vst_audio_argv(
     predictions_output_dir: Path,
     audio_dir: Path,
-    num_samples: int,
     param_spec_name: str,
     preset_path: str,
-    *,
-    subprocess_runner: SubprocessRunner | None = None,
-) -> None:
-    """Render audio for the predicted patches and validate per-sample outputs (file presence and
-    non-silent WAVs).
+) -> list[str]:
+    """Build the argv list for ``scripts/predict_vst_audio.py`` rendering.
 
-    ``param_spec_name`` and ``preset_path`` must match the values used to capture the patches —
-    otherwise ``predict_vst_audio.py`` would fall back to its own defaults (``surge_xt`` /
-    ``presets/surge-base.vstpreset``) and decode/render against a mismatched spec.
+    On Linux the VST headless wrapper is prepended so the subprocess inherits a Xvfb display.
+    Pure function — does not touch ``audio_dir`` or invoke ``predict_vst_audio.py``.
 
-    :raises FileNotFoundError: if the headless wrapper is missing on Linux, if any sample directory
-        is missing, or if a per-sample artifact (target.wav, pred.wav, spec.png, params.csv) is
-        absent.
-    :raises ValueError: if a rendered WAV's peak amplitude is below ``SILENCE_PEAK_THRESHOLD``.
+    :raises FileNotFoundError: on Linux when ``_VST_HEADLESS_WRAPPER`` is absent.
     """
     args: list[str] = []
     if sys.platform == "linux":
@@ -744,21 +736,19 @@ def _render_predicted_audio(
         preset_path,
         "-t",
     ]
-    runner = subprocess_runner if subprocess_runner is not None else subprocess.run
-    try:
-        runner(  # noqa: S603
-            args,
-            check=True,
-            timeout=_VST_SUBPROCESS_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired:
-        logger.error(
-            "predict_vst_audio timed out after %ss; command: %s",
-            _VST_SUBPROCESS_TIMEOUT_SECONDS,
-            args,
-        )
-        raise
+    return args
 
+
+def _validate_rendered_audio_dir(audio_dir: Path, num_samples: int) -> None:
+    """Verify ``predict_vst_audio.py`` wrote ``num_samples`` complete sample directories.
+
+    Each ``sample_{i}`` directory must contain the four expected artifacts (``target.wav``,
+    ``pred.wav``, ``spec.png``, ``params.csv``) and the rendered WAVs must not be silent.
+    Pure function — only reads from ``audio_dir``.
+
+    :raises FileNotFoundError: if a sample directory is missing or any artifact is absent.
+    :raises ValueError: if a rendered WAV's peak amplitude is below ``SILENCE_PEAK_THRESHOLD``.
+    """
     sample_dirs = sorted(d for d in audio_dir.iterdir() if d.is_dir())
     actual_sample_names = [d.name for d in sample_dirs]
     expected_sample_names = [f"sample_{i}" for i in range(num_samples)]
@@ -778,6 +768,50 @@ def _render_predicted_audio(
             peak = float(np.abs(audio).max())
             if peak <= SILENCE_PEAK_THRESHOLD:
                 raise ValueError(f"{sample_dir.name}/{wav_name} is silent (peak={peak:.2e})")
+
+
+def _render_predicted_audio(
+    predictions_output_dir: Path,
+    audio_dir: Path,
+    num_samples: int,
+    param_spec_name: str,
+    preset_path: str,
+    *,
+    subprocess_runner: SubprocessRunner | None = None,
+) -> None:
+    """Render audio for the predicted patches and validate per-sample outputs.
+
+    Thin orchestrator over :func:`_build_predict_vst_audio_argv` (argv construction) and
+    :func:`_validate_rendered_audio_dir` (post-render checks); both are pure functions
+    independently testable without a ``subprocess_runner``.
+
+    ``param_spec_name`` and ``preset_path`` must match the values used to capture the patches —
+    otherwise ``predict_vst_audio.py`` would fall back to its own defaults (``surge_xt`` /
+    ``presets/surge-base.vstpreset``) and decode/render against a mismatched spec.
+
+    :raises FileNotFoundError: if the headless wrapper is missing on Linux, if any sample directory
+        is missing, or if a per-sample artifact (target.wav, pred.wav, spec.png, params.csv) is
+        absent.
+    :raises ValueError: if a rendered WAV's peak amplitude is below ``SILENCE_PEAK_THRESHOLD``.
+    """
+    args = _build_predict_vst_audio_argv(
+        predictions_output_dir, audio_dir, param_spec_name, preset_path
+    )
+    runner = subprocess_runner if subprocess_runner is not None else subprocess.run
+    try:
+        runner(  # noqa: S603
+            args,
+            check=True,
+            timeout=_VST_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        logger.error(
+            "predict_vst_audio timed out after %ss; command: %s",
+            _VST_SUBPROCESS_TIMEOUT_SECONDS,
+            args,
+        )
+        raise
+    _validate_rendered_audio_dir(audio_dir, num_samples)
 
 
 def _compute_and_validate_metrics(

--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -467,7 +467,7 @@ class TestMidiListener:
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
         # ``daemon=True`` so a hung listener can't block pytest shutdown if the
-        # fixture-side ``drain_event`` assertion below fails before we set ``stop_event``.
+        # ``drain_event`` assertion below fails before we set ``stop_event``.
         listener_thread = threading.Thread(
             target=surge_xt_interactive.midi_listener,
             args=("fake-port", midi_queue, stop_event),

--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -466,17 +466,24 @@ class TestMidiListener:
 
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
+        # ``daemon=True`` so a hung listener can't block pytest shutdown if the
+        # fixture-side ``drain_event`` assertion below fails before we set ``stop_event``.
         listener_thread = threading.Thread(
             target=surge_xt_interactive.midi_listener,
             args=("fake-port", midi_queue, stop_event),
             kwargs={"port_opener": fake_port_opener},
+            daemon=True,
         )
         listener_thread.start()
-        # ``_FakeMidiPortHandle`` flips ``drain_event`` once the queued list is empty,
-        # so we know the listener has observed every message before we ask it to stop.
-        assert drain_event.wait(timeout=2.0), "listener did not drain fake messages"
-        stop_event.set()
-        listener_thread.join(timeout=2.0)
+        # Belt-and-suspenders: even though the thread is now daemonic, signal shutdown
+        # and join in a finally block so a failed drain assertion still cleans up.
+        try:
+            # ``_FakeMidiPortHandle`` flips ``drain_event`` once the queued list is empty,
+            # so we know the listener has observed every message before we ask it to stop.
+            assert drain_event.wait(timeout=2.0), "listener did not drain fake messages"
+        finally:
+            stop_event.set()
+            listener_thread.join(timeout=2.0)
         assert not listener_thread.is_alive(), "listener did not exit on stop_event"
 
         drained: list[tuple[list[int], float]] = []

--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -533,9 +533,7 @@ class TestMidiListener:
 
 
 class _FakeStream:
-    """Captures buffers written by ``play_audio``; serves as an ``AudioStream`` stand-in."""
-
-    default_output_device_name: str = "fake-device"
+    """Captures buffers written by ``play_audio``; an ``AudioStreamProtocol`` stand-in."""
 
     def __init__(self) -> None:
         self.writes: list[np.ndarray] = []
@@ -551,11 +549,26 @@ class _FakeStream:
 
 
 class _RecordingPlugin:
-    """Stand-in for a ``VST3Plugin`` that records the ``messages`` arg to ``process()``."""
+    """Stand-in for a ``VST3Plugin`` that records the ``messages`` arg to ``process()``.
 
-    def __init__(self, channels: int, buffer_size: int) -> None:
+    When ``stop_event`` and ``stop_after_n_calls`` are provided, the Nth ``process()``
+    invocation flips ``stop_event`` so ``play_audio`` exits its loop deterministically.
+    This replaces the late ``monkeypatch.setattr(plugin, "process", ...)`` re-bind that
+    earlier versions of ``TestPlayAudioQueueDrain`` used to drive shutdown.
+    """
+
+    def __init__(
+        self,
+        channels: int,
+        buffer_size: int,
+        *,
+        stop_event: threading.Event | None = None,
+        stop_after_n_calls: int = 1,
+    ) -> None:
         self._channels = channels
         self._buffer_size = buffer_size
+        self._stop_event = stop_event
+        self._stop_after_n_calls = stop_after_n_calls
         self.messages_per_call: list[list[tuple[list[int], float]]] = []
 
     def process(
@@ -569,108 +582,79 @@ class _RecordingPlugin:
     ) -> np.ndarray:
         assert reset is False
         self.messages_per_call.append(list(messages))
+        if (
+            self._stop_event is not None
+            and len(self.messages_per_call) >= self._stop_after_n_calls
+        ):
+            self._stop_event.set()
         return np.zeros((self._channels, self._buffer_size), dtype=np.float32)
 
 
 class TestPlayAudioQueueDrain:
     """``play_audio`` drains the MIDI queue into ``plugin.process`` once per buffer."""
 
-    def test_queued_events_are_forwarded_to_plugin_process(
-        self, surge_xt_interactive, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_queued_events_are_forwarded_to_plugin_process(self, surge_xt_interactive) -> None:
         """Tuples enqueued by the listener are drained and passed to ``plugin.process``."""
-        plugin = _RecordingPlugin(surge_xt_interactive.CHANNELS, surge_xt_interactive.BUFFER_SIZE)
+        stop_event = threading.Event()
+        plugin = _RecordingPlugin(
+            surge_xt_interactive.CHANNELS,
+            surge_xt_interactive.BUFFER_SIZE,
+            stop_event=stop_event,
+            stop_after_n_calls=1,
+        )
         stream = _FakeStream()
-
-        class _AudioStreamStub:
-            default_output_device_name = "fake-device"
-
-            def __new__(cls, **_kwargs: object) -> "_FakeStream":  # type: ignore[misc]
-                return stream
-
-        monkeypatch.setattr(surge_xt_interactive, "AudioStream", _AudioStreamStub)
 
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         midi_queue.put(([0x90, 0x3C, 0x40], 0.0))
         midi_queue.put(([0x80, 0x3C, 0x00], 0.0))
 
-        stop_event = threading.Event()
-
-        def _stop_after_first_buffer(*_args: object, **_kwargs: object) -> np.ndarray:
-            stop_event.set()
-            plugin.messages_per_call.append(list(_args[0]))  # type: ignore[arg-type]
-            return np.zeros(
-                (surge_xt_interactive.CHANNELS, surge_xt_interactive.BUFFER_SIZE),
-                dtype=np.float32,
-            )
-
-        monkeypatch.setattr(plugin, "process", _stop_after_first_buffer)
-        surge_xt_interactive.play_audio(plugin, stop_event, midi_queue)
+        surge_xt_interactive.play_audio(
+            plugin, stop_event, midi_queue, audio_stream_factory=lambda: stream
+        )
 
         assert plugin.messages_per_call == [[([0x90, 0x3C, 0x40], 0.0), ([0x80, 0x3C, 0x00], 0.0)]]
+        assert stop_event.is_set()
+        assert len(stream.writes) == 1
 
-    def test_none_queue_passes_empty_messages_list(
-        self, surge_xt_interactive, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_none_queue_passes_empty_messages_list(self, surge_xt_interactive) -> None:
         """When no MIDI port is configured, ``play_audio`` is invoked with ``midi_queue=None``."""
-        plugin = _RecordingPlugin(surge_xt_interactive.CHANNELS, surge_xt_interactive.BUFFER_SIZE)
+        stop_event = threading.Event()
+        plugin = _RecordingPlugin(
+            surge_xt_interactive.CHANNELS,
+            surge_xt_interactive.BUFFER_SIZE,
+            stop_event=stop_event,
+            stop_after_n_calls=1,
+        )
         stream = _FakeStream()
 
-        class _AudioStreamStub:
-            default_output_device_name = "fake-device"
-
-            def __new__(cls, **_kwargs: object) -> "_FakeStream":  # type: ignore[misc]
-                return stream
-
-        monkeypatch.setattr(surge_xt_interactive, "AudioStream", _AudioStreamStub)
-
-        stop_event = threading.Event()
-
-        def _stop_after_first_buffer(*_args: object, **_kwargs: object) -> np.ndarray:
-            stop_event.set()
-            plugin.messages_per_call.append(list(_args[0]))  # type: ignore[arg-type]
-            return np.zeros(
-                (surge_xt_interactive.CHANNELS, surge_xt_interactive.BUFFER_SIZE),
-                dtype=np.float32,
-            )
-
-        monkeypatch.setattr(plugin, "process", _stop_after_first_buffer)
-        surge_xt_interactive.play_audio(plugin, stop_event, None)
+        surge_xt_interactive.play_audio(
+            plugin, stop_event, None, audio_stream_factory=lambda: stream
+        )
 
         assert plugin.messages_per_call == [[]]
+        assert stop_event.is_set()
 
-    def test_drain_is_capped_at_max_midi_events_per_buffer(
-        self, surge_xt_interactive, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_drain_is_capped_at_max_midi_events_per_buffer(self, surge_xt_interactive) -> None:
         """A queue larger than ``_MAX_MIDI_EVENTS_PER_BUFFER`` drains in chunks across buffers,
         preventing one realtime callback from stretching to process the full backlog."""
         cap = surge_xt_interactive._MAX_MIDI_EVENTS_PER_BUFFER
-        plugin = _RecordingPlugin(surge_xt_interactive.CHANNELS, surge_xt_interactive.BUFFER_SIZE)
+        stop_event = threading.Event()
+        plugin = _RecordingPlugin(
+            surge_xt_interactive.CHANNELS,
+            surge_xt_interactive.BUFFER_SIZE,
+            stop_event=stop_event,
+            stop_after_n_calls=1,  # stop after the first buffer to assert the per-buffer cap
+        )
         stream = _FakeStream()
-
-        class _AudioStreamStub:
-            default_output_device_name = "fake-device"
-
-            def __new__(cls, **_kwargs: object) -> "_FakeStream":  # type: ignore[misc]
-                return stream
-
-        monkeypatch.setattr(surge_xt_interactive, "AudioStream", _AudioStreamStub)
 
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         # Enqueue cap + 5 events; first buffer should drain ``cap``, leaving 5 in the queue.
         for _ in range(cap + 5):
             midi_queue.put(([0x90, 0x3C, 0x40], 0.0))
 
-        stop_event = threading.Event()
-        # Stop after the first buffer so we can assert the per-buffer cap directly.
-        original_process = plugin.process
-
-        def _stop_after_first_buffer(*args: object, **kwargs: object) -> np.ndarray:
-            stop_event.set()
-            return original_process(*args, **kwargs)  # type: ignore[arg-type]
-
-        monkeypatch.setattr(plugin, "process", _stop_after_first_buffer)
-        surge_xt_interactive.play_audio(plugin, stop_event, midi_queue)
+        surge_xt_interactive.play_audio(
+            plugin, stop_event, midi_queue, audio_stream_factory=lambda: stream
+        )
 
         assert len(plugin.messages_per_call) == 1
         assert len(plugin.messages_per_call[0]) == cap

--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -435,9 +435,7 @@ class _FakeMidiPortHandle:
 class TestMidiListener:
     """``midi_listener`` filters mido messages by type and forwards them to a queue."""
 
-    def test_only_relevant_message_types_are_forwarded(
-        self, surge_xt_interactive, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_only_relevant_message_types_are_forwarded(self, surge_xt_interactive) -> None:
         """note_on/off, control_change, pitchwheel, aftertouch are queued; others are dropped."""
         forwarded = [
             _FakeMidiMessage("note_on", [0x90, 0x3C, 0x40]),
@@ -462,17 +460,16 @@ class TestMidiListener:
         ]
 
         drain_event = threading.Event()
-        monkeypatch.setattr(
-            surge_xt_interactive.mido,
-            "open_input",
-            lambda port_name: _FakeMidiPortHandle(all_messages, drain_event=drain_event),
-        )
+
+        def fake_port_opener(_port_name: str) -> _FakeMidiPortHandle:
+            return _FakeMidiPortHandle(all_messages, drain_event=drain_event)
 
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
         listener_thread = threading.Thread(
             target=surge_xt_interactive.midi_listener,
             args=("fake-port", midi_queue, stop_event),
+            kwargs={"port_opener": fake_port_opener},
         )
         listener_thread.start()
         # ``_FakeMidiPortHandle`` flips ``drain_event`` once the queued list is empty,
@@ -504,31 +501,25 @@ class TestMidiListener:
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
         stop_event.set()
-        # Drop in the idle port via a class-attribute swap so we don't reach the real
-        # mido backend (which would still try to enumerate hardware on import).
-        original_open_input = surge_xt_interactive.mido.open_input
-        surge_xt_interactive.mido.open_input = lambda _port: _IdlePort()
-        try:
-            surge_xt_interactive.midi_listener("fake-port", midi_queue, stop_event)
-        finally:
-            surge_xt_interactive.mido.open_input = original_open_input
+
+        surge_xt_interactive.midi_listener(
+            "fake-port", midi_queue, stop_event, port_opener=lambda _port: _IdlePort()
+        )
 
         assert midi_queue.empty()
 
-    def test_open_input_failure_logs_and_exits_thread(
-        self, surge_xt_interactive, monkeypatch: pytest.MonkeyPatch, caplog
-    ) -> None:
+    def test_open_input_failure_logs_and_exits_thread(self, surge_xt_interactive, caplog) -> None:
         """``midi_listener`` must not raise; failures are logged so the daemon exits cleanly."""
 
-        def _raise(_port_name: str) -> object:
+        def raising_port_opener(_port_name: str) -> object:
             raise OSError("device disconnected")
-
-        monkeypatch.setattr(surge_xt_interactive.mido, "open_input", _raise)
 
         midi_queue: queue.Queue[tuple[list[int], float]] = queue.Queue()
         stop_event = threading.Event()
         with caplog.at_level("ERROR"):
-            surge_xt_interactive.midi_listener("fake-port", midi_queue, stop_event)
+            surge_xt_interactive.midi_listener(
+                "fake-port", midi_queue, stop_event, port_opener=raising_port_opener
+            )
 
         assert midi_queue.empty()
         assert any("MIDI listener thread aborted" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

Step 6 of [#844](https://github.com/tinaudio/synth-setter/issues/844). Stacked on top of [#853](https://github.com/tinaudio/synth-setter/pull/853) (step 5 — `TestPlayAudioQueueDrain`).

Splits `_render_predicted_audio` into three:

| Function | Responsibility |
|---|---|
| `_build_predict_vst_audio_argv(predictions_dir, audio_dir, spec, preset) -> list[str]` | Pure argv construction; raises `FileNotFoundError` on Linux when the headless wrapper is absent |
| `_validate_rendered_audio_dir(audio_dir, num_samples) -> None` | Pure filesystem validation: per-sample dirs, expected artifacts, non-silent WAVs |
| `_render_predicted_audio` (now thin) | Orchestrator: build argv → invoke subprocess (with `TimeoutExpired` logging) → validate |

Production behavior is unchanged — the orchestrator calls exactly the same code paths the helpers expose, so no parallel implementations.

The two pure helpers exist so **step 7** can replace the eight `TestRenderPredictedAudio` monkeypatch-and-prepopulate tests with state-based unit tests (against real `tmp_path` fixtures for the validator) + an e2e test gated on `requires_vst`.

## Diff

```
scripts/surge_xt_interactive.py | 90 ++++++++++++++++++++++++++++-------------
1 file changed, 62 insertions(+), 28 deletions(-)
```

## Test plan

- [x] `pytest tests/scripts/test_surge_xt_interactive.py -m "not slow"` — 63 passed (existing `TestRenderPredictedAudio` tests still pass; orchestrator behavior unchanged)
- [x] `pyright scripts/surge_xt_interactive.py` — 0 errors
- [x] `make format` — clean

## Note on base branch

Stacked: base is `test/de-mock-surge-xt-interactive-step-5`, not `main`. After steps 1–5 land, GitHub will retarget to `main`.

Refs #844