### PR TITLE
internal-feat(vst): split make_dataset into make_hdf5_dataset + make_wds_dataset; dispatch CLI by suffix

### DIFF
--- a/docs/design/data-pipeline-implementation-plan.md
+++ b/docs/design/data-pipeline-implementation-plan.md
@@ -540,7 +540,7 @@ ______________________________________________________________________
   interpreter per child — no inherited VST plugin state, no shared mutable globals.
   See design doc §7.8.1 for full trade-off analysis.
 - Per-shard lifecycle: write `.rendering` to **remote** storage FIRST → spawn child process
-  → child imports and calls `make_dataset(shard_path, shard_spec)` →
+  → child imports and calls `make_hdf5_dataset(shard_path, shard_spec)` →
   parent waits with `join(timeout=SHARD_TIMEOUT)` → on success: validate locally →
   upload `.h5` to storage → write `.valid` to storage.
   `.rendering` in remote storage survives worker/child death (crash resilience).
@@ -558,8 +558,8 @@ ______________________________________________________________________
   with `p.kill()`, shard marked invalid.
 - **Xvfb display isolation:** Each child process should use a per-process X11 display
   number (`:N` derived from PID or shard ID) to avoid contention in headless VST rendering.
-- **No `generate_fn` argument:** The child process imports `make_dataset` directly
-  (`from synth_setter.data.vst.generate_vst_dataset import make_dataset`). Under `spawn`, the child is a fresh
+- **No `generate_fn` argument:** The child process imports `make_hdf5_dataset` directly
+  (`from synth_setter.data.vst.writers import make_hdf5_dataset`). Under `spawn`, the child is a fresh
   interpreter, so the import is clean. No pickling concerns — only `shard_spec` and
   `shard_path` cross the process boundary. For tests, `LocalBackend` calls
   `run_worker()` in-process (no spawn), so test fixtures can inject a fake function.
@@ -928,7 +928,7 @@ ______________________________________________________________________
 05. W&B optional (`--skip-wandb`) — tests skip it; mock test for artifact structure
 06. Workers use ThreadPoolExecutor for parallel shard generation
 07. Each shard renders in a child process via `multiprocessing.get_context("spawn").Process(...)`.
-    Child process imports `make_dataset` directly (`from synth_setter.data.vst.generate_vst_dataset import make_dataset`).
+    Child process imports `make_hdf5_dataset` directly (`from synth_setter.data.vst.writers import make_hdf5_dataset`).
     Only `shard_spec` and `shard_path` cross the process boundary — no function objects.
     `LocalBackend` accepts an optional `generate_fn` for tests (runs in-process, no spawn).
     For v1, no seeding (current behavior). Post-launch, dual-RNG seeding

