### PR TITLE
chore(image-config): drop unused r2_bucket field

### DIFF
--- a/configs/image/dev-snapshot.yaml
+++ b/configs/image/dev-snapshot.yaml
@@ -10,4 +10,3 @@ base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
 torch_backend: "cu128"
-r2_bucket: "intermediate-data"

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -128,7 +128,7 @@ docs:
         covers: "Run ID format, shard ID format, prefix construction rules"
       - pattern: "scripts/r2_shard_report.py"
         covers: "R2 listing commands, shard status reporting, path parsing"
-      - pattern: "configs/image/dev-snapshot.yaml"
+      - pattern: "configs/dataset/*.yaml"
         covers: "r2_bucket value, storage configuration"
       - pattern: "pipeline/entrypoints/generate_dataset.py"
         covers: "rclone upload of spec and shard files, R2 path construction"

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -168,13 +168,12 @@ base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
 torch_backend: "cu128"
-r2_bucket: "intermediate-data"
 ```
 
 Runtime inputs (`github_sha`, `issue_number`) are provided by the caller, not
 stored in the YAML. The schema is tested in
-[test_image_config.py](../../tests/pipeline/test_schemas/test_image_config.py) (22 tests
-covering validation, defaults, and drift detection against the real YAML).
+[test_image_config.py](../../tests/pipeline/test_schemas/test_image_config.py) — covers
+validation, defaults, and drift detection against the real YAML.
 
 ______________________________________________________________________
 

--- a/pipeline/schemas/image_config.py
+++ b/pipeline/schemas/image_config.py
@@ -31,7 +31,6 @@ class ImageConfig(BaseModel, strict=True, extra="forbid"):
     build_mode: Literal["source", "prebuilt"]
     target_platform: Literal["linux/amd64", "linux/arm64"]
     torch_backend: str
-    r2_bucket: str
 
     # --- Runtime fields (from caller, no defaults) ---
     github_sha: str
@@ -52,14 +51,6 @@ class ImageConfig(BaseModel, strict=True, extra="forbid"):
         """Reject zero or negative issue numbers."""
         if v <= 0:
             raise ValueError("issue_number must be a positive integer")
-        return v
-
-    @field_validator("r2_bucket")
-    @classmethod
-    def must_not_be_blank(cls, v: str) -> str:
-        """Reject empty or whitespace-only strings."""
-        if not v.strip():
-            raise ValueError("must not be blank")
         return v
 
 

--- a/tests/pipeline/test_ci/test_load_image_config.py
+++ b/tests/pipeline/test_ci/test_load_image_config.py
@@ -27,7 +27,6 @@ base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
 torch_backend: "cu128"
-r2_bucket: test-bucket
 """
 
 _EXPECTED_LINES = [
@@ -38,7 +37,6 @@ _EXPECTED_LINES = [
     "build_mode=prebuilt",
     "target_platform=linux/amd64",
     "torch_backend=cu128",
-    "r2_bucket=test-bucket",
     f"github_sha={VALID_SHA}",
     "issue_number=311",
     "image_config_id=dev-snapshot",
@@ -248,7 +246,6 @@ base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
 torch_backend: "cu128"
-r2_bucket: test-bucket
 """
         config_path = tmp_path / "dev-snapshot.yaml"
         config_path.write_text(yaml_with_newline)
@@ -282,7 +279,6 @@ base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
 torch_backend: "cu128"
-r2_bucket: test-bucket
 """
         config_path = tmp_path / "dev-snapshot.yaml"
         config_path.write_text(yaml_with_cr)

--- a/tests/pipeline/test_schemas/test_image_config.py
+++ b/tests/pipeline/test_schemas/test_image_config.py
@@ -25,7 +25,6 @@ base_image_tag: ubuntu22_04
 build_mode: prebuilt
 target_platform: linux/amd64
 torch_backend: "cu128"
-r2_bucket: test-bucket
 """
 
 
@@ -61,7 +60,6 @@ class TestLoadImageConfigValid:
         assert result.github_sha == VALID_SHA
         assert result.issue_number == VALID_ISSUE
         assert result.image_config_id == "dev-snapshot"
-        assert result.r2_bucket == "test-bucket"
 
 
 # ---------------------------------------------------------------------------
@@ -122,22 +120,6 @@ class TestIssueNumberValidation:
 
         with pytest.raises(ValidationError, match="issue_number"):
             load_image_config(config_path, github_sha=VALID_SHA, issue_number=-1)
-
-
-# ---------------------------------------------------------------------------
-# load_image_config — r2 field validation
-# ---------------------------------------------------------------------------
-
-
-class TestR2BucketValidation:
-    """r2_bucket must not be empty or whitespace-only."""
-
-    def test_empty_r2_bucket_rejected(self, tmp_path: Path) -> None:
-        """Empty r2_bucket is rejected."""
-        config_path = _write_config(tmp_path, overrides='r2_bucket: ""\n')
-
-        with pytest.raises(ValidationError, match="must not be blank"):
-            load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +198,6 @@ class TestLoadImageConfigErrors:
     def test_missing_field_rejected(self, tmp_path: Path) -> None:
         """YAML missing a required field raises ValidationError."""
         config_path = tmp_path / "incomplete.yaml"
-        # Write config missing r2_bucket
         config_path.write_text(
             "dockerfile: docker/ubuntu22_04/Dockerfile\n"
             "image: tinaudio/synth-setter\n"
@@ -224,7 +205,6 @@ class TestLoadImageConfigErrors:
             "base_image_tag: ubuntu22_04\n"
             "build_mode: prebuilt\n"
             "target_platform: linux/amd64\n"
-            'torch_backend: "cu128"\n'
         )
 
         with pytest.raises(ValidationError):
@@ -276,5 +256,4 @@ class TestStaticFieldsAndYamlMerge:
         assert result.build_mode == "prebuilt"
         assert result.target_platform == "linux/amd64"
         assert result.torch_backend == "cu128"
-        assert result.r2_bucket == "intermediate-data"
         assert result.image_config_id == "dev-snapshot"


### PR DESCRIPTION
## Summary

- Remove the now-unused `r2_bucket` field from `ImageConfig` and `configs/image/dev-snapshot.yaml`.
- Update the two test modules that pinned the field's presence in the schema and CLI output.
- Update `docs/doc-map.yaml`: point `r2_bucket` coverage at `configs/dataset/*.yaml` instead of the image config.

## Why

The only consumer of `ImageConfig` is `.github/workflows/docker-build-validation.yml` (via `pipeline/ci/load_image_config.py`). It reads `dockerfile`, `image`, `build_mode`, `base_image`, `target_platform`, and `torch_backend` from `steps.config.outputs` — but never `r2_bucket`.

The active source of truth for the R2 bucket is `DatasetPipelineSpec.r2_bucket` (in `pipeline/schemas/spec.py`), which flows through the dataset config and is consumed by `generate_dataset.py`, `validate_shard.py`, and `skypilot_launch.py`. CHANGELOG entries already record the migration:

- `fix(workflows): read r2_bucket from dataset config, not image config`
- `docker-build-validation.yml: drop R2_BUCKET from build-args`
- `The pydantic ImageConfig schema still validates r2_bucket because the YAML is still the single source of truth` — that note is now stale; nothing downstream consumes it.

This is a dead-field removal — no behavior change.

## Test plan

- [x] `make test-fast` — 492 passed
- [x] Targeted: `pytest tests/pipeline/test_schemas/test_image_config.py tests/pipeline/test_ci/test_load_image_config.py` — 29 passed
- [x] `make format` — all pre-commit hooks pass (ruff, pyright, prettier, mdformat, etc.)
- [ ] CI green on PR

Refs #932