### PR TITLE
internal-feat(configs): add Hydra dataset config tree + DatasetSpec hardening

### DIFF
--- a/configs/dataset.yaml
+++ b/configs/dataset.yaml
@@ -1,0 +1,25 @@
+# @package _global_
+
+# Top-level @hydra.main composition for dataset generation. Mirrors eval.yaml's
+# shape: each group below contributes a slice of the DatasetSpec the entrypoint
+# constructs in main(). Required (???) fields are filled in by an experiment.
+
+defaults:
+  - _self_
+  - data: ???
+  - render: ???
+  - r2: default
+  - hydra: default
+  - experiment: ???
+
+task_name: ???
+output_format: hdf5
+base_seed: 42
+
+train_val_test_sizes: ???
+# Reserved for per-sample seeding (#884); not consumed yet. Defaulted here
+# so experiments don't all duplicate the same triple.
+train_val_test_seeds: [42, 43, 44]
+
+r2_bucket: ${r2.bucket}
+r2_prefix_root: ${r2.prefix_root}

--- a/configs/dataset.yaml
+++ b/configs/dataset.yaml
@@ -9,6 +9,7 @@ defaults:
   - data: ???
   - render: ???
   - r2: default
+  - paths: default
   - hydra: default
   - experiment: ???
 

--- a/configs/experiment/10-1k-shards.yaml
+++ b/configs/experiment/10-1k-shards.yaml
@@ -1,0 +1,20 @@
+# @package _global_
+
+# Small experiment dataset: 10k total samples → 10 shards at batch_per_shard=1000.
+
+defaults:
+  - override /data: surge_simple
+  - override /render: surge_simple
+  - _self_
+
+task_name: 10-1k-shards
+
+train_val_test_sizes: [10000, 0, 0]
+
+r2_bucket: experiments
+
+render:
+  sample_rate: 44100
+  min_loudness: -50.0
+  sample_batch_size: 64
+  batch_per_shard: 1000

--- a/configs/experiment/ci-materialize-test.yaml
+++ b/configs/experiment/ci-materialize-test.yaml
@@ -1,0 +1,18 @@
+# @package _global_
+
+# Spec materialization smoke test. 96 total samples → 3 shards at
+# batch_per_shard=32. Used by CI to round-trip a YAML through DatasetSpec.
+
+defaults:
+  - override /data: surge_simple
+  - override /render: surge_simple
+  - _self_
+
+task_name: ci-materialize-test
+
+train_val_test_sizes: [32, 32, 32]
+
+render:
+  sample_rate: 16000
+  min_loudness: -50.0
+  batch_per_shard: 32

--- a/configs/experiment/runpod-smoke-shard.yaml
+++ b/configs/experiment/runpod-smoke-shard.yaml
@@ -1,0 +1,20 @@
+# @package _global_
+
+# CI smoke-test config (test-dataset-generation workflow on PR). 12 total
+# samples → 3 shards at batch_per_shard=4, exercising the partitioner without
+# burning compute.
+
+defaults:
+  - override /data: surge_simple
+  - override /render: surge_simple
+  - _self_
+
+task_name: runpod-smoke-shard
+
+train_val_test_sizes: [12, 0, 0]
+
+render:
+  sample_rate: 16000
+  min_loudness: -50.0
+  sample_batch_size: 4
+  batch_per_shard: 4

--- a/configs/experiment/surge-simple-480k-10k.yaml
+++ b/configs/experiment/surge-simple-480k-10k.yaml
@@ -1,0 +1,17 @@
+# @package _global_
+
+# Production surge_simple dataset: 480k total samples → 48 shards at
+# batch_per_shard=10000.
+
+defaults:
+  - override /data: surge_simple
+  - override /render: surge_simple
+  - _self_
+
+task_name: surge-simple-480k-10k
+
+train_val_test_sizes: [440000, 20000, 20000]
+
+render:
+  sample_rate: 44100
+  min_loudness: -50.0

--- a/configs/r2/default.yaml
+++ b/configs/r2/default.yaml
@@ -1,0 +1,2 @@
+bucket: intermediate-data
+prefix_root: data

--- a/configs/render/surge_simple.yaml
+++ b/configs/render/surge_simple.yaml
@@ -1,0 +1,5 @@
+defaults:
+  - surge_xt
+
+param_spec_name: surge_simple
+preset_path: presets/surge-simple.vstpreset

--- a/configs/render/surge_xt.yaml
+++ b/configs/render/surge_xt.yaml
@@ -1,0 +1,11 @@
+plugin_path: plugins/Surge XT.vst3
+preset_path: presets/surge-base.vstpreset
+param_spec_name: surge_xt
+renderer_version: "1.3.4"
+sample_rate: 44100
+channels: 2
+velocity: 100
+signal_duration_seconds: 4.0
+min_loudness: -50.0
+sample_batch_size: 32
+batch_per_shard: 10000

--- a/pipeline/schemas/spec.py
+++ b/pipeline/schemas/spec.py
@@ -13,7 +13,7 @@ layout + render fields.
 from __future__ import annotations
 
 import subprocess
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from functools import cached_property
 from pathlib import Path
 from typing import Any, Literal, cast
@@ -171,13 +171,14 @@ class DatasetSpec(BaseModel):
 
     model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
 
-    # Layout fields. Splits use ``list[int]`` (not tuple) so JSON round-trip
-    # in strict mode survives without coercion (JSON has no tuple type).
+    # Layout fields. Splits are stored as immutable tuples so the frozen-model
+    # guarantee carries through to the contents; JSON-loaded values arrive as
+    # lists and get coerced via ``_splits_list_to_tuple`` below.
     task_name: str
     output_format: Literal["hdf5"]
