### PR TITLE
refactor(eval): extract predict_vst_audio helpers; drop unused param_spec

### DIFF
--- a/.pydoclint-baseline.txt
+++ b/.pydoclint-baseline.txt
@@ -111,10 +111,6 @@ src/synth_setter/evaluation/compute_audio_metrics.py
     DOC201: Function `subdir_matches_pattern` does not have a return section in docstring
     DOC203: Function `subdir_matches_pattern` return type(s) in docstring not consistent with the return annotation. Return annotation has 1 type(s); docstring return section has 0 type(s).
 --------------------
-src/synth_setter/evaluation/predict_vst_audio.py
-    DOC101: Function `params_to_csv`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `params_to_csv`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [param_spec: ParamSpec, pred_note_params: dict[str, float], pred_synth_params: dict[str, float], save_path: str, target_note_params: dict[str, float], target_synth_params: dict[str, float]].
---------------------
 src/synth_setter/metrics.py
     DOC101: Method `LogSpectralDistance.__init__`: Docstring contains fewer arguments than in function signature.
     DOC103: Method `LogSpectralDistance.__init__`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [**kwargs: , eps: float].

--- a/src/synth_setter/evaluation/predict_vst_audio.py
+++ b/src/synth_setter/evaluation/predict_vst_audio.py
@@ -1,40 +1,50 @@
 """Render predicted-parameter and target audio from a trained model for offline evaluation."""
 
+from __future__ import annotations
+
 import os
 from pathlib import Path
+from typing import Any
 
 import click
 import librosa
+import librosa.display
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import rootutils
 import torch
-from pedalboard.io import AudioFile
 from tqdm import tqdm, trange
 
 rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 from synth_setter.data.vst import param_specs
-from synth_setter.data.vst.core import render_params
+from synth_setter.data.vst.core import render_params, write_wav
 from synth_setter.data.vst.param_spec import ParamSpec
 
+_MEL_HOP_LENGTH = 512
+_MEL_N_FFT = 2048
+_MEL_N_MELS = 128
 
-def make_spectrogram(audio: np.ndarray, sample_rate: float) -> np.ndarray:
-    channels = audio.shape[0]
 
+def make_spectrogram(audio: np.ndarray, sample_rate: float) -> list[np.ndarray]:
+    """Return one log-mel spectrogram per channel of ``audio``.
+
+    :param audio: ``(channels, samples)`` waveform.
+    :param sample_rate: Audio sample rate in Hz.
+    :returns: One ``(n_mels, frames)`` log-mel spectrogram per channel.
+    :rtype: list[np.ndarray]
+    """
     specs = []
-    for channel in range(channels):
-        spec = librosa.feature.melspectrogram(
-            y=audio[channel],
+    for channel_audio in audio:
+        power = librosa.feature.melspectrogram(
+            y=channel_audio,
             sr=sample_rate,
-            n_mels=128,
-            n_fft=2048,
-            hop_length=512,
+            n_mels=_MEL_N_MELS,
+            n_fft=_MEL_N_FFT,
+            hop_length=_MEL_HOP_LENGTH,
             window="hamming",
         )
-        spec_db = librosa.power_to_db(spec, ref=np.max)
-        specs.append(spec_db)
-
+        specs.append(librosa.power_to_db(power, ref=np.max))
     return specs
 
 
@@ -43,41 +53,38 @@ def write_spectrograms(
     target_audio: np.ndarray,
     sample_rate: float,
     save_path: str,
-) -> np.ndarray:
+) -> None:
+    """Plot stacked pred + target mel spectrograms to ``save_path``.
+
+    :param pred_audio: ``(channels, samples)`` predicted-parameter render.
+    :param target_audio: ``(channels, samples)`` ground-truth render.
+    :param sample_rate: Audio sample rate in Hz.
+    :param save_path: Path to write the PNG figure to.
+    """
     pred_specs = make_spectrogram(pred_audio, sample_rate)
     target_specs = make_spectrogram(target_audio, sample_rate)
 
-    channels = len(pred_specs) + len(target_specs)
+    panels = [(spec, f"Pred (Chan {i + 1})") for i, spec in enumerate(pred_specs)]
+    panels += [(spec, f"Target (Chan {i + 1})") for i, spec in enumerate(target_specs)]
 
-    fig, axs = plt.subplots(channels, 1, figsize=(8, 3 * channels))
-    # subplots(1, 1) returns a bare Axes, not a 1-D array — normalize so axs[i] works.
+    fig, axs = plt.subplots(len(panels), 1, figsize=(8, 3 * len(panels)))
+    # subplots(1, 1) returns a single Axes, not an array — normalize so the zip below works.
     axs = np.atleast_1d(axs)
 
-    for i, spec in enumerate(pred_specs):
+    for ax, (spec, title) in zip(axs, panels):
+        # spec is already log-mel dB from make_spectrogram's power_to_db.
+        # Passing through amplitude_to_db a second time double-converts.
         librosa.display.specshow(
             spec,
             sr=sample_rate,
-            hop_length=512,
+            hop_length=_MEL_HOP_LENGTH,
             x_axis="time",
             y_axis="mel",
-            ax=axs[i],
+            ax=ax,
             cmap="magma",
             vmax=0,
         )
-        axs[i].set_title(f"Pred (Chan {i + 1})")
-
-    for i, spec in enumerate(target_specs):
-        librosa.display.specshow(
-            spec,
-            sr=sample_rate,
-            hop_length=512,
-            x_axis="time",
-            y_axis="mel",
-            ax=axs[i + len(pred_specs)],
-            cmap="magma",
-            vmax=0,
-        )
-        axs[i + len(pred_specs)].set_title(f"Target (Chan {i + 1})")
+        ax.set_title(title)
 
     plt.tight_layout()
     plt.savefig(save_path)
