### PR TITLE
docs: wire preset_paths registry into surge_xt_interactive

### DIFF
--- a/docs/guides/surge-xt-interactive.md
+++ b/docs/guides/surge-xt-interactive.md
@@ -34,7 +34,8 @@ training pairs that random sampling can't reach.
   walkthrough.
 - Surge XT VST3 at a known path (default `plugins/Surge XT.vst3` —
   satisfied by `make install-surge-xt`).
-- A base preset file (default `presets/surge-base.vstpreset`).
+- A base preset file. Selected automatically from
+  `preset_paths[--param-spec-name]` in `src/data/vst/__init__.py`.
 - A working audio output device. The tool opens a real-time audio
   stream via `pedalboard.io.AudioStream`; headless environments without
   ALSA/PulseAudio cannot run it.
@@ -43,28 +44,38 @@ training pairs that random sampling can't reach.
 
 ## Quick start
 
-Bare audition — open the editor on the base preset, no preloaded params:
+`--param-spec-name` is required in every invocation; it selects the
+parameter spec *and* the matching base preset (loaded via
+`preset_paths[--param-spec-name]`).
+
+Bare audition — open the editor on the registry-selected base preset,
+no preloaded params:
 
 ```bash
-python scripts/surge_xt_interactive.py
+python scripts/surge_xt_interactive.py --param-spec-name surge_xt
 ```
 
 Audition a single prediction row (row index 0 inside `outputs/pred-0.pt`):
 
 ```bash
-python scripts/surge_xt_interactive.py --pred outputs/pred-0.pt:0
+python scripts/surge_xt_interactive.py \
+    --param-spec-name surge_xt \
+    --pred outputs/pred-0.pt:0
 ```
 
 Audition a row from an existing HDF5 dataset:
 
 ```bash
-python scripts/surge_xt_interactive.py --dataset-ref outputs/test.h5:0
+python scripts/surge_xt_interactive.py \
+    --param-spec-name surge_xt \
+    --dataset-ref outputs/test.h5:0
 ```
 
 Record patches and render them into a fresh dataset directory:
 
 ```bash
 python scripts/surge_xt_interactive.py \
+    --param-spec-name surge_xt \
     --pred outputs/pred-0.pt:0 \
     --output-dataset-dir-path outputs/curated-patches/
 ```
@@ -75,6 +86,7 @@ diffs of model predictions:
 
 ```bash
 python scripts/surge_xt_interactive.py \
+    --param-spec-name surge_xt \
     --pred outputs/pred-0.pt:0 \
     --session-recording-path outputs/session.wav
 ```
@@ -95,16 +107,15 @@ raises `click.UsageError`.
 
 ## CLI reference
 
