### PR TITLE
internal-feat(pipeline): inner-shape checks in validate_shard

### DIFF
--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -1403,7 +1403,7 @@ src/
     ci/                 # CI validation scripts (implemented)
       materialize_spec.py # Compose a DatasetSpec from a Hydra experiment and write it to disk as JSON
       validate_spec.py  # Spec structural validation (required fields, git_sha format, etc.)
-      validate_shard.py # Shard validation (valid HDF5, expected datasets, row count); iterates spec.shards via R2
+      validate_shard.py # Shard validation (valid HDF5, full per-dataset shapes via synth_setter.data.vst.shapes — not just row count); iterates spec.shards via R2
       load_image_config.py # Resolve Docker image configuration for the launcher
 
     constants.py        # Well-known filenames and paths (R2_BUCKET, etc.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,7 +270,6 @@ exclude = '''(?x)
   | ^\.worktrees/
   | ^notebooks/
   | ^src/synth_setter/pipeline/ci/load_image_config\.py$
-  | ^src/synth_setter/pipeline/ci/validate_shard\.py$
   | ^src/synth_setter/pipeline/ci/validate_spec\.py$
   | ^src/synth_setter/cli/generate_dataset\.py$
   | ^src/synth_setter/pipeline/skypilot_launch\.py$

--- a/src/synth_setter/pipeline/ci/validate_shard.py
+++ b/src/synth_setter/pipeline/ci/validate_shard.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 """Validate HDF5 shards against a DatasetSpec.
 
-Checks that each shard file is a valid HDF5 file, contains the expected
-datasets (audio, mel_spec, param_array), and that each dataset's row count
-matches ``spec.render.batch_per_shard``.
+Checks that each shard file is a valid HDF5 file, contains the per-row
+arrays the writer emits (``synth_setter.data.vst.shapes.DATASET_FIELD_NAMES``),
+and that each dataset's full ``.shape`` matches what those shape helpers
+predict for ``spec.render`` — i.e. ``(N, C, time)`` for audio,
+``(N, C, n_mels, n_frames)`` for the mel spectrogram, and
+``(N, num_params)`` for the param array.
 
 CLI usage:
     python3 -m synth_setter.pipeline.ci.validate_shard <spec.json|r2://bucket/spec.json>
@@ -20,10 +23,37 @@ from typing import cast
 
 import h5py
 
+from synth_setter.data.vst.shapes import (
+    AUDIO_FIELD,
+    DATASET_FIELD_NAMES,
+    MEL_SPEC_FIELD,
+    PARAM_ARRAY_FIELD,
+    audio_dataset_shape,
+    mel_dataset_shape,
+    param_array_dataset_shape,
+)
 from synth_setter.pipeline.r2_io import downloaded_to_tempfile, is_r2_uri, shard_uri
 from synth_setter.pipeline.schemas.spec import DatasetSpec
 
-_EXPECTED_DATASETS = ("audio", "mel_spec", "param_array")
+
+def _expected_dataset_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
+    """Full per-field shapes (N + inner) the writer emits for ``spec``.
+
+    Keys match ``DATASET_FIELD_NAMES``; values come from the writer's own
+    shape helpers in ``synth_setter.data.vst.shapes`` so a future renderer
+    change that drifts the audio / mel / param shapes fails fast here.
+    """
+    render = spec.render
+    num_samples = render.batch_per_shard
+    return {
+        AUDIO_FIELD: audio_dataset_shape(
+            num_samples, render.channels, render.sample_rate, render.signal_duration_seconds
+        ),
+        MEL_SPEC_FIELD: mel_dataset_shape(
+            num_samples, render.channels, render.sample_rate, render.signal_duration_seconds
+        ),
+        PARAM_ARRAY_FIELD: param_array_dataset_shape(num_samples, spec.num_params),
+    }
 
 
 def validate_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:
@@ -31,8 +61,9 @@ def validate_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:
 
     Checks:
     1. File opens as HDF5
-    2. Contains expected datasets: audio, mel_spec, param_array
-    3. Each dataset's row count (shape[0]) matches spec.render.batch_per_shard
+    2. Contains every dataset named in ``DATASET_FIELD_NAMES``
+    3. Each dataset's full ``.shape`` matches what
+       ``_expected_dataset_shapes`` predicts for ``spec``
 
     Returns list of error strings (empty = valid).
     """
