### PR TITLE
chore(skills): flag merge conflicts and failing checks in /repo-review skills

### DIFF
--- a/.claude/skills/repo-review-full/SKILL.md
+++ b/.claude/skills/repo-review-full/SKILL.md
@@ -2,7 +2,7 @@
 name: repo-review-full
 description: |
   Full multi-skill PR review. Fans out one parallel agent per applicable plugin
-  checklist (selection rules in Step 2) and posts every BLOCK/WARN as an
+  checklist (selection rules in Step 3) and posts every BLOCK/WARN as an
   individual unresolved inline PR review comment. Requires the
   tinaudio-synth-setter-skills plugin.
 ---
@@ -22,12 +22,38 @@ Fetch metadata once:
 
 ```bash
 gh pr view <N> --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \
-  --json number,headRefOid,baseRefOid,files,title,headRefName
+  --json number,headRefOid,baseRefOid,files,title,headRefName,mergeable,mergeStateStatus,statusCheckRollup
 ```
 
 If no PR exists for the current branch, stop and tell the user to push and open a PR first.
 
-## Step 2: Pick which skills to fan out to
+## Step 2: Inspect PR health (merge conflicts + failing checks)
+
+Reviewers need to know up front if the PR can't merge or has failing CI — both are independent of the diff and the fan-out sub-agents would never look for them. The orchestrator handles them; sub-agents don't need to know.
+
+**Merge conflicts.** From the JSON in Step 1:
+
+- `mergeable == "CONFLICTING"` → record one BLOCK line:
+  ```
+  BLOCK: <PR> — [pr-health] Merge conflict with base branch (mergeStateStatus=<value>). Rebase or merge base before review.
+  ```
+- `mergeable == "UNKNOWN"` → GitHub hasn't computed mergeability yet; skip (no finding).
+- `mergeable == "MERGEABLE"` → no finding.
+
+**Failing checks.** Parse `statusCheckRollup` from Step 1. Each entry is either a check run (has `conclusion`) or a legacy commit status (has `state`). A check is *failing* if any of these hold:
+
+- `conclusion` ∈ {`FAILURE`, `TIMED_OUT`, `STARTUP_FAILURE`, `ACTION_REQUIRED`}.
+- `state` ∈ {`FAILURE`, `ERROR`}.
+
+Skip `SUCCESS`, `SKIPPED`, `NEUTRAL`, `CANCELLED`, and anything still pending/in-progress. For each failing entry record one BLOCK line:
+
+```
+BLOCK: <PR> — [pr-health] Failing check: <name> (<conclusion-or-state>) — <detailsUrl-or-targetUrl>
+```
+
+If `gh pr checks <N>` is easier than parsing the JSON, use it — but capture the same fields (name, fail reason, link). Hold these PR-health BLOCK lines aside; Step 6 folds them into the review body (they aren't anchored to diff lines).
+
+## Step 3: Pick which skills to fan out to
 
 Read the file list from Step 1. Map file types → relevant skills:
 
@@ -42,7 +68,7 @@ Read the file list from Step 1. Map file types → relevant skills:
 
 Always run `code-health` and `synth-setter-project-standards`. Other skills opt in based on file extensions in the diff. Note which skills you selected; you'll launch one parallel agent per skill.
 
-## Step 3: Launch parallel review agents
+## Step 4: Launch parallel review agents
 
 Launch one `general-purpose` Agent per selected skill. **All agents in a single message** so they run concurrently (Claude Code supports this — one message with N tool calls = N parallel agents).
 
@@ -74,7 +100,7 @@ Each agent returns a Markdown block:
 
 Aim each agent at a 1500-word ceiling so reports stay scannable. The orchestrator (you) can ask for tighter output if a skill's domain is small.
 
-## Step 4: Aggregate findings
+## Step 5: Aggregate findings
 
 Once every parallel agent returns, parse each report's BLOCK and WARN findings. For each finding, build one entry in the post-review JSON. Prefix each comment body with `[<skill>:<severity>]` so reviewers can see which checklist surfaced it.
 
@@ -109,15 +135,15 @@ A finding becomes:
 
 Do NOT dedupe near-duplicate findings across skills (e.g. shell-style and synth-setter-project-standards both flagging a `[ ]` vs `[[ ]]` issue) — keep each skill's signal independent. Acceptable noise per the plan's out-of-scope list.
 
-## Step 5: Build the findings JSON
+## Step 6: Build the findings JSON
 
-Same shape `post_review.py` consumes:
+Same shape `post_review.py` consumes. **Fold the Step 2 PR-health BLOCKs into `review_body`** (they aren't anchored to diff lines, so they can't be inline comments). Prepend a `## PR health` section listing every PR-health BLOCK; if Step 2 produced nothing, omit the section entirely.
 
 ```json
 {
   "pr_number": <N>,
   "repo": "<owner>/<repo>",
-  "review_body": "Multi-skill review of PR #<N> — <K> parallel passes (<list of skills>). Every BLOCK/WARN posted below as an individual unresolved thread. Findings on files outside the diff are anchored to the line in the diff that *causes* the staleness or rolled into the review body.",
+  "review_body": "Multi-skill review of PR #<N> — <K> parallel passes (<list of skills>). Every BLOCK/WARN posted below as an individual unresolved thread. Findings on files outside the diff are anchored to the line in the diff that *causes* the staleness or rolled into the review body.\n\n## PR health\n\n- **[repo-review-full:block]** [pr-health] Merge conflict with base branch (mergeStateStatus=DIRTY). Rebase or merge base before review.\n- **[repo-review-full:block]** [pr-health] Failing check: ci/test (FAILURE) — https://github.com/.../runs/123",
   "findings": [ ... ]
 }
 ```
@@ -130,7 +156,7 @@ cat > /tmp/repo-review-full-findings.json <<'JSON'
 JSON
 ```
 
-## Step 6: Submit the review
+## Step 7: Submit the review
 
 ```bash
 python3 .claude/skills/_shared/post_review.py < /tmp/repo-review-full-findings.json
@@ -143,7 +169,7 @@ Helper behavior matches `repo-review`:
 - Rolls orphan findings (file outside the diff) into the review body under `## Findings on files outside the diff`.
 - Submits as `event=COMMENT`. Threads stay unresolved.
 
-Report the helper's `html_url` back to the user along with a one-line summary (`Posted N findings: B BLOCK + W WARN across K skills`).
+Report the helper's `html_url` back to the user along with a one-line summary (`Posted N findings: B BLOCK + W WARN across K skills; PR-health flags: <M merge-conflict / F failing-check>`). If PR-health found nothing, drop the trailing `; PR-health flags: ...` clause.
 
 ## Notes
 

--- a/.claude/skills/repo-review-full/SKILL.md
+++ b/.claude/skills/repo-review-full/SKILL.md
@@ -2,9 +2,10 @@
 name: repo-review-full
 description: |
   Full multi-skill PR review. Fans out one parallel agent per applicable plugin
-  checklist (selection rules in Step 3) and posts every BLOCK/WARN as an
-  individual unresolved inline PR review comment. Requires the
-  tinaudio-synth-setter-skills plugin.
+  checklist (selection rules in Step 3) and posts every diff-anchored BLOCK/WARN
+  as an individual unresolved inline PR review comment; non-diff findings
+  (merge conflicts, failing checks) go in a `## PR health` section in the
+  review body. Requires the tinaudio-synth-setter-skills plugin.
 ---
 
 # repo-review-full — Multi-Skill Parallel PR Review
@@ -138,6 +139,8 @@ Do NOT dedupe near-duplicate findings across skills (e.g. shell-style and synth-
 ## Step 6: Build the findings JSON
 
 Same shape `post_review.py` consumes. **Fold the Step 2 PR-health BLOCKs into `review_body`** (they aren't anchored to diff lines, so they can't be inline comments). Prepend a `## PR health` section listing every PR-health BLOCK; if Step 2 produced nothing, omit the section entirely.
+
+Transform each Step 2 BLOCK line into one bullet under `## PR health`: strip the `BLOCK: <PR> — ` prefix and prepend `- **[repo-review-full:block]** `, leaving the `[pr-health] …` body unchanged. For example, `BLOCK: 897 — [pr-health] Failing check: ci/test (FAILURE) — https://…` becomes `- **[repo-review-full:block]** [pr-health] Failing check: ci/test (FAILURE) — https://…`.
 
 ```json
 {

--- a/.claude/skills/repo-review/SKILL.md
+++ b/.claude/skills/repo-review/SKILL.md
@@ -23,12 +23,38 @@ Fetch the PR's metadata once and remember it:
 
 ```bash
 gh pr view <N> --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \
-  --json number,headRefOid,baseRefOid,files,title,headRefName
+  --json number,headRefOid,baseRefOid,files,title,headRefName,mergeable,mergeStateStatus,statusCheckRollup
 ```
 
 If there is no PR for the current branch, stop and tell the user to push and open a PR first.
 
-## Step 2: Read the diff
+## Step 2: Inspect PR health (merge conflicts + failing checks)
+
+Reviewers need to know up front if the PR can't merge or has failing CI — both are independent of the diff but reviewers shouldn't have to dig for them. Surface each as a top-of-review `[repo-review:block]` item folded into the review body in Step 5 (not as inline comments — they have no diff anchor).
+
+**Merge conflicts.** From the JSON in Step 1:
+
+- `mergeable == "CONFLICTING"` → record one BLOCK line:
+  ```
+  BLOCK: <PR> — [pr-health] Merge conflict with base branch (mergeStateStatus=<value>). Rebase or merge base before review.
+  ```
+- `mergeable == "UNKNOWN"` → GitHub hasn't computed mergeability yet; skip (no finding).
+- `mergeable == "MERGEABLE"` → no finding.
+
+**Failing checks.** Parse `statusCheckRollup` from Step 1. Each entry is either a check run (has `conclusion`) or a legacy commit status (has `state`). A check is *failing* if any of these hold:
+
+- `conclusion` ∈ {`FAILURE`, `TIMED_OUT`, `STARTUP_FAILURE`, `ACTION_REQUIRED`}.
+- `state` ∈ {`FAILURE`, `ERROR`}.
+
+Skip `SUCCESS`, `SKIPPED`, `NEUTRAL`, `CANCELLED`, and anything still pending/in-progress — they're noise here. For each failing entry record one BLOCK line:
+
+```
+BLOCK: <PR> — [pr-health] Failing check: <name> (<conclusion-or-state>) — <detailsUrl-or-targetUrl>
+```
+
+If `gh pr checks <N>` is easier than parsing the JSON, use it instead — but capture the same fields (name, fail reason, link).
+
+## Step 3: Read the diff
 
 Get the full unified diff:
 
@@ -38,7 +64,7 @@ gh pr diff <N> --repo <owner>/<repo>
 
 Read every changed file at the head SHA (use the `Read` tool, not `cat`). Skim the PR description for context on intent.
 
-## Step 3: Apply the core checklist
+## Step 4: Apply the core checklist
 
 Evaluate ONLY the changed code. Skip items that don't apply to the diff (e.g. don't flag missing type annotations on a YAML-only PR).
 
@@ -122,17 +148,21 @@ End the listing with:
 Summary: X BLOCK, Y WARN
 ```
 
-If there are zero findings, output `PASS` and stop — do not post an empty review.
+If the checklist found zero findings AND Step 2 found no PR-health BLOCKs (no merge conflict, no failing checks), output `PASS` and stop — do not post an empty review. If PR-health turned up anything, always submit so the merge-conflict / failing-check banner reaches the author.
 
-## Step 4: Build the findings JSON
+## Step 5: Build the findings JSON
 
-Convert your BLOCK/WARN list to the JSON shape `post_review.py` consumes. Each finding becomes one inline comment with a `[repo-review:<severity>]` prefix.
+Convert your BLOCK/WARN list to the JSON shape `post_review.py` consumes. Each diff-anchored finding becomes one inline comment with a `[repo-review:<severity>]` prefix.
+
+**Fold the Step 2 PR-health BLOCKs into `review_body`** (they aren't anchored to diff lines, so they can't be inline comments). Prepend a `## PR health` section listing every PR-health BLOCK; if Step 2 produced nothing, omit the section entirely.
+
+Example shape when both health flags fire:
 
 ```json
 {
   "pr_number": <N>,
   "repo": "<owner>/<repo>",
-  "review_body": "Repo-review (MVP): <X> BLOCK, <Y> WARN. Inline core checklist from CLAUDE.md.",
+  "review_body": "Repo-review (MVP): <X> BLOCK, <Y> WARN. Inline core checklist from CLAUDE.md.\n\n## PR health\n\n- **[repo-review:block]** [pr-health] Merge conflict with base branch (mergeStateStatus=DIRTY). Rebase or merge base before review.\n- **[repo-review:block]** [pr-health] Failing check: ci/test (FAILURE) — https://github.com/.../runs/123",
   "findings": [
     {
       "path": "<path>",
@@ -143,6 +173,8 @@ Convert your BLOCK/WARN list to the JSON shape `post_review.py` consumes. Each f
 }
 ```
 
+Count PR-health BLOCKs toward the `<X> BLOCK` total in the summary. If the checklist found zero issues but PR health did, still submit — don't `PASS`-and-stop when there are merge conflicts or failing checks to surface.
+
 Write the JSON to a temp file (do NOT echo it inline — keep it readable):
 
 ```bash
@@ -151,7 +183,7 @@ cat > /tmp/repo-review-findings.json <<'JSON'
 JSON
 ```
 
-## Step 5: Submit the review
+## Step 6: Submit the review
 
 ```bash
 python3 .claude/skills/_shared/post_review.py < /tmp/repo-review-findings.json

--- a/.claude/skills/repo-review/SKILL.md
+++ b/.claude/skills/repo-review/SKILL.md
@@ -4,8 +4,10 @@ description: |
   Quick PR review using the repo's core checklist (CLAUDE.md hard rules).
   Use when the tinaudio-synth-setter-skills plugin isn't available, or for a
   fast sanity-check before opening for full review. Single agent, no plugin
-  dependency. Posts findings as individual unresolved inline PR review
-  comments via .claude/skills/_shared/post_review.py.
+  dependency. Posts diff-anchored findings as individual unresolved inline
+  PR review comments via .claude/skills/_shared/post_review.py; non-diff
+  findings (merge conflicts, failing checks) go in a `## PR health` section
+  in the review body.
 ---
 
 # repo-review — MVP PR Review
@@ -155,6 +157,8 @@ If the checklist found zero findings AND Step 2 found no PR-health BLOCKs (no me
 Convert your BLOCK/WARN list to the JSON shape `post_review.py` consumes. Each diff-anchored finding becomes one inline comment with a `[repo-review:<severity>]` prefix.
 
 **Fold the Step 2 PR-health BLOCKs into `review_body`** (they aren't anchored to diff lines, so they can't be inline comments). Prepend a `## PR health` section listing every PR-health BLOCK; if Step 2 produced nothing, omit the section entirely.
+
+Transform each Step 2 BLOCK line into one bullet under `## PR health`: strip the `BLOCK: <PR> — ` prefix and prepend `- **[repo-review:block]** `, leaving the `[pr-health] …` body unchanged. For example, `BLOCK: 897 — [pr-health] Failing check: ci/test (FAILURE) — https://…` becomes `- **[repo-review:block]** [pr-health] Failing check: ci/test (FAILURE) — https://…`.
 
 Example shape when both health flags fire:
 


### PR DESCRIPTION
## Summary

- `/repo-review` and `/repo-review-full` now inspect PR-health up front and flag two non-diff signals reviewers always want at the top of a review: **merge conflicts** with the base branch and **failing required checks**.
- Both skills extend their Step 1 `gh pr view` JSON to include `mergeable`, `mergeStateStatus`, `statusCheckRollup`, then emit one block-level finding per conflict and one per failing check.
- These findings have no diff anchor, so they're folded into a new `## PR health` section in `review_body` instead of being posted as inline comments. `post_review.py` is unchanged.

## What counts as "failing"

A check is failing if `conclusion` ∈ {`FAILURE`, `TIMED_OUT`, `STARTUP_FAILURE`, `ACTION_REQUIRED`} or `state` ∈ {`FAILURE`, `ERROR`}. Pending / in-progress / skipped / neutral / cancelled entries are intentionally skipped — the author already sees pending checks in the GitHub UI and we don't want to add noise to the review.

A merge conflict is flagged only when `mergeable == "CONFLICTING"`. `UNKNOWN` (GitHub hasn't computed mergeability yet) is treated as informational and produces no finding.

## Behavior change

- If the diff-checklist found zero issues but PR-health surfaced anything, the skill still submits a review (previously it would output `PASS` and stop). This ensures merge-conflict / failing-check banners always reach the author.

## Test plan

- [ ] Manual: run `/repo-review` against a PR with at least one failing CI check — verify the failing check shows up as a `[repo-review:block]` line in the review body's `## PR health` section.
- [ ] Manual: run `/repo-review` against a PR with a merge conflict — verify the conflict shows up as a `[repo-review:block]` line in the `## PR health` section.
- [ ] Manual: run `/repo-review-full` against the same PRs to confirm orchestrator-side parity.
- [ ] Manual: run either skill on a clean, mergeable PR — verify the `## PR health` section is omitted entirely.

Refs #896