-| Flag                        | Type               | Default                        | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-| --------------------------- | ------------------ | ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--plugin-path` / `-p`      | path               | `plugins/Surge XT.vst3`        | Path to VST3 plugin.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `--preset-path` / `-r`      | path               | `presets/surge-base.vstpreset` | Base preset to load before applying any `--pred` / `--dataset-ref` params.                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `--pred`                    | `PATH:BATCH_IDX`   | unset                          | Prediction reference. When set, the predicted row is decoded and applied to the plugin before the editor opens. Example: `outputs/pred-0.pt:0`.                                                                                                                                                                                                                                                                                                                                                           |
-| `--dataset-ref`             | `PATH:DATASET_IDX` | unset                          | Dataset reference. When set, the dataset row is decoded and applied to the plugin before the editor opens. Example: `outputs/test.h5:0`.                                                                                                                                                                                                                                                                                                                                                                  |
-| `--param-spec-name`         | str                | `surge_xt`                     | Parameter spec name (key into `param_specs`) used to decode prediction/dataset rows applied to the plugin and to enumerate which synth params are captured when recording patches.                                                                                                                                                                                                                                                                                                                        |
-| `--output-dataset-dir-path` | path               | unset                          | Directory to create for the recorded patches. Must not already exist — `make_dataset` writes fixed-size HDF5 datasets without `maxshape` and cannot append to existing files. After the editor is closed, patches captured via the keyboard loop (press `p` to record, `q` to quit) are rendered through the plugin and written to `train.h5` inside this directory via `src.data.vst.generate_vst_dataset.make_dataset` (plus `val.h5`/`test.h5`/`predict.h5` siblings when `--checkpoint-path` is set). |
-| `--checkpoint-path`         | path               | unset                          | Optional checkpoint path to run standalone eval on after rendering captured patches. When set, triggers the `eval_patches` pipeline (`src/eval.py mode=predict` → `predict_vst_audio.py` → `compute_audio_metrics.py`); see [`docs/design/eval-pipeline.md`](../design/eval-pipeline.md) for the full pipeline and `_METRIC_COLUMNS` in the script for the metric series produced.                                                                                                                        |
-| `--session-recording-path`  | path               | unset                          | Optional WAV file to render a deterministic test clip to. When set, the script renders a fixed `SESSION_RECORDING_DURATION_SECONDS` (10 s) WAV containing middle C from `NOTE_START` (2 s) to `NOTE_END` (4 s) through the loaded plugin and exits the audio thread. No live device output. Output depends only on plugin state (preset + `--pred` / `--dataset-ref` params) — same inputs always produce the same WAV. No-op when not set.                                                               |
+| Flag                        | Type               | Default                 | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --------------------------- | ------------------ | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--plugin-path` / `-p`      | path               | `plugins/Surge XT.vst3` | Path to VST3 plugin.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `--pred`                    | `PATH:BATCH_IDX`   | unset                   | Prediction reference. When set, the predicted row is decoded and applied to the plugin before the editor opens. Example: `outputs/pred-0.pt:0`.                                                                                                                                                                                                                                                                                                                                                           |
+| `--dataset-ref`             | `PATH:DATASET_IDX` | unset                   | Dataset reference. When set, the dataset row is decoded and applied to the plugin before the editor opens. Example: `outputs/test.h5:0`.                                                                                                                                                                                                                                                                                                                                                                  |
+| `--param-spec-name`         | choice             | required                | Parameter spec name — one of the keys registered in `src/data/vst/__init__.py` (`param_specs`). Selects which synth params are decoded from prediction/dataset rows, captured into recorded patches, and which base preset is loaded via `preset_paths[--param-spec-name]`. There is no `--preset-path` flag — spec and preset travel together.                                                                                                                                                           |
+| `--output-dataset-dir-path` | path               | unset                   | Directory to create for the recorded patches. Must not already exist — `make_dataset` writes fixed-size HDF5 datasets without `maxshape` and cannot append to existing files. After the editor is closed, patches captured via the keyboard loop (press `p` to record, `q` to quit) are rendered through the plugin and written to `train.h5` inside this directory via `src.data.vst.generate_vst_dataset.make_dataset` (plus `val.h5`/`test.h5`/`predict.h5` siblings when `--checkpoint-path` is set). |
+| `--checkpoint-path`         | path               | unset                   | Optional checkpoint path to run standalone eval on after rendering captured patches. When set, triggers the `eval_patches` pipeline (`src/eval.py mode=predict` → `predict_vst_audio.py` → `compute_audio_metrics.py`); see [`docs/design/eval-pipeline.md`](../design/eval-pipeline.md) for the full pipeline and `_METRIC_COLUMNS` in the script for the metric series produced.                                                                                                                        |
+| `--session-recording-path`  | path               | unset                   | Optional WAV file to render a deterministic test clip to. When set, the script renders a fixed `SESSION_RECORDING_DURATION_SECONDS` (10 s) WAV containing middle C from `NOTE_START` (2 s) to `NOTE_END` (4 s) through the loaded plugin and exits the audio thread. No live device output. Output depends only on plugin state (preset + `--pred` / `--dataset-ref` params) — same inputs always produce the same WAV. No-op when not set.                                                               |
 
 Tip — the help strings above are quoted verbatim from the Click
 decorators in `scripts/surge_xt_interactive.py`. Run