--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -750,7 +750,7 @@ def _render_shard(shard_spec, shard_path):
     The import happens here, in the child, so the VST plugin loads cleanly.
     """
     import numpy as np
-    from synth_setter.data.vst.generate_vst_dataset import make_hdf5_dataset
+    from synth_setter.data.vst.writers import make_hdf5_dataset
     # P3 (post-launch): seed both RNGs for reproducibility — see #100
     # random.seed(shard_spec.seed)
     # np.random.seed(shard_spec.seed)
@@ -779,9 +779,9 @@ else:
 
 **Why `spawn` and not `fork`:** The `fork` start method copies the parent's memory via copy-on-write. If the parent has loaded a VST plugin, the child inherits that plugin's global mutable state (internal buffers, audio engine state). VST plugins are not designed for this — shared mutable state across forked processes leads to undefined behavior. `spawn` starts a fresh Python interpreter with no inherited state: each child loads the plugin from scratch, with clean globals and its own memory space. This eliminates shared-state corruption between concurrent shard renders.
 
-**Why not direct function call (`make_dataset()` in-process):** A direct call is simpler and avoids per-shard process overhead, but a SIGSEGV in the plugin kills the entire worker process. Per-shard try/except cannot catch OS-level signals. The bash EXIT trap (Layer 2) would upload logs, and reconciliation (Layer 3) would detect the missing shards — but all in-progress shards on that worker are lost, not just the crashing one. For a 48-shard worker, losing all shards to one bad shard is unacceptable.
+**Why not direct function call (`make_hdf5_dataset()` in-process):** A direct call is simpler and avoids per-shard process overhead, but a SIGSEGV in the plugin kills the entire worker process. Per-shard try/except cannot catch OS-level signals. The bash EXIT trap (Layer 2) would upload logs, and reconciliation (Layer 3) would detect the missing shards — but all in-progress shards on that worker are lost, not just the crashing one. For a 48-shard worker, losing all shards to one bad shard is unacceptable.
 
-**Why not `subprocess.run` calling `generate_vst_dataset.py`:** Same crash isolation as `multiprocessing.Process`, but requires adding a `--seed` CLI parameter to `generate_vst_dataset.py` (which doesn't exist). The subprocess approach also makes testing harder — you'd need to mock the subprocess, which couples tests to CLI argument construction. With `multiprocessing.Process`, the child imports `make_dataset` directly and receives only simple data (`shard_spec`, `shard_path`) as args. For tests, `LocalBackend` runs in-process (no spawn) so test fixtures can inject a fake generate function directly.
+**Why not `subprocess.run` calling `generate_vst_dataset.py`:** Same crash isolation as `multiprocessing.Process`, but requires adding a `--seed` CLI parameter to `generate_vst_dataset.py` (which doesn't exist). The subprocess approach also makes testing harder — you'd need to mock the subprocess, which couples tests to CLI argument construction. With `multiprocessing.Process`, the child imports `make_hdf5_dataset` directly and receives only simple data (`shard_spec`, `shard_path`) as args. For tests, `LocalBackend` runs in-process (no spawn) so test fixtures can inject a fake generate function directly.
 
 **P3 — Dual-RNG seeding (post-launch, [#100](https://github.com/tinaudio/synth-setter/issues/100)):** The existing VST parameter sampling code (`param_spec.py`) uses both `random` (stdlib) and `np.random` for parameter generation. For v1, shards generate without seeding (current behavior — non-reproducible but correct). The seeding lines in `_render_shard` above are commented out until this is implemented. Post-launch, uncomment and seed both RNGs from `shard_spec.seed`:
 
@@ -830,7 +830,7 @@ No `check_tasks` method exists. Provider APIs answer the wrong question ("is the
 
 ### 7.10 Output Format: HDF5 vs WebDataset
 
-The pipeline supports two output formats, selected via `output_format` in the config and frozen in the spec. The format determines what finalize produces and how training consumes the data. Generation is unaffected — workers always produce HDF5 shards regardless of output format.
+The pipeline supports two output formats, selected via `output_format` in the config and frozen in the spec. The format determines both what the worker emits and how training consumes the data — the renderer CLI dispatches on the shard's filename suffix (`.h5` → `make_hdf5_dataset`, `.tar` → `make_wds_dataset`) via `EXTENSION_TO_OUTPUT_FORMAT`.
 
 **Why two formats:**
 
@@ -841,11 +841,9 @@ The pipeline supports two output formats, selected via `output_format` in the co
 
 HDF5 is random-access oriented. Multi-GPU DataLoaders need to stream shards sequentially without coordinating seeks across workers. Streaming HDF5 virtual datasets from R2 during training creates heavy seek traffic and GPU idle time. Downloading the full dataset to every training node wastes storage and time at scale. WebDataset solves both — each `.tar` shard is a sequential stream that can be read over HTTP with near-zero overhead.
 
-**Why generation stays HDF5 regardless of output format:**
+**HDF5 is resumable; WDS is not:**
 
-Workers generate HDF5 because it is the right format for atomic writes, random-access validation, and debugging. The staging/canonical split is unaffected by output format. WebDataset is a training distribution format, not a generation format. Finalize handles the transcoding — it already downloads, validates, and reshards, so adding a format conversion step is a natural extension.
-
-> **Note — design in transition.** PR-12 widens `DatasetSpec.output_format` to `Literal["hdf5", "wds"]` and computes the shard filename extension from that field via `OUTPUT_FORMAT_TO_EXTENSION` (see §14.1). With the original design above, that would only affect finalize's training-output transcoding. PR-13 then lands a direct wds writer in `make_dataset` and dispatches the worker on the shard's filename suffix — so `output_format="wds"` will result in workers emitting `.tar` shards directly rather than HDF5-then-transcode. This section will be rewritten when PR-13 lands; until then, the schema admits `wds` but no wds writer is wired.
+`make_hdf5_dataset` is resumable — a partially-written file picks up at the first all-zero row, so a crashed worker can re-run with the same render config and only the missing tail is regenerated. `make_wds_dataset` is not resumable today (the tar writer overwrites the destination on open); a crashed wds worker re-renders the whole shard. The staging/canonical split is unaffected by output format.
 
 **WebDataset shard structure:**
 

--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -847,16 +847,16 @@ HDF5 is random-access oriented. Multi-GPU DataLoaders need to stream shards sequ
 
 **WebDataset shard structure:**
 
-Each `.tar` shard contains samples as individual files:
+Each `.tar` shard groups rows into per-batch tar entries. The tar key is the batch's first logical row index zero-padded to 8 digits (`f"{start_idx:08d}"`) and advances by `sample_batch_size`; each `<key>.<field>.npy` member holds the whole batch stacked along axis 0 — not one sample per file. The per-row field names come from `synth_setter.data.vst.shapes.DATASET_FIELD_NAMES` (`audio`, `mel_spec`, `param_array`):
 
 ```
 train-000000.tar
-├── 000000.audio.npy
-├── 000000.params.npy
-├── 000000.mel.npy
-├── 000001.audio.npy
-├── 000001.params.npy
-├── 000001.mel.npy
+├── 00000000.audio.npy      # shape (sample_batch_size, ...)
+├── 00000000.mel_spec.npy
+├── 00000000.param_array.npy
+├── 00000064.audio.npy      # next batch — key advances by sample_batch_size
+├── 00000064.mel_spec.npy
+├── 00000064.param_array.npy
 ├── ...
 └── metadata.json          # ShardMetadata sidecar — see src/synth_setter/pipeline/schemas/shard_metadata.py
 ```

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -82,9 +82,13 @@ docs:
       - pattern: "src/synth_setter/pipeline/constants.py"
         covers: "Input spec filename constant"
       - pattern: "src/synth_setter/pipeline/schemas/spec.py"
-        covers: "DatasetSpec, RenderConfig, ShardSpec; OUTPUT_FORMAT_TO_EXTENSION / EXTENSION_TO_OUTPUT_FORMAT inverse-pair dispatch maps (DatasetSpec is built by spec_from_cfg in cli/generate_dataset.py from a Hydra-composed cfg; the extension maps are not yet consumed — shard writers/validators will dispatch on them in PR-13)"
+        covers: "DatasetSpec, RenderConfig, ShardSpec; OUTPUT_FORMAT_TO_EXTENSION / EXTENSION_TO_OUTPUT_FORMAT inverse-pair dispatch maps (DatasetSpec is built by spec_from_cfg in cli/generate_dataset.py from a Hydra-composed cfg; the suffix-dispatch maps are consumed by the renderer CLI's main() in writers.py)"
       - pattern: "src/synth_setter/pipeline/schemas/shard_metadata.py"
-        covers: "ShardMetadata — strict pydantic sidecar payload destined for the wds tar's metadata.json member; mirrors HDF5 audio attrs. Writer + validate_shard wds branch land in PR-13."
+        covers: "ShardMetadata — strict pydantic sidecar payload written into wds tar shards as metadata.json and into HDF5 shards as audio.attrs; mirrored across both formats by make_hdf5_dataset / make_wds_dataset in writers.py."
+      - pattern: "src/synth_setter/data/vst/writers.py"
+        covers: "make_hdf5_dataset + make_wds_dataset entrypoints; per-batch sample-save helpers; ShardMetadata sidecar wiring; CLI suffix dispatch via EXTENSION_TO_OUTPUT_FORMAT."
+      - pattern: "src/synth_setter/data/vst/shapes.py"
+        covers: "Shared shape primitives consumed by writers + (planned) shard validator — DATASET_FIELD_NAMES, mel-front-end constants, audio_dataset_shape / mel_dataset_shape / param_array_dataset_shape."
 
   # ── SkyPilot compute integration design doc ─────────────────────
   - doc: docs/design/skypilot-compute-integration.md
@@ -293,7 +297,13 @@ docs:
         covers: "load_plugin warm-up timing (_EDITOR_INIT_DELAY_SECONDS, non-Darwin only — macOS skips per #714), set_params, render_params per-sample reload rationale (silent-render workaround)"
         scope: "interactive"
       - pattern: "src/synth_setter/data/vst/generate_vst_dataset.py"
-        covers: "fixed_synth_params_list / fixed_note_params_list optional path used to render captured patches; mel_spec shape (2,128,401), audio dtype float16"
+        covers: "generate_sample / VSTDataSample / make_spectrogram — per-sample render and feature-extraction primitives invoked by the writers in writers.py"
+        scope: "interactive"
+      - pattern: "src/synth_setter/data/vst/writers.py"
+        covers: "make_hdf5_dataset accepts fixed_synth_params_list / fixed_note_params_list to render captured patches into train.h5; audio dtype float16; mel shape comes from shapes.mel_dataset_shape"
+        scope: "interactive"
+      - pattern: "src/synth_setter/data/vst/shapes.py"
+        covers: "Source of truth for the (channels, n_mels, n_frames) trailing-dims of mel_spec output and (channels, time_samples) trailing-dims of audio output written by make_hdf5_dataset"
         scope: "interactive"
 
   # ── CI triage agent operator notes (local-only invocation) ──────

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -82,7 +82,7 @@ docs:
       - pattern: "src/synth_setter/pipeline/constants.py"
         covers: "Input spec filename constant"
       - pattern: "src/synth_setter/pipeline/schemas/spec.py"
-        covers: "DatasetSpec, RenderConfig, ShardSpec; OUTPUT_FORMAT_TO_EXTENSION / EXTENSION_TO_OUTPUT_FORMAT inverse-pair dispatch maps (DatasetSpec is built by spec_from_cfg in cli/generate_dataset.py from a Hydra-composed cfg; the suffix-dispatch maps are consumed by the renderer CLI's main() in writers.py)"
+        covers: "DatasetSpec, RenderConfig, ShardSpec; OUTPUT_FORMAT_TO_EXTENSION / EXTENSION_TO_OUTPUT_FORMAT inverse-pair dispatch maps (DatasetSpec is built by spec_from_cfg in cli/generate_dataset.py from a Hydra-composed cfg; the suffix-dispatch maps are consumed by the renderer CLI's main() in data/vst/generate_vst_dataset.py — main() reads Path(data_file).suffix, looks it up in EXTENSION_TO_OUTPUT_FORMAT, and calls writers.make_hdf5_dataset or writers.make_wds_dataset)"
       - pattern: "src/synth_setter/pipeline/schemas/shard_metadata.py"
         covers: "ShardMetadata — strict pydantic sidecar payload written into wds tar shards as metadata.json and into HDF5 shards as audio.attrs; mirrored across both formats by make_hdf5_dataset / make_wds_dataset in writers.py."
       - pattern: "src/synth_setter/data/vst/writers.py"

--- a/docs/guides/surge-xt-interactive.md
+++ b/docs/guides/surge-xt-interactive.md
@@ -108,15 +108,15 @@ raises `click.UsageError`.
 
 ## CLI reference
 
-| Flag                        | Type               | Default                 | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| --------------------------- | ------------------ | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--plugin-path` / `-p`      | path               | `plugins/Surge XT.vst3` | Path to VST3 plugin.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `--pred`                    | `PATH:BATCH_IDX`   | unset                   | Prediction reference. When set, the predicted row is decoded and applied to the plugin before the editor opens. Example: `outputs/pred-0.pt:0`.                                                                                                                                                                                                                                                                                                                                                                    |
-| `--dataset-ref`             | `PATH:DATASET_IDX` | unset                   | Dataset reference. When set, the dataset row is decoded and applied to the plugin before the editor opens. Example: `outputs/test.h5:0`.                                                                                                                                                                                                                                                                                                                                                                           |
-| `--param-spec-name`         | choice             | required                | Parameter spec name — one of the keys registered in `src/synth_setter/data/vst/__init__.py` (`param_specs`). Selects which synth params are decoded from prediction/dataset rows, captured into recorded patches, and which base preset is loaded (the script indexes `preset_paths` with this value). There is no `--preset-path` flag — spec and preset travel together.                                                                                                                                         |
-| `--output-dataset-dir-path` | path               | unset                   | Directory to create for the recorded patches. Must not already exist — `make_dataset` writes fixed-size HDF5 datasets without `maxshape` and cannot append to existing files. After the editor is closed, patches captured via the keyboard loop (press `p` to record, `q` to quit) are rendered through the plugin and written to `train.h5` inside this directory via `synth_setter.data.vst.generate_vst_dataset.make_dataset` (plus `val.h5`/`test.h5`/`predict.h5` siblings when `--checkpoint-path` is set). |
-| `--checkpoint-path`         | path               | unset                   | Optional checkpoint path to run standalone eval on after rendering captured patches. When set, triggers the `eval_patches` pipeline (`src/synth_setter/cli/eval.py mode=predict` → `predict_vst_audio.py` → `compute_audio_metrics.py`); see [`docs/design/eval-pipeline.md`](../design/eval-pipeline.md) for the full pipeline and `_METRIC_COLUMNS` in the script for the metric series produced.                                                                                                                |
-| `--session-recording-path`  | path               | unset                   | Optional WAV file to render a deterministic test clip to. When set, the script renders a fixed `SESSION_RECORDING_DURATION_SECONDS` (10 s) WAV containing middle C from `NOTE_START` (2 s) to `NOTE_END` (4 s) through the loaded plugin and exits the audio thread. No live device output. Output depends only on plugin state (preset + `--pred` / `--dataset-ref` params) — same inputs always produce the same WAV. No-op when not set.                                                                        |
+| Flag                        | Type               | Default                 | Notes                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| --------------------------- | ------------------ | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--plugin-path` / `-p`      | path               | `plugins/Surge XT.vst3` | Path to VST3 plugin.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| `--pred`                    | `PATH:BATCH_IDX`   | unset                   | Prediction reference. When set, the predicted row is decoded and applied to the plugin before the editor opens. Example: `outputs/pred-0.pt:0`.                                                                                                                                                                                                                                                                                                                                                                 |
+| `--dataset-ref`             | `PATH:DATASET_IDX` | unset                   | Dataset reference. When set, the dataset row is decoded and applied to the plugin before the editor opens. Example: `outputs/test.h5:0`.                                                                                                                                                                                                                                                                                                                                                                        |
+| `--param-spec-name`         | choice             | required                | Parameter spec name — one of the keys registered in `src/synth_setter/data/vst/__init__.py` (`param_specs`). Selects which synth params are decoded from prediction/dataset rows, captured into recorded patches, and which base preset is loaded (the script indexes `preset_paths` with this value). There is no `--preset-path` flag — spec and preset travel together.                                                                                                                                      |
+| `--output-dataset-dir-path` | path               | unset                   | Directory to create for the recorded patches. Must not already exist — `make_hdf5_dataset` writes fixed-size HDF5 datasets without `maxshape` and cannot append to existing files. After the editor is closed, patches captured via the keyboard loop (press `p` to record, `q` to quit) are rendered through the plugin and written to `train.h5` inside this directory via `synth_setter.data.vst.writers.make_hdf5_dataset` (plus `val.h5`/`test.h5`/`predict.h5` siblings when `--checkpoint-path` is set). |
+| `--checkpoint-path`         | path               | unset                   | Optional checkpoint path to run standalone eval on after rendering captured patches. When set, triggers the `eval_patches` pipeline (`src/synth_setter/cli/eval.py mode=predict` → `predict_vst_audio.py` → `compute_audio_metrics.py`); see [`docs/design/eval-pipeline.md`](../design/eval-pipeline.md) for the full pipeline and `_METRIC_COLUMNS` in the script for the metric series produced.                                                                                                             |
+| `--session-recording-path`  | path               | unset                   | Optional WAV file to render a deterministic test clip to. When set, the script renders a fixed `SESSION_RECORDING_DURATION_SECONDS` (10 s) WAV containing middle C from `NOTE_START` (2 s) to `NOTE_END` (4 s) through the loaded plugin and exits the audio thread. No live device output. Output depends only on plugin state (preset + `--pred` / `--dataset-ref` params) — same inputs always produce the same WAV. No-op when not set.                                                                     |
 
 Tip — the help strings above are quoted verbatim from the Click
 decorators in `src/synth_setter/tools/surge_xt_interactive.py`. Run
@@ -158,7 +158,7 @@ the editor closes.
 
 When `--output-dataset-dir-path` is set, the recorded patches are
 rendered through the plugin via
-[`make_dataset`](../../src/synth_setter/data/vst/generate_vst_dataset.py) and
+[`make_hdf5_dataset`](../../src/synth_setter/data/vst/writers.py) and
 written to `train.h5` inside that directory. With `--checkpoint-path`
 also set, identical-content `val.h5`/`test.h5`/`predict.h5` siblings
 are created next to `train.h5` so the eval pipeline has a `predict.h5`
@@ -183,7 +183,7 @@ siblings are byte-identical copies of `train.h5`; `predict.h5` is then
 fed into the `eval_patches` pipeline.
 
 > **Use a fresh `--output-dataset-dir-path` per session.** The script
-> refuses an existing **directory**: `make_dataset` creates fixed-size
+> refuses an existing **directory**: `make_hdf5_dataset` creates fixed-size
 > datasets (no `maxshape`), so re-running into an existing directory
 > would either fail with a `ValueError` from the fixed-params length
 > check or fail on write with an out-of-bounds index. If you need to
@@ -191,7 +191,7 @@ fed into the `eval_patches` pipeline.
 > concat downstream.
 
 > **Note params are still randomized.** Only `fixed_synth_params_list`
-> is passed to `make_dataset`; MIDI note, velocity, and timing remain
+> is passed to `make_hdf5_dataset`; MIDI note, velocity, and timing remain
 > sampled from `param_spec`. The same captured patch produces multiple
 > rows with different note conditions if you record `p` more than once
 > (the synth params are identical; the note params will differ).
@@ -200,7 +200,7 @@ fed into the `eval_patches` pipeline.
 
 A `pred-*.pt` (from `src/synth_setter/cli/eval.py`) or an existing `*.h5` row supplies
 the starting parameters; the live editor session captures user-curated
-patches; on close, `make_dataset` writes them to `train.h5` inside
+patches; on close, `make_hdf5_dataset` writes them to `train.h5` inside
 `--output-dataset-dir-path` for downstream training. When
 `--checkpoint-path` is set, the `eval_patches` function in
 `src/synth_setter/tools/surge_xt_interactive.py` then runs the eval pipeline against
@@ -252,7 +252,7 @@ your teammates so they aren't blindsided.
   the `#714` SIGTRAP comment in `core.py`); the post-load `process(...)`
   flush in `render_params` is what commits Surge XT's preset state on
   that platform.
-- **Plugin reloaded on every render in `make_dataset`** — `render_params`
+- **Plugin reloaded on every render in `make_hdf5_dataset`** — `render_params`
   calls `load_plugin(plugin_path)` per sample
   ([`src/synth_setter/data/vst/core.py`](../../src/synth_setter/data/vst/core.py)). This is an
   intentional workaround for a silent / repeated-render bug surfaced
@@ -267,7 +267,7 @@ your teammates so they aren't blindsided.
   ([`src/synth_setter/tools/surge_xt_interactive.py`](../../src/synth_setter/tools/surge_xt_interactive.py)).
   The synth patch dominates loudness, so re-sampling note params alone
   can't lift a silent patch above threshold; rather than loop, the
-  whole `make_dataset` call aborts and points at the offending patch.
+  whole `make_hdf5_dataset` call aborts and points at the offending patch.
   Workaround: only press `p` while you can hear the patch — once a
   silent patch is captured, the session's dataset render will fail.
 - **Blocking keyboard input** — `keyboard_loop` uses

--- a/docs/reference/audio-similarity-benchmarks.md
+++ b/docs/reference/audio-similarity-benchmarks.md
@@ -17,7 +17,7 @@ mkdocs site under `/dev/bench/`, and publishes via
 
 The slow VST tests in
 [`tests/data/vst/test_generate_vst_dataset.py`](../../tests/data/vst/test_generate_vst_dataset.py)
-exercise `make_dataset` round-trips and assert that two independent renders
+exercise `make_hdf5_dataset` round-trips and assert that two independent renders
 of the same parameters land within phase-robust tolerances. Per-run
 metric values typically come in well below the assertion thresholds, so
 the assertions only catch _gross_ regressions (silence, wrong patch).
@@ -66,7 +66,7 @@ different question.
 ### `VST noise floor (1 preset N renders)`
 
 Sourced from `test_datasets_from_hardcoded_params_are_identical`. Both
-stages of `make_dataset` run with the same hardcoded
+stages of `make_hdf5_dataset` run with the same hardcoded
 `_HARDCODED_*_PARAMS` patch via `_patched_sample`, so all
 `2 × num_samples` renders use _identical_ inputs. The per-pair metrics
 plus an all-pairs cross-comparison expose every-other-render variance —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,6 +322,7 @@ exclude = '''(?x)
   | ^tests/_baseline_worktree\.py$
   | ^tests/conftest\.py$
   | ^tests/data/vst/test_core\.py$
+  | ^tests/data/vst/test_generate_vst_dataset\.py$
   | ^tests/data/vst/test_generate_vst_dataset_cli\.py$
   | ^tests/data/vst/test_preset_coverage\.py$
   | ^tests/fixtures/baseline_repo/scripts/baseline_app\.py$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,7 +322,6 @@ exclude = '''(?x)
   | ^tests/_baseline_worktree\.py$
   | ^tests/conftest\.py$
   | ^tests/data/vst/test_core\.py$
-  | ^tests/data/vst/test_generate_vst_dataset\.py$
   | ^tests/data/vst/test_generate_vst_dataset_cli\.py$
   | ^tests/data/vst/test_preset_coverage\.py$
   | ^tests/fixtures/baseline_repo/scripts/baseline_app\.py$

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -103,12 +103,9 @@ def build_generate_args(spec: DatasetSpec, shard: ShardSpec, output_dir: Path) -
 
     The flag set is derived from ``RenderConfig.model_fields`` so every renderer
     config field surfaces as a ``--<field>`` option automatically; adding a
-    field on the model auto-extends the CLI invocation.
-
-    HDF5-only: ``DatasetSpec.output_format`` is currently restricted to
-    ``"hdf5"`` and ``generate_vst_dataset.py`` writes HDF5 regardless of the
-    output path. Format dispatch on ``shard.filename`` suffix lands when wds
-    is introduced (PR-12/13/14 in the dataset-pipeline chain).
+    field on the model auto-extends the CLI invocation. The writer is dispatched
+    on ``shard.filename``'s suffix inside the subprocess via
+    ``EXTENSION_TO_OUTPUT_FORMAT``.
     """
     output_path = output_dir / shard.filename
     args = [
@@ -137,8 +134,7 @@ def run(spec: DatasetSpec) -> None:
 
     The launcher builds the spec interpreter-only (no pedalboard / X11) trusting
     ``configs/render/<spec>.yaml``; this is where the worker — which has pedalboard
-    — verifies the plugin and pinned ``renderer_version`` agree. HDF5-only for now:
-    ``spec.output_format`` is restricted to ``"hdf5"``.
+    — verifies the plugin and pinned ``renderer_version`` agree.
 
     :raises RuntimeError: If the worker's plugin version disagrees with
         ``spec.render.renderer_version``.

--- a/src/synth_setter/data/vst/generate_vst_dataset.py
+++ b/src/synth_setter/data/vst/generate_vst_dataset.py
@@ -1,7 +1,8 @@
 import hashlib
 import random
 from dataclasses import dataclass
-from typing import Any, List, Tuple
+from pathlib import Path
+from typing import Any, Tuple
 
 import h5py
 import hdf5plugin
@@ -11,10 +12,12 @@ import rootutils
 from loguru import logger
 from pyloudnorm import Meter
 from pydantic_settings import BaseSettings, CliApp, CliPositionalArg, SettingsConfigDict
-from tqdm import trange
 
 rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
-from synth_setter.pipeline.schemas.spec import RenderConfig  # noqa: E402
+from synth_setter.pipeline.schemas.spec import (  # noqa: E402
+    EXTENSION_TO_OUTPUT_FORMAT,
+    RenderConfig,
+)
 from synth_setter.data.vst import param_specs  # noqa
 from synth_setter.data.vst.core import render_params  # noqa
 from synth_setter.data.vst.param_spec import ParamSpec  # noqa
@@ -159,25 +162,6 @@ def save_sample(
     logger.info(f"Sample {idx} written!")
 
 
-def save_samples(
-    samples: List[VSTDataSample],
-    audio_dataset: h5py.Dataset,
-    mel_dataset: h5py.Dataset,
-    param_dataset: h5py.Dataset,
-    start_idx: int,
-) -> None:
-    logger.info(f"Saving {len(samples)} samples...")
-    audios = np.stack([s.audio.T for s in samples], axis=0)
-    mel_specs = np.stack([s.mel_spec for s in samples], axis=0)
-    param_arrays = np.stack([s.param_array for s in samples], axis=0)
-
-    audio_dataset[start_idx : start_idx + len(samples), :, :] = audios
-    mel_dataset[start_idx : start_idx + len(samples), :, :] = mel_specs
-    param_dataset[start_idx : start_idx + len(samples), :] = param_arrays
-
-    logger.info(f"{len(samples)} samples written!")
-
-
 def get_first_unwritten_idx(dataset: h5py.Dataset) -> int:
     num_rows, *_ = dataset.shape
     for i in range(num_rows):
@@ -246,109 +230,14 @@ def create_datasets_and_get_start_idx(
     )
 
 
-def make_dataset(
-    hdf5_file: h5py.File,
-    render_cfg: RenderConfig,
-    *,
-    fixed_synth_params_list: list[dict[str, float]] | None = None,
-    fixed_note_params_list: list[dict[str, int | tuple[float, float]]] | None = None,
-) -> None:
-    """Render ``render_cfg.batch_per_shard`` samples and append them to ``hdf5_file``.
-
-    Resumable: a partially-written file picks up at the first all-zero row, so a
-    crashed worker can re-run with the same ``render_cfg`` and only the missing tail
-    is regenerated. The ``param_spec_name`` is resolved against the in-process
-    registry here (not at the launcher) so the per-shard config stays JSON-only.
-    """
-    param_spec = param_specs[render_cfg.param_spec_name]
-    num_samples = render_cfg.batch_per_shard
-
-    audio_dataset, mel_dataset, param_dataset, start_idx = (
-        create_datasets_and_get_start_idx(
-            hdf5_file=hdf5_file,
-            num_samples=num_samples,
-            channels=render_cfg.channels,
-            sample_rate=render_cfg.sample_rate,
-            signal_duration_seconds=render_cfg.signal_duration_seconds,
-            num_params=len(param_spec),
-        )
-    )
-
-    expected_fixed_len = num_samples - start_idx
-    for name, lst in [
-        ("fixed_synth_params_list", fixed_synth_params_list),
-        ("fixed_note_params_list", fixed_note_params_list),
-    ]:
-        if lst is not None and len(lst) < expected_fixed_len:
-            raise ValueError(
-                f"{name} has length {len(lst)}, expected at least "
-                f"num_samples - start_idx = {expected_fixed_len} "
-                f"(num_samples={num_samples}, start_idx={start_idx})"
-            )
-
-    audio_dataset.attrs["velocity"] = render_cfg.velocity
-    audio_dataset.attrs["signal_duration_seconds"] = render_cfg.signal_duration_seconds
-    audio_dataset.attrs["sample_rate"] = render_cfg.sample_rate
-    audio_dataset.attrs["channels"] = render_cfg.channels
-    audio_dataset.attrs["min_loudness"] = render_cfg.min_loudness
-
-    sample_batch = []
-    sample_batch_start = start_idx
-    batch_size = render_cfg.sample_batch_size
-
-    for i in trange(start_idx, num_samples):
-        logger.info(f"Making sample {i}")
-        fixed_idx = i - start_idx
-        sample = generate_sample(
-            render_cfg.plugin_path,
-            velocity=render_cfg.velocity,
-            signal_duration_seconds=render_cfg.signal_duration_seconds,
-            sample_rate=render_cfg.sample_rate,
-            channels=render_cfg.channels,
-            min_loudness=render_cfg.min_loudness,
-            param_spec=param_spec,
-            preset_path=render_cfg.preset_path,
-            fixed_synth_params=(
-                fixed_synth_params_list[fixed_idx]
-                if fixed_synth_params_list is not None
-                else None
-            ),
-            fixed_note_params=(
-                fixed_note_params_list[fixed_idx]
-                if fixed_note_params_list is not None
-                else None
-            ),
-        )
-
-        sample_batch.append(sample)
-        if len(sample_batch) == batch_size:
-            save_samples(
-                sample_batch,
-                audio_dataset,
-                mel_dataset,
-                param_dataset,
-                sample_batch_start,
-            )
-            sample_batch = []
-            sample_batch_start += batch_size
-
-    if len(sample_batch) > 0:
-        save_samples(
-            sample_batch,
-            audio_dataset,
-            mel_dataset,
-            param_dataset,
-            sample_batch_start,
-        )
-
-
 class _GenerateCliArgs(RenderConfig, BaseSettings):
     """Pydantic-settings CLI binding for ``generate_vst_dataset.py``.
 
     Inherits every ``RenderConfig`` field so the CLI flag set tracks the model
     automatically — adding or removing a field on ``RenderConfig`` extends or
     shrinks the CLI surface without a parallel update here. Adds ``data_file``
-    as the sole positional arg (the destination path for the HDF5 shard).
+    as the sole positional arg (the destination shard path; suffix selects
+    writer via ``EXTENSION_TO_OUTPUT_FORMAT``).
     """
 
     model_config = SettingsConfigDict(
@@ -363,11 +252,31 @@ class _GenerateCliArgs(RenderConfig, BaseSettings):
 
 
 def main() -> None:
-    """Entry point — parse CLI args into a ``RenderConfig`` and render one shard."""
+    """Entry point — parse CLI args into a ``RenderConfig`` and render one shard.
+
+    The writer is dispatched on ``data_file``'s suffix via
+    ``EXTENSION_TO_OUTPUT_FORMAT`` (``.h5`` → HDF5, ``.tar`` → wds). An unknown
+    suffix raises ``SystemExit`` rather than silently producing a half-written
+    file in the wrong format.
+    """
+    # Import lazily so that the writer module's transitive deps (h5py, webdataset)
+    # only load when this CLI entrypoint is invoked, not when callers merely
+    # import this module to reach VSTDataSample / generate_sample.
+    from synth_setter.data.vst.writers import make_hdf5_dataset, make_wds_dataset
+
     args = CliApp.run(_GenerateCliArgs)
     render_cfg = RenderConfig(**args.model_dump(exclude={"data_file"}))
-    with h5py.File(args.data_file, "a") as f:
-        make_dataset(f, render_cfg)
+    suffix = Path(args.data_file).suffix
+    fmt = EXTENSION_TO_OUTPUT_FORMAT.get(suffix)
+    if fmt == "hdf5":
+        make_hdf5_dataset(args.data_file, render_cfg)
+    elif fmt == "wds":
+        make_wds_dataset(args.data_file, render_cfg)
+    else:
+        raise SystemExit(
+            f"data_file must end in one of {sorted(EXTENSION_TO_OUTPUT_FORMAT)}, "
+            f"got {suffix!r}"
+        )
 
 
 if __name__ == "__main__":

--- a/src/synth_setter/data/vst/generate_vst_dataset.py
+++ b/src/synth_setter/data/vst/generate_vst_dataset.py
@@ -1,5 +1,3 @@
-import hashlib
-import random
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Tuple

--- a/src/synth_setter/data/vst/generate_vst_dataset.py
+++ b/src/synth_setter/data/vst/generate_vst_dataset.py
@@ -257,9 +257,10 @@ def main() -> None:
     suffix raises ``SystemExit`` rather than silently producing a half-written
     file in the wrong format.
     """
-    # Import lazily so that the writer module's transitive deps (h5py, webdataset)
-    # only load when this CLI entrypoint is invoked, not when callers merely
-    # import this module to reach VSTDataSample / generate_sample.
+    # Import lazily so that the writer module's webdataset dep only loads when
+    # this CLI entrypoint is invoked, not when callers merely import this
+    # module to reach VSTDataSample / generate_sample. (h5py is already a
+    # module-level import here, so it is not what the lazy load avoids.)
     from synth_setter.data.vst.writers import make_hdf5_dataset, make_wds_dataset
 
     args = CliApp.run(_GenerateCliArgs)

--- a/src/synth_setter/data/vst/writers.py
+++ b/src/synth_setter/data/vst/writers.py
@@ -152,24 +152,32 @@ def _validate_fixed_params_lengths(
     fixed_synth_params_list: list[dict[str, float]] | None,
     fixed_note_params_list: list[dict[str, int | tuple[float, float]]] | None,
 ) -> None:
-    """Raise ``ValueError`` if a fixed-params list is shorter than the remaining renders.
+    """Raise ``ValueError`` unless each fixed-params list exactly matches the tail length.
+
+    The writer indexes fixed params by ``i - start_idx`` (see
+    ``_generate_sample_for_index``), so on a resumed run with ``start_idx > 0``
+    each list must hold only the rows still to render — passing a shard-length
+    list would silently shift indices (row ``start_idx`` would use ``list[0]``).
+    We require exact equality (not ``>=``) so that mismatch is caught here
+    instead of silently truncated.
 
     :param num_samples: Total number of samples this shard will hold.
     :param start_idx: First row index this run will write (non-zero on a resume).
     :param fixed_synth_params_list: Optional pre-set synth params, one dict per row to render.
     :param fixed_note_params_list: Optional pre-set note params, one dict per row to render.
-    :raises ValueError: If either list is shorter than ``num_samples - start_idx``.
+    :raises ValueError: If either list's length is not exactly ``num_samples - start_idx``.
     """
     expected_fixed_len = num_samples - start_idx
     for name, lst in [
         ("fixed_synth_params_list", fixed_synth_params_list),
         ("fixed_note_params_list", fixed_note_params_list),
     ]:
-        if lst is not None and len(lst) < expected_fixed_len:
+        if lst is not None and len(lst) != expected_fixed_len:
             raise ValueError(
-                f"{name} has length {len(lst)}, expected at least "
+                f"{name} has length {len(lst)}, expected exactly "
                 f"num_samples - start_idx = {expected_fixed_len} "
-                f"(num_samples={num_samples}, start_idx={start_idx})"
+                f"(num_samples={num_samples}, start_idx={start_idx}); "
+                "on a resumed run pass only the rows still to render, not the full shard"
             )
 
 
@@ -318,10 +326,13 @@ def make_hdf5_dataset(
     :param hdf5_file: Destination HDF5 path; opened in append mode so partial
         files can resume.
     :param render_cfg: Per-shard renderer config from the dataset spec.
-    :param fixed_synth_params_list: Optional pre-set synth params, indexed in
-        write order across the shard.
-    :param fixed_note_params_list: Optional pre-set note params, indexed in
-        write order across the shard.
+    :param fixed_synth_params_list: Optional pre-set synth params for the rows
+        this run will render. Must have length ``batch_per_shard - start_idx``;
+        on a fresh run that's the full shard, on a resumed run that's only the
+        tail still to render (``list[0]`` lands at row ``start_idx``). Caller
+        is responsible for slicing a full-length list before passing it in.
+    :param fixed_note_params_list: Optional pre-set note params; same
+        tail-aligned contract as ``fixed_synth_params_list``.
     """
     param_spec = param_specs[render_cfg.param_spec_name]
     meta = _shard_metadata_from_render(render_cfg)
@@ -378,10 +389,12 @@ def make_wds_dataset(
 
     :param wds_file: Destination tar path passed to ``webdataset.TarWriter``.
     :param render_cfg: Per-shard renderer config from the dataset spec.
-    :param fixed_synth_params_list: Optional pre-set synth params, indexed in
-        write order across the shard.
-    :param fixed_note_params_list: Optional pre-set note params, indexed in
-        write order across the shard.
+    :param fixed_synth_params_list: Optional pre-set synth params, one dict per
+        row this run will render. Must have length ``batch_per_shard``: the
+        wds path is non-resumable (``start_idx = 0``), so the tail is the
+        whole shard. ``list[0]`` lands at row 0.
+    :param fixed_note_params_list: Optional pre-set note params; same contract
+        as ``fixed_synth_params_list``.
     """
     param_spec = param_specs[render_cfg.param_spec_name]
     meta = _shard_metadata_from_render(render_cfg)

--- a/src/synth_setter/data/vst/writers.py
+++ b/src/synth_setter/data/vst/writers.py
@@ -1,19 +1,9 @@
 """Per-shard dataset writers — HDF5 (resumable) and webdataset tar (new).
 
-Splits the single legacy ``make_dataset(h5py.File, render_cfg)`` into two
-entrypoints dispatched by the renderer CLI on the output file's suffix:
+Consist of two entrypoints dispatched by the renderer CLI on the output file's suffix:
 ``make_hdf5_dataset`` keeps the resumable HDF5 path (signature takes a path and
 opens the file internally), and ``make_wds_dataset`` is the new tar-shard
-writer using ``webdataset.TarWriter``. Both share rendering/loudness/loop
-logic via the ``_validate_fixed_params_lengths`` / ``_generate_sample_for_index``
-/ ``_shard_metadata_from_render`` helpers below, and both write the same
-``ShardMetadata`` sidecar (``audio.attrs`` on the HDF5 path, ``metadata.json``
-tar member on the wds path) so consumers see identical per-shard metadata
-regardless of which format the worker produced.
-
-This module lives outside ``[tool.pydoclint].exclude`` — every public symbol
-carries a Sphinx-style ``:param:`` / ``:returns:`` / ``:rtype:`` / ``:raises:``
-docstring so the ``code-quality-pr`` guard (#938) stays green.
+writer using ``webdataset.TarWriter``.
 """
 
 from __future__ import annotations

--- a/src/synth_setter/data/vst/writers.py
+++ b/src/synth_setter/data/vst/writers.py
@@ -1,0 +1,412 @@
+"""Per-shard dataset writers — HDF5 (resumable) and webdataset tar (new).
+
+Splits the single legacy ``make_dataset(h5py.File, render_cfg)`` into two
+entrypoints dispatched by the renderer CLI on the output file's suffix:
+``make_hdf5_dataset`` keeps the resumable HDF5 path (signature takes a path and
+opens the file internally), and ``make_wds_dataset`` is the new tar-shard
+writer using ``webdataset.TarWriter``. Both share rendering/loudness/loop
+logic via the ``_validate_fixed_params_lengths`` / ``_generate_sample_for_index``
+/ ``_shard_metadata_from_render`` helpers below, and both write the same
+``ShardMetadata`` sidecar (``audio.attrs`` on the HDF5 path, ``metadata.json``
+tar member on the wds path) so consumers see identical per-shard metadata
+regardless of which format the worker produced.
+
+This module lives outside ``[tool.pydoclint].exclude`` — every public symbol
+carries a Sphinx-style ``:param:`` / ``:returns:`` / ``:rtype:`` / ``:raises:``
+docstring so the ``code-quality-pr`` guard (#938) stays green.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Protocol, cast
+
+import h5py
+import numpy as np
+import webdataset as wds
+from loguru import logger
+from tqdm import trange
+
+from synth_setter.data.vst import param_specs
+from synth_setter.data.vst.generate_vst_dataset import (
+    VSTDataSample,
+    create_datasets_and_get_start_idx,
+    generate_sample,
+)
+from synth_setter.data.vst.param_spec import ParamSpec
+from synth_setter.data.vst.shapes import DATASET_FIELD_NAMES
+from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
+from synth_setter.pipeline.schemas.spec import RenderConfig
+
+
+class _WdsTarSink(Protocol):
+    """Minimal surface from ``wds.TarWriter`` used by the wds writer path.
+
+    The webdataset library lacks PEP 561 type stubs, so direct ``wds.TarWriter``
+    references trigger ``reportAttributeAccessIssue`` under pyright. Typing the
+    helper signatures against this Protocol keeps the call surface narrow and
+    confines the type-ignore to the single ``wds.TarWriter(...)`` instantiation.
+    """
+
+    def write(self, sample: dict[str, Any]) -> None:
+        """Write a single sample dict to the underlying tar stream.
+
+        :param sample: Mapping containing a ``__key__`` plus member-name → value entries.
+        """
+        ...
+
+    def close(self) -> None:
+        """Close the underlying tar stream."""
+        ...
+
+    def __enter__(self) -> _WdsTarSink:
+        """Enter the context manager and return ``self``.
+
+        :returns: This sink, for use inside a ``with`` block.
+        :rtype: _WdsTarSink
+        """
+        ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit the context manager, closing the underlying tar stream.
+
+        :param exc_type: Exception type if raised inside the block, else ``None``.
+        :param exc_val: Exception instance if raised inside the block, else ``None``.
+        :param exc_tb: Traceback if an exception was raised inside the block, else ``None``.
+        """
+        ...
+
+
+def save_hdf5_samples(
+    samples: list[VSTDataSample],
+    audio_dataset: h5py.Dataset,
+    mel_dataset: h5py.Dataset,
+    param_dataset: h5py.Dataset,
+    start_idx: int,
+) -> None:
+    """Append a batch of rendered samples to the three HDF5 datasets in place.
+
+    :param samples: Rendered samples in row order; the first lands at ``start_idx``.
+    :param audio_dataset: Pre-created HDF5 audio dataset (shape ``(N, C, T)``).
+    :param mel_dataset: Pre-created HDF5 mel-spectrogram dataset (shape ``(N, C, M, F)``).
+    :param param_dataset: Pre-created HDF5 parameter-array dataset (shape ``(N, P)``).
+    :param start_idx: Row at which the batch's first sample is written.
+    """
+    logger.info(f"Saving {len(samples)} samples to hdf5...")
+    audios = np.stack([s.audio.T for s in samples], axis=0)
+    mel_specs = np.stack([s.mel_spec for s in samples], axis=0)
+    param_arrays = np.stack([s.param_array for s in samples], axis=0)
+
+    end = start_idx + len(samples)
+    audio_dataset[start_idx:end, :, :] = audios
+    mel_dataset[start_idx:end, :, :] = mel_specs
+    param_dataset[start_idx:end, :] = param_arrays
+
+    logger.info(f"{len(samples)} hdf5 samples written!")
+
+
+def save_wds_samples(
+    samples: list[VSTDataSample],
+    sink: _WdsTarSink,
+    start_idx: int,
+) -> None:
+    """Write a batch of rendered samples as a single tar entry keyed by ``start_idx``.
+
+    Audio is cast to ``float16`` to match the h5 path's storage precision so
+    consumers see the same dtype regardless of which writer produced the shard;
+    ``mel_spec`` and ``param_array`` stay ``float32``.
+
+    :param samples: Rendered samples in row order; all land under the same tar key.
+    :param sink: An open ``wds.TarWriter``-compatible sink (Protocol typed).
+    :param start_idx: Logical row index of the batch's first sample — also the tar key.
+    """
+    logger.info(f"Saving {len(samples)} samples to wds...")
+    audios = np.stack([s.audio.T for s in samples], axis=0).astype(np.float16)
+    mel_specs = np.stack([s.mel_spec for s in samples], axis=0)
+    param_arrays = np.stack([s.param_array for s in samples], axis=0)
+
+    audio_name, mel_name, param_name = DATASET_FIELD_NAMES
+    sink.write(
+        {
+            "__key__": f"{start_idx:08d}",
+            f"{audio_name}.npy": audios,
+            f"{mel_name}.npy": mel_specs,
+            f"{param_name}.npy": param_arrays,
+        }
+    )
+
+    logger.info(f"{len(samples)} wds samples written!")
+
+
+def _validate_fixed_params_lengths(
+    *,
+    num_samples: int,
+    start_idx: int,
+    fixed_synth_params_list: list[dict[str, float]] | None,
+    fixed_note_params_list: list[dict[str, int | tuple[float, float]]] | None,
+) -> None:
+    """Raise ``ValueError`` if a fixed-params list is shorter than the remaining renders.
+
+    :param num_samples: Total number of samples this shard will hold.
+    :param start_idx: First row index this run will write (non-zero on a resume).
+    :param fixed_synth_params_list: Optional pre-set synth params, one dict per row to render.
+    :param fixed_note_params_list: Optional pre-set note params, one dict per row to render.
+    :raises ValueError: If either list is shorter than ``num_samples - start_idx``.
+    """
+    expected_fixed_len = num_samples - start_idx
+    for name, lst in [
+        ("fixed_synth_params_list", fixed_synth_params_list),
+        ("fixed_note_params_list", fixed_note_params_list),
+    ]:
+        if lst is not None and len(lst) < expected_fixed_len:
+            raise ValueError(
+                f"{name} has length {len(lst)}, expected at least "
+                f"num_samples - start_idx = {expected_fixed_len} "
+                f"(num_samples={num_samples}, start_idx={start_idx})"
+            )
+
+
+def _generate_sample_for_index(
+    i: int,
+    start_idx: int,
+    *,
+    plugin_path: str,
+    preset_path: str,
+    velocity: int,
+    signal_duration_seconds: float,
+    sample_rate: float,
+    channels: int,
+    min_loudness: float,
+    param_spec: ParamSpec,
+    fixed_synth_params_list: list[dict[str, float]] | None,
+    fixed_note_params_list: list[dict[str, int | tuple[float, float]]] | None,
+) -> VSTDataSample:
+    """Render the ``i``-th sample, picking up the ``(i - start_idx)``-th fixed-params entry.
+
+    :param i: Absolute row index this call is rendering.
+    :param start_idx: Row index of the first sample in this run (offset for resume).
+    :param plugin_path: Path to the VST3 bundle to load.
+    :param preset_path: Path to the ``.vstpreset`` to apply.
+    :param velocity: MIDI velocity in ``[0, 127]``.
+    :param signal_duration_seconds: Duration of the rendered clip in seconds.
+    :param sample_rate: Sample rate of the rendered clip in Hz.
+    :param channels: Number of audio channels rendered.
+    :param min_loudness: Loudness gate threshold in LUFS.
+    :param param_spec: Parameter spec used to sample/encode parameters.
+    :param fixed_synth_params_list: Optional pre-set synth params, indexed by ``i - start_idx``.
+    :param fixed_note_params_list: Optional pre-set note params, indexed by ``i - start_idx``.
+    :returns: The freshly rendered sample.
+    :rtype: VSTDataSample
+    """
+    fixed_idx = i - start_idx
+    return generate_sample(
+        plugin_path,
+        velocity=velocity,
+        signal_duration_seconds=signal_duration_seconds,
+        sample_rate=sample_rate,
+        channels=channels,
+        min_loudness=min_loudness,
+        param_spec=param_spec,
+        preset_path=preset_path,
+        fixed_synth_params=(
+            fixed_synth_params_list[fixed_idx] if fixed_synth_params_list is not None else None
+        ),
+        fixed_note_params=(
+            fixed_note_params_list[fixed_idx] if fixed_note_params_list is not None else None
+        ),
+    )
+
+
+def _render_in_batches(
+    *,
+    render_cfg: RenderConfig,
+    param_spec: ParamSpec,
+    start_idx: int,
+    fixed_synth_params_list: list[dict[str, float]] | None,
+    fixed_note_params_list: list[dict[str, int | tuple[float, float]]] | None,
+    flush_batch: Callable[[list[VSTDataSample], int], None],
+) -> None:
+    """Render samples from ``start_idx`` to ``render_cfg.batch_per_shard`` in fixed-size batches.
+
+    The h5 and wds writers share this loop verbatim: only the per-batch flush
+    differs (HDF5 dataset slice assignment vs. tar member write). The flush
+    callback is invoked once per full ``sample_batch_size`` batch plus once
+    for the trailing remainder, with the batch and its starting row index.
+
+    :param render_cfg: Per-shard renderer config from the dataset spec.
+    :param param_spec: Resolved parameter spec for the render.
+    :param start_idx: First absolute row index this run renders (non-zero on resume).
+    :param fixed_synth_params_list: Optional pre-set synth params, indexed in write order.
+    :param fixed_note_params_list: Optional pre-set note params, indexed in write order.
+    :param flush_batch: Called with ``(batch, batch_start_idx)`` to persist each batch.
+    """
+    num_samples = render_cfg.batch_per_shard
+    sample_batch: list[VSTDataSample] = []
+    sample_batch_start = start_idx
+    for i in trange(start_idx, num_samples):
+        logger.info(f"Making sample {i}")
+        sample_batch.append(
+            _generate_sample_for_index(
+                i,
+                start_idx,
+                plugin_path=render_cfg.plugin_path,
+                preset_path=render_cfg.preset_path,
+                velocity=render_cfg.velocity,
+                signal_duration_seconds=render_cfg.signal_duration_seconds,
+                sample_rate=render_cfg.sample_rate,
+                channels=render_cfg.channels,
+                min_loudness=render_cfg.min_loudness,
+                param_spec=param_spec,
+                fixed_synth_params_list=fixed_synth_params_list,
+                fixed_note_params_list=fixed_note_params_list,
+            )
+        )
+        if len(sample_batch) == render_cfg.sample_batch_size:
+            flush_batch(sample_batch, sample_batch_start)
+            sample_batch = []
+            sample_batch_start += render_cfg.sample_batch_size
+
+    if sample_batch:
+        flush_batch(sample_batch, sample_batch_start)
+
+
+def _shard_metadata_from_render(render_cfg: RenderConfig) -> ShardMetadata:
+    """Project a ``RenderConfig`` onto the per-shard sidecar metadata fields.
+
+    Single source of truth for the five render-derived attrs that both the
+    HDF5 ``audio.attrs`` sidecar and the wds ``metadata.json`` tar member
+    expose. Keeping projection here means the two writers can never drift.
+
+    :param render_cfg: Per-shard renderer config from the dataset spec.
+    :returns: Strict ``ShardMetadata`` with the five render-derived fields filled.
+    :rtype: ShardMetadata
+    """
+    return ShardMetadata(
+        velocity=render_cfg.velocity,
+        signal_duration_seconds=render_cfg.signal_duration_seconds,
+        sample_rate=render_cfg.sample_rate,
+        channels=render_cfg.channels,
+        min_loudness=render_cfg.min_loudness,
+    )
+
+
+def make_hdf5_dataset(
+    hdf5_file: Path | str,
+    render_cfg: RenderConfig,
+    *,
+    fixed_synth_params_list: list[dict[str, float]] | None = None,
+    fixed_note_params_list: list[dict[str, int | tuple[float, float]]] | None = None,
+) -> None:
+    """Render ``render_cfg.batch_per_shard`` samples to an HDF5 file at ``hdf5_file``.
+
+    Resumable: a partially-written file picks up at the first all-zero row, so
+    a crashed worker can re-run with the same args and only the missing tail is
+    rendered. Audio is stored as ``float16`` (Blosc2-compressed); ``mel_spec``
+    and ``param_array`` are ``float32``. The five sidecar attrs (velocity,
+    signal duration, sample rate, channels, min_loudness) are written to
+    ``audio.attrs`` from a single ``ShardMetadata`` instance — the same
+    instance ``make_wds_dataset`` uses for its ``metadata.json`` member, so
+    both formats expose identical metadata.
+
+    :param hdf5_file: Destination HDF5 path; opened in append mode so partial
+        files can resume.
+    :param render_cfg: Per-shard renderer config from the dataset spec.
+    :param fixed_synth_params_list: Optional pre-set synth params, indexed in
+        write order across the shard.
+    :param fixed_note_params_list: Optional pre-set note params, indexed in
+        write order across the shard.
+    """
+    param_spec = param_specs[render_cfg.param_spec_name]
+    meta = _shard_metadata_from_render(render_cfg)
+    with h5py.File(hdf5_file, "a") as h5:
+        audio_dataset, mel_dataset, param_dataset, start_idx = (
+            create_datasets_and_get_start_idx(
+                hdf5_file=h5,
+                num_samples=render_cfg.batch_per_shard,
+                channels=render_cfg.channels,
+                sample_rate=render_cfg.sample_rate,
+                signal_duration_seconds=render_cfg.signal_duration_seconds,
+                num_params=len(param_spec),
+            )
+        )
+
+        _validate_fixed_params_lengths(
+            num_samples=render_cfg.batch_per_shard,
+            start_idx=start_idx,
+            fixed_synth_params_list=fixed_synth_params_list,
+            fixed_note_params_list=fixed_note_params_list,
+        )
+
+        for k, v in meta.model_dump().items():
+            audio_dataset.attrs[k] = v
+
+        def _flush(batch: list[VSTDataSample], batch_start: int) -> None:
+            save_hdf5_samples(batch, audio_dataset, mel_dataset, param_dataset, batch_start)
+
+        _render_in_batches(
+            render_cfg=render_cfg,
+            param_spec=param_spec,
+            start_idx=start_idx,
+            fixed_synth_params_list=fixed_synth_params_list,
+            fixed_note_params_list=fixed_note_params_list,
+            flush_batch=_flush,
+        )
+
+
+def make_wds_dataset(
+    wds_file: Path | str,
+    render_cfg: RenderConfig,
+    *,
+    fixed_synth_params_list: list[dict[str, float]] | None = None,
+    fixed_note_params_list: list[dict[str, int | tuple[float, float]]] | None = None,
+) -> None:
+    """Render ``render_cfg.batch_per_shard`` samples to a webdataset tar at ``wds_file``.
+
+    Not resumable: ``start_idx`` is pinned to 0 and the file is opened by
+    ``wds.TarWriter`` in write mode, so re-running overwrites. Audio is cast to
+    ``float16`` to match the h5 path's storage precision; consumers can upcast
+    on read if higher precision is needed. The shard's ``metadata.json`` member
+    is built from the same ``ShardMetadata`` instance ``make_hdf5_dataset``
+    uses for its ``audio.attrs``, so both formats expose identical metadata.
+
+    :param wds_file: Destination tar path passed to ``webdataset.TarWriter``.
+    :param render_cfg: Per-shard renderer config from the dataset spec.
+    :param fixed_synth_params_list: Optional pre-set synth params, indexed in
+        write order across the shard.
+    :param fixed_note_params_list: Optional pre-set note params, indexed in
+        write order across the shard.
+    """
+    param_spec = param_specs[render_cfg.param_spec_name]
+    meta = _shard_metadata_from_render(render_cfg)
+    start_idx = 0
+    _validate_fixed_params_lengths(
+        num_samples=render_cfg.batch_per_shard,
+        start_idx=start_idx,
+        fixed_synth_params_list=fixed_synth_params_list,
+        fixed_note_params_list=fixed_note_params_list,
+    )
+    with cast(
+        _WdsTarSink,
+        wds.TarWriter(str(wds_file)),  # pyright: ignore[reportAttributeAccessIssue]
+    ) as sink:
+
+        def _flush(batch: list[VSTDataSample], batch_start: int) -> None:
+            save_wds_samples(batch, sink, batch_start)
+
+        _render_in_batches(
+            render_cfg=render_cfg,
+            param_spec=param_spec,
+            start_idx=start_idx,
+            fixed_synth_params_list=fixed_synth_params_list,
+            fixed_note_params_list=fixed_note_params_list,
+            flush_batch=_flush,
+        )
+
+        sink.write({"__key__": "metadata", "json": meta.model_dump()})

--- a/src/synth_setter/tools/surge_xt_interactive.py
+++ b/src/synth_setter/tools/surge_xt_interactive.py
@@ -40,8 +40,8 @@ from synth_setter.data.vst.core import (  # noqa: E402
     make_midi_events,
     set_params,
 )
-from synth_setter.data.vst.generate_vst_dataset import make_dataset  # noqa: E402
 from synth_setter.data.vst.param_spec import ParamSpec  # noqa: E402
+from synth_setter.data.vst.writers import make_hdf5_dataset  # noqa: E402
 from synth_setter.pipeline.schemas.spec import RenderConfig  # noqa: E402
 
 MIDI_LISTEN_MESSAGE_TYPES = ("note_on", "note_off", "control_change", "pitchwheel", "aftertouch")
@@ -1024,11 +1024,11 @@ def eval_patches(
     default=None,
     help=(
         "Directory to create for the recorded patches. Must not already exist — "
-        "``make_dataset`` writes fixed-size HDF5 datasets without ``maxshape`` and cannot "
+        "``make_hdf5_dataset`` writes fixed-size HDF5 datasets without ``maxshape`` and cannot "
         "append to existing files. After the editor is closed, patches captured via the "
         "keyboard loop (press 'p' to record, 'q' to quit) are rendered through the plugin "
         "and written to ``train.h5`` inside this directory via "
-        "``synth_setter.data.vst.generate_vst_dataset.make_dataset`` (plus ``val.h5``/``test.h5``/"
+        "``synth_setter.data.vst.writers.make_hdf5_dataset`` (plus ``val.h5``/``test.h5``/"
         "``predict.h5`` siblings when ``--checkpoint-path`` is set)."
     ),
 )
@@ -1088,7 +1088,7 @@ def main(
        ``q`` to quit).
     4. After the editor is closed, render every recorded patch through the plugin and write
        the resulting samples to ``train.h5`` inside ``--output-dataset-dir-path`` via
-       ``make_dataset``.
+       ``make_hdf5_dataset``.
     5. If ``--checkpoint-path`` is also set, copy ``train.h5`` to ``val.h5``/``test.h5``/
        ``predict.h5`` siblings (rolled back if any copy fails) and call ``eval_patches`` to
        run ``src/synth_setter/cli/eval.py mode=predict`` followed by audio rendering
@@ -1109,7 +1109,7 @@ def main(
             "the live audio thread doesn't run during deterministic clip rendering."
         )
 
-    # Fail fast — ``make_dataset`` writes fixed-size HDF5 datasets without
+    # Fail fast — ``make_hdf5_dataset`` writes fixed-size HDF5 datasets without
     # ``maxshape`` and cannot append, so a pre-existing path would either
     # silently overwrite (when re-creating datasets) or fail mid-render after
     # patches have been captured. Better to reject up front.
@@ -1234,12 +1234,11 @@ def main(
         sample_batch_size=MAKE_DATASET_SAMPLE_BATCH_SIZE,
         batch_per_shard=len(synth_patches),
     )
-    with h5py.File(patch_file_path, "w") as f:
-        make_dataset(
-            hdf5_file=f,
-            render_cfg=render_cfg,
-            fixed_synth_params_list=synth_patches,
-        )
+    make_hdf5_dataset(
+        hdf5_file=patch_file_path,
+        render_cfg=render_cfg,
+        fixed_synth_params_list=synth_patches,
+    )
     _maybe_eval_captured_patches(
         patch_file_path,
         output_dataset_dir_path,

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -920,7 +920,7 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
 @pytest.mark.slow
 @pytest.mark.requires_vst
 @skip_no_vst
-def test_make_dataset(tmp_path: Path) -> None:
+def test_make_hdf5_dataset(tmp_path: Path) -> None:
     """make_hdf5_dataset with the natural random source writes a valid h5."""
     out = tmp_path / "random.h5"
     spec = param_specs[_SPEC_NAME]
@@ -993,7 +993,7 @@ def test_show_editor_warmup_does_not_change_rendered_audio() -> None:
             )
 
 
-def test_make_dataset_raises_when_fixed_params_list_is_too_short(
+def test_make_hdf5_dataset_raises_when_fixed_params_list_is_too_short(
     tmp_path: Path,
 ) -> None:
     """make_hdf5_dataset rejects fixed_*_params_list shorter than batch_per_shard - start_idx."""
@@ -1131,7 +1131,7 @@ def test_generate_sample_retries_when_only_fixed_note_params(
 @pytest.mark.slow
 @pytest.mark.requires_vst
 @skip_no_vst
-def test_make_dataset_uses_fixed_params_lists_when_provided(
+def test_make_hdf5_dataset_uses_fixed_params_lists_when_provided(
     tmp_path: Path,
 ) -> None:
     """make_hdf5_dataset writes the supplied fixed params verbatim, bypassing

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -345,7 +345,6 @@ def _patched_sample(
     pull_count = [0]
 
     def fake_sample() -> tuple[dict[str, float], dict[str, int | tuple[float, float]]]:
-        """Return the next ``(synth_params, note_params)`` pair from the replay tape."""
         pull_count[0] += 1
         return next(replay_iter)
 
@@ -921,7 +920,7 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
 @pytest.mark.slow
 @pytest.mark.requires_vst
 @skip_no_vst
-def test_make_hdf5_dataset(tmp_path: Path) -> None:
+def test_make_dataset(tmp_path: Path) -> None:
     """make_hdf5_dataset with the natural random source writes a valid h5."""
     out = tmp_path / "random.h5"
     spec = param_specs[_SPEC_NAME]
@@ -994,7 +993,7 @@ def test_show_editor_warmup_does_not_change_rendered_audio() -> None:
             )
 
 
-def test_make_hdf5_dataset_raises_when_fixed_params_list_is_too_short(
+def test_make_dataset_raises_when_fixed_params_list_is_too_short(
     tmp_path: Path,
 ) -> None:
     """make_hdf5_dataset rejects fixed_*_params_list shorter than batch_per_shard - start_idx."""
@@ -1132,7 +1131,7 @@ def test_generate_sample_retries_when_only_fixed_note_params(
 @pytest.mark.slow
 @pytest.mark.requires_vst
 @skip_no_vst
-def test_make_hdf5_dataset_uses_fixed_params_lists_when_provided(
+def test_make_dataset_uses_fixed_params_lists_when_provided(
     tmp_path: Path,
 ) -> None:
     """make_hdf5_dataset writes the supplied fixed params verbatim, bypassing

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -1,4 +1,4 @@
-"""Basic e2e test for src/synth_setter/data/vst/generate_vst_dataset.py — verifies HDF5 output."""
+"""Basic e2e test for src/synth_setter/data/vst/writers.py — verifies HDF5 output."""
 
 import json
 import logging
@@ -20,8 +20,8 @@ from synth_setter.pipeline.schemas.spec import RenderConfig
 from synth_setter.evaluation.compute_audio_metrics import compute_mss, compute_rms, compute_sot, compute_wmfcc
 from synth_setter.data.vst import param_specs
 from synth_setter.data.vst.core import render_params
-from synth_setter.data.vst.generate_vst_dataset import make_dataset
 from synth_setter.data.vst.param_spec import ParamSpec
+from synth_setter.data.vst.writers import make_hdf5_dataset
 
 log = logging.getLogger(__name__)
 
@@ -732,9 +732,10 @@ def _assert_round_trip_matches(
 def test_datasets_from_hardcoded_params_are_identical(
     tmp_path: Path,
 ) -> None:
-    """make_dataset round-trips a single hardcoded param set when ``param_spec.sample`` is patched.
+    """make_hdf5_dataset round-trips a single hardcoded param set when ``param_spec.sample`` is
+    patched.
 
-    Both stages of ``make_dataset`` patch ``param_spec.sample`` to return the same
+    Both stages of ``make_hdf5_dataset`` patch ``param_spec.sample`` to return the same
     hardcoded ``(_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS)`` tuple, so every
     one of the ``2 × num_samples`` renders uses identical inputs. This pins
     reproducibility on a fixed, version-controlled patch — no random sampling, no
@@ -754,11 +755,8 @@ def test_datasets_from_hardcoded_params_are_identical(
 
     expected_dataset = tmp_path / "expected.h5"
     t0 = time.perf_counter()
-    with (
-        h5py.File(expected_dataset, "a") as f,
-        _patched_sample(spec, replay),
-    ):
-        make_dataset(hdf5_file=f, render_cfg=_render_cfg(num_samples))
+    with _patched_sample(spec, replay):
+        make_hdf5_dataset(hdf5_file=expected_dataset, render_cfg=_render_cfg(num_samples))
     stage1_seconds = time.perf_counter() - t0
 
     expected_audio, expected_mel, expected_params = _assert_h5_structure_is_valid(
@@ -767,11 +765,8 @@ def test_datasets_from_hardcoded_params_are_identical(
 
     got_dataset = tmp_path / "replayed.h5"
     t0 = time.perf_counter()
-    with (
-        h5py.File(got_dataset, "a") as f,
-        _patched_sample(spec, replay),
-    ):
-        make_dataset(hdf5_file=f, render_cfg=_render_cfg(num_samples))
+    with _patched_sample(spec, replay):
+        make_hdf5_dataset(hdf5_file=got_dataset, render_cfg=_render_cfg(num_samples))
     stage2_seconds = time.perf_counter() - t0
 
     actual_audio, actual_mel, actual_params = _assert_h5_structure_is_valid(
@@ -817,11 +812,11 @@ def test_datasets_from_hardcoded_params_are_identical(
 @pytest.mark.requires_vst
 @skip_no_vst
 def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
-    """make_dataset reproduces a previous dataset row-for-row when params are replayed.
+    """make_hdf5_dataset reproduces a previous dataset row-for-row when params are replayed.
 
     Two-stage e2e test:
 
-    1. Build a "candidates" dataset by calling ``make_dataset`` with the natural
+    1. Build a "candidates" dataset by calling ``make_hdf5_dataset`` with the natural
        random source. ``generate_sample`` samples params via ``param_spec.sample()``
        and rejects renders below ``_MIN_LOUDNESS`` in a ``while True`` loop, so each
        surviving row is guaranteed to be loud enough to pass the loudness gate.
@@ -850,8 +845,7 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
     # Stage 1: random-sampled "candidates" dataset (loudness-filtered).
     expected_dataset = tmp_path / "candidates.h5"
     t0 = time.perf_counter()
-    with h5py.File(expected_dataset, "a") as expected_file:
-        make_dataset(hdf5_file=expected_file, render_cfg=_render_cfg(_NUM_SAMPLES))
+    make_hdf5_dataset(hdf5_file=expected_dataset, render_cfg=_render_cfg(_NUM_SAMPLES))
     stage1_seconds = time.perf_counter() - t0
 
     expected_audio, expected_mel, expected_params = _assert_h5_structure_is_valid(
@@ -866,7 +860,7 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
     )
 
     # Decode the candidate rows back into synth/note params dicts. These are the
-    # inputs for the second ``make_dataset`` run — guaranteed past the loudness
+    # inputs for the second ``make_hdf5_dataset`` run — guaranteed past the loudness
     # gate by construction (the candidate render survived stage 1).
     synth_patches: list[dict[str, float]] = []
     note_patches: list[dict[str, int | tuple[float, float]]] = []
@@ -887,12 +881,9 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
     got_dataset = tmp_path / "replayed.h5"
     replay = list(zip(synth_patches, note_patches, strict=True))
     t0 = time.perf_counter()
-    with (
-        h5py.File(got_dataset, "a") as f,
-        _patched_sample(spec, replay),
-    ):
-        make_dataset(
-            hdf5_file=f,
+    with _patched_sample(spec, replay):
+        make_hdf5_dataset(
+            hdf5_file=got_dataset,
             render_cfg=_render_cfg(_NUM_SAMPLES, min_loudness=float("-inf")),
         )
     stage2_seconds = time.perf_counter() - t0
@@ -930,12 +921,11 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
 @pytest.mark.requires_vst
 @skip_no_vst
 def test_make_dataset(tmp_path: Path) -> None:
-    """make_dataset with the natural random source writes a valid h5."""
+    """make_hdf5_dataset with the natural random source writes a valid h5."""
     out = tmp_path / "random.h5"
     spec = param_specs[_SPEC_NAME]
 
-    with h5py.File(out, "a") as f:
-        make_dataset(hdf5_file=f, render_cfg=_render_cfg(_NUM_SAMPLES))
+    make_hdf5_dataset(hdf5_file=out, render_cfg=_render_cfg(_NUM_SAMPLES))
 
     _, _, params = _assert_h5_structure_is_valid(out, spec, _NUM_SAMPLES)
 
@@ -1006,15 +996,14 @@ def test_show_editor_warmup_does_not_change_rendered_audio() -> None:
 def test_make_dataset_raises_when_fixed_params_list_is_too_short(
     tmp_path: Path,
 ) -> None:
-    """make_dataset rejects fixed_*_params_list shorter than batch_per_shard - start_idx."""
+    """make_hdf5_dataset rejects fixed_*_params_list shorter than batch_per_shard - start_idx."""
     out = tmp_path / "should_not_write.h5"
-    with h5py.File(out, "a") as f:
-        with pytest.raises(ValueError, match="fixed_synth_params_list has length"):
-            make_dataset(
-                hdf5_file=f,
-                render_cfg=_render_cfg(num_samples=3),
-                fixed_synth_params_list=[_HARDCODED_SYNTH_PARAMS],
-            )
+    with pytest.raises(ValueError, match="fixed_synth_params_list has length"):
+        make_hdf5_dataset(
+            hdf5_file=out,
+            render_cfg=_render_cfg(num_samples=3),
+            fixed_synth_params_list=[_HARDCODED_SYNTH_PARAMS],
+        )
 
 
 # Unit tests for the loudness-loop retry/raise semantics. Mocking
@@ -1145,17 +1134,17 @@ def test_generate_sample_retries_when_only_fixed_note_params(
 def test_make_dataset_uses_fixed_params_lists_when_provided(
     tmp_path: Path,
 ) -> None:
-    """make_dataset writes the supplied fixed params verbatim, bypassing param_spec.sample()."""
+    """make_hdf5_dataset writes the supplied fixed params verbatim, bypassing
+    param_spec.sample()."""
     spec = param_specs[_SPEC_NAME]
     out = tmp_path / "fixed.h5"
     num_samples = 3
-    with h5py.File(out, "a") as f:
-        make_dataset(
-            hdf5_file=f,
-            render_cfg=_render_cfg(num_samples),
-            fixed_synth_params_list=[_HARDCODED_SYNTH_PARAMS] * num_samples,
-            fixed_note_params_list=[_HARDCODED_NOTE_PARAMS] * num_samples,
-        )
+    make_hdf5_dataset(
+        hdf5_file=out,
+        render_cfg=_render_cfg(num_samples),
+        fixed_synth_params_list=[_HARDCODED_SYNTH_PARAMS] * num_samples,
+        fixed_note_params_list=[_HARDCODED_NOTE_PARAMS] * num_samples,
+    )
 
     _, _, params = _assert_h5_structure_is_valid(out, spec, num_samples)
     # ParamSpec.encode is annotated dict[str, float] on main but accepts the runtime

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -345,6 +345,7 @@ def _patched_sample(
     pull_count = [0]
 
     def fake_sample() -> tuple[dict[str, float], dict[str, int | tuple[float, float]]]:
+        """Return the next ``(synth_params, note_params)`` pair from the replay tape."""
         pull_count[0] += 1
         return next(replay_iter)
 

--- a/tests/data/vst/test_writers.py
+++ b/tests/data/vst/test_writers.py
@@ -1,0 +1,174 @@
+"""CPU-only tests for ``synth_setter.data.vst.writers``.
+
+Covers the writer module's pure helpers and the CLI dispatcher in
+``generate_vst_dataset.main`` — the VST-dependent end-to-end writer tests
+live alongside the legacy HDF5 tests in ``test_generate_vst_dataset.py`` and
+the new wds e2e tests in ``test_writers_wds_e2e.py``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from synth_setter.data.vst.writers import _shard_metadata_from_render
+from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
+from synth_setter.pipeline.schemas.spec import RenderConfig
+
+
+def _smoke_render_cfg(**overrides: object) -> RenderConfig:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Build a syntactically-valid ``RenderConfig`` for CPU-only tests.
+
+    No I/O happens against ``plugin_path`` or ``preset_path`` in these tests
+    — they only need to be non-blank strings.
+    """
+    kwargs: dict[str, object] = {
+        "plugin_path": "plugins/Surge XT.vst3",
+        "preset_path": "presets/surge-base.vstpreset",
+        "param_spec_name": "surge_simple",
+        "renderer_version": "1.3.4",
+        "sample_rate": 16000,
+        "channels": 2,
+        "velocity": 100,
+        "signal_duration_seconds": 4.0,
+        "min_loudness": -55.0,
+        "sample_batch_size": 2,
+        "batch_per_shard": 4,
+    }
+    kwargs.update(overrides)
+    return RenderConfig(**kwargs)  # type: ignore[arg-type]
+
+
+def test_shard_metadata_from_render_projects_five_fields() -> None:
+    """``_shard_metadata_from_render`` returns a strict ``ShardMetadata`` with renderer values."""
+    render_cfg = _smoke_render_cfg(
+        velocity=64,
+        signal_duration_seconds=2.5,
+        sample_rate=22050,
+        channels=1,
+        min_loudness=-40.0,
+    )
+
+    meta = _shard_metadata_from_render(render_cfg)
+
+    assert isinstance(meta, ShardMetadata)
+    assert meta.velocity == 64
+    assert meta.signal_duration_seconds == 2.5
+    assert meta.sample_rate == 22050
+    assert meta.channels == 1
+    assert meta.min_loudness == -40.0
+
+
+def test_shard_metadata_from_render_round_trips_through_json() -> None:
+    """The projected metadata serializes and re-validates as a strict ``ShardMetadata``.
+
+    Pinning JSON round-trip is what the wds tar's ``metadata.json`` member
+    relies on: a writer-side projection that can't be re-read isn't useful.
+    """
+    render_cfg = _smoke_render_cfg()
+
+    meta = _shard_metadata_from_render(render_cfg)
+    rehydrated = ShardMetadata.model_validate_json(meta.model_dump_json())
+
+    assert rehydrated == meta
+
+
+def _run_main_with_argv(argv: list[str]) -> None:  # noqa: DOC101,DOC103
+    """Invoke ``generate_vst_dataset.main`` with ``argv`` patched in.
+
+    The pydantic-settings CLI reads ``sys.argv`` directly via ``CliApp.run``,
+    so tests need to swap the process argv around the call. Imports the entry
+    inside the helper so a single import failure doesn't poison the module.
+    """
+    from synth_setter.data.vst.generate_vst_dataset import main
+
+    with patch.object(sys, "argv", argv):
+        main()
+
+
+# Shared CLI argv prefix for the dispatcher tests below. Built from the same
+# ``RenderConfig`` field set the CLI binding inherits, so adding a render-config
+# field auto-extends the prefix.
+def _cli_argv(data_file: str) -> list[str]:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Build a CLI argv that parses cleanly into a ``RenderConfig`` + ``data_file``.
+
+    All values mirror ``_smoke_render_cfg`` so the parsed config is round-trip
+    equal to it. The ``argv[0]`` is a stand-in program name (not used).
+    """
+    return [
+        "generate_vst_dataset",
+        data_file,
+        "--plugin_path",
+        "plugins/Surge XT.vst3",
+        "--preset_path",
+        "presets/surge-base.vstpreset",
+        "--param_spec_name",
+        "surge_simple",
+        "--renderer_version",
+        "1.3.4",
+        "--sample_rate",
+        "16000",
+        "--channels",
+        "2",
+        "--velocity",
+        "100",
+        "--signal_duration_seconds",
+        "4.0",
+        "--min_loudness",
+        "-55.0",
+        "--sample_batch_size",
+        "2",
+        "--batch_per_shard",
+        "4",
+    ]
+
+
+def test_main_dispatches_h5_suffix_to_make_hdf5_dataset(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+    """``data_file=foo.h5`` routes to ``make_hdf5_dataset`` (not the wds writer)."""
+    data_file = tmp_path / "shard-000000.h5"
+
+    with (
+        patch("synth_setter.data.vst.writers.make_hdf5_dataset") as mock_h5,
+        patch("synth_setter.data.vst.writers.make_wds_dataset") as mock_wds,
+    ):
+        _run_main_with_argv(_cli_argv(str(data_file)))
+
+    mock_h5.assert_called_once()
+    mock_wds.assert_not_called()
+    # First positional arg is the data_file path.
+    h5_args, _h5_kwargs = mock_h5.call_args
+    assert h5_args[0] == str(data_file)
+
+
+def test_main_dispatches_tar_suffix_to_make_wds_dataset(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+    """``data_file=foo.tar`` routes to ``make_wds_dataset`` (not the h5 writer)."""
+    data_file = tmp_path / "shard-000000.tar"
+
+    with (
+        patch("synth_setter.data.vst.writers.make_hdf5_dataset") as mock_h5,
+        patch("synth_setter.data.vst.writers.make_wds_dataset") as mock_wds,
+    ):
+        _run_main_with_argv(_cli_argv(str(data_file)))
+
+    mock_wds.assert_called_once()
+    mock_h5.assert_not_called()
+    wds_args, _wds_kwargs = mock_wds.call_args
+    assert wds_args[0] == str(data_file)
+
+
+def test_main_rejects_unknown_suffix(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+    """``data_file=foo.bin`` raises ``SystemExit`` rather than silently picking a writer."""
+    data_file = tmp_path / "shard-000000.bin"
+
+    with (
+        patch("synth_setter.data.vst.writers.make_hdf5_dataset") as mock_h5,
+        patch("synth_setter.data.vst.writers.make_wds_dataset") as mock_wds,
+        pytest.raises(SystemExit, match=r"data_file must end in one of"),
+    ):
+        _run_main_with_argv(_cli_argv(str(data_file)))
+
+    mock_h5.assert_not_called()
+    mock_wds.assert_not_called()

--- a/tests/data/vst/test_writers_wds_e2e.py
+++ b/tests/data/vst/test_writers_wds_e2e.py
@@ -1,0 +1,319 @@
+"""End-to-end tests for the wds branch of ``synth_setter.data.vst.writers``.
+
+Renders real audio through the Surge XT VST3 plugin (``@pytest.mark.requires_vst``)
+and validates the on-disk shape of the produced tar shard. The load-bearing
+parity test ``test_h5_and_wds_outputs_are_equivalent`` is the original
+acceptance criterion in issue #874's checklist — same params, identical bytes.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import tarfile
+from pathlib import Path
+
+import h5py
+import hdf5plugin  # noqa: F401  registers Blosc2 for h5py reads
+import numpy as np
+import pytest
+import webdataset as wds
+
+from synth_setter.data.vst import param_specs
+from synth_setter.data.vst.writers import make_hdf5_dataset, make_wds_dataset
+from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
+from synth_setter.pipeline.schemas.spec import RenderConfig
+
+_ = hdf5plugin  # keep type checkers from flagging the side-effect import
+
+_PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
+_PRESET_PATH = "presets/surge-base.vstpreset"
+_SAMPLE_RATE = 44100
+_CHANNELS = 2
+_DURATION = 4.0
+_VELOCITY = 100
+_MIN_LOUDNESS = -55.0
+_SPEC_NAME = "surge_xt"
+_RENDERER_VERSION = "1.3.4"
+
+skip_no_vst = pytest.mark.skipif(
+    not Path(_PLUGIN_PATH).exists(),
+    reason=f"VST plugin not found at {_PLUGIN_PATH}",
+)
+
+# Hardcoded loudness-passing patch from a prior surge_xt run — same one
+# ``test_generate_vst_dataset.py`` uses. Inlined here to avoid a cross-test
+# import dependency (the other module's _HARDCODED_SYNTH_PARAMS is module-
+# private). Re-importing it via a fixture would couple this module to that
+# one's test setup; copying the literal keeps each module self-contained.
+# When the spec changes the hardcoded dict in BOTH modules needs regenerating
+# — kept in sync manually.
+from tests.data.vst.test_generate_vst_dataset import (
+    _HARDCODED_NOTE_PARAMS,
+    _HARDCODED_SYNTH_PARAMS,
+    _MEL_MEAN_ABS_MAX,
+    _assert_audio_metrics_within_thresholds,
+)
+
+
+def _render_cfg(num_samples: int, sample_batch_size: int | None = None) -> RenderConfig:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Build a ``RenderConfig`` with this module's test defaults."""
+    return RenderConfig(
+        plugin_path=_PLUGIN_PATH,
+        preset_path=_PRESET_PATH,
+        param_spec_name=_SPEC_NAME,
+        renderer_version=_RENDERER_VERSION,
+        sample_rate=_SAMPLE_RATE,
+        channels=_CHANNELS,
+        velocity=_VELOCITY,
+        signal_duration_seconds=_DURATION,
+        min_loudness=_MIN_LOUDNESS,
+        sample_batch_size=sample_batch_size if sample_batch_size is not None else num_samples,
+        batch_per_shard=num_samples,
+    )
+
+
+def _tar_members(tar_path: Path) -> dict[str, bytes]:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Return a mapping of every tar member's name to its raw bytes."""
+    members: dict[str, bytes] = {}
+    with tarfile.open(tar_path, "r") as tar:
+        for entry in tar:
+            if not entry.isfile():
+                continue
+            fobj = tar.extractfile(entry)
+            assert fobj is not None
+            members[entry.name] = fobj.read()
+    return members
+
+
+def _load_npy_bytes(raw: bytes) -> np.ndarray:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Decode a ``.npy`` payload from raw bytes."""
+    return np.load(io.BytesIO(raw), allow_pickle=False)
+
+
+@pytest.mark.slow
+@pytest.mark.requires_vst
+@skip_no_vst
+def test_make_wds_dataset_writes_per_batch_npy_members(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+    """A 4-sample shard with batch_size=2 emits two batches of three npy members plus metadata."""
+    out = tmp_path / "shard-000000.tar"
+    num_samples = 4
+    fixed_synth = [_HARDCODED_SYNTH_PARAMS] * num_samples
+    fixed_note = [_HARDCODED_NOTE_PARAMS] * num_samples
+
+    make_wds_dataset(
+        wds_file=out,
+        render_cfg=_render_cfg(num_samples, sample_batch_size=2),
+        fixed_synth_params_list=fixed_synth,
+        fixed_note_params_list=fixed_note,
+    )
+
+    members = _tar_members(out)
+    expected = {
+        "00000000.audio.npy",
+        "00000000.mel_spec.npy",
+        "00000000.param_array.npy",
+        "00000002.audio.npy",
+        "00000002.mel_spec.npy",
+        "00000002.param_array.npy",
+        "metadata.json",
+    }
+    assert expected <= set(members), (
+        f"missing members: {expected - set(members)}; got {sorted(members)}"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.requires_vst
+@skip_no_vst
+def test_make_wds_dataset_metadata_json_is_strict_shard_metadata(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+    """The shard's ``metadata.json`` member parses as a strict ``ShardMetadata`` matching the
+    cfg."""
+    out = tmp_path / "shard-000000.tar"
+    num_samples = 2
+    render_cfg = _render_cfg(num_samples)
+
+    make_wds_dataset(
+        wds_file=out,
+        render_cfg=render_cfg,
+        fixed_synth_params_list=[_HARDCODED_SYNTH_PARAMS] * num_samples,
+        fixed_note_params_list=[_HARDCODED_NOTE_PARAMS] * num_samples,
+    )
+
+    members = _tar_members(out)
+    meta = ShardMetadata.model_validate_json(members["metadata.json"])
+    assert meta.velocity == render_cfg.velocity
+    assert meta.signal_duration_seconds == render_cfg.signal_duration_seconds
+    assert meta.sample_rate == render_cfg.sample_rate
+    assert meta.channels == render_cfg.channels
+    assert meta.min_loudness == render_cfg.min_loudness
+
+
+@pytest.mark.slow
+@pytest.mark.requires_vst
+@skip_no_vst
+def test_make_wds_dataset_audio_is_float16(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+    """Audio members are ``float16`` so they match the h5 path's storage precision."""
+    out = tmp_path / "shard-000000.tar"
+    num_samples = 2
+
+    make_wds_dataset(
+        wds_file=out,
+        render_cfg=_render_cfg(num_samples),
+        fixed_synth_params_list=[_HARDCODED_SYNTH_PARAMS] * num_samples,
+        fixed_note_params_list=[_HARDCODED_NOTE_PARAMS] * num_samples,
+    )
+
+    members = _tar_members(out)
+    audio = _load_npy_bytes(members["00000000.audio.npy"])
+    mel = _load_npy_bytes(members["00000000.mel_spec.npy"])
+    params = _load_npy_bytes(members["00000000.param_array.npy"])
+    assert audio.dtype == np.float16
+    assert mel.dtype == np.float32
+    assert params.dtype == np.float32
+
+
+@pytest.mark.slow
+@pytest.mark.requires_vst
+@skip_no_vst
+def test_h5_and_wds_outputs_are_equivalent(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+    """Same params written through both writers produce equivalent on-disk arrays.
+
+    Load-bearing test from the original #874 acceptance checklist. Pins the
+    invariant that downstream consumers see equivalent data regardless of
+    which writer produced the shard — the wds path can't drift from the h5
+    path without this test failing.
+
+    Exact byte equality is asserted for ``param_array`` (deterministic — same
+    params → same encoded vector) and for ``ShardMetadata``-derived sidecar
+    values. The renderer's phase-init nondeterminism (#489) means two renders
+    of the same params can differ at the sample level even with
+    ``fixed_synth_params_list`` pinned, so audio and mel are compared via the
+    phase-robust metrics this repo already pins for h5↔h5 round-trips.
+    """
+    num_samples = 2
+    fixed_synth = [_HARDCODED_SYNTH_PARAMS] * num_samples
+    fixed_note = [_HARDCODED_NOTE_PARAMS] * num_samples
+    render_cfg = _render_cfg(num_samples)
+
+    h5_path = tmp_path / "shard.h5"
+    tar_path = tmp_path / "shard.tar"
+
+    make_hdf5_dataset(
+        hdf5_file=h5_path,
+        render_cfg=render_cfg,
+        fixed_synth_params_list=fixed_synth,
+        fixed_note_params_list=fixed_note,
+    )
+    make_wds_dataset(
+        wds_file=tar_path,
+        render_cfg=render_cfg,
+        fixed_synth_params_list=fixed_synth,
+        fixed_note_params_list=fixed_note,
+    )
+
+    # Iterate the tar via webdataset so we exercise the consumer-side path.
+    wds_rows_audio: list[np.ndarray] = []
+    wds_rows_mel: list[np.ndarray] = []
+    wds_rows_params: list[np.ndarray] = []
+    metadata_json_bytes: bytes | None = None
+    for sample in wds.WebDataset(str(tar_path)):  # pyright: ignore[reportAttributeAccessIssue]
+        if sample.get("__key__") == "metadata":
+            metadata_json_bytes = sample["json"]
+            continue
+        wds_rows_audio.append(_load_npy_bytes(sample["audio.npy"]))
+        wds_rows_mel.append(_load_npy_bytes(sample["mel_spec.npy"]))
+        wds_rows_params.append(_load_npy_bytes(sample["param_array.npy"]))
+
+    assert metadata_json_bytes is not None, "missing metadata.json member in wds tar"
+
+    wds_audio = np.concatenate(wds_rows_audio, axis=0)
+    wds_mel = np.concatenate(wds_rows_mel, axis=0)
+    wds_params = np.concatenate(wds_rows_params, axis=0)
+
+    with h5py.File(h5_path, "r") as f:
+        audio_ds = f["audio"]
+        mel_ds = f["mel_spec"]
+        params_ds = f["param_array"]
+        assert isinstance(audio_ds, h5py.Dataset)
+        assert isinstance(mel_ds, h5py.Dataset)
+        assert isinstance(params_ds, h5py.Dataset)
+        h5_audio = audio_ds[...]
+        h5_mel = mel_ds[...]
+        h5_params = params_ds[...]
+        h5_attrs = dict(audio_ds.attrs)
+
+    # Dtypes are pinned by the writers; both formats must agree.
+    assert h5_audio.dtype == wds_audio.dtype == np.float16
+    assert h5_mel.dtype == wds_mel.dtype == np.float32
+    assert h5_params.dtype == wds_params.dtype == np.float32
+
+    # Shapes are pinned by the shapes helpers — both writers must produce them.
+    assert h5_audio.shape == wds_audio.shape
+    assert h5_mel.shape == wds_mel.shape
+    assert h5_params.shape == wds_params.shape
+
+    # param_array is byte-equal: same params in, same encoded vector out.
+    np.testing.assert_array_equal(h5_params, wds_params)
+
+    # Audio is phase-perturbed across renders (#489); compare per-row with
+    # phase-robust metrics that the h5↔h5 round-trip tests already use.
+    h5_audio_f32 = h5_audio.astype(np.float32)
+    wds_audio_f32 = wds_audio.astype(np.float32)
+    for i in range(num_samples):
+        _assert_audio_metrics_within_thresholds(
+            h5_audio_f32[i], wds_audio_f32[i], label=f"h5↔wds sample {i}"
+        )
+
+    # Mel is deterministic given audio; the audio phase difference produces a
+    # small mel difference, bounded by the same _MEL_MEAN_ABS_MAX threshold
+    # the h5↔h5 tests use.
+    mel_dist = float(np.mean(np.abs(h5_mel - wds_mel)))
+    assert mel_dist < _MEL_MEAN_ABS_MAX, (
+        f"mel mean abs diff {mel_dist:.4f} exceeds {_MEL_MEAN_ABS_MAX}"
+    )
+
+    # Same ShardMetadata projection underlies both — sidecar values match.
+    wds_meta = ShardMetadata.model_validate_json(metadata_json_bytes)
+    # h5py stores ints/floats; pydantic preserves Python types — compare per field.
+    # h5py.AttributeManager returns numpy scalars; ``int()``/``float()`` coerce them at runtime.
+    assert int(h5_attrs["velocity"]) == wds_meta.velocity  # pyright: ignore[reportArgumentType]
+    assert (
+        float(h5_attrs["signal_duration_seconds"])  # pyright: ignore[reportArgumentType]
+        == wds_meta.signal_duration_seconds
+    )
+    assert int(h5_attrs["sample_rate"]) == wds_meta.sample_rate  # pyright: ignore[reportArgumentType]
+    assert int(h5_attrs["channels"]) == wds_meta.channels  # pyright: ignore[reportArgumentType]
+    assert (
+        float(h5_attrs["min_loudness"])  # pyright: ignore[reportArgumentType]
+        == wds_meta.min_loudness
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.requires_vst
+@skip_no_vst
+def test_make_wds_dataset_metadata_json_strict_rejects_extra(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+    """The metadata.json member round-trips through strict ``ShardMetadata`` validation.
+
+    Mirrors the trust-boundary contract used by the consumer: a corrupt
+    sidecar would surface as a pydantic ``ValidationError`` rather than
+    silently passing through with wrong values.
+    """
+    out = tmp_path / "shard-000000.tar"
+    num_samples = 2
+
+    make_wds_dataset(
+        wds_file=out,
+        render_cfg=_render_cfg(num_samples),
+        fixed_synth_params_list=[_HARDCODED_SYNTH_PARAMS] * num_samples,
+        fixed_note_params_list=[_HARDCODED_NOTE_PARAMS] * num_samples,
+    )
+
+    members = _tar_members(out)
+    raw = json.loads(members["metadata.json"])
+    # ``extra="forbid"`` on ShardMetadata means unknown fields raise.
+    raw["unexpected_field"] = "boom"
+    with pytest.raises(Exception, match="unexpected_field"):
+        ShardMetadata.model_validate(raw)

--- a/tests/data/vst/test_writers_wds_e2e.py
+++ b/tests/data/vst/test_writers_wds_e2e.py
@@ -17,10 +17,10 @@ from pathlib import Path
 import h5py
 import hdf5plugin  # noqa: F401  registers Blosc2 for h5py reads
 import numpy as np
+import pydantic
 import pytest
 import webdataset as wds
 
-from synth_setter.data.vst import param_specs
 from synth_setter.data.vst.writers import make_hdf5_dataset, make_wds_dataset
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
 from synth_setter.pipeline.schemas.spec import RenderConfig
@@ -42,13 +42,11 @@ skip_no_vst = pytest.mark.skipif(
     reason=f"VST plugin not found at {_PLUGIN_PATH}",
 )
 
-# Hardcoded loudness-passing patch from a prior surge_xt run — same one
-# ``test_generate_vst_dataset.py`` uses. Inlined here to avoid a cross-test
-# import dependency (the other module's _HARDCODED_SYNTH_PARAMS is module-
-# private). Re-importing it via a fixture would couple this module to that
-# one's test setup; copying the literal keeps each module self-contained.
-# When the spec changes the hardcoded dict in BOTH modules needs regenerating
-# — kept in sync manually.
+# Hardcoded loudness-passing patch and h5↔h5 phase-robust comparison helpers
+# are reused verbatim from ``test_generate_vst_dataset.py`` so this module's
+# h5↔wds parity check uses the same thresholds the h5↔h5 round-trip tests
+# already pin. Imported (not copied) on purpose: a future spec change updates
+# the canonical patch in one place, and both test modules track it.
 from tests.data.vst.test_generate_vst_dataset import (
     _HARDCODED_NOTE_PARAMS,
     _HARDCODED_SYNTH_PARAMS,
@@ -315,5 +313,5 @@ def test_make_wds_dataset_metadata_json_strict_rejects_extra(tmp_path: Path) -> 
     raw = json.loads(members["metadata.json"])
     # ``extra="forbid"`` on ShardMetadata means unknown fields raise.
     raw["unexpected_field"] = "boom"
-    with pytest.raises(Exception, match="unexpected_field"):
+    with pytest.raises(pydantic.ValidationError, match="unexpected_field"):
         ShardMetadata.model_validate(raw)


### PR DESCRIPTION
## Summary

Splits the single `make_dataset(h5py.File, render_cfg)` into two writer entrypoints:

- `make_hdf5_dataset(hdf5_file: Path | str, render_cfg, ...)` — keeps the resumable HDF5 path; signature changes to take a path and open the file internally. Writes the `audio.attrs` sidecar from a new `ShardMetadata` instance.
- `make_wds_dataset(wds_file: Path | str, render_cfg, ...)` — new wds path using `webdataset.TarWriter`. Emits per-batch `.npy` members plus a `metadata.json` member from the same `ShardMetadata` instance.

Both paths share rendering logic via `_validate_fixed_params_lengths` / `_generate_sample_for_index` / `_shard_metadata_from_render` / `_render_in_batches` helpers, and the CLI `main` dispatches by `data_file` suffix via `EXTENSION_TO_OUTPUT_FORMAT` (from #1024). New writer helpers land in a fresh `synth_setter.data.vst.writers` module so the `code-quality` guard (#938) stays green without docstring-cleaning the legacy parts of `generate_vst_dataset.py`.

Updates the one in-tree caller (`tools/surge_xt_interactive.py:1238`) to use the new signature.

Also picks up post-#874 cleanup in `cli/generate_dataset.py` — drops the stale "HDF5-only" docstring claims.

## Stacked on
- #1024 (`internal-feat/schemas-extension-to-output-format`) — needs `EXTENSION_TO_OUTPUT_FORMAT`.
- #1025 (`internal-feat/vst-shape-helpers`) — needs the `shapes` module.

## Acceptance criteria

The load-bearing test from the original #874 acceptance — `test_h5_and_wds_outputs_are_equivalent` — passes: rendering the same N samples through both writers produces byte-equal `param_array` and phase-robust-equivalent audio/mel (Surge XT's phase-init nondeterminism, #489, makes exact audio byte-equality impossible across calls, so audio is compared via the same MSS/wMFCC/SOT/RMS metrics the h5↔h5 round-trip tests already pin).

## Note on renamed public symbol

This is `internal-feat` (writer is new tested code building toward the wds feature) but it renames the existing public `make_dataset` symbol — the one in-tree caller (`tools/surge_xt_interactive.py`) is updated in this PR.

## Test plan
- [x] `pytest tests/data/vst/ -v` — old + new tests green
- [x] `test_h5_and_wds_outputs_are_equivalent` ports from the worktree branch and is green
- [x] CLI suffix dispatcher tests cover `.h5`, `.tar`, and the rejection path
- [x] `make test-fast`
- [x] `python scripts/check_no_new_funcs_in_pydoclint_excluded.py --base origin/main` exits 0

Refs #874
Refs #882