### PR TITLE
test(baseline-configs): strip _target_ at any depth instead of bumping MODEL_BASELINE

### DIFF
--- a/tests/test_compare_baseline_configs.py
+++ b/tests/test_compare_baseline_configs.py
@@ -374,6 +374,39 @@ def _normalize_for_compare(cfg: dict) -> dict:
     return _strip_leaf_keys(stripped, ACCEPTED_DIFF_LEAVES)
 
 
+# Unit tests for _strip_leaf_keys. The end-to-end resolved-config tests exercise
+# this indirectly, but they're slow (~10min) and only pass when `_target_` is the
+# leaf — a focused unit test covers dict/list recursion + the deep-copy contract.
+class TestStripLeafKeys:
+    def test_removes_key_at_top_level(self) -> None:
+        result = _strip_leaf_keys({"_target_": "X", "keep": 1}, ("_target_",))
+        assert result == {"keep": 1}
+
+    def test_removes_key_at_nested_dict_depth(self) -> None:
+        cfg = {"model": {"net": {"_target_": "X", "dim": 8}}}
+        result = _strip_leaf_keys(cfg, ("_target_",))
+        assert result == {"model": {"net": {"dim": 8}}}
+
+    def test_removes_key_inside_dict_in_list(self) -> None:
+        cfg = {"callbacks": [{"_target_": "X", "n": 1}, {"_target_": "Y", "n": 2}]}
+        result = _strip_leaf_keys(cfg, ("_target_",))
+        assert result == {"callbacks": [{"n": 1}, {"n": 2}]}
+
+    def test_does_not_mutate_input(self) -> None:
+        cfg = {"a": {"_target_": "X"}, "b": [{"_target_": "Y"}]}
+        _ = _strip_leaf_keys(cfg, ("_target_",))
+        assert cfg == {"a": {"_target_": "X"}, "b": [{"_target_": "Y"}]}
+
+    def test_empty_leaf_keys_is_identity(self) -> None:
+        cfg = {"_target_": "X", "nested": {"_target_": "Y"}}
+        assert _strip_leaf_keys(cfg, ()) == cfg
+
+    def test_strips_multiple_leaf_names(self) -> None:
+        cfg = {"_target_": "X", "_partial_": True, "keep": 1}
+        result = _strip_leaf_keys(cfg, ("_target_", "_partial_"))
+        assert result == {"keep": 1}
+
+
 def _assert_resolved_configs_equal(baseline: dict, current: dict) -> None:
     """Assert the resolved configs match modulo invocation/deployment-volatile keys."""
     # No custom message: pytest renders a structured dict-diff for ==/!= on

--- a/tests/test_compare_baseline_configs.py
+++ b/tests/test_compare_baseline_configs.py
@@ -12,13 +12,14 @@ Mechanism: for each pinned ref, materialize a detached worktree at that ref,
 run the script there under a PATH shim that captures the resolved Hydra YAML
 (``python ... --cfg job --resolve``), run the same script in the live tree,
 and assert the two YAMLs match modulo invocation/deployment-volatile keys
-(``INVOCATION_PATH_KEYS``, ``ACCEPTED_DIFFS``).
+(``INVOCATION_PATH_KEYS``, ``ACCEPTED_DIFFS``, ``ACCEPTED_DIFF_LEAVES``).
 
 Two pinned constants below: ``FIXTURE_BASELINE`` covers the synthetic-fixture
 sanity tests, and ``MODEL_BASELINE`` pins the ``jobs/train/{kosc,surge}/train.sh``
