### PR TITLE
internal-fix(pipeline): code-health pass on skypilot_launch + pedalboard-free spec import

### DIFF
--- a/scripts/predict_vst_audio.py
+++ b/scripts/predict_vst_audio.py
@@ -12,7 +12,8 @@ from pedalboard.io import AudioFile
 from tqdm import tqdm, trange
 
 rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
-from src.data.vst import param_specs, render_params
+from src.data.vst import param_specs
+from src.data.vst.core import render_params
 from src.data.vst.param_spec import ParamSpec
 
 

--- a/scripts/surge_xt_interactive.py
+++ b/scripts/surge_xt_interactive.py
@@ -32,9 +32,11 @@ from pedalboard.io import AudioFile, AudioStream, StreamResampler  # noqa: E402
 from rich.console import Console  # noqa: E402
 from rich.logging import RichHandler  # noqa: E402
 
-from src.data.vst import load_plugin, load_preset, param_specs, preset_paths  # noqa: E402
+from src.data.vst import param_specs, preset_paths  # noqa: E402
 from src.data.vst.core import (  # noqa: E402
     extract_renderer_version,  # noqa: E402
+    load_plugin,
+    load_preset,
     make_midi_events,
     set_params,
 )

--- a/src/data/vst/__init__.py
+++ b/src/data/vst/__init__.py
@@ -1,19 +1,25 @@
-from src.data.vst.core import load_plugin, load_preset, render_params
+"""Public re-exports for the ``src.data.vst`` package.
+
+Importing this package is intentionally pedalboard-free: callers that need
+``load_plugin`` / ``load_preset`` / ``render_params`` import from
+``src.data.vst.core`` directly. The registry dicts (``param_specs``,
+``preset_paths``) live in ``src.data.vst.param_spec_registry`` and are
+re-exported here for backward compat.
+"""
+
 from src.data.vst.param_spec import ParamSpec
+from src.data.vst.param_spec_registry import param_specs, preset_paths
 from src.data.vst.surge_xt_param_spec import (
+    SURGE_4_PARAM_SPEC,
     SURGE_SIMPLE_PARAM_SPEC,
     SURGE_XT_PARAM_SPEC,
-    SURGE_4_PARAM_SPEC,
 )
 
-param_specs: dict[str, ParamSpec] = {
-    "surge_xt": SURGE_XT_PARAM_SPEC,
-    "surge_simple": SURGE_SIMPLE_PARAM_SPEC,
-    "surge_4": SURGE_4_PARAM_SPEC,
-}
-
-preset_paths: dict[str, str] = {
-    "surge_xt": "presets/surge-base.vstpreset",
-    "surge_simple": "presets/surge-simple.vstpreset",
-    "surge_4": "presets/surge-mini.vstpreset",
-}
+__all__ = [
+    "ParamSpec",
+    "SURGE_4_PARAM_SPEC",
+    "SURGE_SIMPLE_PARAM_SPEC",
+    "SURGE_XT_PARAM_SPEC",
+    "param_specs",
+    "preset_paths",
+]

--- a/src/data/vst/generate_vst_dataset.py
+++ b/src/data/vst/generate_vst_dataset.py
@@ -15,7 +15,8 @@ from tqdm import trange
 
 rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 from src.pipeline.schemas.spec import RenderConfig  # noqa: E402
-from src.data.vst import param_specs, render_params  # noqa
+from src.data.vst import param_specs  # noqa
+from src.data.vst.core import render_params  # noqa
 from src.data.vst.param_spec import ParamSpec  # noqa
 
 

--- a/src/data/vst/param_spec_registry.py
+++ b/src/data/vst/param_spec_registry.py
@@ -1,11 +1,11 @@
 """Pedalboard-free registry of ``ParamSpec`` objects keyed by name.
 
 Importing this module pulls only ``param_spec`` and ``surge_xt_param_spec`` —
-both of which are pure-Python and free of pedalboard / VST3 native deps. Use
-this entrypoint from interpreter-only contexts (the SkyPilot launcher, spec
-construction in ``src.pipeline.schemas.spec``) so importing the spec model
-does not transitively pull pedalboard via ``src.data.vst.__init__``'s
-``from src.data.vst.core import ...``.
+both of which are pure-Python and free of pedalboard / VST3 native deps. This
+is the canonical pedalboard-free entrypoint for interpreter-only contexts
+(the SkyPilot launcher, spec construction in ``src.pipeline.schemas.spec``);
+``src.data.vst`` re-exports the same names for backward compat, but importing
+``src.data.vst.core`` directly is what pulls pedalboard.
 """
 
 from __future__ import annotations

