### PR TITLE
chore: rename pyproject.toml package name to synth-setter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "synth-permutations"
+name = "synth-setter"
 version = "1.0.0"
 description = "Studying the effect of permutation symmetry on audio synthesiser parameter inference."
 authors = [{name = "Khaled Tinubu"}, {name = "tinaudio"}]

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,6 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
-name = "synth-permutations"
-version = "0.6.0"
+name = "synth-setter"
+version = "1.0.0"
 source = { virtual = "." }


### PR DESCRIPTION
## Summary

The repo and project have been called `synth-setter` since the migration from the upstream `ben-hayes/synth-permutations` fork, but `pyproject.toml`'s `[project]` table still declared `name = "synth-permutations"`. This PR aligns the package name with the project identity. Flagged by Copilot on #937 (MkDocs scaffolding) and scoped out of that PR to keep the docs-infra change surgical — this is the follow-up.

Closes #134

## What changed

| File | Change | Rationale |
| --- | --- | --- |
| `pyproject.toml` | `name = "synth-permutations"` → `name = "synth-setter"` | Primary target of this rename |
| `uv.lock` | `name = "synth-permutations"`, `version = "0.6.0"` → `name = "synth-setter"`, `version = "1.0.0"` | Auto-regenerated by `uv lock`. The `version` field was also drifted on `main` (`pyproject.toml` had `1.0.0`, `uv.lock` had `0.6.0`); the lock refresh corrected both fields in one pass. |

## Deliberately left as-is

After `git grep -n synth-permutations` across the repo, the following references were judgment-called as "leave alone" because they describe historical/legacy state rather than the current project:

- **`README.md` line 34** — links to upstream fork `https://github.com/ben-hayes/synth-permutations`. This IS the original project the work was forked from; renaming would silently break the upstream attribution. Leave.
- **`CHANGELOG.md`** — release history is immutable; multiple historical mentions of `synth-permutations` describe the state at the time of those releases. Leave.
- **`docs/org-migration-checklist.md`** — explicitly marked "COMPLETED — retained for historical reference only" (line 3); all `synth-permutations` mentions describe the pre-migration state. Leave.
- **`docs/design/storage-provenance-spec.md` line 257** — documents that legacy W&B runs under `benhayes/synth-permutations` remain read-only, contrasted with new `tinaudio/synth-setter` runs. Historical fact. Leave.
- **`docs/reference/wandb-integration.md` line 172** — `~~Entity/project hardcoded to benhayes/synth-permutations~~ **RESOLVED**` — strikethrough/RESOLVED log entry documenting the prior gap. Historical. Leave.
- **`notebooks/inpsect-models.ipynb`** — `synth-permutations` appears only in cached cell outputs (file paths like `/homes/bjh30/synth-permutations/...`) from an interactive session run by the original fork author on their machine. Not current code or paths — frozen execution traces. Leave.

## W&B project name (no change needed)

`configs/logger/wandb.yaml` already defaults to `synth-setter`:

```yaml
project: "${oc.env:WANDB_PROJECT,synth-setter}"
entity: ${oc.env:WANDB_ENTITY,null}
```

No W&B config currently references `synth-permutations`; nothing to migrate. Existing W&B runs under the legacy project name remain unaffected.

## Flagged for user decision: `setup.py`

`setup.py` at the repo root still has `name="src"` (a legacy template artifact — `name="synth-permutations"` was never set here). This is a separate, pre-existing issue unrelated to the `synth-permutations` → `synth-setter` rename. Modern packaging metadata lives in `pyproject.toml`'s `[project]` table; `setup.py` is dead code for naming purposes but is still touched by CI path filters (`.github/workflows/test*.yml`). Out of scope for this PR.

## Verification

After the edit, `git grep -n synth-permutations` returns only the deliberately-left-alone references listed above:

```
CHANGELOG.md:<multiple historical entries>
README.md:34: upstream fork URL
docs/design/storage-provenance-spec.md:257: legacy W&B note
docs/org-migration-checklist.md:<historical doc, marked COMPLETED>
docs/reference/wandb-integration.md:172: RESOLVED strikethrough
notebooks/inpsect-models.ipynb:<cached cell outputs>
```

No live code or config references `synth-permutations` as the current project name after this change.

## Test plan

- [ ] CI green (ruff, pyright, etc.)
- [ ] `pr-metadata-gate` passes (issue #134 has type=Task, label=code-health, milestone=code-health v1.0.0, parent=Phase #159)
- [ ] `gh pr view <N> --json mergeable` reports `MERGEABLE`