### PR TITLE
feat(metrics): add get_stats_wds for WebDataset shard directories

### DIFF
--- a/src/synth_setter/pipeline/data/stats.py
+++ b/src/synth_setter/pipeline/data/stats.py
@@ -241,26 +241,42 @@ def _iter_mel_batches(shard_path: Path) -> Iterator[np.ndarray]:
     parse errors at the same layer as the validator. Ignores the writer's
     ``metadata.json`` sentinel and other per-row fields.
 
+    Iterates sorted ``TarInfo`` objects (not member names) and extracts
+    by the ``TarInfo`` itself so a malformed archive with duplicate
+    matching names cannot trick ``extractfile`` into returning the same
+    payload twice (tar name lookup resolves to the *last* matching entry
+    regardless of which one we're iterating).
+
     :param shard_path: Filesystem path to one ``shard-*.tar``.
     :yields: One ``(rows, *inner)`` mel array per matched tar member.
     :ytype: np.ndarray
     :raises ValueError: When a matched ``*.mel_spec.npy`` member is not a
-        regular file (``tarfile.extractfile`` returns ``None`` for
-        directories, symlinks, devices, etc.). Treated as a malformed
-        shard so the per-shard guard in :func:`get_stats_wds` cannot be
-        defeated by a mix of readable and unextractable matched members
-        on the same shard.
+        regular file (directory, symlink, hardlink, device, etc.). Hard-
+        and symlinks pointing at another archive member would satisfy
+        ``extractfile != None``, so the check uses ``TarInfo.isfile()``
+        which only returns ``True`` for ``REGTYPE``/``AREGTYPE``. Treated
+        as a malformed shard so the per-shard guard in
+        :func:`get_stats_wds` cannot be defeated by a mix of readable and
+        unreadable matched members on the same shard.
     """
     with tarfile.open(shard_path, mode="r:") as tar:
-        for name in sorted(m.name for m in tar.getmembers()):
-            if not _MEL_SPEC_MEMBER_RE.match(name):
-                continue
-            extracted = tar.extractfile(name)
+        matched = sorted(
+            (m for m in tar.getmembers() if _MEL_SPEC_MEMBER_RE.match(m.name)),
+            key=lambda m: m.name,
+        )
+        for member in matched:
+            if not member.isfile():
+                raise ValueError(
+                    f"shard {shard_path.name}: matched member {member.name!r} is "
+                    f"not a regular file (TarInfo.isfile() is False; rejects "
+                    f"directories, symlinks, hardlinks, and devices); treat as "
+                    f"malformed shard rather than silently skip"
+                )
+            extracted = tar.extractfile(member)
             if extracted is None:
                 raise ValueError(
-                    f"shard {shard_path.name}: matched member {name!r} is "
-                    f"not a regular file (tarfile.extractfile returned None); "
-                    f"treat as malformed shard rather than silently skip"
+                    f"shard {shard_path.name}: matched member {member.name!r} "
+                    f"could not be extracted (tarfile.extractfile returned None)"
                 )
             yield np.load(io.BytesIO(extracted.read()))
 

--- a/src/synth_setter/pipeline/data/stats.py
+++ b/src/synth_setter/pipeline/data/stats.py
@@ -268,6 +268,9 @@ def get_stats_wds(directory: str | Path, mask_degenerate: bool = False) -> None:
         on :func:`get_stats_hdf5` / :func:`get_stats_directory` for the
         downstream rationale.
     :raises FileNotFoundError: When ``directory`` contains no shards.
+    :raises ValueError: When a matched shard has zero readable
+        ``mel_spec.npy`` members — raised eagerly so partial stats are
+        never written silently for a truncated/malformed shard.
     :returns: ``None``. Writes ``stats.npz`` to ``directory / "stats.npz"``.
     :rtype: None
     """
@@ -280,9 +283,17 @@ def get_stats_wds(directory: str | Path, mask_degenerate: bool = False) -> None:
     existing = (0, 0, 0)
     for shard_path in shard_paths:
         logger.info(f"Processing {shard_path.name}...")
+        shard_rows = 0
         for mel_batch in _iter_mel_batches(shard_path):
             for row in mel_batch:
                 existing = update(existing, row)
+                shard_rows += 1
+        if shard_rows == 0:
+            raise ValueError(
+                f"shard {shard_path.name} contained no readable "
+                f"'*.{MEL_SPEC_FIELD}.npy' members; aborting so partial stats "
+                f"are never written silently for a truncated/malformed shard"
+            )
 
     mean, std = finalize(existing, mask_degenerate=mask_degenerate)
 

--- a/src/synth_setter/pipeline/data/stats.py
+++ b/src/synth_setter/pipeline/data/stats.py
@@ -1,6 +1,10 @@
 import argparse
+import io
 import logging
-import os
+import re
+import tarfile
+from collections.abc import Iterator
+from pathlib import Path
 from typing import NamedTuple
 
 import dask.array as da
@@ -12,8 +16,12 @@ from dask.distributed import Client, progress
 rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 from synth_setter.data.audio_datamodule import AudioFolderDataset
 from synth_setter.data.surge_datamodule import SurgeXTDataset
+from synth_setter.data.vst.shapes import MEL_SPEC_FIELD
 
 logger = logging.getLogger(__name__)
+
+_SHARD_GLOB = "shard-*.tar"
+_MEL_SPEC_MEMBER_RE = re.compile(rf"^\d{{8}}\.{re.escape(MEL_SPEC_FIELD)}\.npy$")
 
 # Cap the listed degenerate indices in error/warning messages so a fully
 # degenerate dataset (e.g. count==1 on a 3-D mel spec, ~100k elements) doesn't
@@ -225,18 +233,77 @@ def get_stats_directory(directory, mask_degenerate: bool = False):
     np.savez(out_file, mean=mean, std=std)
 
 
+def _iter_mel_batches(shard_path: Path) -> Iterator[np.ndarray]:
+    """Yield each ``mel_spec.npy`` member's array from one shard, in name-sorted order.
+
+    Mirrors ``validate_shard``'s raw-``tarfile`` idiom so the stats path
+    pulls in no extra runtime deps (no ``webdataset``) and surfaces tar
+    parse errors at the same layer as the validator. Ignores the writer's
+    ``metadata.json`` sentinel and other per-row fields.
+
+    :param shard_path: Filesystem path to one ``shard-*.tar``.
+    :yields: One ``(rows, *inner)`` mel array per matched tar member.
+    :ytype: np.ndarray
+    """
+    with tarfile.open(shard_path, mode="r:") as tar:
+        for name in sorted(m.name for m in tar.getmembers()):
+            if not _MEL_SPEC_MEMBER_RE.match(name):
+                continue
+            extracted = tar.extractfile(name)
+            if extracted is None:
+                continue
+            yield np.load(io.BytesIO(extracted.read()))
+
+
+def get_stats_wds(directory: str | Path, mask_degenerate: bool = False) -> None:
+    """Compute mel-spec mean/std across all ``shard-*.tar`` in ``directory`` and write sibling
+    ``stats.npz``.
+
+    Streams Welford's algorithm row-by-row over each shard's pre-computed
+    ``mel_spec`` arrays — no mel recompute, no full-dataset load.
+
+    :param directory: Path to a directory containing ``shard-*.tar`` shards.
+    :param mask_degenerate: If ``True``, mel bins with zero variance are
+        masked to ``std=1.0`` instead of raising — see the matching flag
+        on :func:`get_stats_hdf5` / :func:`get_stats_directory` for the
+        downstream rationale.
+    :raises FileNotFoundError: When ``directory`` contains no shards.
+    :returns: ``None``. Writes ``stats.npz`` to ``directory / "stats.npz"``.
+    :rtype: None
+    """
+    directory = Path(directory)
+    shard_paths = sorted(directory.glob(_SHARD_GLOB))
+    if not shard_paths:
+        raise FileNotFoundError(f"no {_SHARD_GLOB} files in {directory}")
+    out_file = directory / "stats.npz"
+
+    existing = (0, 0, 0)
+    for shard_path in shard_paths:
+        logger.info(f"Processing {shard_path.name}...")
+        for mel_batch in _iter_mel_batches(shard_path):
+            for row in mel_batch:
+                existing = update(existing, row)
+
+    mean, std = finalize(existing, mask_degenerate=mask_degenerate)
+
+    logger.info(f"Saving to {out_file}")
+    np.savez(out_file, mean=mean, std=std)
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
-            "Compute mean/std statistics over a Surge XT HDF5 file or an audio "
-            "folder and write the result to a sibling stats.npz."
+            "Compute mean/std statistics over a Surge XT HDF5 file, a "
+            "directory of WebDataset shard-*.tar files, or an audio folder, "
+            "and write the result to a sibling stats.npz."
         )
     )
     parser.add_argument(
         "input",
         help=(
-            "Path to a .h5 file (Dask path) or a directory of audio files "
-            "(streaming Welford path)."
+            "Path to a .h5 file (Dask path), a directory containing "
+            "shard-*.tar shards (streaming Welford path), or a directory of "
+            "audio files (streaming Welford path)."
         ),
     )
     parser.add_argument(
@@ -253,8 +320,19 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-if __name__ == "__main__":
-    args = _parse_args()
+def main(argv: list[str] | None = None) -> None:
+    """Parse ``argv`` and dispatch to the matching stats entrypoint.
+
+    Dispatch order: ``.h5`` suffix → :func:`get_stats_hdf5`; directory
+    containing ``shard-*.tar`` → :func:`get_stats_wds`; everything else →
+    :func:`get_stats_directory` (audio folder).
+
+    :param argv: Argument list forwarded to ``argparse``. ``None`` uses
+        ``sys.argv[1:]`` — the standard CLI behavior.
+    :returns: ``None``.
+    :rtype: None
+    """
+    args = _parse_args(argv)
 
     # Without this the stdlib root logger stays at WARNING and the per-file
     # progress + "Saving to..." messages emitted by get_stats_*() are silently
@@ -265,7 +343,14 @@ if __name__ == "__main__":
         format="%(asctime)s %(levelname)s %(name)s: %(message)s",
     )
 