--- a/src/data/vst/param_spec_registry.py
+++ b/src/data/vst/param_spec_registry.py
@@ -1,0 +1,30 @@
+"""Pedalboard-free registry of ``ParamSpec`` objects keyed by name.
+
+Importing this module pulls only ``param_spec`` and ``surge_xt_param_spec`` —
+both of which are pure-Python and free of pedalboard / VST3 native deps. Use
+this entrypoint from interpreter-only contexts (the SkyPilot launcher, spec
+construction in ``src.pipeline.schemas.spec``) so importing the spec model
+does not transitively pull pedalboard via ``src.data.vst.__init__``'s
+``from src.data.vst.core import ...``.
+"""
+
+from __future__ import annotations
+
+from src.data.vst.param_spec import ParamSpec
+from src.data.vst.surge_xt_param_spec import (
+    SURGE_4_PARAM_SPEC,
+    SURGE_SIMPLE_PARAM_SPEC,
+    SURGE_XT_PARAM_SPEC,
+)
+
+param_specs: dict[str, ParamSpec] = {
+    "surge_xt": SURGE_XT_PARAM_SPEC,
+    "surge_simple": SURGE_SIMPLE_PARAM_SPEC,
+    "surge_4": SURGE_4_PARAM_SPEC,
+}
+
+preset_paths: dict[str, str] = {
+    "surge_xt": "presets/surge-base.vstpreset",
+    "surge_simple": "presets/surge-simple.vstpreset",
+    "surge_4": "presets/surge-mini.vstpreset",
+}

--- a/src/pipeline/schemas/spec.py
+++ b/src/pipeline/schemas/spec.py
@@ -388,11 +388,10 @@ class DatasetSpec(BaseModel):
     def num_params(self) -> int:
         """Total encoded parameter count looked up by name in the param-spec registry.
 
-        Imports ``param_specs`` lazily: ``src.data.vst.__init__`` pulls in
-        ``mido`` + ``pedalboard`` via the renderer, which the launcher and
-        validate-spec runner don't have installed. Top-level import here would
-        prevent spec serialization on those minimal envs.
+        Imported from ``param_spec_registry`` (not ``src.data.vst``) so that
+        ``model_dump_json`` — which evaluates this computed field — does not
+        transitively pull ``pedalboard`` into the launcher.
         """
-        from src.data.vst import param_specs
+        from src.data.vst.param_spec_registry import param_specs
 
         return len(param_specs[self.render.param_spec_name])

--- a/src/pipeline/skypilot_launch.py
+++ b/src/pipeline/skypilot_launch.py
@@ -87,9 +87,10 @@ _R2_RCLONE_CONSTANTS: dict[str, str] = {
 }
 
 # Residual `_WORKER_ENV_KEYS` that are not defaulted by `_R2_RCLONE_CONSTANTS`.
-# Used to detect the unconfigured-creds case: the non-secret rclone constants
+# Used to detect the unconfigured-creds case: the rclone TYPE/PROVIDER constants
 # default in, so an "empty" worker_env still has those keys — only this residual
-# subset signals whether real secrets were resolved from .env / process env.
+# subset (R2 access creds, WANDB_API_KEY, WORKER_GIT_REF) signals whether
+# anything was actually resolved from .env / process env.
 _SECRET_WORKER_ENV_KEYS: tuple[str, ...] = tuple(
     k for k in _WORKER_ENV_KEYS if k not in _R2_RCLONE_CONSTANTS
 )

--- a/src/pipeline/skypilot_launch.py
+++ b/src/pipeline/skypilot_launch.py
@@ -30,6 +30,7 @@ SYNTH_SETTER_NUM_WORKERS injected; one shared spec → one r2_prefix.
 
 from __future__ import annotations
 
+import functools
 import os
 import re
 import subprocess
@@ -40,7 +41,6 @@ from pathlib import Path
 
 import click
 import sky
