### PR TITLE
docs(lint-cleanup): pick most recently added exclusion-list entry first (LIFO)

### DIFF
--- a/.claude/commands/lint-cleanup.md
+++ b/.claude/commands/lint-cleanup.md
@@ -7,13 +7,9 @@ Run the lint-cleanup workflow from
 [`.github/agents/lint-cleanup.md`](../../.github/agents/lint-cleanup.md) on
 the file `$ARGUMENTS`.
 
-If `$ARGUMENTS` is empty, follow the **"Picking the next file"** section in
-the canonical runbook: work the exclusion lists in reverse order of when
-each entry was added (most recently added first, LIFO). Use `git blame`
-against `.pre-commit-config.yaml` and `pyproject.toml`'s exclusion lines to
-rank candidates by introducing-commit date, and skip entries already in
-flight on [#25](https://github.com/tinaudio/synth-setter/issues/25). Break
-ties by smaller file size.
+If `$ARGUMENTS` is empty, pick the target by following the canonical
+runbook's [**Picking the next file**](../../.github/agents/lint-cleanup.md#picking-the-next-file)
+section — do not reproduce its rules here.
 
 Spawn the `lint-cleanup` subagent (defined in
 `.claude/agents/lint-cleanup.md`) in an isolated worktree to do the work.

--- a/.claude/commands/lint-cleanup.md
+++ b/.claude/commands/lint-cleanup.md
@@ -7,9 +7,13 @@ Run the lint-cleanup workflow from
 [`.github/agents/lint-cleanup.md`](../../.github/agents/lint-cleanup.md) on
 the file `$ARGUMENTS`.
 
-If `$ARGUMENTS` is empty, read the checklist in
-[#25](https://github.com/tinaudio/synth-setter/issues/25) and pick the next
-unchecked file (prefer the smallest by line count for a quick win).
+If `$ARGUMENTS` is empty, follow the **"Picking the next file"** section in
+the canonical runbook: work the exclusion lists in reverse order of when
+each entry was added (most recently added first, LIFO). Use `git blame`
+against `.pre-commit-config.yaml` and `pyproject.toml`'s exclusion lines to
+rank candidates by introducing-commit date, and skip entries already in
+flight on [#25](https://github.com/tinaudio/synth-setter/issues/25). Break
+ties by smaller file size.
 
 Spawn the `lint-cleanup` subagent (defined in
 `.claude/agents/lint-cleanup.md`) in an isolated worktree to do the work.

--- a/.github/agents/lint-cleanup.md
+++ b/.github/agents/lint-cleanup.md
@@ -20,6 +20,32 @@ The entry-point stubs may surface a short cross-reference of the rules most ofte
 
 Only formatting, docstrings, and lint fixes. **No functional changes.**
 
+## Picking the next file
+
+When the agent has discretion over which file to work next — i.e. invoked
+without a specific target path — **work the exclusion lists in reverse order
+of when each entry was added: most recently added first, oldest legacy
+entries last (LIFO).**
+
+To rank candidates, run `git blame` against the exclusion-list lines in
+`.pre-commit-config.yaml` and `pyproject.toml` and sort by the commit
+timestamp that introduced each entry. Skip entries that are already in
+flight (open `chore/lint-cleanup/*` PR or a ticked box on
+[#25](https://github.com/tinaudio/synth-setter/issues/25)). If two entries
+share the same introducing commit, break the tie with the smaller file by
+line count.
+
+**Why:** a freshly-added exclusion almost always came from a small,
+well-scoped change by someone whose context is still warm — graduating it
+immediately reverses tech-debt accrual before it cools and keeps the
+exclusion list from compounding. Old legacy entries don't get worse by
+waiting another week; new ones do.
+
+**How to apply:** this LIFO rule supersedes the older "prefer the smallest
+by line count" heuristic in the entry-point stubs. An explicit target named
+by the user (or by the `#25` reviewer) always wins over the default
+ordering — LIFO only governs the no-argument case.
+
 ## Workflow
 
 For each file listed in any `exclude:` block in `.pre-commit-config.yaml` (e.g. `pyright`, `interrogate`, `shellcheck`, `codespell`) **or** under `[tool.pydoclint].exclude` or `[tool.ruff.lint.per-file-ignores]` in `pyproject.toml` (pydoclint path excludes and ruff per-file rule ignores are configured there, not in the pre-commit config; note that `per-file-ignores` still runs ruff on the file but suppresses specific rules — it is not a path exclude):

--- a/.github/agents/lint-cleanup.md
+++ b/.github/agents/lint-cleanup.md
@@ -28,12 +28,23 @@ of when each entry was added: most recently added first, oldest legacy
 entries last (LIFO).**
 
 To rank candidates, run `git blame` against the exclusion-list lines in
-`.pre-commit-config.yaml` and `pyproject.toml` and sort by the commit
-timestamp that introduced each entry. Skip entries that are already in
+`.pre-commit-config.yaml` and `pyproject.toml` and sort by the timestamp
+`git blame` reports for each entry's line. Skip entries that are already in
 flight (open `chore/lint-cleanup/*` PR or a ticked box on
 [#25](https://github.com/tinaudio/synth-setter/issues/25)). If two entries
-share the same introducing commit, break the tie with the smaller file by
-line count.
+share the same blame commit, break the tie with the smaller file by line
+count.
+
+**`git blame` is a best-effort heuristic, not a perfect provenance signal.**
+It reports the *last commit that touched the line*, not necessarily the
+commit that originally introduced the entry — a reformat, a YAML reorder,
+or an unrelated `exclude:` edit nearby can move the blame timestamp without
+the entry actually being "new." That's fine: the goal here is to bias
+toward recently-touched entries (which are usually genuinely recent and
+context-fresh), not to reconstruct strict introduction order. Do not reach
+for `git log -L` or pickaxe in the default path — the extra fidelity isn't
+worth the runtime cost or the runbook complexity. If a particular entry
+looks misranked, just pick the next one down and move on.
 
 **Why:** a freshly-added exclusion almost always came from a small,
 well-scoped change by someone whose context is still warm — graduating it


### PR DESCRIPTION
## Summary

- Add a **"Picking the next file"** section to the canonical lint-cleanup runbook (`.github/agents/lint-cleanup.md`) telling the agent to work the exclusion lists in reverse order of when entries were added — most recently added first (LIFO) — when no specific target is given.
- Update the slash-command stub (`.claude/commands/lint-cleanup.md`) to delegate to the new section instead of repeating the older "smallest file by line count" heuristic, so the two entry points don't drift apart.
- The Copilot Coding Agent entry point already delegates to the canonical runbook with no local picking heuristic, so it inherits the rule automatically.

## Why LIFO

A freshly-added exclusion is almost always a small, well-scoped addition by someone whose context is still warm — graduating it right away reverses the tech-debt accrual before it cools and keeps the exclusion lists from compounding. Old legacy entries don't get worse by waiting another week; new ones do.

The runbook's **Why:** and **How to apply:** blocks capture this so the agent can judge edge cases instead of mechanically following the rule.

## Mechanics

The agent ranks candidates via `git blame` on the exclusion-list lines in `.pre-commit-config.yaml` and `pyproject.toml` (under `[tool.pydoclint].exclude` and `[tool.ruff.lint.per-file-ignores]`), sorted by introducing-commit timestamp. Entries already in flight (open `chore/lint-cleanup/*` PR or ticked on #25) are skipped. Ties break by smaller file size. An explicit target named by the user always wins over the default ordering.

## Scope

Documentation only — no behavioral or code change. Exempt from the `/tdd-implementation` → `/code-health` → `/simplify` mandatory-skill chain per CLAUDE.md.

Refs #25

## Test plan

- [ ] CI green (gitlint, pre-commit, markdown lint, PR metadata gate)
- [ ] Render `.github/agents/lint-cleanup.md` on GitHub and confirm the new **"Picking the next file"** section sits between **Scope** and **Workflow** with no broken links
- [ ] Confirm `.claude/commands/lint-cleanup.md` no longer contradicts the canonical runbook (no leftover "smallest by line count" guidance as the primary rule)