### PR TITLE
internal-feat(schemas): add EXTENSION_TO_OUTPUT_FORMAT reverse map

### DIFF
--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -1395,7 +1395,7 @@ src/
 
     schemas/            # Pydantic models (implemented)
       __init__.py
-      spec.py           # DatasetSpec (unified config + runtime), RenderConfig, ShardSpec, OUTPUT_FORMAT_TO_EXTENSION, EXTENSION_TO_OUTPUT_FORMAT (consumed by spec_from_cfg in cli/generate_dataset.py)
+      spec.py           # DatasetSpec (unified config + runtime; built by spec_from_cfg in cli/generate_dataset.py), RenderConfig, ShardSpec; OUTPUT_FORMAT_TO_EXTENSION / EXTENSION_TO_OUTPUT_FORMAT inverse-pair dispatch maps (no consumer yet — shard writers/validators dispatch in PR-13)
       shard_metadata.py # ShardMetadata — wds tar metadata.json sidecar (leaf module, no project imports)
       prefix.py         # DatasetConfigId, DatasetRunId, R2Prefix helpers
       image_config.py   # Docker image configuration

--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -1395,7 +1395,7 @@ src/
 
     schemas/            # Pydantic models (implemented)
       __init__.py
-      spec.py           # DatasetSpec (unified config + runtime), RenderConfig, ShardSpec, OUTPUT_FORMAT_TO_EXTENSION, spec_from_cfg flow
+      spec.py           # DatasetSpec (unified config + runtime), RenderConfig, ShardSpec, OUTPUT_FORMAT_TO_EXTENSION, EXTENSION_TO_OUTPUT_FORMAT, spec_from_cfg flow
       shard_metadata.py # ShardMetadata — wds tar metadata.json sidecar (leaf module, no project imports)
       prefix.py         # DatasetConfigId, DatasetRunId, R2Prefix helpers
       image_config.py   # Docker image configuration

--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -1395,7 +1395,7 @@ src/
 
     schemas/            # Pydantic models (implemented)
       __init__.py
-      spec.py           # DatasetSpec (unified config + runtime), RenderConfig, ShardSpec, OUTPUT_FORMAT_TO_EXTENSION, EXTENSION_TO_OUTPUT_FORMAT, spec_from_cfg flow
+      spec.py           # DatasetSpec (unified config + runtime), RenderConfig, ShardSpec, OUTPUT_FORMAT_TO_EXTENSION, EXTENSION_TO_OUTPUT_FORMAT (consumed by spec_from_cfg in cli/generate_dataset.py)
       shard_metadata.py # ShardMetadata — wds tar metadata.json sidecar (leaf module, no project imports)
       prefix.py         # DatasetConfigId, DatasetRunId, R2Prefix helpers
       image_config.py   # Docker image configuration