-    train_val_test_sizes: list[int] = Field(min_length=3, max_length=3)
+    train_val_test_sizes: tuple[int, int, int]
     # Reserved for per-sample seeding (#884); not consumed yet.
-    train_val_test_seeds: list[int] = Field(min_length=3, max_length=3)
+    train_val_test_seeds: tuple[int, int, int]
     base_seed: int
     r2_bucket: str
     r2_prefix_root: str = DEFAULT_R2_PREFIX_ROOT
@@ -211,20 +212,51 @@ class DatasetSpec(BaseModel):
                 data.pop(computed_key, None)
         return data
 
+    @field_validator("train_val_test_sizes", "train_val_test_seeds", mode="before")
+    @classmethod
+    def _splits_list_to_tuple(cls, value: Any) -> Any:
+        """Coerce JSON-loaded ``list[int]`` into ``tuple[int, int, int]``.
+
+        Tuples are immutable, so the frozen-model guarantee carries through to
+        the contents (a mutable list would let ``spec.train_val_test_sizes[0] =
+        x`` silently invalidate the cached ``shards`` / ``num_shards``). JSON
+        has no native tuple, so model_dump_json emits a list and the worker
+        round-trip lands here on validation; in-process construction can pass
+        either form.
+        """
+        if isinstance(value, list):
+            if len(value) != 3:
+                raise ValueError(f"must have exactly 3 entries, got {len(value)}")
+            return tuple(value)
+        return value
+
     @field_validator("created_at", mode="before")
     @classmethod
     def _parse_iso_datetime(cls, value: Any) -> Any:
-        """Parse an ISO 8601 string into a ``datetime`` so strict mode accepts it.
+        """Parse an ISO 8601 string into a tz-aware UTC ``datetime``.
 
         Strict-mode Python validation rejects str → datetime coercion, so JSON inputs (where
         datetime is a string) need pre-conversion here. Also normalizes the trailing ``Z``
         offset that ``model_dump_json`` emits for UTC, which Python 3.10's ``fromisoformat``
         does not accept (3.11+ does).
+
+        Rejects naive datetimes and non-UTC offsets so error attribution stays at the
+        ``created_at`` boundary rather than surfacing later as a ``run_id`` derivation crash
+        (``make_dataset_wandb_run_id`` requires tz-aware UTC).
         """
         if isinstance(value, str):
             if value.endswith("Z"):
                 value = value[:-1] + "+00:00"
-            return datetime.fromisoformat(value)
+            value = datetime.fromisoformat(value)
+        if isinstance(value, datetime):
+            if value.tzinfo is None:
+                raise ValueError(
+                    f"created_at must be timezone-aware UTC; got naive datetime {value!r}"
+                )
+            if value.utcoffset() != timedelta(0):
+                raise ValueError(
+                    f"created_at must be UTC (offset 0); got offset {value.utcoffset()}"
+                )
         return value
 
     @field_validator("r2_prefix")

--- a/pipeline/schemas/spec.py
+++ b/pipeline/schemas/spec.py
@@ -16,7 +16,7 @@ import subprocess
 from datetime import datetime, timezone
 from functools import cached_property
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import yaml
 from omegaconf import OmegaConf
@@ -133,6 +133,26 @@ class RenderConfig(BaseModel):
         return self
 
 
+# Names paired with ``train_val_test_sizes`` indices in error messages.
+_SPLIT_LABELS: tuple[str, str, str] = ("train", "val", "test")
+
+
+def _default_run_id(data: dict[str, Any]) -> str:
+    """Compute a deterministic run_id from already-validated layout fields."""
+    return make_dataset_wandb_run_id(
+        DatasetConfigId(data["task_name"]), timestamp=data["created_at"]
+    )
+
+
+def _default_r2_prefix(data: dict[str, Any]) -> str:
+    """Compute the R2 object prefix from already-validated layout fields."""
+    return make_r2_prefix(
+        DatasetConfigId(data["task_name"]),
+        data["run_id"],
+        prefix_root=data["r2_prefix_root"],
+    )
+
+
 class DatasetSpec(BaseModel):
     """Unified dataset specification — config + materialized runtime in one model.
 
@@ -144,23 +164,20 @@ class DatasetSpec(BaseModel):
       ``default_factory`` when missing and pass through when present.
     - Workers re-validate ``model_dump_json()`` from R2 and get an equal model.
 
