### PR TITLE
fix(ci-automation): exclude matrix-named auto-approve check from pending count

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -162,7 +162,8 @@ jobs:
           # still saw "1 check(s) failed" from the original run.
           CHECK_DATA=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --jq '
             [.check_runs[]
-              | select(.name != "auto-approve" and .name != "Auto-approve status")
+              | select((.name | startswith("auto-approve")) | not)
+              | select(.name != "Auto-approve status")
             ]
             | group_by(.name)
             | map(sort_by(.id) | last)


### PR DESCRIPTION
## Summary

`.github/workflows/auto-approve.yml` runs its conditions check inside a matrix job (`auto-approve (994)`, `auto-approve (1000)`, …). The `Check all conditions` step previously filtered out only the literal names `auto-approve` and `Auto-approve status` when counting pending check-runs, so the matrix expansion's own in-progress check entry counted as a blocker — every triggered run exited with `reason=1 check(s) still running` before reaching the approve step.

This PR replaces the `select(.name != "auto-approve")` equality with `startswith("auto-approve")` so every matrix variant is excluded.

## Reproduction

PR #994, run [25800111543](https://github.com/tinaudio/synth-setter/actions/runs/25800111543/job/75794778331):

- `13:27:42Z` — `auto-approve (994)` (current matrix job) starts, status=in_progress
- `13:27:45Z` — `Check all conditions` queries `check-runs`, sees `auto-approve (994)` in_progress → `result=neutral`
- `13:27:52Z` — same job completes (too late)

All other CI was green, mergeability `MERGEABLE`, no unresolved Copilot threads.

## Verification

Locally ran the updated jq filter against synthetic data that includes both matrix variants and the `Auto-approve status` summary — both are excluded; real CI checks pass through unchanged. The workflow YAML still parses.

## Mandatory-skill notes

- `/tdd-implementation` — no test harness exists for the jq filter inside the workflow YAML; verified behavior with a synthetic jq input instead.
- `/code-health` / `/simplify` — change is a 2-line jq filter; no refactor surface.

Fixes #999