### PR TITLE
docs(claude-md): mandate /tdd-implementation, /code-health, /simplify on code changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,6 +180,16 @@ Before implementing a new abstraction or design pattern, confirm the scope and a
 - If you're tempted to introduce a new class, config schema, or architectural pattern, ask: "Do we need this now, or is this speculative?" Default to no.
 - Refactoring comes later, driven by real needs, not anticipated ones.
 
+### Mandatory Skills for Code Changes
+
+Whenever Claude implements or modifies non-documentation code (anything other than pure `.md` or `docs/` edits), Claude MUST invoke, in order:
+
+1. `/tdd-implementation` — drive the change test-first.
+2. `/code-health` — review and clean up the resulting code.
+3. `/simplify` — final reuse and efficiency pass.
+
+Pure documentation edits (`.md` files, `docs/`) are exempt. There are no other exemptions — this is a hard rule, not a suggestion.
+
 ## Workflow Rules
 
 ### Commits & Hooks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,6 +188,8 @@ Whenever Claude implements or modifies non-documentation code (anything other th
 2. `/code-health` — review and clean up the resulting code.
 3. `/simplify` — final reuse and efficiency pass.
 
+`/tdd-implementation` and `/code-health` ship in the `tinaudio-synth-setter-skills` plugin (same source as `/repo-review-full`); `/simplify` is a Claude Code built-in. None are defined locally under `.claude/skills/`. If the plugin or built-in is not available in the current environment, note the gap in your response rather than silently skipping the step.
+
 Pure documentation edits (`.md` files, `docs/`) are exempt. There are no other exemptions — this is a hard rule, not a suggestion.
 
 ## Workflow Rules


### PR DESCRIPTION
## Summary

Adds a hard rule to `CLAUDE.md` under "Implementation Approach" requiring Claude to invoke `/tdd-implementation`, `/code-health`, and `/simplify` (in that order) whenever it implements or modifies non-documentation code. Pure `.md` / `docs/` edits remain exempt.

## Why

These three skills are already the canonical implementation-quality tools in this repo, but invocation has been inconsistent. Encoding it as a hard rule in `CLAUDE.md` removes ambiguity.

## Scope

- `CLAUDE.md` only — 10 inserted lines, no other changes.
- No code, config, or workflow touched.

Closes #902