@@ -44,19 +75,18 @@ def validate_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:
     except OSError:
         return [f"file is not valid HDF5: {shard_path}"]
 
+    expected_shapes = _expected_dataset_shapes(spec)
     errors: list[str] = []
     with f:
-        for name in _EXPECTED_DATASETS:
+        for name in DATASET_FIELD_NAMES:
             if name not in f:
                 errors.append(f"missing dataset: {name!r}")
                 continue
 
-            row_count = cast(h5py.Dataset, f[name]).shape[0]
-            if row_count != spec.render.batch_per_shard:
-                errors.append(
-                    f"dataset {name!r} has {row_count} rows, "
-                    f"expected {spec.render.batch_per_shard}"
-                )
+            actual = cast(h5py.Dataset, f[name]).shape
+            expected = expected_shapes[name]
+            if actual != expected:
+                errors.append(f"dataset {name!r} has shape {actual}, expected {expected}")
 
     return errors
 

--- a/src/synth_setter/pipeline/ci/validate_shard.py
+++ b/src/synth_setter/pipeline/ci/validate_shard.py
@@ -42,6 +42,12 @@ def _expected_dataset_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
     Keys match ``DATASET_FIELD_NAMES``; values come from the writer's own
     shape helpers in ``synth_setter.data.vst.shapes`` so a future renderer
     change that drifts the audio / mel / param shapes fails fast here.
+
+    :param spec: Dataset spec whose ``render`` config and ``num_params`` parameterize
+        the per-field shapes the writer would emit for one shard.
+    :returns: Mapping with one entry per writer-emitted dataset name to its full
+        ``(N, ...)`` shape tuple.
+    :rtype: dict[str, tuple[int, ...]]
     """
     render = spec.render
     num_samples = render.batch_per_shard
@@ -65,7 +71,10 @@ def validate_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:
     3. Each dataset's full ``.shape`` matches what
        ``_expected_dataset_shapes`` predicts for ``spec``
 
-    Returns list of error strings (empty = valid).
+    :param shard_path: Local filesystem path to the HDF5 shard to validate.
+    :param spec: Dataset spec the shard is expected to conform to.
+    :returns: List of error strings (empty = valid).
+    :rtype: list[str]
     """
     if not shard_path.exists():
         return [f"shard file not found: {shard_path}"]
@@ -92,7 +101,13 @@ def validate_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:
 
 
 def _load_spec(spec_arg: str) -> DatasetSpec:
-    """Load a spec from a local path or `r2://bucket/key` URI."""
+    """Load a spec from a local path or ``r2://bucket/key`` URI.
+
+    :param spec_arg: Either a local filesystem path or an ``r2://...`` URI pointing
+        at the spec JSON file.
+    :returns: Parsed ``DatasetSpec`` instance.
+    :rtype: DatasetSpec
+    """
     if is_r2_uri(spec_arg):
         with downloaded_to_tempfile(spec_arg) as local_path:
             return DatasetSpec.model_validate_json(local_path.read_text())
@@ -100,10 +115,13 @@ def _load_spec(spec_arg: str) -> DatasetSpec:
 
 
 def validate_all_shards_from_r2(spec: DatasetSpec) -> list[str]:
-    """Validate every shard in `spec.shards` by downloading from R2.
+    """Validate every shard in ``spec.shards`` by downloading from R2.
 
