### PR TITLE
docs(claude-md): require PR titles to stand on their own without the linked issue

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,8 +213,8 @@ A PR title must stand on its own. A reader who is familiar with the project but 
 
 - **Name the specific subject, not just the action.** If the PR migrates *one specific schema or component*, say which one. "Complete migration" or "fix bug" without a noun is not enough.
 - **Don't rely on the issue, PR body, or commit list to disambiguate.** If the title would be ambiguous without that context, it is ambiguous, period.
-- **Keep the conventional-commit prefix and scope.** The added context goes in the human-readable subject after the colon, not in the scope.
-- **Stay under the gitlint title limit.** If the natural phrasing won't fit, shorten the action verb ("complete" → "finish", "remove" → "drop") or compress the scope — but never drop the specific subject to save characters.
+- **Keep the conventional commit prefix and scope.** The added context goes in the human-readable subject after the colon, not in the scope. The scope is a stable component identifier (`pipeline`, `claude-md`); the specific subject lives in the words after the colon.
+- **Stay under the gitlint title limit.** If the natural phrasing won't fit, shorten the action verb ("complete" → "finish", "remove" → "drop") or tighten the subject's phrasing — but never drop the specific subject itself to save characters.
 
 Example:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,22 @@ Pure documentation edits (`.md` files, `docs/`) are exempt. There are no other e
 - In chat responses, use full markdown hyperlinks for PR/issue references: `[#N](https://github.com/tinaudio/synth-setter/issues/N)`. In PR/issue bodies, use bare `Fixes #N` / `Closes #N` / `Refs #N` so GitHub auto-close works.
 - Never add "Generated with Claude Code" or similar attribution footers to PRs, commits, issues, or comments.
 
+### PR Titles
+
+A PR title must stand on its own. A reader who is familiar with the project but has not opened the linked issue should be able to tell from the title alone *what part of the system the PR touches and what concrete change it makes*. Reviewers, release-notes consumers, and people scanning `git log` rarely click through to the issue — the title is the only context many of them get.
+
+- **Name the specific subject, not just the action.** If the PR migrates *one specific schema or component*, say which one. "Complete migration" or "fix bug" without a noun is not enough.
+- **Don't rely on the issue, PR body, or commit list to disambiguate.** If the title would be ambiguous without that context, it is ambiguous, period.
+- **Keep the conventional-commit prefix and scope.** The added context goes in the human-readable subject after the colon, not in the scope.
+- **Stay under the gitlint title limit.** If the natural phrasing won't fit, shorten the action verb ("complete" → "finish", "remove" → "drop") or compress the scope — but never drop the specific subject to save characters.
+
+Example:
+
+- Bad: `feat(pipeline)!: complete Hydra migration; remove load_dataset_spec_yaml`
+- Good: `feat(pipeline)!: complete dataset_spec Hydra migration; remove load_dataset_spec_yaml`
+
+The bad version forces the reader to ask "Hydra migration of *what*?" — the project has had several. The good version answers that question in the title.
+
 ### PR Readiness
 
 A PR is **not ready** — for review, merge, or hand-off — until **all** of these hold:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,7 +230,12 @@ Every PR must:
 ### PR title
 
 Use the same conventional commit format as your commit message (e.g.,
-`feat: add parameter search`, `fix: correct shard validation`).
+`feat(search): add random preset parameter sweep`,
+`fix(pipeline): correct shard checksum validation`). The title must stand
+on its own — a reader who has not opened the linked issue should be able
+to tell from the title alone what part of the system the PR touches and
+what concrete change it makes. See `CLAUDE.md` § "PR Titles" for the full
+rule and worked examples.
 
 ## Code of conduct
 


### PR DESCRIPTION
## Summary

Adds a new \`### PR Titles\` subsection to \`CLAUDE.md\` (under \`## Workflow Rules\`, between \`### PR & Issue References\` and \`### PR Readiness\`) capturing the rule:

> A PR title must stand on its own. A reader who is familiar with the project but has not opened the linked issue should be able to tell from the title alone *what part of the system the PR touches and what concrete change it makes*.

The new subsection includes:

- Four bullet rules (name the specific subject; don't rely on issue/PR body/commit list; keep the conventional-commit prefix and scope; stay under the gitlint title limit).
- A worked example using the real `dataset_spec` Hydra migration title:
  - Bad: `feat(pipeline)!: complete Hydra migration; remove load_dataset_spec_yaml`
  - Good: `feat(pipeline)!: complete dataset_spec Hydra migration; remove load_dataset_spec_yaml`

The bad version forces the reader to ask "Hydra migration of *what*?" — the project has had several. The good version answers that question in the title.

## Why

Reviewers, release-notes consumers, and people scanning `git log` rarely click through to the linked issue — the title is the only context many of them get. Generic action-only titles like "complete migration" or "fix bug" without a specific subject force readers to chase context that the author already had.

## Scope

Docs-only change to `CLAUDE.md`. No code touched.

## Test plan

- [x] `pre-commit run --files CLAUDE.md` passes locally (mdformat + codespell + trailing whitespace + end-of-file).
- [ ] CI green on the PR.
- [ ] Mergeable with `main`.

Closes #934

---

Update (post-doc-drift review): also tightens `CONTRIBUTING.md` § "PR title" so external contributors see the same bar — the prior example titles (`feat: add parameter search`, `fix: correct shard validation`) are exactly the vague form the new CLAUDE.md rule rejects, and would have left two divergent standards in the repo.