### PR TITLE
feat(handoff): add /handoff skill for chain-state handoff artifacts

### DIFF
--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -60,7 +60,6 @@ python3 .claude/skills/handoff/helpers/write_handoff.py \
   [--comment-only | --prompt-only] \
   [--surprise "<category>: <note>" ...] \
   [--anti-pattern "<line>" ...] \
-  [--no-prompt-questions] \
   [--no-save-prompt] \
   [--force]
 ```
@@ -98,7 +97,6 @@ If the writer exited non-zero, surface the stderr verbatim and stop. Common fail
 | `--dry-run` | Render both, post nothing, print everything, leave `chain.yaml` unchanged |
 | `--comment-only` | Post comment, suppress prompt printing |
 | `--prompt-only` | Print prompt, suppress comment posting |
-| `--no-prompt-questions` | Skip the AskUserQuestion step; render with empty Surprises / Anti-patterns sections |
 | `--force` | Bypass the 30-min idempotency guard |
 | `--surprise "<cat>: <note>"` | Add one Surprise row (repeatable) |
 | `--anti-pattern "<line>"` | Add one Anti-pattern line (repeatable) |

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -107,7 +107,7 @@ If the writer exited non-zero, surface the stderr verbatim and stop. Common fail
 - **Never auto-merge a PR.** The chain ends at `gh pr merge` — the user runs that. Handoffs are reversible (delete the comment); merges are not.
 - **No new env vars.** The skill must run with whatever the repo already requires (`gh` auth, `git`).
 - **No absolute paths in templates or imports.** `SKILL_DIR = Path(__file__).resolve().parent.parent` anchors everything.
-- **No new dependencies.** `jinja2` and `pyyaml` are already in the environment (jinja2 transitively via pytorch-lightning; pyyaml in `requirements-app.txt`). Don't add `ruamel.yaml` or other.
+- **Minimal dependency surface.** The skill needs `jinja2` (templating) and `pyyaml` (manifest I/O), both explicitly declared in `requirements-app.txt`. Don't add `ruamel.yaml` or other heavy YAML libs without a strong reason.
 - **One tracking issue per invocation.** Multi-issue chains are out of scope — copy `chain.yaml` to `chain.wds.yaml` and pass `--chain` for a parallel chain.
 - **Skill files (`.claude/handoffs/handoff-*.md`) MUST NOT be committed.** The `.claude/` tree is already `.gitignore`d; the explicit override line in `.gitignore` documents the intent for any future contributor who adds a `!.claude/` allow-list.
 

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -54,6 +54,7 @@ The writer composes both artifacts, applies the idempotency guard, and (unless g
 ```bash
 python3 .claude/skills/handoff/helpers/write_handoff.py \
   [--issue N] \
+  [--repo OWNER/NAME] \
   [--chain PATH] \
   [--dry-run] \
   [--comment-only | --prompt-only] \
@@ -92,6 +93,7 @@ If the writer exited non-zero, surface the stderr verbatim and stop. Common fail
 |------|--------|
 | (none) | Full flow: render, post comment, print + save prompt |
 | `--issue N` | Override `chain.yaml`'s `tracking_issue` |
+| `--repo OWNER/NAME` | Override `chain.yaml`'s `repo` |
 | `--chain PATH` | Use a different manifest (e.g. `chain.wds.yaml`) |
 | `--dry-run` | Render both, post nothing, print everything, leave `chain.yaml` unchanged |
 | `--comment-only` | Post comment, suppress prompt printing |

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: handoff
+description: |
+  Generate the two artifacts a fresh agent needs to continue a multi-PR chain:
+  (1) a handoff-update comment posted to the tracking issue, and (2) a startup
+  prompt printed inline (and saved to .claude/handoffs/) for the next session.
+  Triggered by `/handoff [--issue N] [--dry-run] [--comment-only] [--prompt-only]`.
+  Derives state from chain.yaml + live `gh` queries (prior handoffs, merged PRs,
+  open PRs, Phase task numbering, worktree inventory). Use whenever the user
+  asks to "hand off the chain", "write the next-agent prompt", "post a handoff
+  update", or after a session has driven part of a PR plan toward merge and
+  needs to transfer to a fresh agent.
+---
+
+# handoff — chain handoff artifact generator
+
+You MUST complete every step in order.
+
+## What this skill does
+
+Two artifacts are produced from session state:
+
+1. **Comment** — a `## Handoff update` comment posted to the chain's tracking issue (e.g. #882). Mirrors the structure of [this reference handoff](https://github.com/tinaudio/synth-setter/issues/882#issuecomment-4425353839): done-since-prior, in-flight PRs with explicit next-actions, remaining-chain table (collapsed), Phase task-numbering, recommended task list, worktree inventory, surprises, and ongoing-conventions reminder.
+2. **Prompt** — a markdown block the human pastes into the next fresh agent's first message. Includes a START-HERE link to the just-posted comment, three first-commands-to-run, the dependency graph, the default-action narrative, mandatory-skills cycle, anti-patterns list, and PR-readiness checklist.
+
+The chain itself is encoded in `.claude/skills/handoff/chain.yaml`. The skill reads it, reconciles status against live PR state, writes back only when something changed, and renders the artifacts.
+
+## Step 1: Determine the tracking issue
+
+Default: use the `tracking_issue` from `.claude/skills/handoff/chain.yaml`.
+
+User overrides:
+
+- `/handoff --issue 874` — use issue #874 (e.g. the wds-tail chain).
+- `/handoff --chain .claude/skills/handoff/chain.wds.yaml` — use a different manifest file.
+
+If `chain.yaml` is missing or has no `tracking_issue`, ask the user via `AskUserQuestion` which issue to use, and offer to persist their answer back into the manifest so future invocations don't re-ask.
+
+## Step 2: Collect Surprises and Anti-patterns from the session
+
+The "Surprises" comment section and the "Anti-patterns" prompt section keep the lessons-learned curated by the user, not auto-fabricated. Unless `--no-prompt-questions` was passed:
+
+1. Use `AskUserQuestion` to prompt for **Surprises** with `multiSelect: true` and categories: `Copilot race`, `Maintainer-self-push`, `Infra/dep surprise`, `Tool-quirk`, `Process-race`, `Other`. Skip the question if `multiSelect` is unavailable in the environment — fall back to a plain prompt.
+2. For each selected category, ask the user for a one-line note describing the surprise.
+3. Separately ask for any **Anti-patterns** (things the prior agent tried that didn't work — short list, one-liners).
+4. Pass them to the writer via repeated `--surprise "<category>: <note>"` and `--anti-pattern "<line>"` flags.
+
+If you cannot prompt (non-interactive environment, or user passed `--no-prompt-questions`), render with the sections empty. Better to ship a working handoff than to block on missing lessons.
+
+## Step 3: Invoke the writer
+
+The writer composes both artifacts, applies the idempotency guard, and (unless gated) posts the comment plus saves the prompt locally.
+
+```bash
+python3 .claude/skills/handoff/helpers/write_handoff.py \
+  [--issue N] \
+  [--chain PATH] \
+  [--dry-run] \
+  [--comment-only | --prompt-only] \
+  [--surprise "<category>: <note>" ...] \
+  [--anti-pattern "<line>" ...] \
+  [--no-prompt-questions] \
+  [--no-save-prompt] \
+  [--force]
+```
+
+What it does in order:
+
+1. Reads `chain.yaml`.
+2. Calls `discover_state.derive_state(...)` — queries the tracking issue's comments (filters those whose body starts with `## Handoff update`), merged PRs since the most-recent handoff timestamp (`gh pr list --search "#<N> merged:>YYYY-MM-DDTHH:MM:SSZ"`), open PRs referencing the tracking issue, per-in-flight-PR health (mergeable, review decision, status checks, unresolved review threads via GraphQL, new Copilot comments since head-commit committer date), Phase task-number ceiling (sub-issues of the parent phase, regex-matched against the chain's `task_prefix`), and `git worktree list --porcelain` cross-referenced with `gh pr view <branch>`.
+3. Reconciles `chain.yaml`'s `status` / `pr_number` columns against the live data. Merged PRs become `status: merged`; open PRs matching a chain title become `status: in_flight`. Writes the file back only when something actually changed (preserves the file's leading header comment block via `CHAIN_HEADER`).
+4. **Idempotency guard:** if the most recent prior handoff is younger than 30 minutes, refuses to post unless `--force` is passed. Override only when you have a concrete reason (e.g. a major event happened immediately after the last handoff).
+5. Renders `templates/comment.md.j2` and `templates/prompt.md.j2` (Jinja2, `StrictUndefined`) against the derived state.
+6. Posts the comment via `gh issue comment <N> --body-file <tmp>` and captures its `html_url`.
+7. Re-renders the prompt with the just-posted comment URL embedded as `START HERE`.
+8. Prints the prompt to stdout (unless `--comment-only`).
+9. Saves the prompt to `.claude/handoffs/handoff-YYYY-MM-DD-HHMM.md` (unless `--no-save-prompt`). The `.claude/` tree is `.gitignore`d, so these files stay session-local.
+
+## Step 4: Report back to the user
+
+After a successful run:
+
+- Quote the posted comment's URL.
+- Quote the local path the prompt was saved to.
+- Tell the user the prompt was also printed inline above — they paste it into the next agent's first message.
+
+If the writer exited non-zero, surface the stderr verbatim and stop. Common failure modes: missing `chain.yaml`, `gh` not authenticated, the idempotency guard refused without `--force`.
+
+## Argument surface
+
+| Flag | Effect |
+|------|--------|
+| (none) | Full flow: render, post comment, print + save prompt |
+| `--issue N` | Override `chain.yaml`'s `tracking_issue` |
+| `--chain PATH` | Use a different manifest (e.g. `chain.wds.yaml`) |
+| `--dry-run` | Render both, post nothing, print everything, leave `chain.yaml` unchanged |
+| `--comment-only` | Post comment, suppress prompt printing |
+| `--prompt-only` | Print prompt, suppress comment posting |
+| `--no-prompt-questions` | Skip the AskUserQuestion step; render with empty Surprises / Anti-patterns sections |
+| `--force` | Bypass the 30-min idempotency guard |
+| `--surprise "<cat>: <note>"` | Add one Surprise row (repeatable) |
+| `--anti-pattern "<line>"` | Add one Anti-pattern line (repeatable) |
+| `--no-save-prompt` | Don't save the prompt to `.claude/handoffs/` |
+
+## Constraints (hard rules)
+
+- **Never auto-merge a PR.** The chain ends at `gh pr merge` — the user runs that. Handoffs are reversible (delete the comment); merges are not.
+- **No new env vars.** The skill must run with whatever the repo already requires (`gh` auth, `git`).
+- **No absolute paths in templates or imports.** `SKILL_DIR = Path(__file__).resolve().parent.parent` anchors everything.
+- **No new dependencies.** `jinja2` and `pyyaml` are already in the environment (jinja2 transitively via pytorch-lightning; pyyaml in `requirements-app.txt`). Don't add `ruamel.yaml` or other.
+- **One tracking issue per invocation.** Multi-issue chains are out of scope — copy `chain.yaml` to `chain.wds.yaml` and pass `--chain` for a parallel chain.
+- **Skill files (`.claude/handoffs/handoff-*.md`) MUST NOT be committed.** The `.claude/` tree is already `.gitignore`d; the explicit override line in `.gitignore` documents the intent for any future contributor who adds a `!.claude/` allow-list.
+
+## When the `chain.yaml` doesn't fit the situation
+
+If the user is starting a brand-new chain (no existing manifest), don't try to back-fill from PR history. Instead:
+
+1. Ask the user for the tracking issue, the parent Phase, the task prefix, and the rough list of upcoming PRs.
+2. Write a minimal `chain.yaml` with one plan_pr per upcoming PR (`status: pending`, `pr_number: null`).
+3. Run `/handoff` against the new manifest — its first invocation will have an empty Done-since table and no in-flight PRs, which is correct.
+
+## How the skill is tested
+
+The unit tests under `.claude/skills/handoff/tests/` cover the pure-function surface:
+
+- `test_discover_state.py` — chain.yaml round-trip, worktree porcelain parsing, prior-handoff filtering, Phase task-number extraction, Copilot-comment timestamp filtering, status-check rollup summarization, unresolved-thread counting, chain status reconciliation.
+- `test_write_handoff.py` — template renders (comment + prompt), per-in-flight-PR next-action wording for each state (failing / conflicting / unresolved-threads / approved-clean), prior-handoff breadcrumb rendering, safe-to-remove worktree annotation, idempotency guard window, surprise parsing, ASCII dependency graph for linear-chain and fan-out shapes.
+
+Run with:
+
+```bash
+python3 -m pytest .claude/skills/handoff/tests/ -v
+```
+
+For the integration smoke test, run `/handoff --dry-run` from a live session and spot-check the rendered artifacts against the prior handoff comment they're meant to supersede. The diff between hand-written and skill-generated should be structurally minor (formatting, predecessor breadcrumbs, dependency graph) — no missing rows, no fabricated rows.

--- a/.claude/skills/handoff/chain.yaml
+++ b/.claude/skills/handoff/chain.yaml
@@ -1,0 +1,173 @@
+# Structured manifest of the remaining PR chain rooted at the tracking issue.
+#
+# The /handoff skill reads this on every invocation, updates `status` and
+# `pr_number` from live `gh` queries, and writes the file back only when one
+# of those columns changes. Merged PRs automatically surface in the "Done
+# since prior handoff" table; pending and in-flight PRs surface in the
+# "Remaining chain" table.
+#
+# To start a new chain, copy this file (e.g. chain.wds.yaml) and edit. One
+# tracking issue per chain — multi-issue chains are out of scope.
+tracking_issue: 882
+repo: tinaudio/synth-setter
+parent_phase: 72
+task_prefix: "Task 5"
+
+plan_prs:
+  - id: "PR-5"
+    title: "refactor(pipeline): relocate pipeline/ → src/pipeline/"
+    source_commits: ["51b574e"]
+    linked_issue:
+      strategy: create_under_phase
+      existing: null
+    status: pending
+    pr_number: null
+    depends_on: []
+
+  - id: "PR-6"
+    title: "internal-fix(pipeline): post-relocation doc + comment sweep"
+    source_commits:
+      - "789bf93"
+      - "c2e760b"
+      - "e3eb698"
+      - "9dbe920"
+      - "38eef7d"
+      - "e190ea6"
+      - "f91737b"
+    linked_issue:
+      strategy: create_under_phase
+      existing: null
+    status: pending
+    pr_number: null
+    depends_on: ["PR-5"]
+
+  - id: "PR-7"
+    title: "internal-fix(schemas): tighten DatasetSpec validators + graceful runtime fields"
+    source_commits:
+      - "2e2f4d2"
+      - "2bc6cb5"
+      - "cc8d783"
+      - "d56e496"
+      - "c38417a"
+    notes:
+      - "b516b67 (seeds gate) intentionally dropped — already shipped via #944"
+    linked_issue:
+      strategy: create_under_phase
+      existing: null
+    status: pending
+    pr_number: null
+    depends_on: ["PR-5"]
+
+  - id: "PR-8"
+    title: "internal-fix(pipeline): tighten validate_spec — derive required fields from model"
+    source_commits: ["69e0835"]
+    linked_issue:
+      strategy: create_under_phase
+      existing: null
+    status: pending
+    pr_number: null
+    depends_on: ["PR-5"]
+
+  - id: "PR-9"
+    title: "internal-fix(pipeline): code-health pass on skypilot_launch + pedalboard-free spec import"
+    source_commits:
+      - "eac9d52"
+      - "3e45f1d"
+      - "49b0ab7"
+      - "e8ca78d"
+      - "e7affbb"
+      - "147d705"
+    linked_issue:
+      strategy: create_under_phase
+      existing: null
+    status: pending
+    pr_number: null
+    depends_on: ["PR-5"]
+
+  - id: "PR-11"
+    title: "fix(compute,ci,workflows): docker entrypoint path + validate-spec pydantic + pr-metadata-gate pagination"
+    source_commits: ["b866fb4", "3b0c7cb", "7b71e52"]
+    linked_issue:
+      strategy: create_under_phase
+      existing: null
+    status: pending
+    pr_number: null
+    depends_on: ["PR-5"]
+
+  - id: "PR-12"
+    title: "internal-feat(schemas): add ShardMetadata + EXTENSION_TO_OUTPUT_FORMAT mapping"
+    source_commits:
+      - "95bd6e3"
+      - "9eb526b"
+      - "a455a67"
+      - "e28bd84"
+      - "88cfea3"
+    notes:
+      - "Source commits will need to be re-applied post-relocation if PR-5 lands first."
+    linked_issue:
+      strategy: existing
+      existing: 874
+    status: pending
+    pr_number: null
+    depends_on: ["PR-11"]
+
+  - id: "PR-13"
+    title: "internal-feat(pipeline): support wds writer + tar validate_shard"
+    source_commits:
+      - "0234eeb"
+      - "b0d36ca"
+      - "9d77aa3"
+      - "1720d19"
+      - "3247fd3"
+      - "e0c52f7"
+      - "e1007f6"
+      - "7354ee3"
+      - "27ed53d"
+      - "78dc576"
+      - "cf53448"
+      - "f71905f"
+      - "2ed600d"
+      - "80df242"
+      - "b5bf975"
+      - "218cd13"
+      - "97baacd"
+      - "359ad3e"
+      - "018dcbc"
+      - "32b7eba"
+      - "b885804"
+    linked_issue:
+      strategy: existing
+      existing: 874
+    status: pending
+    pr_number: null
+    depends_on: ["PR-12"]
+
+  - id: "PR-14"
+    title: "feat(pipeline): write WDS tar shard from make_dataset alongside hdf5 (closes #874)"
+    source_commits: ["a465815"]
+    notes:
+      - "PR-14 is the user-facing wiring PR; closes #874."
+    linked_issue:
+      strategy: existing
+      existing: 874
+    status: pending
+    pr_number: null
+    depends_on: ["PR-13"]
+
+  - id: "PR-15"
+    title: "ci(workflows): parallel WDS run in test-dataset-generation matrix"
+    source_commits:
+      - "666a909"
+      - "fd36bdd"
+      - "f6d9b3d"
+      - "478b402"
+      - "b10f30c"
+      - "8dafb19"
+      - "0f27452"
+    linked_issue:
+      strategy: create_under_phase
+      existing: null
+      parent_issue: 874
+    status: pending
+    pr_number: null
+    depends_on: ["PR-14"]

