### PR TITLE
chore(lint-cleanup): wire Claude+Copilot entry points to runbook

### DIFF
--- a/.claude/agents/lint-cleanup.md
+++ b/.claude/agents/lint-cleanup.md
@@ -1,6 +1,6 @@
 ---
 name: lint-cleanup
-description: "Use this agent to clean up pre-existing lint violations in one legacy file from the synth-setter exclusion lists tracked in issue #25. Trigger when the user asks to clean up lint for a specific file, work the #25 checklist, remove a file from `.pre-commit-config.yaml`'s `exclude` blocks, or add docstrings to a legacy module. Follows the canonical workflow in `.github/agents/lint-cleanup.md` — one file per PR, no functional changes, branch `chore/lint-cleanup/<name>`, conventional `chore(lint):` commit, `Refs #25` in the PR body."
+description: "Use this agent to clean up pre-existing lint violations in one legacy file from the synth-setter exclusion lists tracked in issue #25. Trigger when the user asks to clean up lint for a specific file, work the #25 checklist, remove a file from the lint-exclusion lists in `.pre-commit-config.yaml` or `pyproject.toml` (`[tool.pydoclint].exclude`, `[tool.ruff.lint.per-file-ignores]`), or add docstrings to a legacy module. Follows the canonical workflow in `.github/agents/lint-cleanup.md` — one file per PR, no functional changes, branch `chore/lint-cleanup/<name>`, conventional `chore(lint):` commit, `Refs #25` in the PR body."
 tools: Read, Edit, Bash, Grep, Glob
 ---
 

--- a/.claude/agents/lint-cleanup.md
+++ b/.claude/agents/lint-cleanup.md
@@ -1,6 +1,6 @@
 ---
 name: lint-cleanup
-description: Use this agent to clean up pre-existing lint violations in one legacy file from the synth-setter exclusion lists tracked in issue #25. Trigger when the user asks to clean up lint for a specific file, work the #25 checklist, remove a file from `.pre-commit-config.yaml`'s `exclude` blocks, or add docstrings to a legacy module. Follows the canonical workflow in `.github/agents/lint-cleanup.md` — one file per PR, no functional changes, branch `chore/lint-cleanup/<name>`, conventional `chore(lint):` commit, `Refs #25` in the PR body.
+description: "Use this agent to clean up pre-existing lint violations in one legacy file from the synth-setter exclusion lists tracked in issue #25. Trigger when the user asks to clean up lint for a specific file, work the #25 checklist, remove a file from `.pre-commit-config.yaml`'s `exclude` blocks, or add docstrings to a legacy module. Follows the canonical workflow in `.github/agents/lint-cleanup.md` — one file per PR, no functional changes, branch `chore/lint-cleanup/<name>`, conventional `chore(lint):` commit, `Refs #25` in the PR body."
 tools: Read, Edit, Bash, Grep, Glob
 ---
 

