### PR TITLE
ci(workflows): snapshot ~/sky_logs and api-server client logs into run-metadata artifact

### DIFF
--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -256,6 +256,26 @@ jobs:
         if: ${{ always() && inputs.provider == 'skypilot-local' }}
         run: sky local down || true
 
+      # Snapshot SkyPilot's two on-disk log roots into the run-metadata dir so
+      # the existing `Upload run metadata` step picks them up. Without this,
+      # a launcher hang/cancel leaves the operator with only the bare
+      # `View logs: sky api logs -l <id>/file_mounts.log` pointer the SDK
+      # printed to stdout — the actual log file is destroyed with the runner.
+      #   * `~/sky_logs/`                       — CLI invocations (sky local up/down).
+      #   * `~/.sky/api_server/clients/<hash>/sky_logs/` — SDK client logs that
+      #     `sky api logs -l <id>` resolves to (file_mounts.log, provision.log,
+      #     setup.log, etc.). Local API server in 0.12 stores them here.
+      # Placed AFTER `sky local down` so local_down.log is captured too.
+      - name: Snapshot sky logs (skypilot-local row)
+        if: ${{ always() && inputs.provider == 'skypilot-local' }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUN_METADATA_DIR}/sky_logs" "${RUN_METADATA_DIR}/sky_api_server_logs"
+          cp -r "${HOME}/sky_logs/." "${RUN_METADATA_DIR}/sky_logs/" 2>/dev/null || true
+          cp -r "${HOME}/.sky/api_server/clients/." "${RUN_METADATA_DIR}/sky_api_server_logs/" 2>/dev/null || true
+          echo "=== snapshot sizes ==="
+          du -sh "${RUN_METADATA_DIR}/sky_logs" "${RUN_METADATA_DIR}/sky_api_server_logs" 2>/dev/null || true
+
       # ----- runpod / oci row: in-container launcher
       # Optional launcher flags are pre-rendered into env-var strings on the
       # outer step (so GHA expression evaluation stays out of the bash


### PR DESCRIPTION
## Summary

- Add `Snapshot sky logs (skypilot-local row)` step to `.github/workflows/generate-dataset-shards.yaml`, placed after `sky local down` and before `Upload run metadata`.
- Step copies `~/sky_logs/` and `~/.sky/api_server/clients/` into `${RUN_METADATA_DIR}/sky_logs/` and `${RUN_METADATA_DIR}/sky_api_server_logs/` so the existing artifact upload picks them up.
- Gated `if: ${{ always() && inputs.provider == 'skypilot-local' }}` — runs on success, failure, and the GHA-timeout cancel path.

Without this, when the launcher hangs (as happened on the worktree-switch-to-managed-jobs PR — failed [run 25606637509](https://github.com/tinaudio/synth-setter/actions/runs/25606637509/job/75169619278)) the only sky-log breadcrumb is the SDK's stdout pointer:

```
View logs: sky api logs -l sky-2026-05-09-17-08-20-432274/file_mounts.log
```

…and that file is destroyed with the runner. After this change, `file_mounts.log`, `provision.log`, `setup.log`, `local_up.log`, and `local_down.log` all land in the `test-run-metadata-skypilot-local` artifact.

## Scope

`skypilot-local` only. Runpod/oci rows are out of scope — their launcher runs inside `tinaudio/synth-setter:dev-snapshot` with `docker run --rm`, so capturing those logs needs bind-mounts. Deferred until a real diagnosis need surfaces; when `SKYPILOT_API_SERVER_ENDPOINT` is set (the runpod/oci default) api-server-side logs live remotely anyway.

Closes #904

## Test plan

- [ ] PR-trigger run of `Test Dataset Generation` (this PR touches `.github/workflows/generate-dataset-shards.yaml`, which is in the workflow's `paths:` trigger).
- [ ] Inspect the `test-run-metadata-skypilot-local` artifact: confirm `sky_logs/sky-<timestamp>/local_up.log` and `sky_api_server_logs/<user_hash>/sky_logs/sky-<timestamp>/file_mounts.log` are present.