-    ``strict`` is intentionally off on this top-level model so JSON-mode
-    round-trips coerce list→tuple and str→datetime (JSON has no native tuple
-    or datetime types). ``extra="forbid"`` plus the per-field validators keep
-    the trust boundary tight. ``frozen=True`` matches the prior spec's
-    immutability so ``shards``/``num_shards``/``num_params`` cached values
-    can't go stale via post-construction mutation; the internal
-    ``_populate_derived_runtime_fields`` validator uses ``object.__setattr__``
-    to bypass frozen during construction.
+    Strict mode is on (the model is a trust boundary for JSON-from-R2);
+    ``extra="forbid"`` plus the per-field validators keep the boundary tight.
+    Frozen so the materialized artifact is immutable post-construction.
     """
 
-    model_config = ConfigDict(extra="forbid", frozen=True)
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
 
-    # Layout fields
+    # Layout fields. Splits use ``list[int]`` (not tuple) so JSON round-trip
+    # in strict mode survives without coercion (JSON has no tuple type).
     task_name: str
     output_format: Literal["hdf5"]
-    train_val_test_sizes: tuple[int, int, int]
-    train_val_test_seeds: tuple[int, int, int]
+    train_val_test_sizes: list[int] = Field(min_length=3, max_length=3)
+    # Reserved for per-sample seeding (#884); not consumed yet.
+    train_val_test_seeds: list[int] = Field(min_length=3, max_length=3)
     base_seed: int
     r2_bucket: str
     r2_prefix_root: str = DEFAULT_R2_PREFIX_ROOT
@@ -169,14 +186,14 @@ class DatasetSpec(BaseModel):
     render: RenderConfig
 
     # Auto-filled runtime fields. ``default_factory`` runs only when the field
-    # is missing in input — JSON-loaded specs preserve the materialization-time
-    # values that the worker needs to remain consistent across the run. The
-    # lambdas re-look-up the helpers per call so test monkeypatches take effect.
+    # is missing on input — JSON-loaded specs preserve the materialization-time
+    # values that workers must reuse for consistency. Lambdas wrap the
+    # module-level helpers so test monkeypatches take effect.
     git_sha: str = Field(default_factory=lambda: _get_git_sha())
     is_repo_dirty: bool = Field(default_factory=lambda: _is_repo_dirty())
     created_at: datetime = Field(default_factory=lambda: _utc_now())
-    run_id: str = ""
-    r2_prefix: str = ""
+    run_id: str = Field(default_factory=_default_run_id)
+    r2_prefix: str = Field(default_factory=_default_r2_prefix)
 
     @model_validator(mode="before")
     @classmethod
@@ -194,38 +211,27 @@ class DatasetSpec(BaseModel):
                 data.pop(computed_key, None)
         return data
 
-    @model_validator(mode="after")
-    def _populate_derived_runtime_fields(self) -> DatasetSpec:
-        """Fill ``run_id`` / ``r2_prefix`` from ``task_name`` + ``created_at`` when empty.
+    @field_validator("created_at", mode="before")
+    @classmethod
+    def _parse_iso_datetime(cls, value: Any) -> Any:
+        """Parse an ISO 8601 string into a ``datetime`` so strict mode accepts it.
 
-        Empty defaults mean the input dict didn't carry materialization-time values; non-empty
-        values came from a JSON-loaded spec and pass through unchanged.
+        Strict-mode Python validation rejects str → datetime coercion, so JSON inputs (where
+        datetime is a string) need pre-conversion here. Also normalizes the trailing ``Z``
+        offset that ``model_dump_json`` emits for UTC, which Python 3.10's ``fromisoformat``
+        does not accept (3.11+ does).
         """
-        if not self.run_id:
-            object.__setattr__(
-                self,
-                "run_id",
-                make_dataset_wandb_run_id(
-                    DatasetConfigId(self.task_name), timestamp=self.created_at
-                ),
-            )
-        if not self.r2_prefix:
-            object.__setattr__(
-                self,
-                "r2_prefix",
-                make_r2_prefix(
-                    DatasetConfigId(self.task_name),
-                    self.run_id,
-                    prefix_root=self.r2_prefix_root,
-                ),
-            )
-        return self
+        if isinstance(value, str):
+            if value.endswith("Z"):
+                value = value[:-1] + "+00:00"
+            return datetime.fromisoformat(value)
+        return value
 
     @field_validator("r2_prefix")
     @classmethod
     def _r2_prefix_must_end_with_slash(cls, value: str) -> str:
         """Reject prefixes lacking a trailing ``/`` so rclone never gets ".../prefixfilename"."""
-        if value and not value.endswith("/"):
+        if not value.endswith("/"):
             raise ValueError(f"r2_prefix must end with '/' (got: {value!r})")
         return value
 