-    if os.path.splitext(args.input)[-1] == ".h5":
+    input_path = Path(args.input)
+    if input_path.suffix == ".h5":
         get_stats_hdf5(args.input, mask_degenerate=args.mask_degenerate_bins)
+    elif input_path.is_dir() and any(input_path.glob(_SHARD_GLOB)):
+        get_stats_wds(args.input, mask_degenerate=args.mask_degenerate_bins)
     else:
         get_stats_directory(args.input, mask_degenerate=args.mask_degenerate_bins)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/synth_setter/pipeline/data/stats.py
+++ b/src/synth_setter/pipeline/data/stats.py
@@ -244,6 +244,12 @@ def _iter_mel_batches(shard_path: Path) -> Iterator[np.ndarray]:
     :param shard_path: Filesystem path to one ``shard-*.tar``.
     :yields: One ``(rows, *inner)`` mel array per matched tar member.
     :ytype: np.ndarray
+    :raises ValueError: When a matched ``*.mel_spec.npy`` member is not a
+        regular file (``tarfile.extractfile`` returns ``None`` for
+        directories, symlinks, devices, etc.). Treated as a malformed
+        shard so the per-shard guard in :func:`get_stats_wds` cannot be
+        defeated by a mix of readable and unextractable matched members
+        on the same shard.
     """
     with tarfile.open(shard_path, mode="r:") as tar:
         for name in sorted(m.name for m in tar.getmembers()):
@@ -251,7 +257,11 @@ def _iter_mel_batches(shard_path: Path) -> Iterator[np.ndarray]:
                 continue
             extracted = tar.extractfile(name)
             if extracted is None:
-                continue
+                raise ValueError(
+                    f"shard {shard_path.name}: matched member {name!r} is "
+                    f"not a regular file (tarfile.extractfile returned None); "
+                    f"treat as malformed shard rather than silently skip"
+                )
             yield np.load(io.BytesIO(extracted.read()))
 
 

--- a/tests/pipeline/data/test_stats.py
+++ b/tests/pipeline/data/test_stats.py
@@ -526,13 +526,16 @@ def test_get_stats_wds_shard_without_mel_members_raises(
         stats_script.get_stats_wds(str(tmp_path))
 
 
-def test_cli_dispatches_directory_of_tar_shards_to_wds_path(
+def test_cli_dispatches_directory_of_tar_shards_to_wds_path_with_default_flag(
     stats_script: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``main`` routes a directory containing ``shard-*.tar`` to ``get_stats_wds``.
+    """``main`` routes a directory containing ``shard-*.tar`` to ``get_stats_wds`` with
+    ``mask_degenerate=False`` by default.
 
