### PR TITLE
fix(ci): pr-metadata-gate `gh api --paginate --jq '...|length'` sums broken across pages

### DIFF
--- a/.github/workflows/pr-metadata-gate.yaml
+++ b/.github/workflows/pr-metadata-gate.yaml
@@ -30,15 +30,22 @@ jobs:
           echo "::endgroup::"
 
           # --- Linked issue check ---
-          # Check for currently-linked issues via the timeline API
-          # Count "connected" events minus "disconnected" events to get current links
+          # Check for currently-linked issues via the timeline API.
+          # Count "connected" events minus "disconnected" events to get current links.
+          #
+          # `gh api --paginate --jq` runs the jq filter once per fetched page
+          # and concatenates the outputs, so a long-timeline PR yields one
+          # length per page (e.g. "0\n0"). Pipe through awk to sum the
+          # per-page counts into a single integer.
           CONNECTED=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/timeline" \
-            --paginate --jq '[.[] | select(.event == "connected")] | length') || {
+            --paginate --jq '[.[] | select(.event == "connected")] | length' \
+            | awk '{s+=$1} END {print s+0}') || {
             echo "::error::Failed to fetch timeline events from GitHub API. Re-run the job if transient."
             exit 1
           }
           DISCONNECTED=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/timeline" \
-            --paginate --jq '[.[] | select(.event == "disconnected")] | length') || {
+            --paginate --jq '[.[] | select(.event == "disconnected")] | length' \
+            | awk '{s+=$1} END {print s+0}') || {
             echo "::error::Failed to fetch timeline events from GitHub API. Re-run the job if transient."
             exit 1
           }


### PR DESCRIPTION
## Summary

`.github/workflows/pr-metadata-gate.yaml` runs two `gh api --paginate --jq '... | length'` queries against the PR timeline to count `CrossReferencedEvent`s that connect/disconnect a linked issue. `gh api --paginate` runs the `--jq` filter per page, so the output is one length integer per page (e.g. `"0\n0"` for a 2-page timeline). The downstream regex check `^[0-9]+$` then rejects multi-line input → the gate fails on every PR with a 2+-page timeline (long-review PRs).

This patch pipes each `gh api --paginate --jq '... | length'` invocation through `awk '{s+=$1} END {print s}'` so the per-page counts are summed into a single integer.

## Why land this independently of #882

Single-file, 11-line patch to `.github/workflows/pr-metadata-gate.yaml`. Zero dependency on the dataset-pipeline refactor in #882. Already fixing pre-existing breakage on every PR that has accumulated review chatter.

Cherry-picked from umbrella commit `7b71e52` on `worktree-agent-a818f00c8e0fa5bb2`.

## Test plan

- [x] pre-commit (`ruff`, `ruff format`, `pyright`, `Validate GitHub Workflows`, etc.) — clean on the changed file
- [ ] CI's own `check-pr-metadata` step passes on this PR

Closes #888
Part of #882