-import sky.check  # accessed conditionally on the kubernetes path; see provider == "local" branch in main()
 import yaml
 from dotenv import dotenv_values
 from hydra import compose, initialize_config_dir
@@ -85,6 +85,14 @@ _R2_RCLONE_CONSTANTS: dict[str, str] = {
     "RCLONE_CONFIG_R2_TYPE": "s3",
     "RCLONE_CONFIG_R2_PROVIDER": "Cloudflare",
 }
+
+# Residual `_WORKER_ENV_KEYS` that are not defaulted by `_R2_RCLONE_CONSTANTS`.
+# Used to detect the unconfigured-creds case: the non-secret rclone constants
+# default in, so an "empty" worker_env still has those keys — only this residual
+# subset signals whether real secrets were resolved from .env / process env.
+_SECRET_WORKER_ENV_KEYS: tuple[str, ...] = tuple(
+    k for k in _WORKER_ENV_KEYS if k not in _R2_RCLONE_CONSTANTS
+)
 
 _CRED_BOOTSTRAP_SCRIPT = (
     Path(__file__).resolve().parent.parent.parent / "scripts" / "skypilot_write_provider_creds.sh"
@@ -480,14 +488,11 @@ def main(
         )
 
     worker_env = resolve_worker_env(env_file_path)
-    # `_R2_RCLONE_CONSTANTS` defaults TYPE/PROVIDER, so an "empty" worker_env still has those.
-    # Check the actual secret keys to detect the unconfigured-creds case.
-    secret_keys = tuple(k for k in _WORKER_ENV_KEYS if k not in _R2_RCLONE_CONSTANTS)
-    if not any(k in worker_env for k in secret_keys):
+    if not any(k in worker_env for k in _SECRET_WORKER_ENV_KEYS):
         raise click.ClickException(
             "No worker env vars resolved. Set the rclone-R2 keys in process env "
             f"(e.g. via `docker run -e RCLONE_CONFIG_R2_*=...`) or populate {env_file_path}. "
-            f"Expected at least one of: {', '.join(secret_keys)}."
+            f"Expected at least one of: {', '.join(_SECRET_WORKER_ENV_KEYS)}."
         )
 
     # rclone subprocess inherits os.environ; mirror launcher-resolved values so .env wins.
@@ -538,6 +543,9 @@ def main(
     # `sky.check.check` in-process before launch is the documented workaround
     # (test-skypilot-local.yml). RunPod/OCI source creds from disk on every launch.
     if provider == "local":
+        # Deferred so non-kubernetes runs (RunPod / OCI) skip the submodule import entirely.
+        import sky.check
+
         sky.check.check(clouds=["kubernetes"], quiet=False)
 
     # Single-worker keeps the unsuffixed cluster name for backward compatibility with debug
@@ -620,35 +628,58 @@ def _run_workers(
     Returns:
         Per-rank result code (``0`` = success, anything else = failure).
     """
-    num_workers = len(cluster_names)
     worker_image = f"{_WORKER_IMAGE_REPO}:{worker_image_tag}"
-
-    def _launch_get_job_id(rank: int) -> int:
-        cluster = cluster_names[rank]
-        env_for_rank = {
-            **worker_env_base,
-            WORKER_RANK_ENV_VAR: str(rank),
-            NUM_WORKERS_ENV_VAR: str(num_workers),
-            _WORKER_IMAGE_ENV: worker_image,
-        }
-        task = sky.Task.from_yaml(str(template_path))
-        _override_image_id(task, worker_image)
-        task.update_envs(env_for_rank)
-        click.echo(f"[{cluster}] provisioning rank={rank}/{num_workers}")
-        launch_request_id = sky.launch(
-            task,
-            cluster_name=cluster,
-            idle_minutes_to_autostop=5,
-            down=True,
-        )
-        launch_result = sky.stream_and_get(launch_request_id)
-        if launch_result is None or launch_result[0] is None:
-            raise click.ClickException(f"[{cluster}] launch yielded no job_id")
-        return launch_result[0]
-
+    launch_get_job_id = functools.partial(
+        _launch_one_rank,
+        cluster_names=cluster_names,
+        worker_env_base=worker_env_base,
+        worker_image=worker_image,
+        template_path=template_path,
+    )
     if tail:
-        return _run_workers_tail(cluster_names, _launch_get_job_id)
-    return _run_workers_detached(cluster_names, _launch_get_job_id)
+        return _run_workers_tail(cluster_names, launch_get_job_id)
+    return _run_workers_detached(cluster_names, launch_get_job_id)
+
+
+def _launch_one_rank(
+    rank: int,
+    *,
+    cluster_names: list[str],
+    worker_env_base: dict[str, str],
+    worker_image: str,
+    template_path: Path,
+) -> int:
+    """Provision rank ``rank``'s cluster and return its ``job_id``.
+
+    Used by ``_run_workers`` to fan out per-rank launches; lives at module level
+    rather than as a closure so it can be tested directly without re-running
+    the parent ``_run_workers`` setup.
+
+    Raises ``click.ClickException`` if ``sky.launch`` / ``sky.stream_and_get``
+    yields no ``job_id``.
+    """
+    num_workers = len(cluster_names)
+    cluster = cluster_names[rank]
+    env_for_rank = {
+        **worker_env_base,
+        WORKER_RANK_ENV_VAR: str(rank),
+        NUM_WORKERS_ENV_VAR: str(num_workers),
+        _WORKER_IMAGE_ENV: worker_image,
+    }
+    task = sky.Task.from_yaml(str(template_path))
+    _override_image_id(task, worker_image)
+    task.update_envs(env_for_rank)
+    click.echo(f"[{cluster}] provisioning rank={rank}/{num_workers}")
+    launch_request_id = sky.launch(
+        task,
+        cluster_name=cluster,
+        idle_minutes_to_autostop=5,
+        down=True,
+    )
+    launch_result = sky.stream_and_get(launch_request_id)
+    if launch_result is None or launch_result[0] is None:
+        raise click.ClickException(f"[{cluster}] launch yielded no job_id")
+    return launch_result[0]
 
 
 def _run_workers_tail(

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -1999,3 +1999,145 @@ class TestWorkerEnvToOsEnvironBridge:
         assert captured["RCLONE_CONFIG_R2_ACCESS_KEY_ID"] == "ak-from-env"
         assert captured["RCLONE_CONFIG_R2_SECRET_ACCESS_KEY"] == "sk-from-env"  # noqa: S105 — fixture value, not a real secret
         assert captured["RCLONE_CONFIG_R2_ENDPOINT"] == "https://e.r2"
+
+
+# ---------------------------------------------------------------------------
+# _SECRET_WORKER_ENV_KEYS — module-level constant for the unconfigured-creds
+# check. Subset of `_WORKER_ENV_KEYS` excluding the non-secret rclone
+# defaults that ``_R2_RCLONE_CONSTANTS`` already supplies.
+# ---------------------------------------------------------------------------
+
+
+class TestSecretWorkerEnvKeys:
+    """`_SECRET_WORKER_ENV_KEYS` is the residual subset used to detect unconfigured creds."""
+
+    def test_excludes_non_secret_rclone_constants(self) -> None:
+        """TYPE / PROVIDER are public rclone configuration — they must not appear in the secret
+        subset."""
+        from src.pipeline.skypilot_launch import (
+            _R2_RCLONE_CONSTANTS,
+            _SECRET_WORKER_ENV_KEYS,
+        )
+
+        assert "RCLONE_CONFIG_R2_TYPE" not in _SECRET_WORKER_ENV_KEYS
+        assert "RCLONE_CONFIG_R2_PROVIDER" not in _SECRET_WORKER_ENV_KEYS
+        for key in _R2_RCLONE_CONSTANTS:
+            assert key not in _SECRET_WORKER_ENV_KEYS
+
+    def test_includes_runtime_secret_keys(self) -> None:
+        """The access-key / secret-key / endpoint triple must remain in the secret subset."""
+        from src.pipeline.skypilot_launch import _SECRET_WORKER_ENV_KEYS
+
+        assert "RCLONE_CONFIG_R2_ACCESS_KEY_ID" in _SECRET_WORKER_ENV_KEYS
+        assert "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY" in _SECRET_WORKER_ENV_KEYS
+        assert "RCLONE_CONFIG_R2_ENDPOINT" in _SECRET_WORKER_ENV_KEYS
+
+    def test_is_subset_of_worker_env_keys(self) -> None:
+        """The secret subset is closed-form derived from `_WORKER_ENV_KEYS`."""
+        from src.pipeline.skypilot_launch import (
+            _SECRET_WORKER_ENV_KEYS,
+            _WORKER_ENV_KEYS,
+        )
+
+        assert set(_SECRET_WORKER_ENV_KEYS).issubset(set(_WORKER_ENV_KEYS))
+
+
+# ---------------------------------------------------------------------------
+# _launch_one_rank — module-level helper for fan-out launch (lifted from
+# _run_workers closure for testability).
+# ---------------------------------------------------------------------------
+
+
+class TestLaunchOneRank:
+    """`_launch_one_rank` builds the per-rank Task, calls sky.launch, returns the job_id."""
+
+    def test_returns_job_id_from_stream_and_get(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Happy path: stream_and_get returns ``(job_id, ...)`` and the helper returns the
+        job_id."""
+        from src.pipeline.skypilot_launch import _launch_one_rank
+
+        fake_sky = MagicMock()
+        fake_sky.Task.from_yaml.return_value = MagicMock()
+        fake_sky.launch.return_value = "req-1"
+        fake_sky.stream_and_get.return_value = (42, None)
+        monkeypatch.setattr("src.pipeline.skypilot_launch.sky", fake_sky)
+
+        job_id = _launch_one_rank(
+            0,
+            cluster_names=["cluster-0"],
+            worker_env_base={"RCLONE_CONFIG_R2_TYPE": "s3"},
+            worker_image="repo:tag",
+            template_path=Path("template.yaml"),
+        )
+
+        assert job_id == 42
+
+    def test_raises_when_stream_and_get_returns_none(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If stream_and_get yields ``None``, the helper raises ``ClickException``."""
+        from src.pipeline.skypilot_launch import _launch_one_rank
+
+        fake_sky = MagicMock()
+        fake_sky.Task.from_yaml.return_value = MagicMock()
+        fake_sky.launch.return_value = "req-1"
+        fake_sky.stream_and_get.return_value = None
+        monkeypatch.setattr("src.pipeline.skypilot_launch.sky", fake_sky)
+
+        with pytest.raises(click.ClickException, match="launch yielded no job_id"):
+            _launch_one_rank(
+                0,
+                cluster_names=["cluster-0"],
+                worker_env_base={},
+                worker_image="repo:tag",
+                template_path=Path("template.yaml"),
+            )
+
+    def test_raises_when_stream_and_get_returns_none_job_id(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If stream_and_get returns ``(None, ...)``, the helper raises ``ClickException``."""
+        from src.pipeline.skypilot_launch import _launch_one_rank
+
+        fake_sky = MagicMock()
+        fake_sky.Task.from_yaml.return_value = MagicMock()
+        fake_sky.launch.return_value = "req-1"
+        fake_sky.stream_and_get.return_value = (None, None)
+        monkeypatch.setattr("src.pipeline.skypilot_launch.sky", fake_sky)
+
+        with pytest.raises(click.ClickException, match="launch yielded no job_id"):
+            _launch_one_rank(
+                0,
+                cluster_names=["cluster-0"],
+                worker_env_base={},
+                worker_image="repo:tag",
+                template_path=Path("template.yaml"),
+            )
+
+    def test_injects_rank_and_num_workers_into_task_env(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """`update_envs` receives the rank, world size, and worker image alongside the base env."""
+        from src.pipeline.partitioning import NUM_WORKERS_ENV_VAR, WORKER_RANK_ENV_VAR
+        from src.pipeline.skypilot_launch import _WORKER_IMAGE_ENV, _launch_one_rank
+
+        fake_task = MagicMock()
+        fake_sky = MagicMock()
+        fake_sky.Task.from_yaml.return_value = fake_task
+        fake_sky.launch.return_value = "req-1"
+        fake_sky.stream_and_get.return_value = (7, None)
+        monkeypatch.setattr("src.pipeline.skypilot_launch.sky", fake_sky)
+
+        _launch_one_rank(
+            2,
+            cluster_names=["a", "b", "c", "d"],
+            worker_env_base={"BASE_KEY": "base-value"},
+            worker_image="repo:tag",
+            template_path=Path("template.yaml"),
+        )
+
+        envs_passed = fake_task.update_envs.call_args.args[0]
+        assert envs_passed["BASE_KEY"] == "base-value"
+        assert envs_passed[WORKER_RANK_ENV_VAR] == "2"
+        assert envs_passed[NUM_WORKERS_ENV_VAR] == "4"
+        assert envs_passed[_WORKER_IMAGE_ENV] == "repo:tag"

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -532,8 +532,9 @@ class TestSpecImportStaysLauncherPure:
 class TestSpecConstructionStaysPedalboardFree:
     """Importing schemas + building/serializing a DatasetSpec must not load pedalboard.
 
-    Run in a fresh subprocess so the parent test session — which loads pedalboard
-    transitively via ``tests/conftest.py`` — does not poison the check.
+    Run in a fresh subprocess so the parent test session — where earlier tests
+    import ``src.data.vst.core`` (and other modules that pull pedalboard
+    transitively) — does not poison the check.
     """
 
     def test_dataset_spec_num_params_does_not_import_pedalboard(self) -> None:

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -519,3 +519,56 @@ class TestSpecImportStaysLauncherPure:
             f"bare spec import is no longer launcher-pure:\n"
             f"stdout={result.stdout}\nstderr={result.stderr}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Stronger pedalboard-free invariant — construction + serialization must not
+# pull pedalboard either. Catches regressions where the lazy import path
+# inside ``num_params`` (or its callers via ``model_dump_json``) silently
+# starts loading native deps.
+# ---------------------------------------------------------------------------
+
+
+class TestSpecConstructionStaysPedalboardFree:
+    """Importing schemas + building/serializing a DatasetSpec must not load pedalboard.
+
+    Run in a fresh subprocess so the parent test session — which loads pedalboard
+    transitively via ``tests/conftest.py`` — does not poison the check.
+    """
+
+    def test_dataset_spec_num_params_does_not_import_pedalboard(self) -> None:
+        """``num_params`` is emitted by ``model_dump_json`` so its lazy import path runs in every
+        serialize.
+
+        It must remain interpreter-only.
+        """
+        script = (
+            "import sys\n"
+            "from src.pipeline.schemas.spec import DatasetSpec\n"
+            "spec = DatasetSpec(\n"
+            "    task_name='ci', output_format='hdf5', train_val_test_sizes=[1, 0, 0],\n"
+            "    base_seed=0, r2_bucket='b',\n"
+            "    render={\n"
+            "        'plugin_path': '/tmp/x.vst3', 'preset_path': '/tmp/x.vstpreset',\n"
+            "        'param_spec_name': 'surge_simple', 'renderer_version': 'v1',\n"
+            "        'sample_rate': 16000, 'channels': 1, 'velocity': 64,\n"
+            "        'signal_duration_seconds': 1.0, 'min_loudness': -30.0,\n"
+            "        'sample_batch_size': 1, 'batch_per_shard': 1,\n"
+            "    },\n"
+            ")\n"
+            "_ = spec.num_params\n"
+            "_ = spec.model_dump_json()\n"
+            "assert 'pedalboard' not in sys.modules, sorted(\n"
+            "    m for m in sys.modules if m.startswith('pedalboard')\n"
+            ")\n"
+        )
+        result = subprocess.run(  # noqa: S603 — sys.executable + literal script
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"pedalboard leaked into spec serialization:\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )


### PR DESCRIPTION
## Summary

Code-health pass on `src/pipeline/skypilot_launch.py` plus a pedalboard-free `DatasetSpec` import path. Source: umbrella commits `eac9d52`, `3e45f1d`.

- `sky.check` import deferred — module loads cheaply when SkyPilot isn't on the hot path.
- `_SECRET_WORKER_ENV_KEYS` extracted to a constant.
- `_launch_one_rank` lifted to module level (testable in isolation).
- `src.pipeline.schemas.spec` is launcher-pure — importable without `pedalboard` installed.
- Three call sites migrated to import `load_plugin` / `load_preset` / `render_params` directly from `src.data.vst.core`.

## Test plan
- [x] `make test-fast` green (506 passed)
- [x] `make format` clean
- [x] `python -c "from src.pipeline.skypilot_launch import _launch_one_rank, _SECRET_WORKER_ENV_KEYS"` succeeds
- [x] `python -c "from src.pipeline.schemas.spec import DatasetSpec"` does not import pedalboard (pinned by subprocess test)
- [ ] CI green on PR

Closes #962. Refs #882.