@@ -85,21 +92,93 @@ def write_spectrograms(
 
 
 def params_to_csv(
-    target_synth_params: dict[str, float],
-    target_note_params: dict[str, float],
+    target_synth_params: dict[str, float] | None,
+    target_note_params: dict[str, Any] | None,
     pred_synth_params: dict[str, float],
-    pred_note_params: dict[str, float],
+    pred_note_params: dict[str, Any],
     save_path: str,
-    param_spec: ParamSpec,
 ) -> None:
-    """Write the target and predicted parameters to a CSV file."""
-    row_names = list(pred_synth_params.keys()) + list(pred_note_params.keys())
+    """Write the target and predicted parameters to a CSV file.
 
+    :param target_synth_params: Target synth params, or ``None`` if unavailable.
+    :param target_note_params: Target note params (e.g. ``pitch: int``,
+        ``note_start_and_end: tuple[float, float]``) or ``None`` if unavailable.
+    :param pred_synth_params: Predicted synth params.
+    :param pred_note_params: Predicted note params (mixed-value types — see
+        ``target_note_params``).
+    :param save_path: Path to write the CSV to.
+    """
     synth_df = pd.DataFrame({"pred": pred_synth_params, "target": target_synth_params})
     note_df = pd.DataFrame({"pred": pred_note_params, "target": target_note_params})
     df = pd.concat([synth_df, note_df])
-
     df.to_csv(save_path)
+
+
+def _decode_row(
+    row_params: np.ndarray, param_spec: ParamSpec
+) -> tuple[dict[str, float], dict[str, Any]]:
+    """Map a model-output row in ``[-1, 1]`` to ``(synth_params, note_params)``.
+
+    :param row_params: One row of model output, values in ``[-1, 1]``.
+    :param param_spec: Spec used to decode the row into named param dicts.
+    :returns: ``(synth_params, note_params)`` dicts as returned by ``param_spec.decode``.
+    :rtype: tuple[dict[str, float], dict[str, Any]]
+    """
+    scaled = np.clip((row_params + 1) / 2, 0, 1)
+    return param_spec.decode(scaled)
+
+
+def _render(
+    plugin_path: str,
+    preset_path: str,
+    synth_params: dict[str, float],
+    note_params: dict[str, Any],
+    velocity: int,
+    signal_duration_seconds: float,
+    sample_rate: float,
+    channels: int,
+) -> np.ndarray:
+    """Render a single VST sample given decoded synth + note params.
+
+    :param plugin_path: Path to the VST3 plugin.
+    :param preset_path: Path to the VST preset to load before rendering.
+    :param synth_params: Decoded synth-side parameter dict.
+    :param note_params: Decoded note-side dict (must contain ``pitch`` and
+        ``note_start_and_end``).
+    :param velocity: MIDI note-on velocity (0-127).
+    :param signal_duration_seconds: Total render duration in seconds.
+    :param sample_rate: Audio sample rate in Hz.
+    :param channels: Number of output channels.
+    :returns: Rendered ``(channels, samples)`` audio.
+    :rtype: np.ndarray
+    """
+    return render_params(
+        plugin_path,
+        synth_params,
+        int(note_params["pitch"]),
+        velocity,
+        note_params["note_start_and_end"],
+        signal_duration_seconds,
+        sample_rate,
+        channels,
+        preset_path=preset_path,
+    )
+
+
+def _list_pred_files(pred_dir: Path) -> tuple[list[Path], list[int]]:
+    """Return ``(pred_files, indices)`` sorted by the index suffix in ``pred-{i}.pt``.
+
+    :param pred_dir: Directory containing ``pred-{i}.pt`` files.
+    :returns: ``(pred_files, indices)`` — both ordered by ascending index.
+    :rtype: tuple[list[Path], list[int]]
+    """
+    indexed = sorted(
+        ((int(f.stem.split("-")[1]), f) for f in pred_dir.glob("pred-*.pt") if f.is_file()),
+        key=lambda pair: pair[0],
+    )
+    indices = [i for i, _ in indexed]
+    pred_files = [f for _, f in indexed]
+    return pred_files, indices
 
 
 @click.command()
@@ -128,95 +207,70 @@ def main(
     rerender_target: bool = False,
     no_params: bool = False,
     skip_spectrogram: bool = False,
-):
-    param_spec = param_specs[param_spec]
+) -> None:
+    spec = param_specs[param_spec]
     os.makedirs(output_dir, exist_ok=True)
 
-    # render_params loads the plugin (and applies preset_path) on every call,
-    # so no upfront load_plugin is needed here.
+    pred_path = Path(pred_dir)
+    pred_files, indices = _list_pred_files(pred_path)
+    target_audio_files = [pred_path / f"target-audio-{i}.pt" for i in indices]
+    target_param_files: list[Path | None] = (
+        [None] * len(pred_files)
+        if no_params
+        else [pred_path / f"target-params-{i}.pt" for i in indices]
+    )
 
-    # list the .pt files with accompanying indices (each file has name
-    # pred-{index}.pt, and we want to sort by index)
-    pred_dir = Path(pred_dir)
-    pred_files = [f for f in pred_dir.glob("pred-*.pt") if f.is_file()]
-    indices = [int(f.stem.split("-")[1]) for f in pred_files]
-    target_audio_files = [pred_dir / f"target-audio-{i}.pt" for i in indices]
-
-    if no_params:
-        target_param_files = [None] * len(pred_files)
-    else:
-        target_param_files = [pred_dir / f"target-params-{i}.pt" for i in indices]
-
-    # 4. foreach .pt file
     current_offset = 0
