### PR TITLE
ci(testing): wire Codecov gates and consolidate coverage collection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
       - "configs/**"
       - "scripts/**"
       - "pyproject.toml"
+      - "codecov.yml"
       - ".github/workflows/test.yml"
   pull_request:
     branches: [main, "release/*", "dev"]
@@ -19,6 +20,7 @@ on:
       - "configs/**"
       - "scripts/**"
       - "pyproject.toml"
+      - "codecov.yml"
       - ".github/workflows/test.yml"
 
 jobs:
@@ -48,16 +50,27 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv pip install --system -e ".[torch,dev]"
+        run: |
+          uv pip install --system -e ".[torch,dev]"
+          uv pip install --system pytest-cov[toml]
 
       - name: List dependencies
         run: uv pip list --system
 
-      - name: Run pytest
+      - name: Run pytest with coverage
         env:
           HYDRA_FULL_ERROR: "1"
         run: |
-          pytest -n auto -m "not slow and not gpu and not mps" -vv -s
+          pytest -n auto -m "not slow and not gpu and not mps" -vv -s \
+            --cov=src --cov-branch --cov-report=xml --cov-report=term
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          flags: unit-cpu
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
   run_tests_macos:
     runs-on: ${{ matrix.os }}
@@ -85,44 +98,24 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
-        run: uv pip install --system -e ".[torch,dev]"
-
-      - name: List dependencies
-        run: uv pip list --system
-
-      - name: Run pytest
-        env:
-          HYDRA_FULL_ERROR: "1"
-        run: pytest -n auto -m "not slow and not gpu and not mps" -vv -s
-
-  # upload code coverage report
-  code-coverage:
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: Install dependencies
         run: |
           uv pip install --system -e ".[torch,dev]"
           uv pip install --system pytest-cov[toml]
 
-      - name: Run tests and collect coverage
+      - name: List dependencies
+        run: uv pip list --system
+
+      - name: Run pytest with coverage
         env:
           HYDRA_FULL_ERROR: "1"
-        run: pytest -n auto -m "not slow and not gpu and not mps" --cov src # NEEDS TO BE UPDATED WHEN CHANGING THE NAME OF "src" FOLDER
+        run: |
+          pytest -n auto -m "not slow and not gpu and not mps" -vv -s \
+            --cov=src --cov-branch --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
-    timeout-minutes: 40
+        with:
+          files: coverage.xml
+          flags: unit-cpu
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/Makefile
+++ b/Makefile
@@ -141,12 +141,13 @@ install-surge-xt: ## Download Surge XT VST3 into plugins/ (skipped if already pr
 	esac; \
 	echo "Installed $$DEST"
 
-# coverage runs serially (no -n auto): GPU tests require exclusive device
-# access and VRAM contention causes flaky failures with xdist parallelism.
+# Mirrors the --cov flags used by .github/workflows/test.yml so local
+# coverage runs reproduce CI output (xml report feeds Codecov; html is for
+# local browsing).
 coverage: ## Run tests with coverage report
 	pip install uv
 	uv pip install pytest-cov[toml]
-	pytest --cov=src --cov-report=term-missing --cov-report=html -m "not slow"
+	pytest --cov=src --cov-branch --cov-report=xml --cov-report=term-missing --cov-report=html -m "not slow and not gpu and not mps"
 
 benchmark: ## Run performance benchmarks
 	pytest --benchmark-only -m "benchmark" -v

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,80 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        informational: true
+
+comment:
+  layout: "diff, flags, components, files"
+  behavior: default
+  require_changes: false
+
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: unit-cpu
+      paths:
+        - src/synth_setter/
+        - scripts/ci/
+
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: auto
+        threshold: 0.5%
+        informational: true
+  individual_components:
+    - component_id: pipeline
+      name: pipeline
+      paths:
+        - src/synth_setter/pipeline/**
+      statuses:
+        - type: project
+          target: 90%
+          informational: true
+    - component_id: models
+      name: models
+      paths:
+        - src/synth_setter/models/**
+      statuses:
+        - type: project
+          target: 85%
+          informational: true
+    - component_id: data
+      name: data
+      paths:
+        - src/synth_setter/data/**
+    - component_id: evaluation
+      name: evaluation
+      paths:
+        - src/synth_setter/evaluation/**
+    - component_id: tools
+      name: tools
+      paths:
+        - src/synth_setter/tools/**
+      statuses:
+        - type: project
+          target: 50%
+          informational: true
+    - component_id: cli
+      name: cli
+      paths:
+        - src/synth_setter/cli/**
+    - component_id: scripts-ci
+      name: scripts-ci
+      paths:
+        - scripts/ci/**
+
+ignore:
+  - "tests/**"
+  - "**/__main__.py"
+  - "docs/**"
+  - "scripts/skypilot/**"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -372,6 +372,19 @@ minor_tags = ["feat"]
 patch_tags = ["fix", "perf", "revert"]
 
 
