### PR TITLE
internal-feat(ci): wds matrix axis on test-dataset-generation + ci-materialize-test-wds config

### DIFF
--- a/.github/workflows/test-act.yaml
+++ b/.github/workflows/test-act.yaml
@@ -104,7 +104,7 @@ jobs:
       # Real-run the data-pipeline chain via act with provider=local —
       # dropping `-n` lets `setup` populate `$GITHUB_OUTPUT` so the dynamic
       # matrix resolves. Fork PRs skip (R2 secrets unavailable to forks).
-      # Three act-only knobs paper over real act-vs-GHA divergences without
+      # Four act-only knobs paper over real act-vs-GHA divergences without
       # touching the production workflow:
       #   * `--env PIP_BREAK_SYSTEM_PACKAGES=1` — catthehacker's python3.12
       #     ships PEP 668's externally-managed marker; the workflow's
@@ -119,6 +119,15 @@ jobs:
       #   * `--artifact-server-path` — `actions/upload-artifact@v4` needs
       #     `ACTIONS_RUNTIME_TOKEN`; act issues one only when its local
       #     artifact server is enabled via this flag.
+      #   * `--matrix output_format:hdf5` — act runs every matrix cell
+      #     against the same act-runner container, so the parallel
+      #     `actions/setup-python@v6` invocations from `hdf5` and `wds`
+      #     race on `/opt/hostedtoolcache/Python`'s cleanup hook and
+      #     both fail (Directory not empty / cd: bin/: No such file or
+      #     directory). Real GHA gives each matrix cell its own runner,
+      #     so this is purely an act limitation. Restrict the regression
+      #     guard to one cell — the per-cell validate-shards behavior
+      #     itself is exercised by the real GHA matrix on every PR.
       - name: Real-run test-dataset-generation chain via act (provider=local)
         if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
         env:
@@ -139,6 +148,7 @@ jobs:
           act workflow_dispatch \
             -W .github/workflows/test-dataset-generation.yml \
             --input provider=local \
+            --matrix output_format:hdf5 \
             --secret-file "${secrets_file}" \
             --env PIP_BREAK_SYSTEM_PACKAGES=1 \
             --container-options "-v /tmp:/tmp" \

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -224,7 +224,12 @@ jobs:
           elif [[ "${EVENT_NAME}" == "pull_request" ]]; then
             output_formats='["hdf5","wds"]'
           else
