### PR TITLE
ci: skip Copilot dynamic-workflow check-runs in auto-approve

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -160,16 +160,34 @@ jobs:
           # re-triggered check permanently blocks auto-approve.
           # See: PR #142 — check-pr-metadata passed on re-run but auto-approve
           # still saw "1 check(s) failed" from the original run.
-          CHECK_DATA=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" --jq '
-            [.check_runs[]
-              | select((.name | startswith("auto-approve")) | not)
-              | select(.name != "Auto-approve status")
-            ]
-            | group_by(.name)
-            | map(sort_by(.id) | last)
-            | .[]
-            | "\(.status) \(.conclusion // "none") \(.name)"
-          ')
+          #
+          # BUG FIX: The "Copilot code review" workflow is GitHub-managed
+          # (event=="dynamic") and can leave failed bootstrap check-runs
+          # (e.g. a "Prepare" job failing with "Resource not accessible by
+          # integration") attached to the head SHA even when the review
+          # itself posts successfully in a later run. We can't see or re-run
+          # those workflows, and the dedupe-by-name above doesn't help
+          # because the failed check_run name only appears in the failing
+          # run. Filter the whole Copilot suite out. We deliberately do NOT
+          # filter on event=="dynamic" alone — the GitHub-managed default-
+          # setup CodeQL pipeline (workflow name "PR #<n>", event="dynamic")
+          # contributes the `Analyze (actions)` / `Analyze (python)` checks
+          # we DO want to gate on. See PR #1024.
+          COPILOT_SUITE_IDS=$(gh api \
+            "repos/${REPO}/actions/runs?head_sha=${HEAD_SHA}&per_page=100" \
+            --jq '[.workflow_runs[] | select(.name == "Copilot code review") | .check_suite_id] | unique')
+          CHECK_DATA=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+            | jq --argjson skip "$COPILOT_SUITE_IDS" -r '
+              [.check_runs[]
+                | select((.name | startswith("auto-approve")) | not)
+                | select(.name != "Auto-approve status")
+                | select(.check_suite.id as $id | $skip | index($id) | not)
+              ]
+              | group_by(.name)
+              | map(sort_by(.id) | last)
+              | .[]
+              | "\(.status) \(.conclusion // "none") \(.name)"
+            ')
           PENDING=$(echo "$CHECK_DATA" | grep -c "^queued\|^in_progress" || true)
           FAILED=$(echo "$CHECK_DATA" | grep -v "^completed success\|^completed skipped\|^completed neutral\|^queued\|^in_progress" | grep -c . || true)
           if [ "$PENDING" -gt 0 ]; then


### PR DESCRIPTION
## Summary

- `auto-approve.yml` Condition 2 now lists workflow_runs for the head SHA, collects `check_suite_id`s of any workflow_run whose name is `"Copilot code review"`, and filters their check-runs out before counting failures.
- Targets exactly the GitHub-managed Copilot reviewer (which periodically fails its bootstrap `Prepare` job with *"Resource not accessible by integration"* and leaves the failure attached to the SHA forever).
- Deliberately **not** scoped to `event == "dynamic"` broadly — GitHub's default-setup CodeQL pipeline also runs as `event: dynamic` under workflow name `PR #<n>` and contributes the `Analyze (actions)` / `Analyze (python)` checks we still want to gate on.

## Background

Observed on PR #1024:
- `Prepare` (check-run [75889978017](https://github.com/tinaudio/synth-setter/actions/runs/25829235016/job/75889978017)) failed at 22:07:48 with `Unhandled error: HttpError: Resource not accessible by integration`.
- Copilot itself still produced 4 reviews and 9 inline comments — the workflow recovered, but the failed check-run lingered.
- Auto-approve reported `Not eligible / 1 check(s) failed` ([check 75890493539](https://github.com/tinaudio/synth-setter/runs/75890493539)) — every other check on the PR was green.

## Test plan

- [x] Replayed Condition 2 logic locally against PR #1024's head SHA (`5ebfc7e0…`) with the new filter → `PENDING=0 FAILED=0`. Copilot's failed `Prepare` excluded; CodeQL `Analyze (actions)` and `Analyze (python)` preserved alongside all 15 other in-repo workflow checks.
- [x] `python <plugin>/gha-workflow-validator/scripts/validate_workflow.py .github/workflows/auto-approve.yml` → 10 passed, 2 warnings (unrelated: APPROVAL_BOT_APP_ID / APPROVAL_BOT_PRIVATE_KEY are repo secrets), 0 failures.
- [x] `pre-commit run --files .github/workflows/auto-approve.yml` → all hooks pass (check yaml, prettier, codespell, Validate GitHub Workflows).
- [ ] After merge, confirm next PR's auto-approve evaluation no longer trips on a stale Copilot `Prepare` failure.

Closes #1032