### PR TITLE
docs(design): align training-pipeline.md R2 paths with storage-provenance-spec

### DIFF
--- a/docs/design/training-pipeline.md
+++ b/docs/design/training-pipeline.md
@@ -2,10 +2,11 @@
 
 > **Status**: Draft
 > **Author**: ktinubu@
-> **Last Updated**: 2026-03-20
+> **Last Updated**: 2026-05-13
 > **Tracking**: #107
-> **Storage conventions**: [storage-provenance-spec.md](storage-provenance-spec.md)
 > **Issue tracking**: [github-taxonomy.md](github-taxonomy.md)
+
+> **Storage & provenance conventions**: [storage-provenance-spec.md](storage-provenance-spec.md) (authoritative)
 
 ______________________________________________________________________
 
@@ -121,7 +122,7 @@ python -m synth_setter.cli.train \
   ckpt_path=wandb:model-surge-flow-simple:latest
 ```
 
-In the target/experimental setup (scoped and validated on the `experiment` branch — [#409](https://github.com/tinaudio/synth-setter/issues/409)), cloud training is expected to run with `MODE=train`. This downloads the dataset from R2 via rclone, runs `src/synth_setter/cli/train.py` with Hydra config, and uploads checkpoints to R2 at `{R2_PREFIX}/training/{wandb_run_id}/`. On main, checkpoint durability is W&B-only (see Section 6.2).
+In the target/experimental setup (scoped and validated on the `experiment` branch — [#409](https://github.com/tinaudio/synth-setter/issues/409)), cloud training is expected to run with `MODE=train`. This downloads the dataset from R2 via rclone, runs `src/synth_setter/cli/train.py` with Hydra config, and uploads checkpoints to R2 at `r2:intermediate-data/train/{dataset_config_id}/{dataset_wandb_run_id}/{train_config_id}/{train_wandb_run_id}/` (per [storage-provenance-spec.md §2](storage-provenance-spec.md#2-r2-bucket-layout)). On main, checkpoint durability is W&B-only (see Section 6.2).
 
 ### Docker
 
@@ -269,6 +270,18 @@ ______________________________________________________________________
 ## 6. W&B Integration
 
 > Authoritative storage and W&B conventions are defined in [storage-provenance-spec.md](storage-provenance-spec.md#4-wb-artifact-types). Repeated here for training context.
+
+The R2 training-artifact path follows the [storage-provenance-spec](storage-provenance-spec.md) §2 convention:
+
+```
+train/{dataset_config_id}/{dataset_wandb_run_id}/{train_config_id}/{train_wandb_run_id}/
+├── checkpoints/
+│   ├── last.ckpt
+│   └── best.ckpt
+└── config.yaml               # Frozen experiment config
+```
+
+R2 checkpoint upload is not enabled on `main` — checkpoint durability is W&B-only (see §6.2, §7.5). The path above is the layout the experimental `MODE=train` flow ([#409](https://github.com/tinaudio/synth-setter/issues/409)) and any future R2 mirror would write to.
 
 ### 6.1 Dataset Access
 

--- a/docs/design/training-pipeline.md
+++ b/docs/design/training-pipeline.md
@@ -271,7 +271,7 @@ ______________________________________________________________________
 
 > Authoritative storage and W&B conventions are defined in [storage-provenance-spec.md](storage-provenance-spec.md#4-wb-artifact-types). Repeated here for training context.
 
-The R2 training-artifact path follows the [storage-provenance-spec](storage-provenance-spec.md) §2 convention:
+The R2 training-artifact subtree (under the `intermediate-data/` bucket root — see [storage-provenance-spec §2](storage-provenance-spec.md#2-r2-bucket-layout)) mirrors [§3b Training](storage-provenance-spec.md#3b-training):
 
 ```
 train/{dataset_config_id}/{dataset_wandb_run_id}/{train_config_id}/{train_wandb_run_id}/


### PR DESCRIPTION
## Summary

Closes #121.

Aligns `docs/design/training-pipeline.md` with the canonical R2 path and naming conventions in `docs/design/storage-provenance-spec.md` (§2 R2 bucket layout, §3b training contents). This finishes the outstanding half of #121 — eval-pipeline.md was aligned in #145, and this PR applies the same treatment to the training doc.

- R2 path: replace the stale `{R2_PREFIX}/training/{wandb_run_id}/` with the spec's `r2:intermediate-data/train/{dataset_config_id}/{dataset_wandb_run_id}/{train_config_id}/{train_wandb_run_id}/` (note: `train/`, not `training/`, and the full 4-segment key per spec §2).
- Add a canonical R2 layout block at the top of §6 mirroring spec §3b's training subtree, with a one-line note that R2 checkpoint upload is W&B-only on `main` today.
- Upgrade the header storage-conventions reference to the `> **Storage & provenance conventions**: [storage-provenance-spec.md](storage-provenance-spec.md) (authoritative)` framing used in eval-pipeline.md (after #145).
- Bump `Last Updated` to 2026-05-13.

No scope expansion — the spec already governs IDs, W&B identity, artifact naming, lineage, and job_type, and this doc already used those names correctly in §6.1, §6.5, and Appendix A. Only the R2 path and the header cross-reference needed updating.

## Test plan

- [ ] Docs-only change — no code or tests touched.
- [ ] Render check: GitHub renders the new R2 layout code block and the upgraded blockquote header.
- [ ] Cross-reference links resolve: header link, §6 spec link, and §2 anchor (`#2-r2-bucket-layout`) all point at valid targets in `storage-provenance-spec.md`.
- [ ] `grep -n 'R2_PREFIX\|training/{wandb' docs/design/training-pipeline.md` returns no matches (stale pattern fully removed).