### PR TITLE
internal-fix(spec): gate unused train_val_test_seeds with NotImplementedError

### DIFF
--- a/configs/dataset.yaml
+++ b/configs/dataset.yaml
@@ -24,9 +24,6 @@ output_format: hdf5
 base_seed: 42
 
 train_val_test_sizes: ???
-# Reserved for per-sample seeding (#884); not consumed yet. Defaulted here
-# so experiments don't all duplicate the same triple.
-train_val_test_seeds: [42, 43, 44]
 
 r2_bucket: ${r2.bucket}
 r2_prefix_root: ${r2.prefix_root}

--- a/pipeline/ci/validate_spec.py
+++ b/pipeline/ci/validate_spec.py
@@ -28,7 +28,6 @@ _REQUIRED_TOP_LEVEL_FIELDS = [
     "run_id",
     "shards",
     "task_name",
-    "train_val_test_seeds",
     "train_val_test_sizes",
 ]
 _REQUIRED_RENDER_FIELDS = [

--- a/pipeline/schemas/spec.py
+++ b/pipeline/schemas/spec.py
@@ -167,8 +167,10 @@ class DatasetSpec(BaseModel):
     task_name: str
     output_format: Literal["hdf5"]
     train_val_test_sizes: tuple[int, int, int]
-    # Reserved for per-sample seeding (#884); not consumed yet.
-    train_val_test_seeds: tuple[int, int, int]
+    # Reserved for per-sample seeding (#884); not implemented. Accepts only
+    # ``None`` — any non-None value (yaml, JSON, or in-process) raises
+    # ``NotImplementedError`` at construction. See ``_reject_train_val_test_seeds``.
+    train_val_test_seeds: tuple[int, int, int] | None = None
     base_seed: int
     r2_bucket: str
     r2_prefix_root: str = DEFAULT_R2_PREFIX_ROOT
@@ -188,6 +190,22 @@ class DatasetSpec(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
+    def _reject_train_val_test_seeds(cls, data: Any) -> Any:
+        """Reject any non-None ``train_val_test_seeds`` — reserved for #884, not implemented.
+
+        Runs in ``mode="before"`` so ``NotImplementedError`` propagates as-is
+        instead of being wrapped in a ``ValidationError`` (which is what
+        pydantic does for ``ValueError`` raised inside field validators).
+        """
+        if isinstance(data, dict) and data.get("train_val_test_seeds") is not None:
+            raise NotImplementedError(
+                "train_val_test_seeds is reserved for per-sample seeding (#884) "
+                "and is not yet implemented; omit the field"
+            )
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
     def _strip_computed_field_keys(cls, data: Any) -> Any:
         """Strip ``shards`` / ``num_shards`` / ``num_params`` from input.
 
@@ -202,7 +220,7 @@ class DatasetSpec(BaseModel):
                 data.pop(computed_key, None)
         return data
 
-    @field_validator("train_val_test_sizes", "train_val_test_seeds", mode="before")
+    @field_validator("train_val_test_sizes", mode="before")
     @classmethod
     def _splits_list_to_tuple(cls, value: Any) -> Any:
         """Coerce JSON-loaded ``list[int]`` into ``tuple[int, int, int]``.

--- a/tests/pipeline/ci/test_validate_shard.py
+++ b/tests/pipeline/ci/test_validate_shard.py
@@ -58,7 +58,6 @@ def real_spec(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> DatasetSpec:
         task_name="test-dataset",
         output_format="hdf5",
         train_val_test_sizes=(10, 0, 0),
-        train_val_test_seeds=(42, 43, 44),
         base_seed=42,
         r2_bucket="intermediate-data",
         render={

--- a/tests/pipeline/ci/test_validate_spec.py
+++ b/tests/pipeline/ci/test_validate_spec.py
@@ -20,7 +20,6 @@ def _make_valid_spec(*, output_format: str = "hdf5", **overrides: object) -> dic
         "is_repo_dirty": False,
         "output_format": output_format,
         "train_val_test_sizes": [32, 32, 32],
-        "train_val_test_seeds": [42, 43, 44],
         "base_seed": 42,
         "num_params": 92,
         "num_shards": 3,

--- a/tests/pipeline/conftest.py
+++ b/tests/pipeline/conftest.py
@@ -12,7 +12,6 @@ def _make_dataset_spec_kwargs(plugin_path: str = "plugins/Surge XT.vst3") -> dic
         "task_name": "ci-smoke-test",
         "output_format": "hdf5",
         "train_val_test_sizes": [440000, 20000, 20000],
-        "train_val_test_seeds": [42, 43, 44],
         "base_seed": 42,
         "r2_bucket": "intermediate-data",
         "render": {

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -76,7 +76,6 @@ def _base_spec_kwargs(tmp_path: Path, **overrides: object) -> dict[str, object]:
         "is_repo_dirty": False,
         "output_format": "hdf5",
         "train_val_test_sizes": [10000, 0, 0],
-        "train_val_test_seeds": [42, 43, 44],
         "base_seed": 42,
         "r2_bucket": "intermediate-data",
         "render": {

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -40,7 +40,6 @@ def _valid_spec_kwargs(plugin_path: str = "/fake/Plugin.vst3", **overrides: Any)
         "task_name": "ci-smoke-test",
         "output_format": "hdf5",
         "train_val_test_sizes": [300, 0, 0],
-        "train_val_test_seeds": [123, 456, 789],
         "base_seed": 42,
         "r2_bucket": "intermediate-data",
         "render": _valid_render_kwargs(plugin_path),
@@ -234,13 +233,26 @@ class TestDatasetSpecValidators:
         with pytest.raises(ValidationError):
             DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=bad_length))
 
-    @pytest.mark.parametrize("bad_length", [[42, 43], [42, 43, 44, 45]])
-    def test_train_val_test_seeds_must_be_length_three(
-        self, patch_runtime_io: None, bad_length: list[int]
+    @pytest.mark.parametrize(
+        "bad_value",
+        [[42, 43, 44], (42, 43, 44), [1, 2, 3, 4], "anything", 0],
+    )
+    def test_train_val_test_seeds_setting_raises_not_implemented(
+        self, patch_runtime_io: None, bad_value: Any
     ) -> None:
-        """train_val_test_seeds must be exactly length 3 — parity with sizes."""
-        with pytest.raises(ValidationError):
-            DatasetSpec(**_valid_spec_kwargs(train_val_test_seeds=bad_length))
+        """Setting train_val_test_seeds raises NotImplementedError — reserved for #884."""
+        with pytest.raises(NotImplementedError, match="reserved for per-sample seeding"):
+            DatasetSpec(**_valid_spec_kwargs(train_val_test_seeds=bad_value))
+
+    def test_train_val_test_seeds_defaults_to_none(self, patch_runtime_io: None) -> None:
+        """Omitting train_val_test_seeds yields the default None — field is optional."""
+        spec = DatasetSpec(**_valid_spec_kwargs())
+        assert spec.train_val_test_seeds is None
+
+    def test_train_val_test_seeds_explicit_none_is_allowed(self, patch_runtime_io: None) -> None:
+        """Explicit None passes (NotImplementedError gate fires only on non-None)."""
+        spec = DatasetSpec(**_valid_spec_kwargs(train_val_test_seeds=None))
+        assert spec.train_val_test_seeds is None
 
     def test_explicit_empty_r2_prefix_raises(self, patch_runtime_io: None) -> None:
         """An explicit empty ``r2_prefix`` raises via the ``_r2_prefix_must_end_with_slash`` field
@@ -290,7 +302,6 @@ class TestDatasetSpecValidators:
         """
         spec = DatasetSpec(**_valid_spec_kwargs())
         assert isinstance(spec.train_val_test_sizes, tuple)
-        assert isinstance(spec.train_val_test_seeds, tuple)
         with pytest.raises(TypeError):
             spec.train_val_test_sizes[0] = 999  # type: ignore[index]
 

--- a/tests/test_docker_entrypoint.py
+++ b/tests/test_docker_entrypoint.py
@@ -99,7 +99,6 @@ def _valid_spec_payload() -> dict[str, Any]:
         "is_repo_dirty": False,
         "output_format": "hdf5",
         "train_val_test_sizes": [10000, 0, 0],
-        "train_val_test_seeds": [42, 43, 44],
         "base_seed": 42,
         "r2_bucket": "intermediate-data",
         "render": {


### PR DESCRIPTION
## Summary

Filed in response to a self-comment from @ktinubu on [PR #942](https://github.com/tinaudio/synth-setter/pull/942#discussion_r3221956327):

> Let's make `train_val_test_seeds` optional in the `DatasetSpec` and not include it in any of the yamls + experiment configs and raise an unimplemented error if someone tries to set `train_val_test_seeds`. This can be deferred to a separate PR and landed in parallel.

Lands **in parallel** with PR #942 — does not block the foundation chain.

## What changes

- `pipeline/schemas/spec.py`: `train_val_test_seeds: tuple[int, int, int] | None = None`; new `model_validator(mode="before") _reject_train_val_test_seeds` raises `NotImplementedError` for any non-None value (yaml, JSON, or in-process). Removed from `_splits_list_to_tuple` since the field can no longer take a list.
- `configs/dataset.yaml`: drops the field + its rationale comment.
- `pipeline/ci/validate_spec.py`: drops the field from `_REQUIRED_TOP_LEVEL_FIELDS`.
- 7 test fixtures: drop the field from kwargs.
- `tests/pipeline/test_schemas/test_dataset_spec.py`: swap the "must-be-length-three" parametrized tests for "raises NotImplementedError" / "defaults to None" / "explicit None allowed" cases.

## Out of scope

`configs/data/*.yaml` (the Lightning datamodule configs consumed by `src/data/{ksin,kosc,fm}_datamodule.py`) keep their `train_val_test_seeds: [123, 456, 789]` — that's a different field on a different layer (datamodule constructor arg driving train/val/test split RNG, not `DatasetSpec` per-sample seeding).

## Test plan

- [x] `make test-fast` — 496 passed locally.
- [x] `make format` — clean.
- [x] `DatasetSpec(train_val_test_seeds=[42, 43, 44])` raises `NotImplementedError` mentioning #884 (parametrized over list/tuple/wrong-length/non-iterable in `test_train_val_test_seeds_setting_raises_not_implemented`).
- [x] `DatasetSpec(train_val_test_seeds=None)` and omitting the field both yield `spec.train_val_test_seeds is None`.

Closes #943
Refs #884