-configs against a known-good model snapshot. When a config change is
-intentional and is what we want future runs to inherit, bump the relevant
-constant forward to a SHA on ``main`` that includes the change.
+configs against a known-good model snapshot. ``MODEL_BASELINE`` is a stable
+"published-results known-good" anchor — bump it only when the snapshot itself
+is regenerated. Mechanical migrations (e.g. ``_target_:`` renames) get absorbed
+through ``ACCEPTED_DIFFS`` / ``ACCEPTED_DIFF_LEAVES`` instead.
 """
 
 from __future__ import annotations
@@ -81,14 +82,14 @@ PREDICT_SCRIPTS: tuple[str, ...] = (
 # possible: they're more stable/discoverable for humans, and the harness
 # fetches the requested ref itself when needed (see `try_fetch_ref`).
 # FIXTURE_BASELINE pins the synthetic-fixture equality + inequality tests.
-# MODEL_BASELINE pins the K-OSC + SURGE train.sh tests against a known-good
-# model-config snapshot.
-# Update on PR merge: MODEL_BASELINE bumps when a published-results-relevant
-# config change lands and a new release tag is cut.
+# MODEL_BASELINE pins the K-OSC + SURGE train.sh tests against the
+# published-results model-config snapshot. Keep it stable — only bump when the
+# snapshot itself is regenerated. Mechanical migrations go through
+# ACCEPTED_DIFFS / ACCEPTED_DIFF_LEAVES instead.
 FIXTURE_BASELINE = "1bfa7ea9c4b237a4561a9ac546a3e241ecff5951"  # PR #679 merge commit on main
-# Pinned to the initial commit of the Phase 2 src-layout migration (#989) — re-bump to
-# a post-merge tag once #989 lands on main.
-MODEL_BASELINE = "4e0895090f193464a1b716b50e0b2e10a55be2dd"
+# Mechanical migrations (e.g. Phase 2's `src.X` → `synth_setter.X` `_target_:` rewrite,
+# #989) are absorbed via ACCEPTED_DIFF_LEAVES / #993, not by bumping this anchor.
+MODEL_BASELINE = "v0.0.0"
 
 
 @dataclass(frozen=True)
@@ -317,6 +318,17 @@ ACCEPTED_DIFFS: tuple[str, ...] = (
     "data.stats_file",
 )
 
+# Leaf-name keys stripped at every nesting depth. Use this list (vs. ACCEPTED_DIFFS)
+# when a divergence appears at many points in the resolved config and enumerating
+# every dotted path would be brittle (every new model adds another path).
+# Replace each entry with a mechanical-transform check as the helper lands — see #993.
+ACCEPTED_DIFF_LEAVES: tuple[str, ...] = (
+    # Phase 2 src-layout migration (#989) rewrote every `_target_:` from `src.X` to
+    # `synth_setter.X`. Until #993 lands a transform helper, accept any `_target_`
+    # divergence — at the cost of also accepting unrelated `_target_` drift.
+    "_target_",
+)
+
 
 def _strip_dotted_keys(cfg: dict, dotted_paths: tuple[str, ...]) -> dict:
     """Return a deep-copy of ``cfg`` with each dotted key path removed."""
@@ -336,14 +348,37 @@ def _strip_dotted_keys(cfg: dict, dotted_paths: tuple[str, ...]) -> dict:
     return result
 
 
+def _strip_leaf_keys(cfg: dict, leaf_keys: tuple[str, ...]) -> dict:
+    """Return a deep-copy of ``cfg`` with each leaf-name key removed at any depth."""
+    result = copy.deepcopy(cfg)
+    leaves = set(leaf_keys)
+
+    def _walk(node: object) -> None:
+        if isinstance(node, dict):
+            for key in list(node.keys()):
+                if key in leaves:
+                    del node[key]
+                else:
+                    _walk(node[key])
+        elif isinstance(node, list):
+            for item in node:
+                _walk(item)
+
+    _walk(result)
+    return result
+
+
+def _normalize_for_compare(cfg: dict) -> dict:
+    """Apply both strip passes used by the equality/inequality assertions."""
+    stripped = _strip_dotted_keys(cfg, INVOCATION_PATH_KEYS + ACCEPTED_DIFFS)
+    return _strip_leaf_keys(stripped, ACCEPTED_DIFF_LEAVES)
+
+
 def _assert_resolved_configs_equal(baseline: dict, current: dict) -> None:
     """Assert the resolved configs match modulo invocation/deployment-volatile keys."""
-    keys = INVOCATION_PATH_KEYS + ACCEPTED_DIFFS
-    base = _strip_dotted_keys(baseline, keys)
-    cur = _strip_dotted_keys(current, keys)
     # No custom message: pytest renders a structured dict-diff for ==/!= on
     # bare assertions, which is what we want for ~150-line config dicts.
-    assert base == cur
+    assert _normalize_for_compare(baseline) == _normalize_for_compare(current)
 
 
 def _assert_resolved_configs_differ(baseline: dict, current: dict) -> None:
@@ -353,10 +388,7 @@ def _assert_resolved_configs_differ(baseline: dict, current: dict) -> None:
     pattern. Strips the same volatile keys before comparing so the inequality
     reflects real content drift, not unavoidable worktree-vs-live noise.
     """
