### PR TITLE
docs(lint-cleanup): switch workflow target from exclude-list entries to baseline rows

### DIFF
--- a/.claude/agents/lint-cleanup.md
+++ b/.claude/agents/lint-cleanup.md
@@ -1,6 +1,6 @@
 ---
 name: lint-cleanup
-description: "Use this agent to clean up pre-existing lint violations in one legacy file from the synth-setter exclusion lists tracked in issue #25. Trigger when the user asks to clean up lint for a specific file, work the #25 checklist, remove a file from the lint-exclusion lists in `.pre-commit-config.yaml` or `pyproject.toml` (`[tool.pydoclint].exclude`, `[tool.ruff.lint.per-file-ignores]`), or add docstrings to a legacy module. Follows the canonical workflow in `.github/agents/lint-cleanup.md` — one file per PR, no functional changes, branch `chore/lint-cleanup/<name>`, conventional `chore(lint):` commit, `Refs #25` in the PR body."
+description: "Use this agent to clean up pre-existing lint violations in one legacy file: drain rows from `.pydoclint-baseline.txt` (tracked in #938) or graduate a file from other exclusion lists in `.pre-commit-config.yaml` / `pyproject.toml`'s `[tool.ruff.lint.per-file-ignores]` (tracked in #25). Trigger when the user asks to clean up lint for a specific file, work the #938 or #25 checklist, shrink the pydoclint baseline, or add docstrings to a legacy module. Note: `[tool.pydoclint].exclude` is infra-only after #1044 and must not be edited — pydoclint cleanup happens via baseline-row deletions, not exclude-list edits. Follows the canonical workflow in `.github/agents/lint-cleanup.md` — one file per PR, no functional changes, branch `chore/lint-cleanup/<name>`, conventional `chore(lint):` commit, `Refs #938` (pydoclint) or `Refs #25` (other lint stacks) in the PR body."
 tools: Read, Edit, Bash, Grep, Glob
 ---
 
