### PR TITLE
chore: add pydoclint with deep signature/docstring checks

### DIFF
--- a/.github/agents/lint-cleanup.md
+++ b/.github/agents/lint-cleanup.md
@@ -17,7 +17,7 @@ For each file listed in the `exclude` blocks of `pyright`, `interrogate`, `pydoc
 3. **Auto-fix what you can**: `ruff check --fix` and `docformatter --in-place` handle most formatting issues automatically
 4. **Manually fix remaining violations**:
    - `interrogate` missing docstrings: add Sphinx-style docstrings (`:param:`, `:returns:`, `:raises:`) to public functions/classes — matches the `docformatter` config (`style = "sphinx"` in `pyproject.toml`) — and must pass `pydoclint` DOC1xx/DOC2xx/DOC5xx (signature ↔ docstring consistency)
-5. **Remove the file from all `exclude` blocks** in `.pre-commit-config.yaml`
+5. **Remove the file from all `exclude` blocks** in `.pre-commit-config.yaml` **and from `[tool.pydoclint].exclude` in `pyproject.toml`** (pydoclint's path-exclude list lives there, not in the pre-commit config)
 6. **Verify**: `pre-commit run --files <file>` passes all hooks
 7. **Run tests**: `make test-fast` — the quick CPU suite (excludes `slow`, `gpu`, `mps`, `requires_vst`) must still pass as a smoke check; lint-only changes shouldn't affect behavior
 8. **Commit**: Use conventional commits format: `chore(lint): clean up <filename>`

--- a/.github/agents/lint-cleanup.md
+++ b/.github/agents/lint-cleanup.md
@@ -10,13 +10,13 @@ Only formatting, docstrings, and lint fixes. **No functional changes.**
 
 ## Workflow
 
-For each file listed in the `exclude` blocks of `pyright`, `interrogate`, `shellcheck`, `codespell`, and other hooks in `.pre-commit-config.yaml` (ruff per-file-ignores live in `pyproject.toml`):
+For each file listed in the `exclude` blocks of `pyright`, `interrogate`, `pydoclint`, `shellcheck`, `codespell`, and other hooks in `.pre-commit-config.yaml` (ruff per-file-ignores and `[tool.pydoclint].exclude` live in `pyproject.toml`):
 
 1. **Create a branch**: `chore/lint-cleanup/<module-name>` (e.g., `chore/lint-cleanup/surge-datamodule`)
 2. **Run hooks on the file**, e.g. `interrogate`
 3. **Auto-fix what you can**: `ruff check --fix` and `docformatter --in-place` handle most formatting issues automatically
 4. **Manually fix remaining violations**:
-   - `interrogate` missing docstrings: add Sphinx-style docstrings (`:param:`, `:returns:`, `:raises:`) to public functions/classes — matches the `docformatter` config (`style = "sphinx"` in `pyproject.toml`)
+   - `interrogate` missing docstrings: add Sphinx-style docstrings (`:param:`, `:returns:`, `:raises:`) to public functions/classes — matches the `docformatter` config (`style = "sphinx"` in `pyproject.toml`) — and must pass `pydoclint` DOC1xx/DOC2xx/DOC5xx (signature ↔ docstring consistency)
 5. **Remove the file from all `exclude` blocks** in `.pre-commit-config.yaml`
 6. **Verify**: `pre-commit run --files <file>` passes all hooks
 7. **Run tests**: `make test-fast` — the quick CPU suite (excludes `slow`, `gpu`, `mps`, `requires_vst`) must still pass as a smoke check; lint-only changes shouldn't affect behavior
@@ -31,7 +31,7 @@ For each file listed in the `exclude` blocks of `pyright`, `interrogate`, `shell
 - `# noqa` / `# nosec` only with a justification comment explaining why
 - If a file requires functional changes to pass lint (e.g., unused imports that are actually used dynamically), skip it and leave a comment on #25
 - Line length is 99 (configured in `pyproject.toml` under `[tool.ruff]`)
-- Docstrings follow Sphinx style (`:param:`, `:returns:`, `:raises:`) — matches `docformatter` config (`style = "sphinx"` in `pyproject.toml`)
+- Docstrings follow Sphinx style (`:param:`, `:returns:`, `:raises:`) — matches `docformatter` config (`style = "sphinx"` in `pyproject.toml`) — and must pass `pydoclint` DOC1xx/DOC2xx/DOC5xx (signature ↔ docstring consistency)
 - Run `make test-fast` after every file to catch regressions
 
 ## Files

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,11 +160,11 @@ repos:
             src/utils/math\.py
           )$
 