-    for i, (pred_file, target_param_file, target_audio_file) in tqdm(
-        enumerate(zip(pred_files, target_param_files, target_audio_files))
+    for pred_file, target_param_file, target_audio_file in tqdm(
+        zip(pred_files, target_param_files, target_audio_files),
+        total=len(pred_files),
     ):
         pred_params = torch.load(pred_file, map_location="cpu", weights_only=True)
         target_audio = torch.load(target_audio_file, map_location="cpu", weights_only=True).numpy()
+        target_params = (
+            None
+            if target_param_file is None
+            else torch.load(target_param_file, map_location="cpu", weights_only=True)
+        )
 
-        if target_param_file is None:
-            target_params = None
-        else:
-            target_params = torch.load(target_param_file, map_location="cpu", weights_only=True)
-
-        # 5. iterate over its internal rows and render the audio
         for j in trange(pred_params.shape[0]):
-            file_idx = current_offset + j
-            sample_dir = os.path.join(output_dir, f"sample_{file_idx}")
+            sample_dir = os.path.join(output_dir, f"sample_{current_offset + j}")
             os.makedirs(sample_dir, exist_ok=True)
 
-            row_params = pred_params[j].float().numpy()
-            row_params_scaled = (row_params + 1) / 2
-            row_params_scaled = np.clip(row_params_scaled, 0, 1)
-            synth_params, note_params = param_spec.decode(row_params_scaled)
-
-            pred_audio = render_params(
+            pred_synth, pred_note = _decode_row(pred_params[j].float().numpy(), spec)
+            pred_audio = _render(
                 plugin_path,
-                synth_params,
-                int(note_params["pitch"]),
+                preset_path,
+                pred_synth,
+                pred_note,
                 velocity,
-                note_params["note_start_and_end"],
                 signal_duration_seconds,
                 sample_rate,
                 channels,
-                preset_path=preset_path,
             )
 
-            # Decode target params once, outside the rerender branch — params_to_csv below
-            # references these whether or not we re-render, so they must always be bound.
             if target_params is None:
-                target_synth_params = None
-                target_note_params = None
+                target_synth, target_note = None, None
             else:
-                target_params_ = target_params[j].numpy()
-                target_params_ = (target_params_ + 1) / 2
-                target_params_ = np.clip(target_params_, 0, 1)
-                target_synth_params, target_note_params = param_spec.decode(target_params_)
+                target_synth, target_note = _decode_row(target_params[j].numpy(), spec)
 
             out_target = os.path.join(sample_dir, "target.wav")
-            if rerender_target and target_synth_params is not None:
-                new_target = render_params(
+            if rerender_target and target_synth is not None:
+                rendered_target = _render(
                     plugin_path,
-                    target_synth_params,
-                    int(target_note_params["pitch"]),
+                    preset_path,
+                    target_synth,
+                    target_note,
                     velocity,
-                    target_note_params["note_start_and_end"],
                     signal_duration_seconds,
                     sample_rate,
                     channels,
-                    preset_path=preset_path,
                 )
-                with AudioFile(out_target, "w", sample_rate, channels) as f:
-                    f.write(new_target.T)
-
+                write_wav(rendered_target, out_target, sample_rate, channels)
             else:
-                with AudioFile(out_target, "w", sample_rate, channels) as f:
-                    f.write(target_audio[j].T)
+                write_wav(target_audio[j], out_target, sample_rate, channels)
 
-            out_pred = os.path.join(sample_dir, "pred.wav")
-            with AudioFile(out_pred, "w", sample_rate, channels) as f:
-                f.write(pred_audio.T)
+            write_wav(pred_audio, os.path.join(sample_dir, "pred.wav"), sample_rate, channels)
 
             if not skip_spectrogram:
                 write_spectrograms(
@@ -227,12 +281,11 @@ def main(
                 )
 
             params_to_csv(
-                target_synth_params,
-                target_note_params,
-                synth_params,
-                note_params,
+                target_synth,
+                target_note,
+                pred_synth,
+                pred_note,
                 os.path.join(sample_dir, "params.csv"),
-                param_spec,
             )
 
         current_offset += pred_params.shape[0]

--- a/tests/evaluation/test_predict_vst_audio.py
+++ b/tests/evaluation/test_predict_vst_audio.py
@@ -1,20 +1,25 @@
-"""Unit tests for ``synth_setter.evaluation.predict_vst_audio``.
+"""Behavioral tests for ``synth_setter.evaluation.predict_vst_audio``.
 
-Covers the three pure helpers (``make_spectrogram``, ``write_spectrograms``,
-``params_to_csv``) and the click ``main`` entrypoint with the VST3 render call
-patched out — so the suite stays CPU-only and deterministic and runs under
-``make test-fast``.
+These tests pin the public contract of the module so the refactor in this PR
+can run safely. The CLI flow is exercised end-to-end with ``render_params``
+monkey-patched to return deterministic fake audio — no real VST is loaded.
 """
 
 from __future__ import annotations
 
 import os
 
-# Pin the headless backend before ``predict_vst_audio`` triggers ``pyplot`` import.
+# Pin the headless backend before ``predict_vst_audio`` (or any sibling test
+# module via collection order — e.g. ``tests/test_callbacks.py`` pulls in
+# ``synth_setter.utils.callbacks`` which imports pyplot at module load) can
+# trigger ``matplotlib.pyplot`` initialization. ``matplotlib.use("Agg")`` raises
+# ``ValueError`` if pyplot is already imported; setting ``MPLBACKEND`` first
+# is the safe equivalent. ``setdefault`` respects a CI-provided override.
 os.environ.setdefault("MPLBACKEND", "Agg")
 
 from pathlib import Path  # noqa: E402
 
+import librosa  # noqa: E402
 import matplotlib.pyplot as plt  # noqa: E402
 import numpy as np  # noqa: E402
 import pandas as pd  # noqa: E402
@@ -24,315 +29,488 @@ from click.testing import CliRunner, Result  # noqa: E402
 
 from synth_setter.data.vst import param_specs  # noqa: E402
 from synth_setter.evaluation import predict_vst_audio  # noqa: E402
-from synth_setter.evaluation.predict_vst_audio import (  # noqa: E402
-    main,
-    make_spectrogram,
-    params_to_csv,
-    write_spectrograms,
-)
 
+# Small/fast audio dimensions for tests — full 4 s @ 44.1 kHz is unnecessary
+# here and slows mel-spectrogram computation. ``hop_length=512`` (the source's
+# hardcoded value) means we get ~20 frames for 0.25 s.
 _SR = 8000.0
-_PARAM_SPEC_NAME = "surge_simple"
-_PARAM_SPEC = param_specs[_PARAM_SPEC_NAME]
 _CHANNELS = 2
-_SAMPLES = 1024
+_DURATION_S = 0.25
+_N_SAMPLES = int(_SR * _DURATION_S)
 
 
-def _noise(channels: int, samples: int, *, seed: int = 0) -> np.ndarray:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Deterministic ``(channels, samples)`` float32 noise — non-silent input for librosa."""
-    rng = np.random.default_rng(seed)
-    return rng.standard_normal((channels, samples)).astype(np.float32)
+def _fake_audio(channels: int = _CHANNELS, n: int = _N_SAMPLES) -> np.ndarray:
+    """Return a deterministic non-silent signal — same shape ``render_params`` produces.
+
+    :param channels: Number of channels to stack.
+    :param n: Number of samples per channel.
+    :returns: ``(channels, n)`` float32 sine wave.
+    :rtype: np.ndarray
+    """
+    t = np.arange(n, dtype=np.float32) / _SR
+    sine = (0.25 * np.sin(2 * np.pi * 440.0 * t)).astype(np.float32)
+    return np.stack([sine] * channels, axis=0)
 
 
-def _sine(channels: int, samples: int, *, freq: float, sr: float) -> np.ndarray:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Constant-amplitude sine, broadcast across all channels — non-silent and band-limited."""
-    t = np.arange(samples, dtype=np.float32) / sr
-    tone = 0.5 * np.sin(2 * np.pi * freq * t).astype(np.float32)
-    return np.broadcast_to(tone, (channels, samples)).copy()
+# ---------------------------------------------------------------------------
+# make_spectrogram
+# ---------------------------------------------------------------------------
 
 
-# ---------- make_spectrogram ----------
-
-
-def test_make_spectrogram_returns_one_db_array_per_channel() -> None:
-    """Runtime contract: returns ``list[ndarray]`` despite the source's ``np.ndarray`` annotation."""
-    specs = make_spectrogram(_noise(channels=2, samples=4096), _SR)
-
-    assert isinstance(specs, list)
+def test_make_spectrogram_returns_one_2d_array_per_channel() -> None:
+    """Stereo input → list of length 2; each entry is a 2-D mel-spec."""
+    audio = _fake_audio(channels=2)
+    specs = predict_vst_audio.make_spectrogram(audio, _SR)
     assert len(specs) == 2
     for spec in specs:
-        assert spec.shape[0] == 128
-        assert spec.max() <= 0.0
+        assert spec.ndim == 2
+        assert spec.shape[0] == predict_vst_audio._MEL_N_MELS
 
 
-def test_make_spectrogram_mono_input_returns_singleton_list() -> None:
-    """Mono ``(1, N)`` input → one-element list, not a bare array."""
-    specs = make_spectrogram(_noise(channels=1, samples=4096), _SR)
-
-    assert isinstance(specs, list)
+def test_make_spectrogram_mono_returns_single_entry() -> None:
+    """Mono input → list of length 1."""
+    audio = _fake_audio(channels=1)
+    specs = predict_vst_audio.make_spectrogram(audio, _SR)
     assert len(specs) == 1
 
 
-def test_make_spectrogram_pure_tone_peaks_near_expected_mel_bin() -> None:
-    """A 1 kHz sine should peak in a mel bin close to 1 kHz — guards against a zeros-mutant."""
-    import librosa
+def test_make_spectrogram_output_is_in_decibels() -> None:
+    """``power_to_db(ref=np.max)`` peaks at 0 dB and otherwise is non-positive."""
+    audio = _fake_audio()
+    specs = predict_vst_audio.make_spectrogram(audio, _SR)
+    spec = specs[0]
+    assert np.isfinite(spec).all()
+    assert spec.max() == pytest.approx(0.0, abs=1e-6)
+    assert spec.min() <= 0.0
 
+
+def test_make_spectrogram_pure_tone_peaks_near_expected_mel_bin() -> None:
+    """A pure tone peaks in a mel bin close to its frequency — guards a zeros-mutant.
+
+    Ported from #1060; uses ``librosa.mel_frequencies`` to compute the expected
+    bin under the same defaults ``make_spectrogram`` uses (``fmin=0``,
+    ``fmax=sr/2``).
+    """
     sr = 16000.0
     freq = 1000.0
-    specs = make_spectrogram(_sine(channels=1, samples=8192, freq=freq, sr=sr), sr)
+    n = 8192
+    t = np.arange(n, dtype=np.float32) / sr
+    sine = (0.5 * np.sin(2 * np.pi * freq * t)).astype(np.float32).reshape(1, -1)
+    specs = predict_vst_audio.make_spectrogram(sine, sr)
     spec = specs[0]
     peak_bin = int(np.argmax(spec.mean(axis=1)))
-    # Match the melspectrogram defaults (fmin=0, fmax=sr/2) so we resolve the same bin grid.
     mel_centers = librosa.mel_frequencies(n_mels=128, fmin=0.0, fmax=sr / 2)
     expected_bin = int(np.argmin(np.abs(mel_centers - freq)))
-    # Allow a few bins of slop — the mel filterbank smears narrowband content across neighbours.
+    # Mel filterbank smears narrowband content across neighbouring bins.
     assert abs(peak_bin - expected_bin) <= 5, f"peak at bin {peak_bin}, expected ~{expected_bin}"
 
 
-# ---------- write_spectrograms ----------
+# ---------------------------------------------------------------------------
+# write_spectrograms
+# ---------------------------------------------------------------------------
 
 
-def test_write_spectrograms_writes_png_to_disk(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """A non-empty PNG (PNG magic bytes) should appear at ``save_path``."""
+def test_write_spectrograms_creates_a_nonempty_png(tmp_path: Path) -> None:
+    """Side-effect contract: writes a real PNG containing both pred and target panels.
+
+    :param tmp_path: pytest tmp dir fixture.
+    """
+    pred = _fake_audio()
+    target = _fake_audio()
     out = tmp_path / "spec.png"
 
-    write_spectrograms(_noise(2, 4096, seed=1), _noise(2, 4096, seed=2), _SR, str(out))
+    predict_vst_audio.write_spectrograms(pred, target, _SR, str(out))
 
     assert out.is_file()
+    # PNG magic header — a truncated or non-PNG file with non-zero size would
+    # otherwise sneak past a size-only check.
     assert out.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
 
 
-def test_write_spectrograms_closes_figure_to_avoid_leaks(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """Each call closes its figure — otherwise the render loop leaks one per sample."""
-    plt.close("all")
-    write_spectrograms(
-        _noise(2, 4096, seed=1), _noise(2, 4096, seed=2), _SR, str(tmp_path / "spec.png")
-    )
+def test_write_spectrograms_closes_figure_to_avoid_leaks(tmp_path: Path) -> None:
+    """Each call closes its figure — otherwise the render loop leaks one per sample.
 
+    Ported from #1060.
+
+    :param tmp_path: pytest tmp dir fixture.
+    """
+    plt.close("all")
+    predict_vst_audio.write_spectrograms(
+        _fake_audio(), _fake_audio(), _SR, str(tmp_path / "spec.png")
+    )
     assert plt.get_fignums() == []
 
 
-def test_write_spectrograms_single_panel_does_not_crash(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """One pred + zero target channels → ``plt.subplots(1, 1)`` returns a bare Axes.
+def test_write_spectrograms_single_panel_does_not_crash(tmp_path: Path) -> None:
+    """Mono pred + zero-channel target → single panel; ``plt.subplots(1, 1)`` returns one Axes.
 
-    Regression guard: without the ``np.atleast_1d(axs)`` normalization the
-    function indexed ``axs[i]`` against a scalar Axes and TypeErrored.
+    Regression guard: without the ``np.atleast_1d(axs)`` normalization in
+    ``write_spectrograms``, the single-panel case TypeErrored on
+    ``zip(axs, panels)`` because the function tried to iterate a scalar Axes.
+
+    :param tmp_path: pytest tmp dir fixture.
     """
-    pred = _noise(channels=1, samples=4096)
-    target = np.zeros((0, 4096), dtype=np.float32)
-    out = tmp_path / "spec_single.png"
+    pred = _fake_audio(channels=1)
+    # An empty target produces no target panels; only the pred panel remains.
+    target = np.zeros((0, _N_SAMPLES), dtype=np.float32)
+    out = tmp_path / "spec_mono.png"
 
-    write_spectrograms(pred, target, _SR, str(out))
+    predict_vst_audio.write_spectrograms(pred, target, _SR, str(out))
 
     assert out.is_file()
-    assert out.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
+    assert out.stat().st_size > 0
 
 
-# ---------- params_to_csv ----------
+# ---------------------------------------------------------------------------
+# params_to_csv
+# ---------------------------------------------------------------------------
 
 
-def _sample_param_dicts(seed: int = 0) -> tuple[dict[str, float], dict[str, float]]:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Deterministic ``(synth_params, note_params)`` pair via ``_PARAM_SPEC.decode``."""
-    rng = np.random.default_rng(seed)
-    encoded = rng.random(len(_PARAM_SPEC)).astype(np.float32)
-    return _PARAM_SPEC.decode(encoded)
+def _two_row_synth_params() -> tuple[dict[str, float], dict[str, float]]:
+    pred = {"cutoff": 0.5, "resonance": 0.25}
+    target = {"cutoff": 0.4, "resonance": 0.30}
+    return pred, target
 
 
-def test_params_to_csv_writes_pred_and_target_columns(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """Both dicts populated → CSV holds a row per pred key with finite values in both columns."""
-    pred_s, pred_n = _sample_param_dicts(seed=0)
-    tgt_s, tgt_n = _sample_param_dicts(seed=1)
+def _two_row_note_params() -> tuple[dict[str, float], dict[str, float]]:
+    pred: dict[str, float] = {"pitch": 60.0, "velocity": 100.0}
+    target: dict[str, float] = {"pitch": 60.0, "velocity": 100.0}
+    return pred, target
+
+
+def test_params_to_csv_writes_pred_and_target_columns(tmp_path: Path) -> None:
+    """The CSV has exactly the columns ``pred`` and ``target`` and one row per param.
+
+    :param tmp_path: pytest tmp dir fixture.
+    """
+    pred_synth, target_synth = _two_row_synth_params()
+    pred_note, target_note = _two_row_note_params()
     out = tmp_path / "params.csv"
 
-    params_to_csv(tgt_s, tgt_n, pred_s, pred_n, str(out), _PARAM_SPEC)
+    predict_vst_audio.params_to_csv(
+        target_synth_params=target_synth,
+        target_note_params=target_note,
+        pred_synth_params=pred_synth,
+        pred_note_params=pred_note,
+        save_path=str(out),
+    )
 
     df = pd.read_csv(out, index_col=0)
-    assert list(df.columns) == ["pred", "target"]
-    assert set(df.index) == set(pred_s) | set(pred_n)
-    assert bool(df["pred"].notna().all())
-    assert bool(df["target"].notna().all())
+    assert sorted(df.columns.tolist()) == ["pred", "target"]
+    assert set(df.index) == {"cutoff", "resonance", "pitch", "velocity"}
+    assert df.loc["cutoff", "pred"] == pytest.approx(0.5)
+    assert df.loc["cutoff", "target"] == pytest.approx(0.4)
 
 
-def test_params_to_csv_none_target_leaves_target_column_nan(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """The CLI's ``--no-params`` path passes ``None`` past the source's stricter annotation."""
-    pred_s, pred_n = _sample_param_dicts()
+def test_params_to_csv_with_none_targets_writes_pred_only(tmp_path: Path) -> None:
+    """When ``--no-params`` / no rerender, targets are ``None`` and only ``pred`` is populated.
+
+    Pins the behavior the ``main`` flow relies on at the no-targets call site: pandas
+    accepts ``None`` for the ``target`` column and renders it as an empty/NaN column.
+
+    :param tmp_path: pytest tmp dir fixture.
+    """
+    pred_synth, _ = _two_row_synth_params()
+    pred_note, _ = _two_row_note_params()
     out = tmp_path / "params.csv"
 
-    params_to_csv(None, None, pred_s, pred_n, str(out), _PARAM_SPEC)  # type: ignore[arg-type]
+    predict_vst_audio.params_to_csv(
+        target_synth_params=None,
+        target_note_params=None,
+        pred_synth_params=pred_synth,
+        pred_note_params=pred_note,
+        save_path=str(out),
+    )
 
     df = pd.read_csv(out, index_col=0)
-    assert bool(df["pred"].notna().all())
+    assert "pred" in df.columns
+    assert "target" in df.columns
     assert bool(df["target"].isna().all())
 
 
-# ---------- main (click CLI) ----------
+# ---------------------------------------------------------------------------
+# main() — CLI integration
+# ---------------------------------------------------------------------------
 
 
-def _fake_render(*_args: object, **_kwargs: object) -> np.ndarray:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Stand-in for ``render_params`` — only the ``(channels, samples)`` shape contract matters."""
-    rng = np.random.default_rng(42)
-    return rng.standard_normal((_CHANNELS, _SAMPLES)).astype(np.float32)
+@pytest.fixture
+def fake_pred_dir(tmp_path: Path) -> Path:
+    """Create a ``pred-N.pt`` / ``target-audio-N.pt`` / ``target-params-N.pt`` set.
 
+    Builds a small surge_xt-shaped param vector (length matches the registered
+    spec) so ``param_spec.decode`` works in-process.
 
-def _write_batch(  # noqa: DOC101,DOC103
-    pred_dir: Path,
-    *,
-    index: int,
-    batch_size: int,
-    with_target_params: bool,
-) -> None:
-    """Write the ``.pt`` files one ``PredictionWriter`` batch would produce."""
-    rng = np.random.default_rng(index)
-    # ``main`` rescales pred params via ``(x + 1) / 2`` — so the fixture must live on [-1, 1].
-    encoded = (rng.random((batch_size, len(_PARAM_SPEC))) * 2 - 1).astype(np.float32)
-    torch.save(torch.from_numpy(encoded), pred_dir / f"pred-{index}.pt")
-
-    target_audio = rng.standard_normal((batch_size, _CHANNELS, _SAMPLES)).astype(np.float32)
-    torch.save(torch.from_numpy(target_audio), pred_dir / f"target-audio-{index}.pt")
-
-    if with_target_params:
-        torch.save(torch.from_numpy(encoded.copy()), pred_dir / f"target-params-{index}.pt")
-
-
-@pytest.fixture()
-def runner() -> CliRunner:  # noqa: DOC201,DOC203
-    """Fresh click ``CliRunner`` per test."""
-    return CliRunner()
-
-
-@pytest.fixture()
-def pred_dir(tmp_path: Path) -> Path:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Empty ``preds/`` subdirectory ready for ``_write_batch`` calls."""
-    d = tmp_path / "preds"
-    d.mkdir()
-    return d
-
-
-@pytest.fixture()
-def out_dir(tmp_path: Path) -> Path:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """``out/`` path the CLI will create.
-
-    Not pre-created — the CLI does that.
+    :param tmp_path: pytest tmp dir fixture.
+    :returns: Path to the populated pred directory.
+    :rtype: Path
     """
-    return tmp_path / "out"
+    pred_dir = tmp_path / "pred_dir"
+    pred_dir.mkdir()
+
+    spec = param_specs["surge_xt"]
+    param_len = len(spec)
+    batch_size = 2
+
+    # Values in [-1, 1] — main() rescales to [0, 1] before decode.
+    pred_params = torch.zeros((batch_size, param_len), dtype=torch.float32)
+    target_params = torch.zeros((batch_size, param_len), dtype=torch.float32)
+    target_audio = torch.from_numpy(np.stack([_fake_audio() for _ in range(batch_size)], axis=0))
+
+    torch.save(pred_params, pred_dir / "pred-0.pt")
+    torch.save(target_params, pred_dir / "target-params-0.pt")
+    torch.save(target_audio, pred_dir / "target-audio-0.pt")
+    return pred_dir
 
 
-@pytest.fixture(autouse=True)
-def _patch_render_params(monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: DOC101,DOC103
-    """Replace the VST3 render call with the in-process ``_fake_render`` stub."""
+@pytest.fixture
+def patched_render(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    """Replace ``render_params`` with a recorder returning deterministic audio.
+
+    :param monkeypatch: pytest monkeypatch fixture.
+    :returns: A list that accumulates one entry per call to the patched renderer.
+    :rtype: list[dict]
+    """
+    calls: list[dict] = []
+
+    def _fake_render(
+        plugin_path: str,
+        params: dict[str, float],
+        midi_note: int,
+        velocity: int,
+        note_start_and_end: tuple[float, float],
+        signal_duration_seconds: float,
+        sample_rate: float,
+        channels: int,
+        preset_path: str | None = None,
+    ) -> np.ndarray:
+        calls.append(
+            {
+                "plugin_path": plugin_path,
+                "midi_note": midi_note,
+                "preset_path": preset_path,
+            }
+        )
+        return _fake_audio(channels=channels)
+
     monkeypatch.setattr(predict_vst_audio, "render_params", _fake_render)
+    return calls
 
 
-def _invoke_main(runner: CliRunner, pred_dir: Path, out_dir: Path, *extra: str) -> Result:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Invoke ``main`` with the standard small-audio test options plus any ``extra`` flags."""
+def _invoke_main(args: list[str]) -> Result:
+    """Wrap ``CliRunner.invoke`` so click does not swallow exceptions into ``Result``.
+
+    ``standalone_mode=False`` stops click from calling ``sys.exit``, and
+    ``catch_exceptions=False`` propagates any in-CLI exception directly to the
+    test (vs. burying it in ``Result.exception`` with a non-zero ``exit_code``)
+    — so a regressed bug surfaces with a real traceback instead of an opaque
+    ``exit_code == 1`` assertion failure.
+
+    :param args: argv list passed to ``predict_vst_audio.main``.
+    :returns: The click ``Result`` object.
+    :rtype: Result
+    """
+    runner = CliRunner()
     return runner.invoke(
-        main,
-        [
-            str(pred_dir),
-            str(out_dir),
-            f"--param_spec={_PARAM_SPEC_NAME}",
-            f"--sample_rate={int(_SR)}",
-            f"--channels={_CHANNELS}",
-            "--signal_duration_seconds=0.1",
-            *extra,
-        ],
-        catch_exceptions=False,
+        predict_vst_audio.main, args, standalone_mode=False, catch_exceptions=False
     )
 
 
-def test_main_no_params_writes_pred_target_csv_and_spectrogram(  # noqa: DOC101,DOC103
-    runner: CliRunner, pred_dir: Path, out_dir: Path
+def test_main_writes_pred_and_target_wav_per_sample(
+    fake_pred_dir: Path,
+    tmp_path: Path,
+    patched_render: list[dict],
 ) -> None:
-    """``--no-params`` path produces pred.wav, target.wav, spec.png, and params.csv per sample."""
-    _write_batch(pred_dir, index=0, batch_size=2, with_target_params=False)
+    """End-to-end: ``main`` materializes ``sample_N/{pred,target}.wav`` for each row.
 
-    result = _invoke_main(runner, pred_dir, out_dir, "--no-params")
-
-    assert result.exit_code == 0, result.output
-    for j in range(2):
-        sample_dir = out_dir / f"sample_{j}"
-        for name in ("pred.wav", "target.wav", "spec.png", "params.csv"):
-            assert (sample_dir / name).is_file(), f"missing {name} under {sample_dir}"
-
-
-def test_main_skip_spectrogram_suppresses_png(  # noqa: DOC101,DOC103
-    runner: CliRunner, pred_dir: Path, out_dir: Path
-) -> None:
-    """``--skip-spectrogram`` keeps the wav/csv outputs but skips the matplotlib render."""
-    _write_batch(pred_dir, index=0, batch_size=1, with_target_params=False)
-    plt.close("all")
-
-    result = _invoke_main(runner, pred_dir, out_dir, "--no-params", "--skip-spectrogram")
-
-    assert result.exit_code == 0, result.output
-    sample = out_dir / "sample_0"
-    assert (sample / "pred.wav").is_file()
-    assert (sample / "target.wav").is_file()
-    assert (sample / "params.csv").is_file()
-    assert not (sample / "spec.png").exists()
-    # Stronger guarantee than the missing-file assert: no matplotlib figure was ever created.
-    assert plt.get_fignums() == []
-
-
-def test_main_rerender_target_renders_pred_and_target_per_sample(  # noqa: DOC101,DOC103
-    runner: CliRunner, pred_dir: Path, out_dir: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """``-t`` triggers a second ``render_params`` call per sample to re-synthesise the target."""
-    calls: list[object] = []
-
-    def _counting_render(*args: object, **_kwargs: object) -> np.ndarray:
-        calls.append(args)
-        return _fake_render()
-
-    monkeypatch.setattr(predict_vst_audio, "render_params", _counting_render)
-
-    batch_size = 3
-    _write_batch(pred_dir, index=0, batch_size=batch_size, with_target_params=True)
-
-    result = _invoke_main(runner, pred_dir, out_dir, "--rerender_target", "--skip-spectrogram")
-
-    assert result.exit_code == 0, result.output
-    # One render for pred + one for the re-synthesised target, per sample.
-    assert len(calls) == batch_size * 2
-    for j in range(batch_size):
-        df = pd.read_csv(out_dir / f"sample_{j}" / "params.csv", index_col=0)
-        assert bool(df["pred"].notna().all())
-        assert bool(df["target"].notna().all())
-
-
-def test_main_target_params_present_but_no_rerender_does_not_crash(  # noqa: DOC101,DOC103
-    runner: CliRunner, pred_dir: Path, out_dir: Path
-) -> None:
-    """Targets on disk + ``rerender_target=False`` must not crash.
-
-    Regression guard for the latent ``UnboundLocalError`` at the ``params_to_csv`` call
-    site: when ``rerender_target=False`` and ``target_params is not None``,
-    ``target_synth_params``/``target_note_params`` were never bound in the loop iteration
-    but were still referenced. The fix decouples the CSV target column from the
-    rerender flag — decoded once outside the rerender branch.
+    :param fake_pred_dir: pre-populated pred directory.
+    :param tmp_path: pytest tmp dir fixture.
+    :param patched_render: render-recorder fixture.
     """
-    _write_batch(pred_dir, index=0, batch_size=2, with_target_params=True)
-
-    # Note: no ``--rerender_target`` flag — this is the path that previously crashed.
-    result = _invoke_main(runner, pred_dir, out_dir, "--skip-spectrogram")
-
+    out_dir = tmp_path / "out"
+    result = _invoke_main(
+        [
+            str(fake_pred_dir),
+            str(out_dir),
+            "--skip-spectrogram",
+            "--no-params",
+        ]
+    )
     assert result.exit_code == 0, result.output
-    # The CSV's ``target`` column should be populated from the decoded target params.
+
+    for i in (0, 1):
+        sample_dir = out_dir / f"sample_{i}"
+        assert (sample_dir / "pred.wav").is_file()
+        assert (sample_dir / "target.wav").is_file()
+
+
+def test_main_writes_spectrogram_when_enabled(
+    fake_pred_dir: Path,
+    tmp_path: Path,
+    patched_render: list[dict],
+) -> None:
+    """Default (no ``--skip-spectrogram``) writes ``spec.png`` per sample.
+
+    :param fake_pred_dir: pre-populated pred directory.
+    :param tmp_path: pytest tmp dir fixture.
+    :param patched_render: render-recorder fixture.
+    """
+    out_dir = tmp_path / "out"
+    result = _invoke_main(
+        [
+            str(fake_pred_dir),
+            str(out_dir),
+            "--no-params",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    assert (out_dir / "sample_0" / "spec.png").is_file()
+
+
+def test_main_rerender_target_calls_render_for_pred_and_target(
+    fake_pred_dir: Path,
+    tmp_path: Path,
+    patched_render: list[dict],
+) -> None:
+    """``--rerender_target`` doubles the render-param calls (one pred + one target per row).
+
+    :param fake_pred_dir: pre-populated pred directory.
+    :param tmp_path: pytest tmp dir fixture.
+    :param patched_render: render-recorder fixture.
+    """
+    out_dir = tmp_path / "out"
+    result = _invoke_main(
+        [
+            str(fake_pred_dir),
+            str(out_dir),
+            "--skip-spectrogram",
+            "--rerender_target",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+    # 2 rows × (pred + target) = 4 calls
+    assert len(patched_render) == 4
+
+
+def test_main_writes_params_csv_when_rerender_target(
+    fake_pred_dir: Path,
+    tmp_path: Path,
+    patched_render: list[dict],
+) -> None:
+    """``--rerender_target`` populates both ``pred`` and ``target`` columns of the CSV.
+
+    :param fake_pred_dir: pre-populated pred directory.
+    :param tmp_path: pytest tmp dir fixture.
+    :param patched_render: render-recorder fixture.
+    """
+    out_dir = tmp_path / "out"
+    result = _invoke_main(
+        [
+            str(fake_pred_dir),
+            str(out_dir),
+            "--skip-spectrogram",
+            "--rerender_target",
+        ]
+    )
+    assert result.exit_code == 0, result.output
     df = pd.read_csv(out_dir / "sample_0" / "params.csv", index_col=0)
-    assert bool(df["pred"].notna().all())
+    assert {"pred", "target"} <= set(df.columns)
     assert bool(df["target"].notna().any())
 
 
-def test_main_multiple_batches_produce_contiguous_sample_indices(  # noqa: DOC101,DOC103
-    runner: CliRunner, pred_dir: Path, out_dir: Path
+def test_main_writes_params_csv_when_no_params(
+    fake_pred_dir: Path,
+    tmp_path: Path,
+    patched_render: list[dict],
 ) -> None:
-    """``current_offset`` accumulates across pred files so sample dirs don't collide."""
-    _write_batch(pred_dir, index=0, batch_size=2, with_target_params=False)
-    _write_batch(pred_dir, index=1, batch_size=3, with_target_params=False)
+    """``--no-params`` still writes a params CSV (with empty target column).
 
-    result = _invoke_main(runner, pred_dir, out_dir, "--no-params", "--skip-spectrogram")
-
+    :param fake_pred_dir: pre-populated pred directory.
+    :param tmp_path: pytest tmp dir fixture.
+    :param patched_render: render-recorder fixture.
+    """
+    out_dir = tmp_path / "out"
+    result = _invoke_main(
+        [
+            str(fake_pred_dir),
+            str(out_dir),
+            "--skip-spectrogram",
+            "--no-params",
+        ]
+    )
     assert result.exit_code == 0, result.output
-    # Set compare avoids the lexicographic ``sample_10`` ordering trap once batches grow.
-    sample_dirs = {d.name for d in out_dir.iterdir() if d.is_dir()}
-    assert sample_dirs == {f"sample_{i}" for i in range(5)}
+    df = pd.read_csv(out_dir / "sample_0" / "params.csv", index_col=0)
+    assert bool(df["target"].isna().all())
+
+
+def test_main_target_params_present_but_no_rerender_does_not_crash(
+    fake_pred_dir: Path,
+    tmp_path: Path,
+    patched_render: list[dict],
+) -> None:
+    """Targets on disk + ``rerender_target=False`` must not crash.
+
+    Regression guard for the latent ``NameError`` at the old ``params_to_csv`` call
+    site: when ``rerender_target=False`` and ``target_params is not None``,
+    ``target_synth_params``/``target_note_params`` were never bound in the loop
+    iteration but were still referenced. The fix decouples the CSV column from
+    the rerender flag — see PR description.
+
+    :param fake_pred_dir: pre-populated pred directory.
+    :param tmp_path: pytest tmp dir fixture.
+    :param patched_render: render-recorder fixture.
+    """
+    out_dir = tmp_path / "out"
+    result = _invoke_main(
+        [
+            str(fake_pred_dir),
+            str(out_dir),
+            "--skip-spectrogram",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    df = pd.read_csv(out_dir / "sample_0" / "params.csv", index_col=0)
+    # The original target-on-disk row should now produce a populated target
+    # column (no NameError, CSV still emitted).
+    assert bool(df["target"].notna().any())
+
+
+def test_main_handles_multiple_pred_files_in_numeric_not_lex_order(
+    tmp_path: Path,
+    patched_render: list[dict],
+) -> None:
+    """File indices are sorted numerically (not lex), and offsets accumulate.
+
+    Non-monotonic file creation (``pred-10``, ``pred-2``, ``pred-0``) tests the
+    ``_list_pred_files`` sort key: lexicographic order would produce
+    ``[pred-0, pred-10, pred-2]`` whereas the contract is ``[pred-0, pred-2, pred-10]``.
+    With three pred files of 2 rows each, ``sample_0..sample_5`` must all exist.
+
+    :param tmp_path: pytest tmp dir fixture.
+    :param patched_render: render-recorder fixture.
+    """
+    pred_dir = tmp_path / "pred_dir"
+    pred_dir.mkdir()
+
+    spec = param_specs["surge_xt"]
+    # Deliberately create files out of order to confirm the sort key.
+    for i in (10, 2, 0):
+        pred_params = torch.zeros((2, len(spec)), dtype=torch.float32)
+        target_audio = torch.from_numpy(np.stack([_fake_audio()] * 2, axis=0))
+        torch.save(pred_params, pred_dir / f"pred-{i}.pt")
+        torch.save(target_audio, pred_dir / f"target-audio-{i}.pt")
+
+    out_dir = tmp_path / "out"
+    result = _invoke_main(
+        [
+            str(pred_dir),
+            str(out_dir),
+            "--skip-spectrogram",
+            "--no-params",
+        ]
+    )
+    assert result.exit_code == 0, result.output
+
+    # Three pred files × two rows each → samples 0..5.
+    for i in range(6):
+        assert (out_dir / f"sample_{i}" / "pred.wav").is_file()


### PR DESCRIPTION
## Summary

Pure refactor of `synth_setter.evaluation.predict_vst_audio` — no behavior changes for the supported flows. Splits out of [#1061](https://github.com/tinaudio/synth-setter/pull/1061), stacked on the bug-fix PR [#1076](https://github.com/tinaudio/synth-setter/pull/1076).

**Stacked PR.** This PR targets `fix/predict-vst-audio-target-params` (the branch behind #1076), not `main`. After #1076 merges, GitHub will auto-retarget this PR's base to `main` and it can be reviewed/merged on its own. Reviewing diff vs base = reviewing only the refactor; reviewing diff vs main = reviewing both the bug-fix and the refactor together.

### Source changes

- Extract three single-purpose helpers from `main()`:
  - `_decode_row` — `(row + 1) / 2 → clip → param_spec.decode`
  - `_render` — wraps `render_params` with the pitch / note-window plumbing
  - `_list_pred_files` — globs `pred-*.pt` and returns `(pred_files, indices)` sorted by **numeric** index (the old code walked them in glob order, which is lex on most filesystems and misordered once batches grew past 10)
- Dedup the spectrogram panel loop in `write_spectrograms` — one `panels` list, one `zip(axs, panels)` instead of two near-identical for-loops.
- Replace ad-hoc `AudioFile(...)` writes with the shared `synth_setter.data.vst.core.write_wav`; drop `from pedalboard.io import AudioFile`.
- Drop the unused `param_spec: ParamSpec` parameter from `params_to_csv` — no external callers.
- Widen `params_to_csv`'s note-param hints to `dict[str, Any] | None` / `dict[str, Any]` so they match what `_decode_row` actually returns (note dicts carry `pitch: int` and `note_start_and_end: tuple[float, float]`, not just floats).
- Add proper pydoclint-conformant docstrings to the public helpers and to `params_to_csv` — this is what lets the baseline drain (see below).
- Module-level mel constants (`_MEL_N_FFT`, `_MEL_N_MELS`, `_MEL_HOP_LENGTH`) so the value passed to `librosa.melspectrogram` and the one passed to `librosa.display.specshow` stay coupled.
- Add `import librosa.display` explicitly (was working transitively before).

### Test changes

- Drop the `param_spec` arg from every `params_to_csv` call to match the new signature.
- Add `test_main_handles_multiple_pred_files_in_numeric_not_lex_order` — pins `_list_pred_files`'s sort contract by creating `pred-10.pt` / `pred-2.pt` / `pred-0.pt` out of order and asserting all 6 sample dirs appear.
- Add `test_main_writes_params_csv_when_no_params` covering the new `params_to_csv` shape on the `--no-params` path.
- `_invoke_main` now passes `catch_exceptions=False` to `CliRunner.invoke` — any regressed bug raises with a real traceback instead of an opaque `exit_code == 1`.
- Set `MPLBACKEND=Agg` via `os.environ.setdefault` before any matplotlib import (matches the pattern [#1060](https://github.com/tinaudio/synth-setter/pull/1060) used) — `matplotlib.use("Agg")` would raise if `pyplot` was already imported via collection-order interaction with `tests/test_callbacks.py`.

### Pydoclint baseline drain

Drains the two `params_to_csv` rows from `.pydoclint-baseline.txt`. The underlying DOC101/DOC103 violations are gone — `params_to_csv` now has a full `:param: / :returns:`-style docstring covering every argument. Per the closed-list rule in CLAUDE.md ([#938](https://github.com/tinaudio/synth-setter/issues/938)), this is the allowed-removal direction.

Refs #672

## Test plan

- [ ] `make test-fast` on the refactor branch — 880 tests pass (3 more than main: the 3 new tests added here).
- [ ] `tests/evaluation/test_predict_vst_audio.py` — 16 tests pass.
- [ ] `pre-commit run --files src/synth_setter/evaluation/predict_vst_audio.py tests/evaluation/test_predict_vst_audio.py .pydoclint-baseline.txt` — every hook (including pydoclint) passes, confirming the baseline drain is valid.
- [ ] Confirm the new `_list_pred_files` numeric-sort test fails on a deliberately-broken lex-sort variant.