### PR TITLE
test(surge): wire get_dataset_stats --mask-degenerate-bins into smoke fixture, re-enable use_saved_mean_and_variance

### DIFF
--- a/configs/experiment/surge/test-mps.yaml
+++ b/configs/experiment/surge/test-mps.yaml
@@ -37,9 +37,7 @@ data:
   batch_size: 1
   pin_memory: false
   ot: false
-  # Mirrors the smoke fixture which now generates stats.npz via
-  # `scripts/get_dataset_stats.py --mask-degenerate-bins`. CLI runs on the smoke
-  # dataset inherit that stats.npz; CLI runs on other datasets must compute their own.
+  # Requires sibling stats.npz; see #1002.
   use_saved_mean_and_variance: true
   num_workers: 0
 

--- a/configs/experiment/surge/test-mps.yaml
+++ b/configs/experiment/surge/test-mps.yaml
@@ -37,7 +37,10 @@ data:
   batch_size: 1
   pin_memory: false
   ot: false
-  use_saved_mean_and_variance: false
+  # Mirrors the smoke fixture which now generates stats.npz via
+  # `scripts/get_dataset_stats.py --mask-degenerate-bins`. CLI runs on the smoke
+  # dataset inherit that stats.npz; CLI runs on other datasets must compute their own.
+  use_saved_mean_and_variance: true
   num_workers: 0
 
 trainer:

--- a/configs/experiment/surge/test.yaml
+++ b/configs/experiment/surge/test.yaml
@@ -37,9 +37,7 @@ data:
   batch_size: 1
   pin_memory: false
   ot: false
-  # Mirrors the smoke fixture which now generates stats.npz via
-  # `scripts/get_dataset_stats.py --mask-degenerate-bins`. CLI runs on the smoke
-  # dataset inherit that stats.npz; CLI runs on other datasets must compute their own.
+  # Requires sibling stats.npz; see #1002.
   use_saved_mean_and_variance: true
   num_workers: 0
 

--- a/configs/experiment/surge/test.yaml
+++ b/configs/experiment/surge/test.yaml
@@ -37,7 +37,10 @@ data:
   batch_size: 1
   pin_memory: false
   ot: false
-  use_saved_mean_and_variance: false
+  # Mirrors the smoke fixture which now generates stats.npz via
+  # `scripts/get_dataset_stats.py --mask-degenerate-bins`. CLI runs on the smoke
+  # dataset inherit that stats.npz; CLI runs on other datasets must compute their own.
+  use_saved_mean_and_variance: true
   num_workers: 0
 
 trainer:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -332,9 +332,11 @@ def _build_surge_xt_smoke_cfg(accelerator: str, param_spec_name: str) -> DictCon
             cfg.data.batch_size = 1
             cfg.data.pin_memory = False
             cfg.data.ot = False
-            # The 5-sample fixture's stats.npz has zero-std mel bins that poison the batch
-            # with NaN via (mel - mean) / std.
-            cfg.data.use_saved_mean_and_variance = False
+            # `surge_xt_smoke_datasets` writes a sibling stats.npz via
+            # `get_dataset_stats.py --mask-degenerate-bins`, so the SurgeXTDataset's
+            # `(mel - mean) / std` is finite on the smoke fixture's constant bins. Keep
+            # normalization on so the smoke tests exercise the production code path.
+            cfg.data.use_saved_mean_and_variance = True
             cfg.data.num_workers = 0
 
             cfg.trainer.devices = 1
@@ -451,6 +453,43 @@ def surge_xt_smoke_datasets(tmp_path: Path, param_spec_name: str) -> Path:
         "Dataset generation failed to produce train.h5 fixture"
     )
     _validate_surge_dataset(smoke_dataset_dir / "train.h5", NUM_FIXTURE_SAMPLES)
+
+    # Mel normalization stats are computed once over train.h5 and the resulting
+    # stats.npz is shared by the train/val/test splits (all three live in the
+    # same directory). `--mask-degenerate-bins` substitutes std=1.0 at constant
+    # mel bins so the SurgeXTDataset's `(mel - mean) / std` yields 0 on those
+    # bins instead of NaN — see #1002 for the masking semantics.
+    stats_args = [
+        sys.executable,
+        "scripts/get_dataset_stats.py",
+        str(smoke_dataset_dir / "train.h5"),
+        "--mask-degenerate-bins",
+    ]
+    try:
+        result = subprocess.run(  # noqa: S603
+            stats_args,
+            text=True,
+            check=False,
+            timeout=_VST_SUBPROCESS_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(
+            f"get_dataset_stats timed out after {_VST_SUBPROCESS_TIMEOUT_SECONDS}s\n"
+            f"command: {stats_args}\n"
+            f"(child stdout/stderr printed above; rerun with `pytest -s` if captured)",
+            pytrace=False,
+        )
+    if result.returncode != 0:
+        pytest.fail(
+            f"get_dataset_stats failed (exit {result.returncode})\n"
+            f"command: {stats_args}\n"
+            f"(child stdout/stderr printed above; rerun with `pytest -s` if captured)",
+            pytrace=False,
+        )
+    assert (smoke_dataset_dir / "stats.npz").exists(), (
+        "get_dataset_stats failed to produce stats.npz fixture"
+    )
+
     shutil.copy(smoke_dataset_dir / "train.h5", smoke_dataset_dir / "val.h5")
     shutil.copy(smoke_dataset_dir / "train.h5", smoke_dataset_dir / "test.h5")
     return Path(smoke_dataset_dir)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -332,10 +332,7 @@ def _build_surge_xt_smoke_cfg(accelerator: str, param_spec_name: str) -> DictCon
             cfg.data.batch_size = 1
             cfg.data.pin_memory = False
             cfg.data.ot = False
-            # `surge_xt_smoke_datasets` writes a sibling stats.npz via
-            # `get_dataset_stats.py --mask-degenerate-bins`, so the SurgeXTDataset's
-            # `(mel - mean) / std` is finite on the smoke fixture's constant bins. Keep
-            # normalization on so the smoke tests exercise the production code path.
+            # Smoke fixture writes stats.npz via masked get_dataset_stats — see #1002.
             cfg.data.use_saved_mean_and_variance = True
             cfg.data.num_workers = 0
 
@@ -454,11 +451,7 @@ def surge_xt_smoke_datasets(tmp_path: Path, param_spec_name: str) -> Path:
     )
     _validate_surge_dataset(smoke_dataset_dir / "train.h5", NUM_FIXTURE_SAMPLES)
 
