### PR TITLE
docs(claude-md): promote "all CI checks pass" to a top-of-section readiness gate

### DIFF
--- a/.claude/skills/repo-review/SKILL.md
+++ b/.claude/skills/repo-review/SKILL.md
@@ -34,6 +34,8 @@ If there is no PR for the current branch, stop and tell the user to push and ope
 
 Reviewers need to know up front if the PR can't merge or has failing CI — both are independent of the diff but reviewers shouldn't have to dig for them. Surface each as a top-of-review `[repo-review:block]` item folded into the review body in Step 5 (not as inline comments — they have no diff anchor).
 
+Both are hard-gate conditions from CLAUDE.md's `### PR Readiness` ("Hard gate (all four must hold)"). A PR with **any failing CI check** or with `mergeable != MERGEABLE` is **not ready**, regardless of how clean the diff is. Always emit the BLOCK lines below when the conditions fire; don't suppress them because the rest of the review is passing.
+
 **Merge conflicts.** From the JSON in Step 1:
 
 - `mergeable == "CONFLICTING"` → record one BLOCK line:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -251,6 +251,17 @@ The bad version forces the reader to ask "Hydra migration of *what*?" — the pr
 
 ### PR Readiness
 
+**Hard gate (all four must hold).** A PR is ready iff:
+
+1. **CI is fully green** — every required AND optional check passing, none pending, errored, or failing.
+2. **`mergeable=MERGEABLE`** — no merge conflicts and GitHub's mergeability calc is settled (not `UNKNOWN`, not `CONFLICTING`).
+3. **Every open review comment has an inline reply** — human reviewers AND Copilot.
+4. **Copilot has produced no new comments since the last push** — verify both the inline-comments endpoint and the top-level reviews endpoint.
+
+"PR mergeable" alone is **not** the gate — green CI is a separate, equally-hard precondition. All four conditions are AND-ed; failing any one means not ready.
+
+Detailed elaboration of each gate:
+
 A PR is **not ready** — for review, merge, or hand-off — until **all** of these hold:
 
 - **All CI checks pass.** Both required and optional checks must pass — a failing, errored, or still-pending check means not ready.


### PR DESCRIPTION
## Summary

The user noticed that the `### PR Readiness` section in `CLAUDE.md` was easy to gloss over as "PR mergeable" — under-specifying the readiness gate, even though "all CI checks pass" is the *first* of the four hard-gate conditions in the existing detailed list. They asked for it to be made explicit and visually prominent.

This PR makes a docs-only prominence change:

- **`CLAUDE.md`** — adds a top-of-section **"Hard gate (all four must hold)"** callout at the start of `### PR Readiness` enumerating the four AND-ed conditions (CI green, `mergeable=MERGEABLE`, every review comment replied, no new Copilot comments) with an explicit "PR mergeable alone is **not** the gate — green CI is a separate, equally-hard precondition." The existing bulleted detail stays below as the elaboration; no information removed.
- **`.claude/skills/repo-review/SKILL.md`** — one-line cross-reference in Step 2 ("Inspect PR health") to CLAUDE.md's "Hard gate (all four must hold)", reframing the skill's existing merge-conflict + failing-check BLOCK rules as enforcement of the project's readiness rule, not just a "PR health" surfacing convenience.

The substance of the readiness rule is unchanged. The change is purely about prominence — making the AND-of-four obvious to a reader who scans the section rather than reads to the bottom of every bullet.

## Why

The existing prose paragraph (`A PR is not ready until all of these hold:`) followed by four bullets reads naturally as "the headline rule is mergeability, with these details below." A reader doing a fast skim can finish the section with the wrong takeaway. Surfacing the four conditions as a numbered hard-gate list at the top fixes that without restructuring or removing anything.

Closes #1015

## Test plan

- [ ] Verify rendered Markdown of `### PR Readiness` shows the Hard gate callout above the existing prose paragraph.
- [ ] Confirm no substantive change: every bullet in the existing detail list is still present.
- [ ] Confirm `repo-review` skill Step 2 still lists the same BLOCK conditions for `mergeable == "CONFLICTING"` and failing checks.
- [ ] CI green on this PR (a green CI on the very PR that promotes "CI green = ready" feels like the right test).
