### PR TITLE
fix(evaluation): clamp compute_rms denominator to defuse MPS pred.wav silence flake

### DIFF
--- a/scripts/compute_audio_metrics.py
+++ b/scripts/compute_audio_metrics.py
@@ -224,7 +224,18 @@ def compute_rms(target: np.ndarray, pred: np.ndarray) -> float:
     target_norm = np.linalg.vector_norm(target_rms, axis=-1, ord=2)
     pred_norm = np.linalg.vector_norm(pred_rms, axis=-1, ord=2)
 
-    cosine_sim = np.dot(target_rms[0], pred_rms[0]) / (target_norm * pred_norm)
+    # Clamp the denominator so silent pred (``pred_norm == 0``) yields
+    # ``cosine_sim = 0`` instead of NaN from ``0/0`` — same epsilon-clip
+    # pattern as ``compute_sot`` above.
+    denom = target_norm * pred_norm
+    if float(denom) < 1e-12:
+        logger.warning(
+            "compute_rms: denominator underflow "
+            "(target_norm={t:.3e}, pred_norm={p:.3e}); returning 0",
+            t=float(target_norm),
+            p=float(pred_norm),
+        )
+    cosine_sim = np.dot(target_rms[0], pred_rms[0]) / np.clip(denom, 1e-12, None)
 
     return cosine_sim.mean()
 

--- a/scripts/compute_audio_metrics.py
+++ b/scripts/compute_audio_metrics.py
@@ -224,9 +224,9 @@ def compute_rms(target: np.ndarray, pred: np.ndarray) -> float:
     target_norm = np.linalg.vector_norm(target_rms, axis=-1, ord=2)
     pred_norm = np.linalg.vector_norm(pred_rms, axis=-1, ord=2)
 
-    # Clamp the denominator so silent pred (``pred_norm == 0``) yields
-    # ``cosine_sim = 0`` instead of NaN from ``0/0`` — same epsilon-clip
-    # pattern as ``compute_sot`` above.
+    # Silent (or near-silent) pred would make ``pred_norm * target_norm`` underflow
+    # and the cosine become NaN (``0/0``) or unbounded. Short-circuit to ``0`` so the
+    # worst rating is returned and silence cannot be gamed into a higher score.
     denom = target_norm * pred_norm
     if float(denom) < 1e-12:
         logger.warning(
@@ -235,7 +235,8 @@ def compute_rms(target: np.ndarray, pred: np.ndarray) -> float:
             t=float(target_norm),
             p=float(pred_norm),
         )
-    cosine_sim = np.dot(target_rms[0], pred_rms[0]) / np.clip(denom, 1e-12, None)
+        return 0.0
+    cosine_sim = np.dot(target_rms[0], pred_rms[0]) / denom
 
     return cosine_sim.mean()
 

--- a/tests/scripts/test_compute_audio_metrics.py
+++ b/tests/scripts/test_compute_audio_metrics.py
@@ -35,3 +35,16 @@ def test_compute_rms_silent_pred_returns_zero_not_nan() -> None:
     rms = compute_rms(target, pred)
     assert np.isfinite(rms), f"compute_rms produced non-finite {rms!r} for silent pred"
     assert rms == 0.0
+
+
+def test_compute_rms_quiet_nonzero_inputs_return_zero() -> None:
+    """Quiet (but non-zero) inputs whose ``target_norm * pred_norm < 1e-12`` return 0.
+
+    Without the explicit short-circuit, the pre-fix path of
+    ``dot(target_rms, pred_rms) / np.clip(denom, 1e-12, None)`` would return ~``0.4``
+    here (numerator and clamped denominator both ≈ ``4e-13``), contradicting the
+    warning's "returning 0" claim — see the Copilot review on PR #899.
+    """
+    quiet = np.full((1, _SR), 1e-7, dtype=np.float64)
+    rms = compute_rms(quiet, quiet)
+    assert rms == 0.0

