### PR TITLE
chore(ci): tighten test-dataset-generation PR trigger paths

### DIFF
--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -76,11 +76,27 @@ on:
           - skypilot-local
           - runpod
           - oci
+  # Trigger paths are intentionally narrow — this workflow burns runner minutes
+  # (skypilot-local kind cluster + dev-snapshot image pull). Only list paths
+  # whose changes can plausibly break dataset generation. In particular:
+  #
+  #   * `pyproject.toml` is NOT listed — the workflow runs against a pre-built
+  #     `dev-snapshot` image, so dep bumps land via the docker build pipeline,
+  #     not here. Lint/test/dev-only pyproject changes were the largest source
+  #     of false-positive runs.
+  #   * `configs/experiment/**` is narrowed to `generate_dataset/**` — the
+  #     other subdirs (surge/fm/kosc/...) are training experiments and don't
+  #     feed this workflow's Hydra compose.
+  #   * `src/synth_setter/pipeline/schemas/**` is enumerated to the specific
+  #     files actually imported by the generation path (spec / image_config /
+  #     prefix). `shard_metadata.py` is downstream-only and shouldn't fire.
   pull_request:
     paths:
       - "src/synth_setter/data/vst/**"
-      - "src/synth_setter/pipeline/schemas/**"
-      - "configs/experiment/**"
+      - "src/synth_setter/pipeline/schemas/spec.py"
+      - "src/synth_setter/pipeline/schemas/image_config.py"
+      - "src/synth_setter/pipeline/schemas/prefix.py"
+      - "configs/experiment/generate_dataset/**"
       - "configs/dataset.yaml"
       - "configs/render/**"
       - "configs/r2/**"
@@ -97,7 +113,6 @@ on:
       - ".github/workflows/test-dataset-generation.yml"
       - ".github/workflows/generate-dataset-shards.yaml"
       - ".github/workflows/validate-dataset-shards.yaml"
-      - "pyproject.toml"
 
 permissions:
   contents: read

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -80,21 +80,30 @@ on:
   # (skypilot-local kind cluster + dev-snapshot image pull). Only list paths
   # whose changes can plausibly break dataset generation. In particular:
   #
-  #   * `pyproject.toml` is NOT listed — the workflow runs against a pre-built
-  #     `dev-snapshot` image, so dep bumps land via the docker build pipeline,
-  #     not here. Lint/test/dev-only pyproject changes were the largest source
-  #     of false-positive runs.
+  #   * `pyproject.toml` is NOT listed. The worker container pulls the
+  #     pre-built `dev-snapshot` image, so dep bumps don't reach the worker
+  #     side from here. The launcher side IS affected (the `skypilot-local`
+  #     row runs `uv pip install --system -e .` in
+  #     `generate-dataset-shards.yaml`'s "Install launcher deps" step), so
+  #     pyproject changes that break that install would fail this workflow
+  #     too — but they would fail `test.yml` (also `pip install -e .`) and
+  #     `docker-build-validation.yml` (rebuilds the image) FIRST. We accept
+  #     that redundant coverage in exchange for not firing on the steady
+  #     stream of lint / test / dev-only pyproject changes (mutmut, gitlint,
+  #     ruff config, dev-only deps) that were the largest source of
+  #     false-positive runs.
   #   * `configs/experiment/**` is narrowed to `generate_dataset/**` — the
   #     other subdirs (surge/fm/kosc/...) are training experiments and don't
   #     feed this workflow's Hydra compose.
   #   * `src/synth_setter/pipeline/schemas/**` is enumerated to the specific
-  #     files actually imported by the generation path (spec / image_config /
-  #     prefix). `shard_metadata.py` is downstream-only and shouldn't fire.
+  #     files actually imported by the generation path (`spec.py`, `prefix.py`).
+  #     `shard_metadata.py` is downstream-only; `image_config.py` is consumed
+  #     by `pipeline/ci/load_image_config.py` for `docker-build-validation.yml`,
+  #     not by anything `test-dataset-generation` invokes.
   pull_request:
     paths:
       - "src/synth_setter/data/vst/**"
       - "src/synth_setter/pipeline/schemas/spec.py"
-      - "src/synth_setter/pipeline/schemas/image_config.py"
       - "src/synth_setter/pipeline/schemas/prefix.py"
       - "configs/experiment/generate_dataset/**"
       - "configs/dataset.yaml"


### PR DESCRIPTION
## Summary

The `test-dataset-generation.yml` workflow's PR `paths:` filter was firing on changes that can't plausibly affect dataset generation. Each false-positive run burns runner minutes (skypilot-local kind cluster + dev-snapshot image pull). Tightenings:

- **Drop `pyproject.toml`.** The workflow runs against a pre-built `dev-snapshot` docker image, so dep bumps land via `docker-build-validation.yml`, not here. Lint/test/dev-only pyproject changes (mutmut, gitlint, ruff config, dev-only deps) were the largest source of unnecessary runs.
- **Narrow `configs/experiment/**`** → `configs/experiment/generate_dataset/**`. The other subdirs (`surge/`, `fm/`, `kosc/`, ...) are training experiments and don't compose into `dataset.yaml`.
- **Replace the `src/synth_setter/pipeline/schemas/**` glob** with the specific files imported on the generation path: `spec.py`, `image_config.py`, `prefix.py`. `shard_metadata.py` is consumed downstream (finalize/validation) and shouldn't fire this workflow.

A YAML-level comment block above the `pull_request:` key documents why each item is or isn't on the list, so future trigger edits don't undo this without thinking about it.

Other listed paths are already file-specific or genuinely scoped to the data-generation flow — they're untouched.

Closes #1027

## Test plan

- [ ] Workflow YAML parses (covered by the existing `Validate GitHub Workflows` pre-commit hook — passed locally).
- [ ] This PR itself touches `.github/workflows/test-dataset-generation.yml`, so the workflow fires on this PR (sanity check that the trigger list still includes itself).
- [ ] After merge, monitor the next several PRs touching only `pyproject.toml`, `configs/experiment/{surge,fm,kosc}/**`, or `src/synth_setter/pipeline/schemas/shard_metadata.py` and confirm they no longer fire `test-dataset-generation`.