-    Returns aggregated error strings across all shards (empty = all valid). Each error is prefixed
-    with the shard filename so the source is obvious.
+    :param spec: Dataset spec whose ``shards`` list drives the iteration; each
+        listed shard is fetched from R2 under ``r2://{spec.r2_bucket}/{spec.r2_prefix}``.
+    :returns: Aggregated error strings across all shards (empty = all valid). Each
+        error is prefixed with the shard filename so the source is obvious.
+    :rtype: list[str]
     """
     errors: list[str] = []
     for shard in spec.shards:

--- a/tests/pipeline/ci/test_validate_shard_inner_shapes.py
+++ b/tests/pipeline/ci/test_validate_shard_inner_shapes.py
@@ -1,0 +1,251 @@
+"""Inner-shape validation tests for ``synth_setter.pipeline.ci.validate_shard``.
+
+These tests pin the per-dataset full-shape check the validator gained when
+the HDF5 path was tightened to compare each dataset's ``.shape`` tuple to
+the writer's source-of-truth shape helpers in
+``synth_setter.data.vst.shapes`` (instead of only its ``shape[0]`` row
+count). The older row-count tests live alongside in
+``test_validate_shard.py``; this file isolates the new failure modes (wrong
+channels, wrong time samples, wrong mel ``n_frames``, wrong ``num_params``)
+in a sibling that is *not* on the pydoclint exclude list, so the new
+helpers get full sphinx-docstring coverage from day one.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from synth_setter.pipeline.ci.validate_shard import validate_shard
+from synth_setter.pipeline.schemas.spec import DatasetSpec
+
+_VALID_AUDIO_CHANNELS = 2
+_VALID_AUDIO_SAMPLES_PER_ROW = 64000
+_VALID_MEL_INNER_SHAPE: tuple[int, int, int] = (2, 128, 401)
+_VALID_PARAM_LENGTH = 92
+
+
+def _write_h5_with_shapes(path: Path, shapes: dict[str, tuple[int, ...]]) -> None:
+    """Create a minimal HDF5 file with one zero-filled ``float32`` dataset per entry.
+
+    :param path: Filesystem path where the HDF5 file will be written.
+    :param shapes: Mapping from dataset name to its exact ``.shape`` tuple. Each entry
+        becomes a top-level dataset; no attributes or groups are written.
+    :returns: ``None``.
+    :rtype: None
+    """
+    with h5py.File(path, "w") as f:
+        for name, shape in shapes.items():
+            f.create_dataset(name, shape=shape, dtype=np.float32)
+
+
+def _valid_default_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
+    """Return the canonical ``(N, ...)`` shapes the writer would emit for ``spec``.
+
+    Mirrors the shapes ``_expected_dataset_shapes`` computes in the validator under test
+    so that each test case can override exactly one field while leaving the other two
+    correct, isolating the failure mode under test.
+
+    :param spec: The dataset spec whose ``render`` and ``num_params`` drive the shapes.
+    :returns: Mapping with one entry per writer-emitted dataset, each value matching the
+        full ``(N, ...)`` shape the HDF5 writer is expected to produce.
+    :rtype: dict[str, tuple[int, ...]]
+    """
+    n = spec.render.batch_per_shard
+    return {
+        "audio": (n, _VALID_AUDIO_CHANNELS, _VALID_AUDIO_SAMPLES_PER_ROW),
+        "mel_spec": (n, *_VALID_MEL_INNER_SHAPE),
+        "param_array": (n, _VALID_PARAM_LENGTH),
+    }
+
+
+@pytest.fixture()
+def real_spec(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> DatasetSpec:
+    """Build a ``DatasetSpec`` whose render config produces known-good inner shapes.
+
+    The sample rate (``16000``) and duration (``4.0``) make audio time-samples
+    ``64000`` and mel ``n_frames`` ``401``, lining up with ``_VALID_*`` module
+    constants so that overriding a single dimension in a test is unambiguous.
+
+    :param tmp_path: pytest-provided temp directory used for the fake VST3 bundle.
+    :param monkeypatch: pytest monkeypatch to freeze git/timestamp factories the spec
+        validators consult — keeps spec construction deterministic on machines without
+        the repo's git metadata available to the schema layer.
+    :returns: A spec whose render's batch_per_shard / channels / sample_rate /
+        signal_duration_seconds match this module's ``_VALID_*`` constants.
+    :rtype: DatasetSpec
+    """
+    fixed_now = datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._get_git_sha", lambda: "a" * 40)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._is_repo_dirty", lambda: False)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._utc_now", lambda: fixed_now)
+
+    contents = tmp_path / "FakePlugin.vst3" / "Contents"
+    contents.mkdir(parents=True)
+    (contents / "moduleinfo.json").write_text('{"Version": "1.3.4"}')
+
+    return DatasetSpec(
+        task_name="test-dataset",
+        output_format="hdf5",
+        train_val_test_sizes=(10, 0, 0),
+        base_seed=42,
+        r2_bucket="intermediate-data",
+        render={
+            "plugin_path": str(tmp_path / "FakePlugin.vst3"),
+            "preset_path": "presets/surge-base.vstpreset",
+            "param_spec_name": "surge_simple",
+            "renderer_version": "1.3.4",
+            "sample_rate": 16000,
+            "channels": _VALID_AUDIO_CHANNELS,
+            "velocity": 100,
+            "signal_duration_seconds": 4.0,
+            "min_loudness": -55.0,
+            "sample_batch_size": 32,
+            "batch_per_shard": 10,
+        },  # type: ignore[arg-type]
+    )
+
+
+class TestInnerShapeValidation:
+    """Inner-shape (``(N, C, time)`` / ``(N, C, n_mels, n_frames)`` / ``(N, P)``) checks."""
+
+    def test_valid_full_shapes_pass(self, real_spec: DatasetSpec, tmp_path: Path) -> None:
+        """All three datasets at canonical writer shapes produce no errors.
+
+        :param real_spec: The standard test spec.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.h5"
+        _write_h5_with_shapes(shard_path, _valid_default_shapes(real_spec))
+
+        assert validate_shard(shard_path, real_spec) == []
+
+    def test_validate_shard_rejects_wrong_channels(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """Audio written with three channels instead of two surfaces a shape-mismatch error.
+
+        :param real_spec: The standard test spec.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shapes = _valid_default_shapes(real_spec)
+        n = real_spec.render.batch_per_shard
+        shapes["audio"] = (n, 3, _VALID_AUDIO_SAMPLES_PER_ROW)
+        shard_path = tmp_path / "shard-000000.h5"
+        _write_h5_with_shapes(shard_path, shapes)
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert len(errors) == 1
+        assert "audio" in errors[0]
+        assert "shape" in errors[0]
+        assert str((n, 3, _VALID_AUDIO_SAMPLES_PER_ROW)) in errors[0]
+        assert str((n, _VALID_AUDIO_CHANNELS, _VALID_AUDIO_SAMPLES_PER_ROW)) in errors[0]
+
+    def test_validate_shard_rejects_wrong_time_samples(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """Audio with the wrong trailing time-samples dim surfaces a shape-mismatch error.
+
+        :param real_spec: The standard test spec.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shapes = _valid_default_shapes(real_spec)
+        n = real_spec.render.batch_per_shard
+        wrong_time = _VALID_AUDIO_SAMPLES_PER_ROW + 1
+        shapes["audio"] = (n, _VALID_AUDIO_CHANNELS, wrong_time)
+        shard_path = tmp_path / "shard-000000.h5"
+        _write_h5_with_shapes(shard_path, shapes)
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert len(errors) == 1
+        assert "audio" in errors[0]
+        assert str((n, _VALID_AUDIO_CHANNELS, wrong_time)) in errors[0]
+        assert str((n, _VALID_AUDIO_CHANNELS, _VALID_AUDIO_SAMPLES_PER_ROW)) in errors[0]
+
+    def test_validate_shard_rejects_wrong_n_frames_mel(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """Mel with the wrong trailing ``n_frames`` dim surfaces a shape-mismatch error.
+
+        :param real_spec: The standard test spec.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shapes = _valid_default_shapes(real_spec)
+        n = real_spec.render.batch_per_shard
+        valid_channels, valid_n_mels, valid_n_frames = _VALID_MEL_INNER_SHAPE
+        wrong_n_frames = valid_n_frames + 1
+        shapes["mel_spec"] = (n, valid_channels, valid_n_mels, wrong_n_frames)
+        shard_path = tmp_path / "shard-000000.h5"
+        _write_h5_with_shapes(shard_path, shapes)
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert len(errors) == 1
+        assert "mel_spec" in errors[0]
+        assert str((n, valid_channels, valid_n_mels, wrong_n_frames)) in errors[0]
+        assert str((n, valid_channels, valid_n_mels, valid_n_frames)) in errors[0]
+
+    def test_validate_shard_rejects_wrong_num_params(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """Param-array with the wrong width surfaces a shape-mismatch error.
+
+        :param real_spec: The standard test spec.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shapes = _valid_default_shapes(real_spec)
+        n = real_spec.render.batch_per_shard
+        wrong_width = _VALID_PARAM_LENGTH + 1
+        shapes["param_array"] = (n, wrong_width)
+        shard_path = tmp_path / "shard-000000.h5"
+        _write_h5_with_shapes(shard_path, shapes)
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert len(errors) == 1
+        assert "param_array" in errors[0]
+        assert str((n, wrong_width)) in errors[0]
+        assert str((n, _VALID_PARAM_LENGTH)) in errors[0]
+
+    def test_validate_shard_row_count_mismatch_uses_full_shape_format(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """A wrong row count is now reported as a full-shape mismatch, not ``"X rows"``.
+
+        Pins the new error-message format so callers grepping for old ``"rows, expected"``
+        wording have a single place to update. Verifies that the format change applies to
+        the row-count failure mode as well — it's the first-dim case of the same check.
+
+        :param real_spec: The standard test spec.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shapes = _valid_default_shapes(real_spec)
+        wrong_n = real_spec.render.batch_per_shard + 5
+        shapes["audio"] = (wrong_n, _VALID_AUDIO_CHANNELS, _VALID_AUDIO_SAMPLES_PER_ROW)
+        shard_path = tmp_path / "shard-000000.h5"
+        _write_h5_with_shapes(shard_path, shapes)
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert len(errors) == 1
+        assert "audio" in errors[0]
+        assert "shape" in errors[0]
+        assert "rows" not in errors[0]


### PR DESCRIPTION
## Summary

Tightens `synth_setter.pipeline.ci.validate_shard` so every HDF5 dataset in a shard is checked against its full expected shape — not just row count. Uses the writer's source-of-truth shape helpers from `synth_setter.data.vst.shapes` (introduced in #1025) so a future renderer change that drifts the audio/mel/param shapes fails fast at validate time instead of silently shipping mis-shaped shards downstream to training.

Replaces the private `_EXPECTED_DATASETS` tuple with a direct import of `DATASET_FIELD_NAMES`, actualizing the "single source of truth" claim in `shapes.py`'s module docstring.

HDF5-only. The wds tar branch is PR-E in the WDS port roadmap (see #874).

## Stacked on
- #1025 (`internal-feat/vst-shape-helpers`) — needs `shapes.py`.

## Test plan
- [x] `pytest tests/pipeline/ci/test_validate_shard*.py -v` — old + new inner-shape failure modes all green.
- [x] `make test-fast`
- [x] `python scripts/check_no_new_funcs_in_pydoclint_excluded.py --base origin/main` exits 0.

Refs #874
Refs #882