--- a/tests/scripts/test_compute_audio_metrics.py
+++ b/tests/scripts/test_compute_audio_metrics.py
@@ -1,0 +1,37 @@
+"""Unit tests for ``scripts.compute_audio_metrics``."""
+
+import numpy as np
+import pytest
+
+from scripts.compute_audio_metrics import compute_rms
+
+_SR = 44100
+
+
+def _sine(seconds: float = 1.0, freq: float = 440.0, amplitude: float = 0.5) -> np.ndarray:
+    """A mono ``(1, N)`` sine — the shape ``compute_rms`` expects."""
+    t = np.arange(int(seconds * _SR), dtype=np.float32) / _SR
+    return (amplitude * np.sin(2 * np.pi * freq * t)).reshape(1, -1)
+
+
+def test_compute_rms_identical_signal_returns_one() -> None:
+    """``cosine_sim(x, x)`` of a non-silent signal is ``1.0``."""
+    audio = _sine()
+    rms = compute_rms(audio, audio)
+    assert np.isfinite(rms)
+    assert rms == pytest.approx(1.0, abs=1e-6)
+
+
+def test_compute_rms_silent_pred_returns_zero_not_nan() -> None:
+    """Silent pred → ``pred_norm == 0`` → clamped denominator → ``cosine_sim = 0``.
+
+    Regression guard: prior to the denominator clamp, this produced ``0/0 = NaN`` and
+    poisoned downstream metric aggregation. See the MPS flake on
+    ``test_train_eval_surge_xt[mps]`` where a 1-step-trained model can predict params
+    that Surge XT renders as bit-silent audio.
+    """
+    target = _sine()
+    pred = np.zeros_like(target)
+    rms = compute_rms(target, pred)
+    assert np.isfinite(rms), f"compute_rms produced non-finite {rms!r} for silent pred"
+    assert rms == 0.0

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -318,26 +318,24 @@ def test_train_eval_surge_xt(
 
     sample_dirs = sorted(d for d in audio_dir.iterdir() if d.is_dir())
     assert [d.name for d in sample_dirs] == [f"sample_{i}" for i in range(NUM_FIXTURE_SAMPLES)]
-    # ~-120 dBFS — guards against bit-zero audio that would make ``compute_rms``'s
-    # ``pred_norm = ||rms||`` collapse to 0 and the cosine-similarity ratio NaN. The
-    # previous ``1e-4`` cutoff (~ -80 dBFS) was overly conservative for the 1-step-trained
-    # MPS smoke run, where Surge XT's render of the model's predicted params can land in a
-    # quiet region of param space (peak ~3e-5) without being silent enough to underflow
-    # downstream metric math.
-    SILENCE_PEAK_THRESHOLD = 1e-6
+    # ``target.wav`` is rendered from fixture-truth params and must be audible —
+    # silence there would be a real bug. ``pred.wav`` from a 1-step-trained model
+    # can legitimately land in a silent region of Surge XT's param space (MPS
+    # non-determinism); ``compute_rms`` clamps its denominator so silent pred
+    # yields ``cosine_sim = 0`` rather than NaN, and the finite-metric assertion
+    # at the end of this test is the real end check.
     for sample_dir in sample_dirs:
         assert (sample_dir / "target.wav").is_file()
         assert (sample_dir / "pred.wav").is_file()
         assert (sample_dir / "spec.png").is_file()
         assert (sample_dir / "params.csv").is_file()
 
-        for wav_name in ("target.wav", "pred.wav"):
-            with AudioFile(str(sample_dir / wav_name)) as f:
-                audio = f.read(f.frames)
-            peak = float(np.abs(audio).max())
-            assert peak > SILENCE_PEAK_THRESHOLD, (
-                f"{sample_dir.name}/{wav_name} is silent (peak={peak:.2e})"
-            )
+        with AudioFile(str(sample_dir / "target.wav")) as f:
+            target_audio = f.read(f.frames)
+        target_peak = float(np.abs(target_audio).max())
+        assert target_peak > 1e-6, (
+            f"{sample_dir.name}/target.wav is silent (peak={target_peak:.2e})"
+        )
 
     # Compute audio distance metrics (MSS, wMFCC, SOT, RMS) on the rendered pairs.
     metrics_dir = tmp_path / "metrics"


### PR DESCRIPTION
## Summary

- `test_train_eval_surge_xt[mps]` was failing intermittently with `pred.wav is silent`. The silence assertion in the test was a defensive proxy guarding `compute_rms` from `0/0 → NaN` when `pred_norm = 0`.
- Move the protection into `compute_rms` itself: clamp `target_norm * pred_norm` to `1e-12` (mirrors the epsilon-clip pattern already used in `compute_sot`). Silent pred now yields `cosine_sim = 0` instead of `NaN`.
- Drop the `pred.wav` silence assertion in the test. Keep the `target.wav` check — target is rendered from fixture-truth params, so silence there would be a real bug.

## Semantic notes

Returning `0` for silent pred is within the natural `[0, 1]` range of cosine similarity for non-negative vectors (`librosa.feature.rms` is non-negative). It is the worst rating, correctly penalizes silent predictions, and cannot be gamed upward by emitting silence. No consumer relies on `NaN`-as-marker — `scripts/surge_xt_interactive.py:229` rejects `NaN` as a failure mode, confirming the design intent. A `logger.warning` fires when the clamp activates so the "silent pred encountered" signal is not lost.

## Test plan

- [x] `pytest tests/scripts/test_compute_audio_metrics.py` (new) — `compute_rms(target, zeros) == 0`, `compute_rms(target, target) ≈ 1`.
- [x] `pytest tests/test_train.py::test_train_eval_surge_xt -k cpu` — end-to-end smoke passes (75s).
- [x] `make test` — 456 fast tests pass.
- [x] `make format` — all pre-commit hooks pass.
- [ ] `.github/workflows/test-mps.yml` — confirm flake repro rate drops to zero across multiple re-runs.

Closes #898