-  # pydoclint: signature ↔ docstring consistency (DOC1xx args, DOC2xx
-  # returns/yields, DOC3xx style, DOC4xx misc, DOC5xx raises). Config lives in
-  # pyproject.toml under [tool.pydoclint]; the path exclude list there enumerates
-  # files that currently violate the rules and shrinks as files are cleaned up —
-  # tracked by #938.
+  # pydoclint: signature ↔ docstring consistency. Config lives in pyproject.toml
+  # under [tool.pydoclint]; rule families documented at
+  # https://jsh9.github.io/pydoclint/violation_codes.html. The path exclude list
+  # in pyproject.toml enumerates files that currently violate the rules and
+  # shrinks as files are cleaned up — tracked by #938.
   - repo: https://github.com/jsh9/pydoclint
     rev: 0.8.3
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -160,6 +160,16 @@ repos:
             src/utils/math\.py
           )$
 
+  # pydoclint: signature ↔ docstring consistency (DOC1xx args, DOC2xx
+  # returns/yields, DOC3xx style, DOC4xx misc, DOC5xx raises). Config lives in
+  # pyproject.toml under [tool.pydoclint]; the path exclude list there enumerates
+  # files that currently violate the rules and is reduced as files are cleaned up
+  # (tracked in the pydoclint audit issue).
+  - repo: https://github.com/jsh9/pydoclint
+    rev: 0.8.3
+    hooks:
+      - id: pydoclint
+
   # yaml formatting
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.0.0-alpha.6

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -163,8 +163,8 @@ repos:
   # pydoclint: signature ↔ docstring consistency (DOC1xx args, DOC2xx
   # returns/yields, DOC3xx style, DOC4xx misc, DOC5xx raises). Config lives in
   # pyproject.toml under [tool.pydoclint]; the path exclude list there enumerates
