### PR TITLE
build(docker): make /venv/main writable by dev user in devcontainer-tools

### DIFF
--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -416,6 +416,7 @@ ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash -m $USERNAME
 RUN chown -R $USER_UID:$USER_GID .git
+RUN chown -R $USER_UID:$USER_GID /venv/main
 
 # Persist bash history for non-root dev: user
 RUN mkdir -p /commandhistory \

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -416,7 +416,9 @@ ARG USER_GID=$USER_UID
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID --shell /bin/bash -m $USERNAME
 RUN chown -R $USER_UID:$USER_GID .git
-RUN chown -R $USER_UID:$USER_GID /venv/main
+# Directories only: pip writes are governed by the parent dir's permission bit,
+# and skipping files avoids overlayfs copy-up of ~2.5 GB of prebuilt deps.
+RUN find /venv/main -type d -exec chown $USER_UID:$USER_GID {} +
 
 # Persist bash history for non-root dev: user
 RUN mkdir -p /commandhistory \

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -117,7 +117,9 @@ build `FROM dev-base`, the shared parent that holds Surge XT, the venv, and
 the synth-setter source. `devcontainer-tools` adds interactive CLI tooling
 (see the stage's `apt-get install` list and the GitHub CLI install block),
 Node.js + `@anthropic-ai/claude-code` installed system-wide, a non-root
-`dev` user, and a `/commandhistory` directory (owned by `dev`) that
+`dev` user, chowns the baked uv venv at `/venv/main` to `dev` so
+`uv pip install` and editable installs work without sudo, and adds a
+`/commandhistory` directory (owned by `dev`) that
 `.devcontainer/{cpu,gpu}/devcontainer.json` mounts as a named volume so bash
 history survives container rebuilds. The same devcontainer configs also
 overlay `/home/build/synth-setter/plugins` with an anonymous volume so the


### PR DESCRIPTION
## Summary

- The `devcontainer-tools` stage in `docker/ubuntu22_04/Dockerfile` creates a non-root `dev` user but leaves `/venv/main` owned by `root`, so the dev user cannot `pip install` / `uv pip install` into the venv inside a running container without `sudo`.
- Add `RUN chown -R $USER_UID:$USER_GID /venv/main` immediately after the existing `.git` chown so the venv is writable from the dev user out of the box.

This mirrors the chown step that issue #539 calls out as a requirement for running the devcontainer as a non-root user, but lifts it into the base `devcontainer-tools` image so the `.devcontainer/Dockerfile` extension layer no longer needs to repeat it.

Refs #539

## Test plan

- [ ] CI: docker build of the `devcontainer-tools` target succeeds
- [ ] Manual: `docker run --rm --user 1000:1000 <image> uv pip install --no-deps anyio` (or any small package) inside the built image completes without `Permission denied` on `/venv/main`