### PR TITLE
internal-fix(schemas): tighten DatasetSpec validators + graceful runtime fields

### DIFF
--- a/src/generate_dataset.py
+++ b/src/generate_dataset.py
@@ -239,12 +239,13 @@ def spec_from_cfg(cfg: DictConfig) -> DatasetSpec:
     Resolves all interpolations, drops the non-DatasetSpec sub-trees, and constructs the model.
     Raises if the composed config is not a mapping.
     """
-    raw: Any = OmegaConf.to_container(cfg, resolve=True)
+    raw: object = OmegaConf.to_container(cfg, resolve=True)
     if not isinstance(raw, dict):
         raise TypeError(f"composed config is not a mapping: {type(raw).__name__}")
-    for key in _NON_SPEC_KEYS:
-        raw.pop(key, None)
-    return DatasetSpec(**raw)
+    spec_kwargs: dict[str, Any] = {
+        k: v for k, v in raw.items() if isinstance(k, str) and k not in _NON_SPEC_KEYS
+    }
+    return DatasetSpec(**spec_kwargs)
 
 
 @hydra.main(version_base="1.3", config_path="../configs", config_name="dataset")

--- a/src/pipeline/schemas/spec.py
+++ b/src/pipeline/schemas/spec.py
@@ -46,20 +46,39 @@ __all__ = [
 OUTPUT_FORMAT_TO_EXTENSION: dict[str, str] = {"hdf5": ".h5"}
 
 
+# Sentinel returned by ``_get_git_sha`` when called outside a git working
+# tree (worker host without ``.git/``, fresh tarball extract, etc.). Workers
+# normally receive ``git_sha`` populated in the JSON spec from R2, so the
+# default_factory only fires when something has gone off-script — returning
+# a sentinel rather than raising lets the failure surface as a clear
+# "git_sha=git-unavailable" in the spec JSON rather than a CalledProcessError
+# deep in pydantic's default_factory.
+_GIT_UNAVAILABLE_SENTINEL = "git-unavailable"
+
+
 def _get_git_sha() -> str:
-    """Get the current git commit SHA."""
-    result = subprocess.run(  # noqa: S603
-        ["git", "rev-parse", "HEAD"],  # noqa: S607
-        capture_output=True,
-        text=True,
-        check=True,
-    )
+    """Get the current git commit SHA, or a sentinel if unavailable."""
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["git", "rev-parse", "HEAD"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return _GIT_UNAVAILABLE_SENTINEL
     return result.stdout.strip()
 
 
 def _is_repo_dirty() -> bool:
-    """Check if the git working tree has uncommitted changes."""
-    result = subprocess.run(["git", "diff", "--quiet"], capture_output=True)  # noqa: S603, S607
+    """Check if the git working tree has uncommitted changes (False if no git)."""
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["git", "diff", "--quiet"],  # noqa: S607
+            capture_output=True,
+        )
+    except FileNotFoundError:
+        return False
     return result.returncode != 0
 
 
@@ -178,10 +197,11 @@ class DatasetSpec(BaseModel):
     # Sub-model
     render: RenderConfig
 
-    # Auto-filled runtime fields. ``default_factory`` runs only when the field
-    # is missing on input — JSON-loaded specs preserve the materialization-time
-    # values that workers must reuse for consistency. Lambdas wrap the
-    # module-level helpers so test monkeypatches take effect.
+    # Auto-filled runtime fields. The factory runs only when the field is
+    # missing on input — JSON-loaded specs preserve the materialization-time
+    # values workers must reuse. The lambdas around ``_get_git_sha`` etc.
+    # defer the lookup to call time so tests that ``monkeypatch.setattr`` on
+    # the module attribute reach this resolution path.
     git_sha: str = Field(default_factory=lambda: _get_git_sha())
     is_repo_dirty: bool = Field(default_factory=lambda: _is_repo_dirty())
     created_at: datetime = Field(default_factory=lambda: _utc_now())
@@ -216,7 +236,7 @@ class DatasetSpec(BaseModel):
         """
         if isinstance(data, dict):
             data = dict(data)
-            for computed_key in ("shards", "num_shards", "num_params"):
+            for computed_key in cls.model_computed_fields:
                 data.pop(computed_key, None)
         return data
 
@@ -281,6 +301,14 @@ class DatasetSpec(BaseModel):
         """Reject blank buckets so rclone never receives a malformed ``r2:/...`` destination."""
         if not value.strip():
             raise ValueError("r2_bucket must not be blank")