-    # Mel normalization stats are computed once over train.h5 and the resulting
-    # stats.npz is shared by the train/val/test splits (all three live in the
-    # same directory). `--mask-degenerate-bins` substitutes std=1.0 at constant
-    # mel bins so the SurgeXTDataset's `(mel - mean) / std` yields 0 on those
-    # bins instead of NaN — see #1002 for the masking semantics.
+    # Sibling stats.npz; shared across train/val/test splits — see #1002.
     stats_args = [
         sys.executable,
         "scripts/get_dataset_stats.py",


### PR DESCRIPTION
## Summary

The Surge XT smoke fixture (`tests/conftest.py:surge_xt_smoke_datasets`) previously disabled `use_saved_mean_and_variance` because the unmasked `stats.npz` it produced contained zero-variance mel bins that NaN-poisoned `(mel - mean) / std`. With the masking path landed in [PR #1002](https://github.com/tinaudio/synth-setter/pull/1002), the fixture can now compute stats with `--mask-degenerate-bins` and keep normalization enabled — closing the regression-coverage gap called out in that PR's "Follow-ups" section.

Two changes, both in `tests/conftest.py`:

- **`surge_xt_smoke_datasets`** — add a `scripts/get_dataset_stats.py --mask-degenerate-bins` subprocess step after `_validate_surge_dataset` and before the `train.h5 → val.h5/test.h5` copies. The resulting `stats.npz` is written next to `train.h5` and is shared across all three splits (they live in the same directory, and `SurgeXTDataset.get_stats_file_path` resolves to `<dataset_file>.parent / "stats.npz"`). Failure/timeout handling mirrors the existing `generate_vst_dataset` subprocess call in the same fixture.
- **`_build_surge_xt_smoke_cfg`** — flip `cfg.data.use_saved_mean_and_variance` to `True` (the datamodule default) and replace the workaround comment with a pointer to the new stats fixture step.

`test_train_surge_xt` and `test_train_eval_surge_xt` (both `@pytest.mark.requires_vst @pytest.mark.slow`) now exercise the same `(mel - mean) / std` code path that production training runs hit. Their existing finite-loss assertions become the regression guard against future stats-writer regressions.

## Test plan

- [x] `pytest tests/test_train.py::test_cfg_surge_xt_global_wires_param_spec` — 3 passed in 1.34s (CPU-only cfg-shape contract, no VST). Smoke-checks the cfg builder still parses with `use_saved_mean_and_variance=True`.
- [x] `SYNTH_SETTER_PLUGIN_PATH=... pytest "tests/test_train.py::test_train_surge_xt[cpu]" -m requires_vst` — passed in 327.78s. End-to-end exercise of the new stats fixture: dataset generation → `get_dataset_stats --mask-degenerate-bins` → `SurgeXTDataset` loads `stats.npz` → finite `train/loss`.
- [x] `make format` — all hooks pass on the changed file. Pre-existing pyright failure on `tests/pipeline/test_entrypoints/test_skypilot_launch.py` (`mix_stderr` on `CliRunner`) is unrelated and reproduces on `origin/main`.
- [ ] CI: `test-full-cpu` and `test-full-mps` lanes re-run the parametrized `test_train_surge_xt[cpu|mps]` and `test_train_eval_surge_xt[cpu|mps]` with the new stats step.

## Tradeoff

The new `get_dataset_stats.py` step uses Dask (the `get_stats_hdf5` path), which spins up a 4-worker `LocalCluster` per fixture invocation. For the 5-sample smoke fixture this adds ~5–10s of cluster startup overhead to each VST test, on top of the existing ~2-minute VST subprocess. Acceptable: the smoke tests are already in the `slow` + `requires_vst` lane, and the alternative (importing `get_stats_hdf5` directly) would either need the same Dask startup or a new Welford-on-HDF5 code path that duplicates production logic. Keeping the subprocess call matches both the existing fixture pattern (which already invokes `generate_vst_dataset.py` via subprocess) and the production workflow.

Refs #155
