### PR TITLE
docs: add TrainConfig + ModelConfig pydantic schemas to mkdocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -83,22 +83,7 @@ jobs:
       - name: Install docs and dev extras
         run: pip install -e '.[docs,dev]'
 
-      # Two invocations because the conftest hygiene differs:
-      #
-      # 1. ``tests/schemas/`` uses ``--confcutdir=tests/schemas`` so pytest
-      #    still loads ``tests/schemas/conftest.py`` (the ``clean_global_hydra``
-      #    autouse fixture) but stops there — it does NOT walk up to
-      #    ``tests/conftest.py``, which eagerly imports ``lightning`` via
-      #    ``synth_setter.utils`` and would crash on this slim ``[docs,dev]``
-      #    install.
-      # 2. ``tests/test_docs_build.py`` uses ``--noconftest`` because the
-      #    test is self-contained (each test sets up its own Hydra context
-      #    via the session fixture) and has no package-local conftest to
-      #    preserve.
-      #
-      # The session fixture in ``tests/test_docs_build.py`` runs
-      # ``mkdocs build --strict`` itself, so no standalone build step is
-      # needed.
+      # Two pytest invocations because the conftest hygiene differs per path — see PR #1065.
       - name: Run schema tests (preserves tests/schemas/conftest.py)
         run: pytest tests/schemas/ -q --confcutdir=tests/schemas
 
@@ -108,8 +93,10 @@ jobs:
   # Skip on pull_request (the build-docs job above already covers PR
   # validation) and on workflow_run if the upstream run didn't succeed —
   # otherwise we'd republish stale chart data after a failed bench run.
+  # workflow_dispatch is restricted to main so a manual run from a feature
+  # branch can't publish feature-branch docs to Pages.
   deploy-docs:
-    if: github.event_name != 'pull_request' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+    if: github.event_name != 'pull_request' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # Pages publishing + OIDC token live on this job only — the build-docs
@@ -132,6 +119,7 @@ jobs:
         with:
           python-version: "3.10"
           cache: "pip"
+          cache-dependency-path: pyproject.toml
 
       - name: Install docs extras
         run: pip install -e '.[docs]'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,10 +39,12 @@ on:
     types: [completed]
     branches: [main]
 
+# Default to the minimum any job needs (a checkout). The Pages-write /
+# OIDC token grants live on ``deploy-docs`` only — ``build-docs`` runs on
+# PRs (including from forks) and never publishes, so least privilege keeps
+# Pages write off the PR path entirely.
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Serialize Pages deploys: cancel-in-progress: false lets an in-flight deploy
 # finish (avoids a half-published site) while still queuing the next one.
@@ -62,6 +64,11 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Inherits the workflow-level ``contents: read`` and adds nothing — the
+    # PR job has no business with Pages write or OIDC. Pinned explicitly so
+    # a future workflow-level grant can't silently re-broaden this job.
+    permissions:
+      contents: read
     steps:
       - name: Checkout docs source
         uses: actions/checkout@v6
@@ -105,6 +112,12 @@ jobs:
     if: github.event_name != 'pull_request' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Pages publishing + OIDC token live on this job only — the build-docs
+    # PR job runs with the default ``contents: read`` and can't reach Pages.
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
 
     environment:
       name: github-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,15 +76,27 @@ jobs:
       - name: Install docs and dev extras
         run: pip install -e '.[docs,dev]'
 
-      # The docs-build pytest session fixture in ``tests/test_docs_build.py``
-      # runs ``mkdocs build --strict`` itself, so a standalone build step
-      # would just rebuild and double CI wall time. ``--noconftest`` skips
-      # the top-level ``tests/conftest.py`` (which eagerly imports
-      # ``lightning`` via ``synth_setter.utils``); the docs-build tests
-      # don't need that fixture machinery — each test sets up its own
-      # Hydra context.
-      - name: Build site and run docs-build integration tests
-        run: pytest tests/test_docs_build.py tests/schemas/ -q --noconftest
+      # Two invocations because the conftest hygiene differs:
+      #
+      # 1. ``tests/schemas/`` uses ``--confcutdir=tests/schemas`` so pytest
+      #    still loads ``tests/schemas/conftest.py`` (the ``clean_global_hydra``
+      #    autouse fixture) but stops there — it does NOT walk up to
+      #    ``tests/conftest.py``, which eagerly imports ``lightning`` via
+      #    ``synth_setter.utils`` and would crash on this slim ``[docs,dev]``
+      #    install.
+      # 2. ``tests/test_docs_build.py`` uses ``--noconftest`` because the
+      #    test is self-contained (each test sets up its own Hydra context
+      #    via the session fixture) and has no package-local conftest to
+      #    preserve.
+      #
+      # The session fixture in ``tests/test_docs_build.py`` runs
+      # ``mkdocs build --strict`` itself, so no standalone build step is
+      # needed.
+      - name: Run schema tests (preserves tests/schemas/conftest.py)
+        run: pytest tests/schemas/ -q --confcutdir=tests/schemas
+
+      - name: Build site and run docs-build integration test
+        run: pytest tests/test_docs_build.py -q --noconftest
 
   # Skip on pull_request (the build-docs job above already covers PR
   # validation) and on workflow_run if the upstream run didn't succeed —

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,10 +16,7 @@ on:
       - "src/synth_setter/pipeline/schemas/spec.py"
       - "src/synth_setter/schemas/**"
       - ".github/workflows/docs.yml"
-  # PR builds: same path filter as push, but the job is build-only (no
-  # GitHub Pages deploy) so we catch ``mkdocs build --strict`` failures
-  # before they reach main without granting Pages write to forks. Tracked
-  # alongside the docs-build pytest integration in tests/test_docs_build.py.
+  # PR builds run build-docs only (no Pages deploy) — see #967.
   pull_request:
     paths:
       - "docs/**"
@@ -39,10 +36,8 @@ on:
     types: [completed]
     branches: [main]
 
-# Default to the minimum any job needs (a checkout). The Pages-write /
-# OIDC token grants live on ``deploy-docs`` only — ``build-docs`` runs on
-# PRs (including from forks) and never publishes, so least privilege keeps
-# Pages write off the PR path entirely.
+# Least-privilege default; ``pages: write`` / ``id-token: write`` live only
+# on ``deploy-docs`` so PR runs (including from forks) can't reach Pages.
 permissions:
   contents: read
 
@@ -53,20 +48,12 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Build-only smoke check for PRs. Runs ``mkdocs build --strict`` so any
-  # drift between docs/, mkdocs.yml, or the pydantic models that the
-  # config-reference pages render gets caught at PR time. Also runs the
-  # docs-build pytest module so the field-rendering assertions in
-  # ``tests/test_docs_build.py`` actually execute in CI (they skip via
-  # ``importorskip("mkdocs")`` on the default ``[dev]`` install). No Pages
-  # deploy happens here — the deploy-docs job (gated to push/main) owns that.
+  # PR-only build smoke check; deploy-docs handles publishing on push/main.
   build-docs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Inherits the workflow-level ``contents: read`` and adds nothing — the
-    # PR job has no business with Pages write or OIDC. Pinned explicitly so
-    # a future workflow-level grant can't silently re-broaden this job.
+    # Pinned so a future workflow-level grant can't silently re-broaden this job.
     permissions:
       contents: read
     steps:
@@ -90,17 +77,13 @@ jobs:
       - name: Build site and run docs-build integration test
         run: pytest tests/test_docs_build.py -q --noconftest
 
-  # Skip on pull_request (the build-docs job above already covers PR
-  # validation) and on workflow_run if the upstream run didn't succeed —
-  # otherwise we'd republish stale chart data after a failed bench run.
-  # workflow_dispatch is restricted to main so a manual run from a feature
-  # branch can't publish feature-branch docs to Pages.
+  # Skips: pull_request (covered by build-docs), failed workflow_run (would
+  # republish stale bench data), workflow_dispatch off main (no feature-branch
+  # publishing).
   deploy-docs:
     if: github.event_name != 'pull_request' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success') && (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Pages publishing + OIDC token live on this job only — the build-docs
-    # PR job runs with the default ``contents: read`` and can't reach Pages.
     permissions:
       contents: read
       pages: write
@@ -127,14 +110,8 @@ jobs:
       - name: Build site
         run: mkdocs build --strict
 
-      # gh-pages is the benchmark-action's persistence layer; only its
-      # dev/bench/ subtree is republished by the next step. The probe lets a
-      # fresh repo (no gh-pages branch yet) deploy docs without bench while
-      # still failing the workflow loudly on transient errors — explicitly
-      # discriminating HTTP 404 (branch absent, intended soft-skip) from
-      # 5xx / network / auth failures (fail loud). A blanket
-      # `continue-on-error: true` on the checkout, or a `2>&1`-swallowing
-      # probe, would deploy without the chart on a transient blip.
+      # Discriminate 404 (branch absent, soft-skip) from 5xx/auth (fail loud);
+      # a blanket continue-on-error on the checkout would mask transient blips.
       - name: Probe gh-pages branch existence
         id: probe_ghpages
         env:
@@ -159,9 +136,8 @@ jobs:
           ref: gh-pages
           path: gh-pages-data
 
-      # rm -rf before cp avoids the cp -R nested-directory hazard: if
-      # site/dev/bench already exists (mkdocs emits there in the future, or
-      # this step is re-run), cp -R would create site/dev/bench/bench/.
+      # rm -rf before cp -R; otherwise an existing site/dev/bench would
+      # nest the copy as site/dev/bench/bench/.
       - name: Merge benchmark chart into site
         if: steps.probe_ghpages.outputs.exists == 'true'
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -79,8 +79,13 @@ jobs:
       - name: Build site (strict)
         run: mkdocs build --strict
 
+      # ``--noconftest`` skips the top-level ``tests/conftest.py``, which
+      # eagerly imports ``lightning`` via ``synth_setter.utils``. The
+      # build-docs job installs ``[docs,dev]`` (no torch / lightning) to keep
+      # the install lightweight; the docs-build tests don't need that
+      # fixture machinery — each test sets up its own Hydra context.
       - name: Run docs-build integration tests
-        run: pytest tests/test_docs_build.py tests/schemas/ -q
+        run: pytest tests/test_docs_build.py tests/schemas/ -q --noconftest
 
   # Skip on pull_request (the build-docs job above already covers PR
   # validation) and on workflow_run if the upstream run didn't succeed —

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -76,15 +76,14 @@ jobs:
       - name: Install docs and dev extras
         run: pip install -e '.[docs,dev]'
 
-      - name: Build site (strict)
-        run: mkdocs build --strict
-
-      # ``--noconftest`` skips the top-level ``tests/conftest.py``, which
-      # eagerly imports ``lightning`` via ``synth_setter.utils``. The
-      # build-docs job installs ``[docs,dev]`` (no torch / lightning) to keep
-      # the install lightweight; the docs-build tests don't need that
-      # fixture machinery — each test sets up its own Hydra context.
-      - name: Run docs-build integration tests
+      # The docs-build pytest session fixture in ``tests/test_docs_build.py``
+      # runs ``mkdocs build --strict`` itself, so a standalone build step
+      # would just rebuild and double CI wall time. ``--noconftest`` skips
+      # the top-level ``tests/conftest.py`` (which eagerly imports
+      # ``lightning`` via ``synth_setter.utils``); the docs-build tests
+      # don't need that fixture machinery — each test sets up its own
+      # Hydra context.
+      - name: Build site and run docs-build integration tests
         run: pytest tests/test_docs_build.py tests/schemas/ -q --noconftest
 
   # Skip on pull_request (the build-docs job above already covers PR

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,19 @@ on:
       - "mkdocs.yml"
       - "pyproject.toml"
       - "src/synth_setter/pipeline/schemas/spec.py"
+      - "src/synth_setter/schemas/**"
+      - ".github/workflows/docs.yml"
+  # PR builds: same path filter as push, but the job is build-only (no
+  # GitHub Pages deploy) so we catch ``mkdocs build --strict`` failures
+  # before they reach main without granting Pages write to forks. Tracked
+  # alongside the docs-build pytest integration in tests/test_docs_build.py.
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "pyproject.toml"
+      - "src/synth_setter/pipeline/schemas/spec.py"
+      - "src/synth_setter/schemas/**"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
   # Redeploy after the benchmark workflow pushes new chart data to gh-pages.
