### PR TITLE
chore(deps): add ruff and pydantic-settings to requirements-app.txt

### DIFF
--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -12,6 +12,7 @@ click<8.2
 numpy
 oci
 pydantic>=2
+pydantic-settings>=2
 pyyaml
 # Pin must stay in sync with the bare-runner install in
 # .github/workflows/test-skypilot-debug.yml.
@@ -44,6 +45,7 @@ python-dotenv
 rich
 sh
 rootutils
+ruff
 runpod==1.8.1
 scipy==1.14.1
 threadpoolctl


### PR DESCRIPTION
## Summary

- Add `pydantic-settings>=2` (prerequisite for #885: migrate `generate_vst_dataset` CLI to auto-generated flags from `RenderConfig`).
- Add `ruff` as a direct dev dep. Ruff is already configured in `pyproject.toml` (`[tool.ruff]` / `[tool.ruff.lint]`) and runs in `.pre-commit-config.yaml`, but isn't pinned as a project dep — so editor integrations and ad-hoc `ruff check` / `ruff format` invocations require contributors to install it themselves. Adding it here makes the dev environment self-sufficient.

No version pin on `ruff` to keep it in step with the version pre-commit fetches; pre-commit's `rev:` remains the source of truth for the CI-enforced version.

## Test plan

- [ ] CI green (lint + tests unchanged — this only adds two requirements lines).
- [ ] `pip install -r requirements-app.txt` resolves successfully on a clean venv.

Refs #885