### PR TITLE
fix(surge-interactive): bound _validate_metrics_df NaN/Inf error message

### DIFF
--- a/docs/design/eval-pipeline.md
+++ b/docs/design/eval-pipeline.md
@@ -211,6 +211,10 @@ The evaluation pipeline is a three-stage batch pipeline. Each stage is an indepe
 | Docker         | R2             | Xvfb (baked) | Baked in image      | CUDA | `make docker-eval` |
 | GitHub Actions | Repo fixture   | Xvfb         | Headless stub or CI | None | PR trigger         |
 
+### Consumers
+
+Interactive captured-patch evaluation: `scripts/surge_xt_interactive.py --checkpoint-path …` invokes the predict → render → metrics chain end-to-end via `eval_patches` (see [`docs/guides/surge-xt-interactive.md`](../guides/surge-xt-interactive.md)).
+
 ## 5. Stage Definitions
 
 ### 5.1 Predict

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -214,9 +214,15 @@ def _validate_metrics_df(
             f"{metrics_path}: missing expected columns {sorted(missing_columns)}; "
             f"got {sorted(metrics_df.columns)}"
         )
-    numeric = metrics_df[sorted(expected.columns)].to_numpy()
+    expected_cols = sorted(expected.columns)
+    numeric = metrics_df[expected_cols].to_numpy()
     if not np.isfinite(numeric).all():
-        raise ValueError(f"{metrics_path} contains NaN/Inf:\n{metrics_df}")
+        bad_mask = ~np.isfinite(numeric).all(axis=1)
+        bad_rows = metrics_df.loc[bad_mask, expected_cols]
+        raise ValueError(
+            f"{metrics_path} contains NaN/Inf in {len(bad_rows)} of {len(metrics_df)} rows:\n"
+            f"{bad_rows}"
+        )
 
 
 @dataclass(frozen=True)

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -216,8 +216,9 @@ def _validate_metrics_df(
         )
     expected_cols = sorted(expected.columns)
     numeric = metrics_df[expected_cols].to_numpy()
-    if not np.isfinite(numeric).all():
-        bad_mask = ~np.isfinite(numeric).all(axis=1)
+    finite_mask = np.isfinite(numeric)
+    if not finite_mask.all():
+        bad_mask = ~finite_mask.all(axis=1)
         bad_rows = metrics_df.loc[bad_mask, expected_cols]
         raise ValueError(
             f"{metrics_path} contains NaN/Inf in {len(bad_rows)} of {len(metrics_df)} rows:\n"

--- a/tests/scripts/test_surge_xt_interactive.py
+++ b/tests/scripts/test_surge_xt_interactive.py
@@ -980,6 +980,27 @@ class TestValidateMetricsDf:
         with pytest.raises(ValueError, match="NaN/Inf"):
             surge_xt_interactive._validate_metrics_df(Path("metrics.csv"), df, spec)
 
+    def test_nan_error_reports_offending_row_count_not_full_df(self, surge_xt_interactive) -> None:
+        """Error message reports only the offending row count and rows, not the full DataFrame —
+        otherwise a 1000-row metrics.csv with one bad row dumps a thousand lines into the
+        traceback."""
+        df = pd.DataFrame(
+            {
+                "mss": [0.1, float("nan"), 0.3, 0.4, 0.5],
+                "wmfcc": [0.2, 0.3, 0.4, 0.5, 0.6],
+            }
+        )
+        spec = surge_xt_interactive._MetricsFileSpec(rows=5, columns=frozenset({"mss", "wmfcc"}))
+
+        with pytest.raises(ValueError) as exc_info:
+            surge_xt_interactive._validate_metrics_df(Path("metrics.csv"), df, spec)
+
+        msg = str(exc_info.value)
+        assert "1 of 5 rows" in msg
+        # Finite rows must NOT appear in the message (i.e., the helper isn't dumping the full df).
+        assert "0.5" not in msg
+        assert "0.6" not in msg
+
 
 class _RecordingEvalRunner:
     """Test fake matching the ``EvalRunner`` shape from ``surge_xt_interactive``.


### PR DESCRIPTION
Re-lands the two surviving pieces of [#836](https://github.com/tinaudio/synth-setter/pull/836) (closed as stale because most of its diff is already on main after subsequent merges).

## What changed

### `_validate_metrics_df` reports only offending rows

On NaN/Inf, the helper used to format the entire DataFrame into the `ValueError` message:

```python
raise ValueError(f"{metrics_path} contains NaN/Inf:\n{metrics_df}")
```

For a 1000-row `metrics.csv` with a single bad row, that dumps a thousand pandas-formatted lines into the traceback. New behavior — filter to offending rows + the expected metric columns, plus a count:

```python
raise ValueError(
    f"{metrics_path} contains NaN/Inf in {len(bad_rows)} of {len(metrics_df)} rows:\n"
    f"{bad_rows}"
)
```

### `docs/design/eval-pipeline.md` Consumers section

Adds a one-line pointer to `scripts/surge_xt_interactive.py --checkpoint-path …` so readers landing on the eval-pipeline design doc know the user-facing entry point that drives the predict → render → metrics chain.

## Tests

- New `test_nan_error_reports_offending_row_count_not_full_df` asserts the new message format names the offending row count and excludes finite-row values from the dump.
- Adversarial mutation: reverting to the old `f"{metrics_df}"` dump → the new test fails (`AssertionError: assert '1 of 5 rows' in 'metrics.csv contains NaN/Inf:\n…'`).

```
$ python -m pytest tests/scripts/test_surge_xt_interactive.py::TestValidateMetricsDf -q
5 passed in 0.83s
```

Refs #844