@@ -202,16 +213,20 @@ Worked example:
 python -m src.eval +experiment=surge/eval ckpt_path=...
 
 # 2. Audition row 0 of the resulting predictions.
-python scripts/surge_xt_interactive.py --pred outputs/pred-0.pt:0
+python scripts/surge_xt_interactive.py \
+    --param-spec-name surge_xt \
+    --pred outputs/pred-0.pt:0
 
 # 3. When you find sounds you like, record them and produce a dataset.
 python scripts/surge_xt_interactive.py \
+    --param-spec-name surge_xt \
     --pred outputs/pred-0.pt:0 \
     --output-dataset-dir-path outputs/curated-patches/
 
 # 4. (Optional) re-run with --checkpoint-path to also evaluate the
 #    captured patches end-to-end (predict → render → metrics).
 python scripts/surge_xt_interactive.py \
+    --param-spec-name surge_xt \
     --pred outputs/pred-0.pt:0 \
     --output-dataset-dir-path outputs/curated-patches/ \
     --checkpoint-path outputs/checkpoints/last.ckpt
@@ -287,8 +302,8 @@ the top of the script.
 **`KeyError` from `record_patch`.** A param name in the spec isn't in
 `plugin.parameters`. Likely causes: wrong `--param-spec-name` for the
 loaded plugin, or the preset put the plugin into a state where some
-params are hidden. Try `--param-spec-name surge_xt` against the
-default Surge XT preset to rule out config issues.
+params are hidden. Try `--param-spec-name surge_xt` (the registry maps
+this to `presets/surge-base.vstpreset`) to rule out config issues.
 
 **Prediction tensor shape mismatch.** `--pred` requires the second
 dim of the loaded tensor to match `param_specs[--param-spec-name]` row

--- a/docs/guides/surge-xt-interactive.md
+++ b/docs/guides/surge-xt-interactive.md
@@ -35,7 +35,8 @@ training pairs that random sampling can't reach.
 - Surge XT VST3 at a known path (default `plugins/Surge XT.vst3` —
   satisfied by `make install-surge-xt`).
 - A base preset file. Selected automatically from
-  `preset_paths[--param-spec-name]` in `src/data/vst/__init__.py`.
+  `preset_paths[param_spec_name]` in `src/data/vst/__init__.py`
+  (keyed by the value passed to `--param-spec-name`).
 - A working audio output device. The tool opens a real-time audio
   stream via `pedalboard.io.AudioStream`; headless environments without
   ALSA/PulseAudio cannot run it.
@@ -45,8 +46,8 @@ training pairs that random sampling can't reach.
 ## Quick start
 
 `--param-spec-name` is required in every invocation; it selects the
-parameter spec *and* the matching base preset (loaded via
-`preset_paths[--param-spec-name]`).
+parameter spec *and* the matching base preset (loaded by indexing
+`preset_paths` with the value passed to `--param-spec-name`).
 
 Bare audition — open the editor on the registry-selected base preset,
 no preloaded params:
@@ -112,7 +113,7 @@ raises `click.UsageError`.
 | `--plugin-path` / `-p`      | path               | `plugins/Surge XT.vst3` | Path to VST3 plugin.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | `--pred`                    | `PATH:BATCH_IDX`   | unset                   | Prediction reference. When set, the predicted row is decoded and applied to the plugin before the editor opens. Example: `outputs/pred-0.pt:0`.                                                                                                                                                                                                                                                                                                                                                           |
 | `--dataset-ref`             | `PATH:DATASET_IDX` | unset                   | Dataset reference. When set, the dataset row is decoded and applied to the plugin before the editor opens. Example: `outputs/test.h5:0`.                                                                                                                                                                                                                                                                                                                                                                  |