@@ -38,12 +51,44 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  deploy-docs:
+  # Build-only smoke check for PRs. Runs ``mkdocs build --strict`` so any
+  # drift between docs/, mkdocs.yml, or the pydantic models that the
+  # config-reference pages render gets caught at PR time. Also runs the
+  # docs-build pytest module so the field-rendering assertions in
+  # ``tests/test_docs_build.py`` actually execute in CI (they skip via
+  # ``importorskip("mkdocs")`` on the default ``[dev]`` install). No Pages
+  # deploy happens here — the deploy-docs job (gated to push/main) owns that.
+  build-docs:
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Skip on workflow_run when the upstream run didn't succeed — otherwise
-    # we'd republish stale chart data after a failed bench run.
-    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Checkout docs source
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: pyproject.toml
+
+      - name: Install docs and dev extras
+        run: pip install -e '.[docs,dev]'
+
+      - name: Build site (strict)
+        run: mkdocs build --strict
+
+      - name: Run docs-build integration tests
+        run: pytest tests/test_docs_build.py tests/schemas/ -q
+
+  # Skip on pull_request (the build-docs job above already covers PR
+  # validation) and on workflow_run if the upstream run didn't succeed —
+  # otherwise we'd republish stale chart data after a failed bench run.
+  deploy-docs:
+    if: github.event_name != 'pull_request' && (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     environment:
       name: github-pages

--- a/docs/config_reference/callbacks_config.md
+++ b/docs/config_reference/callbacks_config.md
@@ -1,22 +1,9 @@
 # Callbacks Config
 
-`CallbacksConfig` is the pydantic schema for the Lightning callback configs
-under `configs/callbacks/`. Each YAML there either defines a single named
-callback (`model_checkpoint.yaml` → `{"model_checkpoint": {"_target_": ...}}`)
-or composes several via `defaults:` plus per-callback overrides
-(`default.yaml`, `default_surge.yaml`). Once Hydra has finished composing,
-`cfg.callbacks` is a flat mapping from callback-name → callback-instance
-dict, which `synth_setter.utils.instantiate_callbacks` then iterates over —
-`hydra.utils.instantiate` is called only on values that contain `_target_`,
-so unrelated keys are silently skipped.
-
-The schema mirrors that shape: `CallbacksConfig` is a
-[`RootModel`](https://docs.pydantic.dev/latest/concepts/models/#rootmodel-and-custom-root-types)
-wrapping `dict[str, CallbackInstance]`, and each value validates against
-`CallbackInstance`. Variant-specific callback kwargs (`monitor`, `dirpath`,
-`patience`, `every_n_train_steps`, ...) vary per callback and pass through
-via `extra="allow"` on `CallbackInstance` — the constraints on those kwargs
-live on the upstream Lightning / project-local callback class signatures.
+`CallbacksConfig` is a [`RootModel`](https://docs.pydantic.dev/latest/concepts/models/#rootmodel-and-custom-root-types)
+wrapping `dict[str, CallbackInstance]` — the shape of `cfg.callbacks` after
+Hydra composes the YAMLs under `configs/callbacks/`. Only `_target_` is
+typed on each instance; per-callback kwargs pass through via `extra="allow"`.
 
 ## CallbacksConfig
 

--- a/docs/config_reference/callbacks_config.md
+++ b/docs/config_reference/callbacks_config.md
@@ -1,0 +1,27 @@
+# Callbacks Config
+
+`CallbacksConfig` is the pydantic schema for the Lightning callback configs
+under `configs/callbacks/`. Each YAML there either defines a single named
+callback (`model_checkpoint.yaml` → `{"model_checkpoint": {"_target_": ...}}`)
+or composes several via `defaults:` plus per-callback overrides
+(`default.yaml`, `default_surge.yaml`). Once Hydra has finished composing,
+`cfg.callbacks` is a flat mapping from callback-name → callback-instance
+dict, which `synth_setter.utils.instantiate_callbacks` then iterates over —
+`hydra.utils.instantiate` is called only on values that contain `_target_`,
+so unrelated keys are silently skipped.
+
+The schema mirrors that shape: `CallbacksConfig` is a
+[`RootModel`](https://docs.pydantic.dev/latest/concepts/models/#rootmodel-and-custom-root-types)
+wrapping `dict[str, CallbackInstance]`, and each value validates against
+`CallbackInstance`. Variant-specific callback kwargs (`monitor`, `dirpath`,
+`patience`, `every_n_train_steps`, ...) vary per callback and pass through
+via `extra="allow"` on `CallbackInstance` — the constraints on those kwargs
+live on the upstream Lightning / project-local callback class signatures.
+
+## CallbacksConfig
+
+::: synth_setter.schemas.callbacks_config.CallbacksConfig
+
+## CallbackInstance
+
+::: synth_setter.schemas.callbacks_config.CallbackInstance

--- a/docs/config_reference/data_config.md
+++ b/docs/config_reference/data_config.md
@@ -1,0 +1,18 @@
+# Data Config
+
+`DataConfig` is the pydantic schema for the per-datamodule Hydra configs under
+`configs/data/`. Each YAML there picks one `LightningDataModule` via
+`_target_` (e.g. `synth_setter.data.ksin_datamodule.KSinDataModule`,
+`synth_setter.data.surge_datamodule.SurgeDataModule`) and supplies the
+constructor kwargs that module needs. The kwarg surface varies widely across
+modules — synthetic-signal datamodules take seed tuples and `signal_length`,
+file-driven ones take `dataset_root` / `stats_file` paths — so the schema
+types only `_target_` and accepts the rest via `extra="allow"`. Adding a new
+datamodule YAML does not require a schema edit.
+
+Every shipped YAML under `configs/data/` validates against `DataConfig` —
+the field table below is the source of truth for the keys Hydra resolves
+into `cfg.data` before `hydra.utils.instantiate(cfg.data)` builds the
+`LightningDataModule` in `cli/train.py`.
+
+::: synth_setter.schemas.data_config.DataConfig

--- a/docs/config_reference/data_config.md
+++ b/docs/config_reference/data_config.md
@@ -1,18 +1,7 @@
 # Data Config
 
-`DataConfig` is the pydantic schema for the per-datamodule Hydra configs under
-`configs/data/`. Each YAML there picks one `LightningDataModule` via
-`_target_` (e.g. `synth_setter.data.ksin_datamodule.KSinDataModule`,
-`synth_setter.data.surge_datamodule.SurgeDataModule`) and supplies the
-constructor kwargs that module needs. The kwarg surface varies widely across
-modules — synthetic-signal datamodules take seed tuples and `signal_length`,
-file-driven ones take `dataset_root` / `stats_file` paths — so the schema
-types only `_target_` and accepts the rest via `extra="allow"`. Adding a new
-datamodule YAML does not require a schema edit.
-
-Every shipped YAML under `configs/data/` validates against `DataConfig` —
-the field table below is the source of truth for the keys Hydra resolves
-into `cfg.data` before `hydra.utils.instantiate(cfg.data)` builds the
-`LightningDataModule` in `cli/train.py`.
+`DataConfig` is the pydantic schema for the YAMLs under `configs/data/`.
+Only `_target_` is typed; datamodule constructor kwargs vary per module
+and pass through via `extra="allow"`.
 
 ::: synth_setter.schemas.data_config.DataConfig

--- a/docs/config_reference/extras_config.md
+++ b/docs/config_reference/extras_config.md
@@ -1,16 +1,7 @@
 # Extras Config
 
-`ExtrasConfig` is the pydantic schema for the run-time toggles at
-`configs/extras/default.yaml`. The toggles control four small startup
-behaviours invoked from the top of `cli/train.py` via
-`synth_setter.utils.extras(cfg)` — pretty-printing the composed config,
-prompting for tags, silencing warnings, and setting
-`torch.set_float32_matmul_precision`. They're read once and don't affect any
-downstream model / pipeline state, so the schema is intentionally tiny and
-strict (`float32_matmul_precision` is a `Literal` of the three values
-PyTorch accepts).
-
-The shipped `extras: default` composition validates against `ExtrasConfig` —
-the field table below names every toggle the entrypoint reads.
+`ExtrasConfig` is the pydantic schema for `configs/extras/default.yaml` —
+four startup toggles read by `synth_setter.utils.extras(cfg)` at the top of
+`cli/train.py`.
 
 ::: synth_setter.schemas.extras_config.ExtrasConfig

--- a/docs/config_reference/extras_config.md
+++ b/docs/config_reference/extras_config.md
@@ -1,0 +1,16 @@
+# Extras Config
+
+`ExtrasConfig` is the pydantic schema for the run-time toggles at
+`configs/extras/default.yaml`. The toggles control four small startup
+behaviours invoked from the top of `cli/train.py` via
+`synth_setter.utils.extras(cfg)` — pretty-printing the composed config,
+prompting for tags, silencing warnings, and setting
+`torch.set_float32_matmul_precision`. They're read once and don't affect any
+downstream model / pipeline state, so the schema is intentionally tiny and
+strict (`float32_matmul_precision` is a `Literal` of the three values
+PyTorch accepts).
+
+The shipped `extras: default` composition validates against `ExtrasConfig` —
+the field table below names every toggle the entrypoint reads.
+
+::: synth_setter.schemas.extras_config.ExtrasConfig

--- a/docs/config_reference/logger_config.md
+++ b/docs/config_reference/logger_config.md
@@ -1,20 +1,10 @@
 # Logger Config
 
-`LoggerConfig` is the pydantic schema for the Lightning logger configs under
-`configs/logger/`. The layout mirrors callbacks: each YAML either defines a
-single named logger (`wandb.yaml`, `tensorboard.yaml`, `mlflow.yaml`, ...)
-or composes several via `defaults:` (`many_loggers.yaml` pulls in csv +
-tensorboard + wandb). Composed `cfg.logger` is a flat mapping
-name → logger-instance dict, iterated by
-`synth_setter.utils.instantiate_loggers`.
-
-The schema mirrors that shape: `LoggerConfig` is a
-[`RootModel`](https://docs.pydantic.dev/latest/concepts/models/#rootmodel-and-custom-root-types)
-wrapping `dict[str, LoggerInstance]`, and each value validates against
-`LoggerInstance`. Logger-class kwargs (`api_key`, `project`, `save_dir`,
-`tags`, ...) vary per logger and pass through via `extra="allow"` on
-`LoggerInstance` — refer to each upstream logger class for its constructor
-surface.
+`LoggerConfig` is a [`RootModel`](https://docs.pydantic.dev/latest/concepts/models/#rootmodel-and-custom-root-types)
+wrapping `dict[str, LoggerInstance]` — the shape of `cfg.logger` after Hydra
+composes the YAMLs under `configs/logger/`. Only `_target_` is typed on each
+instance; per-logger kwargs pass through via `extra="allow"` (refer to the
+upstream logger class for its constructor).
 
 ## LoggerConfig
 

--- a/docs/config_reference/logger_config.md
+++ b/docs/config_reference/logger_config.md
@@ -1,0 +1,25 @@
+# Logger Config
+
+`LoggerConfig` is the pydantic schema for the Lightning logger configs under
+`configs/logger/`. The layout mirrors callbacks: each YAML either defines a
+single named logger (`wandb.yaml`, `tensorboard.yaml`, `mlflow.yaml`, ...)
+or composes several via `defaults:` (`many_loggers.yaml` pulls in csv +
+tensorboard + wandb). Composed `cfg.logger` is a flat mapping
+name → logger-instance dict, iterated by
+`synth_setter.utils.instantiate_loggers`.
+
+The schema mirrors that shape: `LoggerConfig` is a
+[`RootModel`](https://docs.pydantic.dev/latest/concepts/models/#rootmodel-and-custom-root-types)
+wrapping `dict[str, LoggerInstance]`, and each value validates against
+`LoggerInstance`. Logger-class kwargs (`api_key`, `project`, `save_dir`,
+`tags`, ...) vary per logger and pass through via `extra="allow"` on
+`LoggerInstance` — refer to each upstream logger class for its constructor
+surface.
+
+## LoggerConfig
+
+::: synth_setter.schemas.logger_config.LoggerConfig
+
+## LoggerInstance
+
+::: synth_setter.schemas.logger_config.LoggerInstance

--- a/docs/config_reference/model_config.md
+++ b/docs/config_reference/model_config.md
@@ -1,0 +1,26 @@
+# Model Config
+
+`ModelConfig` is the pydantic schema for the per-model Hydra configs under
+`configs/model/`. Each YAML file there picks one
+`LightningModule` (`_target_`), a partial torch optimizer, an optional partial
+LR scheduler, and the `compile` flag — everything else is variant-specific
+and varies across model modules. The schema documents the common surface area
+and accepts variant fields via `extra="allow"`, so adding a new model YAML
+does not require a schema edit.
+
+Every shipped YAML under `configs/model/` validates against `ModelConfig` —
+the field tables below are the source of truth for the keys Hydra resolves
+into `cfg.model` before `hydra.utils.instantiate(cfg.model)` builds the
+LightningModule in `cli/train.py`.
+
+## ModelConfig
+
+::: synth_setter.schemas.model_config.ModelConfig
+
+## OptimizerConfig
+
+::: synth_setter.schemas.model_config.OptimizerConfig
+
+## SchedulerConfig
+
+::: synth_setter.schemas.model_config.SchedulerConfig

--- a/docs/config_reference/model_config.md
+++ b/docs/config_reference/model_config.md
@@ -1,17 +1,8 @@
 # Model Config
 
-`ModelConfig` is the pydantic schema for the per-model Hydra configs under
-`configs/model/`. Each YAML file there picks one
-`LightningModule` (`_target_`), a partial torch optimizer, an optional partial
-LR scheduler, and the `compile` flag — everything else is variant-specific
-and varies across model modules. The schema documents the common surface area
-and accepts variant fields via `extra="allow"`, so adding a new model YAML
-does not require a schema edit.
-
-Every shipped YAML under `configs/model/` validates against `ModelConfig` —
-the field tables below are the source of truth for the keys Hydra resolves
-into `cfg.model` before `hydra.utils.instantiate(cfg.model)` builds the
-LightningModule in `cli/train.py`.
+`ModelConfig` is the pydantic schema for the YAMLs under `configs/model/`.
+The typed surface is `_target_` + optimizer + optional scheduler + `compile`;
+variant-specific kwargs pass through via `extra="allow"`.
 
 ## ModelConfig
 

--- a/docs/config_reference/paths_config.md
+++ b/docs/config_reference/paths_config.md
@@ -1,15 +1,9 @@
 # Paths Config
 
-`PathsConfig` is the pydantic schema for the path-layout YAML at
-`configs/paths/default.yaml`. The five string fields are interpolated all
-over the rest of the config tree (`${paths.output_dir}/checkpoints`,
-`${paths.log_dir}/mlflow`, the trainer's `default_root_dir`, every logger's
-`save_dir`), so a blank override here propagates as a broken path into half a
-dozen places. The schema types every field as a non-blank string and the
-validator rejects whitespace-only overrides at compose time.
-
-The shipped `paths: default` composition validates against `PathsConfig` —
-the field table below is the source of truth for the keys downstream YAMLs
-may safely interpolate via `${paths.<name>}`.
+`PathsConfig` is the pydantic schema for `configs/paths/default.yaml`. Every
+field is typed `NonBlankStr` because the values are interpolated as
+`${paths.<name>}` across many downstream YAMLs (logger save-dirs, callback
+dirpaths, the trainer's `default_root_dir`), so a whitespace-only override
+would propagate as a broken path into several places.
 
 ::: synth_setter.schemas.paths_config.PathsConfig

--- a/docs/config_reference/paths_config.md
+++ b/docs/config_reference/paths_config.md
@@ -1,0 +1,15 @@
+# Paths Config
+
+`PathsConfig` is the pydantic schema for the path-layout YAML at
+`configs/paths/default.yaml`. The five string fields are interpolated all
+over the rest of the config tree (`${paths.output_dir}/checkpoints`,
+`${paths.log_dir}/mlflow`, the trainer's `default_root_dir`, every logger's
+`save_dir`), so a blank override here propagates as a broken path into half a
+dozen places. The schema types every field as a non-blank string and the
+validator rejects whitespace-only overrides at compose time.
+
+The shipped `paths: default` composition validates against `PathsConfig` —
+the field table below is the source of truth for the keys downstream YAMLs
+may safely interpolate via `${paths.<name>}`.
+
+::: synth_setter.schemas.paths_config.PathsConfig

--- a/docs/config_reference/train_config.md
+++ b/docs/config_reference/train_config.md
@@ -1,17 +1,8 @@
 # Training Config
 
-`TrainConfig` is the pydantic schema for the top-level training configuration
-that `synth-setter-train` (the `@hydra.main` entrypoint in
-`src/synth_setter/cli/train.py`) consumes. It documents the scalar fields the
-entrypoint reads directly — `task_name`, `tags`, `train`, `test`,
-`ckpt_path`, `seed`, `optimized_metric`, `watch_gradients` — while letting
-Hydra-composed subtrees (`data`, `model`, `trainer`, `callbacks`, `logger`,
-`paths`, `extras`, `hydra`, ...) pass through unchanged. Those subtrees have
-their own composition groups under `configs/` and are validated by
-`hydra.utils.instantiate` at call time.
-
-Every shipped composition of `configs/train.yaml` validates against this
-schema — the field table below is the source of truth for what the
-entrypoint expects.
+`TrainConfig` documents the scalar fields the `synth-setter-train` entrypoint
+reads off `configs/train.yaml` directly. Hydra-composed subtrees (`data`,
+`model`, `trainer`, ...) are accepted via `extra="allow"` and validated by
+their own schemas — see the sibling pages.
 
 ::: synth_setter.schemas.train_config.TrainConfig

--- a/docs/config_reference/train_config.md
+++ b/docs/config_reference/train_config.md
@@ -1,0 +1,17 @@
+# Training Config
+
+`TrainConfig` is the pydantic schema for the top-level training configuration
+that `synth-setter-train` (the `@hydra.main` entrypoint in
+`src/synth_setter/cli/train.py`) consumes. It documents the scalar fields the
+entrypoint reads directly — `task_name`, `tags`, `train`, `test`,
+`ckpt_path`, `seed`, `optimized_metric`, `watch_gradients` — while letting
+Hydra-composed subtrees (`data`, `model`, `trainer`, `callbacks`, `logger`,
+`paths`, `extras`, `hydra`, ...) pass through unchanged. Those subtrees have
+their own composition groups under `configs/` and are validated by
+`hydra.utils.instantiate` at call time.
+
+Every shipped composition of `configs/train.yaml` validates against this
+schema — the field table below is the source of truth for what the
+entrypoint expects.
+
+::: synth_setter.schemas.train_config.TrainConfig

--- a/docs/config_reference/trainer_config.md
+++ b/docs/config_reference/trainer_config.md
@@ -1,0 +1,18 @@
+# Trainer Config
+
+`TrainerConfig` is the pydantic schema for the per-trainer Hydra configs
+under `configs/trainer/`. Each YAML there composes onto `default.yaml` and
+overrides the subset of `lightning.pytorch.trainer.Trainer` constructor
+kwargs that matters for its target accelerator — CPU smoke runs, single-GPU
+jobs, DDP, MPS — by selecting `accelerator`, `devices`, and (variant-specific)
+`strategy`, `precision`, `min_steps` / `max_steps`. The typed surface here
+covers the keys all shipped variants actually set; any other `Trainer` kwarg
+passes through via `extra="allow"`, and Lightning's docs are the authority
+on the full constructor.
+
+Every shipped YAML under `configs/trainer/` validates against `TrainerConfig`.
+The field table below is the source of truth for the typed surface; refer to
+[Lightning's `Trainer` API](https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.trainer.trainer.Trainer.html)
+for the full kwarg list.
+
+::: synth_setter.schemas.trainer_config.TrainerConfig

--- a/docs/config_reference/trainer_config.md
+++ b/docs/config_reference/trainer_config.md
@@ -1,18 +1,9 @@
 # Trainer Config
 
-`TrainerConfig` is the pydantic schema for the per-trainer Hydra configs
-under `configs/trainer/`. Each YAML there composes onto `default.yaml` and
-overrides the subset of `lightning.pytorch.trainer.Trainer` constructor
-kwargs that matters for its target accelerator — CPU smoke runs, single-GPU
-jobs, DDP, MPS — by selecting `accelerator`, `devices`, and (variant-specific)
-`strategy`, `precision`, `min_steps` / `max_steps`. The typed surface here
-covers the keys all shipped variants actually set; any other `Trainer` kwarg
-passes through via `extra="allow"`, and Lightning's docs are the authority
-on the full constructor.
-
-Every shipped YAML under `configs/trainer/` validates against `TrainerConfig`.
-The field table below is the source of truth for the typed surface; refer to
+`TrainerConfig` is the pydantic schema for the YAMLs under
+`configs/trainer/`. The typed surface covers the keys all shipped variants
+set; any other `Trainer` kwarg passes through via `extra="allow"`. See
 [Lightning's `Trainer` API](https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.trainer.trainer.Trainer.html)
-for the full kwarg list.
+for the full constructor.
 
 ::: synth_setter.schemas.trainer_config.TrainerConfig

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,16 +30,12 @@ plugins:
       default_handler: python
       handlers:
         python:
-          # PEP src-layout: the ``synth_setter`` package lives under ``src/``,
-          # so mkdocstrings needs ``src`` on its import path. Without this, a
-          # fresh checkout that hasn't run ``pip install -e .`` would fail
-          # ``mkdocs build`` with ``ModuleNotFoundError: synth_setter``.
+          # PEP src-layout: ``synth_setter`` lives under ``src/`` so griffe
+          # needs ``src`` on its import path without an editable install.
           paths: [src]
           options:
-            # griffe-pydantic teaches griffe to surface ``Field(description=...)``
-            # arguments on pydantic BaseModel fields. Without it, the per-field
-            # descriptions in TrainConfig / ModelConfig / OptimizerConfig render
-            # only their type annotations.
+            # griffe-pydantic surfaces ``Field(description=...)`` strings;
+            # without it the docs render only the type annotations.
             extensions:
               - griffe_pydantic:
                   schema: false
@@ -51,9 +47,8 @@ plugins:
             separate_signature: true
             show_signature_annotations: true
 
-# Only surface the config-reference site for now; existing engineering docs
-# under docs/ (architecture, design, guides, etc.) are kept out of the build
-# so this scaffolding can grow incrementally without pulling them in.
+# Only the config-reference site is surfaced for now; the rest of docs/
+# grows into the build incrementally.
 exclude_docs: |
   architecture.md
   doc-map.yaml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,8 +30,19 @@ plugins:
       default_handler: python
       handlers:
         python:
-          paths: [.]
+          # PEP src-layout: the ``synth_setter`` package lives under ``src/``,
+          # so mkdocstrings needs ``src`` on its import path. Without this, a
+          # fresh checkout that hasn't run ``pip install -e .`` would fail
+          # ``mkdocs build`` with ``ModuleNotFoundError: synth_setter``.
+          paths: [src]
           options:
+            # griffe-pydantic teaches griffe to surface ``Field(description=...)``
+            # arguments on pydantic BaseModel fields. Without it, the per-field
+            # descriptions in TrainConfig / ModelConfig / OptimizerConfig render
+            # only their type annotations.
+            extensions:
+              - griffe_pydantic:
+                  schema: false
             show_root_heading: true
             show_source: false
             members_order: source
@@ -58,4 +69,6 @@ nav:
   - Home: index.md
   - Config Reference:
       - Dataset Spec: config_reference/dataset_spec.md
+      - Training Config: config_reference/train_config.md
+      - Model Config: config_reference/model_config.md
   - Benchmarks: https://tinaudio.github.io/synth-setter/dev/bench/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -70,5 +70,11 @@ nav:
   - Config Reference:
       - Dataset Spec: config_reference/dataset_spec.md
       - Training Config: config_reference/train_config.md
+      - Data Config: config_reference/data_config.md
       - Model Config: config_reference/model_config.md
+      - Callbacks Config: config_reference/callbacks_config.md
+      - Logger Config: config_reference/logger_config.md
+      - Trainer Config: config_reference/trainer_config.md
+      - Paths Config: config_reference/paths_config.md
+      - Extras Config: config_reference/extras_config.md
   - Benchmarks: https://tinaudio.github.io/synth-setter/dev/bench/

--- a/src/synth_setter/schemas/__init__.py
+++ b/src/synth_setter/schemas/__init__.py
@@ -14,16 +14,37 @@ independently.
 The schemas use ``strict=True`` to refuse type-coercion at the trust
 boundary, and ``extra="allow"`` so subtrees that Hydra owns the shape of
 pass through unchanged.
+
+Each composition group under ``configs/`` is covered by one schema module
+(``data``, ``model``, ``trainer``, ``callbacks``, ``logger``, ``paths``,
+``extras``) plus ``train_config`` for the top-level ``configs/train.yaml``.
+The ``hydra`` composition group (``configs/hydra/default.yaml``) only sets
+partial overrides on Hydra's own internal config and is intentionally not
+modeled here — Hydra owns that schema.
 """
 
 from synth_setter.schemas._types import NonBlankStr
+from synth_setter.schemas.callbacks_config import CallbackInstance, CallbacksConfig
+from synth_setter.schemas.data_config import DataConfig
+from synth_setter.schemas.extras_config import ExtrasConfig
+from synth_setter.schemas.logger_config import LoggerConfig, LoggerInstance
 from synth_setter.schemas.model_config import ModelConfig, OptimizerConfig, SchedulerConfig
+from synth_setter.schemas.paths_config import PathsConfig
 from synth_setter.schemas.train_config import TrainConfig
+from synth_setter.schemas.trainer_config import TrainerConfig
 
 __all__ = [
+    "CallbackInstance",
+    "CallbacksConfig",
+    "DataConfig",
+    "ExtrasConfig",
+    "LoggerConfig",
+    "LoggerInstance",
     "ModelConfig",
     "NonBlankStr",
     "OptimizerConfig",
+    "PathsConfig",
     "SchedulerConfig",
     "TrainConfig",
+    "TrainerConfig",
 ]

--- a/src/synth_setter/schemas/__init__.py
+++ b/src/synth_setter/schemas/__init__.py
@@ -5,25 +5,24 @@ pages (``mkdocstrings`` + ``griffe-pydantic`` renders their field tables) and
 a sanity check that the training-time YAMLs stay in sync with what the
 entrypoints expect.
 
-Parallel to ``synth_setter.pipeline.schemas`` (which owns ``DatasetSpec`` and
-friends for the distributed data pipeline), this package owns the schemas
-that describe training-time configuration consumed by ``cli/train.py`` —
-kept separate so the two trust boundaries can evolve their strictness
-independently.
+Training-time schemas live in this package; distributed-pipeline schemas
+(``DatasetSpec``, ``ImageConfig``, and friends) live in
+``synth_setter.pipeline.schemas`` so the two trust boundaries can evolve
+their strictness independently.
 
 The schemas use ``strict=True`` to refuse type-coercion at the trust
 boundary, and ``extra="allow"`` so subtrees that Hydra owns the shape of
 pass through unchanged.
 
 Each composition group under ``configs/`` is covered by one schema module
-(``data``, ``model``, ``trainer``, ``callbacks``, ``logger``, ``paths``,
-``extras``) plus ``train_config`` for the top-level ``configs/train.yaml``.
+in this package, plus ``train_config`` for the top-level ``configs/train.yaml``.
 The ``hydra`` composition group (``configs/hydra/default.yaml``) only sets
 partial overrides on Hydra's own internal config and is intentionally not
 modeled here — Hydra owns that schema.
 """
 
-from synth_setter.schemas._types import NonBlankStr
+# _types is a private module; only the names re-exported here are public.
+from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 from synth_setter.schemas.callbacks_config import CallbackInstance, CallbacksConfig
 from synth_setter.schemas.data_config import DataConfig
 from synth_setter.schemas.extras_config import ExtrasConfig
@@ -45,6 +44,7 @@ __all__ = [
     "OptimizerConfig",
     "PathsConfig",
     "SchedulerConfig",
+    "StrictAllowExtraModel",
     "TrainConfig",
     "TrainerConfig",
 ]

--- a/src/synth_setter/schemas/__init__.py
+++ b/src/synth_setter/schemas/__init__.py
@@ -1,0 +1,29 @@
+"""Pydantic schemas that document and validate the project's Hydra configs.
+
+These models are the source of truth for the published mkdocs config-reference
+pages (``mkdocstrings`` + ``griffe-pydantic`` renders their field tables) and
+a sanity check that the training-time YAMLs stay in sync with what the
+entrypoints expect.
+
+Parallel to ``synth_setter.pipeline.schemas`` (which owns ``DatasetSpec`` and
+friends for the distributed data pipeline), this package owns the schemas
+that describe training-time configuration consumed by ``cli/train.py`` —
+kept separate so the two trust boundaries can evolve their strictness
+independently.
+
+The schemas use ``strict=True`` to refuse type-coercion at the trust
+boundary, and ``extra="allow"`` so subtrees that Hydra owns the shape of
+pass through unchanged.
+"""
+
+from synth_setter.schemas._types import NonBlankStr
+from synth_setter.schemas.model_config import ModelConfig, OptimizerConfig, SchedulerConfig
+from synth_setter.schemas.train_config import TrainConfig
+
+__all__ = [
+    "ModelConfig",
+    "NonBlankStr",
+    "OptimizerConfig",
+    "SchedulerConfig",
+    "TrainConfig",
+]

--- a/src/synth_setter/schemas/__init__.py
+++ b/src/synth_setter/schemas/__init__.py
@@ -1,27 +1,16 @@
-"""Pydantic schemas that document and validate the project's Hydra configs.
+"""Pydantic schemas for the training-time Hydra configs.
 
-These models are the source of truth for the published mkdocs config-reference
-pages (``mkdocstrings`` + ``griffe-pydantic`` renders their field tables) and
-a sanity check that the training-time YAMLs stay in sync with what the
-entrypoints expect.
+Source of truth for the mkdocs config-reference pages (rendered by
+``mkdocstrings`` + ``griffe-pydantic``) and a validation harness that pins
+the shipped YAMLs against what the entrypoints expect.
 
-Training-time schemas live in this package; distributed-pipeline schemas
-(``DatasetSpec``, ``ImageConfig``, and friends) live in
-``synth_setter.pipeline.schemas`` so the two trust boundaries can evolve
-their strictness independently.
+Distributed-pipeline schemas live in ``synth_setter.pipeline.schemas`` —
+that's a different trust boundary (closed-shape ``extra="forbid"``) and is
+intentionally separate.
 
-The schemas use ``strict=True`` to refuse type-coercion at the trust
-boundary, and ``extra="allow"`` so subtrees that Hydra owns the shape of
-pass through unchanged.
-
-Each composition group under ``configs/`` is covered by one schema module
-in this package, plus ``train_config`` for the top-level ``configs/train.yaml``.
-The ``hydra`` composition group (``configs/hydra/default.yaml``) only sets
-partial overrides on Hydra's own internal config and is intentionally not
-modeled here — Hydra owns that schema.
+The ``hydra`` composition group is not modeled here; Hydra owns that schema.
 """
 
-# _types is a private module; only the names re-exported here are public.
 from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 from synth_setter.schemas.callbacks_config import CallbackInstance, CallbacksConfig
 from synth_setter.schemas.data_config import DataConfig

--- a/src/synth_setter/schemas/_types.py
+++ b/src/synth_setter/schemas/_types.py
@@ -1,0 +1,21 @@
+"""Shared annotated types used across the training-config schemas.
+
+Lives in a leaf module to avoid a circular import between
+``schemas/__init__.py`` and the ``train_config`` / ``model_config`` modules
+that consume these types.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import StringConstraints
+
+__all__ = ["NonBlankStr"]
+
+
+# Shared annotated type for fields whose blank value would silently break a
+# downstream path derivation (run-id, output dir) or crash a Hydra
+# instantiation. Stripping leading/trailing whitespace before the length
+# check accepts ``"train"`` but rejects ``"   "``.
+NonBlankStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]

--- a/src/synth_setter/schemas/_types.py
+++ b/src/synth_setter/schemas/_types.py
@@ -1,4 +1,4 @@
-"""Shared annotated types used across the training-config schemas.
+"""Shared annotated types and base classes used across the training-config schemas.
 
 Lives in a leaf module to avoid a circular import between
 ``schemas/__init__.py`` and the ``train_config`` / ``model_config`` modules
@@ -9,9 +9,9 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from pydantic import StringConstraints
+from pydantic import BaseModel, ConfigDict, StringConstraints
 
-__all__ = ["NonBlankStr"]
+__all__ = ["NonBlankStr", "StrictAllowExtraModel"]
 
 
 # Shared annotated type for fields whose blank value would silently break a
@@ -19,3 +19,21 @@ __all__ = ["NonBlankStr"]
 # instantiation. Stripping leading/trailing whitespace before the length
 # check accepts ``"train"`` but rejects ``"   "``.
 NonBlankStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class StrictAllowExtraModel(BaseModel):  # noqa: DOC601,DOC603
+    """Project-standard trust-boundary base for Hydra training-config schemas.
+
+    Combines ``strict=True`` (refuse type-coercion at validation time) with
+    ``extra="allow"`` (let Hydra-owned subtree keys pass through unchanged)
+    and ``populate_by_name=True`` (so ``_target_``-style aliases work both
+    by alias and by attribute name).
+
+    The ``extra="allow"`` choice intentionally diverges from
+    ``synth_setter.pipeline.schemas``'s ``extra="forbid"`` posture: pipeline
+    schemas describe data on disk in R2 and benefit from strict closed
+    shapes, while training configs are composed from many Hydra subtrees
+    whose keys vary per variant and would be brittle under ``forbid``.
+    """
+
+    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)

--- a/src/synth_setter/schemas/_types.py
+++ b/src/synth_setter/schemas/_types.py
@@ -1,8 +1,6 @@
-"""Shared annotated types and base classes used across the training-config schemas.
+"""Shared annotated types and base class for the training-config schemas.
 
-Lives in a leaf module to avoid a circular import between
-``schemas/__init__.py`` and the ``train_config`` / ``model_config`` modules
-that consume these types.
+Leaf module to avoid a circular import via ``schemas/__init__.py``.
 """
 
 from __future__ import annotations
@@ -14,26 +12,15 @@ from pydantic import BaseModel, ConfigDict, StringConstraints
 __all__ = ["NonBlankStr", "StrictAllowExtraModel"]
 
 
-# Shared annotated type for fields whose blank value would silently break a
-# downstream path derivation (run-id, output dir) or crash a Hydra
-# instantiation. Stripping leading/trailing whitespace before the length
-# check accepts ``"train"`` but rejects ``"   "``.
+# Strips before the length check, so ``"train"`` passes and ``"   "`` doesn't.
 NonBlankStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
 
 class StrictAllowExtraModel(BaseModel):  # noqa: DOC601,DOC603
-    """Project-standard trust-boundary base for Hydra training-config schemas.
+    """Trust-boundary base: ``strict=True`` + ``extra="allow"`` + alias-by-name.
 
-    Combines ``strict=True`` (refuse type-coercion at validation time) with
-    ``extra="allow"`` (let Hydra-owned subtree keys pass through unchanged)
-    and ``populate_by_name=True`` (so ``_target_``-style aliases work both
-    by alias and by attribute name).
-
-    The ``extra="allow"`` choice intentionally diverges from
-    ``synth_setter.pipeline.schemas``'s ``extra="forbid"`` posture: pipeline
-    schemas describe data on disk in R2 and benefit from strict closed
-    shapes, while training configs are composed from many Hydra subtrees
-    whose keys vary per variant and would be brittle under ``forbid``.
+    Diverges from ``pipeline.schemas``' ``extra="forbid"`` because training
+    configs are composed from many Hydra subtrees whose keys vary per variant.
     """
 
     model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)

--- a/src/synth_setter/schemas/callbacks_config.py
+++ b/src/synth_setter/schemas/callbacks_config.py
@@ -18,19 +18,14 @@ The two schemas here mirror that shape:
 
 from __future__ import annotations
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    RootModel,
-)
+from pydantic import Field, RootModel
 
-from synth_setter.schemas._types import NonBlankStr
+from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 
 __all__ = ["CallbackInstance", "CallbacksConfig"]
 
 
-class CallbackInstance(BaseModel):  # noqa: DOC601,DOC603
+class CallbackInstance(StrictAllowExtraModel):  # noqa: DOC601,DOC603
     """One entry of the ``cfg.callbacks`` dict.
 
     Only ``_target_`` is typed at this layer; callback-class kwargs
@@ -39,8 +34,6 @@ class CallbackInstance(BaseModel):  # noqa: DOC601,DOC603
     on those kwargs live on the upstream Lightning / project-local callback
     class signatures rather than being duplicated here.
     """
-
-    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)
 
     target_: NonBlankStr = Field(
         alias="_target_",

--- a/src/synth_setter/schemas/callbacks_config.py
+++ b/src/synth_setter/schemas/callbacks_config.py
@@ -1,13 +1,15 @@
 """Pydantic schemas for the YAMLs under ``configs/callbacks/``.
 
-After Hydra composes, ``cfg.callbacks`` is a flat ``name → instance`` dict
-that ``synth_setter.utils.instantiate_callbacks`` iterates over (skipping
-entries that lack ``_target_``).
+After Hydra composes, ``cfg.callbacks`` is a flat ``name → instance`` dict.
+The schema requires every value to carry ``_target_``; the runtime helper
+``synth_setter.utils.instantiate_callbacks`` is more lenient and skips
+non-``_target_`` entries, but that path is reserved for raw DictConfigs that
+bypass schema validation.
 """
 
 from __future__ import annotations
 
-from pydantic import Field, RootModel
+from pydantic import ConfigDict, Field, RootModel
 
 from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 
@@ -32,3 +34,5 @@ class CallbacksConfig(RootModel[dict[NonBlankStr, CallbackInstance]]):  # noqa: 
     ``configs/callbacks/none.yaml`` resolves to ``None``, not ``{}``, and is
     handled by ``instantiate_callbacks`` short-circuiting on a falsy config.
     """
+
+    model_config = ConfigDict(strict=True)

--- a/src/synth_setter/schemas/callbacks_config.py
+++ b/src/synth_setter/schemas/callbacks_config.py
@@ -1,0 +1,64 @@
+"""Pydantic schemas for Lightning callback configs under ``configs/callbacks/``.
+
+Each YAML under ``configs/callbacks/`` either defines a single named callback
+(``model_checkpoint.yaml`` → ``{"model_checkpoint": {"_target_": ...}}``) or
+composes several via ``defaults:`` plus per-callback overrides
+(``default.yaml``). Once Hydra has finished composing, ``cfg.callbacks`` is a
+flat mapping from callback-name → callback-instance dict, which
+``synth_setter.utils.instantiate_callbacks`` then iterates over —
+``hydra.utils.instantiate`` is called only on values that contain
+``_target_``, so unrelated keys are silently skipped.
+
+The two schemas here mirror that shape:
+
+* :class:`CallbackInstance` is what each value in the dict must satisfy.
+* :class:`CallbacksConfig` is the top-level :class:`~pydantic.RootModel`
+  that validates the whole dict at once.
+"""
+
+from __future__ import annotations
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+)
+
+from synth_setter.schemas._types import NonBlankStr
+
+__all__ = ["CallbackInstance", "CallbacksConfig"]
+
+
+class CallbackInstance(BaseModel):  # noqa: DOC601,DOC603
+    """One entry of the ``cfg.callbacks`` dict.
+
+    Only ``_target_`` is typed at this layer; callback-class kwargs
+    (``monitor``, ``dirpath``, ``patience``, ``every_n_train_steps``, ...)
+    vary per callback and pass through via ``extra="allow"``. The constraints
+    on those kwargs live on the upstream Lightning / project-local callback
+    class signatures rather than being duplicated here.
+    """
+
+    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)
+
+    target_: NonBlankStr = Field(
+        alias="_target_",
+        description=(
+            "Fully-qualified callback class path. Each entry of "
+            "``cfg.callbacks`` is passed to ``hydra.utils.instantiate``."
+        ),
+    )
+
+
+class CallbacksConfig(RootModel[dict[NonBlankStr, CallbackInstance]]):  # noqa: DOC601,DOC603
+    """Top-level shape of ``cfg.callbacks`` — a mapping of name → instance.
+
+    The keys are callback names (``model_checkpoint``, ``lr_monitor``,
+    ``plot_proj_ii``, ...). Each value validates against
+    :class:`CallbackInstance`. ``configs/callbacks/none.yaml`` is an empty
+    document and Hydra resolves it to ``None`` rather than ``{}``; that
+    pathway bypasses this schema entirely and is handled by
+    ``synth_setter.utils.instantiate_callbacks`` (it short-circuits on a
+    falsy config).
+    """

--- a/src/synth_setter/schemas/callbacks_config.py
+++ b/src/synth_setter/schemas/callbacks_config.py
@@ -1,19 +1,8 @@
-"""Pydantic schemas for Lightning callback configs under ``configs/callbacks/``.
+"""Pydantic schemas for the YAMLs under ``configs/callbacks/``.
 
-Each YAML under ``configs/callbacks/`` either defines a single named callback
-(``model_checkpoint.yaml`` → ``{"model_checkpoint": {"_target_": ...}}``) or
-composes several via ``defaults:`` plus per-callback overrides
-(``default.yaml``). Once Hydra has finished composing, ``cfg.callbacks`` is a
-flat mapping from callback-name → callback-instance dict, which
-``synth_setter.utils.instantiate_callbacks`` then iterates over —
-``hydra.utils.instantiate`` is called only on values that contain
-``_target_``, so unrelated keys are silently skipped.
-
-The two schemas here mirror that shape:
-
-* :class:`CallbackInstance` is what each value in the dict must satisfy.
-* :class:`CallbacksConfig` is the top-level :class:`~pydantic.RootModel`
-  that validates the whole dict at once.
+After Hydra composes, ``cfg.callbacks`` is a flat ``name → instance`` dict
+that ``synth_setter.utils.instantiate_callbacks`` iterates over (skipping
+entries that lack ``_target_``).
 """
 
 from __future__ import annotations
@@ -26,14 +15,7 @@ __all__ = ["CallbackInstance", "CallbacksConfig"]
 
 
 class CallbackInstance(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """One entry of the ``cfg.callbacks`` dict.
-
-    Only ``_target_`` is typed at this layer; callback-class kwargs
-    (``monitor``, ``dirpath``, ``patience``, ``every_n_train_steps``, ...)
-    vary per callback and pass through via ``extra="allow"``. The constraints
-    on those kwargs live on the upstream Lightning / project-local callback
-    class signatures rather than being duplicated here.
-    """
+    """One entry of ``cfg.callbacks``; callback kwargs pass through via ``extra="allow"``."""
 
     target_: NonBlankStr = Field(
         alias="_target_",
@@ -45,13 +27,8 @@ class CallbackInstance(StrictAllowExtraModel):  # noqa: DOC601,DOC603
 
 
 class CallbacksConfig(RootModel[dict[NonBlankStr, CallbackInstance]]):  # noqa: DOC601,DOC603
-    """Top-level shape of ``cfg.callbacks`` — a mapping of name → instance.
+    """Shape of ``cfg.callbacks`` — a ``name → CallbackInstance`` mapping.
 
-    The keys are callback names (``model_checkpoint``, ``lr_monitor``,
-    ``plot_proj_ii``, ...). Each value validates against
-    :class:`CallbackInstance`. ``configs/callbacks/none.yaml`` is an empty
-    document and Hydra resolves it to ``None`` rather than ``{}``; that
-    pathway bypasses this schema entirely and is handled by
-    ``synth_setter.utils.instantiate_callbacks`` (it short-circuits on a
-    falsy config).
+    ``configs/callbacks/none.yaml`` resolves to ``None``, not ``{}``, and is
+    handled by ``instantiate_callbacks`` short-circuiting on a falsy config.
     """

--- a/src/synth_setter/schemas/data_config.py
+++ b/src/synth_setter/schemas/data_config.py
@@ -1,0 +1,45 @@
+"""Pydantic schema for per-datamodule Hydra configs under ``configs/data/``.
+
+Every YAML under ``configs/data/`` selects one ``LightningDataModule`` via
+``_target_`` and supplies the constructor kwargs that module needs. The shape
+varies wildly across modules (``SurgeDataModule`` is path-driven,
+``KSinDataModule`` is purely synthetic with seed tuples), so the typed
+surface is intentionally narrow — only the keys ``cli/train.py`` itself
+reads — and the rest is accepted via ``extra="allow"`` so a new
+datamodule ships without a schema edit.
+"""
+
+from __future__ import annotations
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+)
+
+from synth_setter.schemas._types import NonBlankStr
+
+__all__ = ["DataConfig"]
+
+
+class DataConfig(BaseModel):  # noqa: DOC601,DOC603
+    """Per-datamodule Hydra config (one of the YAMLs under ``configs/data/``).
+
+    Only ``_target_`` is typed at this layer — that's the single key
+    ``cli/train.py`` reads off ``cfg.data`` before delegating to
+    ``hydra.utils.instantiate(cfg.data)``. Datamodule constructor kwargs
+    (``batch_size``, ``num_workers``, ``train_val_test_sizes``,
+    ``dataset_root``, ...) vary across modules and pass through via
+    ``extra="allow"``; their constraints live on the datamodule's
+    ``__init__`` signature rather than being re-stated here.
+    """
+
+    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)
+
+    target_: NonBlankStr = Field(
+        alias="_target_",
+        description=(
+            "Fully-qualified ``LightningDataModule`` class path. Resolved by "
+            "``hydra.utils.instantiate(cfg.data)`` in ``cli/train.py``."
+        ),
+    )

--- a/src/synth_setter/schemas/data_config.py
+++ b/src/synth_setter/schemas/data_config.py
@@ -1,12 +1,7 @@
-"""Pydantic schema for per-datamodule Hydra configs under ``configs/data/``.
+"""Pydantic schema for the YAMLs under ``configs/data/``.
 
-Every YAML under ``configs/data/`` selects one ``LightningDataModule`` via
-``_target_`` and supplies the constructor kwargs that module needs. The shape
-varies wildly across modules (``SurgeDataModule`` is path-driven,
-``KSinDataModule`` is purely synthetic with seed tuples), so the typed
-surface is intentionally narrow — only the keys ``cli/train.py`` itself
-reads — and the rest is accepted via ``extra="allow"`` so a new
-datamodule ships without a schema edit.
+Datamodule kwargs vary per module (``SurgeDataModule`` is path-driven,
+``KSinDataModule`` is synthetic) and pass through via ``extra="allow"``.
 """
 
 from __future__ import annotations
@@ -19,16 +14,7 @@ __all__ = ["DataConfig"]
 
 
 class DataConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """Per-datamodule Hydra config (one of the YAMLs under ``configs/data/``).
-
-    Only ``_target_`` is typed at this layer — that's the single key
-    ``cli/train.py`` reads off ``cfg.data`` before delegating to
-    ``hydra.utils.instantiate(cfg.data)``. Datamodule constructor kwargs
-    (``batch_size``, ``num_workers``, ``train_val_test_sizes``,
-    ``dataset_root``, ...) vary across modules and pass through via
-    ``extra="allow"``; their constraints live on the datamodule's
-    ``__init__`` signature rather than being re-stated here.
-    """
+    """One of the YAMLs under ``configs/data/``; only ``_target_`` is typed."""
 
     target_: NonBlankStr = Field(
         alias="_target_",

--- a/src/synth_setter/schemas/data_config.py
+++ b/src/synth_setter/schemas/data_config.py
@@ -11,18 +11,14 @@ datamodule ships without a schema edit.
 
 from __future__ import annotations
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-)
+from pydantic import Field
 
-from synth_setter.schemas._types import NonBlankStr
+from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 
 __all__ = ["DataConfig"]
 
 
-class DataConfig(BaseModel):  # noqa: DOC601,DOC603
+class DataConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
     """Per-datamodule Hydra config (one of the YAMLs under ``configs/data/``).
 
     Only ``_target_`` is typed at this layer — that's the single key
@@ -33,8 +29,6 @@ class DataConfig(BaseModel):  # noqa: DOC601,DOC603
     ``extra="allow"``; their constraints live on the datamodule's
     ``__init__`` signature rather than being re-stated here.
     """
-
-    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)
 
     target_: NonBlankStr = Field(
         alias="_target_",

--- a/src/synth_setter/schemas/extras_config.py
+++ b/src/synth_setter/schemas/extras_config.py
@@ -11,23 +11,26 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    StrictBool,
-)
+from pydantic import Field, StrictBool
+
+from synth_setter.schemas._types import StrictAllowExtraModel
 
 __all__ = ["ExtrasConfig"]
 
 
-class ExtrasConfig(BaseModel):  # noqa: DOC601,DOC603
+# Allowed values for ``torch.set_float32_matmul_precision`` — kept as a named
+# constant so the docs and the type annotation share one source of truth.
+# Note: the ``Literal[*tuple]`` unpacking syntax requires Python 3.11+ and
+# this project pins ``python_requires = ">=3.10"``, so the type annotation
+# below restates the values explicitly.
+_FLOAT32_MATMUL_PRECISIONS: tuple[str, ...] = ("highest", "high", "medium")
+
+
+class ExtrasConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
     """Run-time toggles read at the top of ``cli/train.py``.
 
     Per-field descriptions live on the ``Field`` definitions below.
     """
-
-    model_config = ConfigDict(strict=True, extra="allow")
 
     ignore_warnings: StrictBool = Field(
         default=False,

--- a/src/synth_setter/schemas/extras_config.py
+++ b/src/synth_setter/schemas/extras_config.py
@@ -1,0 +1,60 @@
+"""Pydantic schema for the run-time extras under ``configs/extras/``.
+
+Toggles consumed by ``synth_setter.utils.extras()`` (the helper invoked
+from ``cli/train.py`` at startup) and by ``torch.set_float32_matmul_precision``.
+The shipped composition is ``configs/extras/default.yaml``; the schema names
+each toggle so a YAML rename surfaces here at validation time rather than
+silently dropping the override.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictBool,
+)
+
+__all__ = ["ExtrasConfig"]
+
+
+class ExtrasConfig(BaseModel):  # noqa: DOC601,DOC603
+    """Run-time toggles read at the top of ``cli/train.py``.
+
+    Per-field descriptions live on the ``Field`` definitions below.
+    """
+
+    model_config = ConfigDict(strict=True, extra="allow")
+
+    ignore_warnings: StrictBool = Field(
+        default=False,
+        description=(
+            "If ``True``, ``synth_setter.utils.extras`` silences Python "
+            "``warnings`` (``warnings.filterwarnings('ignore')``)."
+        ),
+    )
+    enforce_tags: StrictBool = Field(
+        default=True,
+        description=(
+            "If ``True``, ``extras`` prompts on startup when no ``tags`` are "
+            "set so every run ships with at least one tag for the logger."
+        ),
+    )
+    print_config: StrictBool = Field(
+        default=True,
+        description=(
+            "Pretty-print the composed Hydra config tree at startup using "
+            "Rich, helpful for catching surprise overrides at launch."
+        ),
+    )
+    float32_matmul_precision: Literal["highest", "high", "medium"] = Field(
+        default="high",
+        description=(
+            "Passed to ``torch.set_float32_matmul_precision`` — controls "
+            "TF32 on Ampere+ GPUs. ``high`` (the shipped default) trades a "
+            "small numerical error for substantial throughput."
+        ),
+    )

--- a/src/synth_setter/schemas/extras_config.py
+++ b/src/synth_setter/schemas/extras_config.py
@@ -1,10 +1,7 @@
-"""Pydantic schema for the run-time extras under ``configs/extras/``.
+"""Pydantic schema for the startup toggles under ``configs/extras/``.
 
-Toggles consumed by ``synth_setter.utils.extras()`` (the helper invoked
-from ``cli/train.py`` at startup) and by ``torch.set_float32_matmul_precision``.
-The shipped composition is ``configs/extras/default.yaml``; the schema names
-each toggle so a YAML rename surfaces here at validation time rather than
-silently dropping the override.
+Read by ``synth_setter.utils.extras()`` and by
+``torch.set_float32_matmul_precision`` at the top of ``cli/train.py``.
 """
 
 from __future__ import annotations
@@ -18,19 +15,13 @@ from synth_setter.schemas._types import StrictAllowExtraModel
 __all__ = ["ExtrasConfig"]
 
 
-# Allowed values for ``torch.set_float32_matmul_precision`` — kept as a named
-# constant so the docs and the type annotation share one source of truth.
-# Note: the ``Literal[*tuple]`` unpacking syntax requires Python 3.11+ and
-# this project pins ``python_requires = ">=3.10"``, so the type annotation
-# below restates the values explicitly.
+# Restated in the Literal annotation below because Literal[*tuple] unpacking
+# needs Python 3.11+ and the project pins ``python_requires = ">=3.10"``.
 _FLOAT32_MATMUL_PRECISIONS: tuple[str, ...] = ("highest", "high", "medium")
 
 
 class ExtrasConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """Run-time toggles read at the top of ``cli/train.py``.
-
-    Per-field descriptions live on the ``Field`` definitions below.
-    """
+    """Startup toggles consumed by ``synth_setter.utils.extras(cfg)``."""
 
     ignore_warnings: StrictBool = Field(
         default=False,

--- a/src/synth_setter/schemas/logger_config.py
+++ b/src/synth_setter/schemas/logger_config.py
@@ -1,17 +1,8 @@
-"""Pydantic schemas for Lightning logger configs under ``configs/logger/``.
+"""Pydantic schemas for the YAMLs under ``configs/logger/``.
 
-Mirrors the callbacks-config layout: each YAML under ``configs/logger/``
-either defines a single named logger (``wandb.yaml`` →
-``{"wandb": {"_target_": ...}}``) or composes several via ``defaults:``
-(``many_loggers.yaml`` pulls in csv + tensorboard + wandb). Composed
-``cfg.logger`` is a flat mapping name → logger-instance dict, iterated
-by ``synth_setter.utils.instantiate_loggers``.
-
-The two schemas here mirror that shape:
-
-* :class:`LoggerInstance` is what each value in the dict must satisfy.
-* :class:`LoggerConfig` is the top-level :class:`~pydantic.RootModel`
-  that validates the whole dict at once.
+Mirrors the callbacks-config layout: composed ``cfg.logger`` is a flat
+``name → instance`` dict iterated by
+``synth_setter.utils.instantiate_loggers``.
 """
 
 from __future__ import annotations
@@ -24,13 +15,7 @@ __all__ = ["LoggerConfig", "LoggerInstance"]
 
 
 class LoggerInstance(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """One entry of the ``cfg.logger`` dict.
-
-    Only ``_target_`` is typed at this layer; logger-class kwargs
-    (``api_key``, ``project``, ``save_dir``, ``tags``, ...) vary per logger
-    and pass through via ``extra="allow"``. The constraints on those kwargs
-    live on the upstream logger class signatures.
-    """
+    """One entry of ``cfg.logger``; logger kwargs pass through via ``extra="allow"``."""
 
     target_: NonBlankStr = Field(
         alias="_target_",
@@ -43,11 +28,8 @@ class LoggerInstance(StrictAllowExtraModel):  # noqa: DOC601,DOC603
 
 
 class LoggerConfig(RootModel[dict[NonBlankStr, LoggerInstance]]):  # noqa: DOC601,DOC603
-    """Top-level shape of ``cfg.logger`` — a mapping of name → instance.
+    """Shape of ``cfg.logger`` — a ``name → LoggerInstance`` mapping.
 
-    The keys are logger names (``csv``, ``tensorboard``, ``wandb``, ...).
-    Each value validates against :class:`LoggerInstance`.
-    ``instantiate_loggers`` short-circuits when the composed config is falsy
-    (no logger configured), so an empty or ``None`` ``cfg.logger`` is
-    handled outside this schema.
+    ``instantiate_loggers`` short-circuits on a falsy ``cfg.logger`` (empty
+    or ``None``), so that case bypasses this schema.
     """

--- a/src/synth_setter/schemas/logger_config.py
+++ b/src/synth_setter/schemas/logger_config.py
@@ -7,7 +7,7 @@ Mirrors the callbacks-config layout: composed ``cfg.logger`` is a flat
 
 from __future__ import annotations
 
-from pydantic import Field, RootModel
+from pydantic import ConfigDict, Field, RootModel
 
 from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 
@@ -33,3 +33,5 @@ class LoggerConfig(RootModel[dict[NonBlankStr, LoggerInstance]]):  # noqa: DOC60
     ``instantiate_loggers`` short-circuits on a falsy ``cfg.logger`` (empty
     or ``None``), so that case bypasses this schema.
     """
+
+    model_config = ConfigDict(strict=True)

--- a/src/synth_setter/schemas/logger_config.py
+++ b/src/synth_setter/schemas/logger_config.py
@@ -1,0 +1,60 @@
+"""Pydantic schemas for Lightning logger configs under ``configs/logger/``.
+
+Mirrors the callbacks-config layout: each YAML under ``configs/logger/``
+either defines a single named logger (``wandb.yaml`` →
+``{"wandb": {"_target_": ...}}``) or composes several via ``defaults:``
+(``many_loggers.yaml`` pulls in csv + tensorboard + wandb). Composed
+``cfg.logger`` is a flat mapping name → logger-instance dict, iterated
+by ``synth_setter.utils.instantiate_loggers``.
+
+The two schemas here mirror that shape:
+
+* :class:`LoggerInstance` is what each value in the dict must satisfy.
+* :class:`LoggerConfig` is the top-level :class:`~pydantic.RootModel`
+  that validates the whole dict at once.
+"""
+
+from __future__ import annotations
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+)
+
+from synth_setter.schemas._types import NonBlankStr
+
+__all__ = ["LoggerConfig", "LoggerInstance"]
+
+
+class LoggerInstance(BaseModel):  # noqa: DOC601,DOC603
+    """One entry of the ``cfg.logger`` dict.
+
+    Only ``_target_`` is typed at this layer; logger-class kwargs
+    (``api_key``, ``project``, ``save_dir``, ``tags``, ...) vary per logger
+    and pass through via ``extra="allow"``. The constraints on those kwargs
+    live on the upstream logger class signatures.
+    """
+
+    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)
+
+    target_: NonBlankStr = Field(
+        alias="_target_",
+        description=(
+            "Fully-qualified logger class path (e.g. "
+            "``lightning.pytorch.loggers.wandb.WandbLogger``). Each entry of "
+            "``cfg.logger`` is passed to ``hydra.utils.instantiate``."
+        ),
+    )
+
+
+class LoggerConfig(RootModel[dict[NonBlankStr, LoggerInstance]]):  # noqa: DOC601,DOC603
+    """Top-level shape of ``cfg.logger`` — a mapping of name → instance.
+
+    The keys are logger names (``csv``, ``tensorboard``, ``wandb``, ...).
+    Each value validates against :class:`LoggerInstance`.
+    ``instantiate_loggers`` short-circuits when the composed config is falsy
+    (no logger configured), so an empty or ``None`` ``cfg.logger`` is
+    handled outside this schema.
+    """

--- a/src/synth_setter/schemas/logger_config.py
+++ b/src/synth_setter/schemas/logger_config.py
@@ -16,19 +16,14 @@ The two schemas here mirror that shape:
 
 from __future__ import annotations
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    RootModel,
-)
+from pydantic import Field, RootModel
 
-from synth_setter.schemas._types import NonBlankStr
+from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 
 __all__ = ["LoggerConfig", "LoggerInstance"]
 
 
-class LoggerInstance(BaseModel):  # noqa: DOC601,DOC603
+class LoggerInstance(StrictAllowExtraModel):  # noqa: DOC601,DOC603
     """One entry of the ``cfg.logger`` dict.
 
     Only ``_target_`` is typed at this layer; logger-class kwargs
@@ -36,8 +31,6 @@ class LoggerInstance(BaseModel):  # noqa: DOC601,DOC603
     and pass through via ``extra="allow"``. The constraints on those kwargs
     live on the upstream logger class signatures.
     """
-
-    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)
 
     target_: NonBlankStr = Field(
         alias="_target_",

--- a/src/synth_setter/schemas/model_config.py
+++ b/src/synth_setter/schemas/model_config.py
@@ -1,14 +1,8 @@
-"""Pydantic schemas for per-model Hydra configs under ``configs/model/``.
+"""Pydantic schemas for the YAMLs under ``configs/model/``.
 
-Every YAML under ``configs/model/`` declares: the LightningModule target, a
-partial torch optimizer, an optional partial LR scheduler, and a ``compile``
-flag. Variant-specific fields vary per model module and are accepted via
-``extra="allow"`` — adding a new model YAML does not require touching this
-schema.
-
-``_target_`` is exposed on the Python model as ``target_`` (trailing
-underscore) because leading-underscore field names are not addressable on a
-pydantic ``BaseModel``. The alias ``_target_`` is preserved on input/output.
+``_target_`` is exposed as ``target_`` (trailing underscore) because
+leading-underscore field names are not addressable on a pydantic
+``BaseModel``; the ``_target_`` alias is preserved on input/output.
 """
 
 from __future__ import annotations
@@ -26,13 +20,7 @@ __all__ = ["ModelConfig", "OptimizerConfig", "SchedulerConfig"]
 
 
 class OptimizerConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """Partial torch optimizer config injected at fit-time with model parameters.
-
-    ``_partial_: true`` means ``hydra.utils.instantiate`` returns a
-    ``functools.partial`` instead of a fully-constructed optimizer; the
-    LightningModule binds the model parameters at the call site. Per-field
-    descriptions live on the ``Field`` definitions below.
-    """
+    """Partial torch optimizer; the LightningModule binds model params at call time."""
 
     target_: NonBlankStr = Field(
         alias="_target_",
@@ -51,12 +39,7 @@ class OptimizerConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
 
 
 class SchedulerConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """Partial torch LR scheduler config injected at fit-time with the optimizer.
-
-    Several configs ship ``scheduler: null``; in those cases the YAML maps to
-    ``ModelConfig.scheduler = None`` rather than this model. Per-field
-    descriptions live on the ``Field`` definitions below.
-    """
+    """Partial torch LR scheduler; ``scheduler: null`` maps to ``None`` instead."""
 
     target_: NonBlankStr = Field(
         alias="_target_",
@@ -70,13 +53,7 @@ class SchedulerConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
 
 
 class ModelConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """Per-model Hydra config (one of the YAMLs under ``configs/model/``).
-
-    The typed fields are the common surface area; variant-specific keys are
-    accepted via ``extra="allow"`` so a new model module ships without a
-    schema edit. Per-field descriptions live on the ``Field`` definitions
-    below.
-    """
+    """One of the YAMLs under ``configs/model/``; variant kwargs via ``extra="allow"``."""
 
     target_: NonBlankStr = Field(
         alias="_target_",
@@ -95,7 +72,6 @@ class ModelConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
             "scheduler. See ``SchedulerConfig``."
         ),
     )
-    # Field name mirrors the YAML key; shadows the ``compile()`` builtin in cfg.model.compile.
     compile: StrictBool = Field(
         default=True,
         description="Whether to wrap the module in ``torch.compile`` at setup time.",

--- a/src/synth_setter/schemas/model_config.py
+++ b/src/synth_setter/schemas/model_config.py
@@ -1,0 +1,112 @@
+"""Pydantic schemas for per-model Hydra configs under ``configs/model/``.
+
+Every YAML under ``configs/model/`` declares: the LightningModule target, a
+partial torch optimizer, an optional partial LR scheduler, and a ``compile``
+flag. Variant-specific fields vary per model module and are accepted via
+``extra="allow"`` — adding a new model YAML does not require touching this
+schema.
+
+``_target_`` is exposed on the Python model as ``target_`` (trailing
+underscore) because leading-underscore field names are not addressable on a
+pydantic ``BaseModel``. The alias ``_target_`` is preserved on input/output.
+"""
+
+from __future__ import annotations
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    NonNegativeFloat,
+    PositiveFloat,
+    StrictBool,
+)
+
+from synth_setter.schemas._types import NonBlankStr
+
+__all__ = ["ModelConfig", "OptimizerConfig", "SchedulerConfig"]
+
+
+class OptimizerConfig(BaseModel):  # noqa: DOC601,DOC603
+    """Partial torch optimizer config injected at fit-time with model parameters.
+
+    ``_partial_: true`` means ``hydra.utils.instantiate`` returns a
+    ``functools.partial`` instead of a fully-constructed optimizer; the
+    LightningModule binds the model parameters at the call site. Per-field
+    descriptions live on the ``Field`` definitions below.
+    """
+
+    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)
+
+    target_: NonBlankStr = Field(
+        alias="_target_",
+        description="Fully-qualified torch optimizer class path (e.g. ``torch.optim.Adam``).",
+    )
+    partial_: StrictBool = Field(
+        default=True,
+        alias="_partial_",
+        description="Whether Hydra returns a partial; ``True`` is the convention here.",
+    )
+    lr: PositiveFloat = Field(description="Learning rate (must be positive).")
+    weight_decay: NonNegativeFloat = Field(
+        default=0.0,
+        description="L2 weight-decay coefficient (must be non-negative).",
+    )
+
+
+class SchedulerConfig(BaseModel):  # noqa: DOC601,DOC603
+    """Partial torch LR scheduler config injected at fit-time with the optimizer.
+
+    Several configs ship ``scheduler: null``; in those cases the YAML maps to
+    ``ModelConfig.scheduler = None`` rather than this model. Per-field
+    descriptions live on the ``Field`` definitions below.
+    """
+
+    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)
+
+    target_: NonBlankStr = Field(
+        alias="_target_",
+        description="Fully-qualified LR-scheduler class path.",
+    )
+    partial_: StrictBool = Field(
+        default=True,
+        alias="_partial_",
+        description="Whether Hydra returns a partial; conventionally ``True``.",
+    )
+
+
+class ModelConfig(BaseModel):  # noqa: DOC601,DOC603
+    """Per-model Hydra config (one of the YAMLs under ``configs/model/``).
+
+    The typed fields are the common surface area; variant-specific keys are
+    accepted via ``extra="allow"`` so a new model module ships without a
+    schema edit. Per-field descriptions live on the ``Field`` definitions
+    below.
+    """
+
+    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)
+
+    target_: NonBlankStr = Field(
+        alias="_target_",
+        description=(
+            "Fully-qualified ``LightningModule`` class path. Resolved by "
+            "``hydra.utils.instantiate(cfg.model)`` in ``cli/train.py``."
+        ),
+    )
+    optimizer: OptimizerConfig = Field(
+        description="Partial torch optimizer config (see ``OptimizerConfig``)."
+    )
+    scheduler: SchedulerConfig | None = Field(
+        default=None,
+        description=(
+            "Partial LR scheduler config, or ``null`` to run without a "
+            "scheduler. See ``SchedulerConfig``."
+        ),
+    )
+    compile: StrictBool = Field(
+        default=True,
+        description=(
+            "Whether to wrap the module in ``torch.compile`` at setup time. "
+            "Overridden to ``False`` in CI / smoke fixtures for speed."
+        ),
+    )

--- a/src/synth_setter/schemas/model_config.py
+++ b/src/synth_setter/schemas/model_config.py
@@ -14,20 +14,18 @@ pydantic ``BaseModel``. The alias ``_target_`` is preserved on input/output.
 from __future__ import annotations
 
 from pydantic import (
-    BaseModel,
-    ConfigDict,
     Field,
     NonNegativeFloat,
     PositiveFloat,
     StrictBool,
 )
 
-from synth_setter.schemas._types import NonBlankStr
+from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 
 __all__ = ["ModelConfig", "OptimizerConfig", "SchedulerConfig"]
 
 
-class OptimizerConfig(BaseModel):  # noqa: DOC601,DOC603
+class OptimizerConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
     """Partial torch optimizer config injected at fit-time with model parameters.
 
     ``_partial_: true`` means ``hydra.utils.instantiate`` returns a
@@ -35,8 +33,6 @@ class OptimizerConfig(BaseModel):  # noqa: DOC601,DOC603
     LightningModule binds the model parameters at the call site. Per-field
     descriptions live on the ``Field`` definitions below.
     """
-
-    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)
 
     target_: NonBlankStr = Field(
         alias="_target_",
@@ -54,15 +50,13 @@ class OptimizerConfig(BaseModel):  # noqa: DOC601,DOC603
     )
 
 
-class SchedulerConfig(BaseModel):  # noqa: DOC601,DOC603
+class SchedulerConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
     """Partial torch LR scheduler config injected at fit-time with the optimizer.
 
     Several configs ship ``scheduler: null``; in those cases the YAML maps to
     ``ModelConfig.scheduler = None`` rather than this model. Per-field
     descriptions live on the ``Field`` definitions below.
     """
-
-    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)
 
     target_: NonBlankStr = Field(
         alias="_target_",
@@ -75,7 +69,7 @@ class SchedulerConfig(BaseModel):  # noqa: DOC601,DOC603
     )
 
 
-class ModelConfig(BaseModel):  # noqa: DOC601,DOC603
+class ModelConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
     """Per-model Hydra config (one of the YAMLs under ``configs/model/``).
 
     The typed fields are the common surface area; variant-specific keys are
@@ -83,8 +77,6 @@ class ModelConfig(BaseModel):  # noqa: DOC601,DOC603
     schema edit. Per-field descriptions live on the ``Field`` definitions
     below.
     """
-
-    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)
 
     target_: NonBlankStr = Field(
         alias="_target_",
@@ -103,10 +95,8 @@ class ModelConfig(BaseModel):  # noqa: DOC601,DOC603
             "scheduler. See ``SchedulerConfig``."
         ),
     )
+    # Field name mirrors the YAML key; shadows the ``compile()`` builtin in cfg.model.compile.
     compile: StrictBool = Field(
         default=True,
-        description=(
-            "Whether to wrap the module in ``torch.compile`` at setup time. "
-            "Overridden to ``False`` in CI / smoke fixtures for speed."
-        ),
+        description="Whether to wrap the module in ``torch.compile`` at setup time.",
     )

--- a/src/synth_setter/schemas/paths_config.py
+++ b/src/synth_setter/schemas/paths_config.py
@@ -1,11 +1,8 @@
-"""Pydantic schema for the path layout under ``configs/paths/``.
+"""Pydantic schema for ``configs/paths/default.yaml``.
 
-Every shipped composition selects ``paths: default``, so the schema models
-``configs/paths/default.yaml``. The five string fields are all interpolated
-elsewhere (``${paths.output_dir}/checkpoints``, ``${paths.log_dir}/mlflow``)
-and a blank value would silently produce a broken run directory; they're
-typed as :data:`~synth_setter.schemas._types.NonBlankStr` rather than plain
-``str`` so the validator rejects whitespace-only overrides at compose time.
+Fields are typed ``NonBlankStr`` so a whitespace-only override is caught
+here rather than propagating as a broken path through every
+``${paths.<name>}`` interpolation downstream.
 """
 
 from __future__ import annotations
@@ -18,14 +15,7 @@ __all__ = ["PathsConfig"]
 
 
 class PathsConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """Path layout consumed via ``${paths.<name>}`` interpolation across configs.
-
-    These resolve via OmegaConf interpolation in lots of downstream YAMLs
-    (logger save-dirs, callback dirpaths, the trainer's ``default_root_dir``,
-    etc.), so any blank value here propagates as a broken path into half a
-    dozen places. Per-field descriptions live on the ``Field`` definitions
-    below.
-    """
+    """Path layout consumed via ``${paths.<name>}`` interpolation across configs."""
 
     root_dir: NonBlankStr = Field(
         description=(

--- a/src/synth_setter/schemas/paths_config.py
+++ b/src/synth_setter/schemas/paths_config.py
@@ -10,18 +10,14 @@ typed as :data:`~synth_setter.schemas._types.NonBlankStr` rather than plain
 
 from __future__ import annotations
 
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-)
+from pydantic import Field
 
-from synth_setter.schemas._types import NonBlankStr
+from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 
 __all__ = ["PathsConfig"]
 
 
-class PathsConfig(BaseModel):  # noqa: DOC601,DOC603
+class PathsConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
     """Path layout consumed via ``${paths.<name>}`` interpolation across configs.
 
     These resolve via OmegaConf interpolation in lots of downstream YAMLs
@@ -30,8 +26,6 @@ class PathsConfig(BaseModel):  # noqa: DOC601,DOC603
     dozen places. Per-field descriptions live on the ``Field`` definitions
     below.
     """
-
-    model_config = ConfigDict(strict=True, extra="allow")
 
     root_dir: NonBlankStr = Field(
         description=(

--- a/src/synth_setter/schemas/paths_config.py
+++ b/src/synth_setter/schemas/paths_config.py
@@ -1,0 +1,68 @@
+"""Pydantic schema for the path layout under ``configs/paths/``.
+
+Every shipped composition selects ``paths: default``, so the schema models
+``configs/paths/default.yaml``. The five string fields are all interpolated
+elsewhere (``${paths.output_dir}/checkpoints``, ``${paths.log_dir}/mlflow``)
+and a blank value would silently produce a broken run directory; they're
+typed as :data:`~synth_setter.schemas._types.NonBlankStr` rather than plain
+``str`` so the validator rejects whitespace-only overrides at compose time.
+"""
+
+from __future__ import annotations
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+)
+
+from synth_setter.schemas._types import NonBlankStr
+
+__all__ = ["PathsConfig"]
+
+
+class PathsConfig(BaseModel):  # noqa: DOC601,DOC603
+    """Path layout consumed via ``${paths.<name>}`` interpolation across configs.
+
+    These resolve via OmegaConf interpolation in lots of downstream YAMLs
+    (logger save-dirs, callback dirpaths, the trainer's ``default_root_dir``,
+    etc.), so any blank value here propagates as a broken path into half a
+    dozen places. Per-field descriptions live on the ``Field`` definitions
+    below.
+    """
+
+    model_config = ConfigDict(strict=True, extra="allow")
+
+    root_dir: NonBlankStr = Field(
+        description=(
+            "Project root. Default ``${oc.env:PROJECT_ROOT}`` so the active "
+            "checkout is the root; ``rootutils`` sets ``PROJECT_ROOT`` in the "
+            "training entrypoint."
+        ),
+    )
+    data_dir: NonBlankStr = Field(
+        description=(
+            "Default datamodule data root, ``${paths.root_dir}/data/``. "
+            "Individual datamodule configs can override their own root."
+        ),
+    )
+    log_dir: NonBlankStr = Field(
+        description=(
+            "Logger root, ``${paths.root_dir}/logs/``. Consumed by the "
+            "mlflow / tensorboard / wandb logger configs and by Hydra's "
+            "per-run ``output_dir`` template."
+        ),
+    )
+    output_dir: NonBlankStr = Field(
+        description=(
+            "Per-run output dir resolved from ``${hydra:runtime.output_dir}`` — "
+            "Hydra generates a unique path per launch using the template in "
+            "``configs/hydra/default.yaml``."
+        ),
+    )
+    work_dir: NonBlankStr = Field(
+        description=(
+            "Hydra's launch-time working directory, ``${hydra:runtime.cwd}``. "
+            "Useful for resolving user-supplied relative paths."
+        ),
+    )

--- a/src/synth_setter/schemas/train_config.py
+++ b/src/synth_setter/schemas/train_config.py
@@ -7,26 +7,35 @@ and are validated by ``hydra.utils.instantiate`` at call time.
 
 Intentionally documentation-first: tests assert the live composed DictConfig
 validates against ``TrainConfig``, but the entrypoint continues to consume
-the raw ``DictConfig``.
+the raw ``DictConfig``. Currently validated only by the test suite
+(``tests/schemas/test_train_config.py``); the training entrypoint
+(``cli/train.py``) does not call ``TrainConfig.model_validate`` at runtime.
 """
 
 from __future__ import annotations
 
 from pydantic import (
-    BaseModel,
-    ConfigDict,
     Field,
     NonNegativeInt,
     StrictBool,
     StrictStr,
 )
 
-from synth_setter.schemas._types import NonBlankStr
+from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 
 __all__ = ["TrainConfig"]
 
 
-class TrainConfig(BaseModel):  # noqa: DOC601,DOC603
+def _default_tags() -> list[str]:
+    """Return the default ``tags`` list for a fresh ``TrainConfig``.
+
+    :returns: A one-element list containing the placeholder ``"dev"`` tag.
+    :rtype: list[str]
+    """
+    return ["dev"]
+
+
+class TrainConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
     """Top-level training configuration as composed from ``configs/train.yaml``.
 
     Only the typed scalar surface is represented here — the defaults below
@@ -39,8 +48,6 @@ class TrainConfig(BaseModel):  # noqa: DOC601,DOC603
     below and render into the auto-generated docs via ``griffe-pydantic``.
     """
 
-    model_config = ConfigDict(strict=True, extra="allow")
-
     task_name: NonBlankStr = Field(
         default="train",
         description=(
@@ -49,7 +56,7 @@ class TrainConfig(BaseModel):  # noqa: DOC601,DOC603
         ),
     )
     tags: list[StrictStr] = Field(
-        default_factory=lambda: ["dev"],
+        default_factory=_default_tags,
         description=(
             "Free-form tags propagated to the logger (wandb / TensorBoard). "
             "Overwrite from the command line with ``tags='[first, second]'``."
@@ -66,7 +73,7 @@ class TrainConfig(BaseModel):  # noqa: DOC601,DOC603
             "the best checkpoint via the ``model_checkpoint`` callback."
         ),
     )
-    ckpt_path: StrictStr | None = Field(
+    ckpt_path: NonBlankStr | None = Field(
         default=None,
         description=(
             "Path to a Lightning checkpoint. If set, ``trainer.fit`` resumes from "
@@ -80,7 +87,7 @@ class TrainConfig(BaseModel):  # noqa: DOC601,DOC603
             "and Python's ``random``. ``None`` means non-deterministic."
         ),
     )
-    optimized_metric: StrictStr | None = Field(
+    optimized_metric: NonBlankStr | None = Field(
         default=None,
         description=(
             "Name of the callback metric returned to Hydra for hyperparameter "

--- a/src/synth_setter/schemas/train_config.py
+++ b/src/synth_setter/schemas/train_config.py
@@ -1,0 +1,93 @@
+"""Pydantic schema for the top-level training configuration.
+
+Documents the scalar fields the training entrypoint reads from
+``configs/train.yaml`` and treats the Hydra-composed subtrees as opaque
+dicts — those subtrees have their own composition groups under ``configs/``
+and are validated by ``hydra.utils.instantiate`` at call time.
+
+Intentionally documentation-first: tests assert the live composed DictConfig
+validates against ``TrainConfig``, but the entrypoint continues to consume
+the raw ``DictConfig``.
+"""
+
+from __future__ import annotations
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    NonNegativeInt,
+    StrictBool,
+    StrictStr,
+)
+
+from synth_setter.schemas._types import NonBlankStr
+
+__all__ = ["TrainConfig"]
+
+
+class TrainConfig(BaseModel):  # noqa: DOC601,DOC603
+    """Top-level training configuration as composed from ``configs/train.yaml``.
+
+    Constructing ``TrainConfig()`` with no kwargs mirrors a fresh ``compose`` of
+    ``train.yaml``. Hydra-managed subtrees are accepted via ``extra="allow"``;
+    per-field descriptions live on the ``Field`` definitions below and render
+    into the auto-generated docs via ``griffe-pydantic``.
+    """
+
+    model_config = ConfigDict(strict=True, extra="allow")
+
+    task_name: NonBlankStr = Field(
+        default="train",
+        description=(
+            "Logical name for this training run. Used as the output-directory "
+            "stem and to derive the wandb run id."
+        ),
+    )
+    tags: list[StrictStr] = Field(
+        default_factory=lambda: ["dev"],
+        description=(
+            "Free-form tags propagated to the logger (wandb / TensorBoard). "
+            "Overwrite from the command line with ``tags='[first, second]'``."
+        ),
+    )
+    train: StrictBool = Field(
+        default=True,
+        description="Run the fit loop. Set to ``False`` to skip training entirely.",
+    )
+    test: StrictBool = Field(
+        default=True,
+        description=(
+            "Run the test loop on the best checkpoint after fit. Lightning picks "
+            "the best checkpoint via the ``model_checkpoint`` callback."
+        ),
+    )
+    ckpt_path: StrictStr | None = Field(
+        default=None,
+        description=(
+            "Path to a Lightning checkpoint. If set, ``trainer.fit`` resumes from "
+            "this checkpoint and ``trainer.test`` loads it as the test weights."
+        ),
+    )
+    seed: NonNegativeInt | None = Field(
+        default=None,
+        description=(
+            "Seed forwarded to ``lightning.seed_everything`` for PyTorch, NumPy, "
+            "and Python's ``random``. ``None`` means non-deterministic."
+        ),
+    )
+    optimized_metric: StrictStr | None = Field(
+        default=None,
+        description=(
+            "Name of the callback metric returned to Hydra for hyperparameter "
+            "sweeps. ``None`` means ``main()`` returns ``None`` and sweepers "
+            "fall back to their default objective."
+        ),
+    )
+    watch_gradients: StrictBool | None = Field(
+        default=None,
+        description=(
+            "If truthy, attaches a gradient watcher to the logger. ``None`` and "
+            "``False`` behave the same — the watcher is not attached."
+        ),
+    )

--- a/src/synth_setter/schemas/train_config.py
+++ b/src/synth_setter/schemas/train_config.py
@@ -29,10 +29,14 @@ __all__ = ["TrainConfig"]
 class TrainConfig(BaseModel):  # noqa: DOC601,DOC603
     """Top-level training configuration as composed from ``configs/train.yaml``.
 
-    Constructing ``TrainConfig()`` with no kwargs mirrors a fresh ``compose`` of
-    ``train.yaml``. Hydra-managed subtrees are accepted via ``extra="allow"``;
-    per-field descriptions live on the ``Field`` definitions below and render
-    into the auto-generated docs via ``griffe-pydantic``.
+    Only the typed scalar surface is represented here — the defaults below
+    match the corresponding values in ``configs/train.yaml``. Hydra-managed
+    subtrees (``data``, ``model``, ``trainer``, ``callbacks``, ``logger``,
+    ``paths``, ``extras``, ``hydra``, ...) are NOT reconstructed by
+    ``TrainConfig()``; they're accepted via ``extra="allow"`` when validating
+    an externally-composed ``DictConfig`` and must come from real Hydra
+    composition. Per-field descriptions live on the ``Field`` definitions
+    below and render into the auto-generated docs via ``griffe-pydantic``.
     """
 
     model_config = ConfigDict(strict=True, extra="allow")

--- a/src/synth_setter/schemas/train_config.py
+++ b/src/synth_setter/schemas/train_config.py
@@ -1,15 +1,8 @@
-"""Pydantic schema for the top-level training configuration.
+"""Pydantic schema for the top-level ``configs/train.yaml``.
 
-Documents the scalar fields the training entrypoint reads from
-``configs/train.yaml`` and treats the Hydra-composed subtrees as opaque
-dicts — those subtrees have their own composition groups under ``configs/``
-and are validated by ``hydra.utils.instantiate`` at call time.
-
-Intentionally documentation-first: tests assert the live composed DictConfig
-validates against ``TrainConfig``, but the entrypoint continues to consume
-the raw ``DictConfig``. Currently validated only by the test suite
-(``tests/schemas/test_train_config.py``); the training entrypoint
-(``cli/train.py``) does not call ``TrainConfig.model_validate`` at runtime.
+Documentation-first: validated by ``tests/schemas/test_train_config.py``
+against the live composed DictConfig; ``cli/train.py`` continues to consume
+the raw ``DictConfig`` rather than calling ``model_validate``.
 """
 
 from __future__ import annotations
@@ -26,26 +19,17 @@ from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 __all__ = ["TrainConfig"]
 
 
-def _default_tags() -> list[str]:
-    """Return the default ``tags`` list for a fresh ``TrainConfig``.
-
-    :returns: A one-element list containing the placeholder ``"dev"`` tag.
-    :rtype: list[str]
-    """
+def _default_tags() -> list[str]:  # noqa: DOC201,DOC203
+    """Return the placeholder ``["dev"]`` tag list."""
     return ["dev"]
 
 
 class TrainConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """Top-level training configuration as composed from ``configs/train.yaml``.
+    """Top-level training config composed from ``configs/train.yaml``.
 
-    Only the typed scalar surface is represented here — the defaults below
-    match the corresponding values in ``configs/train.yaml``. Hydra-managed
-    subtrees (``data``, ``model``, ``trainer``, ``callbacks``, ``logger``,
-    ``paths``, ``extras``, ``hydra``, ...) are NOT reconstructed by
-    ``TrainConfig()``; they're accepted via ``extra="allow"`` when validating
-    an externally-composed ``DictConfig`` and must come from real Hydra
-    composition. Per-field descriptions live on the ``Field`` definitions
-    below and render into the auto-generated docs via ``griffe-pydantic``.
+    Defaults below mirror ``configs/train.yaml``. Hydra-managed subtrees
+    (``data``, ``model``, ``trainer``, ...) pass through via ``extra="allow"``
+    — ``TrainConfig()`` does not reconstruct them on its own.
     """
 
     task_name: NonBlankStr = Field(

--- a/src/synth_setter/schemas/trainer_config.py
+++ b/src/synth_setter/schemas/trainer_config.py
@@ -1,0 +1,101 @@
+"""Pydantic schema for per-trainer Hydra configs under ``configs/trainer/``.
+
+Every YAML under ``configs/trainer/`` composes onto ``default.yaml`` and
+overrides the subset of ``lightning.pytorch.trainer.Trainer`` kwargs that
+matters for the target accelerator (CPU smoke runs, single-GPU jobs,
+DDP, MPS). The typed surface here covers the keys actually set across the
+shipped variants; the rest of ``Trainer``'s constructor — and any future
+override that comes along — passes through via ``extra="allow"``.
+"""
+
+from __future__ import annotations
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PositiveFloat,
+    PositiveInt,
+    StrictBool,
+    StrictStr,
+)
+
+from synth_setter.schemas._types import NonBlankStr
+
+__all__ = ["TrainerConfig"]
+
+
+class TrainerConfig(BaseModel):  # noqa: DOC601,DOC603
+    """Per-trainer Hydra config (one of the YAMLs under ``configs/trainer/``).
+
+    Typed fields cover the keys the shipped trainer variants actually set;
+    any other ``Trainer`` kwarg (``precision``, ``min_steps``, ``max_steps``,
+    ``strategy``, ``num_nodes``, ``sync_batchnorm``, ...) passes through
+    via ``extra="allow"``. The full constructor surface is documented
+    upstream at lightning.ai.
+    """
+
+    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)
+
+    target_: NonBlankStr = Field(
+        alias="_target_",
+        description=(
+            "Fully-qualified ``lightning.pytorch.trainer.Trainer`` class path. "
+            "Resolved by ``hydra.utils.instantiate(cfg.trainer, ...)`` in "
+            "``cli/train.py``."
+        ),
+    )
+    default_root_dir: StrictStr = Field(
+        description=(
+            "Where Lightning writes logs and checkpoints when no logger overrides "
+            "it. Defaults to ``${paths.output_dir}``, which is Hydra's per-run "
+            "output dir."
+        ),
+    )
+    accelerator: NonBlankStr = Field(
+        description=(
+            "Hardware backend: ``cpu``, ``gpu``, ``mps``, ``tpu``, or ``auto``. "
+            "Each shipped variant under ``configs/trainer/`` pins one explicitly."
+        ),
+    )
+    devices: PositiveInt = Field(
+        description=(
+            "Number of devices on the chosen accelerator. ``1`` for single-GPU "
+            "or CPU; ``4`` for the DDP variant; etc. ``Trainer`` also accepts "
+            "strings / lists but the shipped configs use plain ints."
+        ),
+    )
+    log_every_n_steps: PositiveInt = Field(
+        description=(
+            "Logging cadence for training metrics. ``100`` across all shipped "
+            "variants — passed straight to ``Trainer``."
+        ),
+    )
+    val_check_interval: PositiveInt = Field(
+        description=(
+            "Run the validation loop every N training steps. Set to ``10_000`` "
+            "across the shipped variants."
+        ),
+    )
+    gradient_clip_val: PositiveFloat = Field(
+        description=(
+            "Global-norm gradient-clipping value. ``1.0`` across all shipped "
+            "variants; raise for noisy losses, lower to debug divergence."
+        ),
+    )
+    check_val_every_n_epoch: PositiveInt | None = Field(
+        default=None,
+        description=(
+            "Run validation every N epochs. ``None`` (the shipped default) means "
+            "Lightning falls back to ``val_check_interval`` for step-based "
+            "validation cadence."
+        ),
+    )
+    deterministic: StrictBool = Field(
+        default=False,
+        description=(
+            "Force deterministic ops where Lightning supports it. ``False`` "
+            "across shipped variants (deterministic ops are slower and not all "
+            "MPS ops support them); set ``True`` for reproducibility runs."
+        ),
+    )

--- a/src/synth_setter/schemas/trainer_config.py
+++ b/src/synth_setter/schemas/trainer_config.py
@@ -11,21 +11,18 @@ override that comes along — passes through via ``extra="allow"``.
 from __future__ import annotations
 
 from pydantic import (
-    BaseModel,
-    ConfigDict,
     Field,
     PositiveFloat,
     PositiveInt,
     StrictBool,
-    StrictStr,
 )
 
-from synth_setter.schemas._types import NonBlankStr
+from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 
 __all__ = ["TrainerConfig"]
 
 
-class TrainerConfig(BaseModel):  # noqa: DOC601,DOC603
+class TrainerConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
     """Per-trainer Hydra config (one of the YAMLs under ``configs/trainer/``).
 
     Typed fields cover the keys the shipped trainer variants actually set;
@@ -35,8 +32,6 @@ class TrainerConfig(BaseModel):  # noqa: DOC601,DOC603
     upstream at lightning.ai.
     """
 
-    model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)
-
     target_: NonBlankStr = Field(
         alias="_target_",
         description=(
@@ -45,7 +40,7 @@ class TrainerConfig(BaseModel):  # noqa: DOC601,DOC603
             "``cli/train.py``."
         ),
     )
-    default_root_dir: StrictStr = Field(
+    default_root_dir: NonBlankStr = Field(
         description=(
             "Where Lightning writes logs and checkpoints when no logger overrides "
             "it. Defaults to ``${paths.output_dir}``, which is Hydra's per-run "
@@ -67,21 +62,14 @@ class TrainerConfig(BaseModel):  # noqa: DOC601,DOC603
     )
     log_every_n_steps: PositiveInt = Field(
         description=(
-            "Logging cadence for training metrics. ``100`` across all shipped "
-            "variants — passed straight to ``Trainer``."
+            "Logging cadence (steps) for training metrics; passed straight to ``Trainer``."
         ),
     )
     val_check_interval: PositiveInt = Field(
-        description=(
-            "Run the validation loop every N training steps. Set to ``10_000`` "
-            "across the shipped variants."
-        ),
+        description="Cadence of validation runs; passed straight to ``Trainer``.",
     )
     gradient_clip_val: PositiveFloat = Field(
-        description=(
-            "Global-norm gradient-clipping value. ``1.0`` across all shipped "
-            "variants; raise for noisy losses, lower to debug divergence."
-        ),
+        description="Maximum gradient L2 norm before clipping; passed straight to ``Trainer``.",
     )
     check_val_every_n_epoch: PositiveInt | None = Field(
         default=None,

--- a/src/synth_setter/schemas/trainer_config.py
+++ b/src/synth_setter/schemas/trainer_config.py
@@ -1,11 +1,8 @@
-"""Pydantic schema for per-trainer Hydra configs under ``configs/trainer/``.
+"""Pydantic schema for the YAMLs under ``configs/trainer/``.
 
-Every YAML under ``configs/trainer/`` composes onto ``default.yaml`` and
-overrides the subset of ``lightning.pytorch.trainer.Trainer`` kwargs that
-matters for the target accelerator (CPU smoke runs, single-GPU jobs,
-DDP, MPS). The typed surface here covers the keys actually set across the
-shipped variants; the rest of ``Trainer``'s constructor — and any future
-override that comes along — passes through via ``extra="allow"``.
+Variants compose onto ``default.yaml``. The typed surface covers the keys
+shipped variants set; other ``Trainer`` kwargs pass through via
+``extra="allow"``.
 """
 
 from __future__ import annotations
@@ -23,14 +20,7 @@ __all__ = ["TrainerConfig"]
 
 
 class TrainerConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """Per-trainer Hydra config (one of the YAMLs under ``configs/trainer/``).
-
-    Typed fields cover the keys the shipped trainer variants actually set;
-    any other ``Trainer`` kwarg (``precision``, ``min_steps``, ``max_steps``,
-    ``strategy``, ``num_nodes``, ``sync_batchnorm``, ...) passes through
-    via ``extra="allow"``. The full constructor surface is documented
-    upstream at lightning.ai.
-    """
+    """One of the YAMLs under ``configs/trainer/``; other kwargs ride ``extra="allow"``."""
 
     target_: NonBlankStr = Field(
         alias="_target_",

--- a/tests/schemas/conftest.py
+++ b/tests/schemas/conftest.py
@@ -1,18 +1,31 @@
-"""Shared fixtures for the ``tests/schemas/`` module.
+"""Shared fixtures and helpers for the ``tests/schemas/`` module.
 
 The Hydra global-state dance (``GlobalHydra.instance().clear()`` before each
 ``initialize`` block) belongs in a fixture rather than copy-pasted into every
 helper — that way an xdist-parallelised run can't race on the singleton, and
 a mid-compose exception in one test can't leak initialised state into the
 next.
+
+This conftest must NOT chain into ``tests/conftest.py``'s heavy imports
+(``lightning``, ``torch``, ``h5py``) — composing Hydra configs is a
+documentation-layer concern and we want the suite to stay importable on a
+minimal install. Run as ``pytest tests/schemas/ --confcutdir=tests/schemas``
+(matches ``.github/workflows/docs.yml``).
 """
 
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import Any, cast
 
 import pytest
+from hydra import compose, initialize
 from hydra.core.global_hydra import GlobalHydra
+from omegaconf import OmegaConf
+
+__all__ = ["_to_dict", "compose_subtree", "compose_train_cfg"]
+
+_DEFAULT_OVERRIDES = ["data=ksin", "model=ffn", "trainer=cpu"]
 
 
 @pytest.fixture(autouse=True)
@@ -21,5 +34,64 @@ def clean_global_hydra() -> Iterator[None]:
     if GlobalHydra.instance().is_initialized():
         GlobalHydra.instance().clear()
     yield
-    if GlobalHydra.instance().is_initialized():
-        GlobalHydra.instance().clear()
+    # Defense against a test that forgot to use ``initialize()`` as a context
+    # manager and leaked initialised state into the next test in the package.
+    assert not GlobalHydra.instance().is_initialized(), (
+        "Hydra leaked from a test in tests/schemas/"
+    )
+
+
+def _to_dict(node: Any) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Resolve an OmegaConf node to a typed ``dict[str, Any]`` for pydantic.
+
+    Centralises the ``Any`` boundary so individual test modules don't need
+    to import ``cast`` just to convert an OmegaConf container to a plain
+    dict that ``model_validate`` accepts.
+    """
+    return cast("dict[str, Any]", OmegaConf.to_container(node, resolve=False))
+
+
+def compose_train_cfg(  # noqa: DOC101,DOC103,DOC201,DOC203
+    *,
+    overrides: list[str] | None = None,
+    return_hydra_config: bool = False,
+) -> dict[str, Any]:
+    """Compose ``configs/train.yaml`` and return it as a plain dict.
+
+    The default overrides pin ``data``, ``model``, and ``trainer`` to
+    composable leaves so the suite doesn't depend on the ``???``
+    mandatory-override sentinels in the root config. Caller-supplied
+    overrides are appended after the defaults so the caller can switch
+    one composition group without re-spelling the others.
+
+    The ``clean_global_hydra`` autouse fixture owns the
+    ``GlobalHydra.instance().clear()`` lifecycle, so this helper just
+    calls ``initialize`` directly inside its own context manager.
+    """
+    selected_overrides = list(_DEFAULT_OVERRIDES)
+    if overrides is not None:
+        selected_overrides.extend(overrides)
+    with initialize(version_base="1.3", config_path="../../configs"):
+        cfg = compose(
+            config_name="train.yaml",
+            return_hydra_config=return_hydra_config,
+            overrides=selected_overrides,
+        )
+    return _to_dict(cfg)
+
+
+def compose_subtree(group: str, name: str) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Compose one Hydra group at a specific name and return its subtree.
+
+    Example: ``compose_subtree("data", "ksin")`` returns the ``data``
+    subtree from ``train.yaml`` with ``data=ksin`` selected. The subtree
+    must be a dict (groups that compose to ``None``, e.g. an empty
+    ``callbacks/none.yaml``, are not supported here — callers test those
+    via the parametrized discovery helper).
+    """
+    cfg_dict = compose_train_cfg(overrides=[f"{group}={name}"])
+    subtree = cfg_dict[group]
+    assert isinstance(subtree, dict), (
+        f"compose_subtree({group}={name}) produced {type(subtree).__name__}, not dict"
+    )
+    return cast("dict[str, Any]", subtree)

--- a/tests/schemas/conftest.py
+++ b/tests/schemas/conftest.py
@@ -22,7 +22,11 @@ _DEFAULT_OVERRIDES = ["data=ksin", "model=ffn", "trainer=cpu"]
 
 @pytest.fixture(autouse=True)
 def clean_global_hydra() -> Iterator[None]:
-    """Clear Hydra's global singleton before and after every test in this package."""
+    """Clear Hydra's singleton before the test; assert (don't clear) after.
+
+    Teardown only asserts the singleton is clean — leaking state must surface as a loud failure,
+    not get silently swept away.
+    """
     if GlobalHydra.instance().is_initialized():
         GlobalHydra.instance().clear()
     yield

--- a/tests/schemas/conftest.py
+++ b/tests/schemas/conftest.py
@@ -1,16 +1,8 @@
-"""Shared fixtures and helpers for the ``tests/schemas/`` module.
+"""Shared fixtures and helpers for ``tests/schemas/``.
 
-The Hydra global-state dance (``GlobalHydra.instance().clear()`` before each
-``initialize`` block) belongs in a fixture rather than copy-pasted into every
-helper — that way an xdist-parallelised run can't race on the singleton, and
-a mid-compose exception in one test can't leak initialised state into the
-next.
-
-This conftest must NOT chain into ``tests/conftest.py``'s heavy imports
-(``lightning``, ``torch``, ``h5py``) — composing Hydra configs is a
-documentation-layer concern and we want the suite to stay importable on a
-minimal install. Run as ``pytest tests/schemas/ --confcutdir=tests/schemas``
-(matches ``.github/workflows/docs.yml``).
+Must NOT chain into ``tests/conftest.py``'s ``lightning``/``torch``/``h5py``
+imports — the schemas suite stays importable on a minimal install. Run as
+``pytest tests/schemas/ --confcutdir=tests/schemas``.
 """
 
 from __future__ import annotations
@@ -34,20 +26,13 @@ def clean_global_hydra() -> Iterator[None]:
     if GlobalHydra.instance().is_initialized():
         GlobalHydra.instance().clear()
     yield
-    # Defense against a test that forgot to use ``initialize()`` as a context
-    # manager and leaked initialised state into the next test in the package.
     assert not GlobalHydra.instance().is_initialized(), (
         "Hydra leaked from a test in tests/schemas/"
     )
 
 
 def _to_dict(node: Any) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Resolve an OmegaConf node to a typed ``dict[str, Any]`` for pydantic.
-
-    Centralises the ``Any`` boundary so individual test modules don't need
-    to import ``cast`` just to convert an OmegaConf container to a plain
-    dict that ``model_validate`` accepts.
-    """
+    """Resolve an OmegaConf node to ``dict[str, Any]`` for ``model_validate``."""
     return cast("dict[str, Any]", OmegaConf.to_container(node, resolve=False))
 
 
@@ -58,15 +43,9 @@ def compose_train_cfg(  # noqa: DOC101,DOC103,DOC201,DOC203
 ) -> dict[str, Any]:
     """Compose ``configs/train.yaml`` and return it as a plain dict.
 
-    The default overrides pin ``data``, ``model``, and ``trainer`` to
-    composable leaves so the suite doesn't depend on the ``???``
-    mandatory-override sentinels in the root config. Caller-supplied
-    overrides are appended after the defaults so the caller can switch
-    one composition group without re-spelling the others.
-
-    The ``clean_global_hydra`` autouse fixture owns the
-    ``GlobalHydra.instance().clear()`` lifecycle, so this helper just
-    calls ``initialize`` directly inside its own context manager.
+    Default overrides pin ``data=ksin model=ffn trainer=cpu`` so the suite
+    doesn't depend on root-config ``???`` sentinels; caller overrides are
+    appended after.
     """
     selected_overrides = list(_DEFAULT_OVERRIDES)
     if overrides is not None:
@@ -81,13 +60,10 @@ def compose_train_cfg(  # noqa: DOC101,DOC103,DOC201,DOC203
 
 
 def compose_subtree(group: str, name: str) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Compose one Hydra group at a specific name and return its subtree.
+    """Compose ``train.yaml`` with ``<group>=<name>`` selected and return that subtree.
 
-    Example: ``compose_subtree("data", "ksin")`` returns the ``data``
-    subtree from ``train.yaml`` with ``data=ksin`` selected. The subtree
-    must be a dict (groups that compose to ``None``, e.g. an empty
-    ``callbacks/none.yaml``, are not supported here — callers test those
-    via the parametrized discovery helper).
+    The subtree must be a dict; groups that compose to ``None`` (e.g.
+    ``callbacks/none.yaml``) are unsupported and surfaced via assertion.
     """
     cfg_dict = compose_train_cfg(overrides=[f"{group}={name}"])
     subtree = cfg_dict[group]

--- a/tests/schemas/conftest.py
+++ b/tests/schemas/conftest.py
@@ -1,0 +1,25 @@
+"""Shared fixtures for the ``tests/schemas/`` module.
+
+The Hydra global-state dance (``GlobalHydra.instance().clear()`` before each
+``initialize`` block) belongs in a fixture rather than copy-pasted into every
+helper — that way an xdist-parallelised run can't race on the singleton, and
+a mid-compose exception in one test can't leak initialised state into the
+next.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+from hydra.core.global_hydra import GlobalHydra
+
+
+@pytest.fixture(autouse=True)
+def clean_global_hydra() -> Iterator[None]:
+    """Clear Hydra's global singleton before and after every test in this package."""
+    if GlobalHydra.instance().is_initialized():
+        GlobalHydra.instance().clear()
+    yield
+    if GlobalHydra.instance().is_initialized():
+        GlobalHydra.instance().clear()

--- a/tests/schemas/test_callbacks_config.py
+++ b/tests/schemas/test_callbacks_config.py
@@ -1,10 +1,14 @@
 """Behavioural tests for the ``CallbacksConfig`` / ``CallbackInstance`` models.
 
-Every YAML under ``configs/callbacks/`` that composes into a non-empty dict
-must validate against ``CallbacksConfig`` (a RootModel wrapping
-``dict[str, CallbackInstance]``). ``none.yaml`` is intentionally empty —
-Hydra resolves it to ``None`` and ``instantiate_callbacks`` short-circuits
-on a falsy config, so it's outside the schema's responsibility.
+Every YAML under ``configs/callbacks/`` is a valid ``callbacks=<name>``
+selection — both the multi-callback compositions (``default``,
+``default_surge``, ``eval_surge``) and the individual callback leaves
+(``model_checkpoint``, ``early_stopping``, ``plot_pos_enc``, ...). Every
+one of those that composes into a non-empty dict must validate against
+``CallbacksConfig`` (a RootModel wrapping ``dict[str, CallbackInstance]``).
+``none.yaml`` is intentionally empty — Hydra resolves it to ``None`` and
+``instantiate_callbacks`` short-circuits on a falsy config, so it's
+outside the schema's responsibility.
 
 Callback-class-specific kwargs (``monitor``, ``dirpath``, ``patience``, ...)
 live under ``extra="allow"`` on ``CallbackInstance``; only ``_target_`` is
@@ -25,24 +29,31 @@ from synth_setter.schemas.callbacks_config import CallbackInstance, CallbacksCon
 
 _CALLBACKS_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "callbacks"
 
-# ``none.yaml`` is empty and composes to ``None``; ``instantiate_callbacks``
-# handles that pathway outside the schema. Skip it here.
-_NON_EMPTY_CALLBACK_CONFIGS = frozenset({"default", "default_surge", "eval_surge"})
+# Hydra resolves ``configs/callbacks/none.yaml`` to ``None`` because the
+# file is empty; ``instantiate_callbacks`` short-circuits on the falsy
+# value, so it's outside this schema's responsibility. Every other YAML in
+# the group — both the multi-callback compositions (``default``,
+# ``default_surge``, ``eval_surge``) and the individual callback leaves
+# (``model_checkpoint``, ``early_stopping``, ``plot_pos_enc``, ...) — is
+# selectable via ``callbacks=<name>`` and must validate.
+_NON_DICT_CALLBACK_CONFIGS = frozenset({"none"})
 
 
 def _composable_callback_config_names() -> list[str]:  # noqa: DOC201,DOC203
-    """Return callback-group YAML stems that compose into a non-empty dict.
+    """Return every callback YAML stem that composes into a non-empty dict.
 
-    Only the multi-callback compositions (``default``, ``default_surge``,
-    ``eval_surge``) are valid top-level selections under ``callbacks=...``;
-    the individual callback YAMLs (``model_checkpoint``, ``lr_monitor``,
-    ``rich_progress_bar``, ...) are leaves consumed by ``defaults:`` and
-    aren't themselves group-selectable.
+    Includes both the multi-callback compositions and the individual
+    callback leaves — Hydra accepts any YAML in the group as a
+    ``callbacks=<name>`` selection, so the leaf YAMLs are valid
+    top-level configs too (they compose to a single-entry dict like
+    ``{"model_checkpoint": {"_target_": ...}}``). Only ``none.yaml`` is
+    excluded — it composes to ``None`` and ``instantiate_callbacks``
+    handles that pathway outside the schema.
     """
     available = {p.stem for p in _CALLBACKS_CONFIG_DIR.glob("*.yaml")}
-    selected = sorted(_NON_EMPTY_CALLBACK_CONFIGS & available)
+    selected = sorted(available - _NON_DICT_CALLBACK_CONFIGS)
     assert selected, (
-        f"none of {_NON_EMPTY_CALLBACK_CONFIGS} found under {_CALLBACKS_CONFIG_DIR} — "
+        f"no composable callback YAMLs found under {_CALLBACKS_CONFIG_DIR} — "
         "has the callbacks composition layout changed?"
     )
     return selected
@@ -66,7 +77,7 @@ def _compose_callbacks_cfg(callbacks_name: str) -> dict[str, Any]:  # noqa: DOC1
 
 
 class TestCallbacksConfigAcceptsEveryComposition:
-    """Every non-empty callbacks group must validate against ``CallbacksConfig``."""
+    """Every ``callbacks=<name>``-selectable YAML must validate against ``CallbacksConfig``."""
 
     @pytest.mark.parametrize("callbacks_name", _composable_callback_config_names())
     def test_callbacks_yaml_validates(self, callbacks_name: str) -> None:  # noqa: DOC101,DOC103

--- a/tests/schemas/test_callbacks_config.py
+++ b/tests/schemas/test_callbacks_config.py
@@ -1,18 +1,8 @@
-"""Behavioural tests for the ``CallbacksConfig`` / ``CallbackInstance`` models.
+"""Behavioural tests for ``CallbacksConfig`` / ``CallbackInstance``.
 
-Every YAML under ``configs/callbacks/`` is a valid ``callbacks=<name>``
-selection — both the multi-callback compositions (``default``,
-``default_surge``, ``eval_surge``) and the individual callback leaves
-(``model_checkpoint``, ``early_stopping``, ``plot_pos_enc``, ...). Every
-one of those that composes into a non-empty dict must validate against
-``CallbacksConfig`` (a RootModel wrapping ``dict[str, CallbackInstance]``).
-``none.yaml`` is intentionally empty — Hydra resolves it to ``None`` and
-``instantiate_callbacks`` short-circuits on a falsy config, so it's
-outside the schema's responsibility.
-
-Callback-class-specific kwargs (``monitor``, ``dirpath``, ``patience``, ...)
-live under ``extra="allow"`` on ``CallbackInstance``; only ``_target_`` is
-typed at this layer.
+Every ``callbacks=<name>`` selection that composes to a non-empty dict must
+validate. ``none.yaml`` composes to ``None`` and is handled outside the
+schema (``instantiate_callbacks`` short-circuits on falsy).
 """
 
 from __future__ import annotations
@@ -41,11 +31,7 @@ def _all_callback_config_names() -> list[str]:  # noqa: DOC201,DOC203
 def _compose_callbacks_subtree(  # noqa: DOC101,DOC103,DOC201,DOC203
     callbacks_name: str,
 ) -> dict[str, object] | None:
-    """Compose a full train config with ``callbacks=<callbacks_name>`` selected.
-
-    Returns the raw composed subtree (typically a dict, but for the
-    intentionally-empty ``none.yaml`` it composes to ``None``).
-    """
+    """Compose with ``callbacks=<name>``; returns dict, or ``None`` for ``none.yaml``."""
     cfg_dict = compose_train_cfg(overrides=[f"callbacks={callbacks_name}"])
     return cfg_dict["callbacks"]
 
@@ -53,10 +39,8 @@ def _compose_callbacks_subtree(  # noqa: DOC101,DOC103,DOC201,DOC203
 class TestCallbacksConfigAcceptsEveryComposition:
     """Every ``callbacks=<name>``-selectable YAML must validate against ``CallbacksConfig``.
 
-    Any callback YAML that composes to a non-dict (today only ``none.yaml``,
-    which Hydra resolves to ``None``) is *recorded as a skip with rationale*
-    so a future ``none2.yaml`` surfaces as a noticed skip rather than a
-    silent ``ValidationError`` deep in an assertion stack.
+    Non-dict composes (today only ``none.yaml`` → ``None``) emit pytest skips
+    so a future addition surfaces visibly rather than as a deep ValidationError.
     """
 
     @pytest.mark.parametrize("callbacks_name", _all_callback_config_names())
@@ -69,9 +53,7 @@ class TestCallbacksConfigAcceptsEveryComposition:
                 f"({type(callbacks_subtree).__name__}); schema covers dict form only"
             )
         parsed = CallbacksConfig.model_validate(callbacks_subtree)
-        # ``none.yaml`` composes to ``{}`` and validates as an empty RootModel —
-        # that's the intended ``instantiate_callbacks`` no-op pathway and we
-        # don't want to assert truthiness here.
+        # No truthiness assert: ``none.yaml`` validates as an empty RootModel.
         assert isinstance(parsed, CallbacksConfig)
 
 

--- a/tests/schemas/test_callbacks_config.py
+++ b/tests/schemas/test_callbacks_config.py
@@ -1,0 +1,117 @@
+"""Behavioural tests for the ``CallbacksConfig`` / ``CallbackInstance`` models.
+
+Every YAML under ``configs/callbacks/`` that composes into a non-empty dict
+must validate against ``CallbacksConfig`` (a RootModel wrapping
+``dict[str, CallbackInstance]``). ``none.yaml`` is intentionally empty —
+Hydra resolves it to ``None`` and ``instantiate_callbacks`` short-circuits
+on a falsy config, so it's outside the schema's responsibility.
+
+Callback-class-specific kwargs (``monitor``, ``dirpath``, ``patience``, ...)
+live under ``extra="allow"`` on ``CallbackInstance``; only ``_target_`` is
+typed at this layer.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from hydra import compose, initialize
+from omegaconf import OmegaConf
+from pydantic import ValidationError
+
+from synth_setter.schemas.callbacks_config import CallbackInstance, CallbacksConfig
+
+_CALLBACKS_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "callbacks"
+
+# ``none.yaml`` is empty and composes to ``None``; ``instantiate_callbacks``
+# handles that pathway outside the schema. Skip it here.
+_NON_EMPTY_CALLBACK_CONFIGS = frozenset({"default", "default_surge", "eval_surge"})
+
+
+def _composable_callback_config_names() -> list[str]:  # noqa: DOC201,DOC203
+    """Return callback-group YAML stems that compose into a non-empty dict.
+
+    Only the multi-callback compositions (``default``, ``default_surge``,
+    ``eval_surge``) are valid top-level selections under ``callbacks=...``;
+    the individual callback YAMLs (``model_checkpoint``, ``lr_monitor``,
+    ``rich_progress_bar``, ...) are leaves consumed by ``defaults:`` and
+    aren't themselves group-selectable.
+    """
+    available = {p.stem for p in _CALLBACKS_CONFIG_DIR.glob("*.yaml")}
+    selected = sorted(_NON_EMPTY_CALLBACK_CONFIGS & available)
+    assert selected, (
+        f"none of {_NON_EMPTY_CALLBACK_CONFIGS} found under {_CALLBACKS_CONFIG_DIR} — "
+        "has the callbacks composition layout changed?"
+    )
+    return selected
+
+
+def _compose_callbacks_cfg(callbacks_name: str) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Compose a full train config with ``callbacks=<callbacks_name>`` selected."""
+    with initialize(version_base="1.3", config_path="../../configs"):
+        cfg = compose(
+            config_name="train.yaml",
+            overrides=[
+                f"callbacks={callbacks_name}",
+                "data=ksin",
+                "model=ffn",
+                "trainer=cpu",
+            ],
+        )
+    callbacks_subtree = OmegaConf.to_container(cfg.callbacks, resolve=False)
+    assert isinstance(callbacks_subtree, dict)
+    return cast("dict[str, Any]", callbacks_subtree)
+
+
+class TestCallbacksConfigAcceptsEveryComposition:
+    """Every non-empty callbacks group must validate against ``CallbacksConfig``."""
+
+    @pytest.mark.parametrize("callbacks_name", _composable_callback_config_names())
+    def test_callbacks_yaml_validates(self, callbacks_name: str) -> None:  # noqa: DOC101,DOC103
+        """The composed ``callbacks`` subtree validates as ``CallbacksConfig``."""
+        callbacks_subtree = _compose_callbacks_cfg(callbacks_name)
+        CallbacksConfig.model_validate(callbacks_subtree)
+
+    def test_default_yields_expected_callback_names(self) -> None:
+        """Spot-check that ``default.yaml`` composes the callbacks ``train.py`` expects."""
+        callbacks_subtree = _compose_callbacks_cfg("default")
+        parsed = CallbacksConfig.model_validate(callbacks_subtree)
+        names = set(parsed.root.keys())
+        # Names known to be in default.yaml per its defaults: list.
+        assert {"model_checkpoint", "lr_monitor", "rich_progress_bar"}.issubset(names)
+
+
+_VALID_CALLBACK = {
+    "_target_": "lightning.pytorch.callbacks.ModelCheckpoint",
+    "dirpath": "/tmp/ckpt",  # noqa: S108
+}
+
+
+class TestCallbacksConfigRejectsBadInputs:
+    """Validators must catch obvious mistakes on the typed fields."""
+
+    def test_missing_target_in_instance_rejected(self) -> None:
+        """Each callback instance must carry ``_target_``; reject if absent."""
+        with pytest.raises(ValidationError):
+            CallbacksConfig.model_validate({"model_checkpoint": {"dirpath": "/tmp"}})  # noqa: S108
+
+    def test_blank_target_rejected(self) -> None:
+        """A blank ``_target_`` would crash ``hydra.utils.instantiate`` mid-fit."""
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            CallbacksConfig.model_validate({"cb": {"_target_": "  "}})
+
+    def test_blank_callback_name_rejected(self) -> None:
+        """RootModel key is ``NonBlankStr`` — empty callback names are rejected."""
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            CallbacksConfig.model_validate({"   ": _VALID_CALLBACK})
+
+
+class TestCallbackInstanceDirect:
+    """Direct ``CallbackInstance`` validation works for individual entries."""
+
+    def test_valid_instance_parses(self) -> None:
+        """A minimal valid callback dict parses cleanly."""
+        parsed = CallbackInstance.model_validate(_VALID_CALLBACK)
+        assert parsed.target_ == "lightning.pytorch.callbacks.ModelCheckpoint"

--- a/tests/schemas/test_callbacks_config.py
+++ b/tests/schemas/test_callbacks_config.py
@@ -18,80 +18,61 @@ typed at this layer.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, cast
 
 import pytest
-from hydra import compose, initialize
-from omegaconf import OmegaConf
 from pydantic import ValidationError
 
 from synth_setter.schemas.callbacks_config import CallbackInstance, CallbacksConfig
+from tests.schemas.conftest import compose_train_cfg
 
 _CALLBACKS_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "callbacks"
 
-# Hydra resolves ``configs/callbacks/none.yaml`` to ``None`` because the
-# file is empty; ``instantiate_callbacks`` short-circuits on the falsy
-# value, so it's outside this schema's responsibility. Every other YAML in
-# the group — both the multi-callback compositions (``default``,
-# ``default_surge``, ``eval_surge``) and the individual callback leaves
-# (``model_checkpoint``, ``early_stopping``, ``plot_pos_enc``, ...) — is
-# selectable via ``callbacks=<name>`` and must validate.
-_NON_DICT_CALLBACK_CONFIGS = frozenset({"none"})
 
-
-def _composable_callback_config_names() -> list[str]:  # noqa: DOC201,DOC203
-    """Return every callback YAML stem that composes into a non-empty dict.
-
-    Includes both the multi-callback compositions and the individual
-    callback leaves — Hydra accepts any YAML in the group as a
-    ``callbacks=<name>`` selection, so the leaf YAMLs are valid
-    top-level configs too (they compose to a single-entry dict like
-    ``{"model_checkpoint": {"_target_": ...}}``). Only ``none.yaml`` is
-    excluded — it composes to ``None`` and ``instantiate_callbacks``
-    handles that pathway outside the schema.
-    """
-    available = {p.stem for p in _CALLBACKS_CONFIG_DIR.glob("*.yaml")}
-    selected = sorted(available - _NON_DICT_CALLBACK_CONFIGS)
-    assert selected, (
-        f"no composable callback YAMLs found under {_CALLBACKS_CONFIG_DIR} — "
+def _all_callback_config_names() -> list[str]:  # noqa: DOC201,DOC203
+    """Return every callback YAML stem under ``configs/callbacks/``."""
+    names = sorted(p.stem for p in _CALLBACKS_CONFIG_DIR.glob("*.yaml"))
+    assert names, (
+        f"no callback YAMLs found under {_CALLBACKS_CONFIG_DIR} — "
         "has the callbacks composition layout changed?"
     )
-    return selected
+    return names
 
 
-def _compose_callbacks_cfg(callbacks_name: str) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Compose a full train config with ``callbacks=<callbacks_name>`` selected."""
-    with initialize(version_base="1.3", config_path="../../configs"):
-        cfg = compose(
-            config_name="train.yaml",
-            overrides=[
-                f"callbacks={callbacks_name}",
-                "data=ksin",
-                "model=ffn",
-                "trainer=cpu",
-            ],
-        )
-    callbacks_subtree = OmegaConf.to_container(cfg.callbacks, resolve=False)
-    assert isinstance(callbacks_subtree, dict)
-    return cast("dict[str, Any]", callbacks_subtree)
+def _compose_callbacks_subtree(  # noqa: DOC101,DOC103,DOC201,DOC203
+    callbacks_name: str,
+) -> dict[str, object] | None:
+    """Compose a full train config with ``callbacks=<callbacks_name>`` selected.
+
+    Returns the raw composed subtree (typically a dict, but for the
+    intentionally-empty ``none.yaml`` it composes to ``None``).
+    """
+    cfg_dict = compose_train_cfg(overrides=[f"callbacks={callbacks_name}"])
+    return cfg_dict["callbacks"]
 
 
 class TestCallbacksConfigAcceptsEveryComposition:
-    """Every ``callbacks=<name>``-selectable YAML must validate against ``CallbacksConfig``."""
+    """Every ``callbacks=<name>``-selectable YAML must validate against ``CallbacksConfig``.
 
-    @pytest.mark.parametrize("callbacks_name", _composable_callback_config_names())
+    Any callback YAML that composes to a non-dict (today only ``none.yaml``,
+    which Hydra resolves to ``None``) is *recorded as a skip with rationale*
+    so a future ``none2.yaml`` surfaces as a noticed skip rather than a
+    silent ``ValidationError`` deep in an assertion stack.
+    """
+
+    @pytest.mark.parametrize("callbacks_name", _all_callback_config_names())
     def test_callbacks_yaml_validates(self, callbacks_name: str) -> None:  # noqa: DOC101,DOC103
         """The composed ``callbacks`` subtree validates as ``CallbacksConfig``."""
-        callbacks_subtree = _compose_callbacks_cfg(callbacks_name)
-        CallbacksConfig.model_validate(callbacks_subtree)
-
-    def test_default_yields_expected_callback_names(self) -> None:
-        """Spot-check that ``default.yaml`` composes the callbacks ``train.py`` expects."""
-        callbacks_subtree = _compose_callbacks_cfg("default")
+        callbacks_subtree = _compose_callbacks_subtree(callbacks_name)
+        if not isinstance(callbacks_subtree, dict):
+            pytest.skip(
+                f"callbacks={callbacks_name} composes to non-dict "
+                f"({type(callbacks_subtree).__name__}); schema covers dict form only"
+            )
         parsed = CallbacksConfig.model_validate(callbacks_subtree)
-        names = set(parsed.root.keys())
-        # Names known to be in default.yaml per its defaults: list.
-        assert {"model_checkpoint", "lr_monitor", "rich_progress_bar"}.issubset(names)
+        # ``none.yaml`` composes to ``{}`` and validates as an empty RootModel —
+        # that's the intended ``instantiate_callbacks`` no-op pathway and we
+        # don't want to assert truthiness here.
+        assert isinstance(parsed, CallbacksConfig)
 
 
 _VALID_CALLBACK = {

--- a/tests/schemas/test_callbacks_config.py
+++ b/tests/schemas/test_callbacks_config.py
@@ -53,7 +53,6 @@ class TestCallbacksConfigAcceptsEveryComposition:
                 f"({type(callbacks_subtree).__name__}); schema covers dict form only"
             )
         parsed = CallbacksConfig.model_validate(callbacks_subtree)
-        # No truthiness assert: ``none.yaml`` validates as an empty RootModel.
         assert isinstance(parsed, CallbacksConfig)
 
 

--- a/tests/schemas/test_data_config.py
+++ b/tests/schemas/test_data_config.py
@@ -1,16 +1,8 @@
 """Behavioural tests for the ``DataConfig`` pydantic model.
 
-Every YAML under ``configs/data/`` must validate against ``DataConfig`` —
-that's the contract the published docs assert. Datamodule-specific keys
-live under ``extra="allow"`` so a new datamodule can ship without
-re-touching the schema; the common shape (``_target_``) stays typed.
-
-Some shipped YAMLs declare Hydra ``???`` mandatory-override sentinels for
-fields like ``dataset_root`` / ``stats_file`` / ``predict_file``. OmegaConf
-preserves those as the literal string ``"???"`` under
-``to_container(resolve=False)``; they only fail at attribute access /
-``hydra.utils.instantiate`` time, which is the intended behaviour, so the
-schema sees them as ordinary extras and accepts them.
+Hydra ``???`` mandatory-override sentinels survive ``to_container(resolve=False)``
+as the literal string ``"???"``; the schema sees them as ordinary extras
+and accepts them, deferring the failure to ``hydra.utils.instantiate``.
 """
 
 from __future__ import annotations
@@ -63,17 +55,9 @@ class TestPathsConfigResolvedInterpolation:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """``${oc.env:PROJECT_ROOT}`` resolves to a real path and validates as non-blank."""
-        # PROJECT_ROOT is the only env-var interpolation in paths/default.yaml;
-        # validating against the resolved value (not the literal ${oc.env:...}
-        # template) is what ``NonBlankStr`` actually guards in production.
         monkeypatch.setenv("PROJECT_ROOT", "/tmp/x")  # noqa: S108
-        # ``return_hydra_config=True`` + ``HydraConfig.instance().set_config``
-        # registers the ``hydra`` subtree so ``${hydra:...}`` resolvers can
-        # fire. ``paths.output_dir`` / ``paths.work_dir`` are overridden
-        # explicitly because Hydra's ``runtime.output_dir`` / ``runtime.cwd``
-        # are only populated at fit time, not at compose time. The point of
-        # the test is ``${oc.env:PROJECT_ROOT}`` round-tripping through
-        # ``NonBlankStr``, not the hydra runtime keys.
+        # output_dir / work_dir overridden because ``${hydra:runtime.*}`` is
+        # only populated at fit time, not at compose time.
         with initialize(version_base="1.3", config_path="../../configs"):
             cfg = compose(
                 config_name="train.yaml",

--- a/tests/schemas/test_data_config.py
+++ b/tests/schemas/test_data_config.py
@@ -20,10 +20,13 @@ from typing import Any, cast
 
 import pytest
 from hydra import compose, initialize
+from hydra.core.hydra_config import HydraConfig
 from omegaconf import OmegaConf
 from pydantic import ValidationError
 
 from synth_setter.schemas.data_config import DataConfig
+from synth_setter.schemas.paths_config import PathsConfig
+from tests.schemas.conftest import compose_subtree
 
 _DATA_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "data"
 
@@ -35,32 +38,61 @@ def _all_data_config_names() -> list[str]:  # noqa: DOC201,DOC203
     return names
 
 
-def _compose_data_cfg(data_name: str) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Compose a full train config with ``data=<data_name>`` selected."""
-    with initialize(version_base="1.3", config_path="../../configs"):
-        cfg = compose(
-            config_name="train.yaml",
-            overrides=[f"data={data_name}", "model=ffn", "trainer=cpu"],
-        )
-    data_subtree = OmegaConf.to_container(cfg.data, resolve=False)
-    assert isinstance(data_subtree, dict)
-    return cast("dict[str, Any]", data_subtree)
-
-
 class TestDataConfigAcceptsEveryConfig:
     """Every shipped data YAML must validate against ``DataConfig``."""
 
     @pytest.mark.parametrize("data_name", _all_data_config_names())
     def test_data_yaml_validates(self, data_name: str) -> None:  # noqa: DOC101,DOC103
         """The composed ``data`` subtree validates as ``DataConfig``."""
-        data_subtree = _compose_data_cfg(data_name)
-        DataConfig.model_validate(data_subtree)
+        data_subtree = compose_subtree("data", data_name)
+        parsed = DataConfig.model_validate(data_subtree)
+        assert parsed.target_
 
     def test_target_field_typed(self) -> None:
         """``_target_`` lands on ``target_`` with the expected datamodule path."""
-        data_subtree = _compose_data_cfg("ksin")
+        data_subtree = compose_subtree("data", "ksin")
         parsed = DataConfig.model_validate(data_subtree)
         assert parsed.target_.endswith("KSinDataModule")
+
+
+class TestPathsConfigResolvedInterpolation:
+    """A real resolved ``PROJECT_ROOT`` must round-trip through ``NonBlankStr``."""
+
+    def test_paths_resolved_with_env_var(  # noqa: DOC101,DOC103
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``${oc.env:PROJECT_ROOT}`` resolves to a real path and validates as non-blank."""
+        # PROJECT_ROOT is the only env-var interpolation in paths/default.yaml;
+        # validating against the resolved value (not the literal ${oc.env:...}
+        # template) is what ``NonBlankStr`` actually guards in production.
+        monkeypatch.setenv("PROJECT_ROOT", "/tmp/x")  # noqa: S108
+        # ``return_hydra_config=True`` + ``HydraConfig.instance().set_config``
+        # registers the ``hydra`` subtree so ``${hydra:...}`` resolvers can
+        # fire. ``paths.output_dir`` / ``paths.work_dir`` are overridden
+        # explicitly because Hydra's ``runtime.output_dir`` / ``runtime.cwd``
+        # are only populated at fit time, not at compose time. The point of
+        # the test is ``${oc.env:PROJECT_ROOT}`` round-tripping through
+        # ``NonBlankStr``, not the hydra runtime keys.
+        with initialize(version_base="1.3", config_path="../../configs"):
+            cfg = compose(
+                config_name="train.yaml",
+                return_hydra_config=True,
+                overrides=[
+                    "data=ksin",
+                    "model=ffn",
+                    "trainer=cpu",
+                    "paths.output_dir=/tmp/x/out",  # noqa: S108
+                    "paths.work_dir=/tmp/x",  # noqa: S108
+                ],
+            )
+            HydraConfig.instance().set_config(cfg)
+            resolved_paths = cast(
+                "dict[str, Any]", OmegaConf.to_container(cfg.paths, resolve=True)
+            )
+        parsed = PathsConfig.model_validate(resolved_paths)
+        assert parsed.root_dir == "/tmp/x"  # noqa: S108
+        assert parsed.data_dir.startswith("/tmp/x")  # noqa: S108
 
 
 class TestDataConfigRejectsBadInputs:

--- a/tests/schemas/test_data_config.py
+++ b/tests/schemas/test_data_config.py
@@ -1,0 +1,77 @@
+"""Behavioural tests for the ``DataConfig`` pydantic model.
+
+Every YAML under ``configs/data/`` must validate against ``DataConfig`` —
+that's the contract the published docs assert. Datamodule-specific keys
+live under ``extra="allow"`` so a new datamodule can ship without
+re-touching the schema; the common shape (``_target_``) stays typed.
+
+Some shipped YAMLs declare Hydra ``???`` mandatory-override sentinels for
+fields like ``dataset_root`` / ``stats_file`` / ``predict_file``. OmegaConf
+preserves those as the literal string ``"???"`` under
+``to_container(resolve=False)``; they only fail at attribute access /
+``hydra.utils.instantiate`` time, which is the intended behaviour, so the
+schema sees them as ordinary extras and accepts them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from hydra import compose, initialize
+from omegaconf import OmegaConf
+from pydantic import ValidationError
+
+from synth_setter.schemas.data_config import DataConfig
+
+_DATA_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "data"
+
+
+def _all_data_config_names() -> list[str]:  # noqa: DOC201,DOC203
+    """Return the YAML stem of every direct data config under ``configs/data/``."""
+    names = sorted(p.stem for p in _DATA_CONFIG_DIR.glob("*.yaml"))
+    assert names, f"no data YAMLs found under {_DATA_CONFIG_DIR} — has the layout changed?"
+    return names
+
+
+def _compose_data_cfg(data_name: str) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Compose a full train config with ``data=<data_name>`` selected."""
+    with initialize(version_base="1.3", config_path="../../configs"):
+        cfg = compose(
+            config_name="train.yaml",
+            overrides=[f"data={data_name}", "model=ffn", "trainer=cpu"],
+        )
+    data_subtree = OmegaConf.to_container(cfg.data, resolve=False)
+    assert isinstance(data_subtree, dict)
+    return cast("dict[str, Any]", data_subtree)
+
+
+class TestDataConfigAcceptsEveryConfig:
+    """Every shipped data YAML must validate against ``DataConfig``."""
+
+    @pytest.mark.parametrize("data_name", _all_data_config_names())
+    def test_data_yaml_validates(self, data_name: str) -> None:  # noqa: DOC101,DOC103
+        """The composed ``data`` subtree validates as ``DataConfig``."""
+        data_subtree = _compose_data_cfg(data_name)
+        DataConfig.model_validate(data_subtree)
+
+    def test_target_field_typed(self) -> None:
+        """``_target_`` lands on ``target_`` with the expected datamodule path."""
+        data_subtree = _compose_data_cfg("ksin")
+        parsed = DataConfig.model_validate(data_subtree)
+        assert parsed.target_.endswith("KSinDataModule")
+
+
+class TestDataConfigRejectsBadInputs:
+    """Validators must catch obvious mistakes on the typed fields."""
+
+    def test_missing_target_rejected(self) -> None:
+        """Hydra needs ``_target_`` to instantiate the datamodule — required."""
+        with pytest.raises(ValidationError):
+            DataConfig.model_validate({"batch_size": 32})
+
+    def test_blank_target_rejected(self) -> None:
+        """A blank ``_target_`` would crash ``hydra.utils.instantiate`` mid-run."""
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            DataConfig.model_validate({"_target_": "  ", "batch_size": 32})

--- a/tests/schemas/test_extras_config.py
+++ b/tests/schemas/test_extras_config.py
@@ -10,26 +10,11 @@ instead of producing a confusing runtime error inside
 
 from __future__ import annotations
 
-from typing import Any, cast
-
 import pytest
-from hydra import compose, initialize
-from omegaconf import OmegaConf
 from pydantic import ValidationError
 
 from synth_setter.schemas.extras_config import ExtrasConfig
-
-
-def _compose_extras_cfg() -> dict[str, Any]:  # noqa: DOC201,DOC203
-    """Compose a full train config and return its ``extras`` subtree as a dict."""
-    with initialize(version_base="1.3", config_path="../../configs"):
-        cfg = compose(
-            config_name="train.yaml",
-            overrides=["data=ksin", "model=ffn", "trainer=cpu"],
-        )
-    extras_subtree = OmegaConf.to_container(cfg.extras, resolve=False)
-    assert isinstance(extras_subtree, dict)
-    return cast("dict[str, Any]", extras_subtree)
+from tests.schemas.conftest import compose_subtree
 
 
 class TestExtrasConfigAcceptsDefault:
@@ -37,7 +22,7 @@ class TestExtrasConfigAcceptsDefault:
 
     def test_default_validates(self) -> None:
         """All four toggles land on the parsed model with the YAML values."""
-        extras_subtree = _compose_extras_cfg()
+        extras_subtree = compose_subtree("extras", "default")
         parsed = ExtrasConfig.model_validate(extras_subtree)
         assert parsed.ignore_warnings is False
         assert parsed.enforce_tags is True

--- a/tests/schemas/test_extras_config.py
+++ b/tests/schemas/test_extras_config.py
@@ -1,0 +1,59 @@
+"""Behavioural tests for the ``ExtrasConfig`` pydantic model.
+
+``configs/extras/default.yaml`` is the only composition in the repo. The
+positive case asserts it validates and the typed scalars survive the round
+trip; the negative cases pin the ``StrictBool`` / ``Literal`` constraints
+so a stray ``"yes"`` or unknown precision value fails at compose time
+instead of producing a confusing runtime error inside
+``synth_setter.utils.extras``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from hydra import compose, initialize
+from omegaconf import OmegaConf
+from pydantic import ValidationError
+
+from synth_setter.schemas.extras_config import ExtrasConfig
+
+
+def _compose_extras_cfg() -> dict[str, Any]:  # noqa: DOC201,DOC203
+    """Compose a full train config and return its ``extras`` subtree as a dict."""
+    with initialize(version_base="1.3", config_path="../../configs"):
+        cfg = compose(
+            config_name="train.yaml",
+            overrides=["data=ksin", "model=ffn", "trainer=cpu"],
+        )
+    extras_subtree = OmegaConf.to_container(cfg.extras, resolve=False)
+    assert isinstance(extras_subtree, dict)
+    return cast("dict[str, Any]", extras_subtree)
+
+
+class TestExtrasConfigAcceptsDefault:
+    """The shipped ``extras/default.yaml`` composition validates."""
+
+    def test_default_validates(self) -> None:
+        """All four toggles land on the parsed model with the YAML values."""
+        extras_subtree = _compose_extras_cfg()
+        parsed = ExtrasConfig.model_validate(extras_subtree)
+        assert parsed.ignore_warnings is False
+        assert parsed.enforce_tags is True
+        assert parsed.print_config is True
+        assert parsed.float32_matmul_precision == "high"
+
+
+class TestExtrasConfigRejectsBadInputs:
+    """Validators must catch obvious mistakes on the typed fields."""
+
+    def test_string_bool_rejected_by_strict(self) -> None:
+        """``ignore_warnings`` is ``StrictBool``; ``"yes"`` must not silently coerce."""
+        with pytest.raises(ValidationError, match="bool"):
+            ExtrasConfig.model_validate({"ignore_warnings": "yes"})
+
+    def test_unknown_precision_rejected(self) -> None:
+        """``float32_matmul_precision`` is a ``Literal`` of the three values torch accepts."""
+        with pytest.raises(ValidationError):
+            ExtrasConfig.model_validate({"float32_matmul_precision": "extreme"})

--- a/tests/schemas/test_extras_config.py
+++ b/tests/schemas/test_extras_config.py
@@ -1,11 +1,8 @@
 """Behavioural tests for the ``ExtrasConfig`` pydantic model.
 
-``configs/extras/default.yaml`` is the only composition in the repo. The
-positive case asserts it validates and the typed scalars survive the round
-trip; the negative cases pin the ``StrictBool`` / ``Literal`` constraints
-so a stray ``"yes"`` or unknown precision value fails at compose time
-instead of producing a confusing runtime error inside
-``synth_setter.utils.extras``.
+Pins both directions on the only shipped composition
+(``configs/extras/default.yaml``): valid YAML round-trips, and
+``StrictBool`` / ``Literal`` reject ``"yes"`` / unknown precisions.
 """
 
 from __future__ import annotations

--- a/tests/schemas/test_logger_config.py
+++ b/tests/schemas/test_logger_config.py
@@ -1,0 +1,101 @@
+"""Behavioural tests for the ``LoggerConfig`` / ``LoggerInstance`` models.
+
+Each YAML under ``configs/logger/`` that selects one or more loggers must
+validate against ``LoggerConfig`` (a RootModel wrapping
+``dict[str, LoggerInstance]``). Logger-class-specific kwargs vary per
+backend and live under ``extra="allow"`` on ``LoggerInstance``; only
+``_target_`` is typed at this layer.
+
+The leaf logger YAMLs (``wandb``, ``tensorboard``, ``mlflow``, ``csv``,
+``aim``, ``comet``, ``neptune``) are also legal group selections — they
+each declare a single named logger at the top level. ``many_loggers.yaml``
+is the composition that pulls in several at once.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from hydra import compose, initialize
+from omegaconf import OmegaConf
+from pydantic import ValidationError
+
+from synth_setter.schemas.logger_config import LoggerConfig, LoggerInstance
+
+_LOGGER_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "logger"
+
+
+def _all_logger_config_names() -> list[str]:  # noqa: DOC201,DOC203
+    """Return the YAML stem of every direct logger config under ``configs/logger/``."""
+    names = sorted(p.stem for p in _LOGGER_CONFIG_DIR.glob("*.yaml"))
+    assert names, f"no logger YAMLs found under {_LOGGER_CONFIG_DIR} — has the layout changed?"
+    return names
+
+
+def _compose_logger_cfg(logger_name: str) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Compose a full train config with ``logger=<logger_name>`` selected."""
+    with initialize(version_base="1.3", config_path="../../configs"):
+        cfg = compose(
+            config_name="train.yaml",
+            overrides=[
+                f"logger={logger_name}",
+                "data=ksin",
+                "model=ffn",
+                "trainer=cpu",
+            ],
+        )
+    logger_subtree = OmegaConf.to_container(cfg.logger, resolve=False)
+    assert isinstance(logger_subtree, dict)
+    return cast("dict[str, Any]", logger_subtree)
+
+
+class TestLoggerConfigAcceptsEveryComposition:
+    """Every shipped logger group must validate against ``LoggerConfig``."""
+
+    @pytest.mark.parametrize("logger_name", _all_logger_config_names())
+    def test_logger_yaml_validates(self, logger_name: str) -> None:  # noqa: DOC101,DOC103
+        """The composed ``logger`` subtree validates as ``LoggerConfig``."""
+        logger_subtree = _compose_logger_cfg(logger_name)
+        LoggerConfig.model_validate(logger_subtree)
+
+    def test_many_loggers_yields_multiple_entries(self) -> None:
+        """``many_loggers.yaml`` composes more than one logger entry."""
+        logger_subtree = _compose_logger_cfg("many_loggers")
+        parsed = LoggerConfig.model_validate(logger_subtree)
+        assert len(parsed.root) > 1
+
+
+_VALID_LOGGER = {
+    "_target_": "lightning.pytorch.loggers.csv_logs.CSVLogger",
+    "save_dir": "/tmp/csv",  # noqa: S108
+}
+
+
+class TestLoggerConfigRejectsBadInputs:
+    """Validators must catch obvious mistakes on the typed fields."""
+
+    def test_missing_target_in_instance_rejected(self) -> None:
+        """Each logger instance must carry ``_target_``; reject if absent."""
+        with pytest.raises(ValidationError):
+            LoggerConfig.model_validate({"csv": {"save_dir": "/tmp/csv"}})  # noqa: S108
+
+    def test_blank_target_rejected(self) -> None:
+        """A blank ``_target_`` would crash ``hydra.utils.instantiate`` mid-fit."""
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            LoggerConfig.model_validate({"lg": {"_target_": "  "}})
+
+    def test_blank_logger_name_rejected(self) -> None:
+        """RootModel key is ``NonBlankStr`` — empty logger names are rejected."""
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            LoggerConfig.model_validate({"   ": _VALID_LOGGER})
+
+
+class TestLoggerInstanceDirect:
+    """Direct ``LoggerInstance`` validation works for individual entries."""
+
+    def test_valid_instance_parses(self) -> None:
+        """A minimal valid logger dict parses cleanly."""
+        parsed = LoggerInstance.model_validate(_VALID_LOGGER)
+        assert parsed.target_ == "lightning.pytorch.loggers.csv_logs.CSVLogger"

--- a/tests/schemas/test_logger_config.py
+++ b/tests/schemas/test_logger_config.py
@@ -15,14 +15,12 @@ is the composition that pulls in several at once.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, cast
 
 import pytest
-from hydra import compose, initialize
-from omegaconf import OmegaConf
 from pydantic import ValidationError
 
 from synth_setter.schemas.logger_config import LoggerConfig, LoggerInstance
+from tests.schemas.conftest import compose_subtree
 
 _LOGGER_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "logger"
 
@@ -34,35 +32,19 @@ def _all_logger_config_names() -> list[str]:  # noqa: DOC201,DOC203
     return names
 
 
-def _compose_logger_cfg(logger_name: str) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Compose a full train config with ``logger=<logger_name>`` selected."""
-    with initialize(version_base="1.3", config_path="../../configs"):
-        cfg = compose(
-            config_name="train.yaml",
-            overrides=[
-                f"logger={logger_name}",
-                "data=ksin",
-                "model=ffn",
-                "trainer=cpu",
-            ],
-        )
-    logger_subtree = OmegaConf.to_container(cfg.logger, resolve=False)
-    assert isinstance(logger_subtree, dict)
-    return cast("dict[str, Any]", logger_subtree)
-
-
 class TestLoggerConfigAcceptsEveryComposition:
     """Every shipped logger group must validate against ``LoggerConfig``."""
 
     @pytest.mark.parametrize("logger_name", _all_logger_config_names())
     def test_logger_yaml_validates(self, logger_name: str) -> None:  # noqa: DOC101,DOC103
         """The composed ``logger`` subtree validates as ``LoggerConfig``."""
-        logger_subtree = _compose_logger_cfg(logger_name)
-        LoggerConfig.model_validate(logger_subtree)
+        logger_subtree = compose_subtree("logger", logger_name)
+        parsed = LoggerConfig.model_validate(logger_subtree)
+        assert parsed.root
 
     def test_many_loggers_yields_multiple_entries(self) -> None:
         """``many_loggers.yaml`` composes more than one logger entry."""
-        logger_subtree = _compose_logger_cfg("many_loggers")
+        logger_subtree = compose_subtree("logger", "many_loggers")
         parsed = LoggerConfig.model_validate(logger_subtree)
         assert len(parsed.root) > 1
 

--- a/tests/schemas/test_logger_config.py
+++ b/tests/schemas/test_logger_config.py
@@ -1,15 +1,7 @@
-"""Behavioural tests for the ``LoggerConfig`` / ``LoggerInstance`` models.
+"""Behavioural tests for ``LoggerConfig`` / ``LoggerInstance``.
 
-Each YAML under ``configs/logger/`` that selects one or more loggers must
-validate against ``LoggerConfig`` (a RootModel wrapping
-``dict[str, LoggerInstance]``). Logger-class-specific kwargs vary per
-backend and live under ``extra="allow"`` on ``LoggerInstance``; only
-``_target_`` is typed at this layer.
-
-The leaf logger YAMLs (``wandb``, ``tensorboard``, ``mlflow``, ``csv``,
-``aim``, ``comet``, ``neptune``) are also legal group selections — they
-each declare a single named logger at the top level. ``many_loggers.yaml``
-is the composition that pulls in several at once.
+Every ``configs/logger/`` YAML must validate; logger kwargs ride
+``extra="allow"`` on ``LoggerInstance``.
 """
 
 from __future__ import annotations

--- a/tests/schemas/test_model_config.py
+++ b/tests/schemas/test_model_config.py
@@ -1,10 +1,7 @@
 """Behavioural tests for the ``ModelConfig`` pydantic model.
 
-Every YAML under ``configs/model/`` must validate against ``ModelConfig`` —
-that's the contract the published docs assert. Variant-specific keys live
-under ``extra="allow"`` so a new model module can ship its own fields
-without re-touching the schema; the common shape stays typed and
-documented.
+Every YAML under ``configs/model/`` must validate; variant kwargs ride
+``extra="allow"``.
 """
 
 from __future__ import annotations
@@ -19,14 +16,8 @@ from tests.schemas.conftest import compose_subtree
 
 _MODEL_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "model"
 
-# Reused as a placeholder ``_target_`` across the negative-path cases — the
-# exact dotted path doesn't matter for the validators under test, but
-# centralising it stops the negative tests from looking like they each
-# probe a different module.
 _VALID_TARGET = "synth_setter.models.X"
 
-# Minimal optimizer-config fixture reused by the negative-path cases; defined
-# once so a new constraint adds one row, not a new boilerplate dict.
 _VALID_OPTIMIZER = {
     "_target_": "torch.optim.Adam",
     "_partial_": True,
@@ -35,11 +26,7 @@ _VALID_OPTIMIZER = {
 
 
 def _all_model_config_names() -> list[str]:  # noqa: DOC201,DOC203
-    """Return the YAML stem of every direct model config under ``configs/model/``.
-
-    Subgroups (``configs/model/encoder/`` and similar) compose into a parent
-    via ``defaults:`` and are not top-level model configs; they're excluded.
-    """
+    """Return YAML stems for every top-level model config (skipping subgroup dirs)."""
     names = sorted(p.stem for p in _MODEL_CONFIG_DIR.glob("*.yaml"))
     assert names, f"no model YAMLs found under {_MODEL_CONFIG_DIR} — has the layout changed?"
     return names

--- a/tests/schemas/test_model_config.py
+++ b/tests/schemas/test_model_config.py
@@ -10,16 +10,28 @@ documented.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, cast
 
 import pytest
-from hydra import compose, initialize
-from omegaconf import OmegaConf
 from pydantic import ValidationError
 
 from synth_setter.schemas.model_config import ModelConfig, OptimizerConfig
+from tests.schemas.conftest import compose_subtree
 
 _MODEL_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "model"
+
+# Reused as a placeholder ``_target_`` across the negative-path cases — the
+# exact dotted path doesn't matter for the validators under test, but
+# centralising it stops the negative tests from looking like they each
+# probe a different module.
+_VALID_TARGET = "synth_setter.models.X"
+
+# Minimal optimizer-config fixture reused by the negative-path cases; defined
+# once so a new constraint adds one row, not a new boilerplate dict.
+_VALID_OPTIMIZER = {
+    "_target_": "torch.optim.Adam",
+    "_partial_": True,
+    "lr": 1e-4,
+}
 
 
 def _all_model_config_names() -> list[str]:  # noqa: DOC201,DOC203
@@ -33,26 +45,15 @@ def _all_model_config_names() -> list[str]:  # noqa: DOC201,DOC203
     return names
 
 
-def _compose_model_cfg(model_name: str) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Compose a full train config with ``model=<model_name>`` selected."""
-    with initialize(version_base="1.3", config_path="../../configs"):
-        cfg = compose(
-            config_name="train.yaml",
-            overrides=[f"model={model_name}", "data=ksin", "trainer=cpu"],
-        )
-    model_subtree = OmegaConf.to_container(cfg.model, resolve=False)
-    assert isinstance(model_subtree, dict)
-    return cast("dict[str, Any]", model_subtree)
-
-
 class TestModelConfigAcceptsEveryConfig:
     """Every shipped model YAML must validate against ``ModelConfig``."""
 
     @pytest.mark.parametrize("model_name", _all_model_config_names())
     def test_model_yaml_validates(self, model_name: str) -> None:  # noqa: DOC101,DOC103
         """The composed ``model`` subtree validates as ``ModelConfig``."""
-        model_subtree = _compose_model_cfg(model_name)
-        ModelConfig.model_validate(model_subtree)
+        model_subtree = compose_subtree("model", model_name)
+        parsed = ModelConfig.model_validate(model_subtree)
+        assert parsed.target_
 
 
 class TestModelConfigCommonFields:
@@ -60,7 +61,7 @@ class TestModelConfigCommonFields:
 
     def test_common_fields_typed(self) -> None:
         """``_target_``, ``optimizer``, ``compile`` come through with the right types."""
-        model_subtree = _compose_model_cfg("ffn")
+        model_subtree = compose_subtree("model", "ffn")
         parsed = ModelConfig.model_validate(model_subtree)
         assert parsed.target_.endswith("KSinFeedForwardModule")
         assert isinstance(parsed.optimizer, OptimizerConfig)
@@ -68,18 +69,9 @@ class TestModelConfigCommonFields:
 
     def test_scheduler_optional_none(self) -> None:
         """``scheduler: null`` in YAML parses to ``None`` on the model."""
-        model_subtree = _compose_model_cfg("ffn")
+        model_subtree = compose_subtree("model", "ffn")
         parsed = ModelConfig.model_validate(model_subtree)
         assert parsed.scheduler is None
-
-
-# Minimal optimizer-config fixture reused by the negative-path cases; defined
-# once so a new constraint adds one row, not a new boilerplate dict.
-_VALID_OPTIMIZER = {
-    "_target_": "torch.optim.Adam",
-    "_partial_": True,
-    "lr": 1e-4,
-}
 
 
 class TestModelConfigRejectsBadInputs:
@@ -100,7 +92,7 @@ class TestModelConfigRejectsBadInputs:
         with pytest.raises(ValidationError):
             ModelConfig.model_validate(
                 {
-                    "_target_": "synth_setter.models.X",
+                    "_target_": _VALID_TARGET,
                     "optimizer": {"_target_": "torch.optim.Adam", "_partial_": True},
                 }
             )
@@ -110,7 +102,7 @@ class TestModelConfigRejectsBadInputs:
         with pytest.raises(ValidationError, match="greater than 0"):
             ModelConfig.model_validate(
                 {
-                    "_target_": "synth_setter.models.X",
+                    "_target_": _VALID_TARGET,
                     "optimizer": {**_VALID_OPTIMIZER, "lr": -1.0},
                 }
             )
@@ -120,7 +112,7 @@ class TestModelConfigRejectsBadInputs:
         with pytest.raises(ValidationError, match="greater than or equal to 0"):
             ModelConfig.model_validate(
                 {
-                    "_target_": "synth_setter.models.X",
+                    "_target_": _VALID_TARGET,
                     "optimizer": {**_VALID_OPTIMIZER, "weight_decay": -0.1},
                 }
             )
@@ -130,7 +122,7 @@ class TestModelConfigRejectsBadInputs:
         with pytest.raises(ValidationError, match="at least 1 character"):
             ModelConfig.model_validate(
                 {
-                    "_target_": "synth_setter.models.X",
+                    "_target_": _VALID_TARGET,
                     "optimizer": _VALID_OPTIMIZER,
                     "scheduler": {"_target_": "  ", "_partial_": True},
                 }

--- a/tests/schemas/test_model_config.py
+++ b/tests/schemas/test_model_config.py
@@ -1,0 +1,137 @@
+"""Behavioural tests for the ``ModelConfig`` pydantic model.
+
+Every YAML under ``configs/model/`` must validate against ``ModelConfig`` —
+that's the contract the published docs assert. Variant-specific keys live
+under ``extra="allow"`` so a new model module can ship its own fields
+without re-touching the schema; the common shape stays typed and
+documented.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from hydra import compose, initialize
+from omegaconf import OmegaConf
+from pydantic import ValidationError
+
+from synth_setter.schemas.model_config import ModelConfig, OptimizerConfig
+
+_MODEL_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "model"
+
+
+def _all_model_config_names() -> list[str]:  # noqa: DOC201,DOC203
+    """Return the YAML stem of every direct model config under ``configs/model/``.
+
+    Subgroups (``configs/model/encoder/`` and similar) compose into a parent
+    via ``defaults:`` and are not top-level model configs; they're excluded.
+    """
+    names = sorted(p.stem for p in _MODEL_CONFIG_DIR.glob("*.yaml"))
+    assert names, f"no model YAMLs found under {_MODEL_CONFIG_DIR} — has the layout changed?"
+    return names
+
+
+def _compose_model_cfg(model_name: str) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Compose a full train config with ``model=<model_name>`` selected."""
+    with initialize(version_base="1.3", config_path="../../configs"):
+        cfg = compose(
+            config_name="train.yaml",
+            overrides=[f"model={model_name}", "data=ksin", "trainer=cpu"],
+        )
+    model_subtree = OmegaConf.to_container(cfg.model, resolve=False)
+    assert isinstance(model_subtree, dict)
+    return cast("dict[str, Any]", model_subtree)
+
+
+class TestModelConfigAcceptsEveryConfig:
+    """Every shipped model YAML must validate against ``ModelConfig``."""
+
+    @pytest.mark.parametrize("model_name", _all_model_config_names())
+    def test_model_yaml_validates(self, model_name: str) -> None:  # noqa: DOC101,DOC103
+        """The composed ``model`` subtree validates as ``ModelConfig``."""
+        model_subtree = _compose_model_cfg(model_name)
+        ModelConfig.model_validate(model_subtree)
+
+
+class TestModelConfigCommonFields:
+    """The typed scalar / sub-model fields must land on the parsed model."""
+
+    def test_common_fields_typed(self) -> None:
+        """``_target_``, ``optimizer``, ``compile`` come through with the right types."""
+        model_subtree = _compose_model_cfg("ffn")
+        parsed = ModelConfig.model_validate(model_subtree)
+        assert parsed.target_.endswith("KSinFeedForwardModule")
+        assert isinstance(parsed.optimizer, OptimizerConfig)
+        assert parsed.compile is True
+
+    def test_scheduler_optional_none(self) -> None:
+        """``scheduler: null`` in YAML parses to ``None`` on the model."""
+        model_subtree = _compose_model_cfg("ffn")
+        parsed = ModelConfig.model_validate(model_subtree)
+        assert parsed.scheduler is None
+
+
+# Minimal optimizer-config fixture reused by the negative-path cases; defined
+# once so a new constraint adds one row, not a new boilerplate dict.
+_VALID_OPTIMIZER = {
+    "_target_": "torch.optim.Adam",
+    "_partial_": True,
+    "lr": 1e-4,
+}
+
+
+class TestModelConfigRejectsBadInputs:
+    """Validators must catch obvious mistakes on the typed fields."""
+
+    def test_missing_target_rejected(self) -> None:
+        """Hydra needs ``_target_`` to instantiate the module — required."""
+        with pytest.raises(ValidationError):
+            ModelConfig.model_validate({"optimizer": _VALID_OPTIMIZER})
+
+    def test_blank_target_rejected(self) -> None:
+        """A blank ``_target_`` would crash ``hydra.utils.instantiate`` mid-run."""
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            ModelConfig.model_validate({"_target_": "  ", "optimizer": _VALID_OPTIMIZER})
+
+    def test_missing_lr_rejected(self) -> None:
+        """``OptimizerConfig.lr`` has no default; omitting it must fail validation."""
+        with pytest.raises(ValidationError):
+            ModelConfig.model_validate(
+                {
+                    "_target_": "synth_setter.models.X",
+                    "optimizer": {"_target_": "torch.optim.Adam", "_partial_": True},
+                }
+            )
+
+    def test_negative_lr_rejected(self) -> None:
+        """Negative learning rate is always a bug; surface it at config time."""
+        with pytest.raises(ValidationError, match="greater than 0"):
+            ModelConfig.model_validate(
+                {
+                    "_target_": "synth_setter.models.X",
+                    "optimizer": {**_VALID_OPTIMIZER, "lr": -1.0},
+                }
+            )
+
+    def test_negative_weight_decay_rejected(self) -> None:
+        """Negative weight decay is invalid for torch optimizers; reject it."""
+        with pytest.raises(ValidationError, match="greater than or equal to 0"):
+            ModelConfig.model_validate(
+                {
+                    "_target_": "synth_setter.models.X",
+                    "optimizer": {**_VALID_OPTIMIZER, "weight_decay": -0.1},
+                }
+            )
+
+    def test_blank_scheduler_target_rejected(self) -> None:
+        """A blank scheduler ``_target_`` would crash instantiation mid-fit."""
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            ModelConfig.model_validate(
+                {
+                    "_target_": "synth_setter.models.X",
+                    "optimizer": _VALID_OPTIMIZER,
+                    "scheduler": {"_target_": "  ", "_partial_": True},
+                }
+            )

--- a/tests/schemas/test_paths_config.py
+++ b/tests/schemas/test_paths_config.py
@@ -8,26 +8,11 @@ broken paths into half a dozen downstream YAMLs and must fail early.
 
 from __future__ import annotations
 
-from typing import Any, cast
-
 import pytest
-from hydra import compose, initialize
-from omegaconf import OmegaConf
 from pydantic import ValidationError
 
 from synth_setter.schemas.paths_config import PathsConfig
-
-
-def _compose_paths_cfg() -> dict[str, Any]:  # noqa: DOC201,DOC203
-    """Compose a full train config and return its ``paths`` subtree as a dict."""
-    with initialize(version_base="1.3", config_path="../../configs"):
-        cfg = compose(
-            config_name="train.yaml",
-            overrides=["data=ksin", "model=ffn", "trainer=cpu"],
-        )
-    paths_subtree = OmegaConf.to_container(cfg.paths, resolve=False)
-    assert isinstance(paths_subtree, dict)
-    return cast("dict[str, Any]", paths_subtree)
+from tests.schemas.conftest import compose_subtree
 
 
 class TestPathsConfigAcceptsDefault:
@@ -35,7 +20,7 @@ class TestPathsConfigAcceptsDefault:
 
     def test_default_validates(self) -> None:
         """All five string fields land on the parsed model."""
-        paths_subtree = _compose_paths_cfg()
+        paths_subtree = compose_subtree("paths", "default")
         parsed = PathsConfig.model_validate(paths_subtree)
         # The values are unresolved interpolation templates; we only assert
         # they're non-blank strings, which is what the schema actually

--- a/tests/schemas/test_paths_config.py
+++ b/tests/schemas/test_paths_config.py
@@ -1,0 +1,72 @@
+"""Behavioural tests for the ``PathsConfig`` pydantic model.
+
+The shipped ``paths: default`` composition is the only one in the repo and
+it must validate against ``PathsConfig``. The negative cases pin the
+``NonBlankStr`` contract — empty / whitespace overrides would propagate
+broken paths into half a dozen downstream YAMLs and must fail early.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from hydra import compose, initialize
+from omegaconf import OmegaConf
+from pydantic import ValidationError
+
+from synth_setter.schemas.paths_config import PathsConfig
+
+
+def _compose_paths_cfg() -> dict[str, Any]:  # noqa: DOC201,DOC203
+    """Compose a full train config and return its ``paths`` subtree as a dict."""
+    with initialize(version_base="1.3", config_path="../../configs"):
+        cfg = compose(
+            config_name="train.yaml",
+            overrides=["data=ksin", "model=ffn", "trainer=cpu"],
+        )
+    paths_subtree = OmegaConf.to_container(cfg.paths, resolve=False)
+    assert isinstance(paths_subtree, dict)
+    return cast("dict[str, Any]", paths_subtree)
+
+
+class TestPathsConfigAcceptsDefault:
+    """The shipped ``paths/default.yaml`` composition validates."""
+
+    def test_default_validates(self) -> None:
+        """All five string fields land on the parsed model."""
+        paths_subtree = _compose_paths_cfg()
+        parsed = PathsConfig.model_validate(paths_subtree)
+        # The values are unresolved interpolation templates; we only assert
+        # they're non-blank strings, which is what the schema actually
+        # enforces.
+        assert parsed.root_dir
+        assert parsed.data_dir
+        assert parsed.log_dir
+        assert parsed.output_dir
+        assert parsed.work_dir
+
+
+_VALID_PATHS = {
+    "root_dir": "/proj",
+    "data_dir": "/proj/data",
+    "log_dir": "/proj/logs",
+    "output_dir": "/proj/out",
+    "work_dir": "/proj",
+}
+
+
+class TestPathsConfigRejectsBadInputs:
+    """Validators must reject blank overrides on every path field."""
+
+    @pytest.mark.parametrize("field", list(_VALID_PATHS))
+    def test_blank_field_rejected(self, field: str) -> None:  # noqa: DOC101,DOC103
+        """Each path field rejects whitespace-only overrides."""
+        bad = {**_VALID_PATHS, field: "   "}
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            PathsConfig.model_validate(bad)
+
+    def test_missing_root_dir_rejected(self) -> None:
+        """``root_dir`` has no default — omitting it must fail."""
+        with pytest.raises(ValidationError):
+            PathsConfig.model_validate({k: v for k, v in _VALID_PATHS.items() if k != "root_dir"})

--- a/tests/schemas/test_paths_config.py
+++ b/tests/schemas/test_paths_config.py
@@ -1,9 +1,7 @@
 """Behavioural tests for the ``PathsConfig`` pydantic model.
 
-The shipped ``paths: default`` composition is the only one in the repo and
-it must validate against ``PathsConfig``. The negative cases pin the
-``NonBlankStr`` contract — empty / whitespace overrides would propagate
-broken paths into half a dozen downstream YAMLs and must fail early.
+Pins that ``paths/default.yaml`` validates and that whitespace overrides on
+any field are rejected by ``NonBlankStr``.
 """
 
 from __future__ import annotations
@@ -22,9 +20,7 @@ class TestPathsConfigAcceptsDefault:
         """All five string fields land on the parsed model."""
         paths_subtree = compose_subtree("paths", "default")
         parsed = PathsConfig.model_validate(paths_subtree)
-        # The values are unresolved interpolation templates; we only assert
-        # they're non-blank strings, which is what the schema actually
-        # enforces.
+        # Values here are unresolved interpolation templates; assert non-blank only.
         assert parsed.root_dir
         assert parsed.data_dir
         assert parsed.log_dir

--- a/tests/schemas/test_train_config.py
+++ b/tests/schemas/test_train_config.py
@@ -1,0 +1,89 @@
+"""Behavioural tests for the ``TrainConfig`` pydantic model.
+
+The pydantic model documents the shape of ``configs/train.yaml`` plus its
+``defaults:`` composition. The tests assert two things:
+
+1. The model accepts the live composed config — so the published docs stay
+   honest about what the entrypoint receives at runtime.
+2. The model rejects obvious mistakes (wrong types, blank ``task_name``,
+   negative ``seed``) so the doc-vs-reality contract is enforced at
+   validation time, not just at import.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+from hydra import compose, initialize
+from omegaconf import OmegaConf
+from pydantic import ValidationError
+
+from synth_setter.schemas.train_config import TrainConfig
+
+
+def _composed_train_cfg_dict(  # noqa: DOC101,DOC103,DOC201,DOC203
+    *,
+    return_hydra_config: bool = False,
+) -> dict[str, Any]:
+    """Compose ``configs/train.yaml`` for testing and return it as a plain dict."""
+    with initialize(version_base="1.3", config_path="../../configs"):
+        cfg = compose(
+            config_name="train.yaml",
+            return_hydra_config=return_hydra_config,
+            overrides=["data=ksin", "model=ffn", "trainer=cpu"],
+        )
+    container = OmegaConf.to_container(cfg, resolve=False)
+    assert isinstance(container, dict)
+    return cast("dict[str, Any]", container)
+
+
+class TestTrainConfigAcceptsLiveCompose:
+    """The pydantic model must accept the configs Hydra actually composes."""
+
+    def test_default_composition_validates(self) -> None:
+        """The default ``train.yaml`` composition validates without error."""
+        cfg_dict = _composed_train_cfg_dict()
+        TrainConfig.model_validate(cfg_dict)
+
+    def test_default_composition_with_hydra_subtree_validates(self) -> None:
+        """``return_hydra_config=True`` adds a ``hydra`` key; the model accepts it."""
+        cfg_dict = _composed_train_cfg_dict(return_hydra_config=True)
+        TrainConfig.model_validate(cfg_dict)
+
+    def test_typed_scalars_survive_round_trip(self) -> None:
+        """Every typed scalar lands on the model with the value the YAML declares."""
+        cfg_dict = _composed_train_cfg_dict()
+        model = TrainConfig.model_validate(cfg_dict)
+        assert model.task_name == "train"
+        assert model.tags == ["dev"]
+        assert model.train is True
+        assert model.test is True
+        assert model.ckpt_path is None
+        assert model.seed is None
+        assert model.optimized_metric is None
+        assert model.watch_gradients is None
+
+
+class TestTrainConfigRejectsBadInputs:
+    """Validators must reject obvious mistakes on the scalar fields."""
+
+    def test_blank_task_name_rejected(self) -> None:
+        """A blank ``task_name`` would produce an empty output dir; reject it."""
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            TrainConfig.model_validate({"task_name": "   ", "tags": ["dev"]})
+
+    def test_string_train_flag_rejected_by_strict_bool(self) -> None:
+        """``train`` is ``StrictBool``; ``"yes"`` would otherwise coerce silently."""
+        with pytest.raises(ValidationError, match="bool"):
+            TrainConfig.model_validate({"task_name": "train", "train": "yes"})
+
+    def test_negative_seed_rejected(self) -> None:
+        """Lightning's ``seed_everything`` rejects negative seeds; reject up front."""
+        with pytest.raises(ValidationError, match="greater than or equal to 0"):
+            TrainConfig.model_validate({"task_name": "train", "seed": -1})
+
+    def test_string_tags_rejected(self) -> None:
+        """``tags`` is consumed as ``list[str]`` by the run-id helpers."""
+        with pytest.raises(ValidationError):
+            TrainConfig.model_validate({"task_name": "train", "tags": "dev"})

--- a/tests/schemas/test_train_config.py
+++ b/tests/schemas/test_train_config.py
@@ -1,13 +1,7 @@
 """Behavioural tests for the ``TrainConfig`` pydantic model.
 
-The pydantic model documents the shape of ``configs/train.yaml`` plus its
-``defaults:`` composition. The tests assert two things:
-
-1. The model accepts the live composed config — so the published docs stay
-   honest about what the entrypoint receives at runtime.
-2. The model rejects obvious mistakes (wrong types, blank ``task_name``,
-   negative ``seed``) so the doc-vs-reality contract is enforced at
-   validation time, not just at import.
+Pins both directions: the live composed ``train.yaml`` validates, and
+obvious mistakes (wrong types, blank ``task_name``, negative ``seed``) fail.
 """
 
 from __future__ import annotations
@@ -38,9 +32,7 @@ class TestTrainConfigAcceptsLiveCompose:
         """Every typed scalar lands on the model with the right type / shape."""
         cfg_dict = compose_train_cfg()
         model = TrainConfig.model_validate(cfg_dict)
-        # Assert property — typed scalars, not literal YAML values — so the
-        # test doesn't bake the train.yaml defaults into a second source of
-        # truth that drifts whenever the defaults shift.
+        # Property-based asserts so this test doesn't shadow train.yaml's defaults.
         assert isinstance(model.task_name, str) and model.task_name
         assert all(isinstance(t, str) for t in model.tags)
         assert isinstance(model.train, bool)

--- a/tests/schemas/test_train_config.py
+++ b/tests/schemas/test_train_config.py
@@ -12,30 +12,11 @@ The pydantic model documents the shape of ``configs/train.yaml`` plus its
 
 from __future__ import annotations
 
-from typing import Any, cast
-
 import pytest
-from hydra import compose, initialize
-from omegaconf import OmegaConf
 from pydantic import ValidationError
 
 from synth_setter.schemas.train_config import TrainConfig
-
-
-def _composed_train_cfg_dict(  # noqa: DOC101,DOC103,DOC201,DOC203
-    *,
-    return_hydra_config: bool = False,
-) -> dict[str, Any]:
-    """Compose ``configs/train.yaml`` for testing and return it as a plain dict."""
-    with initialize(version_base="1.3", config_path="../../configs"):
-        cfg = compose(
-            config_name="train.yaml",
-            return_hydra_config=return_hydra_config,
-            overrides=["data=ksin", "model=ffn", "trainer=cpu"],
-        )
-    container = OmegaConf.to_container(cfg, resolve=False)
-    assert isinstance(container, dict)
-    return cast("dict[str, Any]", container)
+from tests.schemas.conftest import compose_train_cfg
 
 
 class TestTrainConfigAcceptsLiveCompose:
@@ -43,26 +24,31 @@ class TestTrainConfigAcceptsLiveCompose:
 
     def test_default_composition_validates(self) -> None:
         """The default ``train.yaml`` composition validates without error."""
-        cfg_dict = _composed_train_cfg_dict()
-        TrainConfig.model_validate(cfg_dict)
+        cfg_dict = compose_train_cfg()
+        parsed = TrainConfig.model_validate(cfg_dict)
+        assert isinstance(parsed, TrainConfig)
 
     def test_default_composition_with_hydra_subtree_validates(self) -> None:
         """``return_hydra_config=True`` adds a ``hydra`` key; the model accepts it."""
-        cfg_dict = _composed_train_cfg_dict(return_hydra_config=True)
-        TrainConfig.model_validate(cfg_dict)
+        cfg_dict = compose_train_cfg(return_hydra_config=True)
+        parsed = TrainConfig.model_validate(cfg_dict)
+        assert isinstance(parsed, TrainConfig)
 
     def test_typed_scalars_survive_round_trip(self) -> None:
-        """Every typed scalar lands on the model with the value the YAML declares."""
-        cfg_dict = _composed_train_cfg_dict()
+        """Every typed scalar lands on the model with the right type / shape."""
+        cfg_dict = compose_train_cfg()
         model = TrainConfig.model_validate(cfg_dict)
-        assert model.task_name == "train"
-        assert model.tags == ["dev"]
-        assert model.train is True
-        assert model.test is True
-        assert model.ckpt_path is None
-        assert model.seed is None
-        assert model.optimized_metric is None
-        assert model.watch_gradients is None
+        # Assert property — typed scalars, not literal YAML values — so the
+        # test doesn't bake the train.yaml defaults into a second source of
+        # truth that drifts whenever the defaults shift.
+        assert isinstance(model.task_name, str) and model.task_name
+        assert all(isinstance(t, str) for t in model.tags)
+        assert isinstance(model.train, bool)
+        assert isinstance(model.test, bool)
+        assert model.ckpt_path is None or isinstance(model.ckpt_path, str)
+        assert model.seed is None or (isinstance(model.seed, int) and model.seed >= 0)
+        assert model.optimized_metric is None or isinstance(model.optimized_metric, str)
+        assert model.watch_gradients is None or isinstance(model.watch_gradients, bool)
 
 
 class TestTrainConfigRejectsBadInputs:
@@ -87,3 +73,13 @@ class TestTrainConfigRejectsBadInputs:
         """``tags`` is consumed as ``list[str]`` by the run-id helpers."""
         with pytest.raises(ValidationError):
             TrainConfig.model_validate({"task_name": "train", "tags": "dev"})
+
+    def test_blank_ckpt_path_rejected(self) -> None:
+        """``ckpt_path`` is ``NonBlankStr | None`` — whitespace must not pass."""
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            TrainConfig.model_validate({"task_name": "train", "ckpt_path": "   "})
+
+    def test_blank_optimized_metric_rejected(self) -> None:
+        """``optimized_metric`` is ``NonBlankStr | None`` — whitespace must not pass."""
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            TrainConfig.model_validate({"task_name": "train", "optimized_metric": "   "})

--- a/tests/schemas/test_trainer_config.py
+++ b/tests/schemas/test_trainer_config.py
@@ -10,14 +10,12 @@ all shipped variants set.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, cast
 
 import pytest
-from hydra import compose, initialize
-from omegaconf import OmegaConf
 from pydantic import ValidationError
 
 from synth_setter.schemas.trainer_config import TrainerConfig
+from tests.schemas.conftest import compose_subtree
 
 _TRAINER_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "trainer"
 
@@ -29,47 +27,36 @@ def _all_trainer_config_names() -> list[str]:  # noqa: DOC201,DOC203
     return names
 
 
-def _compose_trainer_cfg(trainer_name: str) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Compose a full train config with ``trainer=<trainer_name>`` selected."""
-    with initialize(version_base="1.3", config_path="../../configs"):
-        cfg = compose(
-            config_name="train.yaml",
-            overrides=[f"trainer={trainer_name}", "data=ksin", "model=ffn"],
-        )
-    trainer_subtree = OmegaConf.to_container(cfg.trainer, resolve=False)
-    assert isinstance(trainer_subtree, dict)
-    return cast("dict[str, Any]", trainer_subtree)
-
-
 class TestTrainerConfigAcceptsEveryConfig:
     """Every shipped trainer YAML must validate against ``TrainerConfig``."""
 
     @pytest.mark.parametrize("trainer_name", _all_trainer_config_names())
     def test_trainer_yaml_validates(self, trainer_name: str) -> None:  # noqa: DOC101,DOC103
         """The composed ``trainer`` subtree validates as ``TrainerConfig``."""
-        trainer_subtree = _compose_trainer_cfg(trainer_name)
-        TrainerConfig.model_validate(trainer_subtree)
+        trainer_subtree = compose_subtree("trainer", trainer_name)
+        parsed = TrainerConfig.model_validate(trainer_subtree)
+        assert parsed.target_
 
 
 class TestTrainerConfigCommonFields:
-    """The typed scalar fields must land on the parsed model."""
+    """The typed scalar fields must land on the parsed model with the right types."""
 
     def test_default_cpu_fields_typed(self) -> None:
-        """``cpu.yaml`` carries the expected ``_target_`` / accelerator / devices."""
-        trainer_subtree = _compose_trainer_cfg("cpu")
+        """``cpu.yaml`` carries typed fields with sensible values; assert types/ranges."""
+        trainer_subtree = compose_subtree("trainer", "cpu")
         parsed = TrainerConfig.model_validate(trainer_subtree)
         assert parsed.target_ == "lightning.pytorch.trainer.Trainer"
-        assert parsed.accelerator == "cpu"
-        assert parsed.devices == 1
-        assert parsed.log_every_n_steps == 100
-        assert parsed.val_check_interval == 10_000
-        assert parsed.gradient_clip_val == 1.0
-        assert parsed.check_val_every_n_epoch is None
-        assert parsed.deterministic is False
+        assert isinstance(parsed.accelerator, str) and parsed.accelerator
+        assert isinstance(parsed.devices, int) and parsed.devices > 0
+        assert isinstance(parsed.log_every_n_steps, int) and parsed.log_every_n_steps > 0
+        assert isinstance(parsed.val_check_interval, int) and parsed.val_check_interval > 0
+        assert isinstance(parsed.gradient_clip_val, float) and parsed.gradient_clip_val > 0
+        assert parsed.check_val_every_n_epoch is None or parsed.check_val_every_n_epoch > 0
+        assert isinstance(parsed.deterministic, bool)
 
     def test_mps_variant_keeps_overrides(self) -> None:
         """``mps_32_true_non_deterministic.yaml`` overrides accelerator + precision."""
-        trainer_subtree = _compose_trainer_cfg("mps_32_true_non_deterministic")
+        trainer_subtree = compose_subtree("trainer", "mps_32_true_non_deterministic")
         parsed = TrainerConfig.model_validate(trainer_subtree)
         assert parsed.accelerator == "mps"
         assert parsed.deterministic is False
@@ -93,6 +80,11 @@ class TestTrainerConfigRejectsBadInputs:
         """A blank ``accelerator`` would crash Lightning's backend lookup."""
         with pytest.raises(ValidationError, match="at least 1 character"):
             TrainerConfig.model_validate({**_VALID_TRAINER, "accelerator": "   "})
+
+    def test_blank_default_root_dir_rejected(self) -> None:
+        """``default_root_dir`` is ``NonBlankStr`` — whitespace overrides must fail."""
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            TrainerConfig.model_validate({**_VALID_TRAINER, "default_root_dir": "   "})
 
     def test_zero_devices_rejected(self) -> None:
         """``devices=0`` is meaningless for any accelerator; reject up front."""

--- a/tests/schemas/test_trainer_config.py
+++ b/tests/schemas/test_trainer_config.py
@@ -1,0 +1,110 @@
+"""Behavioural tests for the ``TrainerConfig`` pydantic model.
+
+Every YAML under ``configs/trainer/`` must validate against ``TrainerConfig``
+once Hydra finishes composing it onto ``default.yaml``. Variant-specific
+``Trainer`` kwargs (``strategy``, ``precision``, ``min_steps``, ``max_steps``,
+...) live under ``extra="allow"``; the typed surface here covers the keys
+all shipped variants set.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+from hydra import compose, initialize
+from omegaconf import OmegaConf
+from pydantic import ValidationError
+
+from synth_setter.schemas.trainer_config import TrainerConfig
+
+_TRAINER_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "trainer"
+
+
+def _all_trainer_config_names() -> list[str]:  # noqa: DOC201,DOC203
+    """Return the YAML stem of every direct trainer config under ``configs/trainer/``."""
+    names = sorted(p.stem for p in _TRAINER_CONFIG_DIR.glob("*.yaml"))
+    assert names, f"no trainer YAMLs found under {_TRAINER_CONFIG_DIR} — has the layout changed?"
+    return names
+
+
+def _compose_trainer_cfg(trainer_name: str) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Compose a full train config with ``trainer=<trainer_name>`` selected."""
+    with initialize(version_base="1.3", config_path="../../configs"):
+        cfg = compose(
+            config_name="train.yaml",
+            overrides=[f"trainer={trainer_name}", "data=ksin", "model=ffn"],
+        )
+    trainer_subtree = OmegaConf.to_container(cfg.trainer, resolve=False)
+    assert isinstance(trainer_subtree, dict)
+    return cast("dict[str, Any]", trainer_subtree)
+
+
+class TestTrainerConfigAcceptsEveryConfig:
+    """Every shipped trainer YAML must validate against ``TrainerConfig``."""
+
+    @pytest.mark.parametrize("trainer_name", _all_trainer_config_names())
+    def test_trainer_yaml_validates(self, trainer_name: str) -> None:  # noqa: DOC101,DOC103
+        """The composed ``trainer`` subtree validates as ``TrainerConfig``."""
+        trainer_subtree = _compose_trainer_cfg(trainer_name)
+        TrainerConfig.model_validate(trainer_subtree)
+
+
+class TestTrainerConfigCommonFields:
+    """The typed scalar fields must land on the parsed model."""
+
+    def test_default_cpu_fields_typed(self) -> None:
+        """``cpu.yaml`` carries the expected ``_target_`` / accelerator / devices."""
+        trainer_subtree = _compose_trainer_cfg("cpu")
+        parsed = TrainerConfig.model_validate(trainer_subtree)
+        assert parsed.target_ == "lightning.pytorch.trainer.Trainer"
+        assert parsed.accelerator == "cpu"
+        assert parsed.devices == 1
+        assert parsed.log_every_n_steps == 100
+        assert parsed.val_check_interval == 10_000
+        assert parsed.gradient_clip_val == 1.0
+        assert parsed.check_val_every_n_epoch is None
+        assert parsed.deterministic is False
+
+    def test_mps_variant_keeps_overrides(self) -> None:
+        """``mps_32_true_non_deterministic.yaml`` overrides accelerator + precision."""
+        trainer_subtree = _compose_trainer_cfg("mps_32_true_non_deterministic")
+        parsed = TrainerConfig.model_validate(trainer_subtree)
+        assert parsed.accelerator == "mps"
+        assert parsed.deterministic is False
+
+
+_VALID_TRAINER = {
+    "_target_": "lightning.pytorch.trainer.Trainer",
+    "default_root_dir": "/tmp/out",  # noqa: S108
+    "accelerator": "cpu",
+    "devices": 1,
+    "log_every_n_steps": 100,
+    "val_check_interval": 10_000,
+    "gradient_clip_val": 1.0,
+}
+
+
+class TestTrainerConfigRejectsBadInputs:
+    """Validators must catch obvious mistakes on the typed fields."""
+
+    def test_blank_accelerator_rejected(self) -> None:
+        """A blank ``accelerator`` would crash Lightning's backend lookup."""
+        with pytest.raises(ValidationError, match="at least 1 character"):
+            TrainerConfig.model_validate({**_VALID_TRAINER, "accelerator": "   "})
+
+    def test_zero_devices_rejected(self) -> None:
+        """``devices=0`` is meaningless for any accelerator; reject up front."""
+        with pytest.raises(ValidationError, match="greater than 0"):
+            TrainerConfig.model_validate({**_VALID_TRAINER, "devices": 0})
+
+    def test_negative_log_every_n_steps_rejected(self) -> None:
+        """Lightning rejects non-positive logging cadence; surface it here too."""
+        with pytest.raises(ValidationError, match="greater than 0"):
+            TrainerConfig.model_validate({**_VALID_TRAINER, "log_every_n_steps": -1})
+
+    def test_string_deterministic_rejected(self) -> None:
+        """``deterministic`` is ``StrictBool``; ``"yes"`` must not silently coerce."""
+        with pytest.raises(ValidationError, match="bool"):
+            TrainerConfig.model_validate({**_VALID_TRAINER, "deterministic": "yes"})

--- a/tests/schemas/test_trainer_config.py
+++ b/tests/schemas/test_trainer_config.py
@@ -1,10 +1,7 @@
 """Behavioural tests for the ``TrainerConfig`` pydantic model.
 
-Every YAML under ``configs/trainer/`` must validate against ``TrainerConfig``
-once Hydra finishes composing it onto ``default.yaml``. Variant-specific
-``Trainer`` kwargs (``strategy``, ``precision``, ``min_steps``, ``max_steps``,
-...) live under ``extra="allow"``; the typed surface here covers the keys
-all shipped variants set.
+Every YAML under ``configs/trainer/`` must validate; variant ``Trainer``
+kwargs ride ``extra="allow"``.
 """
 
 from __future__ import annotations

--- a/tests/test_docs_build.py
+++ b/tests/test_docs_build.py
@@ -104,10 +104,24 @@ def built_site(  # noqa: DOC101,DOC103,DOC201,DOC203
     return site_dir
 
 
+def _read_page_html(built_site: Path, page: str) -> str:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Read ``<built_site>/<page>/index.html`` with an actionable miss message.
+
+    Pre-asserts ``is_file()`` so a missing page surfaces as a readable
+    assertion instead of a bare ``FileNotFoundError`` from ``read_text``.
+    """
+    page_html = built_site / page / "index.html"
+    assert page_html.is_file(), (
+        f"{page_html} missing from built site — mkdocs did not emit "
+        f"{page} (see test_docs_page_emitted for the per-page check)"
+    )
+    return page_html.read_text()
+
+
 @pytest.fixture(scope="session")
 def page_html_cache(built_site: Path) -> dict[str, str]:  # noqa: DOC101,DOC103,DOC201,DOC203
     """Memoised HTML text for each config-reference page."""
-    return {page: (built_site / page / "index.html").read_text() for page in _PAGE_TO_MODELS}
+    return {page: _read_page_html(built_site, page) for page in _PAGE_TO_MODELS}
 
 
 @pytest.mark.parametrize("page", list(_PAGE_TO_MODELS))

--- a/tests/test_docs_build.py
+++ b/tests/test_docs_build.py
@@ -1,10 +1,15 @@
 """Integration tests for the mkdocs documentation build.
 
 Runs ``mkdocs build --strict`` in a tmp directory and asserts the rendered
-HTML for each auto-generated config-reference page contains the field names
-declared on the corresponding pydantic model. A model field rename / removal
-without a doc update is caught here at PR time rather than silently dropping
-from the published site.
+HTML for each auto-generated config-reference page contains the field
+anchors mkdocstrings emits for every typed field on the corresponding
+pydantic model. A model field rename / removal without a doc update is
+caught here at PR time rather than silently dropping from the published
+site.
+
+Expected field names are derived from ``model.model_fields`` at test time
+(not hard-coded) so a schema rename surfaces as a missing anchor in the
+rendered HTML without anyone having to remember to update a parallel list.
 
 ``mkdocs`` is in the ``[docs]`` optional dependency group; the whole module
 skips cleanly when the import fails so a developer with only ``[dev]``
@@ -13,6 +18,7 @@ installed can still run the suite.
 
 from __future__ import annotations
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -24,34 +30,42 @@ import pytest
 # and griffe-pydantic, which are pinned together in [project.optional-deps].
 pytest.importorskip("mkdocs", reason="docs extras not installed; install with -e '.[docs]'")
 
+from synth_setter.schemas.model_config import ModelConfig, OptimizerConfig, SchedulerConfig
+from synth_setter.schemas.train_config import TrainConfig
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
-# Field names that must appear in the rendered HTML for each page. Sourced
-# from the pydantic models (``TrainConfig``, ``ModelConfig`` family) so a
-# rename on the model surfaces here as a doc-drift failure instead of
-# silently dropping from the published site. ``mkdocs build --strict``
-# already validates the dataset-spec page renders without warnings, so it
-# does not need a field-list entry here.
-_EXPECTED_FIELDS_BY_PAGE: dict[str, tuple[str, ...]] = {
-    "config_reference/train_config": (
-        "task_name",
-        "tags",
-        "train",
-        "test",
-        "ckpt_path",
-        "seed",
-        "optimized_metric",
-        "watch_gradients",
-    ),
-    "config_reference/model_config": (
-        "_target_",
-        "optimizer",
-        "scheduler",
-        "compile",
-        "lr",
-        "weight_decay",
-    ),
+# Pages map to the pydantic classes whose fields they document. The test
+# derives the expected field set from ``model_fields`` at runtime, so a
+# rename or removal on the schema shows up as a missing anchor in the
+# rendered HTML rather than as a manually-updated constant going stale.
+# ``mkdocs build --strict`` already validates the dataset-spec page renders
+# without warnings, so it doesn't need an entry here.
+_PAGE_TO_MODELS: dict[str, tuple[type, ...]] = {
+    "config_reference/train_config": (TrainConfig,),
+    "config_reference/model_config": (ModelConfig, OptimizerConfig, SchedulerConfig),
 }
+
+
+def _expected_field_anchors() -> list[tuple[str, type, str]]:  # noqa: DOC201,DOC203
+    """Build ``(page, model, field_name)`` tuples for every typed field on every model."""
+    triples: list[tuple[str, type, str]] = []
+    for page, models in _PAGE_TO_MODELS.items():
+        for model in models:
+            for field_name in model.model_fields:
+                triples.append((page, model, field_name))
+    return triples
+
+
+def _anchor_pattern(model: type, field_name: str) -> re.Pattern[str]:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Build the regex matching the heading-anchor ``id`` mkdocstrings emits for a field.
+
+    Targeting the structural anchor (``id="module.Class.field"``) instead of a
+    bare substring avoids false positives from short field names appearing in
+    HTML/CSS/JS context (``lr``, ``test``, ``train``).
+    """
+    fqn = re.escape(f"{model.__module__}.{model.__name__}.{field_name}")
+    return re.compile(rf'id="{fqn}"')
 
 
 @pytest.fixture(scope="session")
@@ -83,7 +97,7 @@ def built_site(  # noqa: DOC101,DOC103,DOC201,DOC203
     return site_dir
 
 
-@pytest.mark.parametrize("page", list(_EXPECTED_FIELDS_BY_PAGE))
+@pytest.mark.parametrize("page", list(_PAGE_TO_MODELS))
 def test_docs_page_emitted(built_site: Path, page: str) -> None:  # noqa: DOC101,DOC103
     """Each config-reference page exists in the built site."""
     page_html = built_site / page / "index.html"
@@ -91,14 +105,17 @@ def test_docs_page_emitted(built_site: Path, page: str) -> None:  # noqa: DOC101
 
 
 @pytest.mark.parametrize(
-    ("page", "field"),
-    [(page, field) for page, fields in _EXPECTED_FIELDS_BY_PAGE.items() for field in fields],
+    ("page", "model", "field"),
+    _expected_field_anchors(),
+    ids=lambda v: v if isinstance(v, str) else getattr(v, "__name__", repr(v)),
 )
-def test_docs_page_renders_pydantic_field(  # noqa: DOC101,DOC103
-    built_site: Path, page: str, field: str
+def test_docs_page_renders_pydantic_field_anchor(  # noqa: DOC101,DOC103
+    built_site: Path, page: str, model: type, field: str
 ) -> None:
-    """Each pydantic-model field appears verbatim in its page's HTML."""
+    """Every typed field on every documented model gets its own anchor heading."""
     page_html = (built_site / page / "index.html").read_text(encoding="utf-8")
-    assert field in page_html, (
-        f"field {field!r} missing from {page} — pydantic model and docs page have drifted"
+    pattern = _anchor_pattern(model, field)
+    assert pattern.search(page_html), (
+        f"anchor {pattern.pattern!r} missing from {page} — "
+        f"{model.__name__}.{field} pydantic field and docs page have drifted"
     )

--- a/tests/test_docs_build.py
+++ b/tests/test_docs_build.py
@@ -22,6 +22,7 @@ import pytest
 # griffe-pydantic from the same ``[docs]`` extras group.
 pytest.importorskip("mkdocs", reason="docs extras not installed; install with -e '.[docs]'")
 
+from synth_setter.pipeline.schemas.spec import DatasetSpec
 from synth_setter.schemas.callbacks_config import CallbackInstance
 from synth_setter.schemas.data_config import DataConfig
 from synth_setter.schemas.extras_config import ExtrasConfig
@@ -39,6 +40,7 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 # RootModel wrappers (CallbacksConfig, LoggerConfig) expose only `root`; we
 # document the per-instance class on those pages instead.
 _PAGE_TO_MODELS: dict[str, tuple[type, ...]] = {
+    "config_reference/dataset_spec": (DatasetSpec,),
     "config_reference/train_config": (TrainConfig,),
     "config_reference/data_config": (DataConfig,),
     "config_reference/model_config": (ModelConfig, OptimizerConfig, SchedulerConfig),

--- a/tests/test_docs_build.py
+++ b/tests/test_docs_build.py
@@ -1,0 +1,104 @@
+"""Integration tests for the mkdocs documentation build.
+
+Runs ``mkdocs build --strict`` in a tmp directory and asserts the rendered
+HTML for each auto-generated config-reference page contains the field names
+declared on the corresponding pydantic model. A model field rename / removal
+without a doc update is caught here at PR time rather than silently dropping
+from the published site.
+
+``mkdocs`` is in the ``[docs]`` optional dependency group; the whole module
+skips cleanly when the import fails so a developer with only ``[dev]``
+installed can still run the suite.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Skip the whole module if the docs extras are not installed. mkdocs is the
+# minimum surface; the strict build wires in mkdocs-material, mkdocstrings,
+# and griffe-pydantic, which are pinned together in [project.optional-deps].
+pytest.importorskip("mkdocs", reason="docs extras not installed; install with -e '.[docs]'")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+# Field names that must appear in the rendered HTML for each page. Sourced
+# from the pydantic models (``TrainConfig``, ``ModelConfig`` family) so a
+# rename on the model surfaces here as a doc-drift failure instead of
+# silently dropping from the published site. ``mkdocs build --strict``
+# already validates the dataset-spec page renders without warnings, so it
+# does not need a field-list entry here.
+_EXPECTED_FIELDS_BY_PAGE: dict[str, tuple[str, ...]] = {
+    "config_reference/train_config": (
+        "task_name",
+        "tags",
+        "train",
+        "test",
+        "ckpt_path",
+        "seed",
+        "optimized_metric",
+        "watch_gradients",
+    ),
+    "config_reference/model_config": (
+        "_target_",
+        "optimizer",
+        "scheduler",
+        "compile",
+        "lr",
+        "weight_decay",
+    ),
+}
+
+
+@pytest.fixture(scope="session")
+def built_site(  # noqa: DOC101,DOC103,DOC201,DOC203
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Path:
+    """Run ``mkdocs build --strict`` once per session and return the site dir."""
+    site_dir = tmp_path_factory.mktemp("mkdocs-site")
+    result = subprocess.run(  # noqa: S603
+        [
+            sys.executable,
+            "-m",
+            "mkdocs",
+            "build",
+            "--strict",
+            "--site-dir",
+            str(site_dir),
+        ],
+        cwd=str(PROJECT_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        pytest.fail(
+            f"mkdocs build --strict failed (exit {result.returncode})\n"
+            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+        )
+    return site_dir
+
+
+@pytest.mark.parametrize("page", list(_EXPECTED_FIELDS_BY_PAGE))
+def test_docs_page_emitted(built_site: Path, page: str) -> None:  # noqa: DOC101,DOC103
+    """Each config-reference page exists in the built site."""
+    page_html = built_site / page / "index.html"
+    assert page_html.is_file(), f"{page_html} missing from built site"
+
+
+@pytest.mark.parametrize(
+    ("page", "field"),
+    [(page, field) for page, fields in _EXPECTED_FIELDS_BY_PAGE.items() for field in fields],
+)
+def test_docs_page_renders_pydantic_field(  # noqa: DOC101,DOC103
+    built_site: Path, page: str, field: str
+) -> None:
+    """Each pydantic-model field appears verbatim in its page's HTML."""
+    page_html = (built_site / page / "index.html").read_text(encoding="utf-8")
+    assert field in page_html, (
+        f"field {field!r} missing from {page} — pydantic model and docs page have drifted"
+    )

--- a/tests/test_docs_build.py
+++ b/tests/test_docs_build.py
@@ -28,6 +28,9 @@ import pytest
 # Skip the whole module if the docs extras are not installed. mkdocs is the
 # minimum surface; the strict build wires in mkdocs-material, mkdocstrings,
 # and griffe-pydantic, which are pinned together in [project.optional-deps].
+# The schemas imports immediately below transitively require those extras
+# (griffe-pydantic introspects model_fields at render time), so the skip
+# must precede them.
 pytest.importorskip("mkdocs", reason="docs extras not installed; install with -e '.[docs]'")
 
 from synth_setter.schemas.callbacks_config import CallbackInstance
@@ -39,20 +42,15 @@ from synth_setter.schemas.paths_config import PathsConfig
 from synth_setter.schemas.train_config import TrainConfig
 from synth_setter.schemas.trainer_config import TrainerConfig
 
+# End-to-end mkdocs build is heavyweight (subprocess + mkdocs + mkdocstrings +
+# griffe + every schemas module imported); marker keeps `make test-fast` fast.
+pytestmark = pytest.mark.slow
+
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
-# Pages map to the pydantic classes whose typed fields they document. The
-# test derives the expected field set from ``model_fields`` at runtime, so a
-# rename or removal on the schema shows up as a missing anchor in the
-# rendered HTML rather than as a manually-updated constant going stale.
-# ``mkdocs build --strict`` already validates the dataset-spec page renders
-# without warnings, so it doesn't need an entry here.
-#
-# ``CallbacksConfig`` and ``LoggerConfig`` are ``RootModel`` wrappers around
-# ``dict[str, CallbackInstance | LoggerInstance]``; their only declared field
-# is ``root`` and griffe-pydantic doesn't surface it as an anchor heading.
-# The callbacks/logger pages also render the inner instance model, so the
-# per-field assertions exercise that class instead.
+# Maps each config-reference page to the pydantic class(es) whose typed fields
+# it documents. RootModel wrappers (CallbacksConfig, LoggerConfig) expose only
+# `root`; the per-instance class is documented instead.
 _PAGE_TO_MODELS: dict[str, tuple[type, ...]] = {
     "config_reference/train_config": (TrainConfig,),
     "config_reference/data_config": (DataConfig,),
@@ -75,12 +73,21 @@ def _expected_field_anchors() -> list[tuple[str, type, str]]:  # noqa: DOC201,DO
     return triples
 
 
-def _anchor_pattern(model: type, field_name: str) -> re.Pattern[str]:  # noqa: DOC101,DOC103,DOC201,DOC203
+assert _PAGE_TO_MODELS, "_PAGE_TO_MODELS is empty — config-reference page map is missing"
+assert _expected_field_anchors(), "_expected_field_anchors() is empty — no fields to verify"
+
+
+def _anchor_pattern(model: type, field_name: str) -> re.Pattern[str]:
     """Build the regex matching the heading-anchor ``id`` mkdocstrings emits for a field.
 
     Targeting the structural anchor (``id="module.Class.field"``) instead of a
     bare substring avoids false positives from short field names appearing in
     HTML/CSS/JS context (``lr``, ``test``, ``train``).
+
+    :param model: The pydantic class whose field anchor we expect to find.
+    :param field_name: The field attribute name on ``model``.
+    :returns: Compiled regex anchored on ``id="<module>.<Class>.<field>"``.
+    :rtype: re.Pattern[str]
     """
     fqn = re.escape(f"{model.__module__}.{model.__name__}.{field_name}")
     return re.compile(rf'id="{fqn}"')
@@ -92,27 +99,34 @@ def built_site(  # noqa: DOC101,DOC103,DOC201,DOC203
 ) -> Path:
     """Run ``mkdocs build --strict`` once per session and return the site dir."""
     site_dir = tmp_path_factory.mktemp("mkdocs-site")
-    result = subprocess.run(  # noqa: S603
-        [
-            sys.executable,
-            "-m",
-            "mkdocs",
-            "build",
-            "--strict",
-            "--site-dir",
-            str(site_dir),
-        ],
-        cwd=str(PROJECT_ROOT),
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    if result.returncode != 0:
+    try:
+        subprocess.run(  # noqa: S603
+            [
+                sys.executable,
+                "-m",
+                "mkdocs",
+                "build",
+                "--strict",
+                "--site-dir",
+                str(site_dir),
+            ],
+            cwd=str(PROJECT_ROOT),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
         pytest.fail(
-            f"mkdocs build --strict failed (exit {result.returncode})\n"
-            f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+            f"mkdocs build --strict failed (exit {exc.returncode})\n"
+            f"--- stdout ---\n{exc.stdout}\n--- stderr ---\n{exc.stderr}"
         )
     return site_dir
+
+
+@pytest.fixture(scope="session")
+def page_html_cache(built_site: Path) -> dict[str, str]:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Memoised HTML text for each config-reference page."""
+    return {page: (built_site / page / "index.html").read_text() for page in _PAGE_TO_MODELS}
 
 
 @pytest.mark.parametrize("page", list(_PAGE_TO_MODELS))
@@ -128,20 +142,26 @@ def test_docs_page_emitted(built_site: Path, page: str) -> None:  # noqa: DOC101
     ids=lambda v: v if isinstance(v, str) else getattr(v, "__name__", repr(v)),
 )
 def test_docs_page_renders_pydantic_field_anchor(  # noqa: DOC101,DOC103
-    built_site: Path, page: str, model: type, field: str
+    page_html_cache: dict[str, str], page: str, model: type, field: str
 ) -> None:
     """Every typed field on every documented model gets its own anchor heading."""
-    # Assert the file exists before reading so a missing page surfaces as a
-    # clear pytest assertion (with the page name) rather than the raw
-    # FileNotFoundError that ``read_text`` would raise — the dedicated
-    # ``test_docs_page_emitted`` case still owns the per-page emission check.
-    page_html_path = built_site / page / "index.html"
-    assert page_html_path.is_file(), (
-        f"{page_html_path} missing from built site — see test_docs_page_emitted"
-    )
-    page_html = page_html_path.read_text(encoding="utf-8")
+    assert page in page_html_cache, f"{page} missing from built site — see test_docs_page_emitted"
+    page_html = page_html_cache[page]
     pattern = _anchor_pattern(model, field)
     assert pattern.search(page_html), (
         f"anchor {pattern.pattern!r} missing from {page} — "
         f"{model.__name__}.{field} pydantic field and docs page have drifted"
+    )
+
+
+def test_docs_train_config_renders_field_description(  # noqa: DOC101,DOC103
+    page_html_cache: dict[str, str],
+) -> None:
+    """``TrainConfig.task_name``'s ``Field(description=...)`` text renders in the page."""
+    description = TrainConfig.model_fields["task_name"].description
+    assert description, "TrainConfig.task_name has no Field(description=...) to spot-check"
+    page_html = page_html_cache["config_reference/train_config"]
+    assert description in page_html, (
+        f"TrainConfig.task_name description {description!r} missing from rendered page — "
+        f"mkdocstrings emitted the anchor but dropped the Field(description=...) body"
     )

--- a/tests/test_docs_build.py
+++ b/tests/test_docs_build.py
@@ -131,7 +131,15 @@ def test_docs_page_renders_pydantic_field_anchor(  # noqa: DOC101,DOC103
     built_site: Path, page: str, model: type, field: str
 ) -> None:
     """Every typed field on every documented model gets its own anchor heading."""
-    page_html = (built_site / page / "index.html").read_text(encoding="utf-8")
+    # Assert the file exists before reading so a missing page surfaces as a
+    # clear pytest assertion (with the page name) rather than the raw
+    # FileNotFoundError that ``read_text`` would raise — the dedicated
+    # ``test_docs_page_emitted`` case still owns the per-page emission check.
+    page_html_path = built_site / page / "index.html"
+    assert page_html_path.is_file(), (
+        f"{page_html_path} missing from built site — see test_docs_page_emitted"
+    )
+    page_html = page_html_path.read_text(encoding="utf-8")
     pattern = _anchor_pattern(model, field)
     assert pattern.search(page_html), (
         f"anchor {pattern.pattern!r} missing from {page} — "

--- a/tests/test_docs_build.py
+++ b/tests/test_docs_build.py
@@ -30,20 +30,38 @@ import pytest
 # and griffe-pydantic, which are pinned together in [project.optional-deps].
 pytest.importorskip("mkdocs", reason="docs extras not installed; install with -e '.[docs]'")
 
+from synth_setter.schemas.callbacks_config import CallbackInstance
+from synth_setter.schemas.data_config import DataConfig
+from synth_setter.schemas.extras_config import ExtrasConfig
+from synth_setter.schemas.logger_config import LoggerInstance
 from synth_setter.schemas.model_config import ModelConfig, OptimizerConfig, SchedulerConfig
+from synth_setter.schemas.paths_config import PathsConfig
 from synth_setter.schemas.train_config import TrainConfig
+from synth_setter.schemas.trainer_config import TrainerConfig
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
-# Pages map to the pydantic classes whose fields they document. The test
-# derives the expected field set from ``model_fields`` at runtime, so a
+# Pages map to the pydantic classes whose typed fields they document. The
+# test derives the expected field set from ``model_fields`` at runtime, so a
 # rename or removal on the schema shows up as a missing anchor in the
 # rendered HTML rather than as a manually-updated constant going stale.
 # ``mkdocs build --strict`` already validates the dataset-spec page renders
 # without warnings, so it doesn't need an entry here.
+#
+# ``CallbacksConfig`` and ``LoggerConfig`` are ``RootModel`` wrappers around
+# ``dict[str, CallbackInstance | LoggerInstance]``; their only declared field
+# is ``root`` and griffe-pydantic doesn't surface it as an anchor heading.
+# The callbacks/logger pages also render the inner instance model, so the
+# per-field assertions exercise that class instead.
 _PAGE_TO_MODELS: dict[str, tuple[type, ...]] = {
     "config_reference/train_config": (TrainConfig,),
+    "config_reference/data_config": (DataConfig,),
     "config_reference/model_config": (ModelConfig, OptimizerConfig, SchedulerConfig),
+    "config_reference/callbacks_config": (CallbackInstance,),
+    "config_reference/logger_config": (LoggerInstance,),
+    "config_reference/trainer_config": (TrainerConfig,),
+    "config_reference/paths_config": (PathsConfig,),
+    "config_reference/extras_config": (ExtrasConfig,),
 }
 
 

--- a/tests/test_docs_build.py
+++ b/tests/test_docs_build.py
@@ -1,19 +1,12 @@
 """Integration tests for the mkdocs documentation build.
 
-Runs ``mkdocs build --strict`` in a tmp directory and asserts the rendered
-HTML for each auto-generated config-reference page contains the field
-anchors mkdocstrings emits for every typed field on the corresponding
-pydantic model. A model field rename / removal without a doc update is
-caught here at PR time rather than silently dropping from the published
-site.
+Runs ``mkdocs build --strict`` once per session and asserts each
+config-reference page renders an anchor for every typed pydantic field on
+its documented model. Field names are derived from ``model_fields`` at test
+time so a rename surfaces as a missing anchor without a parallel list.
 
-Expected field names are derived from ``model.model_fields`` at test time
-(not hard-coded) so a schema rename surfaces as a missing anchor in the
-rendered HTML without anyone having to remember to update a parallel list.
-
-``mkdocs`` is in the ``[docs]`` optional dependency group; the whole module
-skips cleanly when the import fails so a developer with only ``[dev]``
-installed can still run the suite.
+Whole module skips on a minimal ``[dev]`` install via
+``pytest.importorskip("mkdocs")``.
 """
 
 from __future__ import annotations
@@ -25,12 +18,8 @@ from pathlib import Path
 
 import pytest
 
-# Skip the whole module if the docs extras are not installed. mkdocs is the
-# minimum surface; the strict build wires in mkdocs-material, mkdocstrings,
-# and griffe-pydantic, which are pinned together in [project.optional-deps].
-# The schemas imports immediately below transitively require those extras
-# (griffe-pydantic introspects model_fields at render time), so the skip
-# must precede them.
+# Skip precedes the schemas imports because they transitively require
+# griffe-pydantic from the same ``[docs]`` extras group.
 pytest.importorskip("mkdocs", reason="docs extras not installed; install with -e '.[docs]'")
 
 from synth_setter.schemas.callbacks_config import CallbackInstance
@@ -42,15 +31,13 @@ from synth_setter.schemas.paths_config import PathsConfig
 from synth_setter.schemas.train_config import TrainConfig
 from synth_setter.schemas.trainer_config import TrainerConfig
 
-# End-to-end mkdocs build is heavyweight (subprocess + mkdocs + mkdocstrings +
-# griffe + every schemas module imported); marker keeps `make test-fast` fast.
+# mkdocs subprocess + griffe walk is heavyweight; keeps `make test-fast` fast.
 pytestmark = pytest.mark.slow
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 
-# Maps each config-reference page to the pydantic class(es) whose typed fields
-# it documents. RootModel wrappers (CallbacksConfig, LoggerConfig) expose only
-# `root`; the per-instance class is documented instead.
+# RootModel wrappers (CallbacksConfig, LoggerConfig) expose only `root`; we
+# document the per-instance class on those pages instead.
 _PAGE_TO_MODELS: dict[str, tuple[type, ...]] = {
     "config_reference/train_config": (TrainConfig,),
     "config_reference/data_config": (DataConfig,),
@@ -77,17 +64,11 @@ assert _PAGE_TO_MODELS, "_PAGE_TO_MODELS is empty — config-reference page map 
 assert _expected_field_anchors(), "_expected_field_anchors() is empty — no fields to verify"
 
 
-def _anchor_pattern(model: type, field_name: str) -> re.Pattern[str]:
-    """Build the regex matching the heading-anchor ``id`` mkdocstrings emits for a field.
+def _anchor_pattern(model: type, field_name: str) -> re.Pattern[str]:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Compile a regex for the ``id="<module>.<Class>.<field>"`` anchor mkdocstrings emits.
 
-    Targeting the structural anchor (``id="module.Class.field"``) instead of a
-    bare substring avoids false positives from short field names appearing in
-    HTML/CSS/JS context (``lr``, ``test``, ``train``).
-
-    :param model: The pydantic class whose field anchor we expect to find.
-    :param field_name: The field attribute name on ``model``.
-    :returns: Compiled regex anchored on ``id="<module>.<Class>.<field>"``.
-    :rtype: re.Pattern[str]
+    Matches the structural anchor (not a bare substring) so short field names
+    (``lr``, ``test``, ``train``) don't false-positive on HTML/CSS/JS context.
     """
     fqn = re.escape(f"{model.__module__}.{model.__name__}.{field_name}")
     return re.compile(rf'id="{fqn}"')


### PR DESCRIPTION
## Summary

Adds the second and third models to the auto-generated config-reference site stood up by [#936](https://github.com/tinaudio/synth-setter/issues/936) — the training entrypoint's `configs/train.yaml` (`TrainConfig`) and the per-model YAMLs under `configs/model/` (`ModelConfig` + `OptimizerConfig` + `SchedulerConfig`). The schemas use `strict=True, extra=\"allow\"` so they refuse silent coercion on the typed scalar surface while letting Hydra-composed subtrees pass through, and `mkdocstrings` + `griffe-pydantic` render the per-field `description=` strings into two new pages under `docs/config_reference/`.

## What's in the diff

- `src/synth_setter/schemas/{__init__,_types,train_config,model_config}.py` — new sibling to `synth_setter.pipeline.schemas/`. The shared `NonBlankStr` annotation lives in `_types.py` to avoid a circular import.
- `docs/config_reference/{train_config,model_config}.md` — new mkdocstrings pages.
- `mkdocs.yml` — `paths: [src]` (PEP src-layout fix), `griffe-pydantic` extension wired in, two new nav entries.
- `tests/schemas/` — behavioural tests asserting every shipped train/model YAML validates and bad inputs are rejected. The `clean_global_hydra` autouse fixture in `conftest.py` keeps xdist-parallel runs deterministic.
- `tests/test_docs_build.py` — runs `mkdocs build --strict` and asserts each pydantic field name renders in its page HTML, catching drift between the schemas and the published pages at PR time.
- `.github/workflows/docs.yml` — gains a `build-docs` job on `pull_request` events that installs `[docs,dev]`, runs `mkdocs build --strict`, and exercises both `tests/test_docs_build.py` and `tests/schemas/` so the field-rendering assertions actually execute in CI.

## Why a new `synth_setter/schemas/` package

There's an existing `synth_setter.pipeline.schemas` for pipeline-side trust boundaries (DatasetSpec, ImageConfig, ShardMetadata). The training-time configs are a separate trust boundary with different strictness conventions (`extra=\"allow\"` to let Hydra-composed subtrees pass through), so they live in a parallel `synth_setter.schemas` package rather than mixing into the pipeline namespace. The module docstring on `synth_setter/schemas/__init__.py` calls this out.

## Test plan

- [ ] CI green on `build-docs` job (build + pytest)
- [ ] CI green on `test` job (no regression in `tests/test_configs.py` etc.)
- [ ] Local `mkdocs serve` renders both new pages with field tables
- [ ] All 39 new tests pass: `pytest tests/schemas/ tests/test_docs_build.py`
- [ ] Pre-commit hooks pass (ruff, pyright, pydoclint, etc.)

Refs #936