-            DISPATCH_FORMAT=$(python3 -c "
+            # Capture stderr to a temp file so a Hydra compose failure (missing
+            # experiment, config-typing error, missing `output_format` key,
+            # etc.) surfaces the traceback in the action log instead of leaving
+            # operators with only "Process completed with exit code 1".
+            DISPATCH_STDERR=$(mktemp)
+            if ! DISPATCH_FORMAT=$(python3 -c "
           import os
           import sys
           from pathlib import Path
@@ -234,7 +239,13 @@ jobs:
           with initialize_config_dir(version_base='1.3', config_dir=cfg_dir):
               cfg = compose(config_name='dataset', overrides=[f'experiment={experiment}'])
           sys.stdout.write(cfg.output_format)
-          " 2>/dev/null | tail -n 1)
+          " 2>"${DISPATCH_STDERR}" | tail -n 1); then
+              echo "Hydra compose failed for experiment='${DISPATCH_DATASET_CONFIG}' (stderr below):" >&2
+              cat "${DISPATCH_STDERR}" >&2
+              rm -f "${DISPATCH_STDERR}"
+              exit 1
+            fi
+            rm -f "${DISPATCH_STDERR}"
             output_formats="[\"${DISPATCH_FORMAT}\"]"
           fi
           echo "providers=${providers}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -140,6 +140,14 @@ jobs:
   #                             job (no launcher).
   #   * `providers_launcher`  — subset routed through the
   #                             `generate-dataset-shards.yaml` reusable.
+  #   * `output_formats`      — shard-format axis. On pull_request both rows
+  #                             (`hdf5`, `wds`) run because the workflow pins a
+  #                             per-format experiment config for each. On
+  #                             workflow_dispatch the matrix collapses to the
+  #                             single format the dispatched config resolves to
+  #                             — a single config hardcodes one `output_format`,
+  #                             and the spec-format cross-check would otherwise
+  #                             fail the non-matching cell.
   #   * `r2_bucket`           — Cloudflare R2 bucket name (from
   #                             configs/image/dev-snapshot.yaml). Used to
   #                             construct the spec_uri the validate job pulls.
@@ -170,12 +178,23 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # configs/hydra/default.yaml's `defaults` block overrides job_logging /
+      # hydra_logging to `colorlog`, which is provided by the hydra-colorlog
+      # plugin. Without it, Hydra compose fails with:
+      #   MissingConfigException: Could not find 'hydra/job_logging/colorlog'
+      # Pin both to the same versions as [project.dependencies] in pyproject.toml.
+      # Installed before the `matrix` step because that step also composes the
+      # dispatched config to resolve `output_format` on workflow_dispatch.
+      - name: Install Hydra for dataset-config composition
+        run: pip install "hydra-core==1.3.2" "hydra-colorlog==1.2.0"
+
       - id: matrix
         env:
           EVENT_NAME: ${{ github.event_name }}
           PROVIDER_INPUT: ${{ inputs.provider || 'all' }}
           PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
           REPO: ${{ github.repository }}
+          DISPATCH_DATASET_CONFIG: ${{ inputs.dataset_config || 'generate_dataset/smoke-shard' }}
         run: |
           set -euo pipefail
           if [[ "${EVENT_NAME}" == "pull_request" && "${PR_HEAD_REPO}" == "${REPO}" ]]; then
@@ -193,10 +212,29 @@ jobs:
           fi
           providers_local=$(python3 -c "import json,sys; ps=json.loads(sys.argv[1]); print(json.dumps([p for p in ps if p == 'local']))" "${providers}")
           providers_launcher=$(python3 -c "import json,sys; ps=json.loads(sys.argv[1]); print(json.dumps([p for p in ps if p != 'local']))" "${providers}")
+          # On pull_request we pin two distinct per-format experiment configs
+          # (`smoke-shard` for hdf5, `ci-materialize-test-wds` for wds), so the
+          # matrix expands to both cells. On workflow_dispatch the user supplies
+          # a single experiment config which hardcodes one `output_format`, so
+          # the matrix collapses to whatever format that config resolves to —
+          # otherwise the cell whose `matrix.output_format` doesn't match would
+          # deterministically fail the spec-format cross-check.
           if [[ "${providers}" == "[]" ]]; then
             output_formats='[]'
-          else
+          elif [[ "${EVENT_NAME}" == "pull_request" ]]; then
             output_formats='["hdf5","wds"]'
+          else
+            DISPATCH_FORMAT=$(python3 -c "
+          import os
+          from pathlib import Path
+          from hydra import compose, initialize_config_dir
+          cfg_dir = str(Path.cwd() / 'configs')
+          experiment = os.environ['DISPATCH_DATASET_CONFIG']
+          with initialize_config_dir(version_base='1.3', config_dir=cfg_dir):
+              cfg = compose(config_name='dataset', overrides=[f'experiment={experiment}'])
+          print(cfg.output_format)
+          ")
+            output_formats="[\"${DISPATCH_FORMAT}\"]"
           fi
           echo "providers=${providers}" >> "${GITHUB_OUTPUT}"
           echo "providers_local=${providers_local}" >> "${GITHUB_OUTPUT}"
@@ -206,14 +244,6 @@ jobs:
           echo "providers_local: ${providers_local}"
           echo "providers_launcher: ${providers_launcher}"
           echo "output_formats: ${output_formats}"
-
-      # configs/hydra/default.yaml's `defaults` block overrides job_logging /
-      # hydra_logging to `colorlog`, which is provided by the hydra-colorlog
-      # plugin. Without it, Hydra compose fails with:
-      #   MissingConfigException: Could not find 'hydra/job_logging/colorlog'
-      # Pin both to the same versions as [project.dependencies] in pyproject.toml.
-      - name: Install Hydra for dataset-config composition
-        run: pip install "hydra-core==1.3.2" "hydra-colorlog==1.2.0"
 
       # Bucket comes from the composed dataset config (the source of truth the
       # launcher uses for `spec.r2_bucket` and therefore for its R2 upload

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -164,6 +164,7 @@ jobs:
       providers: ${{ steps.matrix.outputs.providers }}
       providers_local: ${{ steps.matrix.outputs.providers_local }}
       providers_launcher: ${{ steps.matrix.outputs.providers_launcher }}
+      output_formats: ${{ steps.matrix.outputs.output_formats }}
       r2_bucket: ${{ steps.bucket.outputs.r2_bucket }}
     steps:
       - name: Checkout
@@ -192,12 +193,19 @@ jobs:
           fi
           providers_local=$(python3 -c "import json,sys; ps=json.loads(sys.argv[1]); print(json.dumps([p for p in ps if p == 'local']))" "${providers}")
           providers_launcher=$(python3 -c "import json,sys; ps=json.loads(sys.argv[1]); print(json.dumps([p for p in ps if p != 'local']))" "${providers}")
+          if [[ "${providers}" == "[]" ]]; then
+            output_formats='[]'
+          else
+            output_formats='["hdf5","wds"]'
+          fi
           echo "providers=${providers}" >> "${GITHUB_OUTPUT}"
           echo "providers_local=${providers_local}" >> "${GITHUB_OUTPUT}"
           echo "providers_launcher=${providers_launcher}" >> "${GITHUB_OUTPUT}"
+          echo "output_formats=${output_formats}" >> "${GITHUB_OUTPUT}"
           echo "providers: ${providers}"
           echo "providers_local: ${providers_local}"
           echo "providers_launcher: ${providers_launcher}"
+          echo "output_formats: ${output_formats}"
 
       # configs/hydra/default.yaml's `defaults` block overrides job_logging /
       # hydra_logging to `colorlog`, which is provided by the hydra-colorlog
@@ -242,7 +250,7 @@ jobs:
   # `skypilot-launcher-specs/<cluster_name>.json` key the launcher uses for
   # the other providers, so validate-dataset-shards.yaml is provider-agnostic.
   generate-local:
-    name: Run generate_dataset (${{ matrix.provider }})
+    name: Run generate_dataset (${{ matrix.provider }} / ${{ matrix.output_format }})
     needs: setup
     if: ${{ needs.setup.outputs.providers_local != '[]' }}
     runs-on: ubuntu-latest
@@ -251,16 +259,19 @@ jobs:
       fail-fast: false
       matrix:
         provider: ${{ fromJSON(needs.setup.outputs.providers_local) }}
+        output_format: ${{ fromJSON(needs.setup.outputs.output_formats) }}
     env:
       DATASET_CONFIG: >-
         ${{
           github.event_name == 'pull_request'
-            && 'generate_dataset/smoke-shard'
+            && (matrix.output_format == 'wds'
+                && 'generate_dataset/ci-materialize-test-wds'
+                || 'generate_dataset/smoke-shard')
             || (inputs.dataset_config || 'generate_dataset/smoke-shard')
         }}
       IMAGE_TAG: ${{ inputs.docker_image_tag || 'dev-snapshot' }}
       IMAGE: tinaudio/synth-setter:${{ inputs.docker_image_tag || 'dev-snapshot' }}
-      CLUSTER_NAME: synth-setter-smoke-${{ matrix.provider }}-${{ github.run_id }}-${{ github.run_attempt }}
+      CLUSTER_NAME: synth-setter-smoke-${{ matrix.provider }}-${{ matrix.output_format }}-${{ github.run_id }}-${{ github.run_attempt }}
       R2_BUCKET: ${{ needs.setup.outputs.r2_bucket }}
     steps:
       - name: Checkout
@@ -270,7 +281,7 @@ jobs:
         run: docker pull --quiet "${IMAGE}"
 
       - name: Prepare run-metadata mount
-        run: mkdir -p "/tmp/run-metadata-${{ matrix.provider }}"
+        run: mkdir -p "/tmp/run-metadata-${{ matrix.provider }}-${{ matrix.output_format }}"
 
       - name: Run generate_dataset locally (inside container)
         env:
@@ -282,7 +293,7 @@ jobs:
           set -euo pipefail
           docker run --rm \
             -v "${{ github.workspace }}:/home/build/synth-setter" \
-            -v "/tmp/run-metadata-${{ matrix.provider }}:/run-metadata" \
+            -v "/tmp/run-metadata-${{ matrix.provider }}-${{ matrix.output_format }}:/run-metadata" \
             -e CONFIG_PATH \
             -e RCLONE_CONFIG_R2_TYPE=s3 \
             -e RCLONE_CONFIG_R2_PROVIDER=Cloudflare \
@@ -302,7 +313,7 @@ jobs:
                 --spec /run-metadata/input_spec.json
               chmod 0644 /run-metadata/input_spec.json
             ' \
-            2>&1 | tee "/tmp/run-metadata-${{ matrix.provider }}/generate.log"
+            2>&1 | tee "/tmp/run-metadata-${{ matrix.provider }}-${{ matrix.output_format }}/generate.log"
 
       # Upload the spec to R2 at the same path-shape the launcher uses, so
       # validate-dataset-shards.yaml can read it without knowing whether the
@@ -318,7 +329,7 @@ jobs:
           set -euo pipefail
           docker run --rm \
             -v "${{ github.workspace }}:/home/build/synth-setter:ro" \
-            -v "/tmp/run-metadata-${{ matrix.provider }}:/run-metadata:ro" \
+            -v "/tmp/run-metadata-${{ matrix.provider }}-${{ matrix.output_format }}:/run-metadata:ro" \
             -e RCLONE_CONFIG_R2_TYPE=s3 \
             -e RCLONE_CONFIG_R2_PROVIDER=Cloudflare \
             -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
@@ -336,23 +347,34 @@ jobs:
           print(f'spec uploaded to {uri}')
           "
 
-      - name: Validate spec exists
+      # Cross-check that the spec the worker materialized actually has the
+      # output_format the matrix cell expects — a regression where Hydra
+      # resolved the wrong experiment would otherwise silently produce hdf5
+      # shards under the wds cell and fail at validate-shards much later.
+      - name: Validate spec exists and matches matrix output_format
+        env:
+          EXPECTED_FORMAT: ${{ matrix.output_format }}
         run: |
           set -euo pipefail
-          SPEC_PATH="/tmp/run-metadata-${{ matrix.provider }}/input_spec.json"
+          SPEC_PATH="/tmp/run-metadata-${{ matrix.provider }}-${{ matrix.output_format }}/input_spec.json"
           if [[ ! -f "${SPEC_PATH}" ]]; then
             echo "::error::input_spec.json not found at ${SPEC_PATH}"
             exit 1
           fi
-          echo "=== Materialized Spec (${{ matrix.provider }}) ==="
+          echo "=== Materialized Spec (${{ matrix.provider }} / ${{ matrix.output_format }}) ==="
           head -20 "${SPEC_PATH}"
+          ACTUAL_FORMAT=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['output_format'])" "${SPEC_PATH}")
+          if [[ "${ACTUAL_FORMAT}" != "${EXPECTED_FORMAT}" ]]; then
+            echo "::error::spec output_format=${ACTUAL_FORMAT} but matrix expected ${EXPECTED_FORMAT}"
+            exit 1
+          fi
 
       - name: Upload run metadata
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-run-metadata-${{ matrix.provider }}
-          path: /tmp/run-metadata-${{ matrix.provider }}/
+          name: test-run-metadata-${{ matrix.provider }}-${{ matrix.output_format }}
+          path: /tmp/run-metadata-${{ matrix.provider }}-${{ matrix.output_format }}/
           retention-days: 7
           if-no-files-found: warn
 
@@ -362,46 +384,50 @@ jobs:
   # `--num-workers 1` override for skypilot-local mirrors today's hardcoded
   # behavior — the single-node kind cluster can't host parallel workers (#843).
   generate-launcher:
-    name: Run generate_dataset (${{ matrix.provider }})
+    name: Run generate_dataset (${{ matrix.provider }} / ${{ matrix.output_format }})
     needs: setup
     if: ${{ needs.setup.outputs.providers_launcher != '[]' }}
     strategy:
       fail-fast: false
       matrix:
         provider: ${{ fromJSON(needs.setup.outputs.providers_launcher) }}
+        output_format: ${{ fromJSON(needs.setup.outputs.output_formats) }}
     uses: ./.github/workflows/generate-dataset-shards.yaml
     with:
       provider: ${{ matrix.provider }}
       dataset_config: >-
         ${{
           github.event_name == 'pull_request'
-            && 'generate_dataset/smoke-shard'
+            && (matrix.output_format == 'wds'
+                && 'generate_dataset/ci-materialize-test-wds'
+                || 'generate_dataset/smoke-shard')
             || (inputs.dataset_config || 'generate_dataset/smoke-shard')
         }}
       image_tag: ${{ inputs.docker_image_tag || 'dev-snapshot' }}
-      cluster_name: synth-setter-smoke-${{ matrix.provider }}-${{ github.run_id }}-${{ github.run_attempt }}
+      cluster_name: synth-setter-smoke-${{ matrix.provider }}-${{ matrix.output_format }}-${{ github.run_id }}-${{ github.run_attempt }}
       num_workers: ${{ matrix.provider == 'skypilot-local' && '1' || '' }}
       tail: true
       local: ${{ matrix.provider == 'skypilot-local' }}
-      artifact_name: test-run-metadata-${{ matrix.provider }}
+      artifact_name: test-run-metadata-${{ matrix.provider }}-${{ matrix.output_format }}
     secrets: inherit
 
   # validate-spec + validate-shard pull the spec from R2 directly. The URI is
-  # constructed deterministically from the per-provider cluster_name pattern
+  # constructed deterministically from the per-cell cluster_name pattern
   # (matching what generate-launcher's launcher and generate-local's explicit
-  # upload step both write to). `if: !cancelled()` decouples each provider's
-  # validate cell from the OTHER provider's generate outcome — RunPod
-  # transients won't skip OCI validation.
+  # upload step both write to). `if: !cancelled()` decouples each provider ×
+  # output_format cell from the OTHER cells' generate outcomes — RunPod
+  # transients won't skip OCI validation, and an hdf5 failure won't skip wds.
   validate:
-    name: Validate ${{ matrix.provider }} dataset
+    name: Validate ${{ matrix.provider }} / ${{ matrix.output_format }} dataset
     needs: [setup, generate-local, generate-launcher]
     if: ${{ !cancelled() && needs.setup.outputs.providers != '[]' }}
     strategy:
       fail-fast: false
       matrix:
         provider: ${{ fromJSON(needs.setup.outputs.providers) }}
+        output_format: ${{ fromJSON(needs.setup.outputs.output_formats) }}
     uses: ./.github/workflows/validate-dataset-shards.yaml
     with:
       image_tag: ${{ inputs.docker_image_tag || 'dev-snapshot' }}
-      spec_uri: r2://${{ needs.setup.outputs.r2_bucket }}/skypilot-launcher-specs/synth-setter-smoke-${{ matrix.provider }}-${{ github.run_id }}-${{ github.run_attempt }}.json
+      spec_uri: r2://${{ needs.setup.outputs.r2_bucket }}/skypilot-launcher-specs/synth-setter-smoke-${{ matrix.provider }}-${{ matrix.output_format }}-${{ github.run_id }}-${{ github.run_attempt }}.json
     secrets: inherit

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -296,7 +296,7 @@ jobs:
         ${{
           github.event_name == 'pull_request'
             && (matrix.output_format == 'wds'
-                && 'generate_dataset/ci-materialize-test-wds'
+                && 'generate_dataset/smoke-shard-wds'
                 || 'generate_dataset/smoke-shard')
             || (inputs.dataset_config || 'generate_dataset/smoke-shard')
         }}
@@ -430,7 +430,7 @@ jobs:
         ${{
           github.event_name == 'pull_request'
             && (matrix.output_format == 'wds'
-                && 'generate_dataset/ci-materialize-test-wds'
+                && 'generate_dataset/smoke-shard-wds'
                 || 'generate_dataset/smoke-shard')
             || (inputs.dataset_config || 'generate_dataset/smoke-shard')
         }}

--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -226,14 +226,15 @@ jobs:
           else
             DISPATCH_FORMAT=$(python3 -c "
           import os
+          import sys
           from pathlib import Path
           from hydra import compose, initialize_config_dir
           cfg_dir = str(Path.cwd() / 'configs')
           experiment = os.environ['DISPATCH_DATASET_CONFIG']
           with initialize_config_dir(version_base='1.3', config_dir=cfg_dir):
               cfg = compose(config_name='dataset', overrides=[f'experiment={experiment}'])
-          print(cfg.output_format)
-          ")
+          sys.stdout.write(cfg.output_format)
+          " 2>/dev/null | tail -n 1)
             output_formats="[\"${DISPATCH_FORMAT}\"]"
           fi
           echo "providers=${providers}" >> "${GITHUB_OUTPUT}"
@@ -282,7 +283,7 @@ jobs:
   generate-local:
     name: Run generate_dataset (${{ matrix.provider }} / ${{ matrix.output_format }})
     needs: setup
-    if: ${{ needs.setup.outputs.providers_local != '[]' }}
+    if: ${{ needs.setup.outputs.providers_local != '[]' && needs.setup.outputs.output_formats != '[]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     strategy:
@@ -416,7 +417,7 @@ jobs:
   generate-launcher:
     name: Run generate_dataset (${{ matrix.provider }} / ${{ matrix.output_format }})
     needs: setup
-    if: ${{ needs.setup.outputs.providers_launcher != '[]' }}
+    if: ${{ needs.setup.outputs.providers_launcher != '[]' && needs.setup.outputs.output_formats != '[]' }}
     strategy:
       fail-fast: false
       matrix:
@@ -450,7 +451,7 @@ jobs:
   validate:
     name: Validate ${{ matrix.provider }} / ${{ matrix.output_format }} dataset
     needs: [setup, generate-local, generate-launcher]
-    if: ${{ !cancelled() && needs.setup.outputs.providers != '[]' }}
+    if: ${{ !cancelled() && needs.setup.outputs.providers != '[]' && needs.setup.outputs.output_formats != '[]' }}
     strategy:
       fail-fast: false
       matrix:

--- a/configs/experiment/generate_dataset/ci-materialize-test-wds.yaml
+++ b/configs/experiment/generate_dataset/ci-materialize-test-wds.yaml
@@ -19,4 +19,8 @@ train_val_test_sizes: [32, 32, 32]
 render:
   sample_rate: 16000
   min_loudness: -50.0
+  # `sample_batch_size` equals `batch_per_shard` here so each shard renders in
+  # one sample batch — matches `smoke-shard.yaml`'s explicit style and pins the
+  # batching shape against the `surge_xt` render-group default of 32.
+  sample_batch_size: 32
   batch_per_shard: 32

--- a/configs/experiment/generate_dataset/ci-materialize-test-wds.yaml
+++ b/configs/experiment/generate_dataset/ci-materialize-test-wds.yaml
@@ -1,0 +1,22 @@
+# @package _global_
+
+# WDS-format sibling of ci-materialize-test. Mirrors that experiment's render
+# volume (96 samples → 3 shards at batch_per_shard=32) but writes `.tar`
+# instead of `.h5`, so test-dataset-generation.yml's matrix can exercise both
+# formats with the same payload shape.
+
+defaults:
+  - override /data: surge_simple
+  - override /render: surge_simple
+  - _self_
+
+task_name: ci-materialize-test-wds
+
+output_format: wds
+
+train_val_test_sizes: [32, 32, 32]
+
+render:
+  sample_rate: 16000
+  min_loudness: -50.0
+  batch_per_shard: 32

--- a/configs/experiment/generate_dataset/smoke-shard-wds.yaml
+++ b/configs/experiment/generate_dataset/smoke-shard-wds.yaml
@@ -1,0 +1,25 @@
+# @package _global_
+
+# WDS-format sibling of `smoke-shard`. Same 12-sample / 3-shard render volume
+# (batch_per_shard=4), but writes `.tar` instead of `.h5`, so the PR-time
+# test-dataset-generation matrix can exercise both formats inside the
+# `generate-dataset-shards` reusable's 20-min step timeout. The larger
+# `ci-materialize-test-wds.yaml` config (96 samples) stays around for
+# workflow_dispatch coverage where the step timeout is moot.
+
+defaults:
+  - override /data: surge_simple
+  - override /render: surge_simple
+  - _self_
+
+task_name: smoke-shard-wds
+
+output_format: wds
+
+train_val_test_sizes: [12, 0, 0]
+
+render:
+  sample_rate: 16000
+  min_loudness: -50.0
+  sample_batch_size: 4
+  batch_per_shard: 4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -341,7 +341,12 @@ exclude = '''(?x)
   | ^tests/pipeline/test_schemas/test_image_config\.py$
   | ^tests/pipeline/test_schemas/test_shard_metadata\.py$
   | ^tests/pipeline/test_schemas/test_prefix\.py$
-  | ^tests/infra/
+  | ^tests/infra/conftest\.py$
+  | ^tests/infra/test_devcontainer_attached_mode\.py$
+  | ^tests/infra/test_gh_auth_flow\.py$
+  | ^tests/infra/test_no_secrets_in_image\.py$
+  | ^tests/infra/test_post_create_performance\.py$
+  | ^tests/infra/test_workflows_under_act\.py$
   | ^tests/evaluation/test_compute_audio_metrics\.py$
   | ^tests/pipeline/data/test_r2_report\.py$
   | ^tests/scripts/skypilot/test_write_provider_creds\.py$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -341,6 +341,10 @@ exclude = '''(?x)
   | ^tests/pipeline/test_schemas/test_image_config\.py$
   | ^tests/pipeline/test_schemas/test_shard_metadata\.py$
   | ^tests/pipeline/test_schemas/test_prefix\.py$
+  # tests/infra/: the blanket `^tests/infra/` exclusion was removed in #1036
+  # to graduate test_dataset_generation_matrix.py into pydoclint coverage.
+  # New tests under tests/infra/ are now subject to pydoclint by default —
+  # write the docstrings rather than re-adding `^tests/infra/` here.
   | ^tests/infra/conftest\.py$
   | ^tests/infra/test_devcontainer_attached_mode\.py$
   | ^tests/infra/test_gh_auth_flow\.py$

--- a/tests/infra/test_dataset_generation_matrix.py
+++ b/tests/infra/test_dataset_generation_matrix.py
@@ -24,13 +24,22 @@ LAUNCHER_JOBS = ("generate-local", "generate-launcher")
 
 @pytest.fixture(scope="module")
 def workflow(project_root: Path) -> dict:
-    """Parsed test-dataset-generation.yml as a plain dict."""
+    """Load `test-dataset-generation.yml` once per module.
+
+    :param project_root: Repo root provided by the `tests/infra/conftest.py` fixture.
+    :returns: Parsed YAML as a plain dict.
+    :rtype: dict
+    """
     return yaml.safe_load((project_root / WORKFLOW_RELATIVE_PATH).read_text())
 
 
 @pytest.mark.parametrize("job_name", LAUNCHER_JOBS)
 def test_generate_job_has_output_format_matrix_axis(workflow: dict, job_name: str) -> None:
-    """Both generate jobs declare an `output_format` strategy.matrix axis."""
+    """Assert both generate jobs declare an `output_format` strategy.matrix axis.
+
+    :param workflow: Parsed workflow YAML from the module-scoped fixture.
+    :param job_name: One of `generate-local` / `generate-launcher` (parametrized).
+    """
     job = workflow["jobs"][job_name]
     matrix = job["strategy"]["matrix"]
     assert "output_format" in matrix, (
@@ -41,7 +50,11 @@ def test_generate_job_has_output_format_matrix_axis(workflow: dict, job_name: st
 
 @pytest.mark.parametrize("job_name", LAUNCHER_JOBS)
 def test_generate_job_cluster_name_includes_output_format(workflow: dict, job_name: str) -> None:
-    """Cluster name interpolates `matrix.output_format` so wds and hdf5 cells diverge."""
+    """Assert cluster name interpolates `matrix.output_format` so the cells diverge.
+
+    :param workflow: Parsed workflow YAML from the module-scoped fixture.
+    :param job_name: One of `generate-local` / `generate-launcher` (parametrized).
+    """
     job = workflow["jobs"][job_name]
     cluster_template = _cluster_name_template(job, job_name)
     assert "matrix.output_format" in cluster_template, (
@@ -51,7 +64,10 @@ def test_generate_job_cluster_name_includes_output_format(workflow: dict, job_na
 
 
 def test_validate_spec_uri_includes_output_format(workflow: dict) -> None:
-    """The validate job's spec_uri template namespaces by matrix.output_format."""
+    """Assert the validate job's spec_uri template namespaces by matrix.output_format.
+
+    :param workflow: Parsed workflow YAML from the module-scoped fixture.
+    """
     validate = workflow["jobs"]["validate"]
     spec_uri = validate["with"]["spec_uri"]
     assert "matrix.output_format" in spec_uri, (
@@ -60,7 +76,10 @@ def test_validate_spec_uri_includes_output_format(workflow: dict) -> None:
 
 
 def test_setup_emits_output_formats_with_both_rows(workflow: dict) -> None:
-    """`setup` job's matrix step emits an output_formats list containing hdf5 + wds."""
+    """Assert `setup` emits an `output_formats` output containing hdf5 + wds.
+
+    :param workflow: Parsed workflow YAML from the module-scoped fixture.
+    """
     matrix_step = _find_step(workflow["jobs"]["setup"]["steps"], step_id="matrix")
     run_script = matrix_step["run"]
     assert "hdf5" in run_script and "wds" in run_script, (
@@ -72,14 +91,29 @@ def test_setup_emits_output_formats_with_both_rows(workflow: dict) -> None:
 
 
 def _cluster_name_template(job: dict, job_name: str) -> str:
-    """Return the cluster_name interpolation string for a generate job."""
+    """Return the cluster_name interpolation string for a generate job.
+
+    :param job: Parsed job dict.
+    :param job_name: `generate-local` reads `env.CLUSTER_NAME`; the launcher variant
+        reads `with.cluster_name` (reusable workflow input).
+    :returns: Raw `${{ ... }}` template string, unresolved.
+    :rtype: str
+    """
     if job_name == "generate-local":
         return job["env"]["CLUSTER_NAME"]
     return job["with"]["cluster_name"]
 
 
 def _find_step(steps: list[dict], *, step_id: str) -> dict:
-    """Return the first step in `steps` whose `id` matches `step_id`."""
+    """Return the first step in `steps` whose `id` matches `step_id`.
+
+    :param steps: The job's `steps` list.
+    :param step_id: Value to match against each step's `id` field.
+    :returns: The matched step dict.
+    :rtype: dict
+    :raises AssertionError: If no step in `steps` has the given `id`. Surfaces as a
+        normal pytest failure rather than a soft None return.
+    """
     for step in steps:
         if step.get("id") == step_id:
             return step

--- a/tests/infra/test_dataset_generation_matrix.py
+++ b/tests/infra/test_dataset_generation_matrix.py
@@ -90,6 +90,48 @@ def test_setup_emits_output_formats_with_both_rows(workflow: dict) -> None:
     )
 
 
+def test_setup_matrix_step_branches_on_event_name(workflow: dict) -> None:
+    """Assert `setup.matrix` sets `output_formats` in all three event-name branches.
+
+    The bash logic in `setup.matrix` has three branches that each must assign
+    `output_formats`:
+
+    1. ``providers == '[]'`` (fork PR / unsupported event) → ``output_formats='[]'``.
+    2. ``pull_request`` (same-repo) → both rows: ``output_formats='["hdf5","wds"]'``.
+    3. ``workflow_dispatch`` → collapse to the single format the dispatched
+       experiment resolves to, via Hydra compose of ``DISPATCH_DATASET_CONFIG``.
+
+    A future edit that drops one branch (e.g. accidentally removing the
+    workflow_dispatch fallback or the providers-empty short-circuit) would
+    leave a code path where ``output_formats`` is never set and the downstream
+    ``fromJSON(...)`` matrix expansion fails opaquely. This test pins the three
+    branches at the source-script level so the regression fails fast in CI.
+
+    :param workflow: Parsed workflow YAML from the module-scoped fixture.
+    """
+    matrix_step = _find_step(workflow["jobs"]["setup"]["steps"], step_id="matrix")
+    run_script = matrix_step["run"]
+
+    assert "output_formats='[]'" in run_script, (
+        "setup.matrix is missing the providers-empty branch that emits an empty "
+        "output_formats list — without it, fork-PR runs would leave the output unset."
+    )
+    assert 'output_formats=\'["hdf5","wds"]\'' in run_script, (
+        "setup.matrix is missing the pull_request branch that emits both hdf5 and wds "
+        "rows — without it, PR-time CI would never exercise the new wds matrix cell."
+    )
+    assert "DISPATCH_DATASET_CONFIG" in run_script and "compose" in run_script, (
+        "setup.matrix is missing the workflow_dispatch fallback that composes the "
+        "dispatched experiment with Hydra to resolve a single output_format — "
+        "without it, dispatch runs would fall through to an unset output_formats."
+    )
+    assert 'output_formats="[\\"${DISPATCH_FORMAT}\\"]"' in run_script, (
+        "setup.matrix's workflow_dispatch branch must assign output_formats from the "
+        "Hydra-composed DISPATCH_FORMAT — without that assignment, dispatch runs "
+        "would leave output_formats unset and break fromJSON downstream."
+    )
+
+
 def _cluster_name_template(job: dict, job_name: str) -> str:
     """Return the cluster_name interpolation string for a generate job.
 

--- a/tests/infra/test_dataset_generation_matrix.py
+++ b/tests/infra/test_dataset_generation_matrix.py
@@ -1,0 +1,86 @@
+"""Static assertions on the test-dataset-generation workflow's matrix shape.
+
+The PR exercises both `hdf5` and `wds` shard formats through the same generate +
+validate plumbing. These tests parse `test-dataset-generation.yml` and assert
+that the `output_format` axis is wired into both the `generate-local` and
+`generate-launcher` strategy matrices, and that cluster names + spec URIs are
+namespaced by `matrix.output_format` so the matrix cells don't collide on the
+launcher's R2 spec key.
+
+Kept as a stand-alone YAML parse (no `act`) so the assertion runs on every CI
+worker without needing the `act` binary on PATH.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_RELATIVE_PATH = Path(".github") / "workflows" / "test-dataset-generation.yml"
+LAUNCHER_JOBS = ("generate-local", "generate-launcher")
+
+
+@pytest.fixture(scope="module")
+def workflow(project_root: Path) -> dict:
+    """Parsed test-dataset-generation.yml as a plain dict."""
+    return yaml.safe_load((project_root / WORKFLOW_RELATIVE_PATH).read_text())
+
+
+@pytest.mark.parametrize("job_name", LAUNCHER_JOBS)
+def test_generate_job_has_output_format_matrix_axis(workflow: dict, job_name: str) -> None:
+    """Both generate jobs declare an `output_format` strategy.matrix axis."""
+    job = workflow["jobs"][job_name]
+    matrix = job["strategy"]["matrix"]
+    assert "output_format" in matrix, (
+        f"{job_name}.strategy.matrix is missing the `output_format` axis — "
+        f"found keys: {sorted(matrix.keys())}"
+    )
+
+
+@pytest.mark.parametrize("job_name", LAUNCHER_JOBS)
+def test_generate_job_cluster_name_includes_output_format(workflow: dict, job_name: str) -> None:
+    """Cluster name interpolates `matrix.output_format` so wds and hdf5 cells diverge."""
+    job = workflow["jobs"][job_name]
+    cluster_template = _cluster_name_template(job, job_name)
+    assert "matrix.output_format" in cluster_template, (
+        f"{job_name} cluster_name template does not interpolate matrix.output_format — "
+        f"got: {cluster_template!r}"
+    )
+
+
+def test_validate_spec_uri_includes_output_format(workflow: dict) -> None:
+    """The validate job's spec_uri template namespaces by matrix.output_format."""
+    validate = workflow["jobs"]["validate"]
+    spec_uri = validate["with"]["spec_uri"]
+    assert "matrix.output_format" in spec_uri, (
+        f"validate.with.spec_uri does not interpolate matrix.output_format — got: {spec_uri!r}"
+    )
+
+
+def test_setup_emits_output_formats_with_both_rows(workflow: dict) -> None:
+    """`setup` job's matrix step emits an output_formats list containing hdf5 + wds."""
+    matrix_step = _find_step(workflow["jobs"]["setup"]["steps"], step_id="matrix")
+    run_script = matrix_step["run"]
+    assert "hdf5" in run_script and "wds" in run_script, (
+        "setup.matrix step must emit both 'hdf5' and 'wds' in its output_formats list"
+    )
+    assert "output_formats" in workflow["jobs"]["setup"]["outputs"], (
+        "setup.outputs is missing the `output_formats` key consumed by downstream jobs"
+    )
+
+
+def _cluster_name_template(job: dict, job_name: str) -> str:
+    """Return the cluster_name interpolation string for a generate job."""
+    if job_name == "generate-local":
+        return job["env"]["CLUSTER_NAME"]
+    return job["with"]["cluster_name"]
+
+
+def _find_step(steps: list[dict], *, step_id: str) -> dict:
+    """Return the first step in `steps` whose `id` matches `step_id`."""
+    for step in steps:
+        if step.get("id") == step_id:
+            return step
+    raise AssertionError(f"No step with id={step_id!r} found in {steps!r}")

--- a/tests/pipeline/test_configs/test_experiment_yamls.py
+++ b/tests/pipeline/test_configs/test_experiment_yamls.py
@@ -33,6 +33,7 @@ DATASET_EXPERIMENTS: tuple[str, ...] = (
     "generate_dataset/ci-materialize-test",
     "generate_dataset/ci-materialize-test-wds",
     "generate_dataset/smoke-shard",
+    "generate_dataset/smoke-shard-wds",
     "generate_dataset/surge-simple-480k-10k",
 )
 

--- a/tests/pipeline/test_configs/test_experiment_yamls.py
+++ b/tests/pipeline/test_configs/test_experiment_yamls.py
@@ -31,6 +31,7 @@ CONFIG_DIR = Path(__file__).resolve().parent.parent.parent.parent / "configs"
 DATASET_EXPERIMENTS: tuple[str, ...] = (
     "generate_dataset/10-1k-shards",
     "generate_dataset/ci-materialize-test",
+    "generate_dataset/ci-materialize-test-wds",
     "generate_dataset/smoke-shard",
     "generate_dataset/surge-simple-480k-10k",
 )


### PR DESCRIPTION
## Summary

Adds `output_format: [hdf5, wds]` as a `strategy.matrix` axis on `test-dataset-generation.yml`'s `generate-local` and `generate-launcher` jobs, plus matching propagation through the `validate` job's `spec_uri` template. `CLUSTER_NAME` and the validate-side `spec_uri` are now namespaced by `matrix.output_format` so the matrix cells don't collide on the launcher's R2 spec key.

Adds a sibling Hydra experiment config `configs/experiment/generate_dataset/ci-materialize-test-wds.yaml` mirroring `ci-materialize-test.yaml`'s render volume but with `output_format: wds`.

Adds `tests/infra/test_dataset_generation_matrix.py` to pin the matrix shape (TDD red-then-green): asserts both generate jobs declare the `output_format` axis, `cluster_name` and `spec_uri` interpolate `matrix.output_format`, and `setup` emits an `output_formats` output containing both `hdf5` and `wds`.

## Dependency on PR-E

The wds writer is `synth_setter.data.vst.writers.make_wds_dataset` (landed in #1030); the wds validator's tar branch lands in PR-E (#1035). Until #1035 merges to `main`, this PR's wds matrix row will fail at validate-shards. PR is therefore opened as **draft** — will be marked ready once #1035 merges and this branch is rebased.

## Test plan

- [ ] `make test-fast` covers `tests/infra/test_dataset_generation_matrix.py`
- [ ] CI: `test-dataset-generation` workflow exercises both `hdf5` and `wds` matrix rows on `pull_request` events
- [ ] hdf5 matrix row still passes end-to-end (no regression from the matrix expansion)
- [ ] wds matrix row passes end-to-end once #1035 merges and this PR rebases

Refs #874