### PR TITLE
internal-fix(pipeline): tighten validate_spec — derive required fields from model

### DIFF
--- a/src/pipeline/ci/validate_spec.py
+++ b/src/pipeline/ci/validate_spec.py
@@ -10,42 +10,25 @@ from __future__ import annotations
 import json
 import sys
 from pathlib import Path
+from typing import Any
 
 from src.pipeline.r2_io import downloaded_to_tempfile, is_r2_uri
-from src.pipeline.schemas.spec import OUTPUT_FORMAT_TO_EXTENSION
+from src.pipeline.schemas.spec import (
+    OUTPUT_FORMAT_TO_EXTENSION,
+    DatasetSpec,
+    RenderConfig,
+)
 
-_REQUIRED_TOP_LEVEL_FIELDS = [
-    "base_seed",
-    "created_at",
-    "git_sha",
-    "is_repo_dirty",
-    "num_params",
-    "num_shards",
-    "output_format",
-    "r2_bucket",
-    "r2_prefix",
-    "render",
-    "run_id",
-    "shards",
-    "task_name",
-    "train_val_test_sizes",
-]
-_REQUIRED_RENDER_FIELDS = [
-    "batch_per_shard",
-    "channels",
-    "min_loudness",
-    "param_spec_name",
-    "plugin_path",
-    "preset_path",
-    "renderer_version",
-    "sample_batch_size",
-    "sample_rate",
-    "signal_duration_seconds",
-    "velocity",
-]
+# Required keys are derived from the model so adding a field to ``DatasetSpec``
+# (including computed_fields, which serialize on dump) automatically tightens
+# the structural check on the next CI run — no parallel list to update.
+_REQUIRED_TOP_LEVEL_FIELDS: tuple[str, ...] = tuple(
+    sorted(set(DatasetSpec.model_fields) | set(DatasetSpec.model_computed_fields))
+)
+_REQUIRED_RENDER_FIELDS: tuple[str, ...] = tuple(sorted(RenderConfig.model_fields))
 
 
-def validate_structure(spec: dict) -> list[str]:
+def validate_structure(spec: dict[str, Any]) -> list[str]:
     """Validate structural correctness of a spec dict.
 
     Returns a list of error strings (empty means valid).
@@ -85,7 +68,7 @@ def validate_structure(spec: dict) -> list[str]:
     return errors
 
 
-def validate_test_values(spec: dict) -> list[str]:
+def validate_test_values(spec: dict[str, Any]) -> list[str]:
     """Validate test-specific values expected from ci-materialize-test.yaml.
 
     Returns a list of error strings (empty means valid).

--- a/tests/pipeline/ci/test_validate_spec.py
+++ b/tests/pipeline/ci/test_validate_spec.py
@@ -6,7 +6,14 @@ import json
 from pathlib import Path
 from unittest.mock import patch
 
-from src.pipeline.ci.validate_spec import _read_spec_text, validate_structure, validate_test_values
+from src.pipeline.ci.validate_spec import (
+    _REQUIRED_RENDER_FIELDS,
+    _REQUIRED_TOP_LEVEL_FIELDS,
+    _read_spec_text,
+    validate_structure,
+    validate_test_values,
+)
+from src.pipeline.schemas.spec import DatasetSpec, RenderConfig
 
 
 def _make_valid_spec(*, output_format: str = "hdf5", **overrides: object) -> dict:
@@ -20,10 +27,12 @@ def _make_valid_spec(*, output_format: str = "hdf5", **overrides: object) -> dic
         "is_repo_dirty": False,
         "output_format": output_format,
         "train_val_test_sizes": [32, 32, 32],
+        "train_val_test_seeds": None,
         "base_seed": 42,
         "num_params": 92,
         "num_shards": 3,
         "r2_bucket": "intermediate-data",
+        "r2_prefix_root": "data",
         "r2_prefix": "data/test/test-20260328T120000000Z/",
         "render": {
             "plugin_path": "plugins/Surge XT.vst3",
@@ -85,6 +94,27 @@ class TestValidateStructure:
         spec = _make_valid_spec(output_format="parquet")
         errors = validate_structure(spec)
         assert any("output_format" in e and "parquet" in e for e in errors)
+
+    def test_missing_r2_prefix_root_returns_error(self) -> None:
+        """Spec missing r2_prefix_root (a DatasetSpec model field) is rejected.
+
+        Locks the model-derived required set: r2_prefix_root is defined on
+        DatasetSpec with a default, so the hand-rolled required list used to
+        miss it. The derived set surfaces it.
+        """
+        spec = _make_valid_spec()
+        del spec["r2_prefix_root"]
+        errors = validate_structure(spec)
+        assert any("missing" in e and "r2_prefix_root" in e for e in errors)
+
+    def test_required_top_level_fields_match_dataset_spec_model(self) -> None:
+        """Required top-level set is derived from DatasetSpec, not hand-mirrored."""
+        expected = set(DatasetSpec.model_fields) | set(DatasetSpec.model_computed_fields)
+        assert set(_REQUIRED_TOP_LEVEL_FIELDS) == expected
+
+    def test_required_render_fields_match_render_config_model(self) -> None:
+        """Required render set is derived from RenderConfig, not hand-mirrored."""
+        assert set(_REQUIRED_RENDER_FIELDS) == set(RenderConfig.model_fields)
 
 
 class TestValidateTestValues:


### PR DESCRIPTION
## Summary

\`validate_spec\` no longer maintains a parallel list of required top-level fields. The required set is derived directly from \`DatasetSpec.model_fields | DatasetSpec.model_computed_fields\`, so any future field added to \`DatasetSpec\` is automatically required by the CI validator.

Logical source: umbrella commit \`69e0835\` on PR #883.

## Test plan
- [x] \`make test-fast\` green (existing validate_spec tests pass)
- [x] New test: a synthetic spec missing a required field is rejected
- [x] New test: dropping a field from \`DatasetSpec\` would naturally relax the validator (model-driven, not list-driven)
- [ ] CI green on PR

Closes #957. Refs #882, refs #883.