### PR TITLE
test(datamodule): isolate torch RNG state per ot test

### DIFF
--- a/tests/data/test_ot.py
+++ b/tests/data/test_ot.py
@@ -17,7 +17,7 @@ assignment is genuinely the minimum-cost one. This catches subtle bugs the
 from __future__ import annotations
 
 import itertools
-from typing import TypeVar
+from typing import Iterator, TypeVar
 from unittest.mock import patch
 
 import numpy as np
@@ -37,6 +37,22 @@ from synth_setter.data.ot import (
 )
 
 _T = TypeVar("_T")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_torch_rng() -> Iterator[None]:
+    """Snapshot+restore the global torch CPU RNG around every test in this module.
+
+    Several tests call ``torch.manual_seed(0)`` to make ``torch.randn_like``
+    deterministic. Without isolation, that seeding would leak into later tests
+    when the full suite runs under xdist. ``torch.random.fork_rng`` saves the
+    RNG state on entry and restores it on exit, so each test sees the same
+    RNG state as if run alone.
+
+    :yields None: Control returns to the test under the forked RNG context.
+    """
+    with torch.random.fork_rng(devices=[]):
+        yield
 
 
 def _present(x: _T | None) -> _T:


### PR DESCRIPTION
## Summary

Ports a small autouse pytest fixture (`_isolate_torch_rng`) into `tests/data/test_ot.py`. The fixture wraps every test in `torch.random.fork_rng(devices=[])`, snapshotting and restoring the CPU RNG state per test so that `torch.manual_seed(...)` calls inside ot tests can't leak RNG state into downstream tests sharing the same xdist worker.

## Why

This fixture was the one valuable piece from the now-closed #1051 that #1052 (the canonical version) lacked. Rather than reopen #1051, this follow-up ports just the fixture (no extra tests, no extra docstrings) on top of #1052.

## Stacking

This PR is **stacked on #1052** and targets `test/ot-coverage` so the diff shows only the fixture delta. After #1052 merges to `main`, retarget this PR to `main` via `gh pr edit --base main` (or the GitHub UI).

Refs #30
Refs #1052