### PR TITLE
internal-feat(vst): renderer signatures take RenderConfig + migrate CLI to pydantic-settings

### DIFF
--- a/configs/dataset.yaml
+++ b/configs/dataset.yaml
@@ -24,9 +24,6 @@ output_format: hdf5
 base_seed: 42
 
 train_val_test_sizes: ???
-# Reserved for per-sample seeding (#884); not consumed yet. Defaulted here
-# so experiments don't all duplicate the same triple.
-train_val_test_seeds: [42, 43, 44]
 
 r2_bucket: ${r2.bucket}
 r2_prefix_root: ${r2.prefix_root}

--- a/pipeline/ci/validate_spec.py
+++ b/pipeline/ci/validate_spec.py
@@ -28,7 +28,6 @@ _REQUIRED_TOP_LEVEL_FIELDS = [
     "run_id",
     "shards",
     "task_name",
-    "train_val_test_seeds",
     "train_val_test_sizes",
 ]
 _REQUIRED_RENDER_FIELDS = [

--- a/pipeline/entrypoints/generate_dataset.py
+++ b/pipeline/entrypoints/generate_dataset.py
@@ -98,7 +98,11 @@ def _rclone_copy(src: str, dest: str) -> None:
 
 
 def build_generate_args(spec: DatasetSpec, shard: ShardSpec, output_dir: Path) -> list[str]:
-    """Build CLI args for generate_vst_dataset.py from a spec and shard.
+    """Build CLI args for ``generate_vst_dataset.py`` from a spec and shard.
+
+    The flag set is derived from ``RenderConfig.model_fields`` so every renderer
+    config field surfaces as a ``--<field>`` option automatically; adding a
+    field on the model auto-extends the CLI invocation.
 
     HDF5-only: ``DatasetSpec.output_format`` is currently restricted to
     ``"hdf5"`` and ``generate_vst_dataset.py`` writes HDF5 regardless of the
@@ -106,26 +110,12 @@ def build_generate_args(spec: DatasetSpec, shard: ShardSpec, output_dir: Path) -
     is introduced (PR-12/13/14 in the dataset-pipeline chain).
     """
     output_path = output_dir / shard.filename
-    render = spec.render
-    options = {
-        "plugin_path": render.plugin_path,
-        "preset_path": render.preset_path,
-        "sample_rate": render.sample_rate,
-        "channels": render.channels,
-        "velocity": render.velocity,
-        "signal_duration_seconds": render.signal_duration_seconds,
-        "min_loudness": render.min_loudness,
-        "param_spec": render.param_spec_name,
-        "sample_batch_size": render.sample_batch_size,
-    }
-
     args = [
         sys.executable,
         "src/data/vst/generate_vst_dataset.py",
         str(output_path),
-        str(render.batch_per_shard),
     ]
-    for key, value in options.items():
+    for key, value in spec.render.model_dump().items():
         args.extend([f"--{key}", str(value)])
 
     return args

--- a/pipeline/schemas/spec.py
+++ b/pipeline/schemas/spec.py
@@ -167,8 +167,10 @@ class DatasetSpec(BaseModel):
     task_name: str
     output_format: Literal["hdf5"]
     train_val_test_sizes: tuple[int, int, int]
-    # Reserved for per-sample seeding (#884); not consumed yet.
-    train_val_test_seeds: tuple[int, int, int]
+    # Reserved for per-sample seeding (#884); not implemented. Accepts only
+    # ``None`` — any non-None value (yaml, JSON, or in-process) raises
+    # ``NotImplementedError`` at construction. See ``_reject_train_val_test_seeds``.
+    train_val_test_seeds: tuple[int, int, int] | None = None
     base_seed: int
     r2_bucket: str
     r2_prefix_root: str = DEFAULT_R2_PREFIX_ROOT
@@ -188,6 +190,22 @@ class DatasetSpec(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
+    def _reject_train_val_test_seeds(cls, data: Any) -> Any:
+        """Reject any non-None ``train_val_test_seeds`` — reserved for #884, not implemented.
+
+        Runs in ``mode="before"`` so ``NotImplementedError`` propagates as-is
+        instead of being wrapped in a ``ValidationError`` (which is what
+        pydantic does for ``ValueError`` raised inside field validators).
+        """
+        if isinstance(data, dict) and data.get("train_val_test_seeds") is not None:
+            raise NotImplementedError(
+                "train_val_test_seeds is reserved for per-sample seeding (#884) "
+                "and is not yet implemented; omit the field"
+            )
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
     def _strip_computed_field_keys(cls, data: Any) -> Any:
         """Strip ``shards`` / ``num_shards`` / ``num_params`` from input.
 
@@ -202,7 +220,7 @@ class DatasetSpec(BaseModel):
                 data.pop(computed_key, None)
         return data
 
-    @field_validator("train_val_test_sizes", "train_val_test_seeds", mode="before")
+    @field_validator("train_val_test_sizes", mode="before")
     @classmethod
     def _splits_list_to_tuple(cls, value: Any) -> Any:
         """Coerce JSON-loaded ``list[int]`` into ``tuple[int, int, int]``.

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -32,8 +32,13 @@ from pedalboard.io import AudioFile, AudioStream, StreamResampler  # noqa: E402
 from rich.console import Console  # noqa: E402
 from rich.logging import RichHandler  # noqa: E402
 
+from pipeline.schemas.spec import RenderConfig  # noqa: E402
 from src.data.vst import load_plugin, load_preset, param_specs, preset_paths  # noqa: E402
-from src.data.vst.core import make_midi_events, set_params  # noqa: E402
+from src.data.vst.core import (  # noqa: E402
+    extract_renderer_version,  # noqa: E402
+    make_midi_events,
+    set_params,
+)
 from src.data.vst.generate_vst_dataset import make_dataset  # noqa: E402
 from src.data.vst.param_spec import ParamSpec  # noqa: E402
 
@@ -1212,19 +1217,23 @@ def main(
         return
     output_dataset_dir_path.mkdir(parents=True, exist_ok=False)
     patch_file_path = output_dataset_dir_path / "train.h5"
+    render_cfg = RenderConfig(
+        plugin_path=plugin_path,
+        preset_path=preset_path,
+        param_spec_name=param_spec_name,
+        renderer_version=extract_renderer_version(Path(plugin_path)),
+        sample_rate=SAMPLE_RATE,
+        channels=CHANNELS,
+        velocity=MAKE_DATASET_VELOCITY,
+        signal_duration_seconds=MAKE_DATASET_SIGNAL_DURATION_SECONDS,
+        min_loudness=MAKE_DATASET_MIN_LOUDNESS,
+        sample_batch_size=MAKE_DATASET_SAMPLE_BATCH_SIZE,
+        batch_per_shard=len(synth_patches),
+    )
     with h5py.File(patch_file_path, "w") as f:
         make_dataset(
             hdf5_file=f,
-            num_samples=len(synth_patches),
-            plugin_path=plugin_path,
-            preset_path=preset_path,
-            sample_rate=SAMPLE_RATE,
-            channels=CHANNELS,
-            velocity=MAKE_DATASET_VELOCITY,
-            signal_duration_seconds=MAKE_DATASET_SIGNAL_DURATION_SECONDS,
-            min_loudness=MAKE_DATASET_MIN_LOUDNESS,
-            param_spec=param_specs[param_spec_name],
-            sample_batch_size=MAKE_DATASET_SAMPLE_BATCH_SIZE,
+            render_cfg=render_cfg,
             fixed_synth_params_list=synth_patches,
         )
     _maybe_eval_captured_patches(

--- a/src/data/vst/generate_vst_dataset.py
+++ b/src/data/vst/generate_vst_dataset.py
@@ -348,6 +348,7 @@ class _GenerateCliArgs(RenderConfig, BaseSettings):
     model_config = SettingsConfigDict(
         cli_parse_args=True,
         cli_prog_name="generate_vst_dataset",
+        cli_kebab_case=False,
         strict=True,
         extra="forbid",
     )

--- a/src/data/vst/generate_vst_dataset.py
+++ b/src/data/vst/generate_vst_dataset.py
@@ -3,7 +3,6 @@ import random
 from dataclasses import dataclass
 from typing import Any, List, Tuple
 
-import click
 import h5py
 import hdf5plugin
 import librosa
@@ -11,9 +10,11 @@ import numpy as np
 import rootutils
 from loguru import logger
 from pyloudnorm import Meter
+from pydantic_settings import BaseSettings, CliApp, CliPositionalArg, SettingsConfigDict
 from tqdm import trange
 
 rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
+from pipeline.schemas.spec import RenderConfig  # noqa: E402
 from src.data.vst import param_specs, render_params  # noqa
 from src.data.vst.param_spec import ParamSpec  # noqa
 
@@ -241,27 +242,28 @@ def create_datasets_and_get_start_idx(
 
 def make_dataset(
     hdf5_file: h5py.File,
-    num_samples: int,
-    plugin_path: str,
-    preset_path: str,
-    sample_rate: float,
-    channels: int,
-    velocity: int,
-    signal_duration_seconds: float,
-    min_loudness: float,
-    param_spec: ParamSpec,
-    sample_batch_size: int,
+    render_cfg: RenderConfig,
+    *,
     fixed_synth_params_list: list[dict[str, float]] | None = None,
     fixed_note_params_list: list[dict[str, int | tuple[float, float]]] | None = None,
 ) -> None:
+    """Render ``render_cfg.batch_per_shard`` samples and append them to ``hdf5_file``.
+
+    Resumable: a partially-written file picks up at the first all-zero row, so a
+    crashed worker can re-run with the same ``render_cfg`` and only the missing tail
+    is regenerated. The ``param_spec_name`` is resolved against the in-process
+    registry here (not at the launcher) so the per-shard config stays JSON-only.
+    """
+    param_spec = param_specs[render_cfg.param_spec_name]
+    num_samples = render_cfg.batch_per_shard
 
     audio_dataset, mel_dataset, param_dataset, start_idx = (
         create_datasets_and_get_start_idx(
             hdf5_file=hdf5_file,
             num_samples=num_samples,
-            channels=channels,
-            sample_rate=sample_rate,
-            signal_duration_seconds=signal_duration_seconds,
+            channels=render_cfg.channels,
+            sample_rate=render_cfg.sample_rate,
+            signal_duration_seconds=render_cfg.signal_duration_seconds,
             num_params=len(param_spec),
         )
     )
@@ -278,27 +280,28 @@ def make_dataset(
                 f"(num_samples={num_samples}, start_idx={start_idx})"
             )
 
-    audio_dataset.attrs["velocity"] = velocity
-    audio_dataset.attrs["signal_duration_seconds"] = signal_duration_seconds
-    audio_dataset.attrs["sample_rate"] = sample_rate
-    audio_dataset.attrs["channels"] = channels
-    audio_dataset.attrs["min_loudness"] = min_loudness
+    audio_dataset.attrs["velocity"] = render_cfg.velocity
+    audio_dataset.attrs["signal_duration_seconds"] = render_cfg.signal_duration_seconds
+    audio_dataset.attrs["sample_rate"] = render_cfg.sample_rate
+    audio_dataset.attrs["channels"] = render_cfg.channels
+    audio_dataset.attrs["min_loudness"] = render_cfg.min_loudness
 
     sample_batch = []
     sample_batch_start = start_idx
+    batch_size = render_cfg.sample_batch_size
 
     for i in trange(start_idx, num_samples):
         logger.info(f"Making sample {i}")
         fixed_idx = i - start_idx
         sample = generate_sample(
-            plugin_path,
-            velocity=velocity,
-            signal_duration_seconds=signal_duration_seconds,
-            sample_rate=sample_rate,
-            channels=channels,
-            min_loudness=min_loudness,
+            render_cfg.plugin_path,
+            velocity=render_cfg.velocity,
+            signal_duration_seconds=render_cfg.signal_duration_seconds,
+            sample_rate=render_cfg.sample_rate,
+            channels=render_cfg.channels,
+            min_loudness=render_cfg.min_loudness,
             param_spec=param_spec,
-            preset_path=preset_path,
+            preset_path=render_cfg.preset_path,
             fixed_synth_params=(
                 fixed_synth_params_list[fixed_idx]
                 if fixed_synth_params_list is not None
@@ -312,7 +315,7 @@ def make_dataset(
         )
 
         sample_batch.append(sample)
-        if len(sample_batch) == sample_batch_size:
+        if len(sample_batch) == batch_size:
             save_samples(
                 sample_batch,
                 audio_dataset,
@@ -321,7 +324,7 @@ def make_dataset(
                 sample_batch_start,
             )
             sample_batch = []
-            sample_batch_start += sample_batch_size
+            sample_batch_start += batch_size
 
     if len(sample_batch) > 0:
         save_samples(
@@ -333,46 +336,31 @@ def make_dataset(
         )
 
 
-@click.command()
-@click.argument("data_file", type=str, required=True)
-@click.argument("num_samples", type=int, required=True)
-@click.option("--plugin_path", "-p", type=str, default="plugins/Surge XT.vst3")
-@click.option("--preset_path", "-r", type=str, default="presets/surge-base.vstpreset")
-@click.option("--sample_rate", "-s", type=float, default=44100.0)
-@click.option("--channels", "-c", type=int, default=2)
-@click.option("--velocity", "-v", type=int, default=100)
-@click.option("--signal_duration_seconds", "-d", type=float, default=4.0)
-@click.option("--min_loudness", "-l", type=float, default=-55.0)
-@click.option("--param_spec", "-t", type=str, default="surge_xt")
-@click.option("--sample_batch_size", "-b", type=int, default=32)
-def main(
-    data_file: str,
-    num_samples: int,
-    plugin_path: str = "plugins/Surge XT.vst3",
-    preset_path: str = "presets/surge-base.vstpreset",
-    sample_rate: float = 44100.0,
-    channels: int = 2,
-    velocity: int = 100,
-    signal_duration_seconds: float = 4.0,
-    min_loudness: float = -50.0,
-    param_spec: str = "surge_xt",
-    sample_batch_size: int = 32,
-):
-    param_spec = param_specs[param_spec]
-    with h5py.File(data_file, "a") as f:
-        make_dataset(
-            f,
-            num_samples,
-            plugin_path,
-            preset_path,
-            sample_rate,
-            channels,
-            velocity,
-            signal_duration_seconds,
-            min_loudness,
-            param_spec,
-            sample_batch_size,
-        )
+class _GenerateCliArgs(RenderConfig, BaseSettings):
+    """Pydantic-settings CLI binding for ``generate_vst_dataset.py``.
+
+    Inherits every ``RenderConfig`` field so the CLI flag set tracks the model
+    automatically — adding or removing a field on ``RenderConfig`` extends or
+    shrinks the CLI surface without a parallel update here. Adds ``data_file``
+    as the sole positional arg (the destination path for the HDF5 shard).
+    """
+
+    model_config = SettingsConfigDict(
+        cli_parse_args=True,
+        cli_prog_name="generate_vst_dataset",
+        strict=True,
+        extra="forbid",
+    )
+
+    data_file: CliPositionalArg[str]
+
+
+def main() -> None:
+    """Entry point — parse CLI args into a ``RenderConfig`` and render one shard."""
+    args = CliApp.run(_GenerateCliArgs)
+    render_cfg = RenderConfig(**args.model_dump(exclude={"data_file"}))
+    with h5py.File(args.data_file, "a") as f:
+        make_dataset(f, render_cfg)
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -389,7 +389,7 @@ def surge_xt_smoke_datasets(tmp_path: Path, param_spec_name: str) -> Path:
     :param tmp_path: Per-test temporary directory; the dataset is written under
         ``tmp_path / "data" / "smoke"``.
     :param param_spec_name: Param spec name (key into :data:`src.data.vst.param_specs`
-        and :data:`src.data.vst.preset_paths`) — selects the matching ``--param_spec``
+        and :data:`src.data.vst.preset_paths`) — selects the matching ``--param_spec_name``
         and ``--preset_path`` for ``generate_vst_dataset``.
 
     :return: A Path object pointing at the directory containing the N-sample Surge XT smoke-test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """This file prepares config fixtures for other tests."""
 
+import os
 import shutil
 import subprocess
 import sys
@@ -19,12 +20,19 @@ from src.data.vst import param_specs, preset_paths
 from src.utils.utils import register_resolvers
 from tests._baseline_worktree import worktree_for_ref  # noqa: F401 — pytest fixture re-export
 
-# Defaults baked into `src/data/vst/generate_vst_dataset.py` (channels=2,
-# sample_rate=44100, signal_duration_seconds=4.0, mel shape (2, 128, 401)).
-# The fixture invokes the script with these defaults, so the generated H5
-# file must match.
-_SURGE_AUDIO_SAMPLES_PER_CLIP = int(44100 * 4.0)
-_SURGE_AUDIO_CHANNELS = 2
+# Per-clip dimensions for the smoke fixture's HDF5 output. ``RenderConfig`` in
+# ``pipeline.schemas.spec`` declares no field defaults — the fixture passes
+# explicit values for every flag below, so these constants must match the values
+# the subprocess is invoked with.
+_SURGE_FIXTURE_SAMPLE_RATE = 44100
+_SURGE_FIXTURE_CHANNELS = 2
+_SURGE_FIXTURE_DURATION_SECONDS = 4.0
+_SURGE_FIXTURE_VELOCITY = 100
+_SURGE_FIXTURE_MIN_LOUDNESS = -55.0
+_SURGE_FIXTURE_RENDERER_VERSION = "1.3.4"
+_SURGE_FIXTURE_PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH", "plugins/Surge XT.vst3")
+_SURGE_AUDIO_SAMPLES_PER_CLIP = int(_SURGE_FIXTURE_SAMPLE_RATE * _SURGE_FIXTURE_DURATION_SECONDS)
+_SURGE_AUDIO_CHANNELS = _SURGE_FIXTURE_CHANNELS
 _SURGE_MEL_SHAPE = (2, 128, 401)
 # ~-80 dBFS — same threshold used by `test_train_eval_surge_xt` to catch
 # silent renders that would later poison metric computation.
@@ -399,9 +407,17 @@ def surge_xt_smoke_datasets(tmp_path: Path, param_spec_name: str) -> Path:
         sys.executable,
         "src/data/vst/generate_vst_dataset.py",
         str(smoke_dataset_dir / "train.h5"),
-        str(NUM_FIXTURE_SAMPLES),
+        f"--plugin_path={_SURGE_FIXTURE_PLUGIN_PATH}",
         f"--preset_path={preset_paths[param_spec_name]}",
-        f"--param_spec={param_spec_name}",
+        f"--param_spec_name={param_spec_name}",
+        f"--renderer_version={_SURGE_FIXTURE_RENDERER_VERSION}",
+        f"--sample_rate={_SURGE_FIXTURE_SAMPLE_RATE}",
+        f"--channels={_SURGE_FIXTURE_CHANNELS}",
+        f"--velocity={_SURGE_FIXTURE_VELOCITY}",
+        f"--signal_duration_seconds={_SURGE_FIXTURE_DURATION_SECONDS}",
+        f"--min_loudness={_SURGE_FIXTURE_MIN_LOUDNESS}",
+        f"--sample_batch_size={NUM_FIXTURE_SAMPLES}",
+        f"--batch_per_shard={NUM_FIXTURE_SAMPLES}",
     ]
 
     # capture_output=False (default): child inherits parent's stdout/stderr, no pipe is

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -16,6 +16,7 @@ _ = hdf5plugin  # keep type checkers from flagging the side-effect import
 import numpy as np
 import pytest
 
+from pipeline.schemas.spec import RenderConfig
 from scripts.compute_audio_metrics import compute_mss, compute_rms, compute_sot, compute_wmfcc
 from src.data.vst import param_specs
 from src.data.vst.core import render_params
@@ -33,8 +34,30 @@ _DURATION = 4.0
 _VELOCITY = 100
 _MIN_LOUDNESS = -55.0
 _SPEC_NAME = "surge_xt"
+_RENDERER_VERSION = "1.3.4"
 _ABSOLUTE_TOLERANCE = 1e-7
 _RELATIVE_TOLERANCE = 1e-9
+
+
+def _render_cfg(num_samples: int, sample_batch_size: int | None = None) -> RenderConfig:
+    """Build a RenderConfig with this module's test defaults.
+
+    ``batch_per_shard`` is set to ``num_samples`` (one shard = one batch in tests);
+    ``sample_batch_size`` defaults to the same so each test renders in a single batch.
+    """
+    return RenderConfig(
+        plugin_path=_PLUGIN_PATH,
+        preset_path=_PRESET_PATH,
+        param_spec_name=_SPEC_NAME,
+        renderer_version=_RENDERER_VERSION,
+        sample_rate=int(_SAMPLE_RATE),
+        channels=_CHANNELS,
+        velocity=_VELOCITY,
+        signal_duration_seconds=_DURATION,
+        min_loudness=_MIN_LOUDNESS,
+        sample_batch_size=sample_batch_size if sample_batch_size is not None else num_samples,
+        batch_per_shard=num_samples,
+    )
 
 # Phase-robust audio similarity thresholds for replayed-params vs. candidates.
 # Two independent renders of identical params differ at the sample level on main
@@ -728,19 +751,7 @@ def test_datasets_from_hardcoded_params_are_identical(
         h5py.File(expected_dataset, "a") as f,
         _patched_sample(spec, replay),
     ):
-        make_dataset(
-            hdf5_file=f,
-            num_samples=num_samples,
-            plugin_path=_PLUGIN_PATH,
-            preset_path=_PRESET_PATH,
-            sample_rate=_SAMPLE_RATE,
-            channels=_CHANNELS,
-            velocity=_VELOCITY,
-            signal_duration_seconds=_DURATION,
-            min_loudness=_MIN_LOUDNESS,
-            param_spec=spec,
-            sample_batch_size=num_samples,
-        )
+        make_dataset(hdf5_file=f, render_cfg=_render_cfg(num_samples))
     stage1_seconds = time.perf_counter() - t0
 
     expected_audio, expected_mel, expected_params = _assert_h5_structure_is_valid(
@@ -753,19 +764,7 @@ def test_datasets_from_hardcoded_params_are_identical(
         h5py.File(got_dataset, "a") as f,
         _patched_sample(spec, replay),
     ):
-        make_dataset(
-            hdf5_file=f,
-            num_samples=num_samples,
-            plugin_path=_PLUGIN_PATH,
-            preset_path=_PRESET_PATH,
-            sample_rate=_SAMPLE_RATE,
-            channels=_CHANNELS,
-            velocity=_VELOCITY,
-            signal_duration_seconds=_DURATION,
-            min_loudness=_MIN_LOUDNESS,
-            param_spec=spec,
-            sample_batch_size=num_samples,
-        )
+        make_dataset(hdf5_file=f, render_cfg=_render_cfg(num_samples))
     stage2_seconds = time.perf_counter() - t0
 
     actual_audio, actual_mel, actual_params = _assert_h5_structure_is_valid(
@@ -843,19 +842,7 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
     expected_dataset = tmp_path / "candidates.h5"
     t0 = time.perf_counter()
     with h5py.File(expected_dataset, "a") as expected_file:
-        make_dataset(
-            hdf5_file=expected_file,
-            num_samples=_NUM_SAMPLES,
-            plugin_path=_PLUGIN_PATH,
-            preset_path=_PRESET_PATH,
-            sample_rate=_SAMPLE_RATE,
-            channels=_CHANNELS,
-            velocity=_VELOCITY,
-            signal_duration_seconds=_DURATION,
-            min_loudness=_MIN_LOUDNESS,
-            param_spec=spec,
-            sample_batch_size=_NUM_SAMPLES,
-        )
+        make_dataset(hdf5_file=expected_file, render_cfg=_render_cfg(_NUM_SAMPLES))
     stage1_seconds = time.perf_counter() - t0
 
     expected_audio, expected_mel, expected_params = _assert_h5_structure_is_valid(
@@ -892,19 +879,7 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
         h5py.File(got_dataset, "a") as f,
         _patched_sample(spec, replay),
     ):
-        make_dataset(
-            hdf5_file=f,
-            num_samples=_NUM_SAMPLES,
-            plugin_path=_PLUGIN_PATH,
-            preset_path=_PRESET_PATH,
-            sample_rate=_SAMPLE_RATE,
-            channels=_CHANNELS,
-            velocity=_VELOCITY,
-            signal_duration_seconds=_DURATION,
-            min_loudness=_MIN_LOUDNESS,
-            param_spec=spec,
-            sample_batch_size=_NUM_SAMPLES,
-        )
+        make_dataset(hdf5_file=f, render_cfg=_render_cfg(_NUM_SAMPLES))
     stage2_seconds = time.perf_counter() - t0
 
     actual_audio, actual_mel, actual_params = _assert_h5_structure_is_valid(
@@ -945,19 +920,7 @@ def test_make_dataset(tmp_path: Path) -> None:
     spec = param_specs[_SPEC_NAME]
 
     with h5py.File(out, "a") as f:
-        make_dataset(
-            hdf5_file=f,
-            num_samples=_NUM_SAMPLES,
-            plugin_path=_PLUGIN_PATH,
-            preset_path=_PRESET_PATH,
-            sample_rate=_SAMPLE_RATE,
-            channels=_CHANNELS,
-            velocity=_VELOCITY,
-            signal_duration_seconds=_DURATION,
-            min_loudness=_MIN_LOUDNESS,
-            param_spec=spec,
-            sample_batch_size=_NUM_SAMPLES,
-        )
+        make_dataset(hdf5_file=f, render_cfg=_render_cfg(_NUM_SAMPLES))
 
     _, _, params = _assert_h5_structure_is_valid(out, spec, _NUM_SAMPLES)
 
@@ -1028,23 +991,13 @@ def test_show_editor_warmup_does_not_change_rendered_audio() -> None:
 def test_make_dataset_raises_when_fixed_params_list_is_too_short(
     tmp_path: Path,
 ) -> None:
-    """make_dataset rejects fixed_*_params_list shorter than num_samples - start_idx."""
-    spec = param_specs[_SPEC_NAME]
+    """make_dataset rejects fixed_*_params_list shorter than batch_per_shard - start_idx."""
     out = tmp_path / "should_not_write.h5"
     with h5py.File(out, "a") as f:
         with pytest.raises(ValueError, match="fixed_synth_params_list has length"):
             make_dataset(
                 hdf5_file=f,
-                num_samples=3,
-                plugin_path=_PLUGIN_PATH,
-                preset_path=_PRESET_PATH,
-                sample_rate=_SAMPLE_RATE,
-                channels=_CHANNELS,
-                velocity=_VELOCITY,
-                signal_duration_seconds=_DURATION,
-                min_loudness=_MIN_LOUDNESS,
-                param_spec=spec,
-                sample_batch_size=3,
+                render_cfg=_render_cfg(num_samples=3),
                 fixed_synth_params_list=[_HARDCODED_SYNTH_PARAMS],
             )
 
@@ -1184,16 +1137,7 @@ def test_make_dataset_uses_fixed_params_lists_when_provided(
     with h5py.File(out, "a") as f:
         make_dataset(
             hdf5_file=f,
-            num_samples=num_samples,
-            plugin_path=_PLUGIN_PATH,
-            preset_path=_PRESET_PATH,
-            sample_rate=_SAMPLE_RATE,
-            channels=_CHANNELS,
-            velocity=_VELOCITY,
-            signal_duration_seconds=_DURATION,
-            min_loudness=_MIN_LOUDNESS,
-            param_spec=spec,
-            sample_batch_size=num_samples,
+            render_cfg=_render_cfg(num_samples),
             fixed_synth_params_list=[_HARDCODED_SYNTH_PARAMS] * num_samples,
             fixed_note_params_list=[_HARDCODED_NOTE_PARAMS] * num_samples,
         )

--- a/tests/data/vst/test_generate_vst_dataset_cli.py
+++ b/tests/data/vst/test_generate_vst_dataset_cli.py
@@ -8,7 +8,11 @@ if the CLI binding drifts from the model.
 
 from __future__ import annotations
 
-from pipeline.schemas.spec import RenderConfig
+from pathlib import Path
+
+from pipeline.entrypoints.generate_dataset import build_generate_args
+from pipeline.schemas.spec import DatasetSpec, RenderConfig
+from pydantic_settings import CliApp
 from src.data.vst.generate_vst_dataset import _GenerateCliArgs
 
 
@@ -35,3 +39,46 @@ def test_cli_args_class_adds_only_data_file_beyond_render_config() -> None:
 
     extra = cli_fields - render_fields
     assert extra == {"data_file"}
+
+
+def _smoke_spec() -> DatasetSpec:
+    """A minimal ``DatasetSpec`` for round-trip tests — no I/O, no plugin required."""
+    render_cfg = RenderConfig(
+        plugin_path="plugins/Surge XT.vst3",
+        preset_path="presets/surge-base.vstpreset",
+        param_spec_name="surge_simple",
+        renderer_version="1.3.4",
+        sample_rate=16000,
+        channels=2,
+        velocity=100,
+        signal_duration_seconds=4.0,
+        min_loudness=-55.0,
+        sample_batch_size=32,
+        batch_per_shard=10000,
+    )
+    return DatasetSpec(
+        task_name="ci-smoke-test",
+        output_format="hdf5",
+        train_val_test_sizes=(440000, 20000, 20000),
+        train_val_test_seeds=(42, 43, 44),
+        base_seed=42,
+        r2_bucket="intermediate-data",
+        render=render_cfg,
+    )
+
+
+def test_build_generate_args_roundtrips_through_cli_parser() -> None:
+    """Args emitted by ``build_generate_args`` parse back into the same ``RenderConfig``.
+
+    Pins the full producer↔consumer contract: a divergence in flag spelling (kebab vs.
+    underscore), value coercion (int vs. float), or ``extra="forbid"`` rejection would
+    break this round-trip even when the field-set parity tests still pass.
+    """
+    spec = _smoke_spec()
+    args = build_generate_args(spec, spec.shards[0], Path("/tmp"))
+
+    parsed = CliApp.run(_GenerateCliArgs, cli_args=args[2:])
+    reconstructed = RenderConfig(**parsed.model_dump(exclude={"data_file"}))
+
+    assert reconstructed == spec.render
+    assert parsed.data_file == "/tmp/shard-000000.h5"

--- a/tests/data/vst/test_generate_vst_dataset_cli.py
+++ b/tests/data/vst/test_generate_vst_dataset_cli.py
@@ -1,0 +1,37 @@
+"""CLI surface tests for ``src/data/vst/generate_vst_dataset.py``.
+
+Pins the pydantic-settings parity guard: the CLI flag set is derived from
+``RenderConfig.model_fields`` so adding/removing a field on the model
+auto-extends/shrinks the CLI without a parallel code edit. These tests fail
+if the CLI binding drifts from the model.
+"""
+
+from __future__ import annotations
+
+from pipeline.schemas.spec import RenderConfig
+from src.data.vst.generate_vst_dataset import _GenerateCliArgs
+
+
+def test_cli_args_class_inherits_every_render_config_field() -> None:
+    """``_GenerateCliArgs`` carries every ``RenderConfig`` field — flag set follows.
+
+    Subclassing ``RenderConfig`` makes the parity structural rather than convention-
+    enforced: a new field on the model surfaces as a CLI flag automatically.
+    """
+    cli_fields = set(_GenerateCliArgs.model_fields.keys())
+    render_fields = set(RenderConfig.model_fields.keys())
+
+    assert render_fields <= cli_fields
+
+
+def test_cli_args_class_adds_only_data_file_beyond_render_config() -> None:
+    """Beyond ``RenderConfig`` fields, the CLI's only extra binding is ``data_file``.
+
+    Guards against accidental CLI bloat — if someone adds a flag here it should be a deliberate
+    decision, not silent drift.
+    """
+    cli_fields = set(_GenerateCliArgs.model_fields.keys())
+    render_fields = set(RenderConfig.model_fields.keys())
+
+    extra = cli_fields - render_fields
+    assert extra == {"data_file"}

--- a/tests/data/vst/test_generate_vst_dataset_cli.py
+++ b/tests/data/vst/test_generate_vst_dataset_cli.py
@@ -60,7 +60,6 @@ def _smoke_spec() -> DatasetSpec:
         task_name="ci-smoke-test",
         output_format="hdf5",
         train_val_test_sizes=(440000, 20000, 20000),
-        train_val_test_seeds=(42, 43, 44),
         base_seed=42,
         r2_bucket="intermediate-data",
         render=render_cfg,

--- a/tests/pipeline/ci/test_validate_shard.py
+++ b/tests/pipeline/ci/test_validate_shard.py
@@ -58,7 +58,6 @@ def real_spec(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> DatasetSpec:
         task_name="test-dataset",
         output_format="hdf5",
         train_val_test_sizes=(10, 0, 0),
-        train_val_test_seeds=(42, 43, 44),
         base_seed=42,
         r2_bucket="intermediate-data",
         render={

--- a/tests/pipeline/ci/test_validate_spec.py
+++ b/tests/pipeline/ci/test_validate_spec.py
@@ -20,7 +20,6 @@ def _make_valid_spec(*, output_format: str = "hdf5", **overrides: object) -> dic
         "is_repo_dirty": False,
         "output_format": output_format,
         "train_val_test_sizes": [32, 32, 32],
-        "train_val_test_seeds": [42, 43, 44],
         "base_seed": 42,
         "num_params": 92,
         "num_shards": 3,

--- a/tests/pipeline/conftest.py
+++ b/tests/pipeline/conftest.py
@@ -12,7 +12,6 @@ def _make_dataset_spec_kwargs(plugin_path: str = "plugins/Surge XT.vst3") -> dic
         "task_name": "ci-smoke-test",
         "output_format": "hdf5",
         "train_val_test_sizes": [440000, 20000, 20000],
-        "train_val_test_seeds": [42, 43, 44],
         "base_seed": 42,
         "r2_bucket": "intermediate-data",
         "render": {

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -76,7 +76,6 @@ def _base_spec_kwargs(tmp_path: Path, **overrides: object) -> dict[str, object]:
         "is_repo_dirty": False,
         "output_format": "hdf5",
         "train_val_test_sizes": [10000, 0, 0],
-        "train_val_test_seeds": [42, 43, 44],
         "base_seed": 42,
         "r2_bucket": "intermediate-data",
         "render": {

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -27,7 +27,7 @@ from pipeline.entrypoints.generate_dataset import (
     build_generate_args,
     run,
 )
-from pipeline.schemas.spec import DatasetSpec
+from pipeline.schemas.spec import DatasetSpec, RenderConfig
 
 # Reusable VST3 bundle with a real Contents/moduleinfo.json so
 # extract_renderer_version (called by run) returns a deterministic version
@@ -736,41 +736,28 @@ class TestBuildGenerateArgs:
 
         assert args[2] == str(tmp_path / "shard-000000.h5")
 
-    def test_num_samples_is_shard_size(self, spec: DatasetSpec) -> None:
-        """num_samples arg comes from spec.render.batch_per_shard."""
+    def test_batch_per_shard_passed_as_option(self, spec: DatasetSpec) -> None:
+        """batch_per_shard is emitted as ``--batch_per_shard <count>`` flag.
+
+        The CLI no longer takes a positional ``num_samples`` — every renderer
+        config field is exposed as a flag, including the per-shard sample count.
+        """
         shard = spec.shards[0]
 
         args = build_generate_args(spec, shard, Path("out"))
 
-        assert args[3] == str(spec.render.batch_per_shard)
+        flag_idx = args.index("--batch_per_shard")
+        assert args[flag_idx + 1] == str(spec.render.batch_per_shard)
 
-    def test_all_spec_fields_passed_as_options(self, spec: DatasetSpec) -> None:
-        """All generation parameters from spec are passed as --key value options."""
+    def test_all_render_config_fields_passed_as_options(self, spec: DatasetSpec) -> None:
+        """The flag set equals ``RenderConfig.model_fields`` — auto-derived parity guard."""
         shard = spec.shards[0]
 
         args = build_generate_args(spec, shard, Path("out"))
 
-        option_keys: set[str] = set()
-        i = 4
-        while i < len(args):
-            if args[i].startswith("--"):
-                option_keys.add(args[i].lstrip("-"))
-                i += 2
-            else:
-                i += 1
+        option_keys: set[str] = {arg.lstrip("-") for arg in args if arg.startswith("--")}
 
-        expected_keys = {
-            "plugin_path",
-            "preset_path",
-            "sample_rate",
-            "channels",
-            "velocity",
-            "signal_duration_seconds",
-            "min_loudness",
-            "param_spec",
-            "sample_batch_size",
-        }
-        assert expected_keys <= option_keys
+        assert option_keys == set(RenderConfig.model_fields.keys())
 
     def test_args_start_with_python_and_script(self, spec: DatasetSpec) -> None:
         """First arg is the Python executable, second is the generation script."""

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -40,7 +40,6 @@ def _valid_spec_kwargs(plugin_path: str = "/fake/Plugin.vst3", **overrides: Any)
         "task_name": "ci-smoke-test",
         "output_format": "hdf5",
         "train_val_test_sizes": [300, 0, 0],
-        "train_val_test_seeds": [123, 456, 789],
         "base_seed": 42,
         "r2_bucket": "intermediate-data",
         "render": _valid_render_kwargs(plugin_path),
@@ -234,13 +233,26 @@ class TestDatasetSpecValidators:
         with pytest.raises(ValidationError):
             DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=bad_length))
 
-    @pytest.mark.parametrize("bad_length", [[42, 43], [42, 43, 44, 45]])
-    def test_train_val_test_seeds_must_be_length_three(
-        self, patch_runtime_io: None, bad_length: list[int]
+    @pytest.mark.parametrize(
+        "bad_value",
+        [[42, 43, 44], (42, 43, 44), [1, 2, 3, 4], "anything", 0],
+    )
+    def test_train_val_test_seeds_setting_raises_not_implemented(
+        self, patch_runtime_io: None, bad_value: Any
     ) -> None:
-        """train_val_test_seeds must be exactly length 3 — parity with sizes."""
-        with pytest.raises(ValidationError):
-            DatasetSpec(**_valid_spec_kwargs(train_val_test_seeds=bad_length))
+        """Setting train_val_test_seeds raises NotImplementedError — reserved for #884."""
+        with pytest.raises(NotImplementedError, match="reserved for per-sample seeding"):
+            DatasetSpec(**_valid_spec_kwargs(train_val_test_seeds=bad_value))
+
+    def test_train_val_test_seeds_defaults_to_none(self, patch_runtime_io: None) -> None:
+        """Omitting train_val_test_seeds yields the default None — field is optional."""
+        spec = DatasetSpec(**_valid_spec_kwargs())
+        assert spec.train_val_test_seeds is None
+
+    def test_train_val_test_seeds_explicit_none_is_allowed(self, patch_runtime_io: None) -> None:
+        """Explicit None passes (NotImplementedError gate fires only on non-None)."""
+        spec = DatasetSpec(**_valid_spec_kwargs(train_val_test_seeds=None))
+        assert spec.train_val_test_seeds is None
 
     def test_explicit_empty_r2_prefix_raises(self, patch_runtime_io: None) -> None:
         """An explicit empty ``r2_prefix`` raises via the ``_r2_prefix_must_end_with_slash`` field
@@ -290,7 +302,6 @@ class TestDatasetSpecValidators:
         """
         spec = DatasetSpec(**_valid_spec_kwargs())
         assert isinstance(spec.train_val_test_sizes, tuple)
-        assert isinstance(spec.train_val_test_seeds, tuple)
         with pytest.raises(TypeError):
             spec.train_val_test_sizes[0] = 999  # type: ignore[index]
 

--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -99,7 +99,6 @@ def _valid_spec_payload() -> dict[str, Any]:
         "is_repo_dirty": False,
         "output_format": "hdf5",
         "train_val_test_sizes": [10000, 0, 0],
-        "train_val_test_seeds": [42, 43, 44],
         "base_seed": 42,
         "r2_bucket": "intermediate-data",
         "render": {


### PR DESCRIPTION
## Summary

PR-4 in the [foundation chain](https://github.com/tinaudio/synth-setter/issues/882#issuecomment-4424323689) (after PR-3b landed in #917).

- `make_dataset` now takes a single `render_cfg: RenderConfig` arg in place of nine wide kwargs.
- The CLI on `generate_vst_dataset.py` is rebuilt with pydantic-settings: `_GenerateCliArgs(RenderConfig, BaseSettings)` inherits every `RenderConfig` field so the CLI flag set tracks the model automatically. Adding/removing a field on `RenderConfig` extends or shrinks the CLI without a parallel code edit — this closes the drift hazard #885 was filed against.
- `pipeline/entrypoints/generate_dataset.py::build_generate_args` derives the flag set from `RenderConfig.model_fields` for the same reason.
- `scripts/surge_xt_interactive.py` constructs a `RenderConfig` for its captured-patches write; `renderer_version` is pulled from the plugin's static metadata via `extract_renderer_version`.

## Why now

`RenderConfig` landed in PR-1 (#887). PR-3a/3b finished the Hydra migration. With those foundations in main, the renderer surface can now take `RenderConfig` directly and the CLI's drift hazard can be retired in one step — rather than via the interim `--render-cfg-json` blob the umbrella branch used.

Per the [scope decision in the May 11 plan](https://github.com/tinaudio/synth-setter/issues/882#issuecomment-4417500401), the interim per-field click flags (`91430e3` on `worktree-agent-a818f00c8e0fa5bb2`) are skipped — this PR goes directly from "wide kwargs" to "pydantic-settings auto-generated flags".

## Test plan

- [x] `make test-fast` — 493 passed locally.
- [x] `make format` — clean.
- [x] New `tests/data/vst/test_generate_vst_dataset_cli.py` pins the parity invariant: `_GenerateCliArgs.model_fields == RenderConfig.model_fields ∪ {data_file}`.
- [x] `tests/pipeline/test_entrypoints/test_generate_dataset.py::TestBuildGenerateArgs` updated — flag set equals `RenderConfig.model_fields`, `batch_per_shard` arrives as a flag (no longer a positional).
- [x] All 5 `make_dataset` callsites in `tests/data/vst/test_generate_vst_dataset.py` migrated via a new `_render_cfg(num_samples)` helper.

Closes #940
Closes #885
