### PR TITLE
chore(lint): clean up tests/helpers/package_available.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,7 +76,6 @@ repos:
             src/utils/callbacks\.py|
             src/utils/logging_utils\.py|
             tests/conftest\.py|
-            tests/helpers/package_available\.py|
             tests/helpers/run_sh_command\.py
           )$
 


### PR DESCRIPTION
## Summary

Drop `tests/helpers/package_available.py` from the `pyright` `exclude` regex in `.pre-commit-config.yaml`. The file is already type-clean, docstring-clean, and lint-clean under current rules — it was excluded historically but no source edit is needed today; `pyright` runs cleanly on it once unexcluded.

This is the third per-file PR working off the [#25](https://github.com/tinaudio/synth-setter/issues/25) checklist, after the `lint-cleanup` multi-tool agent was wired in #951.

## Test plan

- [x] `pre-commit run --files tests/helpers/package_available.py` passes every hook (including the newly-enabled `pyright`)
- [x] `make test-fast` green (556 passed, 5 skipped, 25.6s)
- [x] No source edits — only `.pre-commit-config.yaml` changes
- [ ] CI green and \`mergeable=MERGEABLE\` (verify once checks finish)

Refs #25