### PR TITLE
internal-feat(pipeline): validate_shard tar branch + EXTENSION_TO_OUTPUT_FORMAT dispatch

### DIFF
--- a/src/synth_setter/pipeline/ci/validate_shard.py
+++ b/src/synth_setter/pipeline/ci/validate_shard.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
-"""Validate HDF5 shards against a DatasetSpec.
+"""Validate dataset shards against a DatasetSpec.
 
-Checks that each shard file is a valid HDF5 file, contains the per-row
-arrays the writer emits (``synth_setter.data.vst.shapes.DATASET_FIELD_NAMES``),
-and that each dataset's full ``.shape`` matches what those shape helpers
-predict for ``spec.render`` — i.e. ``(N, C, time)`` for audio,
-``(N, C, n_mels, n_frames)`` for the mel spectrogram, and
-``(N, num_params)`` for the param array.
+Performs full per-shard validation. Each shard file is dispatched by its
+filename suffix via ``synth_setter.pipeline.schemas.spec.EXTENSION_TO_OUTPUT_FORMAT``
+to either the HDF5 path (``.h5``) or the wds tar path (``.tar``):
+
+- HDF5 path: each top-level dataset's full ``.shape`` matches the writer's
+  source-of-truth shape helpers in ``synth_setter.data.vst.shapes`` —
+  ``(N, C, time)`` for audio, ``(N, C, n_mels, n_frames)`` for the mel
+  spectrogram, and ``(N, num_params)`` for the param array.
+- wds tar path: ``metadata.json`` is present and parses as a strict
+  ``ShardMetadata``; every ``<batch_start_idx:08d>.<field>.npy`` member loads
+  as a numpy array whose trailing dims (``arr.shape[1:]``) match the same
+  shape helpers; and the summed row count per field equals
+  ``spec.render.batch_per_shard``.
 
 CLI usage:
     python3 -m synth_setter.pipeline.ci.validate_shard <spec.json|r2://bucket/spec.json>