-| `--param-spec-name`         | choice             | required                | Parameter spec name — one of the keys registered in `src/data/vst/__init__.py` (`param_specs`). Selects which synth params are decoded from prediction/dataset rows, captured into recorded patches, and which base preset is loaded via `preset_paths[--param-spec-name]`. There is no `--preset-path` flag — spec and preset travel together.                                                                                                                                                           |
+| `--param-spec-name`         | choice             | required                | Parameter spec name — one of the keys registered in `src/data/vst/__init__.py` (`param_specs`). Selects which synth params are decoded from prediction/dataset rows, captured into recorded patches, and which base preset is loaded (the script indexes `preset_paths` with this value). There is no `--preset-path` flag — spec and preset travel together.                                                                                                                                             |
 | `--output-dataset-dir-path` | path               | unset                   | Directory to create for the recorded patches. Must not already exist — `make_dataset` writes fixed-size HDF5 datasets without `maxshape` and cannot append to existing files. After the editor is closed, patches captured via the keyboard loop (press `p` to record, `q` to quit) are rendered through the plugin and written to `train.h5` inside this directory via `src.data.vst.generate_vst_dataset.make_dataset` (plus `val.h5`/`test.h5`/`predict.h5` siblings when `--checkpoint-path` is set). |
 | `--checkpoint-path`         | path               | unset                   | Optional checkpoint path to run standalone eval on after rendering captured patches. When set, triggers the `eval_patches` pipeline (`src/eval.py mode=predict` → `predict_vst_audio.py` → `compute_audio_metrics.py`); see [`docs/design/eval-pipeline.md`](../design/eval-pipeline.md) for the full pipeline and `_METRIC_COLUMNS` in the script for the metric series produced.                                                                                                                        |
 | `--session-recording-path`  | path               | unset                   | Optional WAV file to render a deterministic test clip to. When set, the script renders a fixed `SESSION_RECORDING_DURATION_SECONDS` (10 s) WAV containing middle C from `NOTE_START` (2 s) to `NOTE_END` (4 s) through the loaded plugin and exits the audio thread. No live device output. Output depends only on plugin state (preset + `--pred` / `--dataset-ref` params) — same inputs always produce the same WAV. No-op when not set.                                                               |

--- a/docs/guides/surge-xt-interactive.md
+++ b/docs/guides/surge-xt-interactive.md
@@ -1,7 +1,7 @@
 # Guide: Interactive Surge XT prediction & patch capture
 
 > **Status**: Stable
-> **Last Updated**: 2026-05-07
+> **Last Updated**: 2026-05-08
 > **Source**: [`scripts/surge_xt_interactive.py`](../../scripts/surge_xt_interactive.py)
 
 ______________________________________________________________________
@@ -302,8 +302,8 @@ the top of the script.
 **`KeyError` from `record_patch`.** A param name in the spec isn't in
 `plugin.parameters`. Likely causes: wrong `--param-spec-name` for the
 loaded plugin, or the preset put the plugin into a state where some
-params are hidden. Try `--param-spec-name surge_xt` (the registry maps
-this to `presets/surge-base.vstpreset`) to rule out config issues.
+params are hidden. Try `--param-spec-name surge_xt`; that key resolves
+to a base preset via `preset_paths` in `src/data/vst/__init__.py`.
 
 **Prediction tensor shape mismatch.** `--pred` requires the second
 dim of the loaded tensor to match `param_specs[--param-spec-name]` row

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -32,7 +32,7 @@ from pedalboard.io import AudioFile, AudioStream, StreamResampler  # noqa: E402
 from rich.console import Console  # noqa: E402
 from rich.logging import RichHandler  # noqa: E402
 
-from src.data.vst import load_plugin, load_preset, param_specs  # noqa: E402
+from src.data.vst import load_plugin, load_preset, param_specs, preset_paths  # noqa: E402
 from src.data.vst.core import make_midi_events, set_params  # noqa: E402
 from src.data.vst.generate_vst_dataset import make_dataset  # noqa: E402
 from src.data.vst.param_spec import ParamSpec  # noqa: E402
