### PR TITLE
fix(ci): re-evaluate auto-approve on check_run completions and hourly schedule

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,11 +1,17 @@
 name: Auto-approve PR
 
 # Re-evaluates whenever a condition might change:
-# - CI workflows finish (workflow_run — check_suite doesn't trigger across workflows)
+# - CI workflows finish (workflow_run for the two heaviest workflows;
+#   check_run for every other check, including ones added later)
 # - A review is submitted by a human (bot reviews don't trigger workflows)
 # - PR is marked ready for review (leaves draft)
 # - Manual trigger via workflow_dispatch
+# - Hourly schedule sweep — safety net for blockers that clear without
+#   firing any of the above (notably: Copilot review threads being resolved,
+#   which GitHub does not expose as a workflow trigger).
 on:
+  check_run:
+    types: [completed]
   workflow_run:
     workflows: ["Tests", "Code Quality PR"]
     types: [completed]
@@ -19,15 +25,73 @@ on:
         description: "PR number to evaluate"
         required: true
         type: number
+  schedule:
+    - cron: "0 * * * *"
 
 jobs:
-  auto-approve:
+  discover:
+    # Skip the check_run we create ourselves — otherwise the workflow loops
+    # forever on its own "Auto-approve status" check_run completion.
+    if: >-
+      github.event_name != 'check_run'
+      || github.event.check_run.name != 'Auto-approve status'
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      prs: ${{ steps.list.outputs.prs }}
+    steps:
+      - name: List PRs to evaluate
+        id: list
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          REPO="${{ github.repository }}"
+          EVENT="${{ github.event_name }}"
+          PRS="[]"
+
+          if [ "$EVENT" = "workflow_run" ]; then
+            PR_NUMBER=$(gh api "repos/${REPO}/commits/${{ github.event.workflow_run.head_sha }}/pulls" \
+              --jq '.[0].number // empty')
+            if [ -n "$PR_NUMBER" ]; then PRS="[${PR_NUMBER}]"; fi
+          elif [ "$EVENT" = "check_run" ]; then
+            PR_NUMBER=$(gh api "repos/${REPO}/commits/${{ github.event.check_run.head_sha }}/pulls" \
+              --jq '.[0].number // empty')
+            if [ -n "$PR_NUMBER" ]; then PRS="[${PR_NUMBER}]"; fi
+          elif [ "$EVENT" = "workflow_dispatch" ]; then
+            PRS="[${{ github.event.inputs.pr_number }}]"
+          elif [ "$EVENT" = "schedule" ]; then
+            PRS=$(gh api "repos/${REPO}/pulls?state=open&base=main&per_page=100" \
+              --jq '[.[]
+                | select(.user.login == "ktinubu")
+                | select(.draft == false)
+                | select(.head.repo.full_name == "'"$REPO"'")
+                | .number
+              ]')
+          else
+            PRS="[${{ github.event.pull_request.number }}]"
+          fi
+
+          echo "prs=${PRS}" >> "$GITHUB_OUTPUT"
+          echo "::notice::PRs to evaluate: ${PRS}"
+
+  auto-approve:
+    needs: discover
+    if: needs.discover.outputs.prs != '' && needs.discover.outputs.prs != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
       issues: read
       checks: write
+    strategy:
+      fail-fast: false
+      matrix:
+        pr: ${{ fromJSON(needs.discover.outputs.prs) }}
     steps:
       - name: Generate GitHub App token
         id: app-token
@@ -36,37 +100,13 @@ jobs:
           app-id: ${{ secrets.APPROVAL_BOT_APP_ID }}
           private-key: ${{ secrets.APPROVAL_BOT_PRIVATE_KEY }}
 
-      - name: Resolve PR number
-        id: pr
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            # workflow_run: look up PR from the head SHA of the triggering workflow
-            PR_NUMBER=$(gh api "repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls" \
-              --jq '.[0].number // empty')
-            if [ -z "$PR_NUMBER" ]; then
-              echo "::notice::No PR found for this workflow run (e.g. push to main)"
-              echo "result=skip" >> "$GITHUB_OUTPUT"
-              echo "reason=No PR found for this workflow run" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
-          elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            PR_NUMBER="${{ github.event.inputs.pr_number }}"
-          else
-            PR_NUMBER="${{ github.event.pull_request.number }}"
-          fi
-          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          echo "result=" >> "$GITHUB_OUTPUT"
-
       - name: Check all conditions
-        if: steps.pr.outputs.result != 'skip'
         id: conditions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          PR=${{ steps.pr.outputs.number }}
