### PR TITLE
feat(claude-md): wire comment-hygiene skill into repo-review

### DIFF
--- a/.claude/skills/_shared/repo-review-full-analysis.md
+++ b/.claude/skills/_shared/repo-review-full-analysis.md
@@ -57,13 +57,15 @@ Read the file list from Step 1. Map file types → relevant skills:
 | File pattern | Skills to run |
 |---|---|
 | Always | `code-health`, `synth-setter-project-standards` |
-| `*.py` | `python-style`, `tdd-implementation` |
+| `*.py` | `python-style`, `tdd-implementation`, `comment-hygiene` |
 | `*.sh` or bash inside YAML `run:` blocks | `shell-style` |
-| `.github/workflows/*.{yml,yaml}` | `gha-workflow-validator` |
+| `.github/workflows/*.{yml,yaml}` | `gha-workflow-validator`, `comment-hygiene` |
+| Any `*.{yml,yaml}` under `configs/` | `comment-hygiene` |
+| `docs/doc-map.yaml` | `comment-hygiene` |
 | ML model / pipeline / training code under `src/synth_setter/` | `ml-data-pipeline`, `ml-test` |
 | Diff renames or moves files (anything with `R` in `git diff --name-status`) | `tdd-refactor` |
 
-Always run `code-health` and `synth-setter-project-standards`. Other skills opt in based on file extensions in the diff. Note which skills you selected; you'll launch one parallel agent per skill.
+Always run `code-health` and `synth-setter-project-standards`. Other skills opt in based on file extensions in the diff. `comment-hygiene` deduplicates: even if multiple rows above select it, fan out only one parallel agent per skill. Note which skills you selected; you'll launch one parallel agent per skill.
 
 ## Step 4: Launch parallel review agents
 
@@ -111,6 +113,7 @@ Skill → tag (short form for comment body):
 | Plugin skill | Comment-body tag |
 |---|---|
 | `code-health` | `code-health` |
+| `comment-hygiene` | `comment-hygiene` |
 | `shell-style` | `shell-style` |
 | `python-style` | `python-style` |
 | `gha-workflow-validator` | `gha` |

--- a/.claude/skills/repo-review/SKILL.md
+++ b/.claude/skills/repo-review/SKILL.md
@@ -85,9 +85,25 @@ Categories: `comment-hygiene`, `yaml-bash`, `python`, `shell`, `pipeline`, `secu
 
 **Comment hygiene (CLAUDE.md "Comment Hygiene" + "No Comments Inside YAML run: Block-Scalars")**
 
-- [comment-hygiene] No comment restates a constant value, count, or list contents (`# 6 samples`, `# three things: a, b, c`).
-- [comment-hygiene] No multi-paragraph essay-comments. If a comment runs more than ~2 lines, replace with a one-line pointer to a GitHub issue.
-- [yaml-bash] **No `#`-comments inside `run: |` or `setup: |` block-scalars** in `.github/workflows/*.{yml,yaml}` or `configs/compute/*.yaml`. Comments belong ABOVE the `run:` key, not inside the bash. This is a HARD project rule — flag every occurrence as BLOCK.
+Rule IDs `C1`–`C12` are the full schema in the plugin's `comment-hygiene` skill (run via `/repo-review-full` or directly when the plugin is available). The MVP repeats the highest-signal subset inline so external contributors and plugin-less environments still get coverage. When in doubt about a flag, defer to the plugin's per-finding `Before / After` rewrites.
+
+BLOCK items (hard CLAUDE.md rules — always flag):
+
+- [comment-hygiene C1] **No `#`-comments inside `run: |` or `setup: |` block-scalars** in `.github/workflows/*.{yml,yaml}` or `configs/compute/*.yaml`. Comments belong ABOVE the `run:` key, not inside the bash.
+- [comment-hygiene C2] No comment restates a literal constant value next to its assignment (`num = 6  # 6 items`).
+- [comment-hygiene C3] No comment enumerates list contents in prose (`THINGS = [...]  # a, b, c`). The list IS the source of truth.
+- [comment-hygiene C4] No baked-in counts the code already reports (`# 29 comments triaged`, `# 5 metric series`) — belongs in the PR description, not in source.
+
+WARN items (bloat patterns — flag when the diff adds them):
+
+- [comment-hygiene C5] No multi-line comment essay (>2 lines) without a one-line issue/PR pointer alternative.
+- [comment-hygiene C6] No docstring `:param:` / `:return:` / `:raises:` section that only restates the type hint. Pydoclint requires the summary line only; drop the boilerplate.
+- [comment-hygiene C7] No docstring that only restates the function name (`"""Compute the mel spectrogram."""` on `compute_mel_spectrogram`).
+- [comment-hygiene C8] No generic filler opener (`"""This module provides..."""`, `"""Helper function that..."""`, `"""Utility for..."""`, `"""Wrapper around..."""`).
+- [comment-hygiene C9] No decorative banner separator (`# ----- foo -----`, `# === SECTION ===`, `# ###############`).
+- [comment-hygiene C10] No commented-out config block without a rationale comment beside it explaining why it's disabled.
+- [comment-hygiene C11] No tombstone comment for removed code (`# was X`, `# previously Y`, `# removed in #N`). Git log is authoritative.
+- [comment-hygiene C12] No `doc-map.yaml` description that packs 3+ sub-claims, nested parens, internal `§` section pointers, title-restatement, or filler hedges ("various", "several", "general purpose").
 
 **Python (CLAUDE.md "Writing Code" + plugin `python-style` BLOCK items)**
 

