### PR TITLE
chore(claude-md): gate gh pr create behind /repo-review-full

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,7 +30,7 @@
       },
       {
         "matcher": "Bash",
-        "if": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[;|&`(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'",
+        "if": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[;|&`(][[:space:]]*)([[:alpha:]_][[:alnum:]_]*=[^[:space:]]+[[:space:]]+)*gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'",
         "description": "Pre-PR review gate: blocks gh pr create unless the command contains REVIEW_FULL_DONE=1 (anywhere in the command — recommended as a trailing comment so other gh-pr-create hooks still fire). Forces Claude to invoke /repo-review-full-no-comments and iterate on findings before opening a PR. The acknowledgment token is intentionally Claude-supplied — the gate is a circuit-breaker that forces a pause, not unbypassable security.",
         "hooks": [
           {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,6 +27,17 @@
             "command": "branch=$(git branch --show-current 2>/dev/null || true); if [ -z \"$branch\" ]; then branch=\"DETACHED HEAD\"; fi; echo \"Committing to branch: $branch\" >&2"
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "if": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[;|&`(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'",
+        "description": "Pre-PR review gate: blocks gh pr create unless the command contains REVIEW_FULL_DONE=1 (anywhere in the command — recommended as a trailing comment so other gh-pr-create hooks still fire). Forces Claude to invoke /repo-review-full-no-comments and iterate on findings before opening a PR. The acknowledgment token is intentionally Claude-supplied — the gate is a circuit-breaker that forces a pause, not unbypassable security.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -q 'REVIEW_FULL_DONE=1'; then exit 0; else echo 'BLOCKED: gh pr create requires running /repo-review-full-no-comments first. Run that skill, address every BLOCK/WARN finding (or document why each is intentional), then re-run with REVIEW_FULL_DONE=1 included in the command — recommended as a trailing comment so other hooks still fire: gh pr create --title ... --body ... # REVIEW_FULL_DONE=1' >&2; exit 2; fi"
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,8 +30,8 @@
       },
       {
         "matcher": "Bash",
-        "if": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[;|&`(][[:space:]]*)([[:alpha:]_][[:alnum:]_]*=[^[:space:]]+[[:space:]]+)*gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'",
-        "description": "Pre-PR review gate: blocks gh pr create unless the command contains REVIEW_FULL_DONE=1 (anywhere in the command — recommended as a trailing comment so other gh-pr-create hooks still fire). Forces Claude to invoke /repo-review-full-no-comments and iterate on findings before opening a PR. The acknowledgment token is intentionally Claude-supplied — the gate is a circuit-breaker that forces a pause, not unbypassable security.",
+        "if": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[;|&`(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'",
+        "description": "Pre-PR review gate: blocks gh pr create unless the command contains REVIEW_FULL_DONE=1 (recommended as a trailing comment so other gh-pr-create hooks still fire). Forces Claude to invoke /repo-review-full-no-comments and iterate on findings before opening a PR. The acknowledgment token is intentionally Claude-supplied — the gate is a circuit-breaker that forces a pause, not unbypassable security.",
         "hooks": [
           {
             "type": "command",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,18 @@ Example:
 
 The bad version forces the reader to ask "Hydra migration of *what*?" — the project has had several. The good version answers that question in the title.
 
+### Pre-PR Review Gate
+
+Before every `gh pr create`, run `/repo-review-full-no-comments` and iterate on every BLOCK and WARN finding (fix the code, or document in the PR body why the finding is intentional). Open the PR only after the review report comes back clean.
+
+A `PreToolUse` hook in `.claude/settings.json` enforces this — `gh pr create` is blocked unless the command contains the literal `REVIEW_FULL_DONE=1` (anywhere in the line). Recommended form is a trailing comment, which preserves the other `gh pr create` hooks (doc-drift, pr-checkbox, taxonomy verification):
+
+```bash
+gh pr create --title "..." --body "..."  # REVIEW_FULL_DONE=1
+```
+
+The token is honor-system — it forces a pause to invoke the skill, not unbypassable security. If you genuinely don't need a review for this change (rare; usually pure docs touch-ups already exempt from the mandatory skills), the token still has to be present and the PR description should say why review was skipped.
+
 ### PR Readiness
 
 **Hard gate (all four must hold).** A PR is ready iff:


### PR DESCRIPTION
## Summary

- Adds a `PreToolUse` hook on `Bash`/`gh pr create` in `.claude/settings.json` that blocks PR creation unless the command contains `REVIEW_FULL_DONE=1` (matched anywhere — recommended as a trailing comment).
- Adds a `### Pre-PR Review Gate` sub-section to `CLAUDE.md` so the convention is discoverable.

The token is honor-system — it forces a pause to invoke `/repo-review-full-no-comments` and iterate on its BLOCK/WARN findings, not unbypassable security. The `if` regex matches the same shape as the existing doc-drift hook, so the gate fires on exactly the same set of `gh pr create` invocations.

The acknowledgment is matched as a substring rather than only at start-of-command, so the canonical form is a trailing comment — that keeps `gh pr create ...` at the start of the line, preserving the existing doc-drift, pr-checkbox, and taxonomy-verification `PostToolUse` hooks (whose regexes require `gh` at start-of-command or after a shell operator):

```bash
gh pr create --title "..." --body "..."  # REVIEW_FULL_DONE=1
```

## Test plan

- [x] Pipe-tested the hook command in three branches before installing: missing token → exit 2 + stderr message, trailing-comment token → exit 0, env-var-prefix token → exit 0.
- [x] `jq empty .claude/settings.json` passes; `jq -e` extracts the new hook's `.command`.
- [x] `make format` clean on the worktree (all pre-commit hooks pass).
- [ ] Activate the new hook in a fresh session (open `/hooks` or restart) and confirm a bare `gh pr create` in that session is blocked with the BLOCKED message.
- [ ] Confirm a `gh pr create ... # REVIEW_FULL_DONE=1` invocation in that fresh session passes the gate and the downstream `PostToolUse` hooks (doc-drift, pr-checkbox, taxonomy) still fire.

## Skill applicability

- `/tdd-implementation`, `/code-health`, `/simplify`: not naturally applicable — this is a single hook entry in `.claude/settings.json` plus a CLAUDE.md note, with no Python under test. The TDD-equivalent verification was the three-branch pipe test of the hook command before installation (see Test plan).
- `/repo-review-full-no-comments`: skipped on this PR (the hook isn't yet enforced — that's what this PR adds). Future PRs will go through the gate.

Closes #1072