### PR TITLE
chore(lint): graduate tests/helpers/package_available.py from pydoclint exclude

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,7 +327,6 @@ exclude = '''(?x)
   | ^tests/data/vst/test_preset_coverage\.py$
   | ^tests/fixtures/baseline_repo/scripts/baseline_app\.py$
   | ^tests/fixtures/diff_repo/scripts/diff_app\.py$
-  | ^tests/helpers/package_available\.py$
   | ^tests/helpers/run_if\.py$
   | ^tests/pipeline/ci/test_validate_shard\.py$
   | ^tests/pipeline/ci/test_validate_spec\.py$

--- a/tests/helpers/package_available.py
+++ b/tests/helpers/package_available.py
@@ -8,8 +8,8 @@ def _package_available(package_name: str) -> bool:
     """Check if a package is available in your environment.
 
     :param package_name: The name of the package to be checked.
-
-    :return: `True` if the package is available. `False` otherwise.
+    :returns: ``True`` if the package is available, ``False`` otherwise.
+    :rtype: bool
     """
     try:
         return distribution(package_name) is not None


### PR DESCRIPTION
## Summary

PR #979 cleared `tests/helpers/package_available.py` from `.pre-commit-config.yaml`'s `pyright` exclude but left it in `[tool.pydoclint].exclude` in `pyproject.toml`. Per the lint-cleanup runbook (step 5), graduating a file means clearing it from *every* exclusion list it appears in. This PR finishes that graduation.

- `tests/helpers/package_available.py`: rewrite the `_package_available` return docstring to use the repo's standard Sphinx convention (`:returns:` + `:rtype: bool`, matching `src/synth_setter/data/vst/shapes.py`) so pydoclint's DOC203 (return-type consistency) is satisfied.
- `pyproject.toml`: drop `^tests/helpers/package_available\.py$` from `[tool.pydoclint].exclude`.

No source / behavioural change — docstring formatting only.

## Test plan

- [x] `pre-commit run --files tests/helpers/package_available.py pyproject.toml` — all hooks green (ruff, ruff format, pyright, docformatter, interrogate, pydoclint, codespell, validate-pyproject).
- [ ] CI: required workflows green.
- [ ] Mergeability resolves to `MERGEABLE`.
- [ ] Copilot review (post-push) addressed.

## Notes

- `make test-fast` reports pre-existing failures in this worktree (`pandas` not installed in the venv, plus a few pipeline-import / `dataset_spec` test failures unrelated to this file). Targeted import / consumer test of the changed module passes: `python -c "from tests.helpers.package_available import _package_available, _WANDB_AVAILABLE"` succeeds, and `pytest tests/test_logging_utils.py` is green.
- Branch name uses the `-pydoclint` suffix because `chore/lint-cleanup/package-available` was already used by PR #979 (the prior pyright-only graduation).

Refs #25