--- a/.claude/skills/handoff/helpers/discover_state.py
+++ b/.claude/skills/handoff/helpers/discover_state.py
@@ -1,0 +1,765 @@
+"""State derivation for the /handoff skill.
+
+Reads chain.yaml + live `gh` queries + `git worktree list` and returns a
+DerivedState the templates can render. Pure parsing/aggregation lives in
+free functions so unit tests can exercise the logic without mocking the
+network — subprocess wrappers are kept thin and isolated at module scope.
+
+Public entry point: derive_state(...).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from collections.abc import Iterable
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import yaml
+
+HANDOFF_HEADER_PREFIX = "## Handoff update"
+TASK_TITLE_RE_TEMPLATE = r"^{prefix}\.(\d+)\b"
+COPILOT_LOGIN_RE = re.compile(r"copilot", re.IGNORECASE)
+
+
+@dataclass
+class LinkedIssue:
+    """How a chain PR's tracking issue is sourced — existing or to-be-created."""
+
+    strategy: str = "create_under_phase"
+    existing: int | None = None
+    parent_issue: int | None = None
+
+
+@dataclass
+class ChainPR:
+    """One plan-PR row in `chain.yaml`."""
+
+    id: str
+    title: str
+    source_commits: list[str] = field(default_factory=list)
+    notes: list[str] = field(default_factory=list)
+    linked_issue: LinkedIssue = field(default_factory=LinkedIssue)
+    status: str = "pending"
+    pr_number: int | None = None
+    depends_on: list[str] = field(default_factory=list)
+
+
+@dataclass
+class Chain:
+    """The full chain manifest — header metadata plus a list of plan PRs."""
+
+    tracking_issue: int
+    repo: str
+    parent_phase: int
+    task_prefix: str
+    plan_prs: list[ChainPR] = field(default_factory=list)
+
+
+@dataclass
+class PriorHandoff:
+    """One prior handoff comment on the tracking issue.
+
+    `created_at` is an ISO8601 UTC string straight from the GitHub API — kept
+    as a string because we only ever compare it lexicographically (ISO8601 is
+    lexicographically ordered) and pass it through to the next gh query.
+    """
+
+    comment_id: int
+    url: str
+    created_at: str
+    body: str
+
+
+@dataclass
+class ClosedPR:
+    """One merged PR that referenced the tracking issue since the prior handoff."""
+
+    number: int
+    title: str
+    merged_at: str
+    closes_issues: list[int]
+
+
+@dataclass
+class InFlightPR:
+    """One open PR's health snapshot — feeds the comment's In-flight section."""
+
+    number: int
+    title: str
+    branch: str
+    head_oid: str
+    head_committer_date: str
+    mergeable: str
+    review_decision: str
+    checks_state: str
+    unresolved_threads: int
+    new_copilot_comments_since_push: int
+
+
+@dataclass
+class PhaseTaskNumbering:
+    """Phase N's used `Task N.M` numbers and the next free integer."""
+
+    phase_number: int
+    task_prefix: str
+    used_numbers: list[int]
+
+    @property
+    def next_free(self) -> int:
+        """Return the smallest integer not in `used_numbers` (or 1 if empty)."""
+        return (max(self.used_numbers) + 1) if self.used_numbers else 1
+
+
+@dataclass
+class WorktreeEntry:
+    """One `git worktree list` row, cross-referenced with its PR state."""
+
+    path: str
+    branch: str | None
+    head: str
+    associated_pr_number: int | None
+    associated_pr_state: str | None
+    safe_to_remove: bool
+
+
+@dataclass
+class DerivedState:
+    """The full bundle of state the templates render against."""
+
+    repo: str
+    tracking_issue: int
+    chain: Chain
+    prior_handoffs: list[PriorHandoff]
+    done_since: list[ClosedPR]
+    in_flight: list[InFlightPR]
+    phase_numbering: PhaseTaskNumbering
+    worktrees: list[WorktreeEntry]
+    now_utc: str
+
+
+def run_gh(args: list[str], *, input_text: str | None = None) -> str:
+    """Invoke the gh CLI and return stdout.
+
+    Raises CalledProcessError on failure.
+    """
+    result = subprocess.run(  # noqa: S603 — argv list, no shell
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+        input=input_text,
+    )
+    return result.stdout
+
+
+def run_git(args: list[str]) -> str:
+    """Invoke git and return stdout.
+
+    Raises CalledProcessError on failure.
+    """
+    result = subprocess.run(  # noqa: S603 — argv list, no shell
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+CHAIN_HEADER = """\
+# Structured manifest of the remaining PR chain rooted at the tracking issue.
+#
+# The /handoff skill reads this on every invocation, updates `status` and
+# `pr_number` from live `gh` queries, and writes the file back only when one
+# of those columns changes. Merged PRs automatically surface in the "Done
+# since prior handoff" table; pending and in-flight PRs surface in the
+# "Remaining chain" table.
+#
+# To start a new chain, copy this file (e.g. chain.wds.yaml) and edit. One
+# tracking issue per chain — multi-issue chains are out of scope.
+"""
+
+
+def load_chain(path: Path) -> Chain:
+    """Read chain.yaml into a Chain dataclass."""
+    raw = yaml.safe_load(path.read_text())
+    return _chain_from_dict(raw)
+
+
+def save_chain(path: Path, chain: Chain) -> None:
+    """Write a Chain dataclass back to chain.yaml with the standard header."""
+    body = yaml.safe_dump(_chain_to_dict(chain), sort_keys=False, width=1000, allow_unicode=True)
+    path.write_text(CHAIN_HEADER + body)
+
+
+def chains_equivalent(a: Chain, b: Chain) -> bool:
+    """Return True if two Chains carry the same logical content."""
+    return _chain_to_dict(a) == _chain_to_dict(b)
+
+
+def _chain_from_dict(raw: dict) -> Chain:
+    """Build a Chain from its YAML-loaded dict form."""
+    plan_prs = [_chain_pr_from_dict(row) for row in raw.get("plan_prs", [])]
+    return Chain(
+        tracking_issue=int(raw["tracking_issue"]),
+        repo=str(raw["repo"]),
+        parent_phase=int(raw["parent_phase"]),
+        task_prefix=str(raw["task_prefix"]),
+        plan_prs=plan_prs,
+    )
+
+
+def _chain_pr_from_dict(raw: dict) -> ChainPR:
+    """Build a ChainPR row from its YAML-loaded dict form."""
+    linked = raw.get("linked_issue") or {}
+    return ChainPR(
+        id=str(raw["id"]),
+        title=str(raw["title"]),
+        source_commits=list(raw.get("source_commits") or []),
+        notes=list(raw.get("notes") or []),
+        linked_issue=LinkedIssue(
+            strategy=str(linked.get("strategy", "create_under_phase")),
+            existing=linked.get("existing"),
+            parent_issue=linked.get("parent_issue"),
+        ),
+        status=str(raw.get("status", "pending")),
+        pr_number=raw.get("pr_number"),
+        depends_on=list(raw.get("depends_on") or []),
+    )
+
+
+def _chain_to_dict(chain: Chain) -> dict:
+    """Render a Chain to its YAML-serializable dict form."""
+    return {
+        "tracking_issue": chain.tracking_issue,
+        "repo": chain.repo,
+        "parent_phase": chain.parent_phase,
+        "task_prefix": chain.task_prefix,
+        "plan_prs": [_chain_pr_to_dict(pr) for pr in chain.plan_prs],
+    }
+
+
+def _chain_pr_to_dict(pr: ChainPR) -> dict:
+    """Render a ChainPR row to its YAML-serializable dict form."""
+    row: dict = {
+        "id": pr.id,
+        "title": pr.title,
+        "source_commits": pr.source_commits,
+    }
+    if pr.notes:
+        row["notes"] = pr.notes
+    row["linked_issue"] = {
+        "strategy": pr.linked_issue.strategy,
+        "existing": pr.linked_issue.existing,
+    }
+    if pr.linked_issue.parent_issue is not None:
+        row["linked_issue"]["parent_issue"] = pr.linked_issue.parent_issue
+    row["status"] = pr.status
+    row["pr_number"] = pr.pr_number
+    row["depends_on"] = pr.depends_on
+    return row
+
+
+def filter_handoff_comments(comments: Iterable[dict]) -> list[PriorHandoff]:
+    """Pick handoff-update comments out of the tracking issue's full comment list."""
+    handoffs: list[PriorHandoff] = []
+    for comment in comments:
+        body = comment.get("body") or ""
+        if not body.lstrip().startswith(HANDOFF_HEADER_PREFIX):
+            continue
+        handoffs.append(
+            PriorHandoff(
+                comment_id=int(comment.get("databaseId") or comment.get("id") or 0),
+                url=str(comment.get("url") or ""),
+                created_at=str(comment.get("createdAt") or ""),
+                body=body,
+            )
+        )
+    handoffs.sort(key=lambda h: h.created_at, reverse=True)
+    return handoffs
+
+
+def fetch_issue_comments(repo: str, issue_number: int) -> list[dict]:
+    """Page through every comment on the tracking issue via GraphQL."""
+    owner, name = repo.split("/", 1)
+    nodes: list[dict] = []
+    after: str | None = None
+    query = """
+      query($owner: String!, $name: String!, $number: Int!, $after: String) {
+        repository(owner: $owner, name: $name) {
+          issue(number: $number) {
+            comments(first: 100, after: $after) {
+              nodes { databaseId url body createdAt }
+              pageInfo { hasNextPage endCursor }
+            }
+          }
+        }
+      }
+    """
+    while True:
+        args = [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+            "-F",
+            f"number={issue_number}",
+        ]
+        if after is not None:
+            args += ["-f", f"after={after}"]
+        payload = json.loads(run_gh(args))
+        page = payload["data"]["repository"]["issue"]["comments"]
+        nodes.extend(page["nodes"])
+        if not page["pageInfo"]["hasNextPage"]:
+            return nodes
+        after = page["pageInfo"]["endCursor"]
+
+
+def fetch_done_since(repo: str, tracking_issue: int, since_iso: str | None) -> list[ClosedPR]:
+    """Return merged PRs referencing the tracking issue since `since_iso`.
+
+    `since_iso=None` means "no lower bound" (first handoff). We let GitHub's PR search filter by
+    body-mention of the tracking issue — picks up both `Closes #<N>` and `Refs #<N>` flavors.
+    """
+    search_terms = [f"#{tracking_issue}"]
+    if since_iso:
+        search_terms.append(f"merged:>{since_iso}")
+    args = [
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "merged",
+        "--search",
+        " ".join(search_terms),
+        "--json",
+        "number,title,mergedAt,closingIssuesReferences",
+        "--limit",
+        "100",
+    ]
+    raw = json.loads(run_gh(args))
+    return [_closed_pr_from_dict(row) for row in raw]
+
+
+def _closed_pr_from_dict(raw: dict) -> ClosedPR:
+    """Build a ClosedPR from gh's `pr list --json` row."""
+    closes = []
+    for ref in raw.get("closingIssuesReferences") or []:
+        if ref.get("number") is not None:
+            closes.append(int(ref["number"]))
+    return ClosedPR(
+        number=int(raw["number"]),
+        title=str(raw.get("title", "")),
+        merged_at=str(raw.get("mergedAt", "")),
+        closes_issues=closes,
+    )
+
+
+def fetch_in_flight(repo: str, tracking_issue: int) -> list[InFlightPR]:
+    """Return open PRs that reference the tracking issue, with health fields."""
+    args = [
+        "pr",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--search",
+        f"#{tracking_issue}",
+        "--json",
+        "number",
+        "--limit",
+        "50",
+    ]
+    raw = json.loads(run_gh(args))
+    numbers = [int(row["number"]) for row in raw]
+    return [fetch_one_in_flight(repo, n) for n in numbers]
+
+
+def fetch_one_in_flight(repo: str, pr_number: int) -> InFlightPR:
+    """Fetch the full health snapshot for one in-flight PR."""
+    fields = ",".join(
+        [
+            "number",
+            "title",
+            "headRefName",
+            "headRefOid",
+            "mergeable",
+            "reviewDecision",
+            "statusCheckRollup",
+        ]
+    )
+    raw = json.loads(
+        run_gh(
+            ["pr", "view", str(pr_number), "--repo", repo, "--json", fields],
+        )
+    )
+    head_committer_date = _fetch_commit_committer_date(repo, raw["headRefOid"])
+    new_copilot = _count_new_copilot_comments(repo, pr_number, head_committer_date)
+    unresolved = _fetch_unresolved_threads(repo, pr_number)
+    return InFlightPR(
+        number=int(raw["number"]),
+        title=str(raw["title"]),
+        branch=str(raw["headRefName"]),
+        head_oid=str(raw["headRefOid"]),
+        head_committer_date=head_committer_date,
+        mergeable=str(raw.get("mergeable") or "UNKNOWN"),
+        review_decision=str(raw.get("reviewDecision") or "REVIEW_REQUIRED"),
+        checks_state=summarize_checks(raw.get("statusCheckRollup") or []),
+        unresolved_threads=unresolved,
+        new_copilot_comments_since_push=new_copilot,
+    )
+
+
+def _fetch_unresolved_threads(repo: str, pr_number: int) -> int:
+    """Count unresolved review threads via GraphQL (not exposed on `pr view`)."""
+    owner, name = repo.split("/", 1)
+    query = """
+      query($owner: String!, $name: String!, $number: Int!) {
+        repository(owner: $owner, name: $name) {
+          pullRequest(number: $number) {
+            reviewThreads(first: 100) { nodes { isResolved } }
+          }
+        }
+      }
+    """
+    try:
+        raw = json.loads(
+            run_gh(
+                [
+                    "api",
+                    "graphql",
+                    "-f",
+                    f"query={query}",
+                    "-f",
+                    f"owner={owner}",
+                    "-f",
+                    f"name={name}",
+                    "-F",
+                    f"number={pr_number}",
+                ]
+            )
+        )
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return 0
+    nodes = raw["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+    return count_unresolved_threads(nodes)
+
+
+def _fetch_commit_committer_date(repo: str, sha: str) -> str:
+    """Return the committer date for `sha` as ISO8601, or empty on failure."""
+    try:
+        raw = json.loads(
+            run_gh(["api", f"repos/{repo}/commits/{sha}", "--jq", ".commit.committer.date"])
+        )
+        return str(raw) if not isinstance(raw, dict) else ""
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return ""
+
+
+def _count_new_copilot_comments(repo: str, pr_number: int, since_iso: str) -> int:
+    """Count Copilot review comments created strictly after `since_iso`."""
+    if not since_iso:
+        return 0
+    try:
+        body = run_gh(
+            [
+                "api",
+                f"repos/{repo}/pulls/{pr_number}/comments",
+                "--paginate",
+                "--jq",
+                "[.[] | {login: .user.login, created_at}]",
+            ]
+        )
+        comments = json.loads(body)
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return 0
+    return count_copilot_after(comments, since_iso)
+
+
+def count_copilot_after(comments: list[dict], since_iso: str) -> int:
+    """Pure helper — counts Copilot comments strictly after `since_iso`.
+
+    Empty `since_iso` returns 0: we can't know "new since push" without a
+    push timestamp, so suppressing the count beats reporting a misleading one.
+    """
+    if not since_iso:
+        return 0
+    total = 0
+    for comment in comments:
+        login = str(comment.get("login") or "")
+        if not COPILOT_LOGIN_RE.search(login):
+            continue
+        created = str(comment.get("created_at") or "")
+        if created <= since_iso:
+            continue
+        total += 1
+    return total
+
+
+def summarize_checks(rollup: list[dict]) -> str:
+    """Collapse a status-check rollup into one of: passing / pending / failing."""
+    has_failing = False
+    has_pending = False
+    for entry in rollup:
+        conclusion = str(entry.get("conclusion") or "").upper()
+        state = str(entry.get("state") or "").upper()
+        status = str(entry.get("status") or "").upper()
+        if conclusion in {"FAILURE", "TIMED_OUT", "STARTUP_FAILURE", "ACTION_REQUIRED"}:
+            has_failing = True
+            continue
+        if state in {"FAILURE", "ERROR"}:
+            has_failing = True
+            continue
+        if status in {"IN_PROGRESS", "QUEUED", "PENDING", "WAITING"}:
+            has_pending = True
+            continue
+        if state == "PENDING":
+            has_pending = True
+    if has_failing:
+        return "failing"
+    if has_pending:
+        return "pending"
+    return "passing"
+
+
+def count_unresolved_threads(threads: list[dict]) -> int:
+    """Count review threads that are still unresolved."""
+    return sum(1 for thread in threads if not bool(thread.get("isResolved")))
+
+
+def fetch_phase_numbering(repo: str, phase_number: int, task_prefix: str) -> PhaseTaskNumbering:
+    """Walk Phase N's sub-issues, regex-extract task numbers from titles."""
+    owner, name = repo.split("/", 1)
+    query = """
+      query($owner: String!, $name: String!, $number: Int!) {
+        repository(owner: $owner, name: $name) {
+          issue(number: $number) {
+            subIssues(first: 100) {
+              nodes { number title }
+            }
+          }
+        }
+      }
+    """
+    raw = json.loads(
+        run_gh(
+            [
+                "api",
+                "graphql",
+                "-f",
+                f"query={query}",
+                "-f",
+                f"owner={owner}",
+                "-f",
+                f"name={name}",
+                "-F",
+                f"number={phase_number}",
+            ]
+        )
+    )
+    nodes = raw["data"]["repository"]["issue"]["subIssues"]["nodes"]
+    titles = [str(node.get("title") or "") for node in nodes]
+    used = extract_task_numbers(titles, task_prefix)
+    return PhaseTaskNumbering(
+        phase_number=phase_number, task_prefix=task_prefix, used_numbers=used
+    )
+
+
+def extract_task_numbers(titles: Iterable[str], task_prefix: str) -> list[int]:
+    """Pull `<task_prefix>.N` numbers out of issue titles.
+
+    Pure for unit tests.
+    """
+    regex = re.compile(TASK_TITLE_RE_TEMPLATE.format(prefix=re.escape(task_prefix)))
+    used: list[int] = []
+    for title in titles:
+        match = regex.match(title)
+        if not match:
+            continue
+        used.append(int(match.group(1)))
+    used.sort()
+    return used
+
+
+def list_worktrees() -> list[dict]:
+    """Parse `git worktree list --porcelain` into a list of plain dicts."""
+    raw = run_git(["worktree", "list", "--porcelain"])
+    return parse_worktree_porcelain(raw)
+
+
+def parse_worktree_porcelain(text: str) -> list[dict]:
+    """Pure parser for `git worktree list --porcelain` output."""
+    entries: list[dict] = []
+    current: dict = {}
+    for line in text.splitlines():
+        if line.strip() == "":
+            if current:
+                entries.append(current)
+                current = {}
+            continue
+        if line.startswith("worktree "):
+            current["path"] = line[len("worktree ") :].strip()
+        elif line.startswith("HEAD "):
+            current["head"] = line[len("HEAD ") :].strip()
+        elif line.startswith("branch "):
+            ref = line[len("branch ") :].strip()
+            current["branch"] = ref.removeprefix("refs/heads/")
+        elif line.startswith("detached"):
+            current["detached"] = True
+        elif line.startswith("bare"):
+            current["bare"] = True
+    if current:
+        entries.append(current)
+    return entries
+
+
+def annotate_worktrees(
+    raw_entries: list[dict],
+    pr_by_branch: dict[str, tuple[int, str]],
+) -> list[WorktreeEntry]:
+    """Cross-reference each worktree with its branch's PR state.
+
+    `pr_by_branch` maps branch -> (pr_number, state). State values match
+    `gh pr view --json state` — MERGED / OPEN / CLOSED.
+    """
+    out: list[WorktreeEntry] = []
+    for entry in raw_entries:
+        if entry.get("bare"):
+            continue
+        branch = entry.get("branch")
+        pr_pair = pr_by_branch.get(branch) if branch else None
+        pr_number = pr_pair[0] if pr_pair else None
+        pr_state = pr_pair[1] if pr_pair else None
+        out.append(
+            WorktreeEntry(
+                path=str(entry.get("path", "")),
+                branch=branch,
+                head=str(entry.get("head", "")),
+                associated_pr_number=pr_number,
+                associated_pr_state=pr_state,
+                safe_to_remove=(pr_state in {"MERGED", "CLOSED"}),
+            )
+        )
+    return out
+
+
+def fetch_pr_state_by_branch(repo: str, branches: list[str]) -> dict[str, tuple[int, str]]:
+    """For each branch name, look up its associated PR's number + state."""
+    out: dict[str, tuple[int, str]] = {}
+    for branch in branches:
+        if not branch:
+            continue
+        try:
+            raw = json.loads(
+                run_gh(
+                    [
+                        "pr",
+                        "view",
+                        branch,
+                        "--repo",
+                        repo,
+                        "--json",
+                        "number,state",
+                    ]
+                )
+            )
+        except subprocess.CalledProcessError:
+            continue
+        out[branch] = (int(raw["number"]), str(raw.get("state", "")))
+    return out
+
+
+def update_chain_from_state(
+    chain: Chain,
+    done_since: list[ClosedPR],
+    in_flight: list[InFlightPR],
+) -> Chain:
+    """Reconcile chain.yaml's status/pr_number columns against live PR state.
+
+    Matching rule: chain title prefix vs. PR title prefix. PR titles often
+    add a `(#N)` suffix that conventional-commit linters insert at merge —
+    we match on the leading `prefix:` segment, which is stable.
+    """
+    merged_by_prefix = {_title_prefix(pr.title): pr for pr in done_since}
+    open_by_prefix = {_title_prefix(pr.title): pr for pr in in_flight}
+    new_rows: list[ChainPR] = []
+    for row in chain.plan_prs:
+        chain_prefix = _title_prefix(row.title)
+        merged_pr = merged_by_prefix.get(chain_prefix)
+        open_pr = open_by_prefix.get(chain_prefix)
+        new_row = ChainPR(**asdict(row))
+        new_row.linked_issue = LinkedIssue(**asdict(row.linked_issue))
+        if merged_pr is not None:
+            new_row.status = "merged"
+            new_row.pr_number = merged_pr.number
+        elif open_pr is not None:
+            new_row.status = "in_flight"
+            new_row.pr_number = open_pr.number
+        new_rows.append(new_row)
+    return Chain(
+        tracking_issue=chain.tracking_issue,
+        repo=chain.repo,
+        parent_phase=chain.parent_phase,
+        task_prefix=chain.task_prefix,
+        plan_prs=new_rows,
+    )
+
+
+def _title_prefix(title: str) -> str:
+    """Return the conventional-commit prefix segment, lowercased.
+
+    `feat(pipeline): foo (#123)` -> `feat(pipeline): foo`. We strip the trailing `(#N)` so chain-
+    row titles (which don't carry the number) match merged-PR titles (which often do).
+    """
+    cleaned = re.sub(r"\s*\(#\d+\)\s*$", "", title.strip())
+    return cleaned.lower()
+
+
+def derive_state(
+    repo: str,
+    tracking_issue: int,
+    chain_path: Path,
+    *,
+    now: datetime | None = None,
+) -> DerivedState:
+    """Top-level orchestration.
+
+    Performs every gh + git call, returns the bundle.
+    """
+    chain = load_chain(chain_path)
+    if chain.tracking_issue != tracking_issue:
+        chain.tracking_issue = tracking_issue
+    if chain.repo != repo:
+        chain.repo = repo
+    comments = fetch_issue_comments(repo, tracking_issue)
+    prior_handoffs = filter_handoff_comments(comments)
+    since_iso = prior_handoffs[0].created_at if prior_handoffs else None
+    done_since = fetch_done_since(repo, tracking_issue, since_iso)
+    in_flight = fetch_in_flight(repo, tracking_issue)
+    chain = update_chain_from_state(chain, done_since, in_flight)
+    phase_numbering = fetch_phase_numbering(repo, chain.parent_phase, chain.task_prefix)
+    raw_worktrees = list_worktrees()
+    branches = [entry.get("branch") for entry in raw_worktrees if entry.get("branch")]
+    pr_by_branch = fetch_pr_state_by_branch(repo, [b for b in branches if b])
+    worktrees = annotate_worktrees(raw_worktrees, pr_by_branch)
+    return DerivedState(
+        repo=repo,
+        tracking_issue=tracking_issue,
+        chain=chain,
+        prior_handoffs=prior_handoffs,
+        done_since=done_since,
+        in_flight=in_flight,
+        phase_numbering=phase_numbering,
+        worktrees=worktrees,
+        now_utc=(now or datetime.now(timezone.utc)).strftime("%Y-%m-%d %H:%M UTC"),
+    )

--- a/.claude/skills/handoff/helpers/discover_state.py
+++ b/.claude/skills/handoff/helpers/discover_state.py
@@ -14,7 +14,7 @@ import json
 import re
 import subprocess
 from collections.abc import Iterable
-from dataclasses import asdict, dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -424,34 +424,43 @@ def _fetch_unresolved_threads(repo: str, pr_number: int) -> int:
     """Count unresolved review threads via GraphQL (not exposed on `pr view`)."""
     owner, name = repo.split("/", 1)
     query = """
-      query($owner: String!, $name: String!, $number: Int!) {
+      query($owner: String!, $name: String!, $number: Int!, $after: String) {
         repository(owner: $owner, name: $name) {
           pullRequest(number: $number) {
-            reviewThreads(first: 100) { nodes { isResolved } }
+            reviewThreads(first: 100, after: $after) {
+              nodes { isResolved }
+              pageInfo { hasNextPage endCursor }
+            }
           }
         }
       }
     """
-    try:
-        raw = json.loads(
-            run_gh(
-                [
-                    "api",
-                    "graphql",
-                    "-f",
-                    f"query={query}",
-                    "-f",
-                    f"owner={owner}",
-                    "-f",
-                    f"name={name}",
-                    "-F",
-                    f"number={pr_number}",
-                ]
-            )
-        )
-    except (subprocess.CalledProcessError, json.JSONDecodeError):
-        return 0
-    nodes = raw["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+    after: str | None = None
+    nodes: list[dict] = []
+    while True:
+        args = [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+            "-F",
+            f"number={pr_number}",
+        ]
+        if after is not None:
+            args += ["-f", f"after={after}"]
+        try:
+            raw = json.loads(run_gh(args))
+        except (subprocess.CalledProcessError, json.JSONDecodeError):
+            return 0
+        page = raw["data"]["repository"]["pullRequest"]["reviewThreads"]
+        nodes.extend(page["nodes"])
+        if not page["pageInfo"]["hasNextPage"]:
+            break
+        after = page["pageInfo"]["endCursor"]
     return count_unresolved_threads(nodes)
 
 
@@ -541,36 +550,47 @@ def count_unresolved_threads(threads: list[dict]) -> int:
 
 
 def fetch_phase_numbering(repo: str, phase_number: int, task_prefix: str) -> PhaseTaskNumbering:
-    """Walk Phase N's sub-issues, regex-extract task numbers from titles."""
+    """Walk Phase N's sub-issues, regex-extract task numbers from titles.
+
+    Paginates GraphQL with `after`/`pageInfo.endCursor` so phases with >100
+    sub-issues don't silently truncate the used-numbers list.
+    """
     owner, name = repo.split("/", 1)
     query = """
-      query($owner: String!, $name: String!, $number: Int!) {
+      query($owner: String!, $name: String!, $number: Int!, $after: String) {
         repository(owner: $owner, name: $name) {
           issue(number: $number) {
-            subIssues(first: 100) {
+            subIssues(first: 100, after: $after) {
               nodes { number title }
+              pageInfo { hasNextPage endCursor }
             }
           }
         }
       }
     """
-    raw = json.loads(
-        run_gh(
-            [
-                "api",
-                "graphql",
-                "-f",
-                f"query={query}",
-                "-f",
-                f"owner={owner}",
-                "-f",
-                f"name={name}",
-                "-F",
-                f"number={phase_number}",
-            ]
-        )
-    )
-    nodes = raw["data"]["repository"]["issue"]["subIssues"]["nodes"]
+    after: str | None = None
+    nodes: list[dict] = []
+    while True:
+        args = [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-f",
+            f"owner={owner}",
+            "-f",
+            f"name={name}",
+            "-F",
+            f"number={phase_number}",
+        ]
+        if after is not None:
+            args += ["-f", f"after={after}"]
+        raw = json.loads(run_gh(args))
+        page = raw["data"]["repository"]["issue"]["subIssues"]
+        nodes.extend(page["nodes"])
+        if not page["pageInfo"]["hasNextPage"]:
+            break
+        after = page["pageInfo"]["endCursor"]
     titles = [str(node.get("title") or "") for node in nodes]
     used = extract_task_numbers(titles, task_prefix)
     return PhaseTaskNumbering(
@@ -700,15 +720,12 @@ def update_chain_from_state(
         chain_prefix = _title_prefix(row.title)
         merged_pr = merged_by_prefix.get(chain_prefix)
         open_pr = open_by_prefix.get(chain_prefix)
-        new_row = ChainPR(**asdict(row))
-        new_row.linked_issue = LinkedIssue(**asdict(row.linked_issue))
         if merged_pr is not None:
-            new_row.status = "merged"
-            new_row.pr_number = merged_pr.number
+            new_rows.append(replace(row, status="merged", pr_number=merged_pr.number))
         elif open_pr is not None:
-            new_row.status = "in_flight"
-            new_row.pr_number = open_pr.number
-        new_rows.append(new_row)
+            new_rows.append(replace(row, status="in_flight", pr_number=open_pr.number))
+        else:
+            new_rows.append(replace(row))
     return Chain(
         tracking_issue=chain.tracking_issue,
         repo=chain.repo,

--- a/.claude/skills/handoff/helpers/discover_state.py
+++ b/.claude/skills/handoff/helpers/discover_state.py
@@ -24,6 +24,10 @@ HANDOFF_HEADER_PREFIX = "## Handoff update"
 TASK_TITLE_RE_TEMPLATE = r"^{prefix}\.(\d+)\b"
 COPILOT_LOGIN_RE = re.compile(r"copilot", re.IGNORECASE)
 
+# Repo root anchor for `git -C` so worktree/branch queries succeed regardless
+# of the caller's CWD. Layout: <repo>/.claude/skills/handoff/helpers/<this file>
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
 
 @dataclass
 class LinkedIssue:
@@ -157,12 +161,12 @@ def run_gh(args: list[str], *, input_text: str | None = None) -> str:
 
 
 def run_git(args: list[str]) -> str:
-    """Invoke git and return stdout.
+    """Invoke git anchored at REPO_ROOT and return stdout.
 
     Raises CalledProcessError on failure.
     """
     result = subprocess.run(  # noqa: S603 — argv list, no shell
-        ["git", *args],
+        ["git", "-C", str(REPO_ROOT), *args],
         capture_output=True,
         text=True,
         check=True,

--- a/.claude/skills/handoff/helpers/discover_state.py
+++ b/.claude/skills/handoff/helpers/discover_state.py
@@ -110,7 +110,7 @@ class PhaseTaskNumbering:
 
     @property
     def next_free(self) -> int:
-        """Return the smallest integer not in `used_numbers` (or 1 if empty)."""
+        """Return one past the maximum used number (or 1 if empty)."""
         return (max(self.used_numbers) + 1) if self.used_numbers else 1
 
 

--- a/.claude/skills/handoff/helpers/discover_state.py
+++ b/.claude/skills/handoff/helpers/discover_state.py
@@ -740,10 +740,9 @@ def derive_state(
     Performs every gh + git call, returns the bundle.
     """
     chain = load_chain(chain_path)
-    if chain.tracking_issue != tracking_issue:
-        chain.tracking_issue = tracking_issue
-    if chain.repo != repo:
-        chain.repo = repo
+    # `tracking_issue` / `repo` args control which issue we *query*. They are
+    # session-scoped overrides from the CLI — never propagate them back into
+    # the manifest, or `--issue 999` would silently rewrite chain.yaml.
     comments = fetch_issue_comments(repo, tracking_issue)
     prior_handoffs = filter_handoff_comments(comments)
     since_iso = prior_handoffs[0].created_at if prior_handoffs else None

--- a/.claude/skills/handoff/helpers/discover_state.py
+++ b/.claude/skills/handoff/helpers/discover_state.py
@@ -456,13 +456,16 @@ def _fetch_unresolved_threads(repo: str, pr_number: int) -> int:
 
 
 def _fetch_commit_committer_date(repo: str, sha: str) -> str:
-    """Return the committer date for `sha` as ISO8601, or empty on failure."""
+    """Return the committer date for `sha` as ISO8601, or empty on failure.
+
+    `gh api --jq` prints scalar jq results unquoted, so we use the stripped stdout directly rather
+    than `json.loads()` — see review on PR #950.
+    """
     try:
-        raw = json.loads(
-            run_gh(["api", f"repos/{repo}/commits/{sha}", "--jq", ".commit.committer.date"])
-        )
-        return str(raw) if not isinstance(raw, dict) else ""
-    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        return run_gh(
+            ["api", f"repos/{repo}/commits/{sha}", "--jq", ".commit.committer.date"]
+        ).strip()
+    except subprocess.CalledProcessError:
         return ""
 
 

--- a/.claude/skills/handoff/helpers/write_handoff.py
+++ b/.claude/skills/handoff/helpers/write_handoff.py
@@ -80,10 +80,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--dry-run", action="store_true", help="Render both, post nothing, print everything"
     )
-    parser.add_argument(
+    output_mode = parser.add_mutually_exclusive_group()
+    output_mode.add_argument(
         "--comment-only", action="store_true", help="Post comment, don't print prompt"
     )
-    parser.add_argument(
+    output_mode.add_argument(
         "--prompt-only", action="store_true", help="Print prompt, don't post comment"
     )
     parser.add_argument(

--- a/.claude/skills/handoff/helpers/write_handoff.py
+++ b/.claude/skills/handoff/helpers/write_handoff.py
@@ -12,14 +12,12 @@ Usage examples:
     python3 .claude/skills/handoff/helpers/write_handoff.py --dry-run
     python3 .claude/skills/handoff/helpers/write_handoff.py --comment-only
     python3 .claude/skills/handoff/helpers/write_handoff.py --prompt-only
-    python3 .claude/skills/handoff/helpers/write_handoff.py --no-prompt-questions
     python3 .claude/skills/handoff/helpers/write_handoff.py --force
 """
 
 from __future__ import annotations
 
 import argparse
-import json
 import re
 import subprocess
 import sys
@@ -39,7 +37,9 @@ else:
 SKILL_DIR = Path(__file__).resolve().parent.parent
 TEMPLATES_DIR = SKILL_DIR / "templates"
 CHAIN_PATH = SKILL_DIR / "chain.yaml"
-DEFAULT_HANDOFFS_DIR = Path(".claude/handoffs")
+# Anchored to the `.claude/` tree (two levels above the skill dir) so the save location is stable
+# regardless of CWD — running the writer from anywhere on disk drops prompts in the same place.
+DEFAULT_HANDOFFS_DIR = SKILL_DIR.parent.parent / "handoffs"
 IDEMPOTENCY_GUARD = timedelta(minutes=30)
 
 
@@ -86,11 +86,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     output_mode.add_argument(
         "--prompt-only", action="store_true", help="Print prompt, don't post comment"
-    )
-    parser.add_argument(
-        "--no-prompt-questions",
-        action="store_true",
-        help="Skip the Surprises/Anti-patterns prompts; render with empty sections",
     )
     parser.add_argument(
         "--force",
@@ -321,24 +316,6 @@ def save_prompt_locally(prompt_md: str, now_utc: str) -> Path:
     out_path = DEFAULT_HANDOFFS_DIR / f"handoff-{stamp}.md"
     out_path.write_text(prompt_md)
     return out_path
-
-
-def fetch_tracking_issue_interactive() -> int:
-    """Ask the user for a tracking-issue number when chain.yaml is missing one.
-
-    Reads stdin — non-interactive callers should set the issue via --issue or populate chain.yaml.
-    Returns the parsed integer or raises ValueError.
-    """
-    sys.stderr.write("Tracking issue not configured. Enter issue number: ")
-    sys.stderr.flush()
-    line = sys.stdin.readline().strip()
-    return int(line)
-
-
-def fetch_pr_url(repo: str, pr_number: int) -> str:
-    """Look up a PR's html_url; helper for templates."""
-    raw = json.loads(ds.run_gh(["pr", "view", str(pr_number), "--repo", repo, "--json", "url"]))
-    return str(raw.get("url", ""))
 
 
 if __name__ == "__main__":

--- a/.claude/skills/handoff/helpers/write_handoff.py
+++ b/.claude/skills/handoff/helpers/write_handoff.py
@@ -1,0 +1,344 @@
+"""Compose, post, and print the /handoff artifacts.
+
+Reads chain.yaml + live GitHub state via `discover_state`, renders the
+comment + prompt templates, optionally posts the comment to the tracking
+issue, prints the prompt to stdout, and (default) saves the prompt to
+`.claude/handoffs/handoff-YYYY-MM-DD-HHMM.md`.
+
+Usage examples:
+
+    python3 .claude/skills/handoff/helpers/write_handoff.py
+    python3 .claude/skills/handoff/helpers/write_handoff.py --issue 882
+    python3 .claude/skills/handoff/helpers/write_handoff.py --dry-run
+    python3 .claude/skills/handoff/helpers/write_handoff.py --comment-only
+    python3 .claude/skills/handoff/helpers/write_handoff.py --prompt-only
+    python3 .claude/skills/handoff/helpers/write_handoff.py --no-prompt-questions
+    python3 .claude/skills/handoff/helpers/write_handoff.py --force
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+if __package__:
+    from . import discover_state as ds
+else:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import discover_state as ds  # type: ignore[import-not-found, no-redef]
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+TEMPLATES_DIR = SKILL_DIR / "templates"
+CHAIN_PATH = SKILL_DIR / "chain.yaml"
+DEFAULT_HANDOFFS_DIR = Path(".claude/handoffs")
+IDEMPOTENCY_GUARD = timedelta(minutes=30)
+
+
+@dataclass(frozen=True)
+class Surprise:
+    """One user-curated surprise row for the comment's Surprises section."""
+
+    category: str
+    note: str
+
+
+@dataclass
+class HandoffContext:
+    """Bundles every field the templates reference."""
+
+    repo: str
+    tracking_issue: int
+    chain: ds.Chain
+    prior_handoffs: list[ds.PriorHandoff]
+    done_since: list[ds.ClosedPR]
+    in_flight: list[ds.InFlightPR]
+    phase_numbering: ds.PhaseTaskNumbering
+    worktrees: list[ds.WorktreeEntry]
+    now_utc: str
+    surprises: list[Surprise]
+    anti_patterns: list[str]
+    handoff_comment_url: str | None
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse the writer's CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--issue", type=int, default=None, help="Override tracking-issue number")
+    parser.add_argument("--chain", type=Path, default=CHAIN_PATH, help="Path to chain.yaml")
+    parser.add_argument("--repo", type=str, default=None, help="Override repo (owner/name)")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Render both, post nothing, print everything"
+    )
+    parser.add_argument(
+        "--comment-only", action="store_true", help="Post comment, don't print prompt"
+    )
+    parser.add_argument(
+        "--prompt-only", action="store_true", help="Print prompt, don't post comment"
+    )
+    parser.add_argument(
+        "--no-prompt-questions",
+        action="store_true",
+        help="Skip the Surprises/Anti-patterns prompts; render with empty sections",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Skip the idempotency guard (refuses to post within 30min of a prior handoff)",
+    )
+    parser.add_argument(
+        "--surprise",
+        action="append",
+        default=[],
+        help='Add a surprise. Format: "<category>: <note>". Repeat for multiple.',
+    )
+    parser.add_argument(
+        "--anti-pattern",
+        action="append",
+        default=[],
+        help="Add an anti-pattern line (the prompt's 'don't retry these' list). Repeat for multiple.",
+    )
+    parser.add_argument(
+        "--no-save-prompt",
+        action="store_true",
+        help="Don't save the prompt to .claude/handoffs/handoff-<timestamp>.md",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """End-to-end: derive state, render, post comment, print + save prompt."""
+    args = parse_args(argv)
+
+    chain_path = args.chain.resolve()
+    if not chain_path.exists():
+        sys.stderr.write(f"chain.yaml not found at {chain_path}\n")
+        return 2
+    chain = ds.load_chain(chain_path)
+    repo = args.repo or chain.repo
+    tracking_issue = args.issue or chain.tracking_issue
+
+    sys.stderr.write(f"Deriving state for {repo} tracking #{tracking_issue}...\n")
+    state = ds.derive_state(repo, tracking_issue, chain_path)
+
+    if not args.force and not args.dry_run:
+        guard_msg = check_idempotency_guard(state.prior_handoffs)
+        if guard_msg:
+            sys.stderr.write(guard_msg + "\nRerun with --force to override.\n")
+            return 3
+
+    surprises = [parse_surprise(raw) for raw in args.surprise]
+    anti_patterns = list(args.anti_pattern)
+
+    if not args.dry_run and not ds.chains_equivalent(chain, state.chain):
+        ds.save_chain(chain_path, state.chain)
+        sys.stderr.write("chain.yaml updated with new status/pr_number values\n")
+
+    context = HandoffContext(
+        repo=state.repo,
+        tracking_issue=state.tracking_issue,
+        chain=state.chain,
+        prior_handoffs=state.prior_handoffs,
+        done_since=state.done_since,
+        in_flight=state.in_flight,
+        phase_numbering=state.phase_numbering,
+        worktrees=state.worktrees,
+        now_utc=state.now_utc,
+        surprises=surprises,
+        anti_patterns=anti_patterns,
+        handoff_comment_url=None,
+    )
+    comment_md = render(context, "comment.md.j2")
+    prompt_md = render(context, "prompt.md.j2")
+
+    if args.dry_run:
+        print(f"===== COMMENT (would-post to issue #{tracking_issue}) =====")
+        print(comment_md)
+        print("===== PROMPT =====")
+        print(prompt_md)
+        return 0
+
+    posted_url = None
+    if not args.prompt_only:
+        posted_url = post_comment(repo, tracking_issue, comment_md)
+        sys.stderr.write(f"Posted handoff comment: {posted_url}\n")
+        context.handoff_comment_url = posted_url
+        prompt_md = render(context, "prompt.md.j2")
+
+    if not args.comment_only:
+        if not args.no_save_prompt:
+            saved = save_prompt_locally(prompt_md, state.now_utc)
+            sys.stderr.write(f"Saved prompt to {saved}\n")
+        print(prompt_md)
+
+    return 0
+
+
+def render(context: HandoffContext, template_name: str) -> str:
+    """Render `template_name` against `context`."""
+    env = Environment(  # noqa: S701 — output is markdown for GitHub, not HTML
+        loader=FileSystemLoader(str(TEMPLATES_DIR)),
+        undefined=StrictUndefined,
+        trim_blocks=False,
+        lstrip_blocks=False,
+        keep_trailing_newline=True,
+    )
+    env.globals["render_ascii_graph"] = render_ascii_graph
+    template = env.get_template(template_name)
+    payload = {
+        "repo": context.repo,
+        "tracking_issue": context.tracking_issue,
+        "chain": context.chain,
+        "prior_handoffs": context.prior_handoffs,
+        "done_since": context.done_since,
+        "in_flight": context.in_flight,
+        "phase_numbering": context.phase_numbering,
+        "worktrees": context.worktrees,
+        "now_utc": context.now_utc,
+        "surprises": context.surprises,
+        "anti_patterns": context.anti_patterns,
+        "handoff_comment_url": context.handoff_comment_url,
+    }
+    return template.render(**payload)
+
+
+def render_ascii_graph(rows: list[ds.ChainPR]) -> str:
+    """Topological-level ASCII graph of `rows`.
+
+    Each row's level is `1 + max(level(dep))` over dependencies that are
+    also in `rows`. Same-level rows are listed on consecutive lines under
+    their parent. Pure function (no I/O) — exported as a Jinja global.
+    """
+    if not rows:
+        return "(no remaining PRs)"
+    by_id = {row.id: row for row in rows}
+    level: dict[str, int] = {}
+    for row in rows:
+        level[row.id] = _compute_level(row.id, by_id, level)
+    levels: dict[int, list[str]] = {}
+    for row_id, lvl in level.items():
+        levels.setdefault(lvl, []).append(row_id)
+    out_lines: list[str] = []
+    for lvl in sorted(levels):
+        indent = "  " * (lvl - 1)
+        for row_id in levels[lvl]:
+            row = by_id[row_id]
+            deps_in = [d for d in row.depends_on if d in by_id]
+            arrow = f"  ← {', '.join(deps_in)}" if deps_in else "  (root)"
+            out_lines.append(f"{indent}{row_id}{arrow}")
+    return "\n".join(out_lines)
+
+
+def _compute_level(row_id: str, by_id: dict[str, ds.ChainPR], cache: dict[str, int]) -> int:
+    """Topological level = 1 + max level of dependencies that are in `by_id`."""
+    if row_id in cache:
+        return cache[row_id]
+    row = by_id[row_id]
+    deps_in = [d for d in row.depends_on if d in by_id]
+    lvl = 1 + max((_compute_level(d, by_id, cache) for d in deps_in), default=0)
+    cache[row_id] = lvl
+    return lvl
+
+
+def check_idempotency_guard(prior_handoffs: list[ds.PriorHandoff]) -> str | None:
+    """Return a string message if a handoff was posted within 30min, else None."""
+    if not prior_handoffs:
+        return None
+    most_recent = prior_handoffs[0]
+    created = parse_iso(most_recent.created_at)
+    if created is None:
+        return None
+    age = datetime.now(timezone.utc) - created
+    if age < IDEMPOTENCY_GUARD:
+        minutes = int(age.total_seconds() // 60)
+        return (
+            f"A prior handoff was posted {minutes}min ago at {most_recent.url}. "
+            f"Refusing to post within the {IDEMPOTENCY_GUARD.seconds // 60}min guard window."
+        )
+    return None
+
+
+def parse_iso(text: str) -> datetime | None:
+    """Parse a GitHub ISO8601 timestamp into a tz-aware datetime."""
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def parse_surprise(raw: str) -> Surprise:
+    """Parse `<category>: <note>` into a Surprise."""
+    match = re.match(r"^([^:]+):\s*(.+)$", raw.strip(), flags=re.DOTALL)
+    if not match:
+        return Surprise(category="Other", note=raw.strip())
+    return Surprise(category=match.group(1).strip(), note=match.group(2).strip())
+
+
+def post_comment(repo: str, issue_number: int, body: str) -> str:
+    """Post the rendered comment to the tracking issue, return its html_url."""
+    with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as fh:
+        fh.write(body)
+        body_path = Path(fh.name)
+    try:
+        raw = subprocess.run(  # noqa: S603 — argv list, no shell
+            [
+                "gh",
+                "issue",
+                "comment",
+                str(issue_number),
+                "--repo",
+                repo,
+                "--body-file",
+                str(body_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    finally:
+        body_path.unlink(missing_ok=True)
+    url = raw.stdout.strip().splitlines()[-1] if raw.stdout.strip() else ""
+    return url
+
+
+def save_prompt_locally(prompt_md: str, now_utc: str) -> Path:
+    """Save the rendered prompt under `.claude/handoffs/`."""
+    DEFAULT_HANDOFFS_DIR.mkdir(parents=True, exist_ok=True)
+    stamp = now_utc.replace(" UTC", "").replace(":", "").replace(" ", "-")
+    out_path = DEFAULT_HANDOFFS_DIR / f"handoff-{stamp}.md"
+    out_path.write_text(prompt_md)
+    return out_path
+
+
+def fetch_tracking_issue_interactive() -> int:
+    """Ask the user for a tracking-issue number when chain.yaml is missing one.
+
+    Reads stdin — non-interactive callers should set the issue via --issue or populate chain.yaml.
+    Returns the parsed integer or raises ValueError.
+    """
+    sys.stderr.write("Tracking issue not configured. Enter issue number: ")
+    sys.stderr.flush()
+    line = sys.stdin.readline().strip()
+    return int(line)
+
+
+def fetch_pr_url(repo: str, pr_number: int) -> str:
+    """Look up a PR's html_url; helper for templates."""
+    raw = json.loads(ds.run_gh(["pr", "view", str(pr_number), "--repo", repo, "--json", "url"]))
+    return str(raw.get("url", ""))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/handoff/helpers/write_handoff.py
+++ b/.claude/skills/handoff/helpers/write_handoff.py
@@ -18,6 +18,7 @@ Usage examples:
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import subprocess
 import sys
@@ -113,7 +114,28 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """End-to-end: derive state, render, post comment, print + save prompt."""
+    """End-to-end: derive state, render, post comment, print + save prompt.
+
+    Catches `subprocess.CalledProcessError` and `json.JSONDecodeError` at the
+    top level so `gh`/`git` failures surface as one-line stderr messages
+    instead of stack traces (per SKILL.md's Step 4 contract).
+    """
+    try:
+        return _main(argv)
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip() if isinstance(exc.stderr, str) else ""
+        cmd = " ".join(map(str, exc.cmd)) if isinstance(exc.cmd, (list, tuple)) else str(exc.cmd)
+        sys.stderr.write(f"command failed (exit {exc.returncode}): {cmd}\n")
+        if stderr:
+            sys.stderr.write(stderr + "\n")
+        return exc.returncode or 1
+    except json.JSONDecodeError as exc:
+        sys.stderr.write(f"could not parse JSON from gh: {exc}\n")
+        return 1
+
+
+def _main(argv: list[str] | None) -> int:
+    """Inner main — exception handling is owned by `main()`."""
     args = parse_args(argv)
 
     chain_path = args.chain.resolve()
@@ -136,9 +158,18 @@ def main(argv: list[str] | None = None) -> int:
     surprises = [parse_surprise(raw) for raw in args.surprise]
     anti_patterns = list(args.anti_pattern)
 
-    if not args.dry_run and not ds.chains_equivalent(chain, state.chain):
+    # Don't persist status/pr_number changes back to chain.yaml when a CLI
+    # override is in play — the reconciliation was computed against a
+    # different issue/repo than the manifest's canonical pair.
+    overrides_in_play = args.issue is not None or args.repo is not None
+    if not args.dry_run and not overrides_in_play and not ds.chains_equivalent(chain, state.chain):
         ds.save_chain(chain_path, state.chain)
         sys.stderr.write("chain.yaml updated with new status/pr_number values\n")
+    elif not args.dry_run and overrides_in_play:
+        sys.stderr.write(
+            "chain.yaml not updated: --issue/--repo override in play; "
+            "status/pr_number reconciliation kept session-local.\n"
+        )
 
     context = HandoffContext(
         repo=state.repo,
@@ -235,13 +266,26 @@ def render_ascii_graph(rows: list[ds.ChainPR]) -> str:
     return "\n".join(out_lines)
 
 
-def _compute_level(row_id: str, by_id: dict[str, ds.ChainPR], cache: dict[str, int]) -> int:
-    """Topological level = 1 + max level of dependencies that are in `by_id`."""
+def _compute_level(
+    row_id: str,
+    by_id: dict[str, ds.ChainPR],
+    cache: dict[str, int],
+    visiting: tuple[str, ...] = (),
+) -> int:
+    """Topological level = 1 + max level of dependencies that are in `by_id`.
+
+    Tracks the current DFS path in `visiting` so cycles surface as a
+    descriptive ValueError instead of a Python RecursionError.
+    """
     if row_id in cache:
         return cache[row_id]
+    if row_id in visiting:
+        cycle_path = " → ".join([*visiting, row_id])
+        raise ValueError(f"Cycle detected in chain.yaml dependencies: {cycle_path}")
     row = by_id[row_id]
     deps_in = [d for d in row.depends_on if d in by_id]
-    lvl = 1 + max((_compute_level(d, by_id, cache) for d in deps_in), default=0)
+    next_visiting = (*visiting, row_id)
+    lvl = 1 + max((_compute_level(d, by_id, cache, next_visiting) for d in deps_in), default=0)
     cache[row_id] = lvl
     return lvl
 

--- a/.claude/skills/handoff/templates/comment.md.j2
+++ b/.claude/skills/handoff/templates/comment.md.j2
@@ -64,7 +64,7 @@ _No open PRs reference this tracking issue._
 | Plan PR | Status | PR # | Title | Source-commit pointer | Linked issue | Notes |
 |---------|--------|------|-------|-----------------------|--------------|-------|
 {% for pr in remaining -%}
-| {{ pr.id }} | {{ pr.status }} | {% if pr.pr_number %}#{{ pr.pr_number }}{% else %}—{% endif %} | `{{ pr.title }}` | {{ pr.source_commits | join(", ") }} | {% if pr.linked_issue.existing %}existing #{{ pr.linked_issue.existing }}{% else %}create under #{{ chain.parent_phase }}{% endif %} | {% if pr.notes %}{{ pr.notes | join(" / ") }}{% else %}—{% endif %} |
+| {{ pr.id }} | {{ pr.status }} | {% if pr.pr_number %}#{{ pr.pr_number }}{% else %}—{% endif %} | `{{ pr.title }}` | {{ pr.source_commits | join(", ") }} | {% if pr.linked_issue.existing %}existing #{{ pr.linked_issue.existing }}{% elif pr.linked_issue.parent_issue %}create under #{{ pr.linked_issue.parent_issue }}{% else %}create under #{{ chain.parent_phase }}{% endif %} | {% if pr.notes %}{{ pr.notes | join(" / ") }}{% else %}—{% endif %} |
 {% endfor %}
 
 #### Dependency graph
@@ -83,7 +83,11 @@ _The chain is complete — every plan PR has merged._
 {% if phase_numbering.used_numbers -%}
 Used `{{ chain.task_prefix }}.N` numbers: {{ phase_numbering.used_numbers | join(", ") }}.
 
+{% if remaining -%}
 Next free numbers, in order: **{% for offset in range(remaining | length) %}{{ chain.task_prefix }}.{{ phase_numbering.next_free + offset }}{% if not loop.last %}, {% endif %}{% endfor %}** — assign in plan-PR order.
+{%- else -%}
+Next free number: **`{{ chain.task_prefix }}.{{ phase_numbering.next_free }}`** (chain is complete; reserved for any follow-up Task).
+{%- endif %}
 {%- else -%}
 No existing `{{ chain.task_prefix }}.N` issues found under Phase #{{ chain.parent_phase }}. Start at `{{ chain.task_prefix }}.1`.
 {%- endif %}

--- a/.claude/skills/handoff/templates/comment.md.j2
+++ b/.claude/skills/handoff/templates/comment.md.j2
@@ -1,0 +1,143 @@
+## Handoff update — chain progress as of {{ now_utc }}
+
+{% if prior_handoffs -%}
+{%- set breadcrumbs = [] -%}
+{%- for handoff in prior_handoffs[:3] -%}
+{%- set _ = breadcrumbs.append("[" ~ handoff.created_at[:10] ~ " handoff](" ~ handoff.url ~ ")") -%}
+{%- endfor -%}
+Predecessors: {{ breadcrumbs | join(" ← ") }}{% if prior_handoffs | length > 3 %} ← …{% endif %}
+{% else -%}
+First handoff on tracking issue #{{ tracking_issue }}.
+{% endif %}
+
+A fresh agent reading just this comment + the linked predecessor handoffs should be able to pick the work up.
+
+### Done since the prior handoff
+
+{% if done_since -%}
+| PR | Title | Closes |
+|----|-------|--------|
+{% for pr in done_since -%}
+| #{{ pr.number }} | `{{ pr.title }}` | {% if pr.closes_issues %}{% for n in pr.closes_issues %}#{{ n }}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}—{% endif %} |
+{% endfor %}
+{%- else -%}
+_No new merges referencing this tracking issue since the prior handoff._
+{%- endif %}
+
+### In flight (awaiting maintainer approval or further work)
+
+{% if in_flight -%}
+{% for pr in in_flight %}
+#### PR #{{ pr.number }} — `{{ pr.title }}`
+
+- **Branch:** `{{ pr.branch }}` at `{{ pr.head_oid[:7] }}`
+- **Checks:** {{ pr.checks_state }} · **Mergeable:** {{ pr.mergeable }} · **Review decision:** {{ pr.review_decision }}
+- **Unresolved review threads:** {{ pr.unresolved_threads }} · **New Copilot comments since last push:** {{ pr.new_copilot_comments_since_push }}
+
+##### Next action
+
+{%- if pr.checks_state == "failing" %}
+Fix the failing checks, push, reply inline to each affected review thread linking the fix SHA, then re-poll.
+{%- elif pr.mergeable == "CONFLICTING" %}
+Rebase or merge base, resolve conflicts, push. Reply inline to any review threads invalidated by the rebase.
+{%- elif pr.unresolved_threads > 0 or pr.new_copilot_comments_since_push > 0 %}
+Address the {{ pr.unresolved_threads }} unresolved thread(s) + {{ pr.new_copilot_comments_since_push }} new Copilot comment(s); reply inline linking the fix SHA. Use `/pr-review-resolver`.
+{%- elif pr.review_decision == "REVIEW_REQUIRED" %}
+Wait for maintainer approval — all CI green, mergeable, no open threads.
+{%- elif pr.review_decision == "APPROVED" and pr.mergeable == "MERGEABLE" and pr.checks_state == "passing" %}
+Ready to merge. Confirm with the maintainer, then `gh pr merge --squash`.
+{%- else %}
+Re-poll status; nothing obvious blocking.
+{%- endif %}
+{% endfor %}
+{%- else -%}
+_No open PRs reference this tracking issue._
+{%- endif %}
+
+### Remaining chain (next agent: start here)
+
+{% set remaining = chain.plan_prs | rejectattr("status", "equalto", "merged") | list -%}
+{% if remaining -%}
+<details>
+<summary>Click to expand the {{ remaining | length }}-row table</summary>
+
+| Plan PR | Status | PR # | Title | Source-commit pointer | Linked issue | Notes |
+|---------|--------|------|-------|-----------------------|--------------|-------|
+{% for pr in remaining -%}
+| {{ pr.id }} | {{ pr.status }} | {% if pr.pr_number %}#{{ pr.pr_number }}{% else %}—{% endif %} | `{{ pr.title }}` | {{ pr.source_commits | join(", ") }} | {% if pr.linked_issue.existing %}existing #{{ pr.linked_issue.existing }}{% else %}create under #{{ chain.parent_phase }}{% endif %} | {% if pr.notes %}{{ pr.notes | join(" / ") }}{% else %}—{% endif %} |
+{% endfor %}
+
+#### Dependency graph
+
+```
+{{ render_ascii_graph(remaining) }}
+```
+
+</details>
+{%- else -%}
+_The chain is complete — every plan PR has merged._
+{%- endif %}
+
+### Task numbering — current state of Phase #{{ chain.parent_phase }}
+
+{% if phase_numbering.used_numbers -%}
+Used `{{ chain.task_prefix }}.N` numbers: {{ phase_numbering.used_numbers | join(", ") }}.
+
+Next free numbers, in order: **{% for offset in range(remaining | length) %}{{ chain.task_prefix }}.{{ phase_numbering.next_free + offset }}{% if not loop.last %}, {% endif %}{% endfor %}** — assign in plan-PR order.
+{%- else -%}
+No existing `{{ chain.task_prefix }}.N` issues found under Phase #{{ chain.parent_phase }}. Start at `{{ chain.task_prefix }}.1`.
+{%- endif %}
+
+### Recommended task list for the next agent
+
+{% set first_remaining = remaining[0] if remaining else None -%}
+{% if first_remaining -%}
+1. **Check on any in-flight PRs above.** Each has a Next-action sub-bullet — execute it. Use `/loop 2m gh pr checks <N>` to drive the iteration.
+2. **Once in-flight PRs merge**, file the next Task under Phase #{{ chain.parent_phase }} (next free: `{{ chain.task_prefix }}.{{ phase_numbering.next_free }}`) via `/github-taxonomy`, branch off the latest `origin/main`, and start **{{ first_remaining.id }}** (`{{ first_remaining.title }}`).
+3. **Apply mandatory skills cycle:** `/tdd-implementation` → `/code-health` → `/simplify` on every code-touching PR.
+4. **Drive the rest of the chain in waves** — non-dependent PRs can land in parallel via `/wave-orchestration`.
+{%- else -%}
+1. **The chain is done.** Close out any open follow-ups and archive the worktree(s) listed below.
+{%- endif %}
+
+### Local worktree inventory at handoff
+
+{% set tracked = worktrees | selectattr("branch") | list -%}
+{% if tracked -%}
+{% for entry in tracked -%}
+- `{{ entry.path }}` — branch `{{ entry.branch }}`, head `{{ entry.head[:7] }}`{% if entry.associated_pr_number %} → PR #{{ entry.associated_pr_number }} ({{ entry.associated_pr_state }}){% endif %}{% if entry.safe_to_remove %} · **safe to `git worktree remove`**{% endif %}
+{% endfor %}
+{%- else -%}
+_No additional worktrees on disk._
+{%- endif %}
+{%- set detached_count = worktrees | rejectattr("branch") | list | length -%}
+{%- if detached_count %}
+
+_({{ detached_count }} detached worktrees omitted — typically `/tmp` and `data/` test fixtures.)_
+{%- endif %}
+
+### Surprises this session
+
+{% if surprises -%}
+{% for s in surprises -%}
+- **{{ s.category }}:** {{ s.note }}
+{% endfor %}
+{%- else -%}
+_No surprises recorded._
+{%- endif %}
+
+### Conventions to keep applying
+
+These have been working — the next agent should keep them:
+
+- **One PR = one review surface.** Foundation PRs touch one logical concern each.
+- **Conventional-commit prefix drives semver.** `internal-feat` / `internal-fix` for non-user-facing scaffolding; `feat` / `fix` for user-facing changes; `feat!` for breaking.
+- **CLAUDE.md PR Readiness rule:** a PR is not ready until CI green + `MERGEABLE` + every Copilot thread has an inline reply + Copilot has produced no new comments since the last push. Use `/loop` to drive iteration; don't stop at "I pushed the fix."
+- **`/pr-review-resolver`** for triaging Copilot rounds — addresses every thread, posts inline replies linking the fix SHA, resolves via GraphQL.
+- **`doc-drift` advisory is real signal** — don't dismiss "out of scope" findings without checking.
+- **Mandatory skills cycle:** `/tdd-implementation` → `/code-health` → `/simplify`. Pure docs are exempt.
+- **Taxonomy compliance:** every PR's linked issue needs Type + Domain label + Milestone + Phase parent + Project + Priority. Run `/github-taxonomy` before `gh pr create`.
+
+---
+
+_Generated by `.claude/skills/handoff` from `chain.yaml`. To regenerate, run `/handoff`._

--- a/.claude/skills/handoff/templates/prompt.md.j2
+++ b/.claude/skills/handoff/templates/prompt.md.j2
@@ -1,0 +1,113 @@
+# Continuing the chain rooted at #{{ tracking_issue }}
+
+START HERE: {{ handoff_comment_url or "(handoff comment URL will be inserted on post)" }}
+
+## Run these three commands first to sync with the chain's current state
+
+```bash
+git fetch origin --prune
+{% if in_flight -%}
+{% for pr in in_flight -%}
+gh pr view {{ pr.number }} --repo {{ repo }} --json mergeable,reviewDecision,statusCheckRollup
+{% endfor -%}
+{% else -%}
+# (no in-flight PRs to poll)
+{% endif -%}
+git worktree list
+```
+
+## Default action
+
+{% set first_remaining = (chain.plan_prs | rejectattr("status", "equalto", "merged") | list)[0] if (chain.plan_prs | rejectattr("status", "equalto", "merged") | list) else None -%}
+{% if in_flight -%}
+**Default: drive the in-flight PR(s) above to merge before starting new work.**
+
+For each in-flight PR:
+1. Run `gh pr checks <N> --watch` until checks complete.
+2. If checks fail, diagnose, fix, push, return to step 1.
+3. Check `gh pr view <N> --json mergeable -q .mergeable` — must be `MERGEABLE`.
+4. Use `/pr-review-resolver` to address every open review thread + Copilot comment.
+5. Once green + mergeable + zero open threads, hand back to the maintainer for approval.
+
+Deviate only if:
+- The maintainer explicitly asks you to start a parallel PR first.
+- An in-flight PR is blocked on an external dependency you can't unblock — note in a comment and proceed to the next-remaining chain PR.
+
+{% endif -%}
+{% if first_remaining -%}
+**Next remaining PR after the in-flight ones merge:** {{ first_remaining.id }} — `{{ first_remaining.title }}`
+{% if first_remaining.source_commits -%}
+Source commits on the umbrella branch: {{ first_remaining.source_commits | join(", ") }}
+{% endif -%}
+{% if first_remaining.notes -%}
+Notes:
+{% for note in first_remaining.notes -%}
+- {{ note }}
+{% endfor -%}
+{% endif -%}
+{% if first_remaining.linked_issue.existing -%}
+Link to issue: existing #{{ first_remaining.linked_issue.existing }}
+{% else -%}
+Link to issue: create a new Task under Phase #{{ chain.parent_phase }} (next free: `{{ chain.task_prefix }}.{{ phase_numbering.next_free }}`) via `/github-taxonomy`.
+{% endif -%}
+{% endif %}
+
+## Execution graph (remaining PRs)
+
+```
+{{ render_ascii_graph(chain.plan_prs | rejectattr("status", "equalto", "merged") | list) }}
+```
+
+## Mandatory skills cycle
+
+Every code-touching PR MUST go through, in order:
+
+1. `/tdd-implementation` — drive test-first; pin behavior before writing code.
+2. `/code-health` — review and clean up after green.
+3. `/simplify` — final reuse and efficiency pass.
+
+Pure-documentation edits (`.md`, `docs/`) are exempt; nothing else is.
+
+## Anti-patterns (don't retry these)
+
+{% if anti_patterns -%}
+{% for ap in anti_patterns -%}
+- {{ ap }}
+{% endfor -%}
+{% else -%}
+- _No anti-patterns recorded from the prior session._
+{% endif %}
+
+## PR readiness checklist (CLAUDE.md hard rule)
+
+A PR is not ready until **all** of:
+
+1. All CI checks pass (required + optional).
+2. `gh pr view <N> --json mergeable -q .mergeable` reports `MERGEABLE`.
+3. Every open review thread (human + Copilot) has either a code change linked by commit SHA, or an inline reply with justification.
+4. Copilot has produced no new comments since the last push (poll ~60s after push).
+
+"I pushed the fix" is not "the PR is ready." Iterate with `/loop` until all four conditions hold.
+
+## Worktree inventory you're inheriting
+
+{% set tracked = worktrees | selectattr("branch") | list -%}
+{% if tracked -%}
+{% for entry in tracked -%}
+- `{{ entry.path }}` — `{{ entry.branch }}`{% if entry.associated_pr_number %} → PR #{{ entry.associated_pr_number }} ({{ entry.associated_pr_state }}){% endif %}{% if entry.safe_to_remove %} — **safe to `git worktree remove`**{% endif %}
+{% endfor -%}
+{% else -%}
+_No worktrees inherited._
+{% endif %}
+
+## Reference
+
+- Tracking issue: {{ tracking_issue }}
+- Chain manifest: `.claude/skills/handoff/chain.yaml`
+- Regenerate this prompt: `/handoff`
+- Predecessor handoffs (most recent first):
+{%- for handoff in prior_handoffs[:5] %}
+  - {{ handoff.url }} ({{ handoff.created_at[:10] }})
+{%- else %}
+  _(none — this is the first handoff)_
+{%- endfor %}

--- a/.claude/skills/handoff/templates/prompt.md.j2
+++ b/.claude/skills/handoff/templates/prompt.md.j2
@@ -47,6 +47,8 @@ Notes:
 {% endif -%}
 {% if first_remaining.linked_issue.existing -%}
 Link to issue: existing #{{ first_remaining.linked_issue.existing }}
+{% elif first_remaining.linked_issue.parent_issue -%}
+Link to issue: create a new Task under #{{ first_remaining.linked_issue.parent_issue }} (next free: `{{ chain.task_prefix }}.{{ phase_numbering.next_free }}`) via `/github-taxonomy`.
 {% else -%}
 Link to issue: create a new Task under Phase #{{ chain.parent_phase }} (next free: `{{ chain.task_prefix }}.{{ phase_numbering.next_free }}`) via `/github-taxonomy`.
 {% endif -%}

--- a/.claude/skills/handoff/tests/test_discover_state.py
+++ b/.claude/skills/handoff/tests/test_discover_state.py
@@ -315,6 +315,20 @@ def test_fetch_commit_committer_date_returns_empty_on_subprocess_failure(
     assert ds._fetch_commit_committer_date("org/repo", "abc1234") == ""
 
 
+def test_update_chain_from_state_preserves_tracking_issue_and_repo() -> None:
+    """Session-scoped overrides must NOT bleed back into the saved chain."""
+    chain = ds.Chain(
+        tracking_issue=882,
+        repo="tinaudio/synth-setter",
+        parent_phase=72,
+        task_prefix="Task 5",
+        plan_prs=[ds.ChainPR(id="PR-5", title="foo")],
+    )
+    out = ds.update_chain_from_state(chain, done_since=[], in_flight=[])
+    assert out.tracking_issue == 882
+    assert out.repo == "tinaudio/synth-setter"
+
+
 def test_load_chain_reads_the_shipped_chain_yaml() -> None:
     """The chain.yaml shipped with the skill loads cleanly into a Chain."""
     chain = ds.load_chain(SKILL_ROOT / "chain.yaml")

--- a/.claude/skills/handoff/tests/test_discover_state.py
+++ b/.claude/skills/handoff/tests/test_discover_state.py
@@ -350,3 +350,108 @@ def test_load_chain_reads_the_shipped_chain_yaml() -> None:
     ]
     pr7 = next(pr for pr in chain.plan_prs if pr.id == "PR-7")
     assert any("b516b67" in note for note in pr7.notes)
+
+
+def test_update_chain_from_state_keeps_linked_issue_as_dataclass() -> None:
+    """`linked_issue` survives reconciliation as a LinkedIssue, not a dict."""
+    chain = ds.Chain(
+        tracking_issue=882,
+        repo="org/repo",
+        parent_phase=72,
+        task_prefix="Task 5",
+        plan_prs=[
+            ds.ChainPR(
+                id="PR-5",
+                title="t",
+                linked_issue=ds.LinkedIssue(strategy="existing", existing=874),
+            )
+        ],
+    )
+    out = ds.update_chain_from_state(chain, done_since=[], in_flight=[])
+    assert isinstance(out.plan_prs[0].linked_issue, ds.LinkedIssue)
+    assert out.plan_prs[0].linked_issue.existing == 874
+
+
+def test_fetch_phase_numbering_paginates_subissues(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Phase numbering walks the GraphQL pageInfo loop and merges all pages."""
+    import json as _json
+
+    pages = [
+        {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "subIssues": {
+                            "nodes": [{"number": 1, "title": "Task 5.1: a"}],
+                            "pageInfo": {"hasNextPage": True, "endCursor": "c1"},
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "data": {
+                "repository": {
+                    "issue": {
+                        "subIssues": {
+                            "nodes": [{"number": 2, "title": "Task 5.2: b"}],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        }
+                    }
+                }
+            }
+        },
+    ]
+    calls: list[list[str]] = []
+
+    def fake_run_gh(args: list[str]) -> str:
+        calls.append(args)
+        return _json.dumps(pages[len(calls) - 1])
+
+    monkeypatch.setattr(ds, "run_gh", fake_run_gh)
+    out = ds.fetch_phase_numbering("org/repo", phase_number=72, task_prefix="Task 5")
+    assert out.used_numbers == [1, 2]
+    assert len(calls) == 2
+    second_call_has_cursor = any("after=c1" in s for s in calls[1])
+    assert second_call_has_cursor
+
+
+def test_fetch_unresolved_threads_paginates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Review-thread fetcher walks the pageInfo loop and counts across pages."""
+    import json as _json
+
+    pages = [
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [{"isResolved": False}, {"isResolved": True}],
+                            "pageInfo": {"hasNextPage": True, "endCursor": "c1"},
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [{"isResolved": False}],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        }
+                    }
+                }
+            }
+        },
+    ]
+    calls: list[list[str]] = []
+
+    def fake_run_gh(args: list[str]) -> str:
+        calls.append(args)
+        return _json.dumps(pages[len(calls) - 1])
+
+    monkeypatch.setattr(ds, "run_gh", fake_run_gh)
+    assert ds._fetch_unresolved_threads("org/repo", 42) == 2
+    assert len(calls) == 2

--- a/.claude/skills/handoff/tests/test_discover_state.py
+++ b/.claude/skills/handoff/tests/test_discover_state.py
@@ -1,0 +1,307 @@
+"""Unit tests for handoff/helpers/discover_state.py — pure functions only."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_ROOT))
+
+from helpers import discover_state as ds  # noqa: E402
+
+
+def test_filter_handoff_comments_picks_only_handoff_headers() -> None:
+    """Filter handoff comments picks only handoff headers."""
+    comments = [
+        {
+            "databaseId": 1,
+            "url": "u1",
+            "createdAt": "2026-05-10T00:00:00Z",
+            "body": "## Handoff update — A",
+        },
+        {
+            "databaseId": 2,
+            "url": "u2",
+            "createdAt": "2026-05-09T00:00:00Z",
+            "body": "Some unrelated comment.",
+        },
+        {
+            "databaseId": 3,
+            "url": "u3",
+            "createdAt": "2026-05-11T00:00:00Z",
+            "body": "## Handoff update — B",
+        },
+        {
+            "databaseId": 4,
+            "url": "u4",
+            "createdAt": "2026-05-08T00:00:00Z",
+            "body": "## Other heading",
+        },
+    ]
+    handoffs = ds.filter_handoff_comments(comments)
+    assert [h.comment_id for h in handoffs] == [3, 1]
+    assert handoffs[0].url == "u3"
+    assert handoffs[0].created_at > handoffs[1].created_at
+
+
+def test_filter_handoff_comments_empty_input_returns_empty() -> None:
+    """Filter handoff comments empty input returns empty."""
+    assert ds.filter_handoff_comments([]) == []
+
+
+def test_extract_task_numbers_matches_prefix_and_sorts() -> None:
+    """Extract task numbers matches prefix and sorts."""
+    titles = [
+        "Task 5.1: Schemas",
+        "Task 5.10: WDS Writer",
+        "Task 5.3: Code Health",
+        "Task 6.1: Different Phase",  # ignored
+        "Bug: unrelated",
+    ]
+    assert ds.extract_task_numbers(titles, "Task 5") == [1, 3, 10]
+
+
+def test_extract_task_numbers_no_matches_returns_empty() -> None:
+    """Extract task numbers no matches returns empty."""
+    assert ds.extract_task_numbers(["nothing here", "Task 6.1: bar"], "Task 5") == []
+
+
+def test_phase_numbering_next_free_skips_one_past_max() -> None:
+    """Phase numbering next free skips one past max."""
+    numbering = ds.PhaseTaskNumbering(
+        phase_number=72, task_prefix="Task 5", used_numbers=[1, 3, 7]
+    )
+    assert numbering.next_free == 8
+
+
+def test_phase_numbering_next_free_when_empty_starts_at_one() -> None:
+    """Phase numbering next free when empty starts at one."""
+    numbering = ds.PhaseTaskNumbering(phase_number=72, task_prefix="Task 5", used_numbers=[])
+    assert numbering.next_free == 1
+
+
+def test_parse_worktree_porcelain_parses_typical_output() -> None:
+    """Parse worktree porcelain parses typical output."""
+    text = (
+        "worktree /home/build/synth-setter\n"
+        "HEAD abc123\n"
+        "branch refs/heads/main\n"
+        "\n"
+        "worktree /home/build/synth-setter/.claude.worktrees/pr-4-render-config\n"
+        "HEAD def456\n"
+        "branch refs/heads/pr-4-render-config\n"
+        "\n"
+        "worktree /tmp/detached\n"
+        "HEAD 789abc\n"
+        "detached\n"
+        "\n"
+    )
+    entries = ds.parse_worktree_porcelain(text)
+    assert len(entries) == 3
+    assert entries[0]["branch"] == "main"
+    assert entries[1]["branch"] == "pr-4-render-config"
+    assert entries[2].get("detached") is True
+    assert "branch" not in entries[2]
+
+
+def test_parse_worktree_porcelain_empty_returns_empty() -> None:
+    """Parse worktree porcelain empty returns empty."""
+    assert ds.parse_worktree_porcelain("") == []
+
+
+def test_annotate_worktrees_marks_merged_safe_to_remove() -> None:
+    """Annotate worktrees marks merged safe to remove."""
+    raw = [
+        {"path": "/a", "head": "h1", "branch": "feat-x"},
+        {"path": "/b", "head": "h2", "branch": "feat-y"},
+        {"path": "/c", "head": "h3", "branch": "feat-z"},
+    ]
+    pr_by_branch = {
+        "feat-x": (101, "MERGED"),
+        "feat-y": (102, "OPEN"),
+        # feat-z has no PR
+    }
+    out = ds.annotate_worktrees(raw, pr_by_branch)
+    by_branch = {entry.branch: entry for entry in out}
+    assert by_branch["feat-x"].safe_to_remove is True
+    assert by_branch["feat-x"].associated_pr_number == 101
+    assert by_branch["feat-y"].safe_to_remove is False
+    assert by_branch["feat-z"].safe_to_remove is False
+    assert by_branch["feat-z"].associated_pr_number is None
+
+
+def test_count_copilot_after_filters_by_login_and_timestamp() -> None:
+    """Count copilot after filters by login and timestamp."""
+    comments = [
+        {"login": "copilot", "created_at": "2026-05-11T00:00:00Z"},
+        {"login": "Copilot", "created_at": "2026-05-12T00:00:00Z"},
+        {"login": "human-reviewer", "created_at": "2026-05-12T00:00:00Z"},
+        {"login": "copilot-pr-reviewer[bot]", "created_at": "2026-05-09T00:00:00Z"},
+    ]
+    # since_iso == push time; only strictly-after Copilot comments count.
+    count = ds.count_copilot_after(comments, "2026-05-10T00:00:00Z")
+    assert count == 2
+
+
+def test_count_copilot_after_zero_when_since_empty() -> None:
+    """Count copilot after zero when since empty."""
+    comments = [{"login": "copilot", "created_at": "2026-05-12T00:00:00Z"}]
+    assert ds.count_copilot_after(comments, "") == 0
+
+
+def test_summarize_checks_failing_beats_pending_beats_passing() -> None:
+    """Summarize checks failing beats pending beats passing."""
+    failing = [
+        {"conclusion": "SUCCESS"},
+        {"conclusion": "FAILURE"},
+        {"status": "IN_PROGRESS"},
+    ]
+    assert ds.summarize_checks(failing) == "failing"
+
+    pending = [
+        {"conclusion": "SUCCESS"},
+        {"status": "IN_PROGRESS"},
+    ]
+    assert ds.summarize_checks(pending) == "pending"
+
+    passing = [
+        {"conclusion": "SUCCESS"},
+        {"conclusion": "NEUTRAL"},
+        {"conclusion": "SKIPPED"},
+    ]
+    assert ds.summarize_checks(passing) == "passing"
+
+
+def test_summarize_checks_empty_is_passing() -> None:
+    """Summarize checks empty is passing."""
+    assert ds.summarize_checks([]) == "passing"
+
+
+def test_count_unresolved_threads_filters_resolved() -> None:
+    """Count unresolved threads filters resolved."""
+    threads = [
+        {"isResolved": True},
+        {"isResolved": False},
+        {"isResolved": False},
+        {},
+    ]
+    assert ds.count_unresolved_threads(threads) == 3
+
+
+def test_title_prefix_strips_trailing_pr_number_suffix() -> None:
+    """Title prefix strips trailing pr number suffix."""
+    assert ds._title_prefix("feat(pipeline): foo (#123)") == "feat(pipeline): foo"
+    assert ds._title_prefix("internal-fix(schemas): bar") == "internal-fix(schemas): bar"
+    assert ds._title_prefix("Feat(Pipeline): Foo (#42)") == "feat(pipeline): foo"
+
+
+def test_update_chain_from_state_promotes_merged_and_in_flight() -> None:
+    """Update chain from state promotes merged and in flight."""
+    chain = ds.Chain(
+        tracking_issue=882,
+        repo="org/repo",
+        parent_phase=72,
+        task_prefix="Task 5",
+        plan_prs=[
+            ds.ChainPR(id="PR-5", title="refactor(pipeline): relocate pipeline → src/pipeline"),
+            ds.ChainPR(
+                id="PR-6", title="internal-fix(pipeline): post-relocation doc + comment sweep"
+            ),
+            ds.ChainPR(id="PR-7", title="internal-fix(schemas): tighten validators"),
+        ],
+    )
+    done_since = [
+        ds.ClosedPR(
+            number=999,
+            title="refactor(pipeline): relocate pipeline → src/pipeline (#999)",
+            merged_at="2026-05-12T00:00:00Z",
+            closes_issues=[],
+        )
+    ]
+    in_flight = [
+        ds.InFlightPR(
+            number=1001,
+            title="internal-fix(pipeline): post-relocation doc + comment sweep",
+            branch="b",
+            head_oid="h",
+            head_committer_date="",
+            mergeable="MERGEABLE",
+            review_decision="REVIEW_REQUIRED",
+            checks_state="passing",
+            unresolved_threads=0,
+            new_copilot_comments_since_push=0,
+        )
+    ]
+    out = ds.update_chain_from_state(chain, done_since, in_flight)
+    by_id = {row.id: row for row in out.plan_prs}
+    assert by_id["PR-5"].status == "merged"
+    assert by_id["PR-5"].pr_number == 999
+    assert by_id["PR-6"].status == "in_flight"
+    assert by_id["PR-6"].pr_number == 1001
+    assert by_id["PR-7"].status == "pending"
+    assert by_id["PR-7"].pr_number is None
+
+
+def test_chain_round_trip_preserves_fields(tmp_path: Path) -> None:
+    """Chain round trip preserves fields."""
+    chain = ds.Chain(
+        tracking_issue=882,
+        repo="org/repo",
+        parent_phase=72,
+        task_prefix="Task 5",
+        plan_prs=[
+            ds.ChainPR(
+                id="PR-5",
+                title="refactor(pipeline): relocate",
+                source_commits=["aaa", "bbb"],
+                notes=["watch this one"],
+                linked_issue=ds.LinkedIssue(strategy="existing", existing=874),
+                status="merged",
+                pr_number=999,
+                depends_on=[],
+            ),
+            ds.ChainPR(
+                id="PR-6",
+                title="internal-fix(pipeline): foo",
+                depends_on=["PR-5"],
+            ),
+        ],
+    )
+    path = tmp_path / "chain.yaml"
+    ds.save_chain(path, chain)
+    reloaded = ds.load_chain(path)
+    assert reloaded.tracking_issue == 882
+    assert reloaded.task_prefix == "Task 5"
+    assert len(reloaded.plan_prs) == 2
+    pr5 = reloaded.plan_prs[0]
+    assert pr5.source_commits == ["aaa", "bbb"]
+    assert pr5.notes == ["watch this one"]
+    assert pr5.linked_issue.strategy == "existing"
+    assert pr5.linked_issue.existing == 874
+    assert pr5.status == "merged"
+    assert pr5.pr_number == 999
+    assert reloaded.plan_prs[1].depends_on == ["PR-5"]
+
+
+def test_load_chain_reads_the_shipped_chain_yaml() -> None:
+    """The chain.yaml shipped with the skill loads cleanly into a Chain."""
+    chain = ds.load_chain(SKILL_ROOT / "chain.yaml")
+    assert chain.tracking_issue == 882
+    assert chain.parent_phase == 72
+    assert chain.task_prefix == "Task 5"
+    ids = [pr.id for pr in chain.plan_prs]
+    assert ids == [
+        "PR-5",
+        "PR-6",
+        "PR-7",
+        "PR-8",
+        "PR-9",
+        "PR-11",
+        "PR-12",
+        "PR-13",
+        "PR-14",
+        "PR-15",
+    ]
+    pr7 = next(pr for pr in chain.plan_prs if pr.id == "PR-7")
+    assert any("b516b67" in note for note in pr7.notes)

--- a/.claude/skills/handoff/tests/test_discover_state.py
+++ b/.claude/skills/handoff/tests/test_discover_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 
@@ -110,6 +111,24 @@ def test_parse_worktree_porcelain_parses_typical_output() -> None:
 def test_parse_worktree_porcelain_empty_returns_empty() -> None:
     """Parse worktree porcelain empty returns empty."""
     assert ds.parse_worktree_porcelain("") == []
+
+
+def test_run_git_is_anchored_to_repo_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """`run_git` must prepend `-C <REPO_ROOT>` so it works from any CWD."""
+    captured: dict = {}
+
+    def fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess:
+        captured["argv"] = argv
+        return subprocess.CompletedProcess(argv, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(ds.subprocess, "run", fake_run)
+    monkeypatch.chdir(tmp_path)
+    ds.run_git(["worktree", "list", "--porcelain"])
+    assert captured["argv"][0:3] == ["git", "-C", str(ds.REPO_ROOT)]
+    assert captured["argv"][3:] == ["worktree", "list", "--porcelain"]
 
 
 def test_annotate_worktrees_marks_merged_safe_to_remove() -> None:

--- a/.claude/skills/handoff/tests/test_discover_state.py
+++ b/.claude/skills/handoff/tests/test_discover_state.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 SKILL_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SKILL_ROOT))
 
@@ -282,6 +284,35 @@ def test_chain_round_trip_preserves_fields(tmp_path: Path) -> None:
     assert pr5.status == "merged"
     assert pr5.pr_number == 999
     assert reloaded.plan_prs[1].depends_on == ["PR-5"]
+
+
+def test_fetch_commit_committer_date_uses_raw_jq_string_not_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`gh api --jq` prints scalar values unquoted; helper must use stripped stdout."""
+    captured: dict = {}
+
+    def fake_run_gh(args: list[str]) -> str:
+        captured["args"] = args
+        return "2026-05-11T20:34:56Z\n"
+
+    monkeypatch.setattr(ds, "run_gh", fake_run_gh)
+    out = ds._fetch_commit_committer_date("org/repo", "abc1234")
+    assert out == "2026-05-11T20:34:56Z"
+    assert captured["args"][:2] == ["api", "repos/org/repo/commits/abc1234"]
+
+
+def test_fetch_commit_committer_date_returns_empty_on_subprocess_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Helper returns "" on `gh` failure rather than propagating CalledProcessError."""
+    import subprocess as sp
+
+    def boom(args: list[str]) -> str:
+        raise sp.CalledProcessError(returncode=1, cmd=["gh", *args])
+
+    monkeypatch.setattr(ds, "run_gh", boom)
+    assert ds._fetch_commit_committer_date("org/repo", "abc1234") == ""
 
 
 def test_load_chain_reads_the_shipped_chain_yaml() -> None:

--- a/.claude/skills/handoff/tests/test_write_handoff.py
+++ b/.claude/skills/handoff/tests/test_write_handoff.py
@@ -6,6 +6,8 @@ import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+import pytest
+
 SKILL_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(SKILL_ROOT))
 sys.path.insert(0, str(SKILL_ROOT / "helpers"))
@@ -381,3 +383,82 @@ def test_parse_surprise_with_no_colon_falls_back_to_other() -> None:
     s = wh.parse_surprise("just a free-form note")
     assert s.category == "Other"
     assert s.note == "just a free-form note"
+
+
+def test_parse_args_rejects_comment_only_and_prompt_only_together() -> None:
+    """`--comment-only` and `--prompt-only` are mutually exclusive — argparse must error."""
+    with pytest.raises(SystemExit):
+        wh.parse_args(["--comment-only", "--prompt-only"])
+
+
+def test_render_comment_chain_complete_does_not_emit_empty_bold_list() -> None:
+    """When every plan PR is merged, the Task-numbering section must not render `****`."""
+    chain = ds.Chain(
+        tracking_issue=882,
+        repo="tinaudio/synth-setter",
+        parent_phase=72,
+        task_prefix="Task 5",
+        plan_prs=[ds.ChainPR(id="PR-5", title="t", status="merged", pr_number=900)],
+    )
+    ctx = wh.HandoffContext(
+        repo="tinaudio/synth-setter",
+        tracking_issue=882,
+        chain=chain,
+        prior_handoffs=[],
+        done_since=[],
+        in_flight=[],
+        phase_numbering=ds.PhaseTaskNumbering(
+            phase_number=72, task_prefix="Task 5", used_numbers=[1, 2, 3]
+        ),
+        worktrees=[],
+        now_utc="2026-05-11 22:00 UTC",
+        surprises=[],
+        anti_patterns=[],
+        handoff_comment_url=None,
+    )
+    out = wh.render(ctx, "comment.md.j2")
+    assert "****" not in out
+    assert "chain is complete" in out
+    assert "Task 5.4" in out
+
+
+def test_render_comment_honors_linked_issue_parent_issue_over_phase() -> None:
+    """`linked_issue.parent_issue` overrides `chain.parent_phase` in the remaining table."""
+    chain = ds.Chain(
+        tracking_issue=882,
+        repo="tinaudio/synth-setter",
+        parent_phase=72,
+        task_prefix="Task 5",
+        plan_prs=[
+            ds.ChainPR(
+                id="PR-15",
+                title="ci(workflows): parallel WDS run",
+                linked_issue=ds.LinkedIssue(strategy="create_under_phase", parent_issue=874),
+            )
+        ],
+    )
+    ctx = _minimal_context(chain=chain)
+    out = wh.render(ctx, "comment.md.j2")
+    assert "create under #874" in out
+    assert "create under #72" not in out
+
+
+def test_render_prompt_honors_linked_issue_parent_issue_over_phase() -> None:
+    """Prompt's `Link to issue` line prefers `parent_issue` over `chain.parent_phase`."""
+    chain = ds.Chain(
+        tracking_issue=882,
+        repo="tinaudio/synth-setter",
+        parent_phase=72,
+        task_prefix="Task 5",
+        plan_prs=[
+            ds.ChainPR(
+                id="PR-15",
+                title="ci(workflows): parallel WDS run",
+                linked_issue=ds.LinkedIssue(strategy="create_under_phase", parent_issue=874),
+            )
+        ],
+    )
+    ctx = _minimal_context(chain=chain)
+    out = wh.render(ctx, "prompt.md.j2")
+    assert "create a new Task under #874" in out
+    assert "under Phase #72" not in out

--- a/.claude/skills/handoff/tests/test_write_handoff.py
+++ b/.claude/skills/handoff/tests/test_write_handoff.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -481,3 +482,93 @@ def test_render_prompt_honors_linked_issue_parent_issue_over_phase() -> None:
     out = wh.render(ctx, "prompt.md.j2")
     assert "create a new Task under #874" in out
     assert "under Phase #72" not in out
+
+
+def test_compute_level_detects_cycle_with_descriptive_error() -> None:
+    """A `chain.yaml` cycle raises ValueError naming the offending path."""
+    rows = [
+        ds.ChainPR(id="PR-A", title="t", depends_on=["PR-B"]),
+        ds.ChainPR(id="PR-B", title="t", depends_on=["PR-A"]),
+    ]
+    with pytest.raises(ValueError, match=r"Cycle detected.*PR-A.*PR-B|Cycle detected.*PR-B.*PR-A"):
+        wh.render_ascii_graph(rows)
+
+
+def test_main_skips_chain_save_when_issue_override_in_play(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """`--issue` in play => chain.yaml MUST NOT be rewritten with reconciled rows."""
+    chain_path = tmp_path / "chain.yaml"
+    original_chain = ds.Chain(
+        tracking_issue=882,
+        repo="org/repo",
+        parent_phase=72,
+        task_prefix="Task 5",
+        plan_prs=[ds.ChainPR(id="PR-5", title="refactor(pipeline): relocate")],
+    )
+    ds.save_chain(chain_path, original_chain)
+    before_bytes = chain_path.read_bytes()
+
+    # Build a derived state that differs from the manifest (a new pr_number).
+    reconciled = ds.Chain(
+        tracking_issue=882,
+        repo="org/repo",
+        parent_phase=72,
+        task_prefix="Task 5",
+        plan_prs=[
+            ds.ChainPR(
+                id="PR-5",
+                title="refactor(pipeline): relocate",
+                status="merged",
+                pr_number=12345,
+            )
+        ],
+    )
+    fake_state = ds.DerivedState(
+        repo="org/repo",
+        tracking_issue=999,
+        chain=reconciled,
+        prior_handoffs=[],
+        done_since=[],
+        in_flight=[],
+        phase_numbering=ds.PhaseTaskNumbering(72, "Task 5", []),
+        worktrees=[],
+        now_utc="2026-05-12 00:00 UTC",
+    )
+    monkeypatch.setattr(ds, "derive_state", lambda *a, **kw: fake_state)
+    exit_code = wh.main(["--chain", str(chain_path), "--issue", "999", "--dry-run"])
+    assert exit_code == 0
+    # --dry-run skips save unconditionally; verify the override path also skips
+    # without --dry-run.
+    posted_url: list[str] = []
+    monkeypatch.setattr(wh, "post_comment", lambda *a, **kw: posted_url.append("u") or "u")
+    monkeypatch.setattr(wh, "save_prompt_locally", lambda *a, **kw: tmp_path / "prompt.md")
+    exit_code2 = wh.main(["--chain", str(chain_path), "--issue", "999"])
+    assert exit_code2 == 0
+    assert chain_path.read_bytes() == before_bytes
+
+
+def test_main_catches_calledprocesserror_cleanly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Gh failure surfaces as a one-line stderr message, not a stack trace."""
+    chain_path = tmp_path / "chain.yaml"
+    ds.save_chain(
+        chain_path,
+        ds.Chain(
+            tracking_issue=882,
+            repo="org/repo",
+            parent_phase=72,
+            task_prefix="Task 5",
+            plan_prs=[],
+        ),
+    )
+
+    def boom(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003, ARG001
+        raise subprocess.CalledProcessError(
+            returncode=7, cmd=["gh", "api", "..."], stderr="HTTP 401: auth required"
+        )
+
+    monkeypatch.setattr(ds, "derive_state", boom)
+    exit_code = wh.main(["--chain", str(chain_path), "--dry-run"])
+    assert exit_code == 7

--- a/.claude/skills/handoff/tests/test_write_handoff.py
+++ b/.claude/skills/handoff/tests/test_write_handoff.py
@@ -137,6 +137,51 @@ def test_render_comment_in_flight_next_action_ready_to_merge_when_clean() -> Non
     assert "Ready to merge" in out
 
 
+def test_render_comment_in_flight_next_action_rebase_when_conflicting() -> None:
+    """In-flight next-action wording when the branch conflicts with base."""
+    ctx = _minimal_context(
+        in_flight=[
+            ds.InFlightPR(
+                number=942,
+                title="internal-feat(vst): foo",
+                branch="b",
+                head_oid="abc",
+                head_committer_date="",
+                mergeable="CONFLICTING",
+                review_decision="REVIEW_REQUIRED",
+                checks_state="passing",
+                unresolved_threads=0,
+                new_copilot_comments_since_push=0,
+            )
+        ]
+    )
+    out = wh.render(ctx, "comment.md.j2")
+    assert "Rebase or merge base, resolve conflicts" in out
+
+
+def test_render_comment_in_flight_next_action_address_threads_when_unresolved() -> None:
+    """In-flight next-action wording when there are open review threads."""
+    ctx = _minimal_context(
+        in_flight=[
+            ds.InFlightPR(
+                number=942,
+                title="internal-feat(vst): foo",
+                branch="b",
+                head_oid="abc",
+                head_committer_date="",
+                mergeable="MERGEABLE",
+                review_decision="REVIEW_REQUIRED",
+                checks_state="passing",
+                unresolved_threads=3,
+                new_copilot_comments_since_push=2,
+            )
+        ]
+    )
+    out = wh.render(ctx, "comment.md.j2")
+    assert "Address the 3 unresolved thread(s) + 2 new Copilot comment(s)" in out
+    assert "/pr-review-resolver" in out
+
+
 def test_render_comment_prior_handoff_breadcrumbs() -> None:
     """Render comment prior handoff breadcrumbs."""
     ctx = _minimal_context(

--- a/.claude/skills/handoff/tests/test_write_handoff.py
+++ b/.claude/skills/handoff/tests/test_write_handoff.py
@@ -1,0 +1,338 @@
+"""Unit tests for handoff/helpers/write_handoff.py — pure rendering only."""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+SKILL_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(SKILL_ROOT))
+sys.path.insert(0, str(SKILL_ROOT / "helpers"))
+
+from helpers import discover_state as ds  # noqa: E402
+from helpers import write_handoff as wh  # noqa: E402
+
+
+def _minimal_context(**overrides) -> wh.HandoffContext:
+    chain = ds.Chain(
+        tracking_issue=882,
+        repo="tinaudio/synth-setter",
+        parent_phase=72,
+        task_prefix="Task 5",
+        plan_prs=[
+            ds.ChainPR(
+                id="PR-5",
+                title="refactor(pipeline): relocate pipeline → src/pipeline",
+                source_commits=["abc1234"],
+            ),
+            ds.ChainPR(
+                id="PR-6",
+                title="internal-fix(pipeline): post-relocation doc sweep",
+                source_commits=["def5678"],
+                depends_on=["PR-5"],
+            ),
+        ],
+    )
+    base = wh.HandoffContext(
+        repo="tinaudio/synth-setter",
+        tracking_issue=882,
+        chain=chain,
+        prior_handoffs=[],
+        done_since=[],
+        in_flight=[],
+        phase_numbering=ds.PhaseTaskNumbering(
+            phase_number=72, task_prefix="Task 5", used_numbers=[1, 2, 3]
+        ),
+        worktrees=[],
+        now_utc="2026-05-11 22:00 UTC",
+        surprises=[],
+        anti_patterns=[],
+        handoff_comment_url=None,
+    )
+    for key, value in overrides.items():
+        setattr(base, key, value)
+    return base
+
+
+def test_render_comment_renders_first_handoff_header() -> None:
+    """Render comment renders first handoff header."""
+    out = wh.render(_minimal_context(), "comment.md.j2")
+    assert "## Handoff update — chain progress as of 2026-05-11 22:00 UTC" in out
+    assert "First handoff on tracking issue #882" in out
+
+
+def test_render_comment_lists_remaining_chain_table() -> None:
+    """Render comment lists remaining chain table."""
+    out = wh.render(_minimal_context(), "comment.md.j2")
+    assert "| PR-5 | pending" in out
+    assert "| PR-6 | pending" in out
+    assert "Click to expand the 2-row table" in out
+
+
+def test_render_comment_includes_done_since_when_merged() -> None:
+    """Render comment includes done since when merged."""
+    ctx = _minimal_context(
+        done_since=[
+            ds.ClosedPR(
+                number=999,
+                title="feat(x): foo (#999)",
+                merged_at="2026-05-12T00:00:00Z",
+                closes_issues=[908],
+            ),
+        ]
+    )
+    out = wh.render(ctx, "comment.md.j2")
+    assert "| #999 | `feat(x): foo (#999)` | #908 |" in out
+
+
+def test_render_comment_omits_done_table_when_empty() -> None:
+    """Render comment omits done table when empty."""
+    out = wh.render(_minimal_context(), "comment.md.j2")
+    assert "_No new merges referencing this tracking issue since the prior handoff._" in out
+
+
+def test_render_comment_in_flight_has_next_action_when_failing() -> None:
+    """Render comment in flight has next action when failing."""
+    ctx = _minimal_context(
+        in_flight=[
+            ds.InFlightPR(
+                number=942,
+                title="internal-feat(vst): render config CLI",
+                branch="pr-4",
+                head_oid="899449e0",
+                head_committer_date="2026-05-11T20:00:00Z",
+                mergeable="MERGEABLE",
+                review_decision="REVIEW_REQUIRED",
+                checks_state="failing",
+                unresolved_threads=0,
+                new_copilot_comments_since_push=0,
+            )
+        ]
+    )
+    out = wh.render(ctx, "comment.md.j2")
+    assert "PR #942" in out
+    assert "Fix the failing checks" in out
+
+
+def test_render_comment_in_flight_next_action_ready_to_merge_when_clean() -> None:
+    """Render comment in flight next action ready to merge when clean."""
+    ctx = _minimal_context(
+        in_flight=[
+            ds.InFlightPR(
+                number=942,
+                title="internal-feat(vst): foo",
+                branch="b",
+                head_oid="abc",
+                head_committer_date="2026-05-11T20:00:00Z",
+                mergeable="MERGEABLE",
+                review_decision="APPROVED",
+                checks_state="passing",
+                unresolved_threads=0,
+                new_copilot_comments_since_push=0,
+            )
+        ]
+    )
+    out = wh.render(ctx, "comment.md.j2")
+    assert "Ready to merge" in out
+
+
+def test_render_comment_prior_handoff_breadcrumbs() -> None:
+    """Render comment prior handoff breadcrumbs."""
+    ctx = _minimal_context(
+        prior_handoffs=[
+            ds.PriorHandoff(
+                comment_id=1,
+                url="https://example.com/h1",
+                created_at="2026-05-11T19:50:00Z",
+                body="## Handoff update — A",
+            ),
+            ds.PriorHandoff(
+                comment_id=2,
+                url="https://example.com/h2",
+                created_at="2026-05-11T03:18:00Z",
+                body="## Handoff update — B",
+            ),
+        ]
+    )
+    out = wh.render(ctx, "comment.md.j2")
+    assert "Predecessors:" in out
+    assert "https://example.com/h1" in out
+    assert "https://example.com/h2" in out
+
+
+def test_render_comment_lists_safe_to_remove_worktrees() -> None:
+    """Render comment lists safe to remove worktrees."""
+    ctx = _minimal_context(
+        worktrees=[
+            ds.WorktreeEntry(
+                path="/wt/a",
+                branch="feat-x",
+                head="abc1234",
+                associated_pr_number=101,
+                associated_pr_state="MERGED",
+                safe_to_remove=True,
+            ),
+            ds.WorktreeEntry(
+                path="/wt/b",
+                branch="feat-y",
+                head="def5678",
+                associated_pr_number=102,
+                associated_pr_state="OPEN",
+                safe_to_remove=False,
+            ),
+        ]
+    )
+    out = wh.render(ctx, "comment.md.j2")
+    assert "safe to `git worktree remove`" in out
+    assert "/wt/a" in out
+    assert "/wt/b" in out
+
+
+def test_render_comment_renders_surprises_with_category_lead() -> None:
+    """Render comment renders surprises with category lead."""
+    ctx = _minimal_context(
+        surprises=[
+            wh.Surprise(
+                category="Copilot race", note="Maintainer self-push raced with parallel PR plan."
+            ),
+        ]
+    )
+    out = wh.render(ctx, "comment.md.j2")
+    assert "- **Copilot race:**" in out
+
+
+def test_render_prompt_includes_first_commands_block() -> None:
+    """Render prompt includes first commands block."""
+    ctx = _minimal_context(
+        in_flight=[
+            ds.InFlightPR(
+                number=942,
+                title="t",
+                branch="b",
+                head_oid="abc",
+                head_committer_date="",
+                mergeable="MERGEABLE",
+                review_decision="REVIEW_REQUIRED",
+                checks_state="passing",
+                unresolved_threads=0,
+                new_copilot_comments_since_push=0,
+            )
+        ]
+    )
+    out = wh.render(ctx, "prompt.md.j2")
+    assert "git fetch origin --prune" in out
+    assert "gh pr view 942" in out
+    assert "git worktree list" in out
+
+
+def test_render_prompt_default_action_drives_in_flight_first() -> None:
+    """Render prompt default action drives in flight first."""
+    ctx = _minimal_context(
+        in_flight=[
+            ds.InFlightPR(
+                number=942,
+                title="t",
+                branch="b",
+                head_oid="abc",
+                head_committer_date="",
+                mergeable="MERGEABLE",
+                review_decision="REVIEW_REQUIRED",
+                checks_state="passing",
+                unresolved_threads=0,
+                new_copilot_comments_since_push=0,
+            )
+        ]
+    )
+    out = wh.render(ctx, "prompt.md.j2")
+    assert "Default: drive the in-flight PR(s) above to merge" in out
+
+
+def test_render_prompt_mandatory_skills_cycle_listed() -> None:
+    """Render prompt mandatory skills cycle listed."""
+    out = wh.render(_minimal_context(), "prompt.md.j2")
+    assert "/tdd-implementation" in out
+    assert "/code-health" in out
+    assert "/simplify" in out
+
+
+def test_render_prompt_anti_patterns_render_each_line() -> None:
+    """Render prompt anti patterns render each line."""
+    ctx = _minimal_context(anti_patterns=["Don't compose @hydra.main outside the entrypoint."])
+    out = wh.render(ctx, "prompt.md.j2")
+    assert "Don't compose @hydra.main outside the entrypoint." in out
+
+
+def test_render_ascii_graph_linear_chain() -> None:
+    """Render ascii graph linear chain."""
+    rows = [
+        ds.ChainPR(id="PR-5", title="t"),
+        ds.ChainPR(id="PR-6", title="t", depends_on=["PR-5"]),
+        ds.ChainPR(id="PR-7", title="t", depends_on=["PR-6"]),
+    ]
+    out = wh.render_ascii_graph(rows)
+    lines = out.splitlines()
+    assert "PR-5  (root)" in lines[0]
+    assert "PR-6  ← PR-5" in lines[1]
+    assert "PR-7  ← PR-6" in lines[2]
+
+
+def test_render_ascii_graph_fanout() -> None:
+    """Render ascii graph fanout."""
+    rows = [
+        ds.ChainPR(id="PR-5", title="t"),
+        ds.ChainPR(id="PR-6", title="t", depends_on=["PR-5"]),
+        ds.ChainPR(id="PR-7", title="t", depends_on=["PR-5"]),
+        ds.ChainPR(id="PR-8", title="t", depends_on=["PR-5"]),
+    ]
+    out = wh.render_ascii_graph(rows)
+    assert "PR-5  (root)" in out
+    assert "PR-6  ← PR-5" in out
+    assert "PR-7  ← PR-5" in out
+    assert "PR-8  ← PR-5" in out
+
+
+def test_render_ascii_graph_empty_says_no_remaining() -> None:
+    """Render ascii graph empty says no remaining."""
+    assert wh.render_ascii_graph([]) == "(no remaining PRs)"
+
+
+def test_check_idempotency_guard_blocks_recent_handoff() -> None:
+    """Check idempotency guard blocks recent handoff."""
+    now = datetime.now(timezone.utc)
+    recent = (now - timedelta(minutes=5)).isoformat().replace("+00:00", "Z")
+    handoffs = [
+        ds.PriorHandoff(comment_id=1, url="u", created_at=recent, body="## Handoff update — A")
+    ]
+    msg = wh.check_idempotency_guard(handoffs)
+    assert msg is not None
+    assert "5min ago" in msg
+
+
+def test_check_idempotency_guard_allows_old_handoff() -> None:
+    """Check idempotency guard allows old handoff."""
+    now = datetime.now(timezone.utc)
+    old = (now - timedelta(hours=2)).isoformat().replace("+00:00", "Z")
+    handoffs = [
+        ds.PriorHandoff(comment_id=1, url="u", created_at=old, body="## Handoff update — A")
+    ]
+    assert wh.check_idempotency_guard(handoffs) is None
+
+
+def test_check_idempotency_guard_no_prior_returns_none() -> None:
+    """Check idempotency guard no prior returns none."""
+    assert wh.check_idempotency_guard([]) is None
+
+
+def test_parse_surprise_splits_category_and_note() -> None:
+    """Parse surprise splits category and note."""
+    s = wh.parse_surprise("Copilot race: maintainer self-push raced with parallel PR plan")
+    assert s.category == "Copilot race"
+    assert s.note == "maintainer self-push raced with parallel PR plan"
+
+
+def test_parse_surprise_with_no_colon_falls_back_to_other() -> None:
+    """Parse surprise with no colon falls back to other."""
+    s = wh.parse_surprise("just a free-form note")
+    assert s.category == "Other"
+    assert s.note == "just a free-form note"

--- a/.claude/skills/handoff/tests/test_write_handoff.py
+++ b/.claude/skills/handoff/tests/test_write_handoff.py
@@ -391,6 +391,25 @@ def test_parse_args_rejects_comment_only_and_prompt_only_together() -> None:
         wh.parse_args(["--comment-only", "--prompt-only"])
 
 
+def test_default_handoffs_dir_is_anchored_under_dot_claude() -> None:
+    """Save path must resolve relative to the `.claude/` tree, not CWD."""
+    assert wh.DEFAULT_HANDOFFS_DIR.is_absolute()
+    assert wh.DEFAULT_HANDOFFS_DIR.name == "handoffs"
+    assert wh.DEFAULT_HANDOFFS_DIR.parent.name == ".claude"
+
+
+def test_save_prompt_locally_writes_under_dot_claude_regardless_of_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Running from a sandbox CWD must not create a stray `.claude/handoffs/` there."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(wh, "DEFAULT_HANDOFFS_DIR", tmp_path / "out")
+    saved = wh.save_prompt_locally("# body", "2026-05-12 10:00 UTC")
+    assert saved.parent == tmp_path / "out"
+    assert saved.read_text() == "# body"
+    assert not (tmp_path / ".claude").exists()
+
+
 def test_render_comment_chain_complete_does_not_emit_empty_bold_list() -> None:
     """When every plan PR is merged, the Task-numbering section must not render `****`."""
     chain = ds.Chain(

--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,11 @@ plugins/
 # Claude Code
 .claude/
 
+# Session-local handoff prompts written by /handoff. Redundant with the
+# blanket .claude/ ignore above, but kept explicit so any future contributor
+# who adds a !.claude/ allow-list still won't accidentally commit these.
+.claude/handoffs/handoff-*.md
+
 # Advisory reports written by .claude/hooks/doc-drift.sh and pr-review-resolver.sh
 .agent-reviews/
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ ignore = ["E501", "S101"]
 # with a partial path — `gh` is on PATH by design (same pattern used by the
 # scripts/r2_shard_report.py exemption above).
 ".claude/skills/_shared/post_review.py" = ["T201", "S603", "S607"]
+# .claude/skills/handoff/helpers/*.py: same rationale as post_review.py — shells
+# out to `gh` and `git` on PATH; prints the rendered prompt to stdout.
+".claude/skills/handoff/helpers/*.py" = ["T201", "S603", "S607"]
 "scripts/rewrite_dataset_to_latest.py" = ["ANN001"]
 "scripts/subdir_funtime.py" = ["F841", "ANN001"]
 # S603/S607: rclone subprocess calls in R2 integration test fixtures.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ markers = [
   "network: tests that may make outbound network calls (e.g. `git fetch`)",
 ]
 minversion = "6.0"
-testpaths = "tests/"
+testpaths = ["tests/", ".claude/skills/handoff/tests/"]
 
 [tool.ruff]
 target-version = "py310"

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -27,6 +27,9 @@ einops
 h5py
 hypothesis
 hdf5plugin
+# Used by .claude/skills/handoff/ to render comment + prompt templates. Listed
+# explicitly because CI's pytest imports the skill module during test collection.
+jinja2
 librosa
 loguru==0.7.3
 matplotlib

--- a/tests/data/vst/test_generate_vst_dataset_cli.py
+++ b/tests/data/vst/test_generate_vst_dataset_cli.py
@@ -42,7 +42,11 @@ def test_cli_args_class_adds_only_data_file_beyond_render_config() -> None:
 
 
 def _smoke_spec() -> DatasetSpec:
-    """A minimal ``DatasetSpec`` for round-trip tests — no I/O, no plugin required."""
+    """A minimal ``DatasetSpec`` for round-trip tests — no I/O, no plugin required.
+
+    :returns: a minimal in-memory ``DatasetSpec`` suitable for CLI round-trip tests
+    :rtype: DatasetSpec
+    """
     render_cfg = RenderConfig(
         plugin_path="plugins/Surge XT.vst3",
         preset_path="presets/surge-base.vstpreset",


### PR DESCRIPTION
## Summary

- Project-local `/handoff` skill at `.claude/skills/handoff/` that derives state from `chain.yaml` + live `gh` queries and produces (1) a `## Handoff update` comment posted to the chain's tracking issue and (2) a startup prompt printed inline + saved under `.claude/handoffs/`.
- Replaces hand-written handoffs whose failure modes (state drift, forgotten state, style drift) were causing miscounts and lost predecessor links — see the [reference handoff](https://github.com/tinaudio/synth-setter/issues/882#issuecomment-4425353839) for the pattern this skill automates.
- 39 unit tests under `.claude/skills/handoff/tests/` cover the pure-function surface (parsing, rendering, ASCII dependency graph, idempotency guard).

Closes #949

## What's in the diff

- `.claude/skills/handoff/`
  - `SKILL.md` — frontmatter + step-by-step invocation procedure
  - `chain.yaml` — PR-5..PR-15 manifest for the #882 chain (status/pr_number reconciled on each invocation)
  - `helpers/discover_state.py` — pure parsing helpers + thin `gh`/`git` wrappers (~700 lines)
  - `helpers/write_handoff.py` — Jinja2 composer with idempotency guard + comment poster (~340 lines)
  - `templates/comment.md.j2`, `templates/prompt.md.j2` — `StrictUndefined`-mode templates
  - `tests/` — 39 unit tests
- `pyproject.toml` — per-file-ignores entry mirroring `_shared/post_review.py` (`T201/S603/S607` — `gh`/`git` on PATH by design, stdout for the rendered prompt)
- `.gitignore` — explicit `.claude/handoffs/handoff-*.md` override line (redundant with the `.claude/` blanket ignore but documents intent)
- `tests/data/vst/test_generate_vst_dataset_cli.py` — small unrelated side fix: add `:returns:`/`:rtype:` to `_smoke_spec` docstring so `pydoclint` passes (was a pre-existing failure blocking the pre-commit hook)

## Argument surface

```bash
/handoff                          # full flow: render, post comment, print + save prompt
/handoff --issue 874              # use #874 as the tracking issue
/handoff --dry-run                # render both, post nothing, print everything
/handoff --comment-only           # post comment, suppress prompt printing
/handoff --prompt-only            # print prompt, suppress comment posting
/handoff --no-prompt-questions    # skip AskUserQuestion; empty Surprises/Anti-patterns sections
/handoff --force                  # bypass the 30-min idempotency guard
/handoff --surprise "<cat>: <note>" --anti-pattern "<line>"   # repeatable inline injection
```

## Test plan

- [x] **Unit tests** — `python3 -m pytest .claude/skills/handoff/tests/ -v` — 39 pass (~0.4s)
  ```
  39 passed in 0.43s
  ```
- [x] **Pre-commit clean** — `make format` exits 0 (after the `_smoke_spec` docstring side fix)
- [x] **Live dry-run on #882** — `python3 .claude/skills/handoff/helpers/write_handoff.py --dry-run`
  - Predecessor breadcrumbs link the two existing #882 handoffs (4425353839, 4424323689)
  - "Done since prior handoff" is empty (correct — the most recent handoff covered all merges)
  - "In flight" detects PR #883 with `checks=failing · mergeable=CONFLICTING · review=REVIEW_REQUIRED` and recommends "Fix the failing checks, push, reply inline" as the next action
  - "Remaining chain" lists PR-5 through PR-15 (10 rows, collapsed under `<details>`)
  - Dependency graph renders correctly:
    ```
    PR-5  (root)
      PR-6  ← PR-5
      PR-7  ← PR-5
      PR-8  ← PR-5
      PR-9  ← PR-5
      PR-11  ← PR-5
        PR-12  ← PR-11
          PR-13  ← PR-12
            PR-14  ← PR-13
              PR-15  ← PR-14
    ```
  - Phase task-numbering finds used numbers `[2, 3, 4, 5, 6, 7, 8]` under #72 and reports `Task 5.9` as the next free
  - Worktree inventory cross-references each branch with `gh pr view`; flags MERGED/CLOSED ones as `safe to git worktree remove`
- [x] **Chain.yaml round-trip preservation** — verified `--dry-run` leaves `chain.yaml` byte-identical, and the live-mode save path only writes when status/pr_number actually change (preserving the leading header docstring via `CHAIN_HEADER`)
- [x] **Idempotency guard** — `check_idempotency_guard()` unit-tested for the 5-min-old / 2-hour-old / no-prior cases; refuses to post within 30min unless `--force`

### Skipped (Level 1 integration that requires a clean tracking issue)

- [ ] **Live post against a low-stakes tracking issue** — could not run safely against #882 since it would clutter the live chain. The `--dry-run` path is exhaustively exercised; the `post_comment()` path is a thin `gh issue comment --body-file` wrapper.

## Reviewer notes

- The skill's `discover_state.py` was rewritten mid-implementation when I discovered that `gh search prs` doesn't expose `mergedAt`/`closingIssuesReferences` and `gh pr view` doesn't expose `reviewThreads`. The current code uses `gh pr list --search` for the former and a GraphQL call for the latter — both paths exercised in the live dry-run.
- `chain.yaml` was carefully designed to be **declarative**: source-commit pointers live there, not in code, so re-targeting the skill to a new chain (e.g. the wds tail under #874) is a copy + edit.
- Out of scope per the design conversation: resume mode (Claude Code's `--continue` already handles it), multi-tracking-issue chains, auto-detecting PR-N membership from titles.