### PR TITLE
internal-feat(packaging): Phase 1 — scaffold src/synth_setter package + setuptools src-layout config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ The block-scalar should contain only commands. The reader who wants to know *why
 ### Architecture
 
 - `src/` — ML code (models, data modules, training, evaluation) and the dataset-generation entrypoint (`src/generate_dataset.py`)
+- `src/synth_setter/` — PEP src-layout package; empty scaffold in Phase 1 of [#784](https://github.com/tinaudio/synth-setter/issues/784), receives moved modules across Phases 2–5.
 - `src/pipeline/` — distributed data pipeline (`python -m src.pipeline` planned — [#72](https://github.com/tinaudio/synth-setter/issues/72))
   - `schemas/` — Pydantic models (`DatasetSpec` + `RenderConfig` in `spec.py`, `prefix`, `image_config`; planned: report, card, sample — [#74](https://github.com/tinaudio/synth-setter/issues/74))
   - `ci/` — CI validation scripts (materialize_spec, validate_shard, validate_spec, load_image_config)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,11 +83,12 @@ synth-setter/
 │   ├── models/             #   LightningModules (flow matching, FF, FlowVAE)
 │   │   └── components/     #   Model building blocks (VAE, networks)
 │   ├── utils/              #   Logging, config helpers
-│   └── pipeline/           #   Distributed data pipeline
-│       ├── schemas/        #     Pydantic models (DatasetSpec, RenderConfig, prefix, image_config)
-│       ├── ci/             #     CI validation scripts (materialize_spec, validate_shard, validate_spec)
-│       ├── skypilot_launch.py  # SkyPilot launcher CLI
-│       └── constants.py    #     Shared constants (R2 bucket, spec filename)
+│   ├── pipeline/           #   Distributed data pipeline
+│   │   ├── schemas/        #     Pydantic models (DatasetSpec, RenderConfig, prefix, image_config)
+│   │   ├── ci/             #     CI validation scripts (materialize_spec, validate_shard, validate_spec)
+│   │   ├── skypilot_launch.py  # SkyPilot launcher CLI
+│   │   └── constants.py    #     Shared constants (R2 bucket, spec filename)
+│   └── synth_setter/       #   PEP src-layout package — empty scaffold; receives moved modules across Phases 2–5 of the layout migration ([#784](https://github.com/tinaudio/synth-setter/issues/784))
 │
 ├── configs/                # Hydra YAML configs (and SkyPilot Task templates under compute/)
 │   ├── dataset.yaml        #   Root dataset-generation config (entrypoint mirrors train.yaml / eval.yaml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,36 @@ docs = [
   "griffe-pydantic",
 ]
 
+[tool.setuptools]
+# Phase 1 scaffold: enumerate packages explicitly so that the new
+# `synth_setter` package (physically at src/synth_setter/) is importable as
+# both `synth_setter` (the future canonical PEP src-layout name) AND as
+# `src.synth_setter` (the legacy name used during migration). The legacy
+# `src*` packages are listed here too because they're consumed via
+# `from src.X` at ~52 import sites today. Phases 2–5 rewrite those imports
+# and this list collapses to a `[tool.setuptools.packages.find]` with
+# `where = ["src"]`.
+packages = [
+  "synth_setter",
+  "src",
+  "src.data",
+  "src.data.components",
+  "src.data.vst",
+  "src.models",
+  "src.models.components",
+  "src.pipeline",
+  "src.pipeline.ci",
+  "src.pipeline.schemas",
+  "src.synth_setter",
+  "src.utils",
+]
+
+[tool.setuptools.package-dir]
+# Map the top-level `synth_setter` namespace to its physical location at
+# src/synth_setter/, so it is importable as `synth_setter` (PEP src-layout).
+# Other packages use the implicit root mapping (`src` lives at ./src, etc.).
+"synth_setter" = "src/synth_setter"
+
 [tool.pytest.ini_options]
 addopts = [
   "--color=yes",
@@ -41,6 +71,7 @@ markers = [
   "infra: tests that assert invariants of the devcontainer + GitHub Actions configuration",
 ]
 minversion = "6.0"
+pythonpath = ["src"]
 testpaths = "tests/"
 
 [tool.ruff]


### PR DESCRIPTION
Phase 1 of the PEP src-layout migration described in #784.

Closes #974
Refs #784

## What this PR does (additive only — no file moves)

- Adds `src/synth_setter/__init__.py` (empty package marker).
- Adds `[tool.setuptools]` config in `pyproject.toml` that:
  - Enumerates the existing legacy packages (`src`, `src.data`, `src.models`, `src.pipeline`, `src.utils`, etc.) so `from src.X` imports keep working through Phases 2–5.
  - Adds the new `synth_setter` package, mapped via `package-dir` to its physical location at `src/synth_setter/`.
  - Result: the package is importable as **both** `synth_setter` (the future canonical PEP src-layout name) and `src.synth_setter` (transitional, removable in Phase 5).
- Adds `pythonpath = [\"src\"]` to `[tool.pytest.ini_options]` so `pytest` running from the repo root resolves `import synth_setter` without needing an editable install.

## Why an explicit `packages = [...]` list (and not `find` + `package-dir`)

The naive `[tool.setuptools.packages.find]` + `package-dir` redirect that I tried first installs the package only as `src.synth_setter` — setuptools' `find` discovers the package under its filesystem name, so the `package-dir` mapping for the top-level `synth_setter` name is silently dropped (because that name was never discovered). Verified empirically: a fresh `pip install -e .` exposed only `src`, not `synth_setter`.

Switching to an **explicit `packages` enumeration** is the documented setuptools workaround for this case. The list is transitional — Phases 2–5 rewrite `from src.X` → `from synth_setter.ml.X` etc., and this PR's commit message + the comment in `pyproject.toml` both call out that the list collapses to `where = [\"src\"]` once the migration completes.

## Why this phase ships standalone

It lands the packaging plumbing in isolation so any CI / install regressions surface here, with ~30 lines of diff, before later phases touch ~52 import sites + Hydra `_target_` strings + Dockerfile module paths.

## Verification

Run inside a fresh virtualenv on the worktree:

| # | Check | Result |
|---|---|---|
| 1 | `pip install -e .` in a fresh venv | PASS (installs successfully; `python -c \"import synth_setter; print(synth_setter.__file__)\"` resolves under `src/synth_setter/`) |
| 2 | Legacy `from src import train` import path | PASS (resolves the module file in the clean venv — fails only on uninstalled ML deps, which is expected) |
| 3 | `pytest pythonpath` shim makes `import synth_setter` resolve without install | PASS |
| 4 | `make test-fast` | PASS — 530 passed, 5 skipped, 1 warning in 26.41s |
| 5 | `rg 'from synth_setter\\|import synth_setter' --type py` (should be empty — no consumers yet) | PASS (empty) |

## What this PR explicitly does NOT do (saved for Phases 2–5)

- Does not move any file under `src/`.
- Does not move `src/pipeline/` anywhere.
- Does not rewrite any `from src.X` import.
- Does not touch `setup.py` (deleted in Phase 5).
- Does not change Hydra `_target_:` strings, Dockerfile `python -m` paths, or CI workflow references.

## Trade-off accepted

The `packages = [...]` enumeration is verbose; it stays in the repo for the duration of the migration only. This is the explicit price for keeping the legacy import surface working while the new namespace is scaffolded.