+        return value
+
+    @field_validator("r2_prefix_root")
+    @classmethod
+    def _r2_prefix_root_must_not_be_blank(cls, value: str) -> str:
+        """Reject blank prefix roots so derived ``r2_prefix`` doesn't start with a stray ``/``."""
+        if not value.strip():
+            raise ValueError("r2_prefix_root must not be blank")
         return value
 
     @field_validator("task_name")

--- a/src/pipeline/schemas/spec.py
+++ b/src/pipeline/schemas/spec.py
@@ -71,13 +71,22 @@ def _get_git_sha() -> str:
 
 
 def _is_repo_dirty() -> bool:
-    """Check if the git working tree has uncommitted changes (False if no git)."""
+    """Check if the git working tree has uncommitted changes (False if no git).
+
+    ``git diff --quiet`` exits 0 (clean) or 1 (dirty) inside a repo, and 128
+    when run outside one (``fatal: not a git repository``). Treat exit codes
+    outside {0, 1} as "no usable git" — same contract as ``_get_git_sha``'s
+    sentinel: a worker on a tarball-extracted host gets a benign default
+    rather than a confusing ``is_repo_dirty=True``.
+    """
     try:
         result = subprocess.run(  # noqa: S603
             ["git", "diff", "--quiet"],  # noqa: S607
             capture_output=True,
         )
     except FileNotFoundError:
+        return False
+    if result.returncode not in (0, 1):
         return False
     return result.returncode != 0
 

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -466,6 +466,21 @@ class TestGitHelpersGraceful:
         monkeypatch.setattr(spec_mod.subprocess, "run", _raise)
         assert spec_mod._is_repo_dirty() is False
 