--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -614,7 +614,7 @@ Design target ([#103](https://github.com/tinaudio/synth-setter/issues/103)) adds
 07. **Compute normalization statistics** (mean, std across training set)
 08. **Produce training outputs** — format depends on `output_format` in the spec:
     - `hdf5`: Reshard into `train.h5`, `val.h5`, `test.h5` (HDF5 virtual datasets). Good for local single-GPU training.
-    - `wds`: Transcode into `train-{shard}.tar`, `val-{shard}.tar`, `test-{shard}.tar` (WebDataset archives). Each `.tar` shard contains samples as `{sample_id}.audio.npy` + `{sample_id}.params.npy` + `{sample_id}.mel.npy`, plus a single `metadata.json` sidecar per shard (see the `ShardMetadata` model in `src/pipeline/schemas/shard_metadata.py`). Good for multi-GPU streaming from R2.
+    - `wds`: Transcode into `train-{shard}.tar`, `val-{shard}.tar`, `test-{shard}.tar` (WebDataset archives). Each `.tar` shard contains samples as `{sample_id}.audio.npy` + `{sample_id}.params.npy` + `{sample_id}.mel.npy`, plus a single `metadata.json` sidecar per shard (see the `ShardMetadata` model in `src/synth_setter/pipeline/schemas/shard_metadata.py`). Good for multi-GPU streaming from R2.
 09. **Write `dataset.json`** — self-describing dataset card (includes content hashes, output format, shard manifest)
 10. **Register dataset in W&B** — log as artifact with spec, card, and metrics (§8)
 11. **Upload finalized dataset** to R2
@@ -860,7 +860,7 @@ train-000000.tar
 ├── 000001.params.npy
 ├── 000001.mel.npy
 ├── ...
-└── metadata.json          # ShardMetadata sidecar — see src/pipeline/schemas/shard_metadata.py
+└── metadata.json          # ShardMetadata sidecar — see src/synth_setter/pipeline/schemas/shard_metadata.py
 ```
 
 Shard count is tuned for GPU worker count — one shard per GPU worker per epoch is ideal; exact sizing depends on batch size and network bandwidth.

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -82,8 +82,8 @@ docs:
       - pattern: "src/synth_setter/pipeline/constants.py"
         covers: "Input spec filename constant"
       - pattern: "src/synth_setter/pipeline/schemas/spec.py"
-        covers: "DatasetSpec, RenderConfig, ShardSpec, OUTPUT_FORMAT_TO_EXTENSION, EXTENSION_TO_OUTPUT_FORMAT (Hydra-composed cfg → spec_from_cfg → DatasetSpec)"
-      - pattern: "src/pipeline/schemas/shard_metadata.py"
+        covers: "DatasetSpec, RenderConfig, ShardSpec, OUTPUT_FORMAT_TO_EXTENSION, EXTENSION_TO_OUTPUT_FORMAT (consumed by spec_from_cfg in cli/generate_dataset.py to build DatasetSpec from a Hydra-composed cfg)"
+      - pattern: "src/synth_setter/pipeline/schemas/shard_metadata.py"
         covers: "ShardMetadata — strict pydantic sidecar payload destined for the wds tar's metadata.json member; mirrors HDF5 audio attrs. Writer + validate_shard wds branch land in PR-13."
 
   # ── SkyPilot compute integration design doc ─────────────────────

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -82,7 +82,7 @@ docs:
       - pattern: "src/synth_setter/pipeline/constants.py"
         covers: "Input spec filename constant"
       - pattern: "src/synth_setter/pipeline/schemas/spec.py"
-        covers: "DatasetSpec, RenderConfig, ShardSpec, OUTPUT_FORMAT_TO_EXTENSION (Hydra-composed cfg → spec_from_cfg → DatasetSpec)"
+        covers: "DatasetSpec, RenderConfig, ShardSpec, OUTPUT_FORMAT_TO_EXTENSION, EXTENSION_TO_OUTPUT_FORMAT (Hydra-composed cfg → spec_from_cfg → DatasetSpec)"
       - pattern: "src/pipeline/schemas/shard_metadata.py"
         covers: "ShardMetadata — strict pydantic sidecar payload destined for the wds tar's metadata.json member; mirrors HDF5 audio attrs. Writer + validate_shard wds branch land in PR-13."
 

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -82,7 +82,7 @@ docs:
       - pattern: "src/synth_setter/pipeline/constants.py"
         covers: "Input spec filename constant"
       - pattern: "src/synth_setter/pipeline/schemas/spec.py"
-        covers: "DatasetSpec, RenderConfig, ShardSpec, OUTPUT_FORMAT_TO_EXTENSION, EXTENSION_TO_OUTPUT_FORMAT (consumed by spec_from_cfg in cli/generate_dataset.py to build DatasetSpec from a Hydra-composed cfg)"
+        covers: "DatasetSpec, RenderConfig, ShardSpec; OUTPUT_FORMAT_TO_EXTENSION / EXTENSION_TO_OUTPUT_FORMAT inverse-pair dispatch maps (DatasetSpec is built by spec_from_cfg in cli/generate_dataset.py from a Hydra-composed cfg; the extension maps are not yet consumed — shard writers/validators will dispatch on them in PR-13)"
       - pattern: "src/synth_setter/pipeline/schemas/shard_metadata.py"
         covers: "ShardMetadata — strict pydantic sidecar payload destined for the wds tar's metadata.json member; mirrors HDF5 audio attrs. Writer + validate_shard wds branch land in PR-13."
 

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -33,6 +33,7 @@ from synth_setter.pipeline.schemas.prefix import (
 )
 
 __all__ = [
+    "EXTENSION_TO_OUTPUT_FORMAT",
     "OUTPUT_FORMAT_TO_EXTENSION",
     "DatasetSpec",
     "RenderConfig",
@@ -43,6 +44,10 @@ __all__ = [
 # Adding a format means adding a row here; missing entries surface as KeyError
 # at construction rather than producing a silently-wrong filename.
 OUTPUT_FORMAT_TO_EXTENSION: dict[str, str] = {"hdf5": ".h5", "wds": ".tar"}
+
+# Reverse lookup for dispatching shard writers/validators by file suffix;
+# derived from the forward map so adding a format stays a one-place edit.
+EXTENSION_TO_OUTPUT_FORMAT: dict[str, str] = {v: k for k, v in OUTPUT_FORMAT_TO_EXTENSION.items()}
 
 
 # Sentinel returned by ``_get_git_sha`` when called outside a git working

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -47,7 +47,16 @@ OUTPUT_FORMAT_TO_EXTENSION: dict[str, str] = {"hdf5": ".h5", "wds": ".tar"}
 
 # Reverse lookup for dispatching shard writers/validators by file suffix;
 # derived from the forward map so adding a format stays a one-place edit.
+# Two formats must never share an extension — a collision would silently drop
+# an entry from the dict-comprehension (last-key-wins) and route the wrong
+# format downstream, so guard at import time.
 EXTENSION_TO_OUTPUT_FORMAT: dict[str, str] = {v: k for k, v in OUTPUT_FORMAT_TO_EXTENSION.items()}
+if len(EXTENSION_TO_OUTPUT_FORMAT) != len(OUTPUT_FORMAT_TO_EXTENSION):
+    raise RuntimeError(
+        "Duplicate extensions in OUTPUT_FORMAT_TO_EXTENSION — "
+        "two output formats map to the same suffix: "
+        f"{OUTPUT_FORMAT_TO_EXTENSION!r}"
+    )
 
 
 # Sentinel returned by ``_get_git_sha`` when called outside a git working

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -12,6 +12,8 @@ from pydantic import ValidationError
 
 from synth_setter.data.vst import param_specs
 from synth_setter.pipeline.schemas.spec import (
+    EXTENSION_TO_OUTPUT_FORMAT,
+    OUTPUT_FORMAT_TO_EXTENSION,
     DatasetSpec,
     RenderConfig,
     ShardSpec,
@@ -584,3 +586,15 @@ class TestSpecConstructionStaysPedalboardFree:
             f"pedalboard leaked into spec serialization:\n"
             f"stdout={result.stdout}\nstderr={result.stderr}"
         )
+
+
+def test_extension_to_output_format_is_inverse_of_forward_map():
+    """EXTENSION_TO_OUTPUT_FORMAT round-trips every entry in the forward map."""
+    for output_format, extension in OUTPUT_FORMAT_TO_EXTENSION.items():
+        assert EXTENSION_TO_OUTPUT_FORMAT[extension] == output_format
+
+
+def test_extension_to_output_format_covers_h5_and_tar():
+    """The reverse map dispatches the two formats the pipeline writes today."""
+    assert EXTENSION_TO_OUTPUT_FORMAT[".h5"] == "hdf5"
+    assert EXTENSION_TO_OUTPUT_FORMAT[".tar"] == "wds"

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -12,8 +12,6 @@ from pydantic import ValidationError
 
 from synth_setter.data.vst import param_specs
 from synth_setter.pipeline.schemas.spec import (
-    EXTENSION_TO_OUTPUT_FORMAT,
-    OUTPUT_FORMAT_TO_EXTENSION,
     DatasetSpec,
     RenderConfig,
     ShardSpec,
@@ -586,15 +584,3 @@ class TestSpecConstructionStaysPedalboardFree:
             f"pedalboard leaked into spec serialization:\n"
             f"stdout={result.stdout}\nstderr={result.stderr}"
         )
-
-
-def test_extension_to_output_format_is_inverse_of_forward_map():
-    """EXTENSION_TO_OUTPUT_FORMAT round-trips every entry in the forward map."""
-    for output_format, extension in OUTPUT_FORMAT_TO_EXTENSION.items():
-        assert EXTENSION_TO_OUTPUT_FORMAT[extension] == output_format
-
-
-def test_extension_to_output_format_covers_h5_and_tar():
-    """The reverse map dispatches the two formats the pipeline writes today."""
-    assert EXTENSION_TO_OUTPUT_FORMAT[".h5"] == "hdf5"
-    assert EXTENSION_TO_OUTPUT_FORMAT[".tar"] == "wds"

--- a/tests/pipeline/test_schemas/test_format_dispatch.py
+++ b/tests/pipeline/test_schemas/test_format_dispatch.py
@@ -1,0 +1,20 @@
+"""Tests for the forward/reverse output-format <-> extension maps in ``spec.py``."""
+
+from __future__ import annotations
+
+from synth_setter.pipeline.schemas.spec import (
+    EXTENSION_TO_OUTPUT_FORMAT,
+    OUTPUT_FORMAT_TO_EXTENSION,
+)
+
+
+def test_extension_to_output_format_is_inverse_of_forward_map() -> None:
+    """``EXTENSION_TO_OUTPUT_FORMAT`` round-trips every entry in the forward map."""
+    for output_format, extension in OUTPUT_FORMAT_TO_EXTENSION.items():
+        assert EXTENSION_TO_OUTPUT_FORMAT[extension] == output_format
+
+
+def test_extension_to_output_format_covers_h5_and_tar() -> None:
+    """The reverse map dispatches the two formats the pipeline writes today."""
+    assert EXTENSION_TO_OUTPUT_FORMAT[".h5"] == "hdf5"
+    assert EXTENSION_TO_OUTPUT_FORMAT[".tar"] == "wds"

--- a/tests/pipeline/test_schemas/test_format_dispatch.py
+++ b/tests/pipeline/test_schemas/test_format_dispatch.py
@@ -18,3 +18,13 @@ def test_extension_to_output_format_covers_h5_and_tar() -> None:
     """The reverse map dispatches the two formats the pipeline writes today."""
     assert EXTENSION_TO_OUTPUT_FORMAT[".h5"] == "hdf5"
     assert EXTENSION_TO_OUTPUT_FORMAT[".tar"] == "wds"
+
+
+def test_reverse_map_has_no_silent_collisions() -> None:
+    """The reverse map never loses entries to last-key-wins collisions.
+
+    The forward map must use distinct extensions per format, so reversing it
+    preserves cardinality. This pins the invariant the import-time guard in
+    ``spec.py`` enforces.
+    """
+    assert len(EXTENSION_TO_OUTPUT_FORMAT) == len(OUTPUT_FORMAT_TO_EXTENSION)


### PR DESCRIPTION
## Summary

Adds the reverse map `EXTENSION_TO_OUTPUT_FORMAT` alongside the existing `OUTPUT_FORMAT_TO_EXTENSION` in `synth_setter.pipeline.schemas.spec`. Future WDS work — the shard writer and the shard validator — will dispatch on file suffix (`.h5` → `hdf5`, `.tar` → `wds`), and this map is the single source of truth for that lookup. Derived from the forward map via dict-comprehension so adding a row stays a one-place edit.

No caller changes; pure foundation piece for the WDS port chain.

## Test plan
- [x] `pytest tests/pipeline/test_schemas/test_dataset_spec.py -k extension_to_output_format -v` → 2/2 PASSED
- [x] `pre-commit run --files src/synth_setter/pipeline/schemas/spec.py tests/pipeline/test_schemas/test_dataset_spec.py` → all green (ruff, pyright, docformatter, pydoclint, …)

Refs #874
Refs #882