-  # files that currently violate the rules and is reduced as files are cleaned up
-  # (tracked in the pydoclint audit issue).
+  # files that currently violate the rules and shrinks as files are cleaned up —
+  # tracked by #938.
   - repo: https://github.com/jsh9/pydoclint
     rev: 0.8.3
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,9 @@ every commit. The key tools are:
   (minimum 80%)
 - **[docformatter](https://github.com/PyCQA/docformatter)** for docstring
   normalization (Sphinx style)
+- **[pydoclint](https://github.com/jsh9/pydoclint)** for signature ↔ docstring
+  consistency (Sphinx style; checks args, returns/yields, raises, and class
+  attributes — config in `pyproject.toml` under `[tool.pydoclint]`)
 - **[shellcheck](https://www.shellcheck.net/)** for shell script linting
 - **[mdformat](https://mdformat.readthedocs.io/)** for Markdown formatting
 - **[codespell](https://github.com/codespell-project/codespell)** for typo
@@ -195,13 +198,14 @@ These prefixes do not trigger a release:
 This project runs a comprehensive suite of pre-commit hooks. Common failure
 modes and how to fix them:
 
-| Hook                  | Failure reason                                     | Fix                                                                |
-| --------------------- | -------------------------------------------------- | ------------------------------------------------------------------ |
-| `interrogate`         | Docstring coverage below 80%                       | Add docstrings to new public functions/classes                     |
-| `pyright`             | Type errors in touched files                       | Fix type annotations                                               |
-| `gitlint`             | Commit message doesn't follow conventional commits | Rewrite the commit message (see prefix table above)                |
-| `ruff`                | Lint violations                                    | Ruff auto-fixes formatting; security/import issues need manual fix |
-| `no-commit-to-branch` | Attempted commit to `main`                         | Create a feature branch first                                      |
+| Hook                  | Failure reason                                      | Fix                                                                |
+| --------------------- | --------------------------------------------------- | ------------------------------------------------------------------ |
+| `interrogate`         | Docstring coverage below 80%                        | Add docstrings to new public functions/classes                     |
+| `pydoclint`           | Docstring args/returns/raises don't match signature | Update the docstring (Sphinx style) or the signature so they agree |
+| `pyright`             | Type errors in touched files                        | Fix type annotations                                               |
+| `gitlint`             | Commit message doesn't follow conventional commits  | Rewrite the commit message (see prefix table above)                |
+| `ruff`                | Lint violations                                     | Ruff auto-fixes formatting; security/import issues need manual fix |
+| `no-commit-to-branch` | Attempted commit to `main`                          | Create a feature branch first                                      |
 
 If a hook auto-fixes files (ruff, trailing-whitespace, etc.), stage the fixes
 and commit again.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,10 +109,9 @@ wrap-descriptions = 99
 style = "sphinx"
 black = true
 
-# pydoclint: signature ↔ docstring consistency checks (DOC1xx args, DOC2xx
-# returns/yields, DOC3xx class/style, DOC4xx misc, DOC5xx raises).
-# Sphinx style chosen to match existing :param:/:return: docstrings and the
-# [tool.docformatter] style above.
+# pydoclint: signature ↔ docstring consistency checks. Rule families documented
+# at https://jsh9.github.io/pydoclint/violation_codes.html. Sphinx style chosen
+# to match existing :param:/:return: docstrings and [tool.docformatter] above.
 [tool.pydoclint]
 style = "sphinx"
 arg-type-hints-in-signature = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,8 +126,7 @@ skip-checking-short-docstrings = false
 allow-init-docstring = true
 check-class-attributes = true
 # Path-level exclude regex (verbose). Default infra paths plus files that
-# currently violate the rules; tracked for incremental remediation by the
-# pydoclint audit issue.
+# currently violate the rules — shrinks as files are cleaned up. See #938.
 exclude = '''(?x)
     \.git
   | \.tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,9 +127,9 @@ check-class-attributes = true
 # Path-level exclude regex (verbose). Default infra paths plus files that
 # currently violate the rules — shrinks as files are cleaned up. See #938.
 exclude = '''(?x)
-    \.git
-  | \.tox
-  | \.venv
+    (^|/)\.git(/|$)
+  | (^|/)\.tox(/|$)
+  | (^|/)\.venv(/|$)
   | ^build/
   | ^dist/
   | ^node_modules/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,108 @@ wrap-descriptions = 99
 style = "sphinx"
 black = true
 
+# pydoclint: signature ↔ docstring consistency checks (DOC1xx args, DOC2xx
+# returns/yields, DOC3xx class/style, DOC4xx misc, DOC5xx raises).
+# Sphinx style chosen to match existing :param:/:return: docstrings and the
+# [tool.docformatter] style above.
+[tool.pydoclint]
+style = "sphinx"
+arg-type-hints-in-signature = true
+arg-type-hints-in-docstring = false
+check-return-types = true
+check-yield-types = true
+check-style-mismatch = true
+require-return-section-when-returning-nothing = false
+skip-checking-raises = false
+skip-checking-short-docstrings = false
+allow-init-docstring = true
+check-class-attributes = true
+# Path-level exclude regex (verbose). Default infra paths plus files that
+# currently violate the rules; tracked for incremental remediation by the
+# pydoclint audit issue.
+exclude = '''(?x)
+    \.git
+  | \.tox
+  | \.venv
+  | ^build/
+  | ^dist/
+  | ^node_modules/
+  | ^\.claude/
+  | ^\.worktrees/
+  | ^notebooks/
+  | ^pipeline/ci/load_image_config\.py$
+  | ^pipeline/ci/validate_shard\.py$
+  | ^pipeline/ci/validate_spec\.py$
+  | ^pipeline/entrypoints/generate_dataset\.py$
+  | ^pipeline/entrypoints/skypilot_launch\.py$
+  | ^pipeline/partitioning\.py$
+  | ^pipeline/r2_io\.py$
+  | ^pipeline/schemas/image_config\.py$
+  | ^pipeline/schemas/prefix\.py$
+  | ^pipeline/schemas/spec\.py$
+  | ^scripts/add_music2latent\.py$
+  | ^scripts/compute_audio_metrics\.py$
+  | ^scripts/docker_entrypoint\.py$
+  | ^scripts/predict_vst_audio\.py$
+  | ^scripts/r2_shard_report\.py$
+  | ^scripts/rewrite_dataset_to_latest\.py$
+  | ^scripts/subdir_funtime\.py$
+  | ^scripts/surge_xt_interactive\.py$
+  | ^src/data/audio_datamodule\.py$
+  | ^src/data/fm_datamodule\.py$
+  | ^src/data/kosc_datamodule\.py$
+  | ^src/data/ksin_datamodule\.py$
+  | ^src/data/surge_datamodule\.py$
+  | ^src/data/vst/core\.py$
+  | ^src/data/vst/generate_vst_dataset\.py$
+  | ^src/data/vst/param_spec\.py$
+  | ^src/eval\.py$
+  | ^src/models/components/loss\.py$
+  | ^src/models/components/sinkhorn\.py$
+  | ^src/models/components/transformer\.py$
+  | ^src/models/components/vae\.py$
+  | ^src/models/ksin_flow_matching_module\.py$
+  | ^src/train\.py$
+  | ^src/utils/callbacks\.py$
+  | ^src/utils/instantiators\.py$
+  | ^src/utils/pylogger\.py$
+  | ^src/utils/rich_utils\.py$
+  | ^src/utils/utils\.py$
+  | ^tests/_baseline_worktree\.py$
+  | ^tests/conftest\.py$
+  | ^tests/data/vst/test_core\.py$
+  | ^tests/data/vst/test_generate_vst_dataset\.py$
+  | ^tests/data/vst/test_preset_coverage\.py$
+  | ^tests/fixtures/baseline_repo/scripts/baseline_app\.py$
+  | ^tests/fixtures/diff_repo/scripts/diff_app\.py$
+  | ^tests/helpers/package_available\.py$
+  | ^tests/helpers/run_if\.py$
+  | ^tests/pipeline/ci/test_validate_shard\.py$
+  | ^tests/pipeline/ci/test_validate_spec\.py$
+  | ^tests/pipeline/conftest\.py$
+  | ^tests/pipeline/test_ci/test_load_image_config\.py$
+  | ^tests/pipeline/test_ci/test_materialize_spec\.py$
+  | ^tests/pipeline/test_configs/test_experiment_yamls\.py$
+  | ^tests/pipeline/test_entrypoints/test_generate_dataset\.py$
+  | ^tests/pipeline/test_entrypoints/test_skypilot_launch\.py$
+  | ^tests/pipeline/test_partitioning\.py$
+  | ^tests/pipeline/test_r2_io\.py$
+  | ^tests/pipeline/test_schemas/test_dataset_spec\.py$
+  | ^tests/pipeline/test_schemas/test_image_config\.py$
+  | ^tests/pipeline/test_schemas/test_prefix\.py$
+  | ^tests/scripts/test_compute_audio_metrics\.py$
+  | ^tests/scripts/test_r2_shard_report\.py$
+  | ^tests/scripts/test_skypilot_write_provider_creds\.py$
+  | ^tests/scripts/test_surge_xt_interactive\.py$
+  | ^tests/test_benchmarks\.py$
+  | ^tests/test_callbacks\.py$
+  | ^tests/test_compare_baseline_configs\.py$
+  | ^tests/test_configs\.py$
+  | ^tests/test_docker_entrypoint\.py$
+  | ^tests/test_logging_utils\.py$
+  | ^tests/test_properties\.py$
+'''
+
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
 branch = "main"


### PR DESCRIPTION
## What changed

Adds [pydoclint](https://github.com/jsh9/pydoclint) `0.8.3` as a pre-commit hook to enforce signature ↔ docstring consistency repo-wide:

- **`pyproject.toml`** — new `[tool.pydoclint]` section with the strictest "deep" settings turned on:
  - `style = "sphinx"`
  - `arg-type-hints-in-signature = true`, `arg-type-hints-in-docstring = false`
  - `check-return-types = true`, `check-yield-types = true`
  - `check-style-mismatch = true`
  - `require-return-section-when-returning-nothing = false`
  - `skip-checking-raises = false` ← `raise` ↔ `:raises:` consistency
  - `skip-checking-short-docstrings = false`
  - `allow-init-docstring = true`, `check-class-attributes = true`
  - `exclude` regex listing every file that currently violates the rules
- **`.pre-commit-config.yaml`** — new `jsh9/pydoclint@0.8.3` hook. Wired through `make format` (which runs `pre-commit run -a`) and through `code-quality-pr.yaml` / `code-quality-main.yaml`, which both invoke `pre-commit/action@v3.0.1`.

No docstrings, source files, or test files were touched. No pydoclint rule was relaxed.

## Docstring style decision

Style is **sphinx**, matching the existing `:param X:` / `:return:` / `:raises:` directives in `src/utils/instantiators.py`, `src/utils/logging_utils.py`, `pipeline/r2_io.py`, `pipeline/schemas/*.py`, and most of `tests/`. The repo also already has `[tool.docformatter] style = "sphinx"`, so the docstring-formatting tool and the docstring-linting tool now agree.

`#666` floated migrating the whole repo to google style as a medium-term goal. That migration can run on top of pydoclint with sphinx — it's a one-line config flip plus the rewrite — but is out of scope for this PR (see the open question in the audit issue).

## Why the exclude list is so long

A baseline scan reports **1,661 violations across 71 files** (of 120 .py files total). Per the task brief, every offending file is listed by name in the `exclude` regex so the lint passes green today without touching any docstrings. The list will shrink one chunk at a time per the remediation plan in the audit issue.

The exclude regex uses a verbose pattern (`(?x)…`) so each excluded path lives on its own line — diff-friendly, and removing a path is a one-line edit.

## Audit issue

Full violation breakdown by rule code, per-file violation counts, ordered chunked remediation plan, and decision points are tracked in **[Audit: full pydoclint coverage (#938)](https://github.com/tinaudio/synth-setter/issues/938)**.

## Verification

```
$ pydoclint --quiet .
$ echo $?
0
```

Hook exit was also confirmed on individual file targets (mirroring what pre-commit passes when files are staged) and on a no-exclude run (which reproduces the 1,661-violation baseline that the audit issue documents).

## Open Questions

None at PR-creation time — the decisions made without user input are listed in the audit issue's **Open Questions** section so they can be triaged in one place.

Refs #938
Refs #666
Part of #27