-    keys = INVOCATION_PATH_KEYS + ACCEPTED_DIFFS
-    base = _strip_dotted_keys(baseline, keys)
-    cur = _strip_dotted_keys(current, keys)
-    assert base != cur
+    assert _normalize_for_compare(baseline) != _normalize_for_compare(current)
 
 
 def _resolve_pair(

--- a/tests/test_compare_baseline_configs.py
+++ b/tests/test_compare_baseline_configs.py
@@ -16,10 +16,11 @@ and assert the two YAMLs match modulo invocation/deployment-volatile keys
 
 Two pinned constants below: ``FIXTURE_BASELINE`` covers the synthetic-fixture
 sanity tests, and ``MODEL_BASELINE`` pins the ``jobs/train/{kosc,surge}/train.sh``
-configs against a known-good model snapshot. ``MODEL_BASELINE`` is a stable
-"published-results known-good" anchor — bump it only when the snapshot itself
-is regenerated. Mechanical migrations (e.g. ``_target_:`` renames) get absorbed
-through ``ACCEPTED_DIFFS`` / ``ACCEPTED_DIFF_LEAVES`` instead.
+**and** ``jobs/predict/*.sh`` configs against a known-good model snapshot.
+``MODEL_BASELINE`` is a stable "published-results known-good" anchor — bump it
+only when the snapshot itself is regenerated. Mechanical migrations
+(e.g. ``_target_:`` renames) get absorbed through ``ACCEPTED_DIFFS`` /
+``ACCEPTED_DIFF_LEAVES`` instead.
 """
 
 from __future__ import annotations
@@ -82,10 +83,11 @@ PREDICT_SCRIPTS: tuple[str, ...] = (
 # possible: they're more stable/discoverable for humans, and the harness
 # fetches the requested ref itself when needed (see `try_fetch_ref`).
 # FIXTURE_BASELINE pins the synthetic-fixture equality + inequality tests.
-# MODEL_BASELINE pins the K-OSC + SURGE train.sh tests against the
-# published-results model-config snapshot. Keep it stable — only bump when the
-# snapshot itself is regenerated. Mechanical migrations go through
-# ACCEPTED_DIFFS / ACCEPTED_DIFF_LEAVES instead.
+# MODEL_BASELINE pins the K-OSC + SURGE train.sh tests AND the
+# jobs/predict/*.sh predict-script tests against the published-results
+# model-config snapshot. Keep it stable — only bump when the snapshot itself
+# is regenerated. Mechanical migrations go through ACCEPTED_DIFFS /
+# ACCEPTED_DIFF_LEAVES instead.
 FIXTURE_BASELINE = "1bfa7ea9c4b237a4561a9ac546a3e241ecff5951"  # PR #679 merge commit on main
 # Mechanical migrations (e.g. Phase 2's `src.X` → `synth_setter.X` `_target_:` rewrite,
 # #989) are absorbed via ACCEPTED_DIFF_LEAVES / #993, not by bumping this anchor.


### PR DESCRIPTION
## What this changes

`tests/test_compare_baseline_configs.py` — restore `MODEL_BASELINE = "v0.0.0"` and absorb the Phase 2 `_target_:` rewrite through a new `ACCEPTED_DIFF_LEAVES` list that strips `_target_` keys at every nesting depth.

## Why

PR #991's commit `303eee3` bumped `MODEL_BASELINE` from `"v0.0.0"` to the head of the Phase 2 branch (`4e08950...`) to absorb the resolved-YAML diff from the `src.X` → `synth_setter.X` `_target_:` migration. That call eroded the baseline anchor's value:

- `MODEL_BASELINE` is meant to be the stable "published-results known-good" model-config snapshot. Bumping it to a fresh commit on every phased refactor turns the anchor into a moving target, weakens the comparison test's ability to catch drift, and breaks the v0.0.0 → published-results trace.
- Mechanical migrations have a different shape from real config changes. They should be encoded as accepted divergences with a path to a stronger check, not absorbed by moving the anchor.

## Approach

1. `MODEL_BASELINE = "v0.0.0"` (reverts `303eee3`).
2. New module-level constant `ACCEPTED_DIFF_LEAVES = ("_target_",)` — a list of leaf-name keys to strip at any nesting depth. Distinct from `ACCEPTED_DIFFS` (exact dotted paths) because `_target_` appears at many nesting depths in resolved Hydra configs and enumerating every dotted path would be brittle.
3. New helper `_strip_leaf_keys(cfg, leaf_keys) -> dict` — recursive walk of dict/list nodes, removing every key whose leaf name is in `leaf_keys`. Mirrors `_strip_dotted_keys`'s "pure, deep-copy" contract.
4. New helper `_normalize_for_compare(cfg) -> dict` — composes both strip passes; called by `_assert_resolved_configs_equal` and `_assert_resolved_configs_differ` to eliminate duplicate boilerplate.
5. Module docstring + the comment above `MODEL_BASELINE` updated to document the new bump policy ("anchor is stable; absorb mechanical migrations through the strip lists").

## Trade-off accepted

Until #993 lands a mechanical-transform helper, any `_target_:` divergence — including hypothetical unrelated drift — is stripped silently. This is a transient gap in catch coverage compared to the bump-baseline approach. The mitigation is #993 itself: the transform helper will replace this strip and restore catch coverage by mechanically transforming the baseline's `_target_` value and comparing against the live tree.

## Verification

`pytest tests/test_compare_baseline_configs.py -v` — 87 passed in 642s (KOSC × 44 + SURGE × 8 + PREDICT × 18 + fixture × 8 + miscellany × 9). Same parametrize surface as the previous bump-baseline approach.

```
======================== 87 passed in 642.20s (0:10:42) ========================
```

## Linkage

Refs #993 #989

This PR is the workaround tracked by #993 — it does NOT satisfy #993's acceptance criteria. #993 stays open until the mechanical-transform helper lands, removes `_target_` from `ACCEPTED_DIFF_LEAVES`, and restores comparison fidelity for `_target_` keys.