+          PR=${{ matrix.pr }}
           REPO="${{ github.repository }}"
 
           # Fetch PR metadata once
@@ -182,13 +222,13 @@ jobs:
         run: |
           # Check if this app already approved (avoid duplicate approvals)
           APP_LOGIN="${{ steps.app-token.outputs.app-slug }}[bot]"
-          ALREADY=$(gh api "repos/${{ github.repository }}/pulls/${{ steps.pr.outputs.number }}/reviews" \
+          ALREADY=$(gh api "repos/${{ github.repository }}/pulls/${{ matrix.pr }}/reviews" \
             --jq "[.[] | select(.state == \"APPROVED\") | select(.user.login == \"${APP_LOGIN}\")] | length")
           if [ "$ALREADY" -gt 0 ]; then
             echo "::notice::Bot already approved — skipping duplicate"
             exit 0
           fi
-          gh pr review ${{ steps.pr.outputs.number }} --repo "${{ github.repository }}" --approve \
+          gh pr review ${{ matrix.pr }} --repo "${{ github.repository }}" --approve \
             --body "All conditions met: CI passing, no unresolved Copilot threads. Auto-approved."
 
       # GitHub Actions doesn't support neutral exit codes from shell steps
@@ -197,13 +237,18 @@ jobs:
       # red for ineligible — we create a check run via the Checks API,
       # which is the only mechanism that supports conclusion: "neutral".
       - name: Report status
-        if: always() && steps.pr.outputs.result != 'skip'
+        if: always()
         uses: actions/github-script@v7
         with:
           script: |
             const result = '${{ steps.conditions.outputs.result }}';
             const reason = '${{ steps.conditions.outputs.reason }}';
             const headSha = '${{ steps.conditions.outputs.head_sha }}';
+
+            if (!headSha) {
+              core.warning(`Skipping status report — conditions step did not produce a head_sha (result=${result})`);
+              return;
+            }
 
             // Map result to Checks API conclusion
             // - approve  → success  (green tick)

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -28,6 +28,12 @@ on:
   schedule:
     - cron: "0 * * * *"
 
+# Single source of truth for the author allowlist — referenced by both the
+# scheduled discover query (jobs.discover) and the eligibility check in
+# jobs.auto-approve.conditions.
+env:
+  ALLOWED_AUTHOR: ktinubu
+
 jobs:
   discover:
     # Skip the check_run we create ourselves — otherwise the workflow loops
@@ -49,7 +55,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          REPO="${{ github.repository }}"
+          export REPO="${{ github.repository }}"
           EVENT="${{ github.event_name }}"
           PRS="[]"
 
@@ -64,13 +70,13 @@ jobs:
           elif [ "$EVENT" = "workflow_dispatch" ]; then
             PRS="[${{ github.event.inputs.pr_number }}]"
           elif [ "$EVENT" = "schedule" ]; then
-            PRS=$(gh api "repos/${REPO}/pulls?state=open&base=main&per_page=100" \
-              --jq '[.[]
-                | select(.user.login == "ktinubu")
+            PRS=$(gh api --paginate "repos/${REPO}/pulls?state=open&base=main&per_page=100" \
+              --jq '.[]
+                | select(.user.login == env.ALLOWED_AUTHOR)
                 | select(.draft == false)
-                | select(.head.repo.full_name == "'"$REPO"'")
+                | select(.head.repo.full_name == env.REPO)
                 | .number
-              ]')
+              ' | jq -cs '.')
           else
             PRS="[${{ github.event.pull_request.number }}]"
           fi
@@ -119,8 +125,8 @@ jobs:
 
           PR_AUTHOR=$(echo "$PR_DATA" | jq -r '.author')
 
-          # --- Condition: Only approve PRs by ktinubu ---
-          if [ "$PR_AUTHOR" != "ktinubu" ]; then
+          # --- Condition: Only approve PRs by the allowlisted author ---
+          if [ "$PR_AUTHOR" != "$ALLOWED_AUTHOR" ]; then
             echo "result=failure" >> "$GITHUB_OUTPUT"
             echo "reason=PR author ${PR_AUTHOR} is not eligible for auto-approve" >> "$GITHUB_OUTPUT"
             exit 0

--- a/docs/reference/github-actions.md
+++ b/docs/reference/github-actions.md
@@ -68,6 +68,14 @@ For GitHub Actions concepts, see [GitHub's docs](https://docs.github.com/en/acti
 
 - `auto-approve` triggers on completion of: `Tests`, `Code Quality PR`
 
+**Check-run triggers (`check_run`):**
+
+- `auto-approve` triggers on completion of any check-run on a PR commit (covers all CI workflows beyond the two listed under `workflow_run`, including ones added later). Self-loop on its own `Auto-approve status` check-run is suppressed by a job-level `if:` guard.
+
+**Scheduled triggers (`schedule`):**
+
+- `auto-approve` runs hourly (`0 * * * *`) as a safety net. Catches blockers that clear without firing any workflow event — most notably, Copilot review threads being resolved (GitHub does not expose `pull_request_review_thread` as a workflow trigger). On a scheduled run the `discover` job enumerates every open eligible PR and the `auto-approve` matrix re-evaluates each.
+
 **Artifact chains (`upload-artifact` → `download-artifact`):**
 
 - `test-dataset-generation` still writes a per-provider `test-run-metadata-<provider>` artifact for failure debugging, but the `validate-dataset-shards` jobs no longer consume it — they read the spec from R2 at `r2://<bucket>/skypilot-launcher-specs/<cluster_name>.json` (the `spec_uri` output of `generate-dataset-shards`, or the same path written by the inline `local` cell's explicit upload step).

--- a/docs/reference/github-actions.md
+++ b/docs/reference/github-actions.md
@@ -74,7 +74,7 @@ For GitHub Actions concepts, see [GitHub's docs](https://docs.github.com/en/acti
 
 **Scheduled triggers (`schedule`):**
 
-- `auto-approve` runs hourly (`0 * * * *`) as a safety net. Catches blockers that clear without firing any workflow event — most notably, Copilot review threads being resolved (GitHub does not expose `pull_request_review_thread` as a workflow trigger). On a scheduled run the `discover` job enumerates every open eligible PR and the `auto-approve` matrix re-evaluates each.
+- `auto-approve` runs hourly (`0 * * * *`) as a safety net. Catches blockers that clear without firing any workflow event — most notably, Copilot review threads being resolved (GitHub does not expose `pull_request_review_thread` as a workflow trigger). On a scheduled run the `discover` job paginates the open-PR list and enumerates every eligible PR; the `auto-approve` matrix re-evaluates each.
 
 **Artifact chains (`upload-artifact` → `download-artifact`):**
 


### PR DESCRIPTION
## Summary

The `auto-approve` workflow re-evaluated only on completion of the `Tests` and `Code Quality PR` workflows, on submitted reviews, and on draft → ready transitions. It ran once per trigger and exited. Two real-world conditions cleared blockers without firing those triggers, leaving `Auto-approve status` frozen on "Waiting" until a manual `workflow_dispatch`:

- A non-listed CI workflow (e.g. `cpu-slow`, `test-conda`, `pr-metadata-gate`) was the last to finish — auto-approve already evaluated against the snapshot where it was pending and stayed on "Waiting".
- A Copilot review thread was resolved without a new push — GitHub does not expose `pull_request_review_thread` as a workflow trigger.

PR #939 hit case (2): "Auto-approve status — completed 1 hour ago in 0s, 5 unresolved Copilot thread(s)".

## Changes

`.github/workflows/auto-approve.yml`:

- Add `check_run: [completed]` trigger plus a job-level `if:` guard so our own `Auto-approve status` check_run does not self-loop. Covers every CI workflow on the commit, including ones added later, without maintaining a list under `workflow_run.workflows`.
- Add `schedule: "0 * * * *"` hourly safety-net sweep that enumerates open eligible PRs and re-evaluates each. Catches blockers that don't fire any workflow event (notably Copilot thread resolution).
- Split into a `discover` job (returns JSON array of PR numbers to evaluate) and an `auto-approve` matrix job over those PRs. Per-PR condition logic is unchanged; only the dispatch surface changed.
- Set explicit `timeout-minutes` on both jobs.

`docs/reference/github-actions.md`: documents the new triggers and self-loop guard.

## Test plan

- [x] `python scripts/validate_workflow.py` (gha-workflow-validator skill): 10/14 passed, 0 failures (4 informational/secret-config warnings).
- [x] `act --list -W .github/workflows/auto-approve.yml` parses both jobs across all 6 triggers.
- [x] `make format` (pre-commit hooks): all green.
- [ ] Live: verify a `check_run.completed` for a non-listed CI workflow fires auto-approve within seconds (will surface naturally on the next PR through the pipeline).
- [ ] Live: resolve Copilot threads on this PR without a new push, and confirm the next hourly schedule tick (top of the hour after merge) flips `Auto-approve status` to green without manual `workflow_dispatch`.
- [ ] Verify the `Auto-approve status` check_run we create does not re-trigger the workflow (Actions tab should show no auto-approve runs whose triggering event is our own check_run).

Refs #970