--- a/.claude/skills/repo-review/SKILL.md
+++ b/.claude/skills/repo-review/SKILL.md
@@ -85,7 +85,7 @@ Categories: `comment-hygiene`, `yaml-bash`, `python`, `shell`, `pipeline`, `secu
 
 **Comment hygiene (CLAUDE.md "Comment Hygiene" + "No Comments Inside YAML run: Block-Scalars")**
 
-Rule IDs `C1`–`C12` are the full schema in the plugin's `comment-hygiene` skill (run via `/repo-review-full` or directly when the plugin is available). The MVP repeats the highest-signal subset inline so external contributors and plugin-less environments still get coverage. When in doubt about a flag, defer to the plugin's per-finding `Before / After` rewrites.
+Rule IDs `C1`–`C12` are the full BLOCK/WARN schema in the plugin's `comment-hygiene` skill (run via `/repo-review-full` or directly when the plugin is available). The MVP repeats the same rule IDs inline so external contributors and plugin-less environments still get coverage; what the MVP omits is the plugin's per-finding `Before / After` rewrites (and the two NIT-severity items C13–C14). When in doubt about a flag, defer to the plugin's per-finding rewrites.
 
 BLOCK items (hard CLAUDE.md rules — always flag):
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,7 @@ Canonical checklist reference (full content lives in the plugin):
 5. `python-style` — Google Python Style Guide (21 items)
 6. `shell-style` — Google Shell Style Guide (19 items, `.sh` files + bash inside YAML `run:` blocks)
 7. `ml-test` — ML testing (25 items, model/pipeline test code)
+8. `comment-hygiene` — Inline-text hygiene (12 items, `*.py` + `*.{yml,yaml}` + `docs/doc-map.yaml`: `#`-comments, docstrings, doc-map entries; emits suggested rewrites for every finding)
 
 Review all changed code against every applicable checklist. Skip style issues (Ruff handles formatting and linting).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,7 +234,7 @@ Canonical checklist reference (full content lives in the plugin):
 5. `python-style` — Google Python Style Guide (21 items)
 6. `shell-style` — Google Shell Style Guide (19 items, `.sh` files + bash inside YAML `run:` blocks)
 7. `ml-test` — ML testing (25 items, model/pipeline test code)
-8. `comment-hygiene` — Inline-text hygiene (12 items, `*.py` + `*.{yml,yaml}` + `docs/doc-map.yaml`: `#`-comments, docstrings, doc-map entries; emits suggested rewrites for every finding)
+8. `comment-hygiene` — Inline-text hygiene (12 items; `*.py` + `.github/workflows/*.{yml,yaml}` + `configs/**/*.{yml,yaml}` + `docs/doc-map.yaml`: `#`-comments, docstrings, doc-map entries; emits suggested rewrites for every finding). Requires the `tinaudio-synth-setter-skills` plugin to be installed — `/repo-review-full` will fail-loud if the skill isn't resolvable.
 
 Review all changed code against every applicable checklist. Skip style issues (Ruff handles formatting and linting).
 