@@ -17,11 +24,15 @@ Iterates `spec.shards` and downloads each shard from R2 (under
 
 from __future__ import annotations
 
+import io
 import sys
+import tarfile
 from pathlib import Path
 from typing import cast
 
 import h5py
+import numpy as np
+from pydantic import ValidationError
 
 from synth_setter.data.vst.shapes import (
     AUDIO_FIELD,
@@ -33,7 +44,10 @@ from synth_setter.data.vst.shapes import (
     param_array_dataset_shape,
 )
 from synth_setter.pipeline.r2_io import downloaded_to_tempfile, is_r2_uri, shard_uri
-from synth_setter.pipeline.schemas.spec import DatasetSpec
+from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
+from synth_setter.pipeline.schemas.spec import EXTENSION_TO_OUTPUT_FORMAT, DatasetSpec
+
+_TAR_METADATA_MEMBER = "metadata.json"
 
 
 def _expected_dataset_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
@@ -63,15 +77,14 @@ def _expected_dataset_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
 
 
 def validate_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:
-    """Validate one HDF5 shard against a DatasetSpec.
+    """Validate one shard against a DatasetSpec, dispatching by filename suffix.
 
-    Checks:
-    1. File opens as HDF5
-    2. Contains every dataset named in ``DATASET_FIELD_NAMES``
-    3. Each dataset's full ``.shape`` matches what
-       ``_expected_dataset_shapes`` predicts for ``spec``
+    Suffix dispatch via ``EXTENSION_TO_OUTPUT_FORMAT``: ``.h5`` -> HDF5 path,
+    ``.tar`` -> tar/wds path. Any other suffix is rejected with an error
+    naming the registered set so a typo or wrong-format file does not
+    surface as a misleading "not valid HDF5".
 
-    :param shard_path: Local filesystem path to the HDF5 shard to validate.
+    :param shard_path: Local filesystem path to the shard to validate.
     :param spec: Dataset spec the shard is expected to conform to.
     :returns: List of error strings (empty = valid).
     :rtype: list[str]
@@ -79,6 +92,29 @@ def validate_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:
     if not shard_path.exists():
         return [f"shard file not found: {shard_path}"]
 
+    fmt = EXTENSION_TO_OUTPUT_FORMAT.get(shard_path.suffix)
+    if fmt == "hdf5":
+        return _validate_h5_shard(shard_path, spec)
+    if fmt == "wds":
+        return _validate_tar_shard(shard_path, spec)
+    return [
+        f"unsupported shard suffix {shard_path.suffix!r} "
+        f"(expected one of: {sorted(EXTENSION_TO_OUTPUT_FORMAT)})"
+    ]
+
+
+def _validate_h5_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:
+    """Validate an HDF5 shard's datasets, row counts, and inner shapes.
+
+    Opens the file with h5py, checks every dataset named in ``DATASET_FIELD_NAMES``
+    is present, and that each dataset's full ``.shape`` matches what
+    ``_expected_dataset_shapes`` predicts for ``spec``.
+
+    :param shard_path: Local filesystem path to the HDF5 shard.
+    :param spec: Dataset spec the shard is expected to conform to.
+    :returns: List of error strings (empty = valid).
+    :rtype: list[str]
+    """
     try:
         f = h5py.File(shard_path, "r")
     except OSError:
@@ -91,13 +127,121 @@ def validate_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:
             if name not in f:
                 errors.append(f"missing dataset: {name!r}")
                 continue
-
             actual = cast(h5py.Dataset, f[name]).shape
             expected = expected_shapes[name]
             if actual != expected:
                 errors.append(f"dataset {name!r} has shape {actual}, expected {expected}")
 
     return errors
+
+
+def _validate_tar_metadata(tar: tarfile.TarFile, member_name: str) -> list[str]:
+    """Validate the tar's ``metadata.json`` parses as a strict ``ShardMetadata``.
+
+    Trust-boundary parse: ``ShardMetadata`` is constructed with
+    ``extra="forbid"`` and ``strict=True`` so unknown keys or type-coerced
+    values surface as a ``ValidationError`` instead of being silently accepted.
+
+    :param tar: Open ``TarFile`` handle. Caller owns the lifecycle.
+    :param member_name: Name of the metadata member to extract.
+    :returns: One error string per problem; empty if metadata is valid.
+    :rtype: list[str]
+    """
+    extracted = tar.extractfile(member_name)
+    if extracted is None:
+        return [f"unable to extract tar member: {member_name!r}"]
+    payload = extracted.read()
+    try:
+        ShardMetadata.model_validate_json(payload)
+    except ValidationError as exc:
+        return [f"{member_name}: invalid ShardMetadata: {exc}"]
+    return []
+
+
+def _validate_tar_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:
+    """Validate a wds tar shard's members, metadata, row counts, and inner shapes.
+
+    Tar member layout: per-batch ``<batch_start_idx:08d>.<field>.npy`` plus a
+    single ``metadata.json``. Checks:
+
+    1. The file opens as an uncompressed tar archive.
+    2. ``metadata.json`` is present and parses as a strict ``ShardMetadata``.
+    3. Every batch-keyed ``.npy`` member loads as a numpy array.
+    4. Each per-batch array's trailing dims (``arr.shape[1:]``) match the
+       corresponding writer shape (dropping the N dim).
+    5. The summed row count per field across all batches equals
+       ``spec.render.batch_per_shard``.
+
+    :param shard_path: Local filesystem path to the tar shard.
+    :param spec: Dataset spec the shard is expected to conform to.
+    :returns: List of error strings (empty = valid).
+    :rtype: list[str]
+    """
+    try:
+        tar = tarfile.open(shard_path, mode="r:")
+    except tarfile.TarError:
+        return [f"file is not a valid uncompressed tar archive: {shard_path}"]
+
+    expected_inner = {field: shape[1:] for field, shape in _expected_dataset_shapes(spec).items()}
+    errors: list[str] = []
+    with tar:
+        members = sorted(m.name for m in tar.getmembers())
+
+        if _TAR_METADATA_MEMBER not in members:
+            errors.append(f"missing tar member: {_TAR_METADATA_MEMBER!r}")
+        else:
+            errors.extend(_validate_tar_metadata(tar, _TAR_METADATA_MEMBER))
+
+        rows_by_field: dict[str, int] = {field: 0 for field in DATASET_FIELD_NAMES}
+        seen_by_field: dict[str, int] = {field: 0 for field in DATASET_FIELD_NAMES}
+        for name in members:
+            if not name.endswith(".npy"):
+                continue
+            stem = name[: -len(".npy")]
+            _, _, field = stem.rpartition(".")
+            if field not in rows_by_field:
+                continue
+            arr_or_err = _load_npy_member(tar, name)
+            if isinstance(arr_or_err, str):
+                errors.append(arr_or_err)
+                continue
+            rows_by_field[field] += arr_or_err.shape[0]
+            seen_by_field[field] += 1
+            if arr_or_err.shape[1:] != expected_inner[field]:
+                errors.append(
+                    f"{name}: inner shape {arr_or_err.shape[1:]} does not match "
+                    f"expected {expected_inner[field]}"
+                )
+
+        for field in DATASET_FIELD_NAMES:
+            if seen_by_field[field] == 0:
+                errors.append(f"missing tar member: '*.{field}.npy'")
+                continue
+            if rows_by_field[field] != spec.render.batch_per_shard:
+                errors.append(
+                    f"field {field!r} summed {rows_by_field[field]} rows across "
+                    f"{seen_by_field[field]} batch(es), expected {spec.render.batch_per_shard}"
+                )
+
+    return errors
+
+
+def _load_npy_member(tar: tarfile.TarFile, name: str) -> np.ndarray | str:
+    """Load a ``.npy`` tar member into a numpy array, or return an error string.
+
+    :param tar: Open ``TarFile`` handle. Caller owns the lifecycle.
+    :param name: Name of the ``.npy`` member to extract and load.
+    :returns: Loaded array on success, or a single error-message string describing
+        the extraction or load failure.
+    :rtype: np.ndarray | str
+    """
+    extracted = tar.extractfile(name)
+    if extracted is None:
+        return f"unable to extract tar member: {name!r}"
+    try:
+        return np.load(io.BytesIO(extracted.read()))
+    except (ValueError, EOFError, OSError) as exc:
+        return f"{name}: malformed npy payload: {exc}"
 
 
 def _load_spec(spec_arg: str) -> DatasetSpec:

--- a/src/synth_setter/pipeline/ci/validate_shard.py
+++ b/src/synth_setter/pipeline/ci/validate_shard.py
@@ -25,6 +25,7 @@ Iterates `spec.shards` and downloads each shard from R2 (under
 from __future__ import annotations
 
 import io
+import re
 import sys
 import tarfile
 from pathlib import Path
@@ -48,6 +49,7 @@ from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
 from synth_setter.pipeline.schemas.spec import EXTENSION_TO_OUTPUT_FORMAT, DatasetSpec
 
 _TAR_METADATA_MEMBER = "metadata.json"
+_TAR_NPY_NAME_RE = re.compile(r"^(?P<batch_key>\d{8})\.(?P<field>[^./]+)\.npy$")
 
 
 def _expected_dataset_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
@@ -166,10 +168,14 @@ def _validate_tar_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:
 
     1. The file opens as an uncompressed tar archive.
     2. ``metadata.json`` is present and parses as a strict ``ShardMetadata``.
-    3. Every batch-keyed ``.npy`` member loads as a numpy array.
-    4. Each per-batch array's trailing dims (``arr.shape[1:]``) match the
+    3. Every ``.npy`` member name matches ``<batch_start_idx:08d>.<field>.npy``
+       (no missing or malformed batch keys).
+    4. Every batch-keyed ``.npy`` member loads as a numpy array.
+    5. Within each batch key, all writer fields are present and share the same
+       row count (the writer's per-batch invariant).
+    6. Each per-batch array's trailing dims (``arr.shape[1:]``) match the
        corresponding writer shape (dropping the N dim).
-    5. The summed row count per field across all batches equals
+    7. The summed row count per field across all batches equals
        ``spec.render.batch_per_shard``.
 
     :param shard_path: Local filesystem path to the tar shard.
@@ -192,42 +198,107 @@ def _validate_tar_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:
         else:
             errors.extend(_validate_tar_metadata(tar, _TAR_METADATA_MEMBER))
 
-        rows_by_field: dict[str, int] = {field: 0 for field in DATASET_FIELD_NAMES}
-        seen_by_field: dict[str, int] = {field: 0 for field in DATASET_FIELD_NAMES}
+        rows_by_batch: dict[str, dict[str, int]] = {}
         for name in members:
             if not name.endswith(".npy"):
                 continue
-            stem = name[: -len(".npy")]
-            _, _, field = stem.rpartition(".")
-            if field not in rows_by_field:
+            match = _TAR_NPY_NAME_RE.match(name)
+            if match is None:
+                errors.append(
+                    f"malformed tar member name: {name!r} "
+                    f"(expected '<batch_start_idx:08d>.<field>.npy')"
+                )
+                continue
+            field = match.group("field")
+            if field not in expected_inner:
+                errors.append(f"unknown field in tar member: {name!r}")
                 continue
             arr_or_err = _load_npy_member(tar, name)
             if isinstance(arr_or_err, str):
                 errors.append(arr_or_err)
                 continue
-            rows_by_field[field] += arr_or_err.shape[0]
-            seen_by_field[field] += 1
+            rows_by_batch.setdefault(match.group("batch_key"), {})[field] = arr_or_err.shape[0]
             if arr_or_err.shape[1:] != expected_inner[field]:
                 errors.append(
                     f"{name}: inner shape {arr_or_err.shape[1:]} does not match "
                     f"expected {expected_inner[field]}"
                 )
 
-        for field in DATASET_FIELD_NAMES:
-            if seen_by_field[field] == 0:
-                errors.append(f"missing tar member: '*.{field}.npy'")
-                continue
-            if rows_by_field[field] != spec.render.batch_per_shard:
-                errors.append(
-                    f"field {field!r} summed {rows_by_field[field]} rows across "
-                    f"{seen_by_field[field]} batch(es), expected {spec.render.batch_per_shard}"
-                )
+        errors.extend(_check_per_batch_invariants(rows_by_batch))
+        errors.extend(_check_row_totals(rows_by_batch, spec.render.batch_per_shard))
 
+    return errors
+
+
+def _check_per_batch_invariants(rows_by_batch: dict[str, dict[str, int]]) -> list[str]:
+    """Check the writer's per-batch invariant: every batch key has all fields with matching rows.
+
+    The writer emits one ``.npy`` per ``DATASET_FIELD_NAMES`` for each batch
+    key, and all three are sliced from the same per-sample list — so within
+    a batch the row counts must agree across fields. A drift here would mean
+    misaligned WebDataset samples even if the per-field totals happen to add
+    up.
+
+    :param rows_by_batch: Mapping ``batch_key -> {field: rows}`` populated while
+        iterating tar members. Missing fields surface as the batch key not
+        having an entry for that field.
+    :returns: List of error strings (empty = every batch key has all fields and
+        a single row count).
+    :rtype: list[str]
+    """
+    errors: list[str] = []
+    for batch_key in sorted(rows_by_batch):
+        per_field = rows_by_batch[batch_key]
+        missing = [field for field in DATASET_FIELD_NAMES if field not in per_field]
+        if missing:
+            errors.append(
+                f"batch {batch_key!r} missing field(s): {missing} "
+                f"(expected one '.npy' per field {list(DATASET_FIELD_NAMES)})"
+            )
+            continue
+        row_counts = {per_field[field] for field in DATASET_FIELD_NAMES}
+        if len(row_counts) > 1:
+            errors.append(
+                f"batch {batch_key!r} row-count mismatch across fields: "
+                f"{ {field: per_field[field] for field in DATASET_FIELD_NAMES} }"
+            )
+    return errors
+
+
+def _check_row_totals(rows_by_batch: dict[str, dict[str, int]], batch_per_shard: int) -> list[str]:
+    """Check each field's summed row count across all batches equals ``batch_per_shard``.
+
+    :param rows_by_batch: Mapping ``batch_key -> {field: rows}`` populated while
+        iterating tar members.
+    :param batch_per_shard: The writer's per-shard row total each field must sum to.
+    :returns: List of error strings (empty = every field's row total matches).
+    :rtype: list[str]
+    """
+    errors: list[str] = []
+    for field in DATASET_FIELD_NAMES:
+        batches_with_field = [
+            per_field[field] for per_field in rows_by_batch.values() if field in per_field
+        ]
+        if not batches_with_field:
+            errors.append(f"missing tar member: '*.{field}.npy'")
+            continue
+        total = sum(batches_with_field)
+        if total != batch_per_shard:
+            errors.append(
+                f"field {field!r} summed {total} rows across "
+                f"{len(batches_with_field)} batch(es), expected {batch_per_shard}"
+            )
     return errors
 
 
 def _load_npy_member(tar: tarfile.TarFile, name: str) -> np.ndarray | str:
     """Load a ``.npy`` tar member into a numpy array, or return an error string.
+
+    Rejects payloads that ``np.load`` resolves to anything other than a single
+    ``ndarray`` with at least one dimension (e.g. ``.npz`` bytes saved under a
+    ``.npy`` name resolve to ``NpzFile``; a 0-d scalar has no row dim) — both
+    would later crash the per-batch ``arr.shape[0]`` / ``arr.shape[1:]``
+    accesses with an opaque traceback instead of surfacing here.
 
     :param tar: Open ``TarFile`` handle. Caller owns the lifecycle.
     :param name: Name of the ``.npy`` member to extract and load.
@@ -239,9 +310,14 @@ def _load_npy_member(tar: tarfile.TarFile, name: str) -> np.ndarray | str:
     if extracted is None:
         return f"unable to extract tar member: {name!r}"
     try:
-        return np.load(io.BytesIO(extracted.read()))
+        loaded = np.load(io.BytesIO(extracted.read()))
     except (ValueError, EOFError, OSError) as exc:
         return f"{name}: malformed npy payload: {exc}"
+    if not isinstance(loaded, np.ndarray):
+        return f"{name}: expected a single ndarray, got {type(loaded).__name__}"
+    if loaded.ndim == 0:
+        return f"{name}: expected ndarray with at least one dimension, got 0-d scalar"
+    return loaded
 
 
 def _load_spec(spec_arg: str) -> DatasetSpec:

--- a/tests/pipeline/ci/test_validate_shard_tar.py
+++ b/tests/pipeline/ci/test_validate_shard_tar.py
@@ -370,3 +370,178 @@ class TestTarShardValidation:
         _make_valid_tar_bytes(shard_path, [(0, first), (first, second)])
 
         assert validate_shard(shard_path, real_spec) == []
+
+    def test_validate_shard_tar_rejects_malformed_member_name(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """A ``.npy`` member without the ``<batch:08d>.<field>.npy`` prefix is rejected.
+
+        Guards against silently coercing names like ``audio.npy`` (no batch key)
+        or ``foo.audio.npy`` (non-numeric prefix) into the audio bucket. Even
+        though the trailing field token matches, the writer never emits such
+        names — accepting them would let a malformed shard through.
+
+        :param real_spec: Spec whose render config matches the canonical valid shapes.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.tar"
+        n_rows = real_spec.render.batch_per_shard
+        arrays = _valid_batch_arrays(n_rows)
+        members: dict[str, bytes] = {
+            "audio.npy": _npy_bytes(arrays["audio"]),
+            "00000000.mel_spec.npy": _npy_bytes(arrays["mel_spec"]),
+            "00000000.param_array.npy": _npy_bytes(arrays["param_array"]),
+            "metadata.json": json.dumps(_VALID_METADATA).encode("utf-8"),
+        }
+        _make_tar_with(shard_path, members)
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert any("malformed tar member name" in err and "audio.npy" in err for err in errors)
+
+    def test_validate_shard_tar_rejects_within_batch_row_mismatch(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """A batch key whose per-field row counts disagree surfaces a mismatch error.
+
+        The writer's invariant is that all three fields under one batch key
+        share the same N. A tar where ``audio`` has N rows under one batch
+        key but ``mel_spec``/``param_array`` have different N under that same
+        key would produce misaligned WebDataset samples even if the per-field
+        sums match.
+
+        :param real_spec: Spec whose render config matches the canonical valid shapes.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.tar"
+        total = real_spec.render.batch_per_shard
+        batch_a_audio = 3
+        batch_a_other = total - batch_a_audio
+        batch_b_audio = total - batch_a_audio
+        batch_b_other = batch_a_audio
+        members: dict[str, bytes] = {
+            "00000000.audio.npy": _npy_bytes(_valid_batch_arrays(batch_a_audio)["audio"]),
+            "00000000.mel_spec.npy": _npy_bytes(_valid_batch_arrays(batch_a_other)["mel_spec"]),
+            "00000000.param_array.npy": _npy_bytes(
+                _valid_batch_arrays(batch_a_other)["param_array"]
+            ),
+            f"{batch_a_audio:08d}.audio.npy": _npy_bytes(
+                _valid_batch_arrays(batch_b_audio)["audio"]
+            ),
+            f"{batch_a_audio:08d}.mel_spec.npy": _npy_bytes(
+                _valid_batch_arrays(batch_b_other)["mel_spec"]
+            ),
+            f"{batch_a_audio:08d}.param_array.npy": _npy_bytes(
+                _valid_batch_arrays(batch_b_other)["param_array"]
+            ),
+            "metadata.json": json.dumps(_VALID_METADATA).encode("utf-8"),
+        }
+        _make_tar_with(shard_path, members)
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert any("row-count mismatch" in err for err in errors)
+
+    def test_validate_shard_tar_rejects_batch_key_missing_field(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """A batch key missing one of the three field ``.npy`` files surfaces an error.
+
+        The writer emits one ``.npy`` per ``DATASET_FIELD_NAMES`` for every
+        batch key. A shard with two batch keys where one batch is missing
+        ``param_array`` (yet the field's overall total still hits
+        ``batch_per_shard`` via the other batch) must still be flagged.
+
+        :param real_spec: Spec whose render config matches the canonical valid shapes.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.tar"
+        total = real_spec.render.batch_per_shard
+        first = total // 2
+        second = total - first
+        members: dict[str, bytes] = {
+            "00000000.audio.npy": _npy_bytes(_valid_batch_arrays(first)["audio"]),
+            "00000000.mel_spec.npy": _npy_bytes(_valid_batch_arrays(first)["mel_spec"]),
+            f"{first:08d}.audio.npy": _npy_bytes(_valid_batch_arrays(second)["audio"]),
+            f"{first:08d}.mel_spec.npy": _npy_bytes(_valid_batch_arrays(second)["mel_spec"]),
+            f"{first:08d}.param_array.npy": _npy_bytes(_valid_batch_arrays(second)["param_array"]),
+            "metadata.json": json.dumps(_VALID_METADATA).encode("utf-8"),
+        }
+        members[f"{first + second:08d}.param_array.npy"] = _npy_bytes(
+            _valid_batch_arrays(first)["param_array"]
+        )
+        _make_tar_with(shard_path, members)
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert any(
+            "00000000" in err and "missing field" in err and "param_array" in err for err in errors
+        )
+
+    def test_validate_shard_tar_rejects_npz_payload_under_npy_name(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """A ``.npy`` member whose bytes are actually ``.npz`` (NpzFile) is rejected cleanly.
+
+        Without this guard ``np.load`` would return an ``NpzFile`` which has
+        no ``.shape`` attribute, and the per-batch ``arr.shape[0]`` access
+        would crash with an opaque ``AttributeError`` instead of surfacing
+        the malformed payload as a validation error.
+
+        :param real_spec: Spec whose render config matches the canonical valid shapes.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.tar"
+        n_rows = real_spec.render.batch_per_shard
+        arrays = _valid_batch_arrays(n_rows)
+        npz_buf = io.BytesIO()
+        np.savez(npz_buf, audio=arrays["audio"])
+        members: dict[str, bytes] = {
+            "00000000.audio.npy": npz_buf.getvalue(),
+            "00000000.mel_spec.npy": _npy_bytes(arrays["mel_spec"]),
+            "00000000.param_array.npy": _npy_bytes(arrays["param_array"]),
+            "metadata.json": json.dumps(_VALID_METADATA).encode("utf-8"),
+        }
+        _make_tar_with(shard_path, members)
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert any(
+            "00000000.audio.npy" in err and "expected a single ndarray" in err for err in errors
+        )
+
+    def test_validate_shard_tar_rejects_zero_d_scalar_npy(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """A ``.npy`` member that loads as a 0-d scalar is rejected cleanly.
+
+        A 0-d ndarray has ``.shape == ()`` so ``arr.shape[0]`` would raise
+        ``IndexError`` — we want a targeted validation error instead.
+
+        :param real_spec: Spec whose render config matches the canonical valid shapes.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.tar"
+        n_rows = real_spec.render.batch_per_shard
+        arrays = _valid_batch_arrays(n_rows)
+        members: dict[str, bytes] = {
+            "00000000.audio.npy": _npy_bytes(np.array(0.0, dtype=np.float32)),
+            "00000000.mel_spec.npy": _npy_bytes(arrays["mel_spec"]),
+            "00000000.param_array.npy": _npy_bytes(arrays["param_array"]),
+            "metadata.json": json.dumps(_VALID_METADATA).encode("utf-8"),
+        }
+        _make_tar_with(shard_path, members)
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert any("00000000.audio.npy" in err and "0-d scalar" in err for err in errors)

--- a/tests/pipeline/ci/test_validate_shard_tar.py
+++ b/tests/pipeline/ci/test_validate_shard_tar.py
@@ -1,0 +1,372 @@
+"""Tar/wds branch tests for ``synth_setter.pipeline.ci.validate_shard``.
+
+These tests pin the new dispatch-by-suffix surface that ``validate_shard``
+grew when the tar/wds branch landed alongside the existing HDF5 path:
+
+- ``.h5`` shards continue to run the HDF5 checks (regression guard).
+- ``.tar`` shards run the new tar/wds branch — ``metadata.json`` presence
+  and strict parsing, every ``<batch_key>.<field>.npy`` member loadable as
+  numpy, the summed row count per field equal to ``batch_per_shard``, and
+  each batch's inner shape (``arr.shape[1:]``) equal to the writer's
+  source-of-truth shape helpers in ``synth_setter.data.vst.shapes``.
+- Any other suffix surfaces a clear error naming the supported set.
+
+This file is intentionally *not* on the pydoclint exclude list — every
+helper and test below carries a full sphinx-style docstring (``:param:`` /
+``:returns:`` / ``:rtype:``) so the new defs land with full coverage.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from synth_setter.pipeline.ci.validate_shard import validate_shard
+from synth_setter.pipeline.schemas.spec import DatasetSpec
+
+_VALID_AUDIO_CHANNELS = 2
+_VALID_AUDIO_SAMPLES_PER_ROW = 64000
+_VALID_MEL_INNER_SHAPE: tuple[int, int, int] = (2, 128, 401)
+_VALID_PARAM_LENGTH = 92
+_VALID_METADATA: dict[str, object] = {
+    "velocity": 100,
+    "signal_duration_seconds": 4.0,
+    "sample_rate": 16000,
+    "channels": _VALID_AUDIO_CHANNELS,
+    "min_loudness": -55.0,
+}
+
+
+@pytest.fixture()
+def real_spec(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> DatasetSpec:
+    """Build a ``DatasetSpec`` whose render config matches the module's ``_VALID_*`` constants.
+
+    The sample rate (``16000``) and duration (``4.0``) make audio time-samples
+    ``64000`` and mel ``n_frames`` ``401`` — lining up with ``_VALID_*`` so each
+    test can override exactly one dim while leaving the others correct.
+
+    :param tmp_path: pytest-provided temp directory used for the fake VST3 bundle.
+    :param monkeypatch: pytest monkeypatch used to freeze the git/timestamp factories
+        the spec validators consult — keeps spec construction deterministic on machines
+        without the repo's git metadata available to the schema layer.
+    :returns: Spec whose render fields match the ``_VALID_*`` constants in this module.
+    :rtype: DatasetSpec
+    """
+    fixed_now = datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._get_git_sha", lambda: "a" * 40)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._is_repo_dirty", lambda: False)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._utc_now", lambda: fixed_now)
+
+    contents = tmp_path / "FakePlugin.vst3" / "Contents"
+    contents.mkdir(parents=True)
+    (contents / "moduleinfo.json").write_text('{"Version": "1.3.4"}')
+
+    return DatasetSpec(
+        task_name="test-dataset",
+        output_format="wds",
+        train_val_test_sizes=(10, 0, 0),
+        base_seed=42,
+        r2_bucket="intermediate-data",
+        render={
+            "plugin_path": str(tmp_path / "FakePlugin.vst3"),
+            "preset_path": "presets/surge-base.vstpreset",
+            "param_spec_name": "surge_simple",
+            "renderer_version": "1.3.4",
+            "sample_rate": 16000,
+            "channels": _VALID_AUDIO_CHANNELS,
+            "velocity": 100,
+            "signal_duration_seconds": 4.0,
+            "min_loudness": -55.0,
+            "sample_batch_size": 32,
+            "batch_per_shard": 10,
+        },  # type: ignore[arg-type]
+    )
+
+
+def _npy_bytes(arr: np.ndarray) -> bytes:
+    """Serialize a numpy array to ``.npy`` bytes via an in-memory buffer.
+
+    :param arr: Array to serialize. Any dtype/shape numpy accepts is fine.
+    :returns: Raw ``.npy`` payload bytes — what ``np.load`` would read back.
+    :rtype: bytes
+    """
+    buf = io.BytesIO()
+    np.save(buf, arr)
+    return buf.getvalue()
+
+
+def _make_tar_with(path: Path, members: dict[str, bytes]) -> None:
+    """Write an uncompressed tar at ``path`` with one member per ``members`` entry.
+
+    :param path: Filesystem path where the tar archive will be written.
+    :param members: Mapping from in-tar member name to raw bytes; iteration order
+        is preserved as insertion order.
+    :returns: ``None``.
+    :rtype: None
+    """
+    with tarfile.open(path, mode="w:") as tar:
+        for name, payload in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+
+
+def _valid_batch_arrays(
+    n_rows: int,
+) -> dict[str, np.ndarray]:
+    """Return canonical-shape per-field arrays the writer would emit for one batch.
+
+    :param n_rows: Number of rows for this batch (sum across batches must equal
+        ``spec.render.batch_per_shard``).
+    :returns: Mapping from field name to a zero-filled ``float32`` array at the writer's
+        canonical inner shape.
+    :rtype: dict[str, np.ndarray]
+    """
+    return {
+        "audio": np.zeros(
+            (n_rows, _VALID_AUDIO_CHANNELS, _VALID_AUDIO_SAMPLES_PER_ROW), dtype=np.float32
+        ),
+        "mel_spec": np.zeros((n_rows, *_VALID_MEL_INNER_SHAPE), dtype=np.float32),
+        "param_array": np.zeros((n_rows, _VALID_PARAM_LENGTH), dtype=np.float32),
+    }
+
+
+def _make_valid_tar_bytes(path: Path, batches: list[tuple[int, int]]) -> None:
+    """Write a fully-valid tar shard at ``path`` with the given per-batch row layout.
+
+    ``batches`` is a list of ``(batch_start_idx, n_rows)`` pairs — the writer's
+    naming convention is ``<batch_start_idx:08d>.<field>.npy``. Members are
+    written in writer-style insertion order with ``metadata.json`` last.
+
+    :param path: Filesystem path where the tar archive will be written.
+    :param batches: List of ``(batch_start_idx, n_rows)`` pairs describing each
+        per-batch group of ``.npy`` members in the tar.
+    :returns: ``None``.
+    :rtype: None
+    """
+    members: dict[str, bytes] = {}
+    for batch_start_idx, n_rows in batches:
+        for field, arr in _valid_batch_arrays(n_rows).items():
+            members[f"{batch_start_idx:08d}.{field}.npy"] = _npy_bytes(arr)
+    members["metadata.json"] = json.dumps(_VALID_METADATA).encode("utf-8")
+    _make_tar_with(path, members)
+
+
+def _make_valid_h5_shard(path: Path, n_rows: int) -> None:
+    """Write an HDF5 shard at ``path`` whose datasets match the writer's canonical shapes.
+
+    :param path: Filesystem path where the HDF5 shard will be written.
+    :param n_rows: Row count for every dataset; matched against ``batch_per_shard``.
+    :returns: ``None``.
+    :rtype: None
+    """
+    shapes: dict[str, tuple[int, ...]] = {
+        "audio": (n_rows, _VALID_AUDIO_CHANNELS, _VALID_AUDIO_SAMPLES_PER_ROW),
+        "mel_spec": (n_rows, *_VALID_MEL_INNER_SHAPE),
+        "param_array": (n_rows, _VALID_PARAM_LENGTH),
+    }
+    with h5py.File(path, "w") as f:
+        for name, shape in shapes.items():
+            f.create_dataset(name, shape=shape, dtype=np.float32)
+
+
+class TestSuffixDispatch:
+    """``validate_shard`` dispatches on the shard's filename suffix."""
+
+    def test_validate_shard_dispatches_on_h5_suffix(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """A valid ``.h5`` shard runs the HDF5 path and returns no errors.
+
+        :param real_spec: Spec whose render config matches the canonical valid shapes.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.h5"
+        _make_valid_h5_shard(shard_path, real_spec.render.batch_per_shard)
+
+        assert validate_shard(shard_path, real_spec) == []
+
+    def test_validate_shard_dispatches_on_tar_suffix(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """A valid ``.tar`` shard runs the tar/wds path and returns no errors.
+
+        :param real_spec: Spec whose render config matches the canonical valid shapes.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.tar"
+        _make_valid_tar_bytes(shard_path, [(0, real_spec.render.batch_per_shard)])
+
+        assert validate_shard(shard_path, real_spec) == []
+
+    def test_validate_shard_rejects_unsupported_suffix(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """A ``.bin`` suffix surfaces a clear error naming the registered set.
+
+        :param real_spec: Spec; the suffix dispatch runs before any shape check.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.bin"
+        shard_path.write_bytes(b"not a shard")
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert len(errors) == 1
+        assert ".bin" in errors[0]
+        assert ".h5" in errors[0]
+        assert ".tar" in errors[0]
+
+
+class TestTarShardValidation:
+    """Tar/wds branch validates metadata, members, row counts, and inner shapes."""
+
+    def test_validate_shard_tar_rejects_missing_metadata_json(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """A tar without ``metadata.json`` surfaces a missing-member error.
+
+        :param real_spec: Spec whose render config matches the canonical valid shapes.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.tar"
+        members: dict[str, bytes] = {}
+        for field, arr in _valid_batch_arrays(real_spec.render.batch_per_shard).items():
+            members[f"00000000.{field}.npy"] = _npy_bytes(arr)
+        _make_tar_with(shard_path, members)
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert any("metadata.json" in err for err in errors)
+
+    def test_validate_shard_tar_rejects_invalid_metadata_json(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """A tar whose ``metadata.json`` has an unknown extra field surfaces a ValidationError.
+
+        :param real_spec: Spec whose render config matches the canonical valid shapes.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.tar"
+        members: dict[str, bytes] = {}
+        for field, arr in _valid_batch_arrays(real_spec.render.batch_per_shard).items():
+            members[f"00000000.{field}.npy"] = _npy_bytes(arr)
+        bad_metadata = {**_VALID_METADATA, "unexpected_key": "boom"}
+        members["metadata.json"] = json.dumps(bad_metadata).encode("utf-8")
+        _make_tar_with(shard_path, members)
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert any("metadata.json" in err and "ShardMetadata" in err for err in errors)
+
+    def test_validate_shard_tar_rejects_missing_field_npy(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """A tar missing one field's ``.npy`` members surfaces a missing-field error.
+
+        :param real_spec: Spec whose render config matches the canonical valid shapes.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.tar"
+        members: dict[str, bytes] = {}
+        for field, arr in _valid_batch_arrays(real_spec.render.batch_per_shard).items():
+            if field == "param_array":
+                continue
+            members[f"00000000.{field}.npy"] = _npy_bytes(arr)
+        members["metadata.json"] = json.dumps(_VALID_METADATA).encode("utf-8")
+        _make_tar_with(shard_path, members)
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert any("param_array" in err for err in errors)
+
+    def test_validate_shard_tar_rejects_wrong_row_count(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """A tar whose summed rows-per-field is not ``batch_per_shard`` surfaces an error.
+
+        :param real_spec: Spec whose render config matches the canonical valid shapes.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.tar"
+        wrong_n = real_spec.render.batch_per_shard - 1
+        _make_valid_tar_bytes(shard_path, [(0, wrong_n)])
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert any(
+            "audio" in err and str(real_spec.render.batch_per_shard) in err and str(wrong_n) in err
+            for err in errors
+        )
+
+    def test_validate_shard_tar_rejects_wrong_inner_shape(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """A tar with audio's trailing time-samples dim wrong surfaces an inner-shape error.
+
+        :param real_spec: Spec whose render config matches the canonical valid shapes.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.tar"
+        n_rows = real_spec.render.batch_per_shard
+        wrong_time = _VALID_AUDIO_SAMPLES_PER_ROW + 1
+        members: dict[str, bytes] = {
+            "00000000.audio.npy": _npy_bytes(
+                np.zeros((n_rows, _VALID_AUDIO_CHANNELS, wrong_time), dtype=np.float32)
+            ),
+            "00000000.mel_spec.npy": _npy_bytes(
+                np.zeros((n_rows, *_VALID_MEL_INNER_SHAPE), dtype=np.float32)
+            ),
+            "00000000.param_array.npy": _npy_bytes(
+                np.zeros((n_rows, _VALID_PARAM_LENGTH), dtype=np.float32)
+            ),
+            "metadata.json": json.dumps(_VALID_METADATA).encode("utf-8"),
+        }
+        _make_tar_with(shard_path, members)
+
+        errors = validate_shard(shard_path, real_spec)
+
+        assert any(
+            "audio" in err and "inner shape" in err and str(wrong_time) in err for err in errors
+        )
+
+    def test_validate_shard_tar_accepts_multi_batch_layout(
+        self, real_spec: DatasetSpec, tmp_path: Path
+    ) -> None:
+        """Multiple per-batch ``.npy`` groups that sum to ``batch_per_shard`` pass.
+
+        :param real_spec: Spec whose render config matches the canonical valid shapes.
+        :param tmp_path: pytest-provided temp directory for the shard file.
+        :returns: ``None``.
+        :rtype: None
+        """
+        shard_path = tmp_path / "shard-000000.tar"
+        total = real_spec.render.batch_per_shard
+        first = total // 2
+        second = total - first
+        _make_valid_tar_bytes(shard_path, [(0, first), (first, second)])
+
+        assert validate_shard(shard_path, real_spec) == []


### PR DESCRIPTION
## Summary

Adds the `.tar` branch to `synth_setter.pipeline.ci.validate_shard` so the worker-side validator handles wds shards alongside the existing HDF5 path. Dispatch is by file suffix via `EXTENSION_TO_OUTPUT_FORMAT` (introduced in #1024). The tar path validates:

- `metadata.json` member is present and parses as a strict `ShardMetadata` (extra-fields forbidden).
- Every `<batch_key>.<field>.npy` member loads as a valid numpy array.
- Each field's summed row count across batches equals `spec.render.batch_per_shard`.
- Each batch's trailing-dims (audio time samples, mel n_frames, param-array width) matches the writer's source-of-truth shape helpers in `synth_setter.data.vst.shapes` — same predicate the HDF5 path uses, just applied to `arr.shape[1:]`.

An unsupported suffix (anything not in `EXTENSION_TO_OUTPUT_FORMAT`) returns a clear error naming the supported set instead of falling through to a misleading "not valid HDF5" message.

## Test plan
- [x] `pytest tests/pipeline/ci/test_validate_shard*.py -v` — old HDF5 tests + new dispatch tests + new tar-path tests all green
- [x] `make test-fast`
- [x] `python scripts/check_no_new_funcs_in_pydoclint_excluded.py --base origin/main` exits 0
- [x] `pre-commit run --files src/synth_setter/pipeline/ci/validate_shard.py tests/pipeline/ci/test_validate_shard_tar.py` all green

Refs #874
Refs #882