### PR TITLE
chore(lint): clean up src/utils/math.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -156,8 +156,7 @@ repos:
             src/models/surge_ff_module\.py|
             src/models/surge_flow_matching_module\.py|
             src/models/surge_flowvae_module\.py|
-            src/utils/callbacks\.py|
-            src/utils/math\.py
+            src/utils/callbacks\.py
           )$
 
   # pydoclint: signature ↔ docstring consistency. Config lives in pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,6 @@ ignore = ["E501", "S101"]
 "src/train.py" = ["E402"]
 "src/utils/__init__.py" = ["F401"]
 "src/utils/callbacks.py" = ["F821", "T201", "ANN001"]
-"src/utils/math.py" = ["ANN001"]
 
 [tool.interrogate]
 verbose = 2

--- a/src/utils/math.py
+++ b/src/utils/math.py
@@ -1,5 +1,14 @@
 import torch
 
 
-def divmod(a, b):
+def divmod(a: torch.Tensor, b: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return the floor quotient and remainder of ``a`` divided by ``b``.
+
+    :param a: Dividend tensor.
+    :param b: Divisor tensor.
+    :returns: A ``(floor_quotient, remainder)`` tuple, where ``floor_quotient``
+        is ``torch.div(a, b, rounding_mode="floor")`` and ``remainder`` is
+        ``torch.remainder(a, b)``.
+    :rtype: tuple[torch.Tensor, torch.Tensor]
+    """
     return torch.div(a, b, rounding_mode="floor"), torch.remainder(a, b)

--- a/src/utils/math.py
+++ b/src/utils/math.py
@@ -1,11 +1,12 @@
 import torch
 
 
-def divmod(a: torch.Tensor, b: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+def divmod(a: torch.Tensor, b: int | torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
     """Return the floor quotient and remainder of ``a`` divided by ``b``.
 
     :param a: Dividend tensor.
-    :param b: Divisor tensor.
+    :param b: Divisor. Either a tensor broadcastable against ``a`` or a Python
+        ``int`` scalar (``torch.div``/``torch.remainder`` accept either).
     :returns: A ``(floor_quotient, remainder)`` tuple, where ``floor_quotient``
         is ``torch.div(a, b, rounding_mode="floor")`` and ``remainder`` is
         ``torch.remainder(a, b)``.


### PR DESCRIPTION
## Summary

Cleans up `src/utils/math.py` so it can graduate off the legacy lint-exclusion lists, per the `lint-cleanup` runbook (`.github/agents/lint-cleanup.md`).

- Added `torch.Tensor` type annotations on `divmod`'s parameters and a `tuple[torch.Tensor, torch.Tensor]` return annotation, resolving the `ANN001` suppression.
- Added a Sphinx-style docstring with `:param:`, `:returns:`, and `:rtype:` that satisfies `interrogate` (coverage) and `pydoclint` DOC1xx/DOC2xx (signature/docstring consistency, including DOC203's return-type check).
- Removed `src/utils/math.py` from the `interrogate` `exclude` block in `.pre-commit-config.yaml` (it was the last entry, so the trailing `|` on the previous line went with it) and from the `[tool.ruff.lint.per-file-ignores]` entry in `pyproject.toml`.

No functional changes — `divmod` still returns `(torch.div(a, b, rounding_mode="floor"), torch.remainder(a, b))` for the same inputs.

This is Run 1 of validating the multi-tool lint-cleanup agent wired up in #951.

## Test plan

- [x] `pre-commit run --files src/utils/math.py` — all hooks Passed (interrogate now runs and passes; pydoclint, ruff, ruff format, pyright, docformatter all Passed)
- [x] `make test-fast` — 498 passed, 1 warning, in 26.76s

Refs #25