### PR DESCRIPTION
## Summary

Wires the new [`tinaudio-synth-setter-skills:comment-hygiene`](https://github.com/tinaudio/skills/pull/83) plugin skill into the three synth-setter surfaces that the `/repo-review` and `/repo-review-full` workflows read from. The skill flags filler text in `#`-comments, Python docstrings, YAML / workflow comments, and `docs/doc-map.yaml` entries — and emits a suggested rewrite for every flagged passage.

No edits to existing comments or docstrings in this PR. That cleanup sweep is the natural follow-up once the skill starts firing in CI.

## What changed

| File | Change |
|---|---|
| `CLAUDE.md` | "Code Review" canonical checklist gains `comment-hygiene` as item #8 (list was 7, now 8) |
| `.claude/skills/_shared/repo-review-full-analysis.md` | Step 3 selection table routes `*.py`, `.github/workflows/*.{yml,yaml}`, `configs/*.{yml,yaml}`, and `docs/doc-map.yaml` through the new skill. Step 5 tag table adds the `comment-hygiene` short-form tag for `[comment-hygiene:<severity>]` comment prefixes. Dedup note added (a single skill can be selected by multiple file-pattern rows but should fan out only one parallel agent). |
| `.claude/skills/repo-review/SKILL.md` (MVP) | The existing inline `[comment-hygiene]` block had two rules; expanded to mirror the plugin's `C1`–`C12` schema so external contributors and plugin-less environments see the same checklist surface — without bloating the MVP (per-finding `Before / After` rewrites stay in the plugin). |

Diff is small — 3 files, 26 insertions, 6 deletions:

```
 .claude/skills/_shared/repo-review-full-analysis.md   |  9 ++++++---
 .claude/skills/repo-review/SKILL.md                   | 22 +++++++++++++++++++---
 CLAUDE.md                                             |  1 +
```

## Linkage

- **Plugin PR (must merge first):** [tinaudio/skills#83](https://github.com/tinaudio/skills/pull/83) — adds the `comment-hygiene` skill source. This PR depends on that one landing so the plugin actually serves the skill the orchestrator selects.
- **Tracking issue:** `Refs #1074` (Task under [#441](https://github.com/tinaudio/synth-setter/issues/441) Phase 2: Doc Infrastructure & Drift → [#351](https://github.com/tinaudio/synth-setter/issues/351) Epic: documentation quality and drift detection).

## Out of scope (separate PRs)

- Editing existing comments / docstrings in the codebase against the new checklist (cleanup sweep — likely worth running per-directory under [#1074](https://github.com/tinaudio/synth-setter/issues/1074)'s follow-ups, not in one giant PR).
- Adding `comment-hygiene` to `docs/doc-map.yaml` itself (the skill source lives in the plugin repo, not in synth-setter).
- Any change to `.claude/skills/_shared/post_review.py` (the new tag fits the existing `[<skill>:<severity>]` prefix shape — verified).

## Test plan

- [ ] `pre-commit run --files CLAUDE.md .claude/skills/_shared/repo-review-full-analysis.md .claude/skills/repo-review/SKILL.md` passes (verified locally — mdformat + codespell + trailing-whitespace all clean).
- [ ] CI workflow `pr-metadata-gate.yaml` passes (linked issue [#1074](https://github.com/tinaudio/synth-setter/issues/1074) has type=Task, label=documentation, milestone=`documentation v1.0.0`, parent Phase=#441 — verified before PR creation).
- [ ] After merge + plugin update: run `/repo-review-full` against any PR that touches `*.py` and confirm the orchestrator fans out a `comment-hygiene` agent and posts findings prefixed `[comment-hygiene:block]` / `[comment-hygiene:warn]`.
- [ ] Run `/repo-review` (MVP, no plugin) against the same PR and confirm the expanded `[comment-hygiene]` block surfaces the C1–C12 rules in the inline checklist.

Refs #1074