### PR TITLE
chore(lint): clean up src/synth_setter/utils/instantiators.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,6 @@ exclude = '''(?x)
   | ^src/synth_setter/models/ksin_flow_matching_module\.py$
   | ^src/synth_setter/cli/train\.py$
   | ^src/synth_setter/utils/callbacks\.py$
-  | ^src/synth_setter/utils/instantiators\.py$
   | ^src/synth_setter/utils/rich_utils\.py$
   | ^src/synth_setter/utils/utils\.py$
   | ^tests/_baseline_worktree\.py$

--- a/src/synth_setter/utils/instantiators.py
+++ b/src/synth_setter/utils/instantiators.py
@@ -12,7 +12,9 @@ def instantiate_callbacks(callbacks_cfg: DictConfig) -> list[Callback]:
     """Instantiates callbacks from config.
 
     :param callbacks_cfg: A DictConfig object containing callback configurations.
-    :return: A list of instantiated callbacks.
+    :returns: A list of instantiated callbacks.
+    :rtype: list[Callback]
+    :raises TypeError: If ``callbacks_cfg`` is not a :class:`DictConfig`.
     """
     callbacks: list[Callback] = []
 
@@ -35,7 +37,9 @@ def instantiate_loggers(logger_cfg: DictConfig) -> list[Logger]:
     """Instantiates loggers from config.
 
     :param logger_cfg: A DictConfig object containing logger configurations.
-    :return: A list of instantiated loggers.
+    :returns: A list of instantiated loggers.
+    :rtype: list[Logger]
+    :raises TypeError: If ``logger_cfg`` is not a :class:`DictConfig`.
     """
     logger: list[Logger] = []
 


### PR DESCRIPTION
## Summary

- Cleans up `src/synth_setter/utils/instantiators.py` so it can be removed from `[tool.pydoclint].exclude` in `pyproject.toml`.
- Adds `:raises TypeError:` and `:rtype:` sections to the two public functions to satisfy pydoclint DOC203 / DOC501 / DOC503 (return-type and raises-section consistency).
- Drops the file's entry from the pydoclint exclude list — the file was not present in any other exclusion list (ruff `per-file-ignores`, interrogate, pyright, codespell), so this single change graduates it from `#25`.

No functional changes — docstring-only edits.

Refs #25

## Test plan

- [x] `pre-commit run --files src/synth_setter/utils/instantiators.py pyproject.toml` — all hooks pass (ruff, ruff-format, pyright, docformatter, interrogate, pydoclint, codespell, etc.).
- [x] `python -c "from synth_setter.utils.instantiators import instantiate_callbacks, instantiate_loggers"` — module still imports cleanly.
- [x] `make test-fast` — the only failures (`tests/pipeline/test_ci/test_load_image_config.py`, `tests/pipeline/test_schemas/test_dataset_spec.py`, `tests/scripts/test_get_dataset_stats.py`, and the 5 ImportError test modules) reproduce on a clean `origin/main` checkout and are unrelated to this PR.