@@ -17,9 +17,12 @@ single-sourced so edits land in one place and reach every entry point.
 - The user asks to clean up lint for a specific file (e.g., "clean up
   `src/synth_setter/utils/math.py`").
 - The user wants to work through the next unchecked file on the
-  [#25](https://github.com/tinaudio/synth-setter/issues/25) checklist.
-- A reviewer asks for a file to be removed from `.pre-commit-config.yaml`'s
-  `exclude` blocks (or `pyproject.toml`'s `per-file-ignores`).
+  [#938](https://github.com/tinaudio/synth-setter/issues/938) (pydoclint
+  baseline) or [#25](https://github.com/tinaudio/synth-setter/issues/25)
+  (other lint stacks) checklists.
+- A reviewer asks for a file to be drained from `.pydoclint-baseline.txt`,
+  or removed from a non-pydoclint exclusion list in
+  `.pre-commit-config.yaml` / `pyproject.toml`'s `per-file-ignores`.
 
 ## Quick reminders
 
@@ -28,13 +31,28 @@ These are the rules most often forgotten. Full list is in the runbook.
 - One file per PR (or 2–3 closely related, e.g. a module and its tests).
 - Formatting, docstrings, and lint fixes only — **never** change behavior.
 - Branch: `chore/lint-cleanup/<module-name>`.
-- Commit prefix: `chore(lint):`.
-- PR body uses `Refs #25` (not `Fixes`/`Closes` — #25 stays open until every
-  file is done).
+- Commit prefix: `chore(lint):` (e.g.
+  `chore(lint): clean up <module-name> baseline rows` for pydoclint
+  cleanup chunks).
+- PR body uses `Refs #938` for pydoclint baseline drains, `Refs #25` for
+  other lint stacks (not `Fixes`/`Closes` — both issues stay open until
+  every file is done).
+- Pydoclint cleanup is **baseline-row deletions** plus the corresponding
+  docstring fixes, in a single commit. Regenerate with
+  `pydoclint --generate-baseline=1 src/ tests/ scripts/` and the diff
+  must show only deletions on the file you worked on. Never edit
+  `[tool.pydoclint].exclude` — it is infra-only after #1044.
+- D205 / D401 gotcha: do not bisect a single sentence to "satisfy" the
+  blank-line rule. Rewrite the summary as a complete imperative sentence
+  under ~95 chars and demote elaboration to a body paragraph. See the
+  runbook's D205 section for the canonical bad pattern.
 - Run `make test-fast` before opening the PR.
 - Use an isolated worktree (per `CLAUDE.md`'s git-workflow rules).
 
 ## Output
 
-A green, mergeable PR that removes one file from one or more exclusion blocks
-and ticks its checkbox in [#25](https://github.com/tinaudio/synth-setter/issues/25).
+A green, mergeable PR that either drains a file's rows from
+`.pydoclint-baseline.txt` and ticks its checkbox in
+[#938](https://github.com/tinaudio/synth-setter/issues/938), or removes a
+file from one or more non-pydoclint exclusion blocks and ticks its
+checkbox in [#25](https://github.com/tinaudio/synth-setter/issues/25).

--- a/.claude/commands/lint-cleanup.md
+++ b/.claude/commands/lint-cleanup.md
@@ -1,5 +1,5 @@
 ---
-description: "Run the lint-cleanup workflow on a legacy file from issue #25's exclusion list"
+description: "Run the lint-cleanup workflow on a legacy file from `.pydoclint-baseline.txt` (#938) or another exclusion list (#25)"
 argument-hint: <path-to-file>
 ---
 
@@ -15,4 +15,8 @@ Spawn the `lint-cleanup` subagent (defined in
 `.claude/agents/lint-cleanup.md`) in an isolated worktree to do the work.
 Hand it the path and remind it of the hard rules: one file per PR, no
 behavioral changes, branch `chore/lint-cleanup/<name>`, commit prefix
-`chore(lint):`, PR body has `Refs #25` (not `Fixes`/`Closes`).
+`chore(lint):`, PR body has `Refs #938` (pydoclint baseline drains) or
+`Refs #25` (other lint stacks) — not `Fixes`/`Closes`. Pydoclint cleanup
+edits `.pydoclint-baseline.txt` (regenerate with
+`pydoclint --generate-baseline=1 src/ tests/ scripts/`), never
+`[tool.pydoclint].exclude`.

--- a/.github/agents/lint-cleanup.md
+++ b/.github/agents/lint-cleanup.md
@@ -223,9 +223,9 @@ def parse(s: str) -> PredictionRef:
     """
 ```
 
-The summary ``` "Parse a ``PATH:BATCH_IDX`` string into a." ``` ends with a
-stray period after `"a"` and reads as a sentence fragment. The reader
-has to glue the two halves back together to recover the meaning.
+The summary `"Parse a PATH:BATCH_IDX string into a."` ends with a stray
+period after `"a"` and reads as a sentence fragment. The reader has to
+glue the two halves back together to recover the meaning.
 
 Good — full imperative summary, real description block only when needed:
 

--- a/.github/agents/lint-cleanup.md
+++ b/.github/agents/lint-cleanup.md
@@ -2,19 +2,36 @@
 
 ## Goal
 
-Fix pre-existing lint violations in legacy files one at a time, removing them from the pre-commit exclusion lists in `.pre-commit-config.yaml`. Tracked in #25.
+Fix pre-existing lint violations in legacy files one at a time, draining
+`.pydoclint-baseline.txt` and the surviving entries in `.pre-commit-config.yaml`
+exclusion blocks and `pyproject.toml`'s `[tool.ruff.lint.per-file-ignores]`.
+
+- pydoclint cleanup is tracked in
+  [#938](https://github.com/tinaudio/synth-setter/issues/938).
+- Broader lint-cleanup (pyright, interrogate, shellcheck, codespell, ruff
+  per-file-ignores) is tracked in
+  [#25](https://github.com/tinaudio/synth-setter/issues/25).
+
+[#1044](https://github.com/tinaudio/synth-setter/pull/1044) swapped the
+pydoclint cleanup target from `[tool.pydoclint].exclude` regex entries to
+rows in `.pydoclint-baseline.txt`. The pydoclint exclude list is now
+**infra-only** (matches `.git/`, `.venv/`, `build/`, `dist/`,
+`node_modules/`, `.claude/`, `.worktrees/`, `notebooks/`,
+`tests/fixtures/`) and **must not be edited** by this workflow. Legacy
+docstring violations live as rows in `.pydoclint-baseline.txt`; cleanup
+removes rows.
 
 ## How this is invoked
 
 This runbook is the canonical workflow. Three entry points delegate to it; edits to the steps below land here and reach every entry point automatically.
 
-| Tool                       | Entry point                        | How to invoke                                                                |
-| -------------------------- | ---------------------------------- | ---------------------------------------------------------------------------- |
-| Claude Code (programmatic) | `.claude/agents/lint-cleanup.md`   | `Agent(subagent_type: "lint-cleanup", isolation: "worktree", prompt: "...")` |
-| Claude Code (interactive)  | `.claude/commands/lint-cleanup.md` | Type `/lint-cleanup <path>` in a Claude Code session                         |
-| Copilot Coding Agent       | `.github/copilot-instructions.md`  | Assign a #25 sub-issue to Copilot in the GitHub UI                           |
+| Tool                       | Entry point                        | How to invoke                                                                         |
+| -------------------------- | ---------------------------------- | ------------------------------------------------------------------------------------- |
+| Claude Code (programmatic) | `.claude/agents/lint-cleanup.md`   | `Agent(subagent_type: "lint-cleanup", isolation: "worktree", prompt: "...")`          |
+| Claude Code (interactive)  | `.claude/commands/lint-cleanup.md` | Type `/lint-cleanup <path>` in a Claude Code session                                  |
+| Copilot Coding Agent       | `.github/copilot-instructions.md`  | Assign a #938 (pydoclint) or #25 (broader lint) sub-issue to Copilot in the GitHub UI |
 
-The entry-point stubs may surface a short cross-reference of the rules most often forgotten (commit prefix, `Refs #25`, isolated-worktree requirement) so a contributor seeing only the stub still gets the load-bearing constraints. They must not paraphrase or fork the workflow steps themselves — those live here, single-sourced.
+The entry-point stubs may surface a short cross-reference of the rules most often forgotten (commit prefix, `Refs #938` / `Refs #25`, isolated-worktree requirement) so a contributor seeing only the stub still gets the load-bearing constraints. They must not paraphrase or fork the workflow steps themselves — those live here, single-sourced.
 
 ## Scope
 
@@ -23,17 +40,30 @@ Only formatting, docstrings, and lint fixes. **No functional changes.**
 ## Picking the next file
 
 When the agent has discretion over which file to work next — i.e. invoked
-without a specific target path — **work the exclusion lists in reverse order
-of when each entry was added: most recently added first, oldest legacy
-entries last (LIFO).**
+without a specific target path — **pick a file from `.pydoclint-baseline.txt`,
+preferring files with the smallest violation count first.**
 
-To rank candidates, run `git blame` against the exclusion-list lines in
-`.pre-commit-config.yaml` and `pyproject.toml` and sort by the timestamp
-`git blame` reports for each entry's line. Skip entries that are already in
-flight (open `chore/lint-cleanup/*` PR or a ticked box on
-[#25](https://github.com/tinaudio/synth-setter/issues/25)). If two entries
-share the same blame commit, break the tie with the smaller file by line
-count.
+Group the baseline file's rows by the path header (the bare path line above
+each `DOC1xx`/`DOC2xx`/`DOC5xx`/`DOC6xx` block, separated by
+`--------------------`) and rank candidates by row count ascending. Skip
+files already in flight (open `chore/lint-cleanup/*` PR or a ticked box on
+[#938](https://github.com/tinaudio/synth-setter/issues/938)). If two files
+tie on row count, break the tie with the smaller file by line count.
+
+The LIFO ("most recently added exclude entry first") heuristic that
+governed the pre-#1044 workflow no longer applies to pydoclint. The
+pydoclint exclude list is infra-only after #1044 and doesn't accrue legacy
+entries anymore, so there is no recency signal there. Smallest-by-row-count
+biases toward the most reviewable PRs.
+
+The LIFO rule **still applies** to the other lint stacks tracked under
+[#25](https://github.com/tinaudio/synth-setter/issues/25) — entries in
+`.pre-commit-config.yaml` `exclude:` blocks (pyright, interrogate,
+shellcheck, codespell) and `[tool.ruff.lint.per-file-ignores]` for
+non-pydoclint rules. For those, rank by `git blame` timestamp against the
+exclusion-list lines and pick the most-recently-added entry first; this
+heuristic is unchanged from the pre-#1044 runbook because those exclude
+lists *do* still accrue legacy entries.
 
 **`git blame` is a best-effort heuristic, not a perfect provenance signal.**
 It reports the *last commit that touched the line*, not necessarily the
@@ -46,49 +76,229 @@ for `git log -L` or pickaxe in the default path — the extra fidelity isn't
 worth the runtime cost or the runbook complexity. If a particular entry
 looks misranked, just pick the next one down and move on.
 
-**Why:** a freshly-added exclusion almost always came from a small,
-well-scoped change by someone whose context is still warm — graduating it
-immediately reverses tech-debt accrual before it cools and keeps the
-exclusion list from compounding. Old legacy entries don't get worse by
-waiting another week; new ones do.
+**Why smallest-first for pydoclint baseline rows:** the baseline is a flat
+list of `(file, function, rule)` rows; recency information was lost when
+the rows were generated together by `pydoclint --generate-baseline=1` in
+#1044. The remaining axis worth biasing on is reviewability — small
+files, small PRs, fewer chances for the docstring rewrite to incidentally
+touch unrelated code.
 
-**How to apply:** this LIFO rule supersedes the older "prefer the smallest
-by line count" heuristic in the entry-point stubs. An explicit target named
-by the user (or by the `#25` reviewer) always wins over the default
-ordering — LIFO only governs the no-argument case.
+**Explicit target wins.** A target named by the user (or by the
+#938/#25 reviewer) always supersedes the default ordering — the
+smallest-first / LIFO rules only govern the no-argument case.
+
+**The `[tool.pydoclint].exclude` regex is off-limits.** Do not remove any
+of its bare-entry lines (`^\.git/`, `^build/`, `^notebooks/`,
+`^tests/fixtures/`, etc.) as part of this workflow — they are infra paths,
+not legacy violations to clean up. If you believe an exclude entry should
+be graduated, raise it on
+[#938](https://github.com/tinaudio/synth-setter/issues/938) for a
+maintainer call rather than touching it inline.
 
 ## Workflow
 
-For each file listed in any `exclude:` block in `.pre-commit-config.yaml` (e.g. `pyright`, `interrogate`, `shellcheck`, `codespell`) **or** under `[tool.pydoclint].exclude` or `[tool.ruff.lint.per-file-ignores]` in `pyproject.toml` (pydoclint path excludes and ruff per-file rule ignores are configured there, not in the pre-commit config; note that `per-file-ignores` still runs ruff on the file but suppresses specific rules — it is not a path exclude):
+### For pydoclint baseline rows (the common case under #938)
 
-1. **Create a branch**: `chore/lint-cleanup/<module-name>` (e.g., `chore/lint-cleanup/surge-datamodule`)
-2. **Run hooks on the file**, e.g. `interrogate`
-3. **Auto-fix what you can**: `ruff check --fix` and `docformatter --in-place` handle most formatting issues automatically
-4. **Manually fix remaining violations**:
-   - `interrogate` missing docstrings: add Sphinx-style docstrings (`:param:`, `:returns:`, `:raises:`) to public functions/classes — matches the `docformatter` config (`style = "sphinx"` in `pyproject.toml`) — and must pass `pydoclint` DOC1xx/DOC2xx/DOC5xx (signature ↔ docstring consistency) **and** ruff `D102`/`D103`/`D107` (must-have-docstring on public methods, functions, and `__init__`).
-5. **Remove the file from every exclusion list it appears in.** Check `.pre-commit-config.yaml`'s `exclude:` blocks **and** `pyproject.toml`'s `[tool.pydoclint].exclude` and `[tool.ruff.lint.per-file-ignores]`. A single file may appear in more than one list (e.g. excluded by `interrogate` in pre-commit *and* by `ANN001` per-file-ignore in ruff) — graduating the file means clearing every entry.
-6. **Verify**: `pre-commit run --files <file>` passes all hooks
-7. **Run tests**: `make test-fast` — the quick CPU suite (excludes `slow`, `gpu`, `mps`, `requires_vst`) must still pass as a smoke check; lint-only changes shouldn't affect behavior
-8. **Commit**: Use conventional commits format: `chore(lint): clean up <filename>`
-9. **Open PR**: PR body references `#25` with `Refs #25` (not `Fixes`/`Closes` — #25 stays open until every file is done). Check off the file in the issue checklist. Add to "Code Health" project.
+01. **Create a branch**: `chore/lint-cleanup/<module-name>` (e.g.,
+    `chore/lint-cleanup/surge-datamodule`).
+
+02. **Inspect the file's baseline rows**: open `.pydoclint-baseline.txt`
+    and read every row under the file's path header. Each row names a
+    function/method and a rule code
+    (`DOC101`/`DOC103`/`DOC201`/`DOC203`/`DOC501`/`DOC503`/`DOC601`/`DOC603`)
+    — that's the violation you need to fix.
+
+03. **Run pydoclint against the file directly to see live violations**:
+    `pydoclint <path>`. Compare its output to the rows in the baseline —
+    they should match. If pydoclint reports *fewer* violations on the file
+    than the baseline lists, the baseline is stale for this file
+    (asymmetric-shrink case — see step 6).
+
+04. **Auto-fix what you can**: `ruff check --fix <path>` and
+    `docformatter --in-place <path>` handle most formatting issues
+    automatically.
+
+05. **Manually fix remaining violations**:
+
+    - `DOC1xx` (args): add or repair `:param <name>:` entries so the
+      docstring matches the signature exactly. Sphinx style — matches
+      `[tool.docformatter] style = "sphinx"` in `pyproject.toml`.
+    - `DOC2xx` (returns): add `:returns:` (and the type) when the function
+      has a non-`None` return annotation.
+    - `DOC5xx` (raises): add `:raises <ExceptionType>:` for each exception
+      raised in the body (`skip-checking-raises = false`).
+    - `DOC6xx` (class attrs): document each class attribute via a class
+      docstring attribute table or matching `:ivar:` entries.
+    - Ruff D-family rules are also enforced. After #1044, the set is
+      `D100`/`D101`/`D102`/`D103`/`D107`/`D205`/`D401` — `D100` (module
+      docstring), `D101` (class docstring), `D205` (blank line between
+      summary and description), and `D401` (imperative-mood summary) bite
+      in the rewrite step. Read the **D205 sentence-bisection warning**
+      below before mechanically inserting blank lines.
+
+06. **Regenerate the baseline so the rows you fixed are dropped**:
+
+    ```bash
+    pydoclint --generate-baseline=1 src/ tests/ scripts/
+    ```
+
+    Then inspect `git diff .pydoclint-baseline.txt`. The diff **must show
+    only deletions** for the file you worked on, never additions.
+
+    - If the diff shows additions (anywhere, not just on your file), the
+      change introduced a new violation. Stop, do not commit — diagnose
+      the new violation, fix it, regenerate, and re-check.
+    - If the diff shows deletions on files you did not touch, the baseline
+      was already out of sync with `main` (the asymmetric-shrink case).
+      **Do not silently absorb those deletions into your PR.** Reference
+      [#1055](https://github.com/tinaudio/synth-setter/issues/1055) — the
+      ticket tracking the weekly regenerate-and-PR check for stale
+      baseline rows — in a comment on the PR, and restrict your diff to
+      deletions on the file you intended to fix (e.g., by hand-editing
+      `.pydoclint-baseline.txt` back to drop only the rows you actually
+      addressed). #1055 owns the global stale-row sweep; do not duplicate
+      its work inside a cleanup chunk.
+
+07. **Verify**: `pre-commit run --files <path>` passes all hooks. The
+    pydoclint hook reads `.pydoclint-baseline.txt`; `auto-regenerate-baseline = false`
+    means the hook will fail if your fix introduced a new violation, but
+    it will not silently re-shrink the baseline when you fix one.
+
+08. **Run tests**: `make test-fast` — the quick CPU suite (excludes
+    `slow`, `gpu`, `mps`, `requires_vst`) must still pass as a smoke
+    check; lint-only changes shouldn't affect behavior.
+
+09. **Commit**: Use conventional commits format:
+    `chore(lint): clean up <module-name> baseline rows` (or
+    `chore(lint): drain <module-name> from pydoclint baseline`). The diff
+    must include both the docstring fixes **and** the
+    `.pydoclint-baseline.txt` row deletions in a single commit.
+
+10. **Open PR**: PR body references `#938` with `Refs #938` (not
+    `Fixes`/`Closes` — #938 stays open until the baseline reaches 0
+    rows). Include a one-line summary near the top:
+    `shrinks baseline by N rows` (where N is the deletion count from
+    step 6's diff). Tick the file in the issue checklist. Add to "Code
+    Health" project.
+
+### For other exclusion lists (pyright, interrogate, shellcheck, codespell, ruff per-file-ignores under #25)
+
+These lists are *not* covered by the pydoclint baseline mechanism. The
+pre-#1044 workflow still applies:
+
+1. Pick a file (LIFO via `git blame` — see **Picking the next file**).
+2. Branch `chore/lint-cleanup/<module-name>`.
+3. Run the hook on the file, auto-fix what you can, hand-fix the rest.
+4. **Remove the file from every exclusion list it appears in.** A single
+   file may appear in more than one list (e.g. excluded by `interrogate`
+   in pre-commit *and* by `ANN001` per-file-ignore in ruff) — graduating
+   the file means clearing every entry. **Do not touch `[tool.pydoclint].exclude`**
+   — that list is infra-only after #1044. Pydoclint cleanup happens via
+   the baseline-row path above, not via exclude removal.
+5. `pre-commit run --files <path>` green; `make test-fast` green.
+6. Commit `chore(lint): clean up <filename>`; PR body `Refs #25`.
+
+## D205 sentence-bisection warning
+
+`D205` requires a blank line between the docstring summary and any
+description block. A mechanical fix — "find a too-long single-line
+docstring, insert a blank line in the middle of the sentence" — produces
+an ungrammatical sentence fragment as the summary. This is the dominant
+maintainability regression seen in the #1044 review (Copilot comment
+[3243241015](https://github.com/tinaudio/synth-setter/pull/1044#discussion_r3243241015)
+on `src/synth_setter/tools/surge_xt_interactive.py` flagged the canonical
+bad pattern).
+
+**Do not split a sentence in the middle to satisfy `D205`. Rewrite the
+first line as a complete imperative sentence under ~95 chars and demote
+the rest to a body paragraph after the blank line.**
+
+Bad — mechanical bisection (Copilot's flagged pattern):
+
+```python
+def parse(s: str) -> PredictionRef:
+    """Parse a ``PATH:BATCH_IDX`` string into a.
+
+    ``PredictionRef``.
+    """
+```
+
+The summary ``` "Parse a ``PATH:BATCH_IDX`` string into a." ``` ends with a
+stray period after `"a"` and reads as a sentence fragment. The reader
+has to glue the two halves back together to recover the meaning.
+
+Good — full imperative summary, real description block only when needed:
+
+```python
+def parse(s: str) -> PredictionRef:
+    """Parse a ``PATH:BATCH_IDX`` string into a ``PredictionRef``."""
+```
+
+Or, if elaboration is genuinely warranted:
+
+```python
+def parse(s: str) -> PredictionRef:
+    """Parse a ``PATH:BATCH_IDX`` string into a ``PredictionRef``.
+
+    The path may be absolute or relative; the batch index is an integer
+    offset into the prediction tensor.
+    """
+```
+
+If the natural imperative summary won't fit under ~95 chars, **shorten
+the verb or tighten the noun phrase** — do not bisect. "Compute the …"
+can become "Return …"; "Helper for parsing …" can become "Parse …". The
+summary must stand on its own as a sentence.
+
+The same rule applies to `D401`: rewriting `"Returns the foo."` to
+`"Return the foo."` is fine; rewriting it by splitting the sentence
+across lines to "satisfy" the rule is not.
 
 ## Rules
 
-- One file per PR (or 2-3 closely related files, e.g., a module and its tests)
-- Never change logic, signatures, return values, or behavior
-- Never add features, refactor algorithms, or rename public APIs
-- `# noqa` / `# nosec` only with a justification comment explaining why
-- If a file requires functional changes to pass lint (e.g., unused imports that are actually used dynamically), skip it and leave a comment on #25
-- Line length is 99 (configured in `pyproject.toml` under `[tool.ruff]`)
-- Docstrings follow Sphinx style (`:param:`, `:returns:`, `:raises:`) — matches `docformatter` config (`style = "sphinx"` in `pyproject.toml`) — and must pass `pydoclint` DOC1xx/DOC2xx/DOC5xx (signature ↔ docstring consistency)
-- Run `make test-fast` after every file to catch regressions
+- One file per PR (or 2–3 closely related files, e.g., a module and its
+  tests). For pydoclint cleanups, the PR includes both the docstring
+  fixes and the corresponding `.pydoclint-baseline.txt` row deletions in
+  a single commit.
+- Never change logic, signatures, return values, or behavior.
+- Never add features, refactor algorithms, or rename public APIs.
+- Never edit the `[tool.pydoclint].exclude` regex in `pyproject.toml` —
+  it is infra-only after #1044. Pydoclint cleanup happens via baseline-row
+  deletions, not exclude-list edits.
+- `# noqa` / `# nosec` only with a justification comment explaining why.
+  For `D401` on placeholder command stubs that genuinely name a noun (not
+  an action), `# noqa: D401` is acceptable — there are two existing
+  examples in `src/synth_setter/tools/docker_entrypoint.py`.
+- If a file requires functional changes to pass lint (e.g., unused
+  imports that are actually used dynamically), skip it and leave a
+  comment on [#938](https://github.com/tinaudio/synth-setter/issues/938)
+  (or [#25](https://github.com/tinaudio/synth-setter/issues/25) for
+  non-pydoclint stacks).
+- Line length is 99 (configured in `pyproject.toml` under `[tool.ruff]`).
+- Docstrings follow Sphinx style (`:param:`, `:returns:`, `:raises:`) —
+  matches `docformatter` config (`style = "sphinx"` in `pyproject.toml`)
+  — and must pass `pydoclint` `DOC1xx`/`DOC2xx`/`DOC5xx` (signature ↔
+  docstring consistency) **and** ruff `D100`/`D101`/`D102`/`D103`/`D107`
+  (must-have-docstring on modules/classes/methods/functions/`__init__`)
+  **and** `D205`/`D401` (summary shape and imperative mood — see the
+  bisection warning above).
+- Run `make test-fast` after every file to catch regressions.
 
 ## Files
 
-See the checkbox list in https://github.com/tinaudio/synth-setter/issues/25
+- pydoclint baseline rows: the authoritative source-of-truth for "what's
+  left" is `.pydoclint-baseline.txt` itself. Group its rows by path
+  header to see which files still have violations and how many. See also
+  the checkbox list in
+  [#938](https://github.com/tinaudio/synth-setter/issues/938).
+- Other exclusion lists: see the checkbox list in
+  [#25](https://github.com/tinaudio/synth-setter/issues/25).
 
 ## Done when
 
-- All files removed from exclusion lists
-- `pre-commit run -a` passes cleanly
-- #25 is closed
+- `.pydoclint-baseline.txt` is empty (or contains only rows for files
+  that have been judged out-of-scope on #938).
+- All files removed from non-pydoclint exclusion lists tracked in #25.
+- `pre-commit run -a` passes cleanly.
+- Both [#938](https://github.com/tinaudio/synth-setter/issues/938) and
+  [#25](https://github.com/tinaudio/synth-setter/issues/25) are closed.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,14 +31,27 @@ assigned issue matches one of these workflows, follow the runbook step by
 step:
 
 - [`.github/agents/lint-cleanup.md`](agents/lint-cleanup.md) — clean up
-  pre-existing lint violations in one legacy file from the lint-exclusion
-  lists tracked in [#25](https://github.com/tinaudio/synth-setter/issues/25).
-  Those lists live in `.pre-commit-config.yaml`'s `exclude:` blocks **and** in
-  `pyproject.toml`'s `[tool.pydoclint].exclude` and
-  `[tool.ruff.lint.per-file-ignores]` — graduating a file means clearing it
-  from every list it appears in. **Trigger:** any issue that references #25
-  as its parent, or whose body says "apply `.github/agents/lint-cleanup.md`
-  to `<file>`".
+  pre-existing lint violations in one legacy file. Two cleanup lanes:
+
+  - **Pydoclint baseline drains** (tracked in
+    [#938](https://github.com/tinaudio/synth-setter/issues/938)): pick a
+    file with rows in `.pydoclint-baseline.txt`, fix the docstring
+    violations, regenerate the baseline with
+    `pydoclint --generate-baseline=1 src/ tests/ scripts/`, and commit
+    the docstring fixes plus the baseline-row deletions together. PR
+    body uses `Refs #938`. **Do not edit `[tool.pydoclint].exclude`** —
+    it is infra-only after
+    [#1044](https://github.com/tinaudio/synth-setter/pull/1044) and must
+    not be touched by this workflow.
+  - **Other exclusion lists** (tracked in
+    [#25](https://github.com/tinaudio/synth-setter/issues/25)): files in
+    `.pre-commit-config.yaml`'s `exclude:` blocks (pyright, interrogate,
+    shellcheck, codespell) and `pyproject.toml`'s
+    `[tool.ruff.lint.per-file-ignores]`. Graduate a file by clearing it
+    from every non-pydoclint list it appears in. PR body uses `Refs #25`.
+
+  **Trigger:** any issue that references #938 or #25 as its parent, or
+  whose body says "apply `.github/agents/lint-cleanup.md` to `<file>`".
 
 When in doubt, if an issue does not match a known runbook, follow the general
 contributor flow from `CLAUDE.md` — branch, commit, run `make test-fast`,


### PR DESCRIPTION
## Summary

Update the `lint-cleanup` agent runbook (and the three entry-point stubs that delegate to it) to reflect the workflow change introduced by #1044: legacy pydoclint violations now live as rows in `.pydoclint-baseline.txt`, not as bare entries in `[tool.pydoclint].exclude`. Cleanup chunks now drain baseline rows, regenerate the baseline, and commit the docstring fixes plus row deletions together.

The pydoclint exclude regex is now infra-only (matches `.git/`, `.venv/`, `build/`, `dist/`, `node_modules/`, `.claude/`, `.worktrees/`, `notebooks/`, `tests/fixtures/`) and is called out as off-limits in both the runbook body and the Rules section.

## Substantive changes

`.github/agents/lint-cleanup.md` (canonical runbook):

- **Goal** — restate as draining `.pydoclint-baseline.txt` (#938) plus surviving non-pydoclint exclusion-list entries (#25). Anchor the post-#1044 shape up front.
- **Picking the next file** — for pydoclint: smallest-violation-count first (LIFO loses its signal once the pydoclint exclude list stops accruing legacy entries). LIFO via `git blame` is preserved for the non-pydoclint stacks tracked under #25, because those lists do still accrue.
- **Workflow** — split into two explicit lanes:
  - **pydoclint baseline drains (#938)**: inspect baseline rows, fix violations, regenerate the baseline with `pydoclint --generate-baseline=1 src/ tests/ scripts/`, verify the diff shows only deletions, commit fixes + baseline-row deletions together. Commit message `chore(lint): clean up <module-name> baseline rows`; PR body `Refs #938` with a `shrinks baseline by N rows` summary line.
  - **non-pydoclint exclusion lists (#25)**: unchanged pre-#1044 flow (LIFO file, remove from every list it appears in, commit `chore(lint): clean up <filename>`).
- **D205 sentence-bisection warning** — new section, anchored to Copilot review comment 3243241015 on #1044's `surge_xt_interactive.py` rewrite. Rule: do not split a sentence to satisfy the blank-line requirement; rewrite the summary as a complete imperative sentence and demote elaboration to a real body paragraph. Includes before/after examples.
- **Ruff D-family rule list** — updated to include #1044's additions (`D100`, `D101`, `D205`, `D401`) alongside the existing `D102`/`D103`/`D107`.
- **Asymmetric-shrink case** — added handling: if `pydoclint --generate-baseline=1` produces deletions on files you didn't touch, the baseline was already out of sync with `main`; reference #1055 in the PR thread rather than absorbing the global sweep into a per-file chunk.
- **Rules** — added "never edit `[tool.pydoclint].exclude`" and the `# noqa: D401` carve-out for placeholder command stubs (precedent: `docker_entrypoint.py`).

`.claude/agents/lint-cleanup.md`, `.claude/commands/lint-cleanup.md`, `.github/copilot-instructions.md`:

- Updated trigger conditions, quick reminders, and issue references to cover both #938 (pydoclint) and #25 (other lint stacks). Added the "do not edit `[tool.pydoclint].exclude`" reminder and a one-line D205 bisection warning to the Claude agent stub.

## Context

- Lands on top of #1044 (still open at time of writing) — once #1044 merges, the workflow described here is the only valid path for pydoclint cleanup.
- #1055 is the sibling ticket for the weekly regenerate-and-PR sweep that handles globally-stale baseline rows; this PR points at #1055 for the asymmetric-shrink case rather than trying to handle it inline.

## Test plan

- [x] `pre-commit run --files .claude/agents/lint-cleanup.md .claude/commands/lint-cleanup.md .github/agents/lint-cleanup.md .github/copilot-instructions.md` — green (mdformat reformatted on first run; all hooks pass on the second).
- [ ] Manual readthrough by a reviewer who has driven a recent lint-cleanup PR to confirm the new flow matches reality.

Refs #938