### PR TITLE
chore(lint): clean up tests/helpers/run_if.py and package_available.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -327,8 +327,6 @@ exclude = '''(?x)
   | ^tests/data/vst/test_preset_coverage\.py$
   | ^tests/fixtures/baseline_repo/scripts/baseline_app\.py$
   | ^tests/fixtures/diff_repo/scripts/diff_app\.py$
-  | ^tests/helpers/package_available\.py$
-  | ^tests/helpers/run_if\.py$
   | ^tests/pipeline/ci/test_validate_shard\.py$
   | ^tests/pipeline/ci/test_validate_spec\.py$
   | ^tests/pipeline/conftest\.py$

--- a/tests/helpers/package_available.py
+++ b/tests/helpers/package_available.py
@@ -8,8 +8,8 @@ def _package_available(package_name: str) -> bool:
     """Check if a package is available in your environment.
 
     :param package_name: The name of the package to be checked.
-
-    :return: `True` if the package is available. `False` otherwise.
+    :returns: ``True`` if the package is available, ``False`` otherwise.
+    :rtype: bool
     """
     try:
         return distribution(package_name) is not None

--- a/tests/helpers/run_if.py
+++ b/tests/helpers/run_if.py
@@ -64,15 +64,18 @@ class RunIf:
         :param max_torch: Maximum pytorch version to run test.
         :param min_python: Minimum python version required to run test.
         :param skip_windows: Skip test for Windows platform.
-        :param tpu: If TPU is available.
         :param sh: If `sh` module is required to run the test.
+        :param tpu: If TPU is available.
         :param fairscale: If `fairscale` module is required to run the test.
         :param deepspeed: If `deepspeed` module is required to run the test.
         :param wandb: If `wandb` module is required to run the test.
         :param neptune: If `neptune` module is required to run the test.
         :param comet: If `comet` module is required to run the test.
         :param mlflow: If `mlflow` module is required to run the test.
-        :param kwargs: Native `pytest.mark.skipif` keyword arguments.
+        :param \\*\\*kwargs: Native `pytest.mark.skipif` keyword arguments.
+        :returns: A `pytest.mark.skipif` `MarkDecorator` whose ``condition`` is
+            true when any of the requested capabilities are missing.
+        :rtype: MarkDecorator
         """
         conditions = []
         reasons = []


### PR DESCRIPTION
## Summary

- Add missing pydoclint return sections (DOC201/DOC203) on `_package_available` and `RunIf.__new__`, and align the `**kwargs` docstring entry with the actual signature (DOC103). Order of `:param sh:` and `:param tpu:` reshuffled to match the signature.
- Drop `tests/helpers/run_if.py` and `tests/helpers/package_available.py` from `[tool.pydoclint].exclude` in `pyproject.toml`.
- Pure docstring/lint changes — no behavior, signatures, or return values modified.

Refs #25

## Test plan

- [x] `pre-commit run --files tests/helpers/run_if.py tests/helpers/package_available.py pyproject.toml` — all hooks pass (pydoclint included).
- [x] `make test-fast` — same 3 pre-existing failures / 6 pre-existing import errors as `origin/main` (env-related: `pandas` not installed in the venv); 462 tests pass. The lint changes are docstring-only and don't affect any test.