### PR TITLE
fix(devcontainer): bake main branch into baked image clone

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -37,12 +37,6 @@ cd "$dir"
 # before later git config calls and pre-commit install.
 git config --global --add safe.directory "$(pwd)"
 
-# Isolated devcontainers land detached in the baked image clone — switch to main.
-if ! git symbolic-ref -q HEAD >/dev/null; then
-  git fetch origin main && git checkout -B main origin/main \
-    || echo "WARNING: could not move detached HEAD onto main." >&2
-fi
-
 if [ -n "${RESTRICTED_AGENT_GIT_PAT:-}" ]; then
   # Strip surrounding double or single quotes if present
   # (Docker's --env-file doesn't strip them like shell `source` does)

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -37,6 +37,12 @@ cd "$dir"
 # before later git config calls and pre-commit install.
 git config --global --add safe.directory "$(pwd)"
 
+# Isolated devcontainers land detached in the baked image clone — switch to main.
+if ! git symbolic-ref -q HEAD >/dev/null; then
+  git fetch origin main && git checkout -B main origin/main \
+    || echo "WARNING: could not move detached HEAD onto main." >&2
+fi
+
 if [ -n "${RESTRICTED_AGENT_GIT_PAT:-}" ]; then
   # Strip surrounding double or single quotes if present
   # (Docker's --env-file doesn't strip them like shell `source` does)

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -363,7 +363,8 @@ WORKDIR /home/build/synth-setter
 RUN git init && \
     git remote add origin "https://github.com/tinaudio/synth-setter.git" && \
     git fetch origin && \
-    git checkout --detach "${SYNTH_PERMUTATIONS_GIT_REF}"
+    git checkout -B main "${SYNTH_PERMUTATIONS_GIT_REF}" && \
+    git branch --set-upstream-to=origin/main main
 
 # Install the project package so `import src` works from any working directory.
 # --no-deps: all runtime deps already installed via uv pip install above.


### PR DESCRIPTION
## Summary

- The dev-base stage of `docker/ubuntu22_04/Dockerfile` previously used `git checkout --detach "${SYNTH_PERMUTATIONS_GIT_REF}"`, leaving every devcontainer that lands in the image's WORKDIR in detached HEAD. The isolated `.devcontainer/root_gpu` flavor (no `workspaceMount` override) was the visible victim.
- This PR replaces that with `git checkout -B main "${SYNTH_PERMUTATIONS_GIT_REF}" && git branch --set-upstream-to=origin/main main`. Same SHA, just with a branch name and upstream tracking. `-B` is safe — `git init` two lines earlier produces an empty repo, so there are no existing branches to clobber.
- The runtime post-create.sh guard from the first commit on this branch is reverted; this PR will squash-merge as a single Dockerfile change.

## Why Dockerfile, not post-create.sh

Initial approach (first commit, now reverted): runtime guard in `post-create.sh` that detected detached HEAD and moved to main. [Copilot's review comment](https://github.com/tinaudio/synth-setter/pull/913#discussion_r3219754722) correctly flagged that this would also fire for bind-mounted host workspaces where a user has intentionally checked out a SHA — and `git checkout -B main` would clobber any existing local `main`.

Baking the branch at image-build time sidesteps that entirely: bind-mounted workspaces never see the image WORKDIR's git state, so they cannot trigger the new logic. Other consumers of `dev-base` (the published `devcontainer-tools` image, `freeze-deps`, `dev-snapshot`) inherit the fix without per-stage layers.

## Test plan

- [x] Build a synthetic Dockerfile with the modified RUN instruction and a fake `origin.git`; verify the resulting image's `git branch --show-current` is `main`, HEAD SHA matches `SYNTH_PERMUTATIONS_GIT_REF`, and upstream is `origin/main` (see [verification comment](#issuecomment-4421688530) — superseded; new verification posted on this update).

Fixes #910