### PR TITLE
chore(claude-md): place hook if: inside handler to scope Bash gates

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -86,7 +86,7 @@
       },
       {
         "matcher": "Bash",
-        "description": "Doc-drift advisory review: on gh pr create, runs a headless claude -p session invoking the doc-drift skill (or an inline fallback referencing docs/doc-map.yaml) against git diff against the default branch. Output saved to .agent-reviews/doc-drift-<uuid>.md. On claude -p failure, writes a verbose error report (stderr tail + exit code) and still wakes the session. The `if` guard scopes the hook to gh pr create at the handler level; doc-drift.sh re-validates with its own regex. asyncRewake. Advisory only — does not block.",
+        "description": "Doc-drift advisory review: on gh pr create, runs a headless claude -p session invoking the doc-drift skill (or an inline fallback referencing docs/doc-map.yaml) against git diff against the default branch. Output saved to .agent-reviews/doc-drift-<uuid>.md. On claude -p failure, writes a verbose error report (stderr tail + exit code) and still wakes the session. The `if` guard scopes the hook to gh pr create at the handler level; doc-drift.sh re-validates the command itself. Advisory only — does not block.",
         "hooks": [
           {
             "type": "command",
@@ -100,7 +100,7 @@
       },
       {
         "matcher": "Bash",
-        "description": "PR review resolver: on git push (excluding main/master), waits RESOLVER_SLEEP_SECS (default 360s) for CI and reviewers to settle, then runs the pr-review-resolver skill (or inline fallback) headlessly. Per-branch lockfile dedupes stacked pushes (last push wins). On claude -p failure, writes a verbose error report and still wakes the session. The `if` guard scopes the hook to git push at the handler level; pr-review-resolver.sh re-validates with its own regex. asyncRewake. Advisory only — does not block.",
+        "description": "PR review resolver: on git push (excluding main/master), waits RESOLVER_SLEEP_SECS (default 360s) for CI and reviewers to settle, then runs the pr-review-resolver skill (or inline fallback) headlessly. Per-branch lockfile dedupes stacked pushes (last push wins). On claude -p failure, writes a verbose error report and still wakes the session. The `if` guard scopes the hook to git push at the handler level; pr-review-resolver.sh re-validates the command itself. Advisory only — does not block.",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,22 +19,22 @@
       },
       {
         "matcher": "Bash",
-        "if": "Bash(git commit *)",
         "description": "Branch safety: echoes the current branch name before any git commit. Prints DETACHED HEAD when not on a branch. Goal: catch accidental commits to the wrong branch.",
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(git commit *)",
             "command": "branch=$(git branch --show-current 2>/dev/null || true); if [ -z \"$branch\" ]; then branch=\"DETACHED HEAD\"; fi; echo \"Committing to branch: $branch\" >&2"
           }
         ]
       },
       {
         "matcher": "Bash",
-        "if": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[;|&`(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'",
         "description": "Pre-PR review gate: blocks gh pr create unless the command contains REVIEW_FULL_DONE=1 (recommended as a trailing comment so other gh-pr-create hooks still fire). Forces Claude to invoke /repo-review-full-no-comments and iterate on findings before opening a PR. The acknowledgment token is intentionally Claude-supplied — the gate is a circuit-breaker that forces a pause, not unbypassable security.",
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(gh pr create *)",
             "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -q 'REVIEW_FULL_DONE=1'; then exit 0; else echo 'BLOCKED: gh pr create requires running /repo-review-full-no-comments first. Run that skill, address every BLOCK/WARN finding (or document why each is intentional), then re-run with REVIEW_FULL_DONE=1 included in the command — recommended as a trailing comment so other hooks still fire: gh pr create --title ... --body ... # REVIEW_FULL_DONE=1' >&2; exit 2; fi"
           }
         ]
@@ -86,11 +86,11 @@
       },
       {
         "matcher": "Bash",
-        "if": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[;|&`(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'",
-        "description": "Doc-drift advisory review: on gh pr create, runs a headless claude -p session invoking the doc-drift skill (or an inline fallback referencing docs/doc-map.yaml) against git diff against the default branch. Output saved to .agent-reviews/doc-drift-<uuid>.md. On claude -p failure, writes a verbose error report (stderr tail + exit code) and still wakes the session. The `if` guard is a cheap pre-filter matching gh pr create at start-of-line or after a shell operator; doc-drift.sh re-validates with the same regex. asyncRewake. Advisory only — does not block.",
+        "description": "Doc-drift advisory review: on gh pr create, runs a headless claude -p session invoking the doc-drift skill (or an inline fallback referencing docs/doc-map.yaml) against git diff against the default branch. Output saved to .agent-reviews/doc-drift-<uuid>.md. On claude -p failure, writes a verbose error report (stderr tail + exit code) and still wakes the session. The `if` guard scopes the hook to gh pr create at the handler level; doc-drift.sh re-validates with its own regex. asyncRewake. Advisory only — does not block.",
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(gh pr create *)",
             "asyncRewake": true,
             "timeout": 900,
             "statusMessage": "doc-drift reviewing PR...",
@@ -100,11 +100,11 @@
       },
       {
         "matcher": "Bash",
-        "if": "jq -r '.tool_input.command // \"\"' | grep -qE '(^|[;|&`(][[:space:]]*)git[[:space:]]+push([[:space:]]|$)'",
-        "description": "PR review resolver: on git push (excluding main/master), waits RESOLVER_SLEEP_SECS (default 360s) for CI and reviewers to settle, then runs the pr-review-resolver skill (or inline fallback) headlessly. Per-branch lockfile dedupes stacked pushes (last push wins). On claude -p failure, writes a verbose error report and still wakes the session. The `if` guard is a cheap pre-filter matching git push at shell-word boundaries; pr-review-resolver.sh re-validates with the same regex. asyncRewake. Advisory only — does not block.",
+        "description": "PR review resolver: on git push (excluding main/master), waits RESOLVER_SLEEP_SECS (default 360s) for CI and reviewers to settle, then runs the pr-review-resolver skill (or inline fallback) headlessly. Per-branch lockfile dedupes stacked pushes (last push wins). On claude -p failure, writes a verbose error report and still wakes the session. The `if` guard scopes the hook to git push at the handler level; pr-review-resolver.sh re-validates with its own regex. asyncRewake. Advisory only — does not block.",
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(git push *)",
             "asyncRewake": true,
             "timeout": 1200,
             "statusMessage": "pr-review-resolver scheduled (6 min delay)...",

--- a/tests/claude_hooks/__init__.py
+++ b/tests/claude_hooks/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for .claude/settings.json hook scoping and behavior."""

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -52,19 +52,25 @@ def _find_handler(description_substring: str) -> dict[str, Any]:
     :param description_substring: Substring identifying the matcher-entry's ``description`` field.
     :returns: The single handler dict from the matcher-entry's ``hooks`` list.
     :rtype: dict[str, Any]
-    :raises AssertionError: If no matcher entry matches, or the matched entry has !=1 handler.
+    :raises AssertionError: If zero or >1 matcher entries match, or the matched entry has !=1 handler.
     """
-    for entry in _matcher_entries():
-        if description_substring in entry.get("description", ""):
-            handlers = entry.get("hooks", [])
-            assert len(handlers) == 1, (
-                f"expected exactly one handler under matcher entry "
-                f"matching {description_substring!r}, got {len(handlers)}"
-            )
-            return handlers[0]
-    raise AssertionError(
-        f"no matcher entry found with description containing {description_substring!r}"
-    )
+    matches = [
+        entry
+        for entry in _matcher_entries()
+        if description_substring in entry.get("description", "")
+    ]
+    if len(matches) != 1:
+        raise AssertionError(
+            f"expected exactly one matcher entry with description containing "
+            f"{description_substring!r}, found {len(matches)}"
+        )
+    handlers = matches[0].get("hooks", [])
+    if len(handlers) != 1:
+        raise AssertionError(
+            f"expected exactly one handler under matcher entry "
+            f"matching {description_substring!r}, got {len(handlers)}"
+        )
+    return handlers[0]
 
 
 def _run_inline_hook(

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -1,0 +1,226 @@
+"""Tests that ``.claude/settings.json`` hooks are scoped to the intended commands.
+
+Regression coverage for the bug where ``if:`` was placed on the matcher-entry
+object (sibling of ``matcher``/``hooks``/``description``). Claude Code silently
+ignores ``if:`` at that level, so a hook intended to gate only ``gh pr create``
+fired on every Bash tool call — blocking even ``gh pr view`` and ``ls``.
+
+The fix moves ``if:`` inside each hook handler (sibling of ``type`` and
+``command``) and uses Claude Code permission-rule syntax such as ``Bash(gh pr
+create *)``. Schema reference: https://code.claude.com/docs/en/hooks.md.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SETTINGS_PATH = _REPO_ROOT / ".claude" / "settings.json"
+
+
+def _load_settings() -> dict[str, Any]:
+    """Load ``.claude/settings.json``.
+
+    :returns: The parsed settings dict.
+    :rtype: dict[str, Any]
+    """
+    return json.loads(_SETTINGS_PATH.read_text())
+
+
+def _matcher_entries() -> list[dict[str, Any]]:
+    """Flatten every PreToolUse and PostToolUse matcher-entry object into a single list.
+
+    :returns: The matcher-entry objects from all hook events, in source order.
+    :rtype: list[dict[str, Any]]
+    """
+    return [
+        entry
+        for event_entries in _load_settings().get("hooks", {}).values()
+        for entry in event_entries
+    ]
+
+
+def _find_handler(description_substring: str) -> dict[str, Any]:
+    """Look up the lone hook handler whose matcher-entry description contains a substring.
+
+    :param description_substring: Substring identifying the matcher-entry's ``description`` field.
+    :returns: The single handler dict from the matcher-entry's ``hooks`` list.
+    :rtype: dict[str, Any]
+    :raises AssertionError: If no matcher entry matches, or the matched entry has !=1 handler.
+    """
+    for entry in _matcher_entries():
+        if description_substring in entry.get("description", ""):
+            handlers = entry.get("hooks", [])
+            assert len(handlers) == 1, (
+                f"expected exactly one handler under matcher entry "
+                f"matching {description_substring!r}, got {len(handlers)}"
+            )
+            return handlers[0]
+    raise AssertionError(
+        f"no matcher entry found with description containing {description_substring!r}"
+    )
+
+
+def _run_inline_hook(
+    command_body: str, stdin_payload: dict[str, Any]
+) -> subprocess.CompletedProcess[str]:
+    """Run an inline hook ``command`` body the same way Claude Code does.
+
+    Claude Code invokes the body via the shell and pipes the tool-call JSON to stdin. Tests
+    reproduce that contract.
+
+    :param command_body: The inline shell command from a hook handler.
+    :param stdin_payload: JSON payload sent to the hook on stdin.
+    :returns: The completed subprocess result, with captured stdout/stderr and exit code.
+    :rtype: subprocess.CompletedProcess[str]
+    """
+    return subprocess.run(  # noqa: S603 — controlled command body from our own settings.json
+        ["bash", "-c", command_body],  # noqa: S607 — bash is a hard requirement of the harness
+        input=json.dumps(stdin_payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema regression — the bug this PR fixes
+# ---------------------------------------------------------------------------
+
+
+def test_no_if_at_matcher_entry_level() -> None:
+    """Matcher-entry objects must not carry a top-level ``if:`` field.
+
+    Claude Code's hooks schema places ``if:`` inside each hook handler, not on
+    the matcher entry. A misplaced ``if:`` is silently ignored, so a Bash hook
+    that intended to scope itself to one command runs on every Bash tool call.
+    """
+    offenders = [
+        {"matcher": entry.get("matcher"), "description": entry.get("description", "")[:60]}
+        for entry in _matcher_entries()
+        if "if" in entry
+    ]
+    assert offenders == [], (
+        "Matcher-entry-level `if:` fields are silently dropped by Claude Code. "
+        f"Move each `if:` inside its hook handler (sibling of `type`/`command`). "
+        f"Offenders: {offenders}"
+    )
+
+
+def test_handler_if_values_use_permission_rule_syntax() -> None:
+    """Hook-handler ``if:`` values must be Claude Code permission-rule expressions.
+
+    Shell expressions such as ``jq … | grep -qE …`` were the previous (broken)
+    style of "scoping". The handler-level ``if:`` is parsed as a permission rule
+    (e.g. ``Bash(gh pr create *)``), not as a shell command — only ``Tool(...)``
+    forms are honored.
+    """
+    bad: list[tuple[str, str]] = []
+    for entry in _matcher_entries():
+        for handler in entry.get("hooks", []):
+            value = handler.get("if")
+            if value is None:
+                continue
+            if not (isinstance(value, str) and "(" in value and value.endswith(")")):
+                bad.append((entry.get("description", "")[:60], value))
+    assert bad == [], (
+        "Hook-handler `if:` values must be Claude Code permission-rule syntax such as "
+        f"`Bash(gh pr create *)` — not shell expressions. Offenders: {bad}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-handler scope assertions — the specific gates that drove this bug
+# ---------------------------------------------------------------------------
+
+
+_EXPECTED_HANDLER_SCOPES: list[tuple[str, str]] = [
+    ("Branch safety", "Bash(git commit *)"),
+    ("Pre-PR review gate", "Bash(gh pr create *)"),
+    ("Doc-drift advisory review", "Bash(gh pr create *)"),
+    ("PR review resolver", "Bash(git push *)"),
+]
+
+
+@pytest.mark.parametrize(("description_substring", "expected_if"), _EXPECTED_HANDLER_SCOPES)
+def test_named_handlers_carry_expected_if_scope(
+    description_substring: str, expected_if: str
+) -> None:
+    """Every Bash hook that needs command-specific scoping declares the right ``if:`` rule.
+
+    :param description_substring: Substring identifying the matcher-entry's description.
+    :param expected_if: The permission-rule value the inner hook handler must declare.
+    """
+    handler = _find_handler(description_substring)
+    assert handler.get("if") == expected_if, (
+        f"handler under {description_substring!r} expected `if: {expected_if}`, "
+        f"got {handler.get('if')!r} (missing or wrong scope means this hook fires on "
+        "every Bash call)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behavioural tests for the pre-PR review gate body
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def pre_pr_gate_command() -> str:
+    """Yield the inline shell ``command`` body of the gh-pr-create PreToolUse gate.
+
+    :returns: The inline shell command string.
+    :rtype: str
+    """
+    return _find_handler("Pre-PR review gate")["command"]
+
+
+def test_pre_pr_gate_blocks_when_token_absent(pre_pr_gate_command: str) -> None:
+    """Gate exits 2 with ``BLOCKED`` in stderr when ``REVIEW_FULL_DONE=1`` is missing.
+
+    :param pre_pr_gate_command: The inline shell command from the pre-PR review gate.
+    """
+    result = _run_inline_hook(
+        pre_pr_gate_command,
+        {"tool_input": {"command": "gh pr create --title foo --body bar"}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_pre_pr_gate_allows_when_token_in_trailing_comment(pre_pr_gate_command: str) -> None:
+    """Gate exits 0 when ``REVIEW_FULL_DONE=1`` is present (typically as a trailing comment).
+
+    :param pre_pr_gate_command: The inline shell command from the pre-PR review gate.
+    """
+    result = _run_inline_hook(
+        pre_pr_gate_command,
+        {"tool_input": {"command": "gh pr create --title foo --body bar  # REVIEW_FULL_DONE=1"}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+    assert result.stderr == ""
+
+
+# ---------------------------------------------------------------------------
+# Behavioural test for the branch-print hook
+# ---------------------------------------------------------------------------
+
+
+def test_branch_print_hook_announces_current_branch() -> None:
+    """Branch-print hook writes ``Committing to branch: <name>`` to stderr without failing.
+
+    Stdin is irrelevant to this hook (it shells out to ``git branch
+    --show-current``), but the test still pipes a representative payload to
+    mirror how Claude Code invokes it.
+    """
+    handler = _find_handler("Branch safety")
+    result = _run_inline_hook(
+        handler["command"],
+        {"tool_input": {"command": "git commit -m test"}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+    assert "Committing to branch:" in result.stderr

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -13,6 +13,7 @@ create *)``. Schema reference: https://code.claude.com/docs/en/hooks.md.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from pathlib import Path
 from typing import Any
@@ -79,7 +80,9 @@ def _run_inline_hook(
     :returns: The completed subprocess result, with captured stdout/stderr and exit code.
     :rtype: subprocess.CompletedProcess[str]
     """
-    return subprocess.run(  # noqa: S603 — controlled command body from our own settings.json
+    # Trust boundary: command_body is read from the repo's own checked-in settings.json,
+    # which is maintainer-controlled. Do not reuse this helper against untrusted paths.
+    return subprocess.run(  # noqa: S603
         ["bash", "-c", command_body],  # noqa: S607 — bash is a hard requirement of the harness
         input=json.dumps(stdin_payload),
         capture_output=True,
@@ -112,21 +115,24 @@ def test_no_if_at_matcher_entry_level() -> None:
     )
 
 
+_PERMISSION_RULE_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]*\(.+\)$")
+
+
 def test_handler_if_values_use_permission_rule_syntax() -> None:
-    """Hook-handler ``if:`` values must be Claude Code permission-rule expressions.
+    """Hook-handler ``if:`` values must look like ``Tool(pattern)`` permission rules.
 
     Shell expressions such as ``jq … | grep -qE …`` were the previous (broken)
     style of "scoping". The handler-level ``if:`` is parsed as a permission rule
     (e.g. ``Bash(gh pr create *)``), not as a shell command — only ``Tool(...)``
     forms are honored.
     """
-    bad: list[tuple[str, str]] = []
+    bad: list[tuple[str, Any]] = []
     for entry in _matcher_entries():
         for handler in entry.get("hooks", []):
             value = handler.get("if")
             if value is None:
                 continue
-            if not (isinstance(value, str) and "(" in value and value.endswith(")")):
+            if not (isinstance(value, str) and _PERMISSION_RULE_RE.match(value)):
                 bad.append((entry.get("description", "")[:60], value))
     assert bad == [], (
         "Hook-handler `if:` values must be Claude Code permission-rule syntax such as "
@@ -202,7 +208,7 @@ def test_pre_pr_gate_allows_when_token_in_trailing_comment(pre_pr_gate_command: 
         {"tool_input": {"command": "gh pr create --title foo --body bar  # REVIEW_FULL_DONE=1"}},
     )
     assert result.returncode == 0, (result.returncode, result.stderr)
-    assert result.stderr == ""
+    assert "BLOCKED" not in result.stderr
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Four `Bash` hooks in `.claude/settings.json` declare their `if:` filter on the matcher-entry object. Per the Claude Code hooks schema, `if:` is a *handler-level* field (sibling of `type`/`command`). Placed on the matcher entry it is silently ignored, so each hook fires on every Bash tool call instead of only the targeted command.

Most visible symptom: the pre-PR review gate (`Bash(gh pr create *)`) blocked every Bash call — including read-only ones like `gh pr view`, `ls`, `find` — until `REVIEW_FULL_DONE=1` was added.

Closes #1078

## Fix

Move every `if:` inside its hook handler, and switch the two shell-grep-style values to Claude Code permission-rule syntax (`Bash(gh pr create *)`, `Bash(git push *)`) — only `Tool(...)` rules are honored at the handler level.

## Tests added

`tests/claude_hooks/test_settings_hooks.py` (9 tests):

- schema regression — no matcher-entry-level `if:` (the exact bug shape)
- defensive type check on handler `if:` values (must match `Tool(pattern)` regex)
- parameterised assertion for each of the four scoped Bash handlers (branch-print, pre-PR-create gate, doc-drift, pr-review-resolver) with its expected permission-rule scope
- behavioural tests on the pre-PR-create gate body (blocks without `REVIEW_FULL_DONE=1`, allows with it as a trailing comment)
- behavioural test on the branch-print hook body

## Pre-PR review

Ran a parallel five-skill review against the local diff (since `/repo-review-full-no-comments` requires a PR number to fan out and the very gate this PR fixes blocks `gh pr create`):

| Skill | BLOCK | WARN |
| --- | --- | --- |
| code-health | 0 | 5 |
| synth-setter-project-standards | 0 | 2 |
| python-style | 0 | 1 |
| tdd-implementation | 0 | 4 |
| comment-hygiene | 0 | 4 |

Addressed in commit 8460e61: tightened the `if:`-shape regex; relaxed `stderr == ""` → `"BLOCKED" not in stderr` for the pass-path test; spelled out the `subprocess.run` trust boundary; dropped the floating `asyncRewake.` fragment and the "re-validates with its own regex" implementation-detail bake-in from two `description` fields.

**Intentionally not addressed** (judgment calls — flagged but kept as-is):

- `_find_handler` anchors on free-form `description` substrings. Reviewers worried this is fragile if descriptions are reworded. Keeping it — a noisy lookup failure when a description changes is the correct tripwire; the alternative (anchoring on command-body fragments) couples the test even tighter to implementation.
- `test_branch_print_hook_announces_current_branch` reads the ambient repo's current branch and only asserts the `Committing to branch:` prefix, which already tolerates both branched and `DETACHED HEAD` cases. A hermetic `tmp_path` git repo would add ceremony without value.
- `typing.Any` in `dict[str, Any]` for the JSON-loaded settings blob is the documented pragmatic use of `Any` — the schema isn't statically known at the test boundary.
- The pre-PR-gate `description` keeps the parenthetical "(recommended as a trailing comment so other gh-pr-create hooks still fire)" — it's useful context for a reader who sees the description alone without the BLOCKED message body.

## Related but out of scope

The `pr-checkbox` PostToolUse hook (line 80 in `.claude/settings.json`) uses a naive substring `grep -q 'gh pr create'` on the entire bash command. This PR's own commit messages and issue body contain that literal phrase, which spuriously triggered the "/pr-checkbox" follow-up reminder on every `git commit` / `gh issue create`. Different bug shape (inline filter too loose, not `if:` placement). Tracked separately in #1078's "Out of scope" section.

## Test plan

- [x] `pytest tests/claude_hooks/ -v` — 9 passed
- [x] `pre-commit run --files .claude/settings.json tests/claude_hooks/__init__.py tests/claude_hooks/test_settings_hooks.py` — all hooks pass (ruff, ruff-format, pyright, docformatter, pydoclint, interrogate, codespell)
- [ ] CI green
- [ ] After this merges and Claude Code reloads `.claude/settings.json` in the next session, `gh pr view`, `ls`, `find`, and similar read-only Bash calls should not be blocked by the pre-PR-create gate