### PR TITLE
internal-feat(vst): promote writer shape helpers + DATASET_FIELD_NAMES to public

### DIFF
--- a/src/synth_setter/data/vst/generate_vst_dataset.py
+++ b/src/synth_setter/data/vst/generate_vst_dataset.py
@@ -19,8 +19,11 @@ from synth_setter.data.vst import param_specs  # noqa
 from synth_setter.data.vst.core import render_params  # noqa
 from synth_setter.data.vst.param_spec import ParamSpec  # noqa
 from synth_setter.data.vst.shapes import (
+    AUDIO_FIELD,
     MEL_N_MELS,
+    MEL_SPEC_FIELD,
     MEL_WINDOW,
+    PARAM_ARRAY_FIELD,
     audio_dataset_shape,
     mel_dataset_shape,
     mel_hop_length,
@@ -214,21 +217,21 @@ def create_datasets_and_get_start_idx(
 ):
     audio_dataset, audio_start_idx = create_dataset_and_get_first_unwritten_idx(
         hdf5_file,
-        "audio",
+        AUDIO_FIELD,
         audio_dataset_shape(num_samples, channels, sample_rate, signal_duration_seconds),
         dtype=np.float16,
         compression=hdf5plugin.Blosc2(),
     )
     mel_dataset, mel_start_idx = create_dataset_and_get_first_unwritten_idx(
         hdf5_file,
-        "mel_spec",
+        MEL_SPEC_FIELD,
         mel_dataset_shape(num_samples, channels, sample_rate, signal_duration_seconds),
         dtype=np.float32,
         compression=hdf5plugin.Blosc2(),
     )
     param_dataset, param_start_idx = create_dataset_and_get_first_unwritten_idx(
         hdf5_file,
-        "param_array",
+        PARAM_ARRAY_FIELD,
         param_array_dataset_shape(num_samples, num_params),
         dtype=np.float32,
         compression=hdf5plugin.Blosc2(),

--- a/src/synth_setter/data/vst/generate_vst_dataset.py
+++ b/src/synth_setter/data/vst/generate_vst_dataset.py
@@ -59,6 +59,7 @@ def make_spectrogram(audio: np.ndarray, sample_rate: float) -> np.ndarray:
         n_fft=mel_n_fft(sample_rate),
         hop_length=mel_hop_length(sample_rate),
         window=MEL_WINDOW,
+        center=True,
     )
     spec_db = librosa.power_to_db(spec, ref=np.max)
     return spec_db

--- a/src/synth_setter/data/vst/generate_vst_dataset.py
+++ b/src/synth_setter/data/vst/generate_vst_dataset.py
@@ -20,6 +20,62 @@ from synth_setter.data.vst.core import render_params  # noqa
 from synth_setter.data.vst.param_spec import ParamSpec  # noqa
 
 
+# Per-row arrays the writer emits and the validator checks. Single source of
+# truth for both save_samples below and the shard validator at
+# synth_setter/pipeline/ci/validate_shard.py.
+DATASET_FIELD_NAMES: tuple[str, ...] = ("audio", "mel_spec", "param_array")
+
+# Mel front-end. Centralised so mel_dataset_shape and make_spectrogram
+# agree on the time-axis size.
+MEL_FRAMES_PER_SECOND = 100
+MEL_N_MELS = 128
+MEL_N_FFT_FRACTION_OF_SAMPLE_RATE = 0.025
+MEL_WINDOW = "hamming"
+
+
+def mel_hop_length(sample_rate: float) -> int:
+    """Librosa hop length: ``sample_rate / MEL_FRAMES_PER_SECOND``."""
+    return int(sample_rate / MEL_FRAMES_PER_SECOND)
+
+
+def mel_n_fft(sample_rate: float) -> int:
+    """Librosa FFT window length: ``MEL_N_FFT_FRACTION_OF_SAMPLE_RATE * sample_rate``."""
+    return int(MEL_N_FFT_FRACTION_OF_SAMPLE_RATE * sample_rate)
+
+
+def mel_n_frames(sample_rate: float, signal_duration_seconds: float) -> int:
+    """Number of mel-time frames librosa produces (center=True default).
+
+    Mirrors ``1 + audio_length // hop_length``.
+    """
+    audio_length = int(sample_rate * signal_duration_seconds)
+    return 1 + audio_length // mel_hop_length(sample_rate)
+
+
+def audio_dataset_shape(
+    num_samples: int, channels: int, sample_rate: float, signal_duration_seconds: float
+) -> tuple[int, int, int]:
+    """Audio dataset shape ``(N, C, time_samples)``."""
+    return (num_samples, channels, int(sample_rate * signal_duration_seconds))
+
+
+def mel_dataset_shape(
+    num_samples: int, channels: int, sample_rate: float, signal_duration_seconds: float
+) -> tuple[int, int, int, int]:
+    """Mel-spectrogram dataset shape ``(N, C, n_mels, n_frames)``."""
+    return (
+        num_samples,
+        channels,
+        MEL_N_MELS,
+        mel_n_frames(sample_rate, signal_duration_seconds),
+    )
+
+
+def param_array_dataset_shape(num_samples: int, num_params: int) -> tuple[int, int]:
+    """Param-array dataset shape ``(N, num_params)``."""
+    return (num_samples, num_params)
+
+
 @dataclass
 class VSTDataSample:
     synth_params: dict[str, float]
@@ -39,22 +95,14 @@ class VSTDataSample:
 
 
 def make_spectrogram(audio: np.ndarray, sample_rate: float) -> np.ndarray:
-    """Values hardcoded to be roughly like those used by the audio spectrogram transformer.
-
-    i.e. 100 frames per second, 128 mels, ~25ms window, hamming window.
-    """
-
-    n_fft = int(0.025 * sample_rate)
-    hop_length = int(sample_rate / 100.0)
-    window = "hamming"
-
+    """Per-channel mel-spectrogram in dB; STFT params come from module-level constants."""
     spec = librosa.feature.melspectrogram(
         y=audio,
         sr=sample_rate,
-        n_mels=128,
-        n_fft=n_fft,
-        hop_length=hop_length,
-        window=window,
+        n_mels=MEL_N_MELS,
+        n_fft=mel_n_fft(sample_rate),
+        hop_length=mel_hop_length(sample_rate),
+        window=MEL_WINDOW,
     )
     spec_db = librosa.power_to_db(spec, ref=np.max)
     return spec_db
@@ -214,21 +262,21 @@ def create_datasets_and_get_start_idx(
     audio_dataset, audio_start_idx = create_dataset_and_get_first_unwritten_idx(
         hdf5_file,
         "audio",
-        (num_samples, channels, sample_rate * signal_duration_seconds),
+        audio_dataset_shape(num_samples, channels, sample_rate, signal_duration_seconds),
         dtype=np.float16,
         compression=hdf5plugin.Blosc2(),
     )
     mel_dataset, mel_start_idx = create_dataset_and_get_first_unwritten_idx(
         hdf5_file,
         "mel_spec",
-        (num_samples, 2, 128, 401),
+        mel_dataset_shape(num_samples, channels, sample_rate, signal_duration_seconds),
         dtype=np.float32,
         compression=hdf5plugin.Blosc2(),
     )
     param_dataset, param_start_idx = create_dataset_and_get_first_unwritten_idx(
         hdf5_file,
         "param_array",
-        (num_samples, num_params),  # +1 for MIDI note
+        param_array_dataset_shape(num_samples, num_params),
         dtype=np.float32,
         compression=hdf5plugin.Blosc2(),
     )

--- a/src/synth_setter/data/vst/generate_vst_dataset.py
+++ b/src/synth_setter/data/vst/generate_vst_dataset.py
@@ -18,62 +18,15 @@ from synth_setter.pipeline.schemas.spec import RenderConfig  # noqa: E402
 from synth_setter.data.vst import param_specs  # noqa
 from synth_setter.data.vst.core import render_params  # noqa
 from synth_setter.data.vst.param_spec import ParamSpec  # noqa
-
-
-# Per-row arrays the writer emits and the validator checks. Single source of
-# truth for both save_samples below and the shard validator at
-# synth_setter/pipeline/ci/validate_shard.py.
-DATASET_FIELD_NAMES: tuple[str, ...] = ("audio", "mel_spec", "param_array")
-
-# Mel front-end. Centralised so mel_dataset_shape and make_spectrogram
-# agree on the time-axis size.
-MEL_FRAMES_PER_SECOND = 100
-MEL_N_MELS = 128
-MEL_N_FFT_FRACTION_OF_SAMPLE_RATE = 0.025
-MEL_WINDOW = "hamming"
-
-
-def mel_hop_length(sample_rate: float) -> int:
-    """Librosa hop length: ``sample_rate / MEL_FRAMES_PER_SECOND``."""
-    return int(sample_rate / MEL_FRAMES_PER_SECOND)
-
-
-def mel_n_fft(sample_rate: float) -> int:
-    """Librosa FFT window length: ``MEL_N_FFT_FRACTION_OF_SAMPLE_RATE * sample_rate``."""
-    return int(MEL_N_FFT_FRACTION_OF_SAMPLE_RATE * sample_rate)
-
-
-def mel_n_frames(sample_rate: float, signal_duration_seconds: float) -> int:
-    """Number of mel-time frames librosa produces (center=True default).
-
-    Mirrors ``1 + audio_length // hop_length``.
-    """
-    audio_length = int(sample_rate * signal_duration_seconds)
-    return 1 + audio_length // mel_hop_length(sample_rate)
-
-
-def audio_dataset_shape(
-    num_samples: int, channels: int, sample_rate: float, signal_duration_seconds: float
-) -> tuple[int, int, int]:
-    """Audio dataset shape ``(N, C, time_samples)``."""
-    return (num_samples, channels, int(sample_rate * signal_duration_seconds))
-
-
-def mel_dataset_shape(
-    num_samples: int, channels: int, sample_rate: float, signal_duration_seconds: float
-) -> tuple[int, int, int, int]:
-    """Mel-spectrogram dataset shape ``(N, C, n_mels, n_frames)``."""
-    return (
-        num_samples,
-        channels,
-        MEL_N_MELS,
-        mel_n_frames(sample_rate, signal_duration_seconds),
-    )
-
-
-def param_array_dataset_shape(num_samples: int, num_params: int) -> tuple[int, int]:
-    """Param-array dataset shape ``(N, num_params)``."""
-    return (num_samples, num_params)
+from synth_setter.data.vst.shapes import (
+    MEL_N_MELS,
+    MEL_WINDOW,
+    audio_dataset_shape,
+    mel_dataset_shape,
+    mel_hop_length,
+    mel_n_fft,
+    param_array_dataset_shape,
+)
 
 
 @dataclass

--- a/src/synth_setter/data/vst/shapes.py
+++ b/src/synth_setter/data/vst/shapes.py
@@ -24,11 +24,20 @@ MEL_WINDOW = "hamming"
 def mel_hop_length(sample_rate: float) -> int:
     """Librosa hop length: ``sample_rate / MEL_FRAMES_PER_SECOND``.
 
-    :param sample_rate: Audio sample rate in Hz.
+    :param sample_rate: Audio sample rate in Hz. Must be at least
+        ``MEL_FRAMES_PER_SECOND`` — lower rates would produce a hop length of 0
+        and trigger a ``ZeroDivisionError`` downstream in ``mel_n_frames``.
     :returns: Hop length in samples, rounded down to an integer.
     :rtype: int
+    :raises ValueError: If ``sample_rate`` would produce a hop length of 0.
     """
-    return int(sample_rate / MEL_FRAMES_PER_SECOND)
+    hop = int(sample_rate / MEL_FRAMES_PER_SECOND)
+    if hop <= 0:
+        raise ValueError(
+            f"sample_rate={sample_rate} produces hop length {hop}; "
+            f"sample_rate must be at least MEL_FRAMES_PER_SECOND={MEL_FRAMES_PER_SECOND}."
+        )
+    return hop
 
 
 def mel_n_fft(sample_rate: float) -> int:

--- a/src/synth_setter/data/vst/shapes.py
+++ b/src/synth_setter/data/vst/shapes.py
@@ -25,8 +25,8 @@ def mel_hop_length(sample_rate: float) -> int:
     """Librosa hop length: ``sample_rate / MEL_FRAMES_PER_SECOND``.
 
     :param sample_rate: Audio sample rate in Hz. Must be at least
-        ``MEL_FRAMES_PER_SECOND`` — lower rates would produce a hop length of 0
-        and trigger a ``ZeroDivisionError`` downstream in ``mel_n_frames``.
+        ``MEL_FRAMES_PER_SECOND`` — lower rates round down to a hop of 0,
+        which is not a valid librosa ``hop_length``.
     :returns: Hop length in samples, rounded down to an integer.
     :rtype: int
     :raises ValueError: If ``sample_rate`` would produce a hop length of 0.
@@ -43,11 +43,22 @@ def mel_hop_length(sample_rate: float) -> int:
 def mel_n_fft(sample_rate: float) -> int:
     """Librosa FFT window length: ``MEL_N_FFT_FRACTION_OF_SAMPLE_RATE * sample_rate``.
 
-    :param sample_rate: Audio sample rate in Hz.
+    :param sample_rate: Audio sample rate in Hz. Must be large enough that
+        ``int(MEL_N_FFT_FRACTION_OF_SAMPLE_RATE * sample_rate) >= 1`` —
+        smaller rates round down to ``n_fft=0``, which is not a valid librosa
+        FFT window length.
     :returns: FFT window length in samples, rounded down to an integer.
     :rtype: int
+    :raises ValueError: If ``sample_rate`` would produce ``n_fft`` of 0.
     """
-    return int(MEL_N_FFT_FRACTION_OF_SAMPLE_RATE * sample_rate)
+    n_fft = int(MEL_N_FFT_FRACTION_OF_SAMPLE_RATE * sample_rate)
+    if n_fft <= 0:
+        raise ValueError(
+            f"sample_rate={sample_rate} produces n_fft {n_fft}; "
+            f"sample_rate must be at least "
+            f"1/MEL_N_FFT_FRACTION_OF_SAMPLE_RATE={1 / MEL_N_FFT_FRACTION_OF_SAMPLE_RATE}."
+        )
+    return n_fft
 
 
 def mel_n_frames(sample_rate: float, signal_duration_seconds: float) -> int:

--- a/src/synth_setter/data/vst/shapes.py
+++ b/src/synth_setter/data/vst/shapes.py
@@ -10,7 +10,10 @@ import surface (h5py, pedalboard, the VST renderer).
 
 from __future__ import annotations
 
-DATASET_FIELD_NAMES: tuple[str, ...] = ("audio", "mel_spec", "param_array")
+AUDIO_FIELD: str = "audio"
+MEL_SPEC_FIELD: str = "mel_spec"
+PARAM_ARRAY_FIELD: str = "param_array"
+DATASET_FIELD_NAMES: tuple[str, ...] = (AUDIO_FIELD, MEL_SPEC_FIELD, PARAM_ARRAY_FIELD)
 
 MEL_FRAMES_PER_SECOND = 100
 MEL_N_MELS = 128

--- a/src/synth_setter/data/vst/shapes.py
+++ b/src/synth_setter/data/vst/shapes.py
@@ -1,0 +1,104 @@
+"""Shape and mel-front-end primitives shared by writer and validator.
+
+Hosts the per-row array names (``DATASET_FIELD_NAMES``), the mel-spectrogram
+constants the writer's ``make_spectrogram`` uses, and the audio / mel-spec /
+param-array dataset-shape calculators. Kept as a thin sibling module so that
+the (planned) shard validator and the (planned) wds writer can import these
+primitives without pulling in the rest of ``generate_vst_dataset.py``'s
+import surface (h5py, pedalboard, the VST renderer).
+"""
+
+from __future__ import annotations
+
+DATASET_FIELD_NAMES: tuple[str, ...] = ("audio", "mel_spec", "param_array")
+
+MEL_FRAMES_PER_SECOND = 100
+MEL_N_MELS = 128
+MEL_N_FFT_FRACTION_OF_SAMPLE_RATE = 0.025
+MEL_WINDOW = "hamming"
+
+
+def mel_hop_length(sample_rate: float) -> int:
+    """Librosa hop length: ``sample_rate / MEL_FRAMES_PER_SECOND``.
+
+    :param sample_rate: Audio sample rate in Hz.
+    :returns: Hop length in samples, rounded down to an integer.
+    :rtype: int
+    """
+    return int(sample_rate / MEL_FRAMES_PER_SECOND)
+
+
+def mel_n_fft(sample_rate: float) -> int:
+    """Librosa FFT window length: ``MEL_N_FFT_FRACTION_OF_SAMPLE_RATE * sample_rate``.
+
+    :param sample_rate: Audio sample rate in Hz.
+    :returns: FFT window length in samples, rounded down to an integer.
+    :rtype: int
+    """
+    return int(MEL_N_FFT_FRACTION_OF_SAMPLE_RATE * sample_rate)
+
+
+def mel_n_frames(sample_rate: float, signal_duration_seconds: float) -> int:
+    """Number of mel-time frames librosa produces (``center=True`` default).
+
+    Mirrors librosa's ``1 + audio_length // hop_length`` calculation.
+
+    :param sample_rate: Audio sample rate in Hz.
+    :param signal_duration_seconds: Duration of the rendered audio in seconds.
+    :returns: Number of time frames in the produced mel spectrogram.
+    :rtype: int
+    """
+    audio_length = int(sample_rate * signal_duration_seconds)
+    return 1 + audio_length // mel_hop_length(sample_rate)
+
+
+def audio_dataset_shape(
+    num_samples: int,
+    channels: int,
+    sample_rate: float,
+    signal_duration_seconds: float,
+) -> tuple[int, int, int]:
+    """Audio dataset shape ``(N, C, time_samples)``.
+
+    :param num_samples: Number of rows (shard batch size).
+    :param channels: Audio channels (typically 1 or 2).
+    :param sample_rate: Audio sample rate in Hz.
+    :param signal_duration_seconds: Duration of each rendered sample in seconds.
+    :returns: Three-tuple ``(num_samples, channels, time_samples)``.
+    :rtype: tuple[int, int, int]
+    """
+    return (num_samples, channels, int(sample_rate * signal_duration_seconds))
+
+
+def mel_dataset_shape(
+    num_samples: int,
+    channels: int,
+    sample_rate: float,
+    signal_duration_seconds: float,
+) -> tuple[int, int, int, int]:
+    """Mel-spectrogram dataset shape ``(N, C, n_mels, n_frames)``.
+
+    :param num_samples: Number of rows (shard batch size).
+    :param channels: Audio channels (typically 1 or 2).
+    :param sample_rate: Audio sample rate in Hz.
+    :param signal_duration_seconds: Duration of each rendered sample in seconds.
+    :returns: Four-tuple ``(num_samples, channels, n_mels, n_frames)``.
+    :rtype: tuple[int, int, int, int]
+    """
+    return (
+        num_samples,
+        channels,
+        MEL_N_MELS,
+        mel_n_frames(sample_rate, signal_duration_seconds),
+    )
+
+
+def param_array_dataset_shape(num_samples: int, num_params: int) -> tuple[int, int]:
+    """Param-array dataset shape ``(N, num_params)``.
+
+    :param num_samples: Number of rows (shard batch size).
+    :param num_params: Width of the per-row parameter vector.
+    :returns: Two-tuple ``(num_samples, num_params)``.
+    :rtype: tuple[int, int]
+    """
+    return (num_samples, num_params)

--- a/tests/data/vst/test_shape_helpers.py
+++ b/tests/data/vst/test_shape_helpers.py
@@ -72,6 +72,14 @@ def test_mel_n_fft_matches_legacy_inline_calc() -> None:
     assert mel_n_fft(44100) == 1102
 
 
+def test_mel_n_fft_raises_when_n_fft_would_be_zero() -> None:
+    """Reject sample rates where ``int(0.025 * sr)`` rounds to 0 (not a valid librosa n_fft)."""
+    import pytest
+
+    with pytest.raises(ValueError, match="n_fft 0"):
+        mel_n_fft(10)
+
+
 def test_mel_n_frames_matches_legacy_inline_calc() -> None:
     """``mel_n_frames`` reproduces librosa's center=True frame count: ``1 + len // hop``."""
     # 16k * 4s = 64000 samples, hop = 160 -> 1 + 64000 // 160 = 401.

--- a/tests/data/vst/test_shape_helpers.py
+++ b/tests/data/vst/test_shape_helpers.py
@@ -58,6 +58,14 @@ def test_mel_hop_length_matches_legacy_inline_calc() -> None:
     assert mel_hop_length(44100) == 441
 
 
+def test_mel_hop_length_raises_when_hop_would_be_zero() -> None:
+    """Reject sample rates below MEL_FRAMES_PER_SECOND so n_frames never divides by zero."""
+    import pytest
+
+    with pytest.raises(ValueError, match="hop length 0"):
+        mel_hop_length(50)
+
+
 def test_mel_n_fft_matches_legacy_inline_calc() -> None:
     """``mel_n_fft(16000)`` equals the legacy ``int(0.025 * sr)`` literal (400)."""
     assert mel_n_fft(16000) == 400

--- a/tests/data/vst/test_shape_helpers.py
+++ b/tests/data/vst/test_shape_helpers.py
@@ -12,11 +12,14 @@ import numpy as np
 
 from synth_setter.data.vst.generate_vst_dataset import make_spectrogram
 from synth_setter.data.vst.shapes import (
+    AUDIO_FIELD,
     DATASET_FIELD_NAMES,
     MEL_FRAMES_PER_SECOND,
     MEL_N_FFT_FRACTION_OF_SAMPLE_RATE,
     MEL_N_MELS,
+    MEL_SPEC_FIELD,
     MEL_WINDOW,
+    PARAM_ARRAY_FIELD,
     audio_dataset_shape,
     mel_dataset_shape,
     mel_hop_length,
@@ -29,6 +32,16 @@ from synth_setter.data.vst.shapes import (
 def test_dataset_field_names_match_writer_emissions() -> None:
     """Pins the public field-name tuple; adding a field forces writer + validator update."""
     assert DATASET_FIELD_NAMES == ("audio", "mel_spec", "param_array")
+
+
+def test_dataset_field_constants_match_tuple_order() -> None:
+    """``DATASET_FIELD_NAMES`` is built from the per-field constants the writer uses."""
+    assert DATASET_FIELD_NAMES == (AUDIO_FIELD, MEL_SPEC_FIELD, PARAM_ARRAY_FIELD)
+    assert (AUDIO_FIELD, MEL_SPEC_FIELD, PARAM_ARRAY_FIELD) == (
+        "audio",
+        "mel_spec",
+        "param_array",
+    )
 
 
 def test_mel_front_end_constants_match_legacy_values() -> None:

--- a/tests/data/vst/test_shape_helpers.py
+++ b/tests/data/vst/test_shape_helpers.py
@@ -1,0 +1,99 @@
+"""Unit tests for the public shape primitives in ``generate_vst_dataset``.
+
+The writer and the (planned) shard-validator inner-shape checks share these
+helpers, so each test pins one shape against the legacy inline calculation
+that lived in ``create_datasets_and_get_start_idx`` / ``make_spectrogram`` on
+``main`` before this PR. If anyone changes a constant (n_mels, fps, ...),
+multiple tests here should fail loudly rather than the writer and validator
+silently drifting apart.
+"""
+
+import numpy as np
+
+from synth_setter.data.vst.generate_vst_dataset import (
+    DATASET_FIELD_NAMES,
+    MEL_FRAMES_PER_SECOND,
+    MEL_N_FFT_FRACTION_OF_SAMPLE_RATE,
+    MEL_N_MELS,
+    MEL_WINDOW,
+    audio_dataset_shape,
+    make_spectrogram,
+    mel_dataset_shape,
+    mel_hop_length,
+    mel_n_fft,
+    mel_n_frames,
+    param_array_dataset_shape,
+)
+
+
+def test_dataset_field_names_match_writer_emissions() -> None:
+    """Pins the public field-name tuple; adding a field forces writer + validator update."""
+    assert DATASET_FIELD_NAMES == ("audio", "mel_spec", "param_array")
+
+
+def test_mel_front_end_constants_match_legacy_values() -> None:
+    """Pin the four module-level mel-front-end constants against legacy literals."""
+    assert MEL_FRAMES_PER_SECOND == 100
+    assert MEL_N_MELS == 128
+    assert MEL_N_FFT_FRACTION_OF_SAMPLE_RATE == 0.025
+    assert MEL_WINDOW == "hamming"
+
+
+def test_mel_hop_length_matches_legacy_inline_calc() -> None:
+    """``mel_hop_length(16000)`` equals the legacy ``int(sr / 100.0)`` literal (160)."""
+    assert mel_hop_length(16000) == 160
+    assert mel_hop_length(44100) == 441
+
+
+def test_mel_n_fft_matches_legacy_inline_calc() -> None:
+    """``mel_n_fft(16000)`` equals the legacy ``int(0.025 * sr)`` literal (400)."""
+    assert mel_n_fft(16000) == 400
+    assert mel_n_fft(44100) == 1102
+
+
+def test_mel_n_frames_matches_legacy_inline_calc() -> None:
+    """``mel_n_frames`` reproduces librosa's center=True frame count: ``1 + len // hop``."""
+    # 16k * 4s = 64000 samples, hop = 160 -> 1 + 64000 // 160 = 401.
+    assert mel_n_frames(16000, 4.0) == 401
+    # 44.1k * 4s = 176400 samples, hop = 441 -> 1 + 176400 // 441 = 401.
+    assert mel_n_frames(44100, 4.0) == 401
+
+
+def test_audio_dataset_shape_matches_legacy_inline_calc() -> None:
+    """Pins ``(num_samples, channels, int(sample_rate * signal_duration_seconds))``."""
+    assert audio_dataset_shape(2, 2, 16000, 4.0) == (2, 2, 64000)
+    assert audio_dataset_shape(5, 2, 44100, 4.0) == (5, 2, 176400)
+
+
+def test_mel_dataset_shape_matches_legacy_inline_calc() -> None:
+    """Pins ``(num_samples, channels, 128, n_frames)`` for 16k x 4s and 44.1k x 4s."""
+    assert mel_dataset_shape(2, 2, 16000, 4.0) == (2, 2, 128, 401)
+    assert mel_dataset_shape(5, 2, 44100, 4.0) == (5, 2, 128, 401)
+
+
+def test_param_array_dataset_shape_matches_legacy_inline_calc() -> None:
+    """Pins ``(num_samples, num_params)``."""
+    assert param_array_dataset_shape(2, 175) == (2, 175)
+    assert param_array_dataset_shape(0, 0) == (0, 0)
+
+
+def test_make_spectrogram_output_shape_matches_mel_dataset_shape_helper() -> None:
+    """make_spectrogram and mel_dataset_shape agree on the trailing (n_mels, n_frames).
+
+    This is the load-bearing invariant the writer and validator both rely on:
+    the actual librosa call inside ``make_spectrogram`` and the precomputed
+    ``mel_dataset_shape`` must produce the same trailing dimensions. Tests a
+    1-channel and a 2-channel render — librosa's behavior is per-channel so
+    the helper pads the channel dimension symmetrically.
+    """
+    sample_rate = 16000
+    duration = 4.0
+    audio_length = int(sample_rate * duration)
+
+    mono = np.zeros((audio_length,), dtype=np.float32)
+    mono_spec = make_spectrogram(mono, sample_rate)
+    assert mono_spec.shape == mel_dataset_shape(1, 1, sample_rate, duration)[2:]
+
+    stereo = np.zeros((2, audio_length), dtype=np.float32)
+    stereo_spec = make_spectrogram(stereo, sample_rate)
+    assert stereo_spec.shape == (2, *mel_dataset_shape(1, 1, sample_rate, duration)[2:])

--- a/tests/data/vst/test_shape_helpers.py
+++ b/tests/data/vst/test_shape_helpers.py
@@ -1,4 +1,4 @@
-"""Unit tests for the public shape primitives in ``generate_vst_dataset``.
+"""Unit tests for the shape primitives in ``synth_setter.data.vst.shapes``.
 
 The writer and the (planned) shard-validator inner-shape checks share these
 helpers, so each test pins one shape against the legacy inline calculation
@@ -10,14 +10,14 @@ silently drifting apart.
 
 import numpy as np
 
-from synth_setter.data.vst.generate_vst_dataset import (
+from synth_setter.data.vst.generate_vst_dataset import make_spectrogram
+from synth_setter.data.vst.shapes import (
     DATASET_FIELD_NAMES,
     MEL_FRAMES_PER_SECOND,
     MEL_N_FFT_FRACTION_OF_SAMPLE_RATE,
     MEL_N_MELS,
     MEL_WINDOW,
     audio_dataset_shape,
-    make_spectrogram,
     mel_dataset_shape,
     mel_hop_length,
     mel_n_fft,


### PR DESCRIPTION
## Summary

Promotes the per-row array names and the audio/mel/param shape calculators inside `synth_setter.data.vst.generate_vst_dataset` to public, module-level helpers (`DATASET_FIELD_NAMES`, `audio_dataset_shape`, `mel_dataset_shape`, `param_array_dataset_shape`) plus the mel-front-end constants and `mel_hop_length` / `mel_n_fft` / `mel_n_frames` helpers. `make_spectrogram` and `create_datasets_and_get_start_idx` now call the new helpers; behavior is byte-identical.

Foundation for the upcoming WDS writer and shard-validator inner-shape checks, which need to share these primitives with the validator side.

## Test plan
- [x] `pytest tests/data/vst/test_generate_vst_dataset.py -v` (pre-existing tests still green)
- [x] New helper tests pin every shape against today's inline calculations
- [x] `make test-fast`

Refs #874
Refs #882