### PR TITLE
chore(pydoclint): adversarial probe (do-not-merge)

### DIFF
--- a/src/eval.py
+++ b/src/eval.py
@@ -131,3 +131,19 @@ def main(cfg: DictConfig) -> None:
 
 if __name__ == "__main__":
     main()
+
+
+# P6 — adversarial probe; do-not-merge. This file is in
+# [tool.pydoclint].exclude in pyproject.toml, so the function below
+# should NOT be linted by pre-commit even though it has a deliberately
+# broken sphinx docstring (mismatched :param: name, missing :raises:).
+# See the adversarial probe PR for results.
+def adversarial_excluded_probe(x: int) -> int:
+    """Add one — broken docstring.
+
+    :param y: WRONG NAME — signature has ``x``.
+    :return: result.
+    """
+    if x < 0:
+        raise ValueError("negative")
+    return x + 1

--- a/tests/_pydoclint_adversarial_lab.py
+++ b/tests/_pydoclint_adversarial_lab.py
@@ -1,0 +1,151 @@
+"""Adversarial probe surface for pydoclint 0.8.3.
+
+This module exists to test what the pydoclint pre-commit hook catches and
+what slips past it. It is intentionally NOT pytest-collected (the leading
+underscore in the filename keeps pytest from collecting it, and it contains
+no ``test_*`` functions). It is also NOT in ``[tool.pydoclint].exclude``,
+so pydoclint will run on it.
+
+Every function/class below contains a docstring defect that a reviewer
+would reject, but that pydoclint 0.8.3 (as configured in
+``[tool.pydoclint]``) reports zero violations on. The whole file is meant
+to pass pre-commit cleanly — that is the slip surface this PR documents.
+
+The positive controls that prove the rules *do* fire (DOC101/DOC103,
+DOC501/DOC503, narrative+params → DOC101/DOC103/DOC201/DOC203) are
+verified separately in the PR description and not included here, because
+including them would fail the lint and obscure the slip surface.
+
+Do not import or call anything in this file from production code.
+
+See PR #939 (pydoclint adoption) and issue #938 (audit / remediation).
+"""
+
+from __future__ import annotations
+
+
+# ---------------------------------------------------------------------------
+# P1 — Missing docstring entirely.
+#
+# pydoclint defers "must have a docstring" to pydocstyle / flake8-docstrings
+# (see ``pydoclint/visitor.py:210-215``: "We don't check functions without
+# docstrings"). Neither is wired into pre-commit; only ``interrogate`` is,
+# and interrogate enforces coverage % at the file level, not per-function.
+# A new public function with NO docstring at all passes pydoclint without
+# a single DOCxxx flag.
+# ---------------------------------------------------------------------------
+def silent_no_docstring(x: int, y: int) -> int:
+    return x + y
+
+
+# ---------------------------------------------------------------------------
+# P2 — Transitive raise (helper raises, caller does not).
+#
+# ``hasRaiseStatements`` (``pydoclint/utils/return_yield_raise.py:106-112``)
+# only walks ``ast.Raise`` nodes in the immediate function body, not into
+# called helpers. ``run_workflow`` propagates a ValueError from
+# ``_helper_that_raises`` but doesn't declare it. Reviewer expectation: the
+# caller's docstring should list ``:raises ValueError:``. Pydoclint gives
+# no DOC501 / DOC503 because there is no ``raise`` keyword in the caller.
+# ---------------------------------------------------------------------------
+def _helper_that_raises() -> None:
+    """Raise unconditionally.
+
+    :raises ValueError: always.
+    """
+    raise ValueError("boom")
+
+
+def run_workflow() -> None:
+    """Run the workflow."""
+    _helper_that_raises()
+
+
+# ---------------------------------------------------------------------------
+# P3 — Instance attributes set in ``__init__`` are invisible to the
+# class-attribute checker.
+#
+# ``extractClassAttributesFromNode``
+# (``pydoclint/utils/visitor_helper.py:136-227``) only inspects class-level
+# ``ast.AnnAssign`` / ``ast.Assign`` statements, not ``self.x = ...``
+# assignments inside ``__init__``. The class below has no class-level
+# attributes at all — both ``id`` and ``name`` live entirely on instances.
+# The class docstring claims ``:ivar id:`` but mentions nothing about
+# ``name``. Pydoclint reports nothing.
+# ---------------------------------------------------------------------------
+class Account:
+    """Account record.
+
+    :ivar id: identifier.
+    """
+
+    def __init__(self, id: int, name: str) -> None:
+        """Initialise.
+
+        :param id: identifier.
+        :param name: account holder name.
+        """
+        self.id = id
+        self.name = name
+
+
+# ---------------------------------------------------------------------------
+# P4 — Narrative-only docstring on a function with no params, no return
+# value, and no direct raises.
+#
+# ``_containsSphinxStylePattern`` / ``_containsNumpyStylePattern`` /
+# ``_containsGoogleStylePattern`` (``pydoclint/utils/parse_docstring.py:127-171``)
+# return False on prose with no section markers; when no style matches,
+# DOC003 is suppressed. With no params, no return value, no raise statement,
+# pydoclint has nothing to mismatch against — the gate passes a prose
+# docstring that says effectively nothing about the function's behaviour.
+#
+# Note: this only slips when the signature has nothing to check. A
+# narrative-only docstring on ``def f(x, y) -> int`` correctly fires
+# DOC101/DOC103/DOC201/DOC203 — pydoclint catches that case.
+# ---------------------------------------------------------------------------
+def vague_void_function() -> None:
+    """Do the thing."""
+
+
+# ---------------------------------------------------------------------------
+# P5 — ``# noqa: DOCxxx`` suppression on the docstring-closing line.
+#
+# The CLI default for ``--native-mode-noqa-location`` is ``"docstring"``
+# (``pydoclint/main.py:402-410``), so pydoclint reads suppression comments
+# from the line containing the closing ``\"\"\"``. A real DOC101/DOC103
+# violation (signature has ``x``, ``y``; docstring documents ``a``, ``b``)
+# is silenced because the suppression line carries both codes. The lint
+# passes; the docstring is silently allowed to lie about parameter names.
+# ---------------------------------------------------------------------------
+def with_docstring_line_noqa_suppression(x: int, y: int) -> int:
+    """Add.
+
+    :param a: WRONG NAME — actually called ``x``.
+    :param b: WRONG NAME — actually called ``y``.
+    :return int: result.
+    """  # noqa: DOC101, DOC103
+    return x + y
+
+
+# ---------------------------------------------------------------------------
+# P5b — companion to P5: the *natural* place to put a noqa (the ``def``
+# line, mirroring flake8/ruff convention) does NOT work under the CLI
+# default. The suppression below is read by the noqa parser but never
+# applied, because the default location is ``"docstring"``, not
+# ``"definition"``. The hook does fire here — but the developer who wrote
+# this comment thinks it doesn't. Both behaviours surprise: the suppression
+# either silently slips a violation (P5) or silently fails (P5b).
+#
+# To keep the slip surface clean (this file should pass pre-commit), we do
+# NOT actually create a violation here — the function below is a docstring
+# that already matches its signature. The ``# noqa`` is harmless prose.
+# The point is the documented surprise, not a runtime demonstration.
+# ---------------------------------------------------------------------------
+def def_line_noqa_is_inert(x: int) -> int:  # noqa: DOC101, DOC103
+    """Add one.
+
+    :param x: input.
+    :return int: result.
+    """
+    return x + 1