-    Spies on each dispatch target so the assertion verifies the chosen branch, not the resulting
-    stats file (those are covered by the behavior tests above).
+    Spies record ``(branch, mask_degenerate)`` so this test pins both the
+    chosen branch *and* the default-False forwarding. A regression that
+    accidentally hardcoded ``True`` (or dropped the kwarg entirely) would
+    fail here, not silently change normalization behavior in production.
 
     :param stats_script: Imported stats module (fixture).
     :param tmp_path: pytest tmp dir used as the synthetic shard directory.
@@ -542,20 +545,33 @@ def test_cli_dispatches_directory_of_tar_shards_to_wds_path(
     mel = rng.normal(size=(2, 2, 2)).astype(np.float32)
     _write_mel_shard(tmp_path / "shard-000000.tar", [mel])
 
-    calls: list[str] = []
-    monkeypatch.setattr(stats_script, "get_stats_wds", lambda *a, **kw: calls.append("wds"))
-    monkeypatch.setattr(stats_script, "get_stats_hdf5", lambda *a, **kw: calls.append("hdf5"))
-    monkeypatch.setattr(stats_script, "get_stats_directory", lambda *a, **kw: calls.append("dir"))
+    calls: list[tuple[str, bool]] = []
+    monkeypatch.setattr(
+        stats_script,
+        "get_stats_wds",
+        lambda *a, **kw: calls.append(("wds", kw.get("mask_degenerate", False))),
+    )
+    monkeypatch.setattr(
+        stats_script,
+        "get_stats_hdf5",
+        lambda *a, **kw: calls.append(("hdf5", kw.get("mask_degenerate", False))),
+    )
+    monkeypatch.setattr(
+        stats_script,
+        "get_stats_directory",
+        lambda *a, **kw: calls.append(("dir", kw.get("mask_degenerate", False))),
+    )
 
     stats_script.main([str(tmp_path)])
 
-    assert calls == ["wds"]
+    assert calls == [("wds", False)]
 
 
-def test_cli_dispatches_h5_input_to_hdf5_path(
+def test_cli_dispatches_h5_input_to_hdf5_path_with_default_flag(
     stats_script: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``main`` routes a ``.h5`` input to ``get_stats_hdf5`` (regression guard).
+    """``main`` routes a ``.h5`` input to ``get_stats_hdf5`` with ``mask_degenerate=False`` by
+    default.
 
     :param stats_script: Imported stats module (fixture).
     :param tmp_path: pytest tmp dir used to place a sentinel ``.h5`` path.
@@ -564,33 +580,134 @@ def test_cli_dispatches_h5_input_to_hdf5_path(
     h5_path = tmp_path / "train.h5"
     h5_path.write_bytes(b"")
 
-    calls: list[str] = []
-    monkeypatch.setattr(stats_script, "get_stats_wds", lambda *a, **kw: calls.append("wds"))
-    monkeypatch.setattr(stats_script, "get_stats_hdf5", lambda *a, **kw: calls.append("hdf5"))
-    monkeypatch.setattr(stats_script, "get_stats_directory", lambda *a, **kw: calls.append("dir"))
+    calls: list[tuple[str, bool]] = []
+    monkeypatch.setattr(
+        stats_script,
+        "get_stats_wds",
+        lambda *a, **kw: calls.append(("wds", kw.get("mask_degenerate", False))),
+    )
+    monkeypatch.setattr(
+        stats_script,
+        "get_stats_hdf5",
+        lambda *a, **kw: calls.append(("hdf5", kw.get("mask_degenerate", False))),
+    )
+    monkeypatch.setattr(
+        stats_script,
+        "get_stats_directory",
+        lambda *a, **kw: calls.append(("dir", kw.get("mask_degenerate", False))),
+    )
 
     stats_script.main([str(h5_path)])
 
-    assert calls == ["hdf5"]
+    assert calls == [("hdf5", False)]
 
 
-def test_cli_dispatches_directory_without_tars_to_audio_directory_path(
+def test_cli_dispatches_directory_without_tars_to_audio_directory_path_with_default_flag(
     stats_script: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``main`` falls back to ``get_stats_directory`` when the directory has no shards.
+    """``main`` falls back to ``get_stats_directory`` with ``mask_degenerate=False`` by default.
 
     :param stats_script: Imported stats module (fixture).
     :param tmp_path: pytest tmp dir used as the (no-shard) input directory.
     :param monkeypatch: pytest fixture for swapping in spy callables.
     """
-    calls: list[str] = []
-    monkeypatch.setattr(stats_script, "get_stats_wds", lambda *a, **kw: calls.append("wds"))
-    monkeypatch.setattr(stats_script, "get_stats_hdf5", lambda *a, **kw: calls.append("hdf5"))
-    monkeypatch.setattr(stats_script, "get_stats_directory", lambda *a, **kw: calls.append("dir"))
+    calls: list[tuple[str, bool]] = []
+    monkeypatch.setattr(
+        stats_script,
+        "get_stats_wds",
+        lambda *a, **kw: calls.append(("wds", kw.get("mask_degenerate", False))),
+    )
+    monkeypatch.setattr(
+        stats_script,
+        "get_stats_hdf5",
+        lambda *a, **kw: calls.append(("hdf5", kw.get("mask_degenerate", False))),
+    )
+    monkeypatch.setattr(
+        stats_script,
+        "get_stats_directory",
+        lambda *a, **kw: calls.append(("dir", kw.get("mask_degenerate", False))),
+    )
 
     stats_script.main([str(tmp_path)])
 
-    assert calls == ["dir"]
+    assert calls == [("dir", False)]
+
+
+def test_cli_forwards_mask_degenerate_bins_flag_to_wds_path(
+    stats_script: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``main`` with ``--mask-degenerate-bins`` forwards ``mask_degenerate=True`` to
+    ``get_stats_wds``.
+
+    The CLI dispatch hands the parsed argparse flag through as a kwarg — a regression that
+    hardcoded the value or dropped the kwarg would silently change normalization behavior on
+    degenerate-bin datasets without changing which entrypoint runs.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the synthetic shard directory.
+    :param monkeypatch: pytest fixture for swapping in spy callables.
+    """
+    rng = np.random.default_rng(8)
+    mel = rng.normal(size=(2, 2, 2)).astype(np.float32)
+    _write_mel_shard(tmp_path / "shard-000000.tar", [mel])
+
+    calls: list[tuple[str, bool]] = []
+    monkeypatch.setattr(
+        stats_script,
+        "get_stats_wds",
+        lambda *a, **kw: calls.append(("wds", kw.get("mask_degenerate", False))),
+    )
+
+    stats_script.main([str(tmp_path), "--mask-degenerate-bins"])
+
+    assert calls == [("wds", True)]
+
+
+def test_cli_forwards_mask_degenerate_bins_flag_to_hdf5_path(
+    stats_script: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``main`` with ``--mask-degenerate-bins`` forwards ``mask_degenerate=True`` to
+    ``get_stats_hdf5``.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used to place a sentinel ``.h5`` path.
+    :param monkeypatch: pytest fixture for swapping in spy callables.
+    """
+    h5_path = tmp_path / "train.h5"
+    h5_path.write_bytes(b"")
+
+    calls: list[tuple[str, bool]] = []
+    monkeypatch.setattr(
+        stats_script,
+        "get_stats_hdf5",
+        lambda *a, **kw: calls.append(("hdf5", kw.get("mask_degenerate", False))),
+    )
+
+    stats_script.main([str(h5_path), "--mask-degenerate-bins"])
+
+    assert calls == [("hdf5", True)]
+
+
+def test_cli_forwards_mask_degenerate_bins_flag_to_audio_directory_path(
+    stats_script: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``main`` with ``--mask-degenerate-bins`` forwards ``mask_degenerate=True`` to
+    ``get_stats_directory``.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the (no-shard) input directory.
+    :param monkeypatch: pytest fixture for swapping in spy callables.
+    """
+    calls: list[tuple[str, bool]] = []
+    monkeypatch.setattr(
+        stats_script,
+        "get_stats_directory",
+        lambda *a, **kw: calls.append(("dir", kw.get("mask_degenerate", False))),
+    )
+
+    stats_script.main([str(tmp_path), "--mask-degenerate-bins"])
+
+    assert calls == [("dir", True)]
 
 
 def test_cli_help_advertises_mask_degenerate_bins_flag(

--- a/tests/pipeline/data/test_stats.py
+++ b/tests/pipeline/data/test_stats.py
@@ -526,6 +526,42 @@ def test_get_stats_wds_shard_without_mel_members_raises(
         stats_script.get_stats_wds(str(tmp_path))
 
 
+def test_get_stats_wds_shard_with_unextractable_mel_member_raises(
+    stats_script: ModuleType, tmp_path: Path
+) -> None:
+    """A matched ``*.mel_spec.npy`` member that is not a regular file raises ``ValueError``.
+
+    ``tarfile.extractfile`` returns ``None`` for directories, symlinks,
+    devices, etc. Silently skipping such a member would let a shard with
+    *some* readable mel members defeat the per-shard ``shard_rows == 0``
+    guard and still write partial stats. The malformed-member error is
+    raised eagerly so any unextractable matched member aborts the run.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the synthetic shard directory.
+    """
+    rng = np.random.default_rng(8)
+    mel = rng.normal(size=(2, 2, 2)).astype(np.float32)
+    buf = io.BytesIO()
+    np.save(buf, mel)
+    payload = buf.getvalue()
+
+    shard_path = tmp_path / "shard-000000.tar"
+    with tarfile.open(shard_path, mode="w:") as tar:
+        info = tarfile.TarInfo(name="00000000.mel_spec.npy")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+        # Second matched member is a *directory* entry; ``extractfile`` returns
+        # None for it. A silent ``continue`` would let the readable member
+        # above contribute rows and let the function write partial stats.
+        dir_info = tarfile.TarInfo(name="00000002.mel_spec.npy")
+        dir_info.type = tarfile.DIRTYPE
+        tar.addfile(dir_info)
+
+    with pytest.raises(ValueError, match=r"00000002\.mel_spec\.npy.*not a regular file"):
+        stats_script.get_stats_wds(str(tmp_path))
+
+
 def test_cli_dispatches_directory_of_tar_shards_to_wds_path_with_default_flag(
     stats_script: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/pipeline/data/test_stats.py
+++ b/tests/pipeline/data/test_stats.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import logging
 import tarfile
+from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType
 
@@ -250,13 +251,16 @@ def test_finalize_with_at_most_one_sample_raises_distinct_error(stats_script: Mo
 def _write_mel_shard(path: Path, mel_batches: list[np.ndarray]) -> None:
     """Write a tar shard at ``path`` containing one ``mel_spec.npy`` per batch.
 
-    Mirrors the writer's per-batch member naming convention
-    (``<batch_start_idx:08d>.mel_spec.npy``) and tacks on the
-    ``metadata.json`` sentinel that the writer always emits — so the test
-    fixtures look structurally like real shards. Other writer fields
-    (``audio``, ``param_array``) are intentionally omitted: the stats path
-    only consumes ``mel_spec``, and including them would just slow tests
-    down.
+    Mirrors the writer's per-batch naming convention exactly — the tar key
+    for each batch is the *cumulative row offset* where the batch starts
+    (``writers.py``: ``"__key__": f"{start_idx:08d}"``), not the batch
+    ordinal. So a shard with batches of size 4, 7, 3 emits members
+    ``00000000.mel_spec.npy``, ``00000004.mel_spec.npy``,
+    ``00000011.mel_spec.npy``. Using ordinals instead would silently
+    hide bugs in code that depends on batch keys. The ``metadata.json``
+    sentinel mirrors the writer; other per-row fields (``audio``,
+    ``param_array``) are intentionally omitted — the stats path only
+    consumes ``mel_spec``.
 
     :param path: Filesystem path where the tar archive will be written.
     :param mel_batches: One mel array per batch, each shaped
@@ -266,13 +270,15 @@ def _write_mel_shard(path: Path, mel_batches: list[np.ndarray]) -> None:
     :rtype: None
     """
     with tarfile.open(path, mode="w:") as tar:
-        for batch_index, mel in enumerate(mel_batches):
+        start_idx = 0
+        for mel in mel_batches:
             buf = io.BytesIO()
             np.save(buf, mel)
             payload = buf.getvalue()
-            info = tarfile.TarInfo(name=f"{batch_index:08d}.mel_spec.npy")
+            info = tarfile.TarInfo(name=f"{start_idx:08d}.mel_spec.npy")
             info.size = len(payload)
             tar.addfile(info, io.BytesIO(payload))
+            start_idx += mel.shape[0]
         metadata = b"{}"
         info = tarfile.TarInfo(name="metadata.json")
         info.size = len(metadata)
@@ -401,29 +407,65 @@ def test_get_stats_wds_no_shards_in_directory_raises(
 
 
 def test_get_stats_wds_iterates_sorted_shard_order(
+    stats_script: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Shard filenames are processed in lexicographic order so logs and any future order-sensitive
+    consumers stay reproducible.
+
+    Welford mean/std are order-invariant, so a result-only assertion would
+    pass regardless of iteration order. Spying on ``_iter_mel_batches``
+    captures the actual processing sequence so the determinism
+    requirement is observable.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the synthetic shard directory.
+    :param monkeypatch: pytest fixture used to install the order-recording spy.
+    """
+    rng = np.random.default_rng(5)
+    mel = rng.normal(size=(3, 2, 2)).astype(np.float32)
+    for shard_name in ("shard-000002.tar", "shard-000000.tar", "shard-000001.tar"):
+        _write_mel_shard(tmp_path / shard_name, [mel])
+
+    visited: list[str] = []
+    real_iter = stats_script._iter_mel_batches
+
+    def recording_iter(shard_path: Path) -> Iterator[np.ndarray]:
+        visited.append(Path(shard_path).name)
+        yield from real_iter(shard_path)
+
+    monkeypatch.setattr(stats_script, "_iter_mel_batches", recording_iter)
+
+    stats_script.get_stats_wds(str(tmp_path))
+
+    assert visited == ["shard-000000.tar", "shard-000001.tar", "shard-000002.tar"]
+
+
+def test_get_stats_wds_shard_without_mel_members_raises(
     stats_script: ModuleType, tmp_path: Path
 ) -> None:
-    """Shard filenames are processed in lexicographic order so results are reproducible.
+    """A shard tar that exists but has zero readable ``mel_spec.npy`` members raises
+    ``ValueError``.
 
-    Welford is order-invariant for mean/std, so order doesn't change the
-    answer — but the dispatch glob must yield a deterministic sequence so
-    log-line ordering and any future order-sensitive accumulators stay
-    reproducible across filesystems whose ``glob`` returns inode order.
+    A silent skip would let a truncated or wrong-schema shard contribute
+    nothing to the Welford accumulator while the function still wrote
+    ``stats.npz`` from the remaining shards — partial normalization stats
+    are a footgun.
 
     :param stats_script: Imported stats module (fixture).
     :param tmp_path: pytest tmp dir used as the synthetic shard directory.
     """
-    rng = np.random.default_rng(5)
-    mel_a = rng.normal(size=(3, 2, 2)).astype(np.float32)
-    mel_b = rng.normal(size=(3, 2, 2)).astype(np.float32)
-    _write_mel_shard(tmp_path / "shard-000001.tar", [mel_b])
-    _write_mel_shard(tmp_path / "shard-000000.tar", [mel_a])
+    rng = np.random.default_rng(7)
+    mel = rng.normal(size=(2, 2, 2)).astype(np.float32)
+    _write_mel_shard(tmp_path / "shard-000000.tar", [mel])
 
-    stats_script.get_stats_wds(str(tmp_path))
+    empty_tar = tmp_path / "shard-000001.tar"
+    with tarfile.open(empty_tar, mode="w:") as tar:
+        info = tarfile.TarInfo(name="metadata.json")
+        info.size = 2
+        tar.addfile(info, io.BytesIO(b"{}"))
 
-    stacked = np.concatenate([mel_a, mel_b], axis=0)
-    out = np.load(tmp_path / "stats.npz")
-    np.testing.assert_allclose(out["mean"], stacked.mean(axis=0), rtol=1e-5, atol=1e-6)
+    with pytest.raises(ValueError, match=r"shard-000001\.tar contained no readable"):
+        stats_script.get_stats_wds(str(tmp_path))
 
 
 def test_cli_dispatches_directory_of_tar_shards_to_wds_path(

--- a/tests/pipeline/data/test_stats.py
+++ b/tests/pipeline/data/test_stats.py
@@ -327,6 +327,64 @@ def test_get_stats_wds_matches_numpy_baseline_across_shards(
     np.testing.assert_allclose(out["std"], stacked.std(axis=0, ddof=0), rtol=1e-5, atol=1e-6)
 
 
+def test_get_stats_wds_two_value_textbook_welford_state(
+    stats_script: ModuleType, tmp_path: Path
+) -> None:
+    """The textbook ``[1.0, 3.0]`` two-value example yields the documented mean and population std.
+
+    Pins the canonical Welford worked-example: after two updates the state
+    is ``count=2, mean=2.0, M2=2.0``. ``finalize()`` returns population
+    std (``variance = M2 / count`` — matches every other test in this
+    file), so std is ``sqrt(2.0 / 2) = 1.0``. Sample std (``ddof=1``,
+    which the spec sketches as ``M2 / (n-1) = 2.0``) is intentionally
+    *not* what this stats path computes.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the synthetic shard directory.
+    """
+    mel = np.array([[1.0], [3.0]], dtype=np.float64)
+    _write_mel_shard(tmp_path / "shard-000000.tar", [mel])
+
+    stats_script.get_stats_wds(str(tmp_path))
+
+    out = np.load(tmp_path / "stats.npz")
+    np.testing.assert_allclose(out["mean"], np.array([2.0]))
+    np.testing.assert_allclose(out["std"], np.array([1.0]))
+
+
+def test_get_stats_wds_large_near_equal_values_avoid_catastrophic_cancellation(
+    stats_script: ModuleType, tmp_path: Path
+) -> None:
+    """Welford preserves precision on ``[1e9+1..1e9+4]`` where the naive two-pass formula loses
+    significance.
+
+    The naive ``var = (sum(x**2) - sum(x)**2 / n) / n`` subtracts two
+    near-equal ~4e18 floats and loses most of the answer to rounding.
+    Welford's running correction keeps full precision because it
+    operates on deviations from the running mean rather than the raw
+    sums. Mean is asserted with an absolute tolerance (not relative) so
+    a regression that drops the ``.5`` fractional part — the exact
+    failure mode of catastrophic cancellation here — would fail loudly.
+
+    Inputs are float64; float32 cannot represent ``1e9 + k`` for
+    ``k in {1..4}`` distinctly (its integer-precision ceiling is
+    ``2**24 ≈ 1.68e7``), so casting to float32 would collapse the four
+    values before they ever reached Welford.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the synthetic shard directory.
+    """
+    values = np.array([1e9 + 1, 1e9 + 2, 1e9 + 3, 1e9 + 4], dtype=np.float64)
+    mel = values.reshape(4, 1)
+    _write_mel_shard(tmp_path / "shard-000000.tar", [mel])
+
+    stats_script.get_stats_wds(str(tmp_path))
+
+    out = np.load(tmp_path / "stats.npz")
+    np.testing.assert_allclose(out["mean"], np.array([1_000_000_002.5]), rtol=0, atol=1e-6)
+    np.testing.assert_allclose(out["std"], np.array([np.sqrt(1.25)]), rtol=1e-9, atol=0)
+
+
 def test_get_stats_wds_handles_multiple_batches_per_shard(
     stats_script: ModuleType, tmp_path: Path
 ) -> None:

--- a/tests/pipeline/data/test_stats.py
+++ b/tests/pipeline/data/test_stats.py
@@ -531,11 +531,10 @@ def test_get_stats_wds_shard_with_unextractable_mel_member_raises(
 ) -> None:
     """A matched ``*.mel_spec.npy`` member that is not a regular file raises ``ValueError``.
 
-    ``tarfile.extractfile`` returns ``None`` for directories, symlinks,
-    devices, etc. Silently skipping such a member would let a shard with
-    *some* readable mel members defeat the per-shard ``shard_rows == 0``
-    guard and still write partial stats. The malformed-member error is
-    raised eagerly so any unextractable matched member aborts the run.
+    A non-regular matched member (directory, symlink, hardlink, device)
+    must be rejected eagerly. Silently skipping such a member would let
+    a shard with *some* readable mel members defeat the per-shard
+    ``shard_rows == 0`` guard and still write partial stats.
 
     :param stats_script: Imported stats module (fixture).
     :param tmp_path: pytest tmp dir used as the synthetic shard directory.
@@ -551,15 +550,86 @@ def test_get_stats_wds_shard_with_unextractable_mel_member_raises(
         info = tarfile.TarInfo(name="00000000.mel_spec.npy")
         info.size = len(payload)
         tar.addfile(info, io.BytesIO(payload))
-        # Second matched member is a *directory* entry; ``extractfile`` returns
-        # None for it. A silent ``continue`` would let the readable member
-        # above contribute rows and let the function write partial stats.
+        # Second matched member is a *directory* entry; ``TarInfo.isfile()``
+        # is False for it. A silent ``continue`` would let the readable
+        # member above contribute rows and write partial stats.
         dir_info = tarfile.TarInfo(name="00000002.mel_spec.npy")
         dir_info.type = tarfile.DIRTYPE
         tar.addfile(dir_info)
 
     with pytest.raises(ValueError, match=r"00000002\.mel_spec\.npy.*not a regular file"):
         stats_script.get_stats_wds(str(tmp_path))
+
+
+def test_get_stats_wds_shard_with_symlink_mel_member_raises(
+    stats_script: ModuleType, tmp_path: Path
+) -> None:
+    """A matched ``*.mel_spec.npy`` symlink to another archive member raises ``ValueError``.
+
+    ``tarfile.extractfile`` happily returns a file object for a symlink
+    or hardlink that resolves to another archive member, so a bare
+    ``extractfile is None`` check is not enough. Using
+    ``TarInfo.isfile()`` (matches only ``REGTYPE``/``AREGTYPE``) rejects
+    a link named like a mel batch — otherwise the same payload could be
+    counted multiple times.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the synthetic shard directory.
+    """
+    rng = np.random.default_rng(9)
+    mel = rng.normal(size=(2, 2, 2)).astype(np.float32)
+    buf = io.BytesIO()
+    np.save(buf, mel)
+    payload = buf.getvalue()
+
+    shard_path = tmp_path / "shard-000000.tar"
+    with tarfile.open(shard_path, mode="w:") as tar:
+        info = tarfile.TarInfo(name="00000000.mel_spec.npy")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+        sym_info = tarfile.TarInfo(name="00000002.mel_spec.npy")
+        sym_info.type = tarfile.SYMTYPE
+        sym_info.linkname = "00000000.mel_spec.npy"
+        tar.addfile(sym_info)
+
+    with pytest.raises(ValueError, match=r"00000002\.mel_spec\.npy.*not a regular file"):
+        stats_script.get_stats_wds(str(tmp_path))
+
+
+def test_get_stats_wds_shard_with_duplicate_named_mel_members_yields_each_payload(
+    stats_script: ModuleType, tmp_path: Path
+) -> None:
+    """Two matched members with the same name yield two distinct payloads, not one twice.
+
+    ``tarfile.extractfile(name)`` resolves by name lookup and returns
+    only the *last* matching entry, so iterating ``TarInfo`` objects and
+    extracting each by the ``TarInfo`` itself is required to avoid
+    counting the same payload twice on a malformed (duplicate-name)
+    archive.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the synthetic shard directory.
+    """
+    payload_a = io.BytesIO()
+    np.save(payload_a, np.zeros((1, 2, 2), dtype=np.float32))
+    bytes_a = payload_a.getvalue()
+    payload_b = io.BytesIO()
+    np.save(payload_b, np.ones((1, 2, 2), dtype=np.float32))
+    bytes_b = payload_b.getvalue()
+
+    shard_path = tmp_path / "shard-000000.tar"
+    with tarfile.open(shard_path, mode="w:") as tar:
+        for raw in (bytes_a, bytes_b):
+            info = tarfile.TarInfo(name="00000000.mel_spec.npy")
+            info.size = len(raw)
+            tar.addfile(info, io.BytesIO(raw))
+
+    arrays = list(stats_script._iter_mel_batches(shard_path))
+    assert len(arrays) == 2
+    # If extractfile resolved by name, both entries would resolve to the
+    # last addfile (all-ones); pin that we see both payloads.
+    sums = sorted(float(a.sum()) for a in arrays)
+    assert sums == [0.0, 4.0]
 
 
 def test_cli_dispatches_directory_of_tar_shards_to_wds_path_with_default_flag(

--- a/tests/pipeline/data/test_stats.py
+++ b/tests/pipeline/data/test_stats.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import io
 import logging
+import tarfile
+from pathlib import Path
 from types import ModuleType
 
 import numpy as np
@@ -242,6 +245,252 @@ def test_finalize_with_at_most_one_sample_raises_distinct_error(stats_script: Mo
             stats_script.finalize(existing)
         with pytest.raises(ValueError, match=r"<=1 samples"):
             stats_script.finalize(existing, mask_degenerate=True)
+
+
+def _write_mel_shard(path: Path, mel_batches: list[np.ndarray]) -> None:
+    """Write a tar shard at ``path`` containing one ``mel_spec.npy`` per batch.
+
+    Mirrors the writer's per-batch member naming convention
+    (``<batch_start_idx:08d>.mel_spec.npy``) and tacks on the
+    ``metadata.json`` sentinel that the writer always emits — so the test
+    fixtures look structurally like real shards. Other writer fields
+    (``audio``, ``param_array``) are intentionally omitted: the stats path
+    only consumes ``mel_spec``, and including them would just slow tests
+    down.
+
+    :param path: Filesystem path where the tar archive will be written.
+    :param mel_batches: One mel array per batch, each shaped
+        ``(rows, ...inner)``. Inner shape must agree across batches so the
+        Welford reduction over rows is well-defined.
+    :returns: ``None``.
+    :rtype: None
+    """
+    with tarfile.open(path, mode="w:") as tar:
+        for batch_index, mel in enumerate(mel_batches):
+            buf = io.BytesIO()
+            np.save(buf, mel)
+            payload = buf.getvalue()
+            info = tarfile.TarInfo(name=f"{batch_index:08d}.mel_spec.npy")
+            info.size = len(payload)
+            tar.addfile(info, io.BytesIO(payload))
+        metadata = b"{}"
+        info = tarfile.TarInfo(name="metadata.json")
+        info.size = len(metadata)
+        tar.addfile(info, io.BytesIO(metadata))
+
+
+def test_get_stats_wds_writes_sibling_stats_npz_with_mel_inner_shape(
+    stats_script: ModuleType, tmp_path: Path
+) -> None:
+    """One shard with a known mel batch yields ``stats.npz`` sibling whose arrays match
+    ``mel.shape[1:]``.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the synthetic shard directory.
+    """
+    rng = np.random.default_rng(0)
+    mel = rng.normal(size=(8, 2, 4, 5)).astype(np.float32)
+    _write_mel_shard(tmp_path / "shard-000000.tar", [mel])
+
+    stats_script.get_stats_wds(str(tmp_path))
+
+    out = np.load(tmp_path / "stats.npz")
+    assert out["mean"].shape == (2, 4, 5)
+    assert out["std"].shape == (2, 4, 5)
+
+
+def test_get_stats_wds_matches_numpy_baseline_across_shards(
+    stats_script: ModuleType, tmp_path: Path
+) -> None:
+    """Mean and std across two shards match ``np.mean``/``np.std`` over the stacked rows.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the synthetic shard directory.
+    """
+    rng = np.random.default_rng(1)
+    mel_a = rng.normal(size=(5, 3, 4)).astype(np.float32)
+    mel_b = rng.normal(size=(7, 3, 4)).astype(np.float32)
+    _write_mel_shard(tmp_path / "shard-000000.tar", [mel_a])
+    _write_mel_shard(tmp_path / "shard-000001.tar", [mel_b])
+
+    stats_script.get_stats_wds(str(tmp_path))
+
+    stacked = np.concatenate([mel_a, mel_b], axis=0)
+    out = np.load(tmp_path / "stats.npz")
+    np.testing.assert_allclose(out["mean"], stacked.mean(axis=0), rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(out["std"], stacked.std(axis=0, ddof=0), rtol=1e-5, atol=1e-6)
+
+
+def test_get_stats_wds_handles_multiple_batches_per_shard(
+    stats_script: ModuleType, tmp_path: Path
+) -> None:
+    """Multiple per-batch ``mel_spec.npy`` members in one shard are summed via Welford.
+
+    The writer can split a shard into several ``<batch_key>.mel_spec.npy`` members. The stats path
+    must iterate all of them, not just the first.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the synthetic shard directory.
+    """
+    rng = np.random.default_rng(2)
+    batch_a = rng.normal(size=(4, 3, 4)).astype(np.float32)
+    batch_b = rng.normal(size=(6, 3, 4)).astype(np.float32)
+    _write_mel_shard(tmp_path / "shard-000000.tar", [batch_a, batch_b])
+
+    stats_script.get_stats_wds(str(tmp_path))
+
+    stacked = np.concatenate([batch_a, batch_b], axis=0)
+    out = np.load(tmp_path / "stats.npz")
+    np.testing.assert_allclose(out["mean"], stacked.mean(axis=0), rtol=1e-5, atol=1e-6)
+    np.testing.assert_allclose(out["std"], stacked.std(axis=0, ddof=0), rtol=1e-5, atol=1e-6)
+
+
+def test_get_stats_wds_raises_on_constant_bin_by_default(
+    stats_script: ModuleType, tmp_path: Path
+) -> None:
+    """A bin that is constant across all rows raises ``ValueError`` from the existing degeneracy
+    check.
+
+    Reuses ``_check_degenerate_bins`` via ``finalize``; this test pins
+    that get_stats_wds wires into the same code path as the other two
+    entrypoints.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the synthetic shard directory.
+    """
+    rng = np.random.default_rng(3)
+    mel = rng.normal(size=(8, 2, 3)).astype(np.float32)
+    mel[:, 1, 2] = 0.5
+    _write_mel_shard(tmp_path / "shard-000000.tar", [mel])
+
+    with pytest.raises(ValueError, match=r"zero variance"):
+        stats_script.get_stats_wds(str(tmp_path))
+
+
+def test_get_stats_wds_masks_constant_bin_when_flag_set(
+    stats_script: ModuleType, tmp_path: Path
+) -> None:
+    """``mask_degenerate=True`` substitutes ``std=1.0`` at the constant position and writes the
+    file.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the synthetic shard directory.
+    """
+    rng = np.random.default_rng(4)
+    mel = rng.normal(size=(8, 2, 3)).astype(np.float32)
+    mel[:, 1, 2] = 0.5
+    _write_mel_shard(tmp_path / "shard-000000.tar", [mel])
+
+    stats_script.get_stats_wds(str(tmp_path), mask_degenerate=True)
+
+    out = np.load(tmp_path / "stats.npz")
+    assert out["std"][1, 2] == 1.0
+    np.testing.assert_allclose(out["mean"][1, 2], 0.5)
+
+
+def test_get_stats_wds_no_shards_in_directory_raises(
+    stats_script: ModuleType, tmp_path: Path
+) -> None:
+    """A directory with no ``shard-*.tar`` raises ``FileNotFoundError`` naming the directory.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the (empty) shard directory.
+    """
+    with pytest.raises(FileNotFoundError, match=str(tmp_path)):
+        stats_script.get_stats_wds(str(tmp_path))
+
+
+def test_get_stats_wds_iterates_sorted_shard_order(
+    stats_script: ModuleType, tmp_path: Path
+) -> None:
+    """Shard filenames are processed in lexicographic order so results are reproducible.
+
+    Welford is order-invariant for mean/std, so order doesn't change the
+    answer — but the dispatch glob must yield a deterministic sequence so
+    log-line ordering and any future order-sensitive accumulators stay
+    reproducible across filesystems whose ``glob`` returns inode order.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the synthetic shard directory.
+    """
+    rng = np.random.default_rng(5)
+    mel_a = rng.normal(size=(3, 2, 2)).astype(np.float32)
+    mel_b = rng.normal(size=(3, 2, 2)).astype(np.float32)
+    _write_mel_shard(tmp_path / "shard-000001.tar", [mel_b])
+    _write_mel_shard(tmp_path / "shard-000000.tar", [mel_a])
+
+    stats_script.get_stats_wds(str(tmp_path))
+
+    stacked = np.concatenate([mel_a, mel_b], axis=0)
+    out = np.load(tmp_path / "stats.npz")
+    np.testing.assert_allclose(out["mean"], stacked.mean(axis=0), rtol=1e-5, atol=1e-6)
+
+
+def test_cli_dispatches_directory_of_tar_shards_to_wds_path(
+    stats_script: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``main`` routes a directory containing ``shard-*.tar`` to ``get_stats_wds``.
+
+    Spies on each dispatch target so the assertion verifies the chosen branch, not the resulting
+    stats file (those are covered by the behavior tests above).
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the synthetic shard directory.
+    :param monkeypatch: pytest fixture for swapping in spy callables.
+    """
+    rng = np.random.default_rng(6)
+    mel = rng.normal(size=(2, 2, 2)).astype(np.float32)
+    _write_mel_shard(tmp_path / "shard-000000.tar", [mel])
+
+    calls: list[str] = []
+    monkeypatch.setattr(stats_script, "get_stats_wds", lambda *a, **kw: calls.append("wds"))
+    monkeypatch.setattr(stats_script, "get_stats_hdf5", lambda *a, **kw: calls.append("hdf5"))
+    monkeypatch.setattr(stats_script, "get_stats_directory", lambda *a, **kw: calls.append("dir"))
+
+    stats_script.main([str(tmp_path)])
+
+    assert calls == ["wds"]
+
+
+def test_cli_dispatches_h5_input_to_hdf5_path(
+    stats_script: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``main`` routes a ``.h5`` input to ``get_stats_hdf5`` (regression guard).
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used to place a sentinel ``.h5`` path.
+    :param monkeypatch: pytest fixture for swapping in spy callables.
+    """
+    h5_path = tmp_path / "train.h5"
+    h5_path.write_bytes(b"")
+
+    calls: list[str] = []
+    monkeypatch.setattr(stats_script, "get_stats_wds", lambda *a, **kw: calls.append("wds"))
+    monkeypatch.setattr(stats_script, "get_stats_hdf5", lambda *a, **kw: calls.append("hdf5"))
+    monkeypatch.setattr(stats_script, "get_stats_directory", lambda *a, **kw: calls.append("dir"))
+
+    stats_script.main([str(h5_path)])
+
+    assert calls == ["hdf5"]
+
+
+def test_cli_dispatches_directory_without_tars_to_audio_directory_path(
+    stats_script: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``main`` falls back to ``get_stats_directory`` when the directory has no shards.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: pytest tmp dir used as the (no-shard) input directory.
+    :param monkeypatch: pytest fixture for swapping in spy callables.
+    """
+    calls: list[str] = []
+    monkeypatch.setattr(stats_script, "get_stats_wds", lambda *a, **kw: calls.append("wds"))
+    monkeypatch.setattr(stats_script, "get_stats_hdf5", lambda *a, **kw: calls.append("hdf5"))
+    monkeypatch.setattr(stats_script, "get_stats_directory", lambda *a, **kw: calls.append("dir"))
+
+    stats_script.main([str(tmp_path)])
+
+    assert calls == ["dir"]
 
 
 def test_cli_help_advertises_mask_degenerate_bins_flag(


### PR DESCRIPTION
## Summary

- Adds `get_stats_wds(directory, mask_degenerate=False)` in `src/synth_setter/pipeline/data/stats.py` to compute mean/std mel-spec stats over a directory of `shard-*.tar` WebDataset shards, writing the sibling `stats.npz` the datamodules already load.
- Reuses every existing Welford helper (`update`, `finalize`, `_check_degenerate_bins`, `_fix_degenerate_bins`) — no recomputed mel, no Dask, no new runtime deps.
- Refactors the `__main__` block into a `main(argv=None)` function so the suffix-based dispatch (`.h5` → hdf5, dir-with-`shard-*.tar` → wds, else → audio dir) is testable in-process per the mutmut discipline in `CLAUDE.md`.

## How it works

`_iter_mel_batches` opens each shard with raw `tarfile` (same idiom as `validate_shard.py`, no `webdataset` dep), filters to `<batch_key:08d>.mel_spec.npy` members, and yields each batch's ndarray. `get_stats_wds` streams rows through the existing Welford `update()` and finalizes once at the end. The shard naming and `mel_spec` field name are sourced from `synth_setter.data.vst.shapes.MEL_SPEC_FIELD`.

## Out of scope

- Reading shards directly from R2 — local-dir only for v1.
- Per-shard parallelization — single-pass is plenty; profile first.
- Datamodule or config changes — output path and format unchanged.

## Test plan

- [x] 10 new in-process unit tests in `tests/pipeline/data/test_stats.py` covering: sibling file shape, multi-shard numpy baseline, multi-batch-per-shard, degenerate-default raises, degenerate-masked path, empty-dir raises, sort-order determinism, and all three CLI dispatch branches.
- [x] `make test-fast` equivalent — 424 pipeline tests pass.
- [x] `make format` — all hooks pass (ruff, pyright, pydoclint, docformatter, interrogate).
- [ ] End-to-end on a real R2 shard directory (operator step): `rclone copy --checksum r2://...shard-*.tar ./tmp/shards/` then `python -m synth_setter.pipeline.data.stats ./tmp/shards/`.
- [ ] Mutmut run on Linux CI (`.github/workflows/mutmut.yaml`).

Closes #1042