### PR TITLE
chore(lint): clean up src/utils/pylogger.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,7 +211,6 @@ exclude = '''(?x)
   | ^src/train\.py$
   | ^src/utils/callbacks\.py$
   | ^src/utils/instantiators\.py$
-  | ^src/utils/pylogger\.py$
   | ^src/utils/rich_utils\.py$
   | ^src/utils/utils\.py$
   | ^tests/_baseline_worktree\.py$

--- a/src/utils/pylogger.py
+++ b/src/utils/pylogger.py
@@ -32,8 +32,9 @@ class RankedLogger(logging.LoggerAdapter):
         :param level: The level to log at. Look at `logging.__init__.py` for more information.
         :param msg: The message to log.
         :param rank: The rank to log at.
-        :param args: Additional args to pass to the underlying logging function.
-        :param kwargs: Any additional keyword args to pass to the underlying logging function.
+        :param \\*args: Additional args to pass to the underlying logging function.
+        :param \\*\\*kwargs: Any additional keyword args to pass to the underlying logging function.
+        :raises RuntimeError: If ``rank_zero_only.rank`` has not been set before this call.
         """
         if self.isEnabledFor(level):
             msg, kwargs = self.process(msg, kwargs)


### PR DESCRIPTION
## Summary

- Remove `src/utils/pylogger.py` from the `[tool.pydoclint].exclude` list in `pyproject.toml`.
- Update the `RankedLogger.log` docstring to satisfy `pydoclint`:
  - Document `*args` / `**kwargs` so `:param:` entries match the function signature (DOC103).
  - Add a `:raises RuntimeError:` section for the existing `raise RuntimeError(...)` (DOC501/DOC503).

No functional changes — the only code edit is to a docstring.

Refs #25.

## Verification

- `pre-commit run --files src/utils/pylogger.py pyproject.toml` — all hooks pass (ruff, ruff-format, pyright, docformatter, interrogate, pydoclint, codespell, etc.).
- `make test-fast` — 556 passed, 5 skipped.

## Test plan

- [x] `pre-commit run --files src/utils/pylogger.py pyproject.toml` clean
- [x] `make test-fast` clean
- [ ] CI green on PR