@@ -999,20 +999,14 @@ def eval_patches(
     ),
 )
 @click.option(
-    "--preset-path",
-    "-r",
-    type=str,
-    default="presets/surge-base.vstpreset",
-    help="Base preset to load before applying any --pred / --dataset-ref params.",
-)
-@click.option(
     "--param-spec-name",
-    type=str,
-    default="surge_xt",
+    type=click.Choice(sorted(param_specs.keys())),
+    required=True,
     help=(
-        "Parameter spec name (key into ``param_specs``) used to decode prediction/dataset "
-        "rows applied to the plugin and to enumerate which synth params are captured when "
-        "recording patches."
+        "Parameter spec name used to decode prediction/dataset rows applied to the plugin, "
+        "to enumerate which synth params are captured when recording patches, and to select "
+        "the matching base preset via ``preset_paths``. Required — pass one of the registered "
+        "spec names; the matching base preset is loaded automatically."
     ),
 )
 @click.option(
@@ -1064,7 +1058,6 @@ def main(
     plugin_path: str,
     pred: PredictionRef | None,
     dataset_ref: DatasetRef | None,
-    preset_path: str,
     param_spec_name: str,
     output_dataset_dir_path: Path | None,
     midi_port: str | None,
@@ -1073,9 +1066,12 @@ def main(
 ) -> None:
     """Open Surge XT GUI with real-time audio streaming and record patches to an HDF5 dataset.
 
+    The base preset is selected by ``preset_paths[param_spec_name]`` so a spec/preset
+    mismatch is unrepresentable.
+
     Flow:
 
-    1. Load the plugin and base preset.
+    1. Resolve the base preset from ``preset_paths[param_spec_name]`` and load it.
     2. If ``--pred`` or ``--dataset-ref`` is provided, decode the referenced row and apply
        it to the plugin before the editor opens.
     3. Open the plugin's GUI editor; in parallel, stream audio to the default output device
@@ -1090,6 +1086,7 @@ def main(
        (``predict_vst_audio.py``) and metric computation (``compute_audio_metrics.py``) on
        the captured patches.
     """
+    preset_path = preset_paths[param_spec_name]
     if dataset_ref is not None and pred is not None:
         raise click.UsageError(
             "--pred and --dataset-ref are mutually exclusive; pass at most one."


### PR DESCRIPTION
## Summary

Final wiring step for the `preset_paths` registry in `scripts/surge_xt_interactive.py`. Replaces the stale [#831](https://github.com/tinaudio/synth-setter/pull/831) — that branch was based on long-merged predecessors and its diff vs. `main` had grown to ±10k LOC of unrelated drift. This PR is a fresh branch off current `main` containing only the wiring delta.

- `--preset-path` is removed; the base preset is selected by `preset_paths[param_spec_name]`. A spec/preset mismatch is now unrepresentable.
- `--param-spec-name` becomes a `click.Choice(sorted(param_specs.keys()))` with `required=True` (was `str`, default `"surge_xt"`).
- `main()` resolves the preset path from the registry and threads the same string through `make_dataset` and `_maybe_eval_captured_patches`. The eval-helper signatures (and their tests) stay unchanged — registry resolution lives at the CLI boundary, downstream code is untouched.
- `docs/guides/surge-xt-interactive.md` updated: CLI table drops `--preset-path` and marks `--param-spec-name` required-choice; prerequisites and every quick-start example pass `--param-spec-name` explicitly.

Net diff: +45 / -33 across 2 files.

## Out of scope

- Tests don't invoke `main()` via Click and assert on flags; helper signatures are unchanged, so the existing 74-test suite for this script passes without edits.

Refs #866

## Test plan

- [x] `pyright scripts/surge_xt_interactive.py` -> 0 errors (pre-commit `pyright` hook passed)
- [x] `python3 -c "import ast; ast.parse(open('scripts/surge_xt_interactive.py').read())"` -> parse OK
- [x] No leftover `--preset-path` Click flag in script or guide (`grep` confirms)
- [x] `pytest tests/scripts/test_surge_xt_interactive.py -m "not slow"` -> 74 passed (the lone deselect is `TestLoadDatasetSynthParams::test_loads_row_from_surge_xt_smoke_fixture`, which needs the Surge XT VST3 plugin binary at `plugins/Surge XT.vst3` — unavailable in this env, unrelated to this change)
- [x] Pre-commit hooks pass on commit (ruff/pyright/mdformat/docformatter/interrogate all green)