### PR TITLE
docs(reference): add Benchmarks nav entry linking to dev/bench Pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,3 +58,4 @@ nav:
   - Home: index.md
   - Config Reference:
       - Dataset Spec: config_reference/dataset_spec.md
+  - Benchmarks: https://tinaudio.github.io/synth-setter/dev/bench/


### PR DESCRIPTION
## Summary

Adds a single external-URL entry to `mkdocs.yml`'s `nav` so the benchmark chart at `https://tinaudio.github.io/synth-setter/dev/bench/` shows up in the docs-site top bar. Clicking it leaves the MkDocs site for the standalone `github-action-benchmark` page deployed at that URL.

Closes #987

## Diff

```diff
 nav:
   - Home: index.md
   - Config Reference:
       - Dataset Spec: config_reference/dataset_spec.md
+  - Benchmarks: https://tinaudio.github.io/synth-setter/dev/bench/
```

## Verification

- [x] `mkdocs build --strict` exits 0, no warnings.
- [x] Rendered `site/index.html` contains anchor with the expected target:
  ```
  href='https://tinaudio.github.io/synth-setter/dev/bench/' text='Benchmarks'
  ```
- [x] Destination URL returns `HTTP/2 200`.
- [x] `make format` clean.

## Heads-up: no automatic external-link indicator

Material for MkDocs renders external-URL nav entries with the same anchor classes as internal entries (`md-tabs__link` / `md-nav__link`) — no `target="_blank"`, no external-arrow icon. The link still works; it just visually looks like any other top-bar tab. If we want a visual cue that this entry leaves the MkDocs site, that's a follow-up — either a small theme override or one of Material's extensions, but neither is in scope here.

## Why this is a docs-only change

The bench chart isn't part of the MkDocs source — it's produced by `github-action-benchmark` and stitched into `site/` at deploy-time by the workflow's bench-merge step (#980). Linking to it from the nav requires no changes to the deploy pipeline; the URL just needed to be on a nav line.

## Mandatory-skills note

Pure `mkdocs.yml` edit (one nav line). No Python or shell source touched, so `/tdd-implementation` and `/code-health` were not applicable. `/simplify` was effectively done inline (one line, no abstractions). Flagged per CLAUDE.md's "note the gap" instruction.