### PR DESCRIPTION
## Purpose

This PR is **a probe, not a feature**. It exists to answer one question: *what kind of bad docstring slips past the pydoclint 0.8.3 hook that [#939](https://github.com/tinaudio/synth-setter/pull/939) just merged?*

The probe pushes docstrings that a reviewer would reject but pydoclint reports zero violations on. The PR's expected outcome is **CI green** — that's the slip surface. If CI goes red, something the probe assumed was a slip is actually caught (also a finding).

**Do not merge.** This PR will be closed unmerged once the per-probe outcomes are confirmed by CI.

## What's in the diff

| File | Surface | Note |
|---|---|---|
| `tests/_pydoclint_adversarial_lab.py` (new) | NOT excluded; pydoclint runs on it | Five labelled probes P1–P5 (one with a P5b companion). Module docstring cites the pydoclint source line behind each blind spot. |
| `src/eval.py` (appended) | IN `[tool.pydoclint].exclude` | Adds `adversarial_excluded_probe` with a deliberately broken sphinx docstring (mismatched `:param:` name + raise without `:raises:`). Hook should report "Skipping files…" for this file. |

The probe file is not pytest-collected (leading underscore, no `test_*` functions) and `make test-fast` still produces 498 passed.

## Positive controls (run locally, not pushed)

To prove pydoclint *is* running on the probe file, three controls were verified out of band:

| Function | Pattern | Result |
|---|---|---|
| `real_violation(x) → :param y:` | Mismatched arg name | DOC103, DOC203 fire |
| `raises_undocumented(x)` calls `raise ValueError(...)` with no `:raises:` | Direct raise | DOC501, DOC503 fire |
| `vague_with_params(x, y) → "Compute the thing."` | Narrative docstring on a function with typed params | DOC101, DOC103, DOC201, DOC203 all fire |

These were left out of the pushed file so the slip surface stays a clean exit-0 demonstration.

## Probe matrix — expected outcomes

| ID | What it probes | Source citation | Expected CI behaviour |
|---|---|---|---|
| **P1** | Function with no docstring at all | `pydoclint/visitor.py:210-215` — *"We don't check functions without docstrings"* | SLIP (no DOCxxx) |
| **P2** | Caller propagates exception raised by helper; no `:raises:` | `pydoclint/utils/return_yield_raise.py:106-112` — walks `ast.Raise` in immediate body only | SLIP |
| **P3** | Class attributes set in `__init__` via `self.x = ...`, claimed via `:ivar:` in class docstring, undocumented for `name` | `pydoclint/utils/visitor_helper.py:136-227` — scans class-level annotations/assignments only | SLIP |
| **P4** | Narrative-only docstring on a function with no params, no return, no raise | `pydoclint/utils/parse_docstring.py:127-171` — DOC003 suppressed when no style markers found; with nothing in the signature to mismatch, no DOC1xx/2xx/5xx fires either | SLIP |
| **P5** | `# noqa: DOC101, DOC103` on the **docstring-closing line** silences a real arg-name mismatch | `pydoclint/main.py:402-410` — CLI default `native-mode-noqa-location = "docstring"` | SLIP |
| **P5b** | Companion: same suppression placed on the **`def` line** is silently inert under the default location. This file does not contain a real violation at P5b; the point is the surprise mode (developer thinks suppression works, it doesn't — under the *current* config, that means the lint catches an unwanted real violation; under a future config flip to `definition`, that means suppressions silently start succeeding where users meant them to fail). | Same as P5 | NO-OP here, but a documented gotcha |
| **P6** | Adversarial function appended to `src/eval.py`, which is in `[tool.pydoclint].exclude`. Pre-commit ran with `--files src/eval.py tests/_pydoclint_adversarial_lab.py` skips this file entirely. | `pyproject.toml` `[tool.pydoclint].exclude` | SLIP (file silently skipped) |

## Local verification before push

```text
$ pydoclint --quiet tests/_pydoclint_adversarial_lab.py
$ echo $?
0

$ pre-commit run pydoclint --files tests/_pydoclint_adversarial_lab.py src/eval.py
pydoclint................................................................Passed
$ echo $?
0

$ python -m pytest --collect-only tests/_pydoclint_adversarial_lab.py
collected 0 items
no tests collected in 0.31s

$ make test-fast
... 498 passed, 1 warning in 26.20s
```

The lint-direct call against the controls (out-of-band) reported the expected DOC101/DOC103/DOC203/DOC501/DOC503/DOC201 — proving pydoclint is reading the probe file when invoked, just not flagging any of P1–P5.

## What this PR is NOT

- It is **not** a request to merge bad docstrings into `main`.
- It is **not** a complaint about pydoclint — these blind spots are documented upstream and largely inherent to the "lint what's there, not what's missing" design.
- It is **not** a recommendation to tighten any specific rule today. The maintainer call (in [#938](https://github.com/tinaudio/synth-setter/issues/938) under a new "Pydoclint blind spots discovered by adversarial probe" section) is whether any of these gaps need a second tool wired in (pydocstyle for P1; a transitive-raise checker for P2; an attribute-coverage extension for P3) or whether they're accepted as inherent.

## Follow-up

A summary comment will be posted on [#939](https://github.com/tinaudio/synth-setter/pull/939) once CI confirms the slip outcomes here, and the open-question section of [#938](https://github.com/tinaudio/synth-setter/issues/938) will be extended with the documented gaps. After that, this PR will be closed unmerged and the branch deleted.

Refs #938

Part of #27