@@ -255,7 +261,7 @@ class DatasetSpec(BaseModel):
         spec-validation time rather than mid-render.
         """
         bps = self.render.batch_per_shard
-        for label, size in zip(("train", "val", "test"), self.train_val_test_sizes, strict=True):
+        for label, size in zip(_SPLIT_LABELS, self.train_val_test_sizes, strict=True):
             if size < 0:
                 raise ValueError(f"train_val_test_sizes[{label}] must be non-negative, got {size}")
             if size % bps != 0:
@@ -348,7 +354,7 @@ def _resolve_legacy_extends(config_path: Path, raw: dict[str, Any]) -> dict[str,
     base_resolved = _resolve_legacy_extends(base_path, base_raw)
     override = {k: v for k, v in raw.items() if k != _LEGACY_EXTENDS_KEY}
     merged = OmegaConf.merge(OmegaConf.create(base_resolved), OmegaConf.create(override))
-    return OmegaConf.to_container(merged, resolve=True)  # type: ignore[return-value]
+    return cast(dict[str, Any], OmegaConf.to_container(merged, resolve=True))
 
 
 # Pinned plugin version baked into ``tinaudio/synth-setter:dev-snapshot``;
@@ -374,16 +380,16 @@ def _legacy_dict_to_dataset_spec_kwargs(raw: dict[str, Any], task_name: str) -> 
             f"sum(splits)={splits_total_shards} (train={splits['train']}, "
             f"val={splits['val']}, test={splits['test']}); update one or the other"
         )
-    train_val_test_sizes = (
+    train_val_test_sizes = [
         splits["train"] * shard_size,
         splits["val"] * shard_size,
         splits["test"] * shard_size,
-    )
-    train_val_test_seeds = (
+    ]
+    train_val_test_seeds = [
         raw["base_seed"],
         raw["base_seed"] + 1,
         raw["base_seed"] + 2,
-    )
+    ]
     render = {
         "plugin_path": raw["plugin_path"],
         "preset_path": raw["preset_path"],

--- a/tests/pipeline/ci/test_validate_shard.py
+++ b/tests/pipeline/ci/test_validate_shard.py
@@ -58,8 +58,8 @@ def real_spec(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> DatasetSpec:
     return DatasetSpec(
         task_name="test-dataset",
         output_format="hdf5",
-        train_val_test_sizes=(10, 0, 0),
-        train_val_test_seeds=(42, 43, 44),
+        train_val_test_sizes=[10, 0, 0],
+        train_val_test_seeds=[42, 43, 44],
         base_seed=42,
         r2_bucket="intermediate-data",
         render={

--- a/tests/pipeline/ci/test_validate_shard.py
+++ b/tests/pipeline/ci/test_validate_shard.py
@@ -58,8 +58,8 @@ def real_spec(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> DatasetSpec:
     return DatasetSpec(
         task_name="test-dataset",
         output_format="hdf5",
-        train_val_test_sizes=[10, 0, 0],
-        train_val_test_seeds=[42, 43, 44],
+        train_val_test_sizes=(10, 0, 0),
+        train_val_test_seeds=(42, 43, 44),
         base_seed=42,
         r2_bucket="intermediate-data",
         render={

--- a/tests/pipeline/conftest.py
+++ b/tests/pipeline/conftest.py
@@ -34,8 +34,8 @@ def _make_dataset_spec_kwargs(plugin_path: str = "plugins/Surge XT.vst3") -> dic
     return {
         "task_name": "ci-smoke-test",
         "output_format": "hdf5",
-        "train_val_test_sizes": (440000, 20000, 20000),
-        "train_val_test_seeds": (42, 43, 44),
+        "train_val_test_sizes": [440000, 20000, 20000],
+        "train_val_test_seeds": [42, 43, 44],
         "base_seed": 42,
         "r2_bucket": "intermediate-data",
         "render": {

--- a/tests/pipeline/test_configs/test_experiment_yamls.py
+++ b/tests/pipeline/test_configs/test_experiment_yamls.py
@@ -1,0 +1,65 @@
+"""Round-trip every dataset experiment YAML through DatasetSpec validation.
+
+Each datagen experiment under ``configs/experiment/*.yaml`` (excluding the
+train-side experiments nested under ``kosc/``, ``ksin/``, etc.) composes via
+Hydra's ``initialize_config_dir`` + ``compose``. The composed dict — minus
+the ``data:``, ``r2:``, and ``hydra:`` group sub-trees that are lifted to
+top-level via interpolation — must validate as ``DatasetSpec`` and JSON
+round-trip without drift.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from hydra import compose, initialize_config_dir
+from omegaconf import OmegaConf
+
+from pipeline.schemas.spec import DatasetSpec
+
+CONFIG_DIR = Path(__file__).resolve().parent.parent.parent.parent / "configs"
+
+# Datagen experiments — flat at the top of configs/experiment/. Excludes the
+# train-side experiment subdirectories (kosc/, ksin/, surge/, etc.) which use
+# train.yaml's composition.
+DATASET_EXPERIMENTS: tuple[str, ...] = (
+    "10-1k-shards",
+    "ci-materialize-test",
+    "runpod-smoke-shard",
+    "surge-simple-480k-10k",
+)
+
+
+def _compose_dataset_spec(experiment: str) -> DatasetSpec:
+    """Compose ``configs/dataset.yaml`` with the named experiment override."""
+    with initialize_config_dir(version_base="1.3", config_dir=str(CONFIG_DIR)):
+        cfg = compose(
+            config_name="dataset",
+            overrides=[f"experiment={experiment}", "+dataset_root=/dev/null"],
+        )
+    raw: Any = OmegaConf.to_container(cfg, resolve=True)
+    assert isinstance(raw, dict), f"composed config is not a mapping: {type(raw).__name__}"
+    raw.pop("data", None)
+    raw.pop("r2", None)
+    raw.pop("hydra", None)
+    raw.pop("dataset_root", None)
+    return DatasetSpec(**raw)
+
+
+@pytest.mark.parametrize("experiment", DATASET_EXPERIMENTS)
+def test_experiment_yaml_validates_as_dataset_spec(experiment: str) -> None:
+    """Each composed experiment validates as DatasetSpec."""
+    spec = _compose_dataset_spec(experiment)
+    assert spec.task_name == experiment
+    assert spec.num_shards >= 1
+    assert spec.num_params > 0
+
+
+@pytest.mark.parametrize("experiment", DATASET_EXPERIMENTS)
+def test_experiment_yaml_json_round_trips(experiment: str) -> None:
+    """``model_dump_json`` → ``model_validate_json`` yields an equal model."""
+    spec = _compose_dataset_spec(experiment)
+    restored = DatasetSpec.model_validate_json(spec.model_dump_json())
+    assert restored == spec

--- a/tests/pipeline/test_configs/test_experiment_yamls.py
+++ b/tests/pipeline/test_configs/test_experiment_yamls.py
@@ -1,11 +1,16 @@
-"""Round-trip every dataset experiment YAML through DatasetSpec validation.
+"""Round-trip an explicit allowlist of dataset experiment YAMLs through DatasetSpec.
 
-Each datagen experiment under ``configs/experiment/*.yaml`` (excluding the
-train-side experiments nested under ``kosc/``, ``ksin/``, etc.) composes via
-Hydra's ``initialize_config_dir`` + ``compose``. The composed dict — minus
-the ``data:``, ``r2:``, and ``hydra:`` group sub-trees that are lifted to
-top-level via interpolation — must validate as ``DatasetSpec`` and JSON
-round-trip without drift.
+Each entry in :data:`DATASET_EXPERIMENTS` names a top-level datagen experiment under
+``configs/experiment/`` that composes ``dataset.yaml`` via Hydra's
+``initialize_config_dir`` + ``compose``. The composed dict — minus the ``data:``,
+``r2:``, and ``hydra:`` group sub-trees that are lifted to top-level via interpolation
+— must validate as ``DatasetSpec`` and JSON round-trip without drift.
+
+The list is curated rather than auto-discovered: ``configs/experiment/`` also holds
+train-side configs (top-level files like ``time_weighting.yaml`` and the nested
+``kosc/``, ``ksin/``, ``surge/``, … subdirectories) that compose ``train.yaml``, not
+``dataset.yaml``, and would not validate as ``DatasetSpec``. Add a new entry here when
+landing a new datagen experiment.
 """
 
 from __future__ import annotations
@@ -21,9 +26,8 @@ from pipeline.schemas.spec import DatasetSpec
 
 CONFIG_DIR = Path(__file__).resolve().parent.parent.parent.parent / "configs"
 
-# Datagen experiments — flat at the top of configs/experiment/. Excludes the
-# train-side experiment subdirectories (kosc/, ksin/, surge/, etc.) which use
-# train.yaml's composition.
+# Curated list of datagen experiments (those that compose dataset.yaml). See the
+# module docstring for why this is an allowlist rather than a directory scan.
 DATASET_EXPERIMENTS: tuple[str, ...] = (
     "10-1k-shards",
     "ci-materialize-test",

--- a/tests/pipeline/test_configs/test_experiment_yamls.py
+++ b/tests/pipeline/test_configs/test_experiment_yamls.py
@@ -39,16 +39,20 @@ DATASET_EXPERIMENTS: tuple[str, ...] = (
 def _compose_dataset_spec(experiment: str) -> DatasetSpec:
     """Compose ``configs/dataset.yaml`` with the named experiment override."""
     with initialize_config_dir(version_base="1.3", config_dir=str(CONFIG_DIR)):
-        cfg = compose(
-            config_name="dataset",
-            overrides=[f"experiment={experiment}", "+dataset_root=/dev/null"],
-        )
+        cfg = compose(config_name="dataset", overrides=[f"experiment={experiment}"])
+    # ``configs/paths/default.yaml`` interpolates ``${oc.env:PROJECT_ROOT}`` and
+    # ``${hydra:runtime.output_dir}``; the latter is only set under @hydra.main,
+    # not bare ``compose()``. Pin both so ``resolve=True`` doesn't trip in unit
+    # tests (mirrors the train/eval conftest pattern in ``tests/conftest.py``).
+    cfg.paths.root_dir = str(CONFIG_DIR.parent)
+    cfg.paths.output_dir = str(CONFIG_DIR.parent)
+    cfg.paths.work_dir = str(CONFIG_DIR.parent)
     raw: Any = OmegaConf.to_container(cfg, resolve=True)
     assert isinstance(raw, dict), f"composed config is not a mapping: {type(raw).__name__}"
     raw.pop("data", None)
     raw.pop("r2", None)
     raw.pop("hydra", None)
-    raw.pop("dataset_root", None)
+    raw.pop("paths", None)
     return DatasetSpec(**raw)
 
 

--- a/tests/pipeline/test_configs/test_experiment_yamls.py
+++ b/tests/pipeline/test_configs/test_experiment_yamls.py
@@ -2,9 +2,10 @@
 
 Each entry in :data:`DATASET_EXPERIMENTS` names a top-level datagen experiment under
 ``configs/experiment/`` that composes ``dataset.yaml`` via Hydra's
-``initialize_config_dir`` + ``compose``. The composed dict — minus the ``data:``,
-``r2:``, and ``hydra:`` group sub-trees that are lifted to top-level via interpolation
-— must validate as ``DatasetSpec`` and JSON round-trip without drift.
+``initialize_config_dir`` + ``compose``. The composed dict — minus the non-``DatasetSpec``
+group sub-trees (``data:``, ``r2:``, ``paths:``, and ``hydra:``) that are either lifted
+to top-level via interpolation or only exist for Hydra runtime — must validate as
+``DatasetSpec`` and JSON round-trip without drift.
 
 The list is curated rather than auto-discovered: ``configs/experiment/`` also holds
 train-side configs (top-level files like ``time_weighting.yaml`` and the nested

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -75,8 +75,8 @@ def _base_spec_kwargs(tmp_path: Path, **overrides: object) -> dict[str, object]:
         "git_sha": "a" * 40,
         "is_repo_dirty": False,
         "output_format": "hdf5",
-        "train_val_test_sizes": (10000, 0, 0),
-        "train_val_test_seeds": (42, 43, 44),
+        "train_val_test_sizes": [10000, 0, 0],
+        "train_val_test_seeds": [42, 43, 44],
         "base_seed": 42,
         "r2_bucket": "intermediate-data",
         "render": {
@@ -107,7 +107,7 @@ def _multi_shard_spec(tmp_path: Path, n: int = 3) -> DatasetSpec:
     """Return a DatasetSpec with ``n`` shards (deterministic filenames/seeds)."""
     kwargs = _base_spec_kwargs(
         tmp_path,
-        train_val_test_sizes=(10000 * n, 0, 0),
+        train_val_test_sizes=[10000 * n, 0, 0],
     )
     return DatasetSpec(**kwargs)  # type: ignore[arg-type]
 

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -247,8 +247,8 @@ class TestDatasetSpecValidators:
             DatasetSpec(**_valid_spec_kwargs(train_val_test_seeds=bad_length))
 
     def test_explicit_empty_r2_prefix_raises(self, patch_runtime_io: None) -> None:
-        """An explicit empty ``r2_prefix`` raises (the default_factory's "no slash" check
-        fires)."""
+        """An explicit empty ``r2_prefix`` raises via the ``_r2_prefix_must_end_with_slash`` field
+        validator (the default_factory is bypassed when a value is supplied)."""
         with pytest.raises(ValidationError, match="r2_prefix must end with"):
             DatasetSpec(**_valid_spec_kwargs(r2_prefix=""))
 

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -268,6 +268,44 @@ class TestDatasetSpecValidators:
         with pytest.raises(ValidationError):
             DatasetSpec(**payload)
 
+    def test_naive_created_at_string_raises(self, patch_runtime_io: None) -> None:
+        """Naive ISO datetimes are rejected at the ``created_at`` boundary.
+
+        ``make_dataset_wandb_run_id`` downstream needs tz-aware UTC; without this check
+        an invalid ``created_at`` would surface as a run_id derivation crash with the
+        wrong error attribution.
+        """
+        payload = {**_valid_spec_kwargs(), "created_at": "2026-03-28T12:00:00"}
+        with pytest.raises(ValidationError, match="created_at must be timezone-aware UTC"):
+            DatasetSpec(**payload)
+
+    def test_non_utc_created_at_string_raises(self, patch_runtime_io: None) -> None:
+        """Non-UTC ISO offsets are rejected so run_id derivation produces correct timestamps."""
+        payload = {**_valid_spec_kwargs(), "created_at": "2026-03-28T12:00:00+05:00"}
+        with pytest.raises(ValidationError, match="created_at must be UTC"):
+            DatasetSpec(**payload)
+
+    def test_train_val_test_sizes_stored_as_immutable_tuple(self, patch_runtime_io: None) -> None:
+        """Splits stored as ``tuple`` so in-place mutation can't invalidate cached ``shards``.
+
+        ``frozen=True`` only blocks attribute reassignment, not in-place mutation of
+        contained-types. Tuple makes in-place mutation a ``TypeError``, preserving the
+        frozen contract end-to-end.
+        """
+        spec = DatasetSpec(**_valid_spec_kwargs())
+        assert isinstance(spec.train_val_test_sizes, tuple)
+        assert isinstance(spec.train_val_test_seeds, tuple)
+        with pytest.raises(TypeError):
+            spec.train_val_test_sizes[0] = 999  # type: ignore[index]
+
+    def test_train_val_test_sizes_accepts_json_list(self, patch_runtime_io: None) -> None:
+        """JSON-loaded specs deliver lists (no native tuple type); they coerce to tuples on
+        input."""
+        payload = {**_valid_spec_kwargs(), "train_val_test_sizes": [300, 0, 0]}
+        spec = DatasetSpec(**payload)
+        assert spec.train_val_test_sizes == (300, 0, 0)
+        assert isinstance(spec.train_val_test_sizes, tuple)
+
 
 # ---------------------------------------------------------------------------
 # DatasetSpec — computed fields
@@ -427,7 +465,7 @@ class TestLoadDatasetSpecYaml:
         spec = load_dataset_spec_yaml(legacy_yaml)
         assert spec.task_name == "ci-smoke-test"
         assert spec.output_format == "hdf5"
-        assert spec.train_val_test_sizes == [300, 0, 0]
+        assert spec.train_val_test_sizes == (300, 0, 0)
         assert spec.render.plugin_path == "plugins/Surge XT.vst3"
         assert spec.render.batch_per_shard == 100
         assert spec.num_shards == 3

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -43,8 +43,8 @@ def _valid_spec_kwargs(plugin_path: str = "/fake/Plugin.vst3", **overrides: Any)
     kwargs: dict[str, Any] = {
         "task_name": "ci-smoke-test",
         "output_format": "hdf5",
-        "train_val_test_sizes": (300, 0, 0),
-        "train_val_test_seeds": (123, 456, 789),
+        "train_val_test_sizes": [300, 0, 0],
+        "train_val_test_seeds": [123, 456, 789],
         "base_seed": 42,
         "r2_bucket": "intermediate-data",
         "render": _valid_render_kwargs(plugin_path),
@@ -203,22 +203,70 @@ class TestDatasetSpecValidators:
     ) -> None:
         """A split size that doesn't divide evenly into ``batch_per_shard`` raises."""
         with pytest.raises(ValidationError, match="not a multiple"):
-            DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=(150, 0, 0)))
+            DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=[150, 0, 0]))
 
     def test_negative_split_size_raises(self, patch_runtime_io: None) -> None:
         """Negative split sizes raise rather than silently truncating shards."""
         with pytest.raises(ValidationError, match="must be non-negative"):
-            DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=(-100, 0, 0)))
+            DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=[-100, 0, 0]))
 
     def test_zero_total_split_raises(self, patch_runtime_io: None) -> None:
         """Three-zero splits raise (a dataset with zero samples is a config error)."""
         with pytest.raises(ValidationError, match="must sum to a positive count"):
-            DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=(0, 0, 0)))
+            DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=[0, 0, 0]))
 
     def test_invalid_output_format_literal_raises(self, patch_runtime_io: None) -> None:
         """An output_format outside ``Literal['hdf5']`` is rejected by Pydantic literal check."""
         with pytest.raises(ValidationError):
             DatasetSpec(**_valid_spec_kwargs(output_format="parquet"))
+
+    def test_strict_mode_rejects_int_for_string_field(self, patch_runtime_io: None) -> None:
+        """Strict mode rejects silent int→str coercion at the trust boundary."""
+        with pytest.raises(ValidationError):
+            DatasetSpec(**_valid_spec_kwargs(task_name=12345))
+
+    def test_strict_mode_rejects_string_for_bool_field(self, patch_runtime_io: None) -> None:
+        """Strict mode rejects silent str→bool coercion (e.g., ``is_repo_dirty="false"``)."""
+        with pytest.raises(ValidationError):
+            DatasetSpec(**_valid_spec_kwargs(is_repo_dirty="false"))
+
+    @pytest.mark.parametrize("bad_length", [[300, 0], [300, 0, 0, 0]])
+    def test_train_val_test_sizes_must_be_length_three(
+        self, patch_runtime_io: None, bad_length: list[int]
+    ) -> None:
+        """train_val_test_sizes must be exactly length 3 — not 2, not 4."""
+        with pytest.raises(ValidationError):
+            DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=bad_length))
+
+    @pytest.mark.parametrize("bad_length", [[42, 43], [42, 43, 44, 45]])
+    def test_train_val_test_seeds_must_be_length_three(
+        self, patch_runtime_io: None, bad_length: list[int]
+    ) -> None:
+        """train_val_test_seeds must be exactly length 3 — parity with sizes."""
+        with pytest.raises(ValidationError):
+            DatasetSpec(**_valid_spec_kwargs(train_val_test_seeds=bad_length))
+
+    def test_explicit_empty_r2_prefix_raises(self, patch_runtime_io: None) -> None:
+        """An explicit empty ``r2_prefix`` raises (the default_factory's "no slash" check
+        fires)."""
+        with pytest.raises(ValidationError, match="r2_prefix must end with"):
+            DatasetSpec(**_valid_spec_kwargs(r2_prefix=""))
+
+    def test_z_suffixed_created_at_string_parses(self, patch_runtime_io: None) -> None:
+        """``model_dump_json``'s ``Z``-suffixed UTC timestamps round-trip on Python 3.10.
+
+        ``datetime.fromisoformat`` rejects the ``Z`` offset on 3.10 (accepts on 3.11+); the
+        ``_parse_iso_datetime`` validator normalizes it before strict-mode validation runs.
+        """
+        payload = {**_valid_spec_kwargs(), "created_at": "2026-03-28T12:00:00Z"}
+        spec = DatasetSpec(**payload)
+        assert spec.created_at == FIXED_NOW
+
+    def test_malformed_created_at_string_raises(self, patch_runtime_io: None) -> None:
+        """A malformed datetime string surfaces a clear validation error, not a silent coerce."""
+        payload = {**_valid_spec_kwargs(), "created_at": "not-a-datetime"}
+        with pytest.raises(ValidationError):
+            DatasetSpec(**payload)
 
 
 # ---------------------------------------------------------------------------
@@ -231,18 +279,18 @@ class TestDatasetSpecComputedFields:
 
     def test_shards_count_matches_total_size_div_batch(self, patch_runtime_io: None) -> None:
         """num_shards = sum(train_val_test_sizes) / batch_per_shard."""
-        spec = DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=(400, 100, 100)))
+        spec = DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=[400, 100, 100]))
         assert spec.num_shards == 6
         assert len(spec.shards) == 6
 
     def test_shard_seeds_are_base_plus_shard_id(self, patch_runtime_io: None) -> None:
         """Per-shard seed equals ``base_seed + shard_id``."""
-        spec = DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=(300, 0, 0)))
+        spec = DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=[300, 0, 0]))
         assert [s.seed for s in spec.shards] == [42, 43, 44]
 
     def test_shard_filenames_zero_padded_six_digits(self, patch_runtime_io: None) -> None:
         """Shard filenames use the ``shard-NNNNNN`` six-digit zero-padded form."""
-        spec = DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=(300, 0, 0)))
+        spec = DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=[300, 0, 0]))
         assert spec.shards[0].filename == "shard-000000.h5"
         assert spec.shards[-1].filename == "shard-000002.h5"
 
@@ -287,7 +335,7 @@ class TestDatasetSpecRoundTrip:
 
     def test_json_round_trip_preserves_shards(self, patch_runtime_io: None) -> None:
         """Computed ``shards`` / ``num_shards`` round-trip identically through JSON."""
-        spec = DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=(400, 100, 100)))
+        spec = DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=[400, 100, 100]))
         restored = DatasetSpec.model_validate_json(spec.model_dump_json())
         assert restored.shards == spec.shards
         assert restored.num_shards == spec.num_shards
@@ -379,7 +427,7 @@ class TestLoadDatasetSpecYaml:
         spec = load_dataset_spec_yaml(legacy_yaml)
         assert spec.task_name == "ci-smoke-test"
         assert spec.output_format == "hdf5"
-        assert spec.train_val_test_sizes == (300, 0, 0)
+        assert spec.train_val_test_sizes == [300, 0, 0]
         assert spec.render.plugin_path == "plugins/Surge XT.vst3"
         assert spec.render.batch_per_shard == 100
         assert spec.num_shards == 3


### PR DESCRIPTION
## Summary

Follow-up to PR-1 ([#887](https://github.com/tinaudio/synth-setter/pull/887)). Adds the Hydra-composable dataset config tree that PR-3 will hook into when migrating the launcher to `@hydra.main`, and hardens `DatasetSpec` for the trust boundary the compose path needs.

- New top-level `configs/dataset.yaml` + per-group `configs/render/`, `configs/r2/`, `configs/experiment/`.
- New `tests/pipeline/test_configs/test_experiment_yamls.py` — every experiment composes via Hydra, validates as `DatasetSpec`, and JSON round-trips with no drift.
- `DatasetSpec` hardening: re-add `strict=True`, switch tuple→list[int] with `Field(min_length=3, max_length=3)`, replace the `_populate_derived_runtime_fields` validator + `object.__setattr__` workaround with `Field(default_factory=_default_run_id)` / `_default_r2_prefix`, add `_parse_iso_datetime` for `Z`-suffixed UTC.

## Scope guard rails

- `output_format` stays restricted to `hdf5` — wds (and its experiment variants `*-wds.yaml`) land with #874's PR-12/13/14 tail.
- The legacy bridge `load_dataset_spec_yaml`, `configs/dataset/*.yaml`, and `pipeline.ci.materialize_spec` stay through this PR. PR-3 removes all three alongside the entrypoint's `@hydra.main` migration.
- `train_val_test_seeds` is required by the schema but unused — reserved for per-sample seeding (#884). Defaulted at `configs/dataset.yaml` so experiments don't repeat the triple.

## Files

| Added | |
| --- | --- |
| `configs/dataset.yaml` | Top-level `@hydra.main` composition target |
| `configs/render/surge_xt.yaml` | Renderer params, `batch_per_shard`, `renderer_version` |
| `configs/render/surge_simple.yaml` | Inherits surge_xt; overrides `param_spec_name` + `preset_path` |
| `configs/r2/default.yaml` | Bucket + `prefix_root` |
| `configs/experiment/ci-materialize-test.yaml` | 96-sample / 3-shard smoke |
| `configs/experiment/runpod-smoke-shard.yaml` | 12-sample CI smoke |
| `configs/experiment/surge-simple-480k-10k.yaml` | 480k production |
| `configs/experiment/10-1k-shards.yaml` | 10k experiments |
| `tests/pipeline/test_configs/test_experiment_yamls.py` | Hydra compose → `DatasetSpec` round-trip per experiment |

| Modified | What changed |
| --- | --- |
| `pipeline/schemas/spec.py` | DatasetSpec hardening (see above) |
| `tests/pipeline/conftest.py` | tuple → list for `train_val_test_sizes`/`_seeds` |
| `tests/pipeline/test_schemas/test_dataset_spec.py` | Same; 5 new behavioral pins for strict mode, list-length, Z-iso, empty-prefix |
| `tests/pipeline/ci/test_validate_shard.py` | Same tuple → list |
| `tests/pipeline/test_entrypoints/test_generate_dataset.py` | Same tuple → list |

## Mandatory skills run

Per CLAUDE.md mandate for non-doc code changes:

- `/tdd-implementation` — 9 new behavioral tests added covering each hardening item; Red phase honored on the strict/list/Z changes (the 5 added after the initial commit failed without the hardening). Coverage gaps in `train_val_test_seeds` length, `is_repo_dirty` strict-rejection, empty-`r2_prefix`, and malformed-datetime were caught and pinned before commit.
- `/code-health` — flagged the dead `data.get("r2_prefix_root", DEFAULT_R2_PREFIX_ROOT)` fallback (Pydantic populates defaults before later factories) → simplified to `data["r2_prefix_root"]`.
- `/simplify` — flagged redundant `output_format: hdf5` in every experiment (already the dataset.yaml default) → dropped. Also `train_val_test_seeds: ???` was required-with-identical-value across 4 experiments → defaulted at dataset.yaml.

## Test plan

- [x] `make test-fast` — **474 passed** (PR-1 baseline 457 + 8 new experiment YAML round-trip tests + 9 new schema-hardening behavioral pins, including 4 added in response to /tdd-implementation gap analysis)
- [x] `make format` — all pre-commit hooks pass (ruff, ruff-format, pyright, docformatter, mdformat, codespell, …)
- [ ] CI green on PR
- [ ] Maintainer review

## Verification

```text
$ python3 -m pytest tests/pipeline/test_configs -v
tests/pipeline/test_configs/test_experiment_yamls.py::test_experiment_yaml_validates_as_dataset_spec[10-1k-shards] PASSED
tests/pipeline/test_configs/test_experiment_yamls.py::test_experiment_yaml_validates_as_dataset_spec[ci-materialize-test] PASSED
tests/pipeline/test_configs/test_experiment_yamls.py::test_experiment_yaml_validates_as_dataset_spec[runpod-smoke-shard] PASSED
tests/pipeline/test_configs/test_experiment_yamls.py::test_experiment_yaml_validates_as_dataset_spec[surge-simple-480k-10k] PASSED
tests/pipeline/test_configs/test_experiment_yamls.py::test_experiment_yaml_json_round_trips[10-1k-shards] PASSED
tests/pipeline/test_configs/test_experiment_yamls.py::test_experiment_yaml_json_round_trips[ci-materialize-test] PASSED
tests/pipeline/test_configs/test_experiment_yamls.py::test_experiment_yaml_json_round_trips[runpod-smoke-shard] PASSED
tests/pipeline/test_configs/test_experiment_yamls.py::test_experiment_yaml_json_round_trips[surge-simple-480k-10k] PASSED
```

Part of #906