--- a/.claude/agents/lint-cleanup.md
+++ b/.claude/agents/lint-cleanup.md
@@ -21,7 +21,7 @@ single-sourced so edits land in one place and reach every entry point.
 - A reviewer asks for a file to be removed from `.pre-commit-config.yaml`'s
   `exclude` blocks (or `pyproject.toml`'s `per-file-ignores`).
 
-## Hard rules (cross-reference, not duplicate)
+## Quick reminders
 
 These are the rules most often forgotten. Full list is in the runbook.
 

--- a/.claude/agents/lint-cleanup.md
+++ b/.claude/agents/lint-cleanup.md
@@ -1,0 +1,40 @@
+---
+name: lint-cleanup
+description: Use this agent to clean up pre-existing lint violations in one legacy file from the synth-setter exclusion lists tracked in issue #25. Trigger when the user asks to clean up lint for a specific file, work the #25 checklist, remove a file from `.pre-commit-config.yaml`'s `exclude` blocks, or add docstrings to a legacy module. Follows the canonical workflow in `.github/agents/lint-cleanup.md` — one file per PR, no functional changes, branch `chore/lint-cleanup/<name>`, conventional `chore(lint):` commit, `Refs #25` in the PR body.
+tools: Read, Edit, Bash, Grep, Glob
+---
+
+# Lint Cleanup Agent
+
+**Source of truth:** [`.github/agents/lint-cleanup.md`](../../.github/agents/lint-cleanup.md) in the repo root.
+
+Read that file at the start of every session and follow its steps in order. Do
+not duplicate or paraphrase the steps here — the runbook is intentionally
+single-sourced so edits land in one place and reach every entry point.
+
+## When to spawn this subagent
+
+- The user asks to clean up lint for a specific file (e.g., "clean up
+  `src/utils/math.py`").
+- The user wants to work through the next unchecked file on the
+  [#25](https://github.com/tinaudio/synth-setter/issues/25) checklist.
+- A reviewer asks for a file to be removed from `.pre-commit-config.yaml`'s
+  `exclude` blocks (or `pyproject.toml`'s `per-file-ignores`).
+
+## Hard rules (cross-reference, not duplicate)
+
+These are the rules most often forgotten. Full list is in the runbook.
+
+- One file per PR (or 2–3 closely related, e.g. a module and its tests).
+- Formatting, docstrings, and lint fixes only — **never** change behavior.
+- Branch: `chore/lint-cleanup/<module-name>`.
+- Commit prefix: `chore(lint):`.
+- PR body uses `Refs #25` (not `Fixes`/`Closes` — #25 stays open until every
+  file is done).
+- Run `make test-fast` before opening the PR.
+- Use an isolated worktree (per `CLAUDE.md`'s git-workflow rules).
+
+## Output
+
+A green, mergeable PR that removes one file from one or more exclusion blocks
+and ticks its checkbox in [#25](https://github.com/tinaudio/synth-setter/issues/25).

--- a/.claude/commands/lint-cleanup.md
+++ b/.claude/commands/lint-cleanup.md
@@ -1,5 +1,5 @@
 ---
-description: Run the lint-cleanup workflow on a legacy file from issue #25's exclusion list
+description: "Run the lint-cleanup workflow on a legacy file from issue #25's exclusion list"
 argument-hint: <path-to-file>
 ---
 

--- a/.claude/commands/lint-cleanup.md
+++ b/.claude/commands/lint-cleanup.md
@@ -1,0 +1,18 @@
+---
+description: Run the lint-cleanup workflow on a legacy file from issue #25's exclusion list
+argument-hint: <path-to-file>
+---
+
+Run the lint-cleanup workflow from
+[`.github/agents/lint-cleanup.md`](../../.github/agents/lint-cleanup.md) on
+the file `$ARGUMENTS`.
+
+If `$ARGUMENTS` is empty, read the checklist in
+[#25](https://github.com/tinaudio/synth-setter/issues/25) and pick the next
+unchecked file (prefer the smallest by line count for a quick win).
+
+Spawn the `lint-cleanup` subagent (defined in
+`.claude/agents/lint-cleanup.md`) in an isolated worktree to do the work.
+Hand it the path and remind it of the hard rules: one file per PR, no
+behavioral changes, branch `chore/lint-cleanup/<name>`, commit prefix
+`chore(lint):`, PR body has `Refs #25` (not `Fixes`/`Closes`).

--- a/.github/agents/lint-cleanup.md
+++ b/.github/agents/lint-cleanup.md
@@ -14,7 +14,7 @@ This runbook is the canonical workflow. Three entry points delegate to it; edits
 | Claude Code (interactive)  | `.claude/commands/lint-cleanup.md` | Type `/lint-cleanup <path>` in a Claude Code session  |
 | Copilot Coding Agent       | `.github/copilot-instructions.md`  | Assign a #25 sub-issue to Copilot in the GitHub UI    |
 
-Do **not** paraphrase the workflow steps into the entry-point stubs — they are intentionally thin pointers so the runbook stays single-sourced.
+The entry-point stubs may surface a short cross-reference of the rules most often forgotten (commit prefix, `Refs #25`, isolated-worktree requirement) so a contributor seeing only the stub still gets the load-bearing constraints. They must not paraphrase or fork the workflow steps themselves — those live here, single-sourced.
 
 ## Scope
 
@@ -33,7 +33,7 @@ For each file listed in the `exclude` blocks of `pyright`, `interrogate`, `pydoc
 6. **Verify**: `pre-commit run --files <file>` passes all hooks
 7. **Run tests**: `make test-fast` — the quick CPU suite (excludes `slow`, `gpu`, `mps`, `requires_vst`) must still pass as a smoke check; lint-only changes shouldn't affect behavior
 8. **Commit**: Use conventional commits format: `chore(lint): clean up <filename>`
-9. **Open PR**: Reference #25, check off the file in the issue checklist. Add to "Code Health" project.
+9. **Open PR**: PR body references `#25` with `Refs #25` (not `Fixes`/`Closes` — #25 stays open until every file is done). Check off the file in the issue checklist. Add to "Code Health" project.
 
 ## Rules
 

--- a/.github/agents/lint-cleanup.md
+++ b/.github/agents/lint-cleanup.md
@@ -22,14 +22,14 @@ Only formatting, docstrings, and lint fixes. **No functional changes.**
 
 ## Workflow
 
-For each file listed in the `exclude` blocks of `pyright`, `interrogate`, `pydoclint`, `shellcheck`, `codespell`, and other hooks in `.pre-commit-config.yaml` (ruff per-file-ignores and `[tool.pydoclint].exclude` live in `pyproject.toml`):
+For each file listed in any `exclude:` block in `.pre-commit-config.yaml` (e.g. `pyright`, `interrogate`, `shellcheck`, `codespell`) **or** under `[tool.pydoclint].exclude` or `[tool.ruff.lint.per-file-ignores]` in `pyproject.toml` (pydoclint and ruff configure their path-excludes there, not in the pre-commit config):
 
 1. **Create a branch**: `chore/lint-cleanup/<module-name>` (e.g., `chore/lint-cleanup/surge-datamodule`)
 2. **Run hooks on the file**, e.g. `interrogate`
 3. **Auto-fix what you can**: `ruff check --fix` and `docformatter --in-place` handle most formatting issues automatically
 4. **Manually fix remaining violations**:
    - `interrogate` missing docstrings: add Sphinx-style docstrings (`:param:`, `:returns:`, `:raises:`) to public functions/classes — matches the `docformatter` config (`style = "sphinx"` in `pyproject.toml`) — and must pass `pydoclint` DOC1xx/DOC2xx/DOC5xx (signature ↔ docstring consistency)
-5. **Remove the file from all `exclude` blocks** in `.pre-commit-config.yaml` **and from `[tool.pydoclint].exclude` in `pyproject.toml`** (pydoclint's path-exclude list lives there, not in the pre-commit config)
+5. **Remove the file from every exclusion list it appears in.** Check `.pre-commit-config.yaml`'s `exclude:` blocks **and** `pyproject.toml`'s `[tool.pydoclint].exclude` and `[tool.ruff.lint.per-file-ignores]`. A single file may appear in more than one list (e.g. excluded by `interrogate` in pre-commit *and* by `ANN001` per-file-ignore in ruff) — graduating the file means clearing every entry.
 6. **Verify**: `pre-commit run --files <file>` passes all hooks
 7. **Run tests**: `make test-fast` — the quick CPU suite (excludes `slow`, `gpu`, `mps`, `requires_vst`) must still pass as a smoke check; lint-only changes shouldn't affect behavior
 8. **Commit**: Use conventional commits format: `chore(lint): clean up <filename>`

--- a/.github/agents/lint-cleanup.md
+++ b/.github/agents/lint-cleanup.md
@@ -4,6 +4,18 @@
 
 Fix pre-existing lint violations in legacy files one at a time, removing them from the pre-commit exclusion lists in `.pre-commit-config.yaml`. Tracked in #25.
 
+## How this is invoked
+
+This runbook is the canonical workflow. Three entry points delegate to it; edits to the steps below land here and reach every entry point automatically.
+
+| Tool                       | Entry point                        | How to invoke                                         |
+| -------------------------- | ---------------------------------- | ----------------------------------------------------- |
+| Claude Code (programmatic) | `.claude/agents/lint-cleanup.md`   | `Agent(subagent_type: "lint-cleanup", prompt: "...")` |
+| Claude Code (interactive)  | `.claude/commands/lint-cleanup.md` | Type `/lint-cleanup <path>` in a Claude Code session  |
+| Copilot Coding Agent       | `.github/copilot-instructions.md`  | Assign a #25 sub-issue to Copilot in the GitHub UI    |
+
+Do **not** paraphrase the workflow steps into the entry-point stubs — they are intentionally thin pointers so the runbook stays single-sourced.
+
 ## Scope
 
 Only formatting, docstrings, and lint fixes. **No functional changes.**

--- a/.github/agents/lint-cleanup.md
+++ b/.github/agents/lint-cleanup.md
@@ -8,11 +8,11 @@ Fix pre-existing lint violations in legacy files one at a time, removing them fr
 
 This runbook is the canonical workflow. Three entry points delegate to it; edits to the steps below land here and reach every entry point automatically.
 
-| Tool                       | Entry point                        | How to invoke                                         |
-| -------------------------- | ---------------------------------- | ----------------------------------------------------- |
-| Claude Code (programmatic) | `.claude/agents/lint-cleanup.md`   | `Agent(subagent_type: "lint-cleanup", prompt: "...")` |
-| Claude Code (interactive)  | `.claude/commands/lint-cleanup.md` | Type `/lint-cleanup <path>` in a Claude Code session  |
-| Copilot Coding Agent       | `.github/copilot-instructions.md`  | Assign a #25 sub-issue to Copilot in the GitHub UI    |
+| Tool                       | Entry point                        | How to invoke                                                                |
+| -------------------------- | ---------------------------------- | ---------------------------------------------------------------------------- |
+| Claude Code (programmatic) | `.claude/agents/lint-cleanup.md`   | `Agent(subagent_type: "lint-cleanup", isolation: "worktree", prompt: "...")` |
+| Claude Code (interactive)  | `.claude/commands/lint-cleanup.md` | Type `/lint-cleanup <path>` in a Claude Code session                         |
+| Copilot Coding Agent       | `.github/copilot-instructions.md`  | Assign a #25 sub-issue to Copilot in the GitHub UI                           |
 
 The entry-point stubs may surface a short cross-reference of the rules most often forgotten (commit prefix, `Refs #25`, isolated-worktree requirement) so a contributor seeing only the stub still gets the load-bearing constraints. They must not paraphrase or fork the workflow steps themselves — those live here, single-sourced.
 
@@ -22,7 +22,7 @@ Only formatting, docstrings, and lint fixes. **No functional changes.**
 
 ## Workflow
 
-For each file listed in any `exclude:` block in `.pre-commit-config.yaml` (e.g. `pyright`, `interrogate`, `shellcheck`, `codespell`) **or** under `[tool.pydoclint].exclude` or `[tool.ruff.lint.per-file-ignores]` in `pyproject.toml` (pydoclint and ruff configure their path-excludes there, not in the pre-commit config):
+For each file listed in any `exclude:` block in `.pre-commit-config.yaml` (e.g. `pyright`, `interrogate`, `shellcheck`, `codespell`) **or** under `[tool.pydoclint].exclude` or `[tool.ruff.lint.per-file-ignores]` in `pyproject.toml` (pydoclint path excludes and ruff per-file rule ignores are configured there, not in the pre-commit config; note that `per-file-ignores` still runs ruff on the file but suppresses specific rules — it is not a path exclude):
 
 1. **Create a branch**: `chore/lint-cleanup/<module-name>` (e.g., `chore/lint-cleanup/surge-datamodule`)
 2. **Run hooks on the file**, e.g. `interrogate`

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,8 +16,9 @@ architecture. A few rules that PRs most often violate:
 
 - Run `make format` before committing.
 - Every PR body must link a taxonomy-compliant issue via `Refs #N` /
-  `Fixes #N` / `Closes #N`. The `pr-metadata-gate.yaml` CI check enforces
-  this.
+  `Fixes #N` / `Closes #N` / `Part of #N`. The `pr-metadata-gate.yaml` CI
+  check enforces this; see `CLAUDE.md` for the authoritative list and the
+  semantics of each keyword.
 - PR titles and commit messages must follow conventional commits — gitlint
   will reject otherwise.
 - Never add "Generated with Claude Code", "Generated with Copilot", or

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,41 @@
+# Copilot instructions for synth-setter
+
+This file is read by GitHub Copilot Coding Agent (the autonomous issue → PR
+flow) and by Copilot Chat for repo-wide context. It is **not** the primary
+contributor guide — [`CLAUDE.md`](../CLAUDE.md) is the source of truth for
+project conventions, and every contributor (human or agent) is expected to
+follow it. This file points to `CLAUDE.md` and adds Copilot-specific routing
+for known agentic workflows.
+
+## Read first
+
+Before opening a PR, read [`CLAUDE.md`](../CLAUDE.md). It covers code
+standards, commit conventions (gitlint enforces `feat:`/`fix:`/
+`internal-feat:`/`chore:`/...), PR readiness rules, testing commands, and
+architecture. A few rules that PRs most often violate:
+
+- Run `make format` before committing.
+- Every PR body must link a taxonomy-compliant issue via `Refs #N` /
+  `Fixes #N` / `Closes #N`. The `pr-metadata-gate.yaml` CI check enforces
+  this.
+- PR titles and commit messages must follow conventional commits — gitlint
+  will reject otherwise.
+- Never add "Generated with Claude Code", "Generated with Copilot", or
+  similar attribution footers to commits, PRs, or comments.
+
+## Agent runbooks under `.github/agents/`
+
+Specific recurring tasks have dedicated runbooks in `.github/agents/`. When an
+assigned issue matches one of these workflows, follow the runbook step by
+step:
+
+- [`.github/agents/lint-cleanup.md`](agents/lint-cleanup.md) — clean up
+  pre-existing lint violations in one legacy file from the exclusion lists in
+  `.pre-commit-config.yaml`. Tracked in
+  [#25](https://github.com/tinaudio/synth-setter/issues/25). **Trigger:** any
+  issue that references #25 as its parent, or whose body says "apply
+  `.github/agents/lint-cleanup.md` to `<file>`".
+
+When in doubt, if an issue does not match a known runbook, follow the general
+contributor flow from `CLAUDE.md` — branch, commit, run `make test-fast`,
+open a PR with a linked issue, address review.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,11 +31,14 @@ assigned issue matches one of these workflows, follow the runbook step by
 step:
 
 - [`.github/agents/lint-cleanup.md`](agents/lint-cleanup.md) — clean up
-  pre-existing lint violations in one legacy file from the exclusion lists in
-  `.pre-commit-config.yaml`. Tracked in
-  [#25](https://github.com/tinaudio/synth-setter/issues/25). **Trigger:** any
-  issue that references #25 as its parent, or whose body says "apply
-  `.github/agents/lint-cleanup.md` to `<file>`".
+  pre-existing lint violations in one legacy file from the lint-exclusion
+  lists tracked in [#25](https://github.com/tinaudio/synth-setter/issues/25).
+  Those lists live in `.pre-commit-config.yaml`'s `exclude:` blocks **and** in
+  `pyproject.toml`'s `[tool.pydoclint].exclude` and
+  `[tool.ruff.lint.per-file-ignores]` — graduating a file means clearing it
+  from every list it appears in. **Trigger:** any issue that references #25
+  as its parent, or whose body says "apply `.github/agents/lint-cleanup.md`
+  to `<file>`".
 
 When in doubt, if an issue does not match a known runbook, follow the general
 contributor flow from `CLAUDE.md` — branch, commit, run `make test-fast`,


### PR DESCRIPTION
## Summary

`.github/agents/lint-cleanup.md` was a free-form runbook with no harness wiring — nothing in the repo or in any tool's discovery rules picked it up. This PR makes the runbook invocable from both Claude Code and GitHub Copilot by adding three thin entry points that delegate to the canonical workflow:

- `.claude/agents/lint-cleanup.md` — Claude Code subagent. Spawnable via `Agent(subagent_type: "lint-cleanup", ...)`.
- `.claude/commands/lint-cleanup.md` — Claude Code slash command. Typed as `/lint-cleanup <path>`.
- `.github/copilot-instructions.md` — Copilot Coding Agent repo-wide context. Routes #25 sub-issues assigned to Copilot at the canonical runbook. Also points Copilot at `CLAUDE.md` for general project conventions (commit format, PR readiness, no attribution footers) so Copilot-authored PRs don't immediately trip the metadata or gitlint gates.

Each stub is a pointer, not a copy — the workflow stays single-sourced in `.github/agents/lint-cleanup.md`. The canonical runbook gets a small "How this is invoked" header section so contributors discover the entry points from the source-of-truth doc.

This PR is documentation-only — no code or behaviour changes. Phase B (validation runs on real files via the new entry points) follows in separate PRs.

## Test plan

- [ ] Inspect the four files for accuracy (no duplicated workflow steps; pointers correctly resolve)
- [ ] `pre-commit run --files .claude/agents/lint-cleanup.md .claude/commands/lint-cleanup.md .github/agents/lint-cleanup.md .github/copilot-instructions.md` passes (verified locally before push)
- [ ] CI green on `pr-metadata-gate.yaml` and the other required checks
- [ ] After merge: spawn `Agent(subagent_type: "lint-cleanup", ...)` on a small target file (`src/utils/math.py`) and confirm the subagent is discovered and the workflow executes end-to-end — tracked as Run 1 of the plan
- [ ] After merge: assign a #25 sub-issue to Copilot in the GitHub UI and confirm Copilot's PR follows the runbook — tracked as Run 2 of the plan

Refs #25