### PR TITLE
docs(claude-md): require inline replies on PR review comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,7 @@ Only skip as "no GPU available" if both probes indicate no usable CUDA GPU: `nvi
 ### PR Review Comments
 
 - Always reply to PR review comments after pushing a fix — never push silently.
-- Reply **inline on the specific review comment** that the change addresses (using `gh api repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies` or the equivalent threaded reply), not as a generic top-level PR comment. One inline reply per comment addressed.
+- Reply **inline on the specific review comment** that the change addresses (using `gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies` or the equivalent threaded reply), not as a generic top-level PR comment. One inline reply per comment addressed.
 - Link the specific fix commit SHA in the reply (e.g., "Fixed in abc1234").
 - If a pushed change addresses multiple review comments, post a separate inline reply on each — do not consolidate them into a single comment elsewhere on the PR.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,9 @@ Only skip as "no GPU available" if both probes indicate no usable CUDA GPU: `nvi
 ### PR Review Comments
 
 - Always reply to PR review comments after pushing a fix — never push silently.
+- Reply **inline on the specific review comment** that the change addresses (using `gh api repos/{owner}/{repo}/pulls/{pr}/comments/{comment_id}/replies` or the equivalent threaded reply), not as a generic top-level PR comment. One inline reply per comment addressed.
 - Link the specific fix commit SHA in the reply (e.g., "Fixed in abc1234").
+- If a pushed change addresses multiple review comments, post a separate inline reply on each — do not consolidate them into a single comment elsewhere on the PR.
 
 ### GitHub Project
 


### PR DESCRIPTION
## Summary

- Updates the **PR Review Comments** subsection in `CLAUDE.md` to require Claude to reply **inline on the specific review comment** that a pushed change addresses, instead of posting a generic top-level PR comment.
- Adds an explicit rule: when a single pushed change addresses multiple review comments, post a separate inline reply on each — do not consolidate them into one summary comment elsewhere on the PR.
- Threading replies onto the exact comment keeps each reviewer thread unambiguously resolved and surfaces the fix commit SHA where the reviewer is already reading.

Refs #900
Refs #442

## Test plan

- [ ] `make format` passes (pre-commit hooks: ruff, mdformat, codespell, etc.)
- [ ] CI `pr-metadata-gate` passes (linked issue #900 has Task type + `documentation` label + `documentation v1.0.0` milestone + traces to Epic #351 via Phase #442)
- [ ] Render the updated `CLAUDE.md` section in the PR diff view to confirm the markdown bullets render correctly