+    def test_is_repo_dirty_returns_false_when_outside_git_worktree(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``git diff --quiet`` exits 128 outside a worktree — treat as "no git", not "dirty"."""
+        import src.pipeline.schemas.spec as spec_mod
+
+        class _FakeCompleted:
+            returncode = 128
+
+        def _fake(*args: object, **kwargs: object) -> _FakeCompleted:
+            return _FakeCompleted()
+
+        monkeypatch.setattr(spec_mod.subprocess, "run", _fake)
+        assert spec_mod._is_repo_dirty() is False
+
 
 # ---------------------------------------------------------------------------
 # Bare import is launcher-pure — no pedalboard / src.data.vst.core load
@@ -479,10 +494,11 @@ class TestSpecImportStaysLauncherPure:
         """`import src.pipeline.schemas.spec` alone must not transitively load
         ``src.data.vst.core`` or ``pedalboard``.
 
-        spec.py's two lazy imports (``_param_spec_name_must_be_registered``,
-        ``num_params``) point at ``src.data.vst`` lazily. If either is re-promoted
-        to module level — or repointed at a heavier module — this test fails
-        immediately, preserving the launcher's interpreter-only contract.
+        ``spec.py``'s only ``src.data.vst`` import is inside
+        ``DatasetSpec.num_params`` and runs lazily. If it is re-promoted to
+        module level — or another heavy import is added at module load — this
+        test fails immediately, preserving the launcher's interpreter-only
+        contract.
         """
         script = (
             "import sys\n"

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import subprocess
+import sys
 from datetime import datetime, timezone
 from typing import Any
 
@@ -185,6 +187,13 @@ class TestDatasetSpecValidators:
         """Blank task_name raises (derived run_id / r2_prefix would be empty-prefixed)."""
         with pytest.raises(ValidationError, match="task_name must not be blank"):
             DatasetSpec(**_valid_spec_kwargs(task_name="   "))
+
+    def test_r2_prefix_root_blank_raises(self, patch_runtime_io: None) -> None:
+        """Blank or whitespace-only r2_prefix_root raises so derived r2_prefix doesn't start with a
+        stray ``/``."""
+        for blank in ("", "   ", "\t\n"):
+            with pytest.raises(ValidationError, match="r2_prefix_root must not be blank"):
+                DatasetSpec(**_valid_spec_kwargs(r2_prefix_root=blank))
 
     def test_explicit_r2_prefix_missing_trailing_slash_raises(
         self, patch_runtime_io: None
@@ -411,3 +420,86 @@ class TestDatasetSpecRoundTrip:
             spec_mod._get_git_sha = original
 
         assert restored.git_sha == "abc123def456"
+
+
+# ---------------------------------------------------------------------------
+# Graceful git helpers — _get_git_sha / _is_repo_dirty under missing .git/
+# ---------------------------------------------------------------------------
+
+
+class TestGitHelpersGraceful:
+    """``_get_git_sha`` and ``_is_repo_dirty`` must not crash when ``.git/`` is unavailable."""
+
+    def test_get_git_sha_returns_sentinel_on_called_process_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-zero ``git rev-parse`` exit returns the sentinel rather than raising."""
+        import src.pipeline.schemas.spec as spec_mod
+
+        def _raise(*args: object, **kwargs: object) -> object:
+            raise subprocess.CalledProcessError(returncode=128, cmd=["git", "rev-parse", "HEAD"])
+
+        monkeypatch.setattr(spec_mod.subprocess, "run", _raise)
+        assert spec_mod._get_git_sha() == spec_mod._GIT_UNAVAILABLE_SENTINEL
+
+    def test_get_git_sha_returns_sentinel_when_git_binary_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing ``git`` binary yields the sentinel — worker hosts without git survive."""
+        import src.pipeline.schemas.spec as spec_mod
+
+        def _raise(*args: object, **kwargs: object) -> object:
+            raise FileNotFoundError("git")
+
+        monkeypatch.setattr(spec_mod.subprocess, "run", _raise)
+        assert spec_mod._get_git_sha() == spec_mod._GIT_UNAVAILABLE_SENTINEL
+
+    def test_is_repo_dirty_returns_false_when_git_binary_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A missing ``git`` binary makes ``_is_repo_dirty`` return False rather than raise."""
+        import src.pipeline.schemas.spec as spec_mod
+
+        def _raise(*args: object, **kwargs: object) -> object:
+            raise FileNotFoundError("git")
+
+        monkeypatch.setattr(spec_mod.subprocess, "run", _raise)
+        assert spec_mod._is_repo_dirty() is False
+
+
+# ---------------------------------------------------------------------------
+# Bare import is launcher-pure — no pedalboard / src.data.vst.core load
+# ---------------------------------------------------------------------------
+
+
+class TestSpecImportStaysLauncherPure:
+    """``import src.pipeline.schemas.spec`` alone must not pull heavy modules."""
+
+    def test_bare_spec_import_does_not_pull_data_vst_core(self) -> None:
+        """`import src.pipeline.schemas.spec` alone must not transitively load
+        ``src.data.vst.core`` or ``pedalboard``.
+
+        spec.py's two lazy imports (``_param_spec_name_must_be_registered``,
+        ``num_params``) point at ``src.data.vst`` lazily. If either is re-promoted
+        to module level — or repointed at a heavier module — this test fails
+        immediately, preserving the launcher's interpreter-only contract.
+        """
+        script = (
+            "import sys\n"
+            "import src.pipeline.schemas.spec  # noqa: F401\n"
+            "for name in ('src.data.vst.core', 'src.data.vst', 'pedalboard'):\n"
+            "    assert name not in sys.modules, (\n"
+            "        f'{name!r} leaked into spec module import; '\n"
+            "        f'this breaks the launcher-pure invariant'\n"
+            "    )\n"
+        )
+        result = subprocess.run(  # noqa: S603 — sys.executable + literal script
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"bare spec import is no longer launcher-pure:\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )


### PR DESCRIPTION
## Summary

Five small hardening steps on `DatasetSpec` and its construction surface, surfaced during the foundation chain. Source: umbrella commits `2e2f4d2`, `2bc6cb5`, `cc8d783`, `d56e496`, `c38417a` on PR #883 (`b516b67`'s seeds-gate work landed earlier via #944).

- Computed-field set derived from `cls.model_computed_fields` (no parallel list to maintain).
- New `_r2_prefix_root_must_not_be_blank` field validator so derived `r2_prefix` can't start with a stray `/`.
- `_get_git_sha` / `_is_repo_dirty` no longer crash on `CalledProcessError` / `FileNotFoundError` — they return a `git-unavailable` sentinel / `False` so workers without `.git/` don't tracaback inside pydantic's default_factory.
- Hydra→Pydantic trust-boundary narrowing on `spec_from_cfg`: `raw: Any` → `raw: object` plus explicit `isinstance(k, str)` filter.
- Bare-import-pure invariant pinned by a new test — `import src.pipeline.schemas.spec` must not pull `src.data.vst`, `src.data.vst.core`, or `pedalboard` into `sys.modules`.

Sharpened the lambda-wrap rationale comment for `default_factory=lambda: _get_git_sha()` so a future "simplification" reader sees that `monkeypatch.setattr` on the module attribute is what depends on it.

## Test plan
- [x] `make test-fast` green (503 passed)
- [x] `make format` clean
- [x] `python -c "from src.pipeline.schemas.spec import DatasetSpec"` runs without loading pedalboard (the new test pins this)
- [ ] CI green on PR

Closes #958. Refs #882, refs #883.