### PR TITLE
ci: install synth_setter package in cpu-slow workflow

### DIFF
--- a/.github/workflows/cpu-slow.yml
+++ b/.github/workflows/cpu-slow.yml
@@ -58,6 +58,7 @@ jobs:
         run: |
           uv pip install --system -r requirements.txt
           uv pip install --system sh
+          uv pip install --system -e .
 
       - name: List dependencies
         run: uv pip list --system


### PR DESCRIPTION
## Summary

- The `cpu-slow` workflow's install step ran `uv pip install --system -r requirements.txt` + `sh` but never installed the project itself. After the layout refactor in [#1001](https://github.com/tinaudio/synth-setter/pull/1001) dropped the legacy `src/` package, `synth_setter` is no longer importable via implicit sys.path — it must be installed.
- `tests/test_compare_baseline_configs.py` shells out to `jobs/train/{kosc,surge}/train.sh`, which run `python -m synth_setter.cli.train`. Without an installed package these subprocess invocations failed with `ModuleNotFoundError: No module named 'synth_setter'`, taking down the entire post-merge slow suite ([failed run](https://github.com/tinaudio/synth-setter/actions/runs/25808569641)).
- Add `uv pip install --system -e .` to the install step, mirroring what `.github/workflows/test.yml` already does for the PR test workflows.

## Test plan

- [ ] `cpu-slow` workflow run on this PR branch passes (the same `test_kosc_train_configs_are_equal`, `test_surge_train_configs_are_equal`, and `test_predict_configs_are_equal` parametrizations that failed at runs/25808569641).
- [ ] Confirm post-install `python -c "import synth_setter"` would succeed (implied by `pip install -e .` resolving the synth_setter package declared in `pyproject.toml`).

Fixes #815