### PR TITLE
feat(workflows): surface launcher knobs on test-dataset-generation dispatch

### DIFF
--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -364,10 +364,20 @@ jobs:
   # upload step both write to). `if: !cancelled()` decouples each provider's
   # validate cell from the OTHER provider's generate outcome — RunPod
   # transients won't skip OCI validation.
+  #
+  # Skip on workflow_dispatch with `tail: false` — without --tail the launcher
+  # exits after provisioning, so workers haven't actually rendered/uploaded
+  # shards yet when validate would run. PR-trigger always uses --tail and is
+  # always validated.
   validate:
     name: Validate ${{ matrix.provider }} dataset
     needs: [setup, generate-local, generate-launcher]
-    if: ${{ !cancelled() && needs.setup.outputs.providers != '[]' }}
+    if: >-
+      ${{
+        !cancelled()
+        && needs.setup.outputs.providers != '[]'
+        && (github.event_name != 'workflow_dispatch' || inputs.tail)
+      }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -74,6 +74,26 @@ on:
           - skypilot-local
           - runpod
           - oci
+      num_workers:
+        description: "Override --num-workers (empty = use the dataset config's value; 1 forced for skypilot-local)."
+        required: false
+        type: string
+        default: ""
+      tail:
+        description: "Pass --tail to the launcher (stream logs + unconditional cluster teardown)."
+        required: false
+        type: boolean
+        default: true
+      local_dispatch:
+        description: "Pass --local to the launcher (force local SDK dispatch; mutually exclusive with api_server). Implicit for skypilot-local."
+        required: false
+        type: boolean
+        default: false
+      api_server:
+        description: "Remote SkyPilot API server URL. Empty = inherit env. Mutually exclusive with local_dispatch."
+        required: false
+        type: string
+        default: ""
   pull_request:
     paths:
       - "src/data/vst/**"
@@ -302,9 +322,16 @@ jobs:
 
   # `skypilot-local` / `runpod` / `oci` rows: route through the official
   # launcher reusable. Cluster name includes `github.run_attempt` so re-running
-  # a failed job doesn't collide on the launcher's R2 spec key. The
-  # `--num-workers 1` override for skypilot-local mirrors today's hardcoded
-  # behavior — the single-node kind cluster can't host parallel workers (#843).
+  # a failed job doesn't collide on the launcher's R2 spec key.
+  #
+  # Knob precedence per row:
+  #   * num_workers — `skypilot-local` always passes `1` (#843; single-node
+  #     kind can't host parallel workers). Other providers pass the dispatch
+  #     input through (empty = use the dataset config's `num_workers`).
+  #   * local       — `skypilot-local` always passes `true` (#841; clears
+  #     inherited SKYPILOT_API_SERVER_ENDPOINT so this row can't accidentally
+  #     route remote). Other providers honor the dispatch input.
+  #   * tail / api_server — dispatch inputs flow through unchanged.
   generate-launcher:
     name: Run generate_dataset (${{ matrix.provider }})
     needs: setup
@@ -324,10 +351,10 @@ jobs:
         }}
       image_tag: ${{ inputs.docker_image_tag || 'dev-snapshot' }}
       cluster_name: synth-setter-smoke-${{ matrix.provider }}-${{ github.run_id }}-${{ github.run_attempt }}
-      num_workers: ${{ matrix.provider == 'skypilot-local' && '1' || '' }}
-      tail: true
-      local: ${{ matrix.provider == 'skypilot-local' }}
-      api_server: ""
+      num_workers: ${{ matrix.provider == 'skypilot-local' && '1' || (github.event_name == 'pull_request' && '' || (inputs.num_workers || '')) }}
+      tail: ${{ github.event_name == 'pull_request' && true || inputs.tail }}
+      local: ${{ matrix.provider == 'skypilot-local' || (github.event_name == 'workflow_dispatch' && inputs.local_dispatch) }}
+      api_server: ${{ github.event_name == 'pull_request' && '' || (inputs.api_server || '') }}
       artifact_name: test-run-metadata-${{ matrix.provider }}
     secrets: inherit
 


### PR DESCRIPTION
## Summary

Stacked on #863. Surfaces the launcher knobs (`num_workers`, `tail`, `local_dispatch`, `api_server`) on `test-dataset-generation.yml`'s `workflow_dispatch` inputs so operators can override them at manual-trigger time without editing the workflow.

The reusable `generate-dataset-shards.yaml` already accepts all four inputs (added in #858); this PR is the wrapper change that exposes them. PR-triggered runs continue using today's hardcoded values via explicit `github.event_name == 'pull_request'` gates.

## What changes

```yaml
workflow_dispatch.inputs:
  num_workers:    string,  default ''     # empty = use config's num_workers
  tail:           boolean, default true   # passes --tail/--no-tail
  local_dispatch: boolean, default false  # passes --local
  api_server:     string,  default ''     # passes --api-server <url>
```

Per-row knob precedence in `generate-launcher`:

- `num_workers` — `skypilot-local` always passes `1` (#843); other providers honor the dispatch input (empty → config value).
- `local` — `skypilot-local` always passes `true` (#841); other providers honor `inputs.local_dispatch` on dispatch.
- `tail` / `api_server` — flow through unchanged.

## Test plan

- [x] `make format` clean
- [x] `gha-workflow-validator` 0 failures (25 checks; same warning class as the other two reusables — info-only secret existence + reusable-call timeout-minutes false-positives)
- [ ] PR-trigger CI run — confirms PR runs still produce the same `skypilot-local, tail=true, local=true, num_workers=1` shape (auto-runs on push)
- [ ] Manual `workflow_dispatch` with overrides (e.g. `provider=runpod, num_workers=3, tail=false`) — confirms the reusable receives the overridden values (user-driven, billable)

Closes #861