+[tool.coverage.run]
+source = ["src/synth_setter", "scripts/ci"]
+branch = true
+parallel = true
+relative_files = true
+omit = ["**/__main__.py"]
+
+
+[tool.coverage.paths]
+source = ["src/synth_setter", "*/src/synth_setter"]
+scripts = ["scripts/ci", "*/scripts/ci"]
+
+
 [tool.coverage.report]
 exclude_lines = [
     "pragma: nocover",


### PR DESCRIPTION
## Summary

Steps 2–4 of the coverage-enforcement roadmap in #14. This PR builds the gating infrastructure; **step 1 (Codecov GitHub App install + `CODECOV_TOKEN` secret) is org-admin work in the UI and lands separately** — until that's done, the upload step in this workflow is a graceful no-op (`fail_ci_if_error: false`).

### What's in here

- **`.github/workflows/test.yml`** — collapse the duplicate `code-coverage` job into the existing matrix legs (`ubuntu 3.10`, `ubuntu 3.11`, `macos 3.10`). Each leg now writes `coverage.xml` and uploads under the `unit-cpu` flag. Saves ~20 min of CI per PR.
- **`pyproject.toml`** — add `[tool.coverage.run]` (source, `branch=true`, `parallel=true`, `relative_files=true`, `omit=["**/__main__.py"]`) and `[tool.coverage.paths]` so reports from different worktree paths merge cleanly.
- **`codecov.yml`** (new) — project + patch status checks (`informational: true` initially), `unit-cpu` flag, per-directory component targets:
  - `pipeline` 90%
  - `models` 85%
  - `tools` 50%
  - everything else: `auto` (no regression beyond 0.5% threshold)
  - Validated against `https://codecov.io/validate` (returns "Valid!").
- **`Makefile`** — align `make coverage` with the CI flags (`--cov-branch`, xml+html reports, same marker filter).

### Deliberately deferred (separate PRs)

- Wiring coverage into GPU (`test-gpu.yml`), MPS (`test-mps.yml`), VST (`test-vst-slow.yml`), and slow (`cpu-slow.yml`) workflows with their own flags — each has runner nuances and warrants its own review.
- `diff-cover` fallback gate.
- Codecov badge in `README.md`.
- Flipping `codecov/project` and `codecov/patch` from `informational` to required branch-protection checks (do this after ~1 week of baseline numbers).
- Backfilling tests to reach 80% — tracked separately by #30.

### Why `informational: true` initially

Lets Codecov post deltas on every PR without blocking merges. Once we have a week of data to calibrate the project target (`auto` will lock in current baseline), flip both statuses to non-informational and add them to branch protection.

## Test plan

- [x] `pyproject.toml` parses; `[tool.coverage.run]` and `[tool.coverage.paths]` populated as expected.
- [x] `.github/workflows/test.yml` and `codecov.yml` parse as valid YAML; `pre-commit run --files …` passes (including `Validate GitHub Workflows`).
- [x] `codecov.yml` accepted by `https://codecov.io/validate` ("Valid!").
- [ ] CI runs: each matrix leg produces `coverage.xml` and the Codecov upload step runs without erroring (no-op until token lands, which is fine).
- [ ] After step 1 lands separately: confirm Codecov posts a PR comment with the `diff, flags, components, files` layout, and that `flags=unit-cpu` + components show up.

Refs #14, #149, #155, #30