### PR TITLE
internal-feat(pipeline): Hydra-driven generate_dataset SkyPilot dispatch + CI migration

### DIFF
--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -1,24 +1,31 @@
 name: Generate Dataset Shards
 
-# Reusable workflow that owns one provider's launcher invocation. Callers fan
-# out across providers (see test-dataset-generation.yml) and pass per-provider
-# values via inputs. Behavior is identical to the inline blocks this replaced —
-# inputs are simple passthroughs to `synth_setter.pipeline.skypilot_launch` flags
-# plus the artifact-name knob the validate-dataset-shards.yaml downstream
-# expects to find on disk.
+# Reusable workflow that owns one provider's generate_dataset invocation.
+# Callers fan out across providers (see test-dataset-generation.yml) and pass
+# per-provider values via inputs. The skypilot-local and runpod paths drive
+# the Hydra-first `synth-setter-generate-dataset` entrypoint with
+# `skypilot_launch.compute_template=...` overrides; the OCI path continues
+# to invoke the legacy `python -m synth_setter.pipeline.skypilot_launch` click
+# CLI because OCI's sub-docker `run:` block can't be replaced by the new
+# dispatch's cmd injection (SkyPilot OCI backend rejects `image_id: docker:<image>`).
 #
 # Provider-specific behavior:
 #   * `skypilot-local` — provisions a kind cluster on the runner via
 #     `sky local up`, loads the dev-snapshot image into kind, writes the
 #     managed-jobs controller-resource shrink into ~/.sky/config.yaml so the
-#     controller pod fits on kind, and invokes the launcher against
-#     `configs/compute/local-template.yaml` (cloud: kubernetes). The launcher
-#     skips its cred bootstrap for the local provider. Always tears down kind
-#     in `if: always()`.
-#   * `runpod` / `oci` — in-container launcher invocation against the matching
-#     `configs/compute/*-template.yaml`. The launcher's `_run_cred_bootstrap`
-#     writes provider creds inside the container; if SKYPILOT_API_SERVER_ENDPOINT
-#     is set, the bootstrap is skipped (the remote API server holds creds).
+#     controller pod fits on kind, and invokes `synth-setter-generate-dataset`
+#     with `skypilot_launch.compute_template=configs/compute/local-template.yaml`.
+#     The launcher detects `cloud: kubernetes` and skips its cred bootstrap.
+#     Always tears down kind in `if: always()`.
+#   * `runpod` — in-container invocation of `synth-setter-generate-dataset`
+#     against `configs/compute/runpod-template.yaml`. The launcher's
+#     `_run_cred_bootstrap` writes provider creds inside the container; if
+#     SKYPILOT_API_SERVER_ENDPOINT is set, the bootstrap is skipped (the remote
+#     API server holds creds).
+#   * `oci` — legacy in-container `python -m synth_setter.pipeline.skypilot_launch`
+#     against `configs/compute/oci-cpu-template.yaml`. The OCI template keeps
+#     its `run:` block (sub-docker invocation) because OCI's backend can't
+#     ingest a pinned `image_id: docker:<image>`.
 #
 # Required secrets (callers should `secrets: inherit`):
 #   RCLONE_CONFIG_R2_ACCESS_KEY_ID, RCLONE_CONFIG_R2_SECRET_ACCESS_KEY,
@@ -233,19 +240,25 @@ jobs:
           YAML
           chmod 600 "${HOME}/.sky/config.yaml"
 
-      # `--local` flips the launcher's local-vs-remote dispatch (#841); today's
-      # skypilot-local caller passes it `true` to clear any inherited
-      # SKYPILOT_API_SERVER_ENDPOINT. `num_workers: '1'` overrides the config
-      # because the kind cluster can't host parallel workers (#843). The
-      # argument array is built conditionally so optional flags don't expand
-      # to empty strings.
+      # `skypilot_launch.local=true` flips the launcher's local-vs-remote dispatch
+      # (#841); today's skypilot-local caller sets it to clear any inherited
+      # SKYPILOT_API_SERVER_ENDPOINT. `skypilot_launch.num_workers=1` overrides
+      # the config default because the kind cluster can't host parallel workers
+      # (#843). The override array is built conditionally so optional flags
+      # don't expand to empty strings.
+      #
+      # materialize_spec runs first to write input_spec.json — the launcher's
+      # entrypoint doesn't have a `--spec-out` equivalent (Hydra-internal),
+      # so this gives the downstream `Compute spec_uri output` step its r2_bucket
+      # source and provides a debug artifact via the run-metadata upload.
+      #
       # 20-min step cap: if the launcher (sky.jobs SDK) hangs, fail-fast and
       # let the `if: always()` `Snapshot sky logs` step run, instead of
       # burning the full 60-min job timeout before logs are uploaded.
       # NOTE: step-level timeout sends SIGKILL — Python `finally` blocks in the
       # launcher are bypassed. Operators may need `sky jobs cancel --name <job-name>`
       # manually after a timeout. See #876.
-      - name: Run launcher against local-template (skypilot-local row)
+      - name: Run synth-setter-generate-dataset against local-template (skypilot-local row)
         if: ${{ inputs.provider == 'skypilot-local' }}
         timeout-minutes: 20
         env:
@@ -261,25 +274,26 @@ jobs:
           INPUT_NUM_WORKERS: ${{ inputs.num_workers }}
         run: |
           set -euo pipefail
-          ARGS=(
-            --experiment "$CONFIG_PATH"
-            --template configs/compute/local-template.yaml
-            --job-name "$CLUSTER_NAME"
-            --worker-image-tag "$IMAGE_TAG"
-            --spec-out "${RUN_METADATA_DIR}/input_spec.json"
+          python -m synth_setter.pipeline.ci.materialize_spec \
+            "$CONFIG_PATH" "${RUN_METADATA_DIR}"
+          chmod 0644 "${RUN_METADATA_DIR}/input_spec.json"
+          OVERRIDES=(
+            "experiment=$CONFIG_PATH"
+            "skypilot_launch.compute_template=configs/compute/local-template.yaml"
+            "skypilot_launch.job_name=$CLUSTER_NAME"
+            "skypilot_launch.worker_image_tag=$IMAGE_TAG"
           )
           if [[ "$INPUT_LOCAL" == "true" ]]; then
-            ARGS+=(--local)
+            OVERRIDES+=("skypilot_launch.local=true")
           fi
           if [[ -n "$INPUT_NUM_WORKERS" ]]; then
-            ARGS+=(--num-workers "$INPUT_NUM_WORKERS")
+            OVERRIDES+=("skypilot_launch.num_workers=$INPUT_NUM_WORKERS")
           fi
           if [[ "$INPUT_TAIL" == "true" ]]; then
-            ARGS+=(--tail)
+            OVERRIDES+=("skypilot_launch.tail=true")
           fi
-          python -m synth_setter.pipeline.skypilot_launch "${ARGS[@]}" \
+          synth-setter-generate-dataset "${OVERRIDES[@]}" \
             2>&1 | tee "${RUN_METADATA_DIR}/generate.log"
-          chmod 0644 "${RUN_METADATA_DIR}/input_spec.json"
 
       # Capture controller-side state (apiserver + on-pod provision.log) before
       # `sky local down` reaps the kind cluster. See scripts/skypilot/capture-state.sh
@@ -319,20 +333,82 @@ jobs:
           echo "=== snapshot sizes ==="
           du -sh "${RUN_METADATA_DIR}/sky_logs" "${RUN_METADATA_DIR}/sky_api_server_logs" 2>/dev/null || true
 
-      # ----- runpod / oci row: in-container launcher
+      # ----- runpod row: in-container synth-setter-generate-dataset
       # Optional launcher flags are pre-rendered into env-var strings on the
       # outer step (so GHA expression evaluation stays out of the bash
       # block-scalar) and expanded unquoted inside docker so empty values
       # disappear. SKYPILOT_API_SERVER_ENDPOINT (when the secret is set)
-      # routes the launcher to the remote API server through the env-passthrough
-      # branch of `_apply_dispatch_mode`; pass `local: true` to override.
-      - name: Launch SkyPilot job (inside container; streams logs + blocks until done)
-        if: ${{ inputs.provider == 'runpod' || inputs.provider == 'oci' }}
+      # routes the launcher to the remote API server; pass `local: true` to
+      # override. materialize_spec runs first inside the container to write
+      # /run-metadata/input_spec.json for the spec_uri output step.
+      - name: Run synth-setter-generate-dataset against runpod-template (runpod row; in container)
+        if: ${{ inputs.provider == 'runpod' }}
         env:
           SKYPILOT_API_SERVER_ENDPOINT: ${{ secrets.SKYPILOT_API_SERVER_ENDPOINT }}
-          TEMPLATE: configs/compute/${{ inputs.provider == 'oci' && 'oci-cpu' || inputs.provider }}-template.yaml
+          TEMPLATE: configs/compute/runpod-template.yaml
           CLUSTER_NAME: ${{ steps.cluster.outputs.name }}
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          WORKER_GIT_REF: ${{ github.event.pull_request.head.sha || github.sha }}
+          NUM_WORKERS_OVERRIDE: ${{ inputs.num_workers != '' && format('skypilot_launch.num_workers={0}', inputs.num_workers) || '' }}
+          TAIL_OVERRIDE: ${{ inputs.tail && 'skypilot_launch.tail=true' || '' }}
+          LOCAL_OVERRIDE: ${{ inputs.local && 'skypilot_launch.local=true' || '' }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "${{ github.workspace }}:/home/build/synth-setter" \
+            -v "${RUN_METADATA_DIR}:/run-metadata" \
+            -e SKYPILOT_API_SERVER_ENDPOINT \
+            -e PROVIDER \
+            -e TEMPLATE \
+            -e CLUSTER_NAME \
+            -e IMAGE_TAG \
+            -e RUNPOD_API_KEY \
+            -e CONFIG_PATH \
+            -e WORKER_GIT_REF \
+            -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
+            -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
+            -e RCLONE_CONFIG_R2_ENDPOINT \
+            -e R2_ACCOUNT_ID \
+            -e WANDB_API_KEY \
+            -e NUM_WORKERS_OVERRIDE \
+            -e TAIL_OVERRIDE \
+            -e LOCAL_OVERRIDE \
+            "${IMAGE}" \
+            bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              git config --global --add safe.directory /home/build/synth-setter
+              bash docker/ubuntu22_04/ensure_plugin_symlinks.sh
+              python -m synth_setter.pipeline.ci.materialize_spec "$CONFIG_PATH" /run-metadata
+              chmod 0644 /run-metadata/input_spec.json
+              synth-setter-generate-dataset \
+                "experiment=$CONFIG_PATH" \
+                "skypilot_launch.compute_template=$TEMPLATE" \
+                "skypilot_launch.job_name=$CLUSTER_NAME" \
+                "skypilot_launch.worker_image_tag=$IMAGE_TAG" \
+                $LOCAL_OVERRIDE $NUM_WORKERS_OVERRIDE $TAIL_OVERRIDE
+            ' \
+            2>&1 | tee "${RUN_METADATA_DIR}/generate.log"
+
+      # ----- oci row: legacy click CLI (in-container)
+      # OCI stays on `python -m synth_setter.pipeline.skypilot_launch` because
+      # configs/compute/oci-cpu-template.yaml's `run:` block is a sub-docker
+      # invocation that the new dispatch's cmd injection can't replicate —
+      # SkyPilot's OCI backend rejects `image_id: docker:<image>` so the
+      # worker container has to be brought up by the template's bash, not by
+      # SkyPilot itself. Migrating OCI requires either a docker-preinstalled
+      # OCI image or per-provider cmd wrapping in dispatch_via_skypilot.
+      - name: Launch SkyPilot job (oci row; legacy click CLI; in container)
+        if: ${{ inputs.provider == 'oci' }}
+        env:
+          SKYPILOT_API_SERVER_ENDPOINT: ${{ secrets.SKYPILOT_API_SERVER_ENDPOINT }}
+          TEMPLATE: configs/compute/oci-cpu-template.yaml
+          CLUSTER_NAME: ${{ steps.cluster.outputs.name }}
           OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
           OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
           OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
@@ -357,7 +433,6 @@ jobs:
             -e TEMPLATE \
             -e CLUSTER_NAME \
             -e IMAGE_TAG \
-            -e RUNPOD_API_KEY \
             -e OCI_USER_OCID \
             -e OCI_TENANCY_OCID \
             -e OCI_FINGERPRINT \

--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -2,27 +2,21 @@ name: Generate Dataset Shards
 
 # Reusable workflow that owns one provider's generate_dataset invocation.
 # Callers fan out across providers (see test-dataset-generation.yml) and pass
-# per-provider values via inputs. All three providers drive the Hydra-first
-# `synth-setter-generate-dataset` entrypoint via `skypilot_launch.compute_template=...`
-# Hydra overrides; OCI's compute template uses the `${WORKER_CMD}` sentinel
-# (substituted by `_load_compute_template_with_cmd`) so the launcher's worker
-# cmd lands inside the OCI sub-docker invocation that the OCI backend forces
-# (SkyPilot's OCI backend rejects `image_id: docker:<image>`).
+# per-provider values via inputs. All providers drive `synth-setter-generate-dataset`
+# with a `skypilot_launch.compute_template=...` Hydra override.
 #
 # Provider-specific behavior:
 #   * `skypilot-local` — provisions a kind cluster on the runner via
 #     `sky local up`, loads the dev-snapshot image into kind, writes the
 #     managed-jobs controller-resource shrink into ~/.sky/config.yaml so the
-#     controller pod fits on kind, and invokes `synth-setter-generate-dataset`
-#     with `skypilot_launch.compute_template=configs/compute/local-template.yaml`.
-#     The launcher detects `cloud: kubernetes` and skips its cred bootstrap.
-#     Always tears down kind in `if: always()`.
-#   * `runpod` / `oci` — in-container invocation of `synth-setter-generate-dataset`
-#     against the matching `configs/compute/*-template.yaml`. The launcher's
-#     `_run_cred_bootstrap` writes provider creds inside the container; if
-#     SKYPILOT_API_SERVER_ENDPOINT is set, the bootstrap is skipped (the remote
-#     API server holds creds). OCI's template uses `${WORKER_CMD}`; runpod's
-#     template has no `run:` (cmd is injected directly).
+#     controller pod fits on kind, then invokes against
+#     `configs/compute/local-template.yaml`. The launcher detects
+#     `cloud: kubernetes` and skips its cred bootstrap. Always tears down
+#     kind in `if: always()`.
+#   * `runpod` / `oci` — in-container invocation against the matching
+#     `configs/compute/*-template.yaml`. The launcher's `_run_cred_bootstrap`
+#     writes provider creds inside the container; if SKYPILOT_API_SERVER_ENDPOINT
+#     is set, the bootstrap is skipped (the remote API server holds creds).
 #
 # Required secrets (callers should `secrets: inherit`):
 #   RCLONE_CONFIG_R2_ACCESS_KEY_ID, RCLONE_CONFIG_R2_SECRET_ACCESS_KEY,
@@ -238,23 +232,20 @@ jobs:
           chmod 600 "${HOME}/.sky/config.yaml"
 
       # `skypilot_launch.local=true` flips the launcher's local-vs-remote dispatch
-      # (#841); today's skypilot-local caller sets it to clear any inherited
+      # (#841); the skypilot-local caller sets it to clear any inherited
       # SKYPILOT_API_SERVER_ENDPOINT. `skypilot_launch.num_workers=1` overrides
       # the config default because the kind cluster can't host parallel workers
       # (#843). The override array is built conditionally so optional flags
       # don't expand to empty strings.
       #
-      # materialize_spec runs first to write input_spec.json — the launcher's
-      # entrypoint doesn't have a `--spec-out` equivalent (Hydra-internal),
-      # so this gives the downstream `Compute spec_uri output` step its r2_bucket
-      # source and provides a debug artifact via the run-metadata upload.
+      # materialize_spec runs first to produce input_spec.json for the
+      # downstream `Compute spec_uri output` step (the Hydra entrypoint has no
+      # `--spec-out` equivalent) and as a run-metadata debug artifact.
       #
-      # 20-min step cap: if the launcher (sky.jobs SDK) hangs, fail-fast and
-      # let the `if: always()` `Snapshot sky logs` step run, instead of
-      # burning the full 60-min job timeout before logs are uploaded.
-      # NOTE: step-level timeout sends SIGKILL — Python `finally` blocks in the
-      # launcher are bypassed. Operators may need `sky jobs cancel --name <job-name>`
-      # manually after a timeout. See #876.
+      # 20-min step cap caps a hung launcher so the `if: always()` log-snapshot
+      # step still runs. NOTE: step-level timeout sends SIGKILL — `finally`
+      # blocks are bypassed; operators may need to `sky jobs cancel` manually.
+      # See #876.
       - name: Run synth-setter-generate-dataset against local-template (skypilot-local row)
         if: ${{ inputs.provider == 'skypilot-local' }}
         timeout-minutes: 20
@@ -331,16 +322,13 @@ jobs:
           du -sh "${RUN_METADATA_DIR}/sky_logs" "${RUN_METADATA_DIR}/sky_api_server_logs" 2>/dev/null || true
 
       # ----- runpod / oci row: in-container synth-setter-generate-dataset
-      # Both cloud providers drive the new Hydra entrypoint; OCI's template
-      # uses ${WORKER_CMD} substitution in its run: block so the launcher's
-      # cmd lands inside the OCI sub-docker invocation (configs/compute/oci-cpu-template.yaml).
-      # Optional launcher flags are pre-rendered into env-var strings on the
-      # outer step (so GHA expression evaluation stays out of the bash
+      # Optional Hydra overrides are pre-rendered into env-var strings at the
+      # outer step (keeping GHA expression evaluation out of the bash
       # block-scalar) and expanded unquoted inside docker so empty values
-      # disappear. SKYPILOT_API_SERVER_ENDPOINT (when the secret is set)
-      # routes the launcher to the remote API server; pass `local: true` to
-      # override. materialize_spec runs first inside the container to write
-      # /run-metadata/input_spec.json for the spec_uri output step.
+      # disappear. SKYPILOT_API_SERVER_ENDPOINT (when set) routes the launcher
+      # to the remote API server; pass `local: true` to override. materialize_spec
+      # runs first inside the container to write /run-metadata/input_spec.json
+      # for the spec_uri output step.
       - name: Run synth-setter-generate-dataset (runpod / oci row; in container)
         if: ${{ inputs.provider == 'runpod' || inputs.provider == 'oci' }}
         env:

--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -2,12 +2,12 @@ name: Generate Dataset Shards
 
 # Reusable workflow that owns one provider's generate_dataset invocation.
 # Callers fan out across providers (see test-dataset-generation.yml) and pass
-# per-provider values via inputs. The skypilot-local and runpod paths drive
-# the Hydra-first `synth-setter-generate-dataset` entrypoint with
-# `skypilot_launch.compute_template=...` overrides; the OCI path continues
-# to invoke the legacy `python -m synth_setter.pipeline.skypilot_launch` click
-# CLI because OCI's sub-docker `run:` block can't be replaced by the new
-# dispatch's cmd injection (SkyPilot OCI backend rejects `image_id: docker:<image>`).
+# per-provider values via inputs. All three providers drive the Hydra-first
+# `synth-setter-generate-dataset` entrypoint via `skypilot_launch.compute_template=...`
+# Hydra overrides; OCI's compute template uses the `${WORKER_CMD}` sentinel
+# (substituted by `_load_compute_template_with_cmd`) so the launcher's worker
+# cmd lands inside the OCI sub-docker invocation that the OCI backend forces
+# (SkyPilot's OCI backend rejects `image_id: docker:<image>`).
 #
 # Provider-specific behavior:
 #   * `skypilot-local` — provisions a kind cluster on the runner via
@@ -17,15 +17,12 @@ name: Generate Dataset Shards
 #     with `skypilot_launch.compute_template=configs/compute/local-template.yaml`.
 #     The launcher detects `cloud: kubernetes` and skips its cred bootstrap.
 #     Always tears down kind in `if: always()`.
-#   * `runpod` — in-container invocation of `synth-setter-generate-dataset`
-#     against `configs/compute/runpod-template.yaml`. The launcher's
+#   * `runpod` / `oci` — in-container invocation of `synth-setter-generate-dataset`
+#     against the matching `configs/compute/*-template.yaml`. The launcher's
 #     `_run_cred_bootstrap` writes provider creds inside the container; if
 #     SKYPILOT_API_SERVER_ENDPOINT is set, the bootstrap is skipped (the remote
-#     API server holds creds).
-#   * `oci` — legacy in-container `python -m synth_setter.pipeline.skypilot_launch`
-#     against `configs/compute/oci-cpu-template.yaml`. The OCI template keeps
-#     its `run:` block (sub-docker invocation) because OCI's backend can't
-#     ingest a pinned `image_id: docker:<image>`.
+#     API server holds creds). OCI's template uses `${WORKER_CMD}`; runpod's
+#     template has no `run:` (cmd is injected directly).
 #
 # Required secrets (callers should `secrets: inherit`):
 #   RCLONE_CONFIG_R2_ACCESS_KEY_ID, RCLONE_CONFIG_R2_SECRET_ACCESS_KEY,
@@ -333,7 +330,10 @@ jobs:
           echo "=== snapshot sizes ==="
           du -sh "${RUN_METADATA_DIR}/sky_logs" "${RUN_METADATA_DIR}/sky_api_server_logs" 2>/dev/null || true
 
-      # ----- runpod row: in-container synth-setter-generate-dataset
+      # ----- runpod / oci row: in-container synth-setter-generate-dataset
+      # Both cloud providers drive the new Hydra entrypoint; OCI's template
+      # uses ${WORKER_CMD} substitution in its run: block so the launcher's
+      # cmd lands inside the OCI sub-docker invocation (configs/compute/oci-cpu-template.yaml).
       # Optional launcher flags are pre-rendered into env-var strings on the
       # outer step (so GHA expression evaluation stays out of the bash
       # block-scalar) and expanded unquoted inside docker so empty values
@@ -341,13 +341,18 @@ jobs:
       # routes the launcher to the remote API server; pass `local: true` to
       # override. materialize_spec runs first inside the container to write
       # /run-metadata/input_spec.json for the spec_uri output step.
-      - name: Run synth-setter-generate-dataset against runpod-template (runpod row; in container)
-        if: ${{ inputs.provider == 'runpod' }}
+      - name: Run synth-setter-generate-dataset (runpod / oci row; in container)
+        if: ${{ inputs.provider == 'runpod' || inputs.provider == 'oci' }}
         env:
           SKYPILOT_API_SERVER_ENDPOINT: ${{ secrets.SKYPILOT_API_SERVER_ENDPOINT }}
-          TEMPLATE: configs/compute/runpod-template.yaml
+          TEMPLATE: configs/compute/${{ inputs.provider == 'oci' && 'oci-cpu' || inputs.provider }}-template.yaml
           CLUSTER_NAME: ${{ steps.cluster.outputs.name }}
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
+          OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
+          OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
+          OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
+          OCI_REGION: ${{ secrets.OCI_REGION }}
+          OCI_API_KEY_PEM: ${{ secrets.OCI_API_KEY_PEM }}
           RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
           RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
           RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
@@ -368,6 +373,11 @@ jobs:
             -e CLUSTER_NAME \
             -e IMAGE_TAG \
             -e RUNPOD_API_KEY \
+            -e OCI_USER_OCID \
+            -e OCI_TENANCY_OCID \
+            -e OCI_FINGERPRINT \
+            -e OCI_REGION \
+            -e OCI_API_KEY_PEM \
             -e CONFIG_PATH \
             -e WORKER_GIT_REF \
             -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
@@ -392,77 +402,6 @@ jobs:
                 "skypilot_launch.job_name=$CLUSTER_NAME" \
                 "skypilot_launch.worker_image_tag=$IMAGE_TAG" \
                 $LOCAL_OVERRIDE $NUM_WORKERS_OVERRIDE $TAIL_OVERRIDE
-            ' \
-            2>&1 | tee "${RUN_METADATA_DIR}/generate.log"
-
-      # ----- oci row: legacy click CLI (in-container)
-      # OCI stays on `python -m synth_setter.pipeline.skypilot_launch` because
-      # configs/compute/oci-cpu-template.yaml's `run:` block is a sub-docker
-      # invocation that the new dispatch's cmd injection can't replicate —
-      # SkyPilot's OCI backend rejects `image_id: docker:<image>` so the
-      # worker container has to be brought up by the template's bash, not by
-      # SkyPilot itself. Migrating OCI requires either a docker-preinstalled
-      # OCI image or per-provider cmd wrapping in dispatch_via_skypilot.
-      - name: Launch SkyPilot job (oci row; legacy click CLI; in container)
-        if: ${{ inputs.provider == 'oci' }}
-        env:
-          SKYPILOT_API_SERVER_ENDPOINT: ${{ secrets.SKYPILOT_API_SERVER_ENDPOINT }}
-          TEMPLATE: configs/compute/oci-cpu-template.yaml
-          CLUSTER_NAME: ${{ steps.cluster.outputs.name }}
-          OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
-          OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
-          OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
-          OCI_REGION: ${{ secrets.OCI_REGION }}
-          OCI_API_KEY_PEM: ${{ secrets.OCI_API_KEY_PEM }}
-          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
-          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
-          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
-          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
-          WORKER_GIT_REF: ${{ github.event.pull_request.head.sha || github.sha }}
-          NUM_WORKERS_FLAG: ${{ inputs.num_workers != '' && format('--num-workers {0}', inputs.num_workers) || '' }}
-          TAIL_FLAG: ${{ inputs.tail && '--tail' || '' }}
-          LOCAL_FLAG: ${{ inputs.local && '--local' || '' }}
-        run: |
-          set -euo pipefail
-          docker run --rm \
-            -v "${{ github.workspace }}:/home/build/synth-setter" \
-            -v "${RUN_METADATA_DIR}:/run-metadata" \
-            -e SKYPILOT_API_SERVER_ENDPOINT \
-            -e PROVIDER \
-            -e TEMPLATE \
-            -e CLUSTER_NAME \
-            -e IMAGE_TAG \
-            -e OCI_USER_OCID \
-            -e OCI_TENANCY_OCID \
-            -e OCI_FINGERPRINT \
-            -e OCI_REGION \
-            -e OCI_API_KEY_PEM \
-            -e CONFIG_PATH \
-            -e WORKER_GIT_REF \
-            -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
-            -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
-            -e RCLONE_CONFIG_R2_ENDPOINT \
-            -e R2_ACCOUNT_ID \
-            -e WANDB_API_KEY \
-            -e NUM_WORKERS_FLAG \
-            -e TAIL_FLAG \
-            -e LOCAL_FLAG \
-            "${IMAGE}" \
-            bash -c '
-              set -euo pipefail
-              cd /home/build/synth-setter
-              git config --global --add safe.directory /home/build/synth-setter
-              bash docker/ubuntu22_04/ensure_plugin_symlinks.sh
-              python -m synth_setter.pipeline.skypilot_launch \
-                --experiment "$CONFIG_PATH" \
-                --template "$TEMPLATE" \
-                --job-name "$CLUSTER_NAME" \
-                --worker-image-tag "$IMAGE_TAG" \
-                --spec-out /tmp/input_spec.json \
-                $LOCAL_FLAG $NUM_WORKERS_FLAG $TAIL_FLAG
-              cp /tmp/input_spec.json /run-metadata/input_spec.json
-              chmod 0644 /run-metadata/input_spec.json
             ' \
             2>&1 | tee "${RUN_METADATA_DIR}/generate.log"
 

--- a/configs/compute/local-template.yaml
+++ b/configs/compute/local-template.yaml
@@ -1,10 +1,18 @@
 # SkyPilot task template for the local Kubernetes (kind) backend.
 #
-# Loaded by src/synth_setter/pipeline/skypilot_launch.py via sky.Task.from_yaml(...)
-# when --template configs/compute/local-template.yaml is passed (the
+# Loaded by src/synth_setter/pipeline/skypilot_launch.py's
+# dispatch_via_skypilot via sky.Task.from_yaml_config(...) when
+# cfg.skypilot_launch.compute_template points at this file (e.g. for the
 # `skypilot-local` row of test-dataset-generation's matrix). Provisioning
 # expects a `sky local up`-managed kind cluster ("skypilot" kubectl context)
 # already running.
+#
+# No `run:` block: the launcher injects the worker-side cmd
+# (`cd /home/build/synth-setter && bash scripts/sync_worker_checkout.sh &&
+#  exec synth-setter-generate-dataset-from-hydra <overrides>`) at dispatch
+# time via _build_worker_cmd in src/synth_setter/cli/generate_dataset.py.
+# Adding a run: here would be rejected by _load_compute_template_with_cmd's
+# conflict guard.
 #
 # The launcher detects `cloud: kubernetes` and SKIPS its cred bootstrap —
 # kind needs no compute creds (R2 env vars are forwarded into the pod via
@@ -12,14 +20,12 @@
 # resource shrink directly to ~/.sky/config.yaml before launch (the SkyPilot
 # defaults of cpus=4+/mem=4x/disk_size=50 don't fit on GHA's kind cluster,
 # and k8s rejects disk_size). See PR #876.
-# R2 still ships the materialized spec
-# (`r2://<bucket>/skypilot-launcher-specs/<job>.json`).
 #
 # Image: `tinaudio/synth-setter:<worker-image-tag>` is loaded into the kind
 # cluster via `kind load docker-image` ahead of launch (CI does this; for
 # local dev `kind load docker-image tinaudio/synth-setter:dev-snapshot --name skypilot`
 # pulls from the local docker daemon). `image_id` is set per-launch by the
-# launcher from --worker-image-tag.
+# launcher from skypilot_launch.worker_image_tag.
 
 resources:
   cloud: kubernetes
@@ -30,15 +36,14 @@ resources:
   # disk_size omitted: kind/k8s backend rejects the field — see PR #876.
 
 # Placeholders. Real values are injected by the launcher via update_envs.
-# WORKER_SPEC_URI is set per-launch by the launcher to the r2:// URI of the
-# uploaded spec; the worker downloads from there via load_spec_from_uri.
+# WORKER_GIT_REF is forwarded so sync_worker_checkout.sh can fetch the PR
+# head over the image-baked checkout when set.
 envs:
   RCLONE_CONFIG_R2_TYPE: ""
   RCLONE_CONFIG_R2_PROVIDER: ""
   RCLONE_CONFIG_R2_ACCESS_KEY_ID: ""
   RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ""
   RCLONE_CONFIG_R2_ENDPOINT: ""
-  WORKER_SPEC_URI: ""
   WORKER_GIT_REF: ""
   SYNTH_SETTER_WORKER_RANK: ""
   SYNTH_SETTER_NUM_WORKERS: ""
@@ -46,15 +51,3 @@ envs:
 setup: |
   set -euo pipefail
   echo "synth-setter worker ready (host: $(hostname))"
-
-# The image ships src/synth_setter/tools/docker_entrypoint.py baked at /usr/local/bin/entrypoint.py,
-# but PR CI bypasses image bake-lag via sync_worker_checkout.sh (WORKER_GIT_REF).
-# Run the synced script from the checkout — not the baked one — so the worker
-# picks up entrypoint changes from the PR head before main publishes a new
-# dev-snapshot.
-run: |
-  set -euo pipefail
-  cd /home/build/synth-setter
-  echo "skypilot-run-cwd: $(pwd)"
-  bash scripts/sync_worker_checkout.sh
-  exec python -m synth_setter.tools.docker_entrypoint generate_dataset --spec "${WORKER_SPEC_URI}"

--- a/configs/compute/local-template.yaml
+++ b/configs/compute/local-template.yaml
@@ -1,31 +1,20 @@
 # SkyPilot task template for the local Kubernetes (kind) backend.
 #
-# Loaded by src/synth_setter/pipeline/skypilot_launch.py's
-# dispatch_via_skypilot via sky.Task.from_yaml_config(...) when
-# cfg.skypilot_launch.compute_template points at this file (e.g. for the
-# `skypilot-local` row of test-dataset-generation's matrix). Provisioning
-# expects a `sky local up`-managed kind cluster ("skypilot" kubectl context)
-# already running.
+# Loaded by dispatch_via_skypilot via sky.Task.from_yaml_config(...).
+# Provisioning expects a `sky local up`-managed kind cluster ("skypilot"
+# kubectl context) already running.
 #
-# No `run:` block: the launcher injects the worker-side cmd
-# (`cd /home/build/synth-setter && bash scripts/sync_worker_checkout.sh &&
-#  exec synth-setter-generate-dataset-from-hydra <overrides>`) at dispatch
-# time via _build_worker_cmd in src/synth_setter/cli/generate_dataset.py.
-# Adding a run: here would be rejected by _load_compute_template_with_cmd's
-# conflict guard.
+# No `run:` block — the launcher's _build_worker_cmd injects one. Adding a
+# `run:` here would be rejected by _load_compute_template_with_cmd.
 #
 # The launcher detects `cloud: kubernetes` and SKIPS its cred bootstrap —
-# kind needs no compute creds (R2 env vars are forwarded into the pod via
-# task.update_envs) and the CI workflow writes the managed-jobs controller-
-# resource shrink directly to ~/.sky/config.yaml before launch (the SkyPilot
-# defaults of cpus=4+/mem=4x/disk_size=50 don't fit on GHA's kind cluster,
-# and k8s rejects disk_size). See PR #876.
+# kind needs no compute creds. The CI workflow writes a managed-jobs
+# controller-resource shrink to ~/.sky/config.yaml before launch so the
+# controller fits on GHA's kind cluster — see PR #876.
 #
 # Image: `tinaudio/synth-setter:<worker-image-tag>` is loaded into the kind
-# cluster via `kind load docker-image` ahead of launch (CI does this; for
-# local dev `kind load docker-image tinaudio/synth-setter:dev-snapshot --name skypilot`
-# pulls from the local docker daemon). `image_id` is set per-launch by the
-# launcher from skypilot_launch.worker_image_tag.
+# cluster via `kind load docker-image` ahead of launch. `image_id` is set
+# per-launch by the launcher from skypilot_launch.worker_image_tag.
 
 resources:
   cloud: kubernetes

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -2,13 +2,11 @@
 # Sibling of runpod-template.yaml — see docs/design/skypilot-compute-integration.md.
 #
 # OCI-specific: the worker image is pulled and run as a sub-docker invocation
-# inside the run: block because SkyPilot's OCI backend rejects `image_id: docker:<image>`.
-# This template uses the ${WORKER_CMD} sentinel: dispatch_via_skypilot's
-# _load_compute_template_with_cmd substitutes the launcher's worker cmd
-# (cd / sync_worker_checkout.sh / exec synth-setter-generate-dataset-from-hydra)
-# into the inner `bash -c` body. The outer `sudo docker run` scaffolding stays
-# YAML-owned because it can't live in the cmd (it must run on the OCI VM host,
-# not inside the worker container).
+# inside the run: block — SkyPilot's OCI backend rejects `image_id: docker:<image>`.
+# Uses the ${WORKER_CMD} sentinel so _load_compute_template_with_cmd can
+# substitute the launcher's worker cmd into the inner `bash -c` body; the
+# outer `sudo docker run` must run on the OCI VM host, not inside the worker
+# container, so it stays YAML-owned.
 # Region intentionally not pinned — `~/.oci/config` is the single source of truth.
 
 resources:
@@ -65,10 +63,9 @@ setup: |
 
 # run: launches the worker container ourselves (OCI backend can't ingest a
 # docker image_id). --privileged + --ulimit nofile is the expedient hammer
-# for the Xvfb/dbus stack — follow-up to find the minimal cap set: #776. No
-# bind-mount: image is source of truth, and the worker cmd (substituted into
-# ${WORKER_CMD} by the launcher) runs sync_worker_checkout.sh inside the
-# container for the WORKER_GIT_REF PR-CI bake-lag bypass.
+# for the Xvfb/dbus stack — minimal-cap follow-up: #776. No bind-mount:
+# image is source of truth; the substituted ${WORKER_CMD} runs
+# sync_worker_checkout.sh inside the container for the PR-CI bake-lag bypass.
 run: |
   set -euo pipefail
   : "${WORKER_IMAGE:?WORKER_IMAGE must be set by the launcher; refusing to docker run an unset image}"

--- a/configs/compute/oci-cpu-template.yaml
+++ b/configs/compute/oci-cpu-template.yaml
@@ -3,6 +3,12 @@
 #
 # OCI-specific: the worker image is pulled and run as a sub-docker invocation
 # inside the run: block because SkyPilot's OCI backend rejects `image_id: docker:<image>`.
+# This template uses the ${WORKER_CMD} sentinel: dispatch_via_skypilot's
+# _load_compute_template_with_cmd substitutes the launcher's worker cmd
+# (cd / sync_worker_checkout.sh / exec synth-setter-generate-dataset-from-hydra)
+# into the inner `bash -c` body. The outer `sudo docker run` scaffolding stays
+# YAML-owned because it can't live in the cmd (it must run on the OCI VM host,
+# not inside the worker container).
 # Region intentionally not pinned — `~/.oci/config` is the single source of truth.
 
 resources:
@@ -21,7 +27,6 @@ envs:
   RCLONE_CONFIG_R2_ACCESS_KEY_ID: ""
   RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ""
   RCLONE_CONFIG_R2_ENDPOINT: ""
-  WORKER_SPEC_URI: ""
   WORKER_IMAGE: ""
   WORKER_GIT_REF: ""
   SYNTH_SETTER_WORKER_RANK: ""
@@ -61,11 +66,12 @@ setup: |
 # run: launches the worker container ourselves (OCI backend can't ingest a
 # docker image_id). --privileged + --ulimit nofile is the expedient hammer
 # for the Xvfb/dbus stack — follow-up to find the minimal cap set: #776. No
-# bind-mount: image is source of truth, sync_worker_checkout.sh handles the
-# WORKER_GIT_REF PR-CI bake-lag bypass without clobbering image-baked symlinks.
+# bind-mount: image is source of truth, and the worker cmd (substituted into
+# ${WORKER_CMD} by the launcher) runs sync_worker_checkout.sh inside the
+# container for the WORKER_GIT_REF PR-CI bake-lag bypass.
 run: |
   set -euo pipefail
-  : "${WORKER_IMAGE:?WORKER_IMAGE must be set by the launcher (--worker-image-tag); refusing to docker run an unset image}"
+  : "${WORKER_IMAGE:?WORKER_IMAGE must be set by the launcher; refusing to docker run an unset image}"
   echo "skypilot-run-cwd: $(pwd) host: $(hostname)"
   sudo -E docker run --rm \
     --privileged \
@@ -75,14 +81,8 @@ run: |
     -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
     -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
     -e RCLONE_CONFIG_R2_ENDPOINT \
-    -e WORKER_SPEC_URI \
     -e WORKER_GIT_REF \
     -e SYNTH_SETTER_WORKER_RANK \
     -e SYNTH_SETTER_NUM_WORKERS \
     "$WORKER_IMAGE" \
-    bash -c '
-      set -euo pipefail
-      cd /home/build/synth-setter
-      bash scripts/sync_worker_checkout.sh
-      exec python -m synth_setter.tools.docker_entrypoint generate_dataset --spec "$WORKER_SPEC_URI"
-    '
+    bash -c "${WORKER_CMD}"

--- a/configs/compute/runpod-template.yaml
+++ b/configs/compute/runpod-template.yaml
@@ -1,27 +1,19 @@
 # SkyPilot task template for RunPod.
 #
-# Loaded by src/synth_setter/pipeline/skypilot_launch.py's
-# dispatch_via_skypilot via sky.Task.from_yaml_config(...).
-# The launcher uploads the materialized spec to R2 (`r2://<bucket>/skypilot-launcher-specs/<job>.json`)
-# and injects credentials + the spec URI via task.update_envs(...) before
-# calling sky.launch(task, cluster_name=..., down=True). Unmanaged launch
-# (not sky.jobs.launch) — RunPod has no managed-jobs controller backend.
+# Loaded by dispatch_via_skypilot via sky.Task.from_yaml_config(...).
+# The launcher uploads the materialized spec to R2 and injects creds + the
+# spec URI via task.update_envs(...) before calling sky.launch(...). Unmanaged
+# launch — RunPod has no managed-jobs controller backend.
 #
-# No `run:` block: the launcher injects the worker-side cmd
-# (`cd /home/build/synth-setter && bash scripts/sync_worker_checkout.sh &&
-#  exec synth-setter-generate-dataset-from-hydra <overrides>`) at dispatch
-# time via _build_worker_cmd in src/synth_setter/cli/generate_dataset.py.
-# Adding a run: here would be rejected by _load_compute_template_with_cmd's
-# conflict guard.
+# No `run:` block — the launcher's _build_worker_cmd injects one. Adding a
+# `run:` here would be rejected by _load_compute_template_with_cmd.
 #
-# Spec ships via R2 (not file_mounts) because programmatic `task.update_file_mounts(...)`
-# triggers a SkyPilot RunPod-backend pubkey-overflow rejection at pod-create
-# time (see #749 for evidence + investigation status).
+# Spec ships via R2 (not file_mounts) — RunPod backend rejects programmatic
+# task.update_file_mounts(...) with a pubkey-overflow error. See #749.
 #
-# Image: `tinaudio/synth-setter:<worker-image-tag>` must exist on Docker Hub
-# (e.g. `make docker-build-dev-snapshot` then `docker push` for the default
-# `dev-snapshot` tag) before launch. `image_id` is set per-launch by the
-# launcher from skypilot_launch.worker_image_tag.
+# Image: `tinaudio/synth-setter:<worker-image-tag>` must be pushed to Docker
+# Hub before launch. `image_id` is set per-launch by the launcher from
+# skypilot_launch.worker_image_tag.
 
 resources:
   cloud: runpod

--- a/configs/compute/runpod-template.yaml
+++ b/configs/compute/runpod-template.yaml
@@ -1,10 +1,18 @@
 # SkyPilot task template for RunPod.
 #
-# Loaded by src/synth_setter/pipeline/skypilot_launch.py via sky.Task.from_yaml(...).
-# The launcher uploads the materialized spec to R2 (`r2://<bucket>/skypilot-launcher-specs/<cluster>.json`)
+# Loaded by src/synth_setter/pipeline/skypilot_launch.py's
+# dispatch_via_skypilot via sky.Task.from_yaml_config(...).
+# The launcher uploads the materialized spec to R2 (`r2://<bucket>/skypilot-launcher-specs/<job>.json`)
 # and injects credentials + the spec URI via task.update_envs(...) before
 # calling sky.launch(task, cluster_name=..., down=True). Unmanaged launch
 # (not sky.jobs.launch) — RunPod has no managed-jobs controller backend.
+#
+# No `run:` block: the launcher injects the worker-side cmd
+# (`cd /home/build/synth-setter && bash scripts/sync_worker_checkout.sh &&
+#  exec synth-setter-generate-dataset-from-hydra <overrides>`) at dispatch
+# time via _build_worker_cmd in src/synth_setter/cli/generate_dataset.py.
+# Adding a run: here would be rejected by _load_compute_template_with_cmd's
+# conflict guard.
 #
 # Spec ships via R2 (not file_mounts) because programmatic `task.update_file_mounts(...)`
 # triggers a SkyPilot RunPod-backend pubkey-overflow rejection at pod-create
@@ -13,7 +21,7 @@
 # Image: `tinaudio/synth-setter:<worker-image-tag>` must exist on Docker Hub
 # (e.g. `make docker-build-dev-snapshot` then `docker push` for the default
 # `dev-snapshot` tag) before launch. `image_id` is set per-launch by the
-# launcher from --worker-image-tag.
+# launcher from skypilot_launch.worker_image_tag.
 
 resources:
   cloud: runpod
@@ -34,15 +42,14 @@ resources:
   disk_size: 50
 
 # Placeholders. Real values are injected by the launcher via update_envs.
-# WORKER_SPEC_URI is set per-cluster by the launcher to the r2:// URI of the
-# uploaded spec; the worker downloads from there via load_spec_from_uri.
+# WORKER_GIT_REF is forwarded so sync_worker_checkout.sh can fetch the PR
+# head over the image-baked checkout when set (PR-CI bake-lag bypass).
 envs:
   RCLONE_CONFIG_R2_TYPE: ""
   RCLONE_CONFIG_R2_PROVIDER: ""
   RCLONE_CONFIG_R2_ACCESS_KEY_ID: ""
   RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ""
   RCLONE_CONFIG_R2_ENDPOINT: ""
-  WORKER_SPEC_URI: ""
   WORKER_GIT_REF: ""
   # Per-rank partition env. Source of truth: src/synth_setter/pipeline/partitioning.py.
   SYNTH_SETTER_WORKER_RANK: ""
@@ -51,14 +58,3 @@ envs:
 setup: |
   set -euo pipefail
   echo "synth-setter worker ready (host: $(hostname))"
-
-# sync_worker_checkout.sh handles the WORKER_GIT_REF PR-CI bake-lag bypass.
-# The synced checkout's src/synth_setter/tools/docker_entrypoint.py is invoked directly so
-# entrypoint changes on the PR head land before main rebuilds dev-snapshot —
-# /usr/local/bin/entrypoint.py is the baked copy and lags by one main rebuild.
-run: |
-  set -euo pipefail
-  cd /home/build/synth-setter
-  echo "skypilot-run-cwd: $(pwd)"
-  bash scripts/sync_worker_checkout.sh
-  exec python -m synth_setter.tools.docker_entrypoint generate_dataset --spec "$WORKER_SPEC_URI"

--- a/configs/dataset.yaml
+++ b/configs/dataset.yaml
@@ -11,6 +11,7 @@ defaults:
   - r2: default
   - paths: default
   - hydra: default
+  - skypilot_launch: default
   - experiment: ???
 
 task_name: ???

--- a/configs/skypilot_launch/default.yaml
+++ b/configs/skypilot_launch/default.yaml
@@ -1,9 +1,6 @@
-# Default SkyPilot dispatch settings consumed by
-# ``synth_setter.cli.generate_dataset.main``. ``compute_template: null`` means
-# the run stays in-process — set it to a YAML path under ``configs/compute/``
-# (e.g. ``skypilot_launch.compute_template=configs/compute/runpod-template.yaml``)
-# to dispatch the render through SkyPilot via
-# ``synth_setter.pipeline.skypilot_launch.dispatch_via_skypilot``.
+# SkyPilot dispatch knobs for synth-setter-generate-dataset.
+# compute_template stays null → run in-process; point it at a configs/compute/*.yaml
+# to dispatch via SkyPilot. See generate_dataset.main for dispatch semantics.
 
 compute_template: null
 env_file: .env

--- a/configs/skypilot_launch/default.yaml
+++ b/configs/skypilot_launch/default.yaml
@@ -1,0 +1,15 @@
+# Default SkyPilot dispatch settings consumed by
+# ``synth_setter.cli.generate_dataset.main``. ``compute_template: null`` means
+# the run stays in-process — set it to a YAML path under ``configs/compute/``
+# (e.g. ``skypilot_launch.compute_template=configs/compute/runpod-template.yaml``)
+# to dispatch the render through SkyPilot via
+# ``synth_setter.pipeline.skypilot_launch.dispatch_via_skypilot``.
+
+compute_template: null
+env_file: .env
+job_name: null
+num_workers: 1
+worker_image_tag: dev-snapshot
+tail: false
+api_server: null
+local: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ all = [
 synth-setter-train = "synth_setter.cli.train:main"
 synth-setter-eval = "synth_setter.cli.eval:main"
 synth-setter-generate-dataset = "synth_setter.cli.generate_dataset:main"
+synth-setter-generate-dataset-from-hydra = "synth_setter.cli.generate_dataset:from_hydra"
 
 
 

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -313,45 +313,27 @@ def _build_worker_cmd(overrides: list[str]) -> str:  # noqa: DOC203
 
 
 @hydra.main(version_base="1.3", config_path="../../../configs", config_name="dataset")
-def from_hydra(cfg: DictConfig) -> None:
-    """Worker-side ``@hydra.main`` entry: build the spec and render it in-process.
-
-    Exposed as the ``synth-setter-generate-dataset-from-hydra`` console script
-    and injected by :func:`main` as the ``run:`` block of each dispatched
-    ``sky.Task``. Re-enters the same Hydra composition the operator typed
-    locally so the worker's spec matches byte-for-byte; the ``skypilot_launch``
-    sub-tree is left composed but unread (it's a no-op on the worker side).
-
-    :param cfg: The Hydra-composed dataset cfg passed by ``@hydra.main``.
-    """
+def from_hydra(cfg: DictConfig) -> None:  # noqa: DOC101,DOC103
+    """Worker-side @hydra.main entry: build the spec and render it in-process."""
     run(spec_from_cfg(cfg))
 
 
 def main() -> None:
     """User-facing CLI: compose dataset cfg from argv, dispatch local or via SkyPilot.
 
-    Programmatic ``initialize_config_dir`` + ``compose`` instead of
-    ``@hydra.main`` so we can inspect ``cfg.skypilot_launch.compute_template``
-    and choose the dispatch branch before Hydra would otherwise hand the cfg
-    straight to the body. Trailing argv items are forwarded verbatim as Hydra
-    overrides (``experiment=foo data=ksin skypilot_launch.compute_template=…``);
-    when the worker re-enters via :func:`from_hydra`, the same argv is replayed
-    so the composition matches byte-for-byte across the launcher/worker boundary.
-
-    When ``cfg.skypilot_launch.compute_template`` is ``None`` the spec runs in
-    this process via :func:`run`; otherwise the spec is dispatched to the named
-    SkyPilot template via :func:`dispatch_via_skypilot`.
+    Programmatic ``initialize_config_dir`` + ``compose`` instead of ``@hydra.main``
+    so we can inspect ``cfg.skypilot_launch.compute_template`` and pick the dispatch
+    branch before Hydra would otherwise hand the cfg straight to the body. Trailing
+    argv items are replayed verbatim on the worker via :func:`from_hydra` so the
+    composition matches byte-for-byte across the launcher/worker boundary.
     """
     overrides = list(sys.argv[1:])
 
     with initialize_config_dir(version_base="1.3", config_dir=str(_CONFIG_DIR)):
         cfg = compose(config_name="dataset", overrides=overrides)
 
-    # Programmatic ``compose()`` doesn't populate ``hydra.runtime.output_dir``,
-    # so ``paths.output_dir = ${hydra:runtime.output_dir}`` would otherwise raise
-    # at the resolve step inside ``spec_from_cfg``. Pin to the repo root — the
-    # spec doesn't read these fields, but ``OmegaConf.to_container(resolve=True)``
-    # eagerly resolves every interpolation in the tree.
+    # Pin paths.* so spec_from_cfg's resolve step doesn't trip on the
+    # unset ${hydra:runtime.output_dir} interpolation under programmatic compose.
     cfg.paths.root_dir = str(_REPO_ROOT)
     cfg.paths.output_dir = str(_REPO_ROOT)
     cfg.paths.work_dir = str(_REPO_ROOT)
@@ -363,8 +345,7 @@ def main() -> None:
         run(spec)
         return
 
-    # Deferred so the local path doesn't pay the SkyPilot / click import cost
-    # (sky + click pull in heavy provider SDKs on import).
+    # Deferred — SkyPilot / click pull in heavy provider SDKs on import.
     from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 
     sky_cfg = sky_cfg.model_copy(update={"cmd": _build_worker_cmd(overrides)})

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -61,6 +61,15 @@ _NON_SPEC_KEYS: tuple[str, ...] = (
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _CONFIG_DIR = _REPO_ROOT / "configs"
 
+# Path of the synth-setter checkout *inside the worker container*. Matches the
+# dev-snapshot image's baked checkout (see docker/ubuntu22_04/Dockerfile —
+# WORKDIR /home/build/synth-setter) and the `cd /home/build/synth-setter` line
+# every configs/compute/*-template.yaml's legacy `run:` block hardcoded. The
+# launcher's own ``_REPO_ROOT`` is the path on the *launcher* filesystem (e.g.
+# /home/runner/work/... on a bare GH-actions runner) — it does not necessarily
+# exist on the worker, so the worker-side cmd must use this constant.
+_WORKER_REPO_ROOT = "/home/build/synth-setter"
+
 
 def load_spec_from_uri(spec_uri: str) -> DatasetSpec:
     """Load a DatasetSpec from a local path or `r2://bucket/key` URI.
@@ -295,16 +304,20 @@ def _build_worker_cmd(overrides: list[str]) -> str:  # noqa: DOC203
     """Reconstruct the worker-side bash command that re-enters Hydra via from_hydra.
 
     Each override is shell-quoted individually so values with spaces or special
-    chars survive the bash interpretation inside ``sky.Task.run``. Worker image
-    WORKDIR matches the launcher's repo root, so the leading ``cd`` keeps the
-    cmd cwd-independent on both sides of the dispatch.
+    chars survive the bash interpretation inside ``sky.Task.run``. The leading
+    ``cd`` targets :data:`_WORKER_REPO_ROOT` (the dev-snapshot image's checkout
+    path), not the launcher's ``_REPO_ROOT`` — those paths only coincide when
+    the launcher itself runs inside dev-snapshot. ``sync_worker_checkout.sh``
+    runs between cd and exec so PR-CI workers fetch the PR head over the
+    image-baked checkout (see #735 / #841 for the bake-lag bypass).
 
     :param overrides: The launcher's ``sys.argv[1:]`` — the operator's Hydra
         overrides, replayed verbatim on the worker.
     :return: Bash one-liner suitable for use as a ``sky.Task`` ``run:`` block.
     """
     parts = [
-        f"cd {shlex.quote(str(_REPO_ROOT))}",
+        f"cd {shlex.quote(_WORKER_REPO_ROOT)}",
+        "bash scripts/sync_worker_checkout.sh",
         "exec synth-setter-generate-dataset-from-hydra",
     ]
     if overrides:

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -1,15 +1,26 @@
 """Spec-driven generate_dataset runner.
 
-``main(cfg)`` is the Hydra-composed CLI entry, invoked via
-``python -m synth_setter.cli.generate_dataset experiment=<id>`` (or the
-``synth-setter-generate-dataset`` console script).
+This module exposes two console-script surfaces:
 
-The click CLI in ``src/synth_setter/tools/docker_entrypoint.py`` is the SkyPilot-worker entry that reads a
-pre-materialized spec from R2 via ``load_spec_from_uri``.
+- ``synth-setter-generate-dataset`` → :func:`main` — user-facing entry. Composes
+  the dataset config from ``sys.argv`` Hydra overrides, builds the
+  ``DatasetSpec``, and either renders the spec in-process (when
+  ``cfg.skypilot_launch.compute_template`` is ``null``) or dispatches the same
+  argv to a SkyPilot worker via ``dispatch_via_skypilot``.
+- ``synth-setter-generate-dataset-from-hydra`` → :func:`from_hydra` — worker-side
+  entry. Pure ``@hydra.main`` composition + ``run(spec)``; this is the command
+  the SkyPilot launcher injects as each ``sky.Task`` ``run:`` block so the
+  worker reproduces the operator's composition without re-entering the
+  dispatch branch.
+
+The click CLI in ``src/synth_setter/tools/docker_entrypoint.py`` is a separate
+SkyPilot-worker entry kept for the legacy WORKER_SPEC_URI flow consumed by the
+``configs/compute/*-template.yaml`` templates' ``run:`` blocks.
 """
 
 from __future__ import annotations
 
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -18,6 +29,7 @@ from typing import Any
 
 import hydra
 import rootutils
+from hydra import compose, initialize_config_dir
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
@@ -31,12 +43,27 @@ from synth_setter.pipeline.partitioning import (  # noqa: E402
     get_my_shards,
     read_rank_world_from_env,
 )
+from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig  # noqa: E402
 from synth_setter.pipeline.schemas.spec import DatasetSpec, ShardSpec  # noqa: E402
 
 # Composed-config keys that aren't DatasetSpec fields: ``data`` / ``r2`` are interpolation
 # sources for top-level keys; ``paths`` / ``hydra`` exist only for Hydra runtime; ``run_name``
-# is a Hydra-output-dir interpolation source (see ``configs/dataset.yaml``).
-_NON_SPEC_KEYS: tuple[str, ...] = ("data", "r2", "paths", "hydra", "run_name")
+# is a Hydra-output-dir interpolation source (see ``configs/dataset.yaml``); and
+# ``skypilot_launch`` is a dispatch-mode sub-tree consumed by :func:`main` before spec
+# construction.
+_NON_SPEC_KEYS: tuple[str, ...] = (
+    "data",
+    "r2",
+    "paths",
+    "hydra",
+    "run_name",
+    "skypilot_launch",
+)
+
+# Resolved relative to this file so the entry-point runs from any cwd. ``parents[3]``
+# climbs ``cli/`` → ``synth_setter/`` → ``src/`` → repo root.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CONFIG_DIR = _REPO_ROOT / "configs"
 
 
 def load_spec_from_uri(spec_uri: str) -> DatasetSpec:
@@ -237,10 +264,104 @@ def spec_from_cfg(cfg: DictConfig) -> DatasetSpec:
     return DatasetSpec(**spec_kwargs)
 
 
+def _sky_cfg_from_dataset_cfg(cfg: DictConfig) -> SkypilotLaunchConfig:  # noqa: DOC203
+    """Validate the ``skypilot_launch`` sub-tree of a composed dataset cfg.
+
+    Resolves interpolations so any ``${oc.env:…}`` defaults are concrete by the
+    time the launcher reads them; raises if the sub-tree isn't a mapping (which
+    would mean a defaults-list misconfig at the YAML layer, not user input).
+
+    :param cfg: Composed dataset cfg whose ``skypilot_launch`` sub-tree carries
+        the launcher knobs (compute_template, num_workers, …).
+    :return: Validated ``SkypilotLaunchConfig`` with ``cmd`` unset (the entrypoint
+        populates ``cmd`` later via ``model_copy(update=...)``).
+    :raises TypeError: ``cfg.skypilot_launch`` did not resolve to a mapping.
+    """
+    raw: object = OmegaConf.to_container(cfg.skypilot_launch, resolve=True)
+    if not isinstance(raw, dict):
+        raise TypeError(f"cfg.skypilot_launch must compose to a mapping; got {type(raw).__name__}")
+    sky_kwargs: dict[str, Any] = {k: v for k, v in raw.items() if isinstance(k, str)}
+    return SkypilotLaunchConfig(**sky_kwargs)
+
+
+def _build_worker_cmd(overrides: list[str]) -> str:  # noqa: DOC203
+    """Reconstruct the worker-side bash command that re-enters Hydra via from_hydra.
+
+    The cd into ``_REPO_ROOT`` is for the worker image (whose WORKDIR is
+    ``/home/build/synth-setter``); both sides of the dispatch share the same
+    repo path, so passing ``_REPO_ROOT`` from the launcher keeps the cmd
+    independent of where the operator launched from. Each override is shell-
+    quoted individually so values with spaces or special chars survive the
+    bash interpretation inside ``sky.Task.run``.
+
+    :param overrides: The launcher's ``sys.argv[1:]`` — the operator's Hydra
+        overrides, replayed verbatim on the worker.
+    :return: Bash one-liner suitable for use as a ``sky.Task`` ``run:`` block.
+    """
+    quoted = " ".join(shlex.quote(o) for o in overrides)
+    return (
+        f"cd {shlex.quote(str(_REPO_ROOT))} && "
+        f"exec synth-setter-generate-dataset-from-hydra {quoted}".rstrip()
+    )
+
+
 @hydra.main(version_base="1.3", config_path="../../../configs", config_name="dataset")
-def main(cfg: DictConfig) -> None:
-    """Hydra-composed CLI entry: ``python -m synth_setter.cli.generate_dataset experiment=<id>``."""
+def from_hydra(cfg: DictConfig) -> None:
+    """Worker-side ``@hydra.main`` entry: build the spec and render it in-process.
+
+    Exposed as the ``synth-setter-generate-dataset-from-hydra`` console script
+    and injected by :func:`main` as the ``run:`` block of each dispatched
+    ``sky.Task``. Re-enters the same Hydra composition the operator typed
+    locally so the worker's spec matches byte-for-byte; the ``skypilot_launch``
+    sub-tree is left composed but unread (it's a no-op on the worker side).
+
+    :param cfg: The Hydra-composed dataset cfg passed by ``@hydra.main``.
+    """
     run(spec_from_cfg(cfg))
+
+
+def main() -> None:
+    """User-facing CLI: compose dataset cfg from argv, dispatch local or via SkyPilot.
+
+    Programmatic ``initialize_config_dir`` + ``compose`` instead of
+    ``@hydra.main`` so we can inspect ``cfg.skypilot_launch.compute_template``
+    and choose the dispatch branch before Hydra would otherwise hand the cfg
+    straight to the body. Trailing argv items are forwarded verbatim as Hydra
+    overrides (``experiment=foo data=ksin skypilot_launch.compute_template=…``);
+    when the worker re-enters via :func:`from_hydra`, the same argv is replayed
+    so the composition matches byte-for-byte across the launcher/worker boundary.
+
+    When ``cfg.skypilot_launch.compute_template`` is ``None`` the spec runs in
+    this process via :func:`run`; otherwise the spec is dispatched to the named
+    SkyPilot template via :func:`dispatch_via_skypilot`.
+    """
+    overrides = list(sys.argv[1:])
+
+    with initialize_config_dir(version_base="1.3", config_dir=str(_CONFIG_DIR)):
+        cfg = compose(config_name="dataset", overrides=overrides)
+
+    # Programmatic ``compose()`` doesn't populate ``hydra.runtime.output_dir``,
+    # so ``paths.output_dir = ${hydra:runtime.output_dir}`` would otherwise raise
+    # at the resolve step inside ``spec_from_cfg``. Pin to the repo root — the
+    # spec doesn't read these fields, but ``OmegaConf.to_container(resolve=True)``
+    # eagerly resolves every interpolation in the tree.
+    cfg.paths.root_dir = str(_REPO_ROOT)
+    cfg.paths.output_dir = str(_REPO_ROOT)
+    cfg.paths.work_dir = str(_REPO_ROOT)
+
+    spec = spec_from_cfg(cfg)
+    sky_cfg = _sky_cfg_from_dataset_cfg(cfg)
+
+    if sky_cfg.compute_template is None:
+        run(spec)
+        return
+
+    # Deferred so the local path doesn't pay the SkyPilot / click import cost
+    # (sky + click pull in heavy provider SDKs on import).
+    from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
+
+    sky_cfg = sky_cfg.model_copy(update={"cmd": _build_worker_cmd(overrides)})
+    dispatch_via_skypilot(spec, sky_cfg)
 
 
 if __name__ == "__main__":

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -1,21 +1,12 @@
 """Spec-driven generate_dataset runner.
 
-This module exposes two console-script surfaces:
+Two console-script surfaces:
 
-- ``synth-setter-generate-dataset`` → :func:`main` — user-facing entry. Composes
-  the dataset config from ``sys.argv`` Hydra overrides, builds the
-  ``DatasetSpec``, and either renders the spec in-process (when
-  ``cfg.skypilot_launch.compute_template`` is ``null``) or dispatches the same
-  argv to a SkyPilot worker via ``dispatch_via_skypilot``.
-- ``synth-setter-generate-dataset-from-hydra`` → :func:`from_hydra` — worker-side
-  entry. Pure ``@hydra.main`` composition + ``run(spec)``; this is the command
-  the SkyPilot launcher injects as each ``sky.Task`` ``run:`` block so the
-  worker reproduces the operator's composition without re-entering the
-  dispatch branch.
-
-The click CLI in ``src/synth_setter/tools/docker_entrypoint.py`` is a separate
-SkyPilot-worker entry kept for the legacy WORKER_SPEC_URI flow consumed by the
-``configs/compute/*-template.yaml`` templates' ``run:`` blocks.
+- ``synth-setter-generate-dataset`` → :func:`main` — operator entry; runs the
+  spec in-process or dispatches it to SkyPilot based on
+  ``cfg.skypilot_launch.compute_template``.
+- ``synth-setter-generate-dataset-from-hydra`` → :func:`from_hydra` — worker
+  entry; pure ``@hydra.main`` re-compose so launcher/worker share argv.
 """
 
 from __future__ import annotations
@@ -61,13 +52,8 @@ _NON_SPEC_KEYS: tuple[str, ...] = (
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _CONFIG_DIR = _REPO_ROOT / "configs"
 
-# Path of the synth-setter checkout *inside the worker container*. Matches the
-# dev-snapshot image's baked checkout (see docker/ubuntu22_04/Dockerfile —
-# WORKDIR /home/build/synth-setter) and the `cd /home/build/synth-setter` line
-# every configs/compute/*-template.yaml's legacy `run:` block hardcoded. The
-# launcher's own ``_REPO_ROOT`` is the path on the *launcher* filesystem (e.g.
-# /home/runner/work/... on a bare GH-actions runner) — it does not necessarily
-# exist on the worker, so the worker-side cmd must use this constant.
+# Worker-side checkout path — baked WORKDIR of the dev-snapshot image, not the
+# launcher's _REPO_ROOT (which may not exist on the worker filesystem).
 _WORKER_REPO_ROOT = "/home/build/synth-setter"
 
 
@@ -272,19 +258,13 @@ def spec_from_cfg(cfg: DictConfig) -> DatasetSpec:
 def _sky_cfg_from_dataset_cfg(cfg: DictConfig) -> SkypilotLaunchConfig:  # noqa: DOC203
     """Validate the ``skypilot_launch`` sub-tree of a composed dataset cfg.
 
-    Resolves interpolations so any ``${oc.env:…}`` defaults are concrete by the
-    time the launcher reads them; raises if the sub-tree isn't a mapping (which
-    would mean a defaults-list misconfig at the YAML layer, not user input).
+    Rejects operator-supplied ``cmd`` — it is launcher-internal (built from
+    argv by :func:`main`), so a CLI override would shadow that construction
+    and bypass the trust boundary.
 
-    Operator-supplied ``skypilot_launch.cmd`` is rejected loudly here: ``cmd``
-    is launcher-internal (the worker-side bash one-liner :func:`main` builds
-    from argv), so a CLI override would silently shadow that construction and
-    is exactly the kind of injection vector the trust boundary exists to catch.
-
-    :param cfg: Composed dataset cfg whose ``skypilot_launch`` sub-tree carries
-        the launcher knobs (compute_template, num_workers, …).
-    :return: Validated ``SkypilotLaunchConfig`` with ``cmd`` unset (the entrypoint
-        populates ``cmd`` later via ``model_copy(update=...)``).
+    :param cfg: Composed dataset cfg.
+    :return: Validated config with ``cmd`` unset; the entrypoint populates it
+        later via ``model_copy(update=...)``.
     :raises TypeError: ``cfg.skypilot_launch`` did not resolve to a mapping.
     :raises ValueError: operator supplied ``skypilot_launch.cmd`` from Hydra.
     """
@@ -303,28 +283,20 @@ def _sky_cfg_from_dataset_cfg(cfg: DictConfig) -> SkypilotLaunchConfig:  # noqa:
 def _build_worker_cmd(overrides: list[str], spec: DatasetSpec) -> str:  # noqa: DOC203
     """Reconstruct the worker-side bash command that re-enters Hydra via from_hydra.
 
-    Each override is shell-quoted individually so values with spaces or special
-    chars survive the bash interpretation inside ``sky.Task.run``. The leading
-    ``cd`` targets :data:`_WORKER_REPO_ROOT` (the dev-snapshot image's checkout
-    path), not the launcher's ``_REPO_ROOT`` — those paths only coincide when
-    the launcher itself runs inside dev-snapshot. ``sync_worker_checkout.sh``
-    runs between cd and exec so PR-CI workers fetch the PR head over the
-    image-baked checkout (see #735 / #841 for the bake-lag bypass).
+    Each override is shell-quoted individually so spaces/metachars survive bash
+    interpretation. ``sync_worker_checkout.sh`` runs between cd and exec for
+    the PR-CI bake-lag bypass (see #735 / #841).
 
-    ``DatasetSpec.created_at`` is pinned via a ``+created_at='<iso>'`` Hydra
-    override so the worker's re-compose lands on the same ``r2_prefix`` as the
-    launcher's spec (otherwise ``default_factory=lambda: _utc_now()`` fires
-    twice and worker shards land at a different prefix than the validate step
-    expects). ``run_id`` / ``r2_prefix`` derive from ``created_at`` via
-    ``DatasetSpec``'s default factories, so pinning only ``created_at`` is
-    sufficient — see ``_default_run_id`` / ``_default_r2_prefix`` in
-    ``synth_setter.pipeline.schemas.spec``.
+    ``spec.created_at`` is pinned as a Hydra override so the worker's
+    re-compose lands on the same ``r2_prefix`` as the launcher (the
+    ``default_factory`` that produces it would otherwise fire twice and the
+    derived ``run_id`` / ``r2_prefix`` would diverge — see
+    ``_default_run_id`` / ``_default_r2_prefix`` in
+    ``synth_setter.pipeline.schemas.spec``).
 
-    :param overrides: The launcher's ``sys.argv[1:]`` — the operator's Hydra
-        overrides, replayed verbatim on the worker.
-    :param spec: The launcher's already-constructed ``DatasetSpec``; runtime
-        fields populated by ``default_factory`` here are pinned into the
-        worker overrides to keep the launcher / worker composes deterministic.
+    :param overrides: Operator's Hydra overrides (launcher's ``sys.argv[1:]``).
+    :param spec: Launcher's ``DatasetSpec``; runtime fields are pinned into
+        the worker overrides for compose determinism.
     :return: Bash one-liner suitable for use as a ``sky.Task`` ``run:`` block.
     """
     pinned_overrides = [f"+created_at={spec.created_at.isoformat()}"]
@@ -345,21 +317,20 @@ def from_hydra(cfg: DictConfig) -> None:  # noqa: DOC101,DOC103
 
 
 def main() -> None:
-    """User-facing CLI: compose dataset cfg from argv, dispatch local or via SkyPilot.
+    """Operator CLI: compose dataset cfg from argv, then run locally or dispatch to SkyPilot.
 
-    Programmatic ``initialize_config_dir`` + ``compose`` instead of ``@hydra.main``
-    so we can inspect ``cfg.skypilot_launch.compute_template`` and pick the dispatch
-    branch before Hydra would otherwise hand the cfg straight to the body. Trailing
-    argv items are replayed verbatim on the worker via :func:`from_hydra` so the
-    composition matches byte-for-byte across the launcher/worker boundary.
+    Uses programmatic compose (not ``@hydra.main``) so the dispatch branch can
+    be picked from ``cfg.skypilot_launch.compute_template`` before Hydra would
+    hand the cfg straight to the body. Overrides are replayed verbatim on the
+    worker so the launcher/worker composition matches byte-for-byte.
     """
     overrides = list(sys.argv[1:])
 
     with initialize_config_dir(version_base="1.3", config_dir=str(_CONFIG_DIR)):
         cfg = compose(config_name="dataset", overrides=overrides)
 
-    # Pin paths.* so spec_from_cfg's resolve step doesn't trip on the
-    # unset ${hydra:runtime.output_dir} interpolation under programmatic compose.
+    # Programmatic compose leaves ${hydra:runtime.output_dir} unset; pin paths.*
+    # so spec_from_cfg's resolve step doesn't trip on the unresolved interpolation.
     cfg.paths.root_dir = str(_REPO_ROOT)
     cfg.paths.output_dir = str(_REPO_ROOT)
     cfg.paths.work_dir = str(_REPO_ROOT)
@@ -371,7 +342,7 @@ def main() -> None:
         run(spec)
         return
 
-    # Deferred — SkyPilot / click pull in heavy provider SDKs on import.
+    # Deferred import — SkyPilot pulls heavy provider SDKs on import.
     from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 
     sky_cfg = sky_cfg.model_copy(update={"cmd": _build_worker_cmd(overrides, spec)})

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -300,7 +300,7 @@ def _sky_cfg_from_dataset_cfg(cfg: DictConfig) -> SkypilotLaunchConfig:  # noqa:
     return SkypilotLaunchConfig(**sky_kwargs)
 
 
-def _build_worker_cmd(overrides: list[str]) -> str:  # noqa: DOC203
+def _build_worker_cmd(overrides: list[str], spec: DatasetSpec) -> str:  # noqa: DOC203
     """Reconstruct the worker-side bash command that re-enters Hydra via from_hydra.
 
     Each override is shell-quoted individually so values with spaces or special
@@ -311,17 +311,30 @@ def _build_worker_cmd(overrides: list[str]) -> str:  # noqa: DOC203
     runs between cd and exec so PR-CI workers fetch the PR head over the
     image-baked checkout (see #735 / #841 for the bake-lag bypass).
 
+    ``DatasetSpec.created_at`` is pinned via a ``+created_at='<iso>'`` Hydra
+    override so the worker's re-compose lands on the same ``r2_prefix`` as the
+    launcher's spec (otherwise ``default_factory=lambda: _utc_now()`` fires
+    twice and worker shards land at a different prefix than the validate step
+    expects). ``run_id`` / ``r2_prefix`` derive from ``created_at`` via
+    ``DatasetSpec``'s default factories, so pinning only ``created_at`` is
+    sufficient — see ``_default_run_id`` / ``_default_r2_prefix`` in
+    ``synth_setter.pipeline.schemas.spec``.
+
     :param overrides: The launcher's ``sys.argv[1:]`` — the operator's Hydra
         overrides, replayed verbatim on the worker.
+    :param spec: The launcher's already-constructed ``DatasetSpec``; runtime
+        fields populated by ``default_factory`` here are pinned into the
+        worker overrides to keep the launcher / worker composes deterministic.
     :return: Bash one-liner suitable for use as a ``sky.Task`` ``run:`` block.
     """
+    pinned_overrides = [f"+created_at={spec.created_at.isoformat()}"]
+    all_overrides = list(overrides) + pinned_overrides
     parts = [
         f"cd {shlex.quote(_WORKER_REPO_ROOT)}",
         "bash scripts/sync_worker_checkout.sh",
-        "exec synth-setter-generate-dataset-from-hydra",
+        "exec synth-setter-generate-dataset-from-hydra "
+        + " ".join(shlex.quote(o) for o in all_overrides),
     ]
-    if overrides:
-        parts[-1] += " " + " ".join(shlex.quote(o) for o in overrides)
     return " && ".join(parts)
 
 
@@ -361,7 +374,7 @@ def main() -> None:
     # Deferred — SkyPilot / click pull in heavy provider SDKs on import.
     from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 
-    sky_cfg = sky_cfg.model_copy(update={"cmd": _build_worker_cmd(overrides)})
+    sky_cfg = sky_cfg.model_copy(update={"cmd": _build_worker_cmd(overrides, spec)})
     dispatch_via_skypilot(spec, sky_cfg)
 
 

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -46,11 +46,8 @@ from synth_setter.pipeline.partitioning import (  # noqa: E402
 from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig  # noqa: E402
 from synth_setter.pipeline.schemas.spec import DatasetSpec, ShardSpec  # noqa: E402
 
-# Composed-config keys that aren't DatasetSpec fields: ``data`` / ``r2`` are interpolation
-# sources for top-level keys; ``paths`` / ``hydra`` exist only for Hydra runtime; ``run_name``
-# is a Hydra-output-dir interpolation source (see ``configs/dataset.yaml``); and
-# ``skypilot_launch`` is a dispatch-mode sub-tree consumed by :func:`main` before spec
-# construction.
+# Composed-config keys that aren't DatasetSpec fields (interpolation sources, Hydra
+# runtime, dispatch-mode sub-trees). See configs/dataset.yaml for the live set.
 _NON_SPEC_KEYS: tuple[str, ...] = (
     "data",
     "r2",
@@ -60,8 +57,7 @@ _NON_SPEC_KEYS: tuple[str, ...] = (
     "skypilot_launch",
 )
 
-# Resolved relative to this file so the entry-point runs from any cwd. ``parents[3]``
-# climbs ``cli/`` → ``synth_setter/`` → ``src/`` → repo root.
+# Resolve repo root from this file so the entry-point is cwd-independent.
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _CONFIG_DIR = _REPO_ROOT / "configs"
 
@@ -271,38 +267,49 @@ def _sky_cfg_from_dataset_cfg(cfg: DictConfig) -> SkypilotLaunchConfig:  # noqa:
     time the launcher reads them; raises if the sub-tree isn't a mapping (which
     would mean a defaults-list misconfig at the YAML layer, not user input).
 
+    Operator-supplied ``skypilot_launch.cmd`` is rejected loudly here: ``cmd``
+    is launcher-internal (the worker-side bash one-liner :func:`main` builds
+    from argv), so a CLI override would silently shadow that construction and
+    is exactly the kind of injection vector the trust boundary exists to catch.
+
     :param cfg: Composed dataset cfg whose ``skypilot_launch`` sub-tree carries
         the launcher knobs (compute_template, num_workers, …).
     :return: Validated ``SkypilotLaunchConfig`` with ``cmd`` unset (the entrypoint
         populates ``cmd`` later via ``model_copy(update=...)``).
     :raises TypeError: ``cfg.skypilot_launch`` did not resolve to a mapping.
+    :raises ValueError: operator supplied ``skypilot_launch.cmd`` from Hydra.
     """
     raw: object = OmegaConf.to_container(cfg.skypilot_launch, resolve=True)
     if not isinstance(raw, dict):
         raise TypeError(f"cfg.skypilot_launch must compose to a mapping; got {type(raw).__name__}")
     sky_kwargs: dict[str, Any] = {k: v for k, v in raw.items() if isinstance(k, str)}
+    if sky_kwargs.get("cmd") is not None:
+        raise ValueError(
+            "skypilot_launch.cmd is launcher-internal and cannot be set from Hydra; "
+            "the worker-side bash one-liner is built from argv by main()."
+        )
     return SkypilotLaunchConfig(**sky_kwargs)
 
 
 def _build_worker_cmd(overrides: list[str]) -> str:  # noqa: DOC203
     """Reconstruct the worker-side bash command that re-enters Hydra via from_hydra.
 
-    The cd into ``_REPO_ROOT`` is for the worker image (whose WORKDIR is
-    ``/home/build/synth-setter``); both sides of the dispatch share the same
-    repo path, so passing ``_REPO_ROOT`` from the launcher keeps the cmd
-    independent of where the operator launched from. Each override is shell-
-    quoted individually so values with spaces or special chars survive the
-    bash interpretation inside ``sky.Task.run``.
+    Each override is shell-quoted individually so values with spaces or special
+    chars survive the bash interpretation inside ``sky.Task.run``. Worker image
+    WORKDIR matches the launcher's repo root, so the leading ``cd`` keeps the
+    cmd cwd-independent on both sides of the dispatch.
 
     :param overrides: The launcher's ``sys.argv[1:]`` — the operator's Hydra
         overrides, replayed verbatim on the worker.
     :return: Bash one-liner suitable for use as a ``sky.Task`` ``run:`` block.
     """
-    quoted = " ".join(shlex.quote(o) for o in overrides)
-    return (
-        f"cd {shlex.quote(str(_REPO_ROOT))} && "
-        f"exec synth-setter-generate-dataset-from-hydra {quoted}".rstrip()
-    )
+    parts = [
+        f"cd {shlex.quote(str(_REPO_ROOT))}",
+        "exec synth-setter-generate-dataset-from-hydra",
+    ]
+    if overrides:
+        parts[-1] += " " + " ".join(shlex.quote(o) for o in overrides)
+    return " && ".join(parts)
 
 
 @hydra.main(version_base="1.3", config_path="../../../configs", config_name="dataset")

--- a/src/synth_setter/pipeline/schemas/skypilot_launch.py
+++ b/src/synth_setter/pipeline/schemas/skypilot_launch.py
@@ -1,14 +1,9 @@
 """SkyPilot launcher config schema.
 
-``SkypilotLaunchConfig`` is the Pydantic-validated payload that
-``synth_setter.pipeline.skypilot_launch.dispatch_via_skypilot`` consumes. It
-mirrors the click CLI's option set so the Hydra-driven entrypoint
-(``synth_setter.cli.generate_dataset.main``) and the legacy click CLI dispatch
-through the same launcher code path.
-
-The model intentionally captures *launcher* knobs only — anything the worker
-itself needs (R2 creds, WORKER_GIT_REF, etc.) is resolved separately via
-``resolve_worker_env`` from the ``.env`` file at ``env_file``.
+``SkypilotLaunchConfig`` is the Pydantic-validated payload consumed by
+``synth_setter.pipeline.skypilot_launch.dispatch_via_skypilot``. Captures
+*launcher* knobs only; worker-side secrets (R2 creds, WORKER_GIT_REF) are
+resolved separately via ``resolve_worker_env``.
 """
 
 from __future__ import annotations
@@ -17,15 +12,7 @@ from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class SkypilotLaunchConfig(BaseModel):  # noqa: DOC601,DOC603
-    """Validated SkyPilot launch parameters.
-
-    ``compute_template`` is the only field that actually selects whether to
-    dispatch — left None it signals to the Hydra entrypoint that this run
-    stays in-process. ``cmd`` is the bash command to inject as the
-    ``sky.Task`` ``run:`` block; populated by the Hydra entrypoint at dispatch
-    time from the current ``sys.argv`` overrides so the worker re-enters the
-    same Hydra composition via ``synth-setter-generate-dataset-from-hydra``.
-    """
+    """Validated SkyPilot launch parameters consumed by dispatch_via_skypilot."""
 
     model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
 

--- a/src/synth_setter/pipeline/schemas/skypilot_launch.py
+++ b/src/synth_setter/pipeline/schemas/skypilot_launch.py
@@ -1,0 +1,58 @@
+"""SkyPilot launcher config schema.
+
+``SkypilotLaunchConfig`` is the Pydantic-validated payload that
+``synth_setter.pipeline.skypilot_launch.dispatch_via_skypilot`` consumes. It
+mirrors the click CLI's option set so the Hydra-driven entrypoint
+(``synth_setter.cli.generate_dataset.main``) and the legacy click CLI dispatch
+through the same launcher code path.
+
+The model intentionally captures *launcher* knobs only — anything the worker
+itself needs (R2 creds, WORKER_GIT_REF, etc.) is resolved separately via
+``resolve_worker_env`` from the ``.env`` file at ``env_file``.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, field_validator
+
+
+class SkypilotLaunchConfig(BaseModel):  # noqa: DOC601,DOC603
+    """Validated SkyPilot launch parameters.
+
+    ``compute_template`` is the only field that actually selects whether to
+    dispatch — left None it signals to the Hydra entrypoint that this run
+    stays in-process. ``cmd`` is the bash command to inject as the
+    ``sky.Task`` ``run:`` block; populated by the Hydra entrypoint at dispatch
+    time from the current ``sys.argv`` overrides so the worker re-enters the
+    same Hydra composition via ``synth-setter-generate-dataset-from-hydra``.
+    """
+
+    model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
+
+    compute_template: str | None = None
+    cmd: str | None = None
+    env_file: str | None = None
+    job_name: str | None = None
+    num_workers: int = 1
+    worker_image_tag: str = "dev-snapshot"
+    tail: bool = False
+    api_server: str | None = None
+    local: bool = False
+
+    @field_validator("num_workers")
+    @classmethod
+    def num_workers_must_be_positive(cls, v: int) -> int:  # noqa: DOC101,DOC103,DOC201,DOC203,DOC501,DOC503
+        """Reject zero or negative worker counts."""
+        if v < 1:
+            raise ValueError(f"num_workers must be >= 1, got {v}")
+        return v
+
+    @field_validator("api_server")
+    @classmethod
+    def api_server_must_be_non_blank(cls, v: str | None) -> str | None:  # noqa: DOC101,DOC103,DOC201,DOC203,DOC501,DOC503
+        """Reject blank/whitespace-only api_server values; strip surrounding whitespace."""
+        if v is None:
+            return v
+        if not v.strip():
+            raise ValueError("api_server must be a non-empty URL when set")
+        return v.strip()

--- a/src/synth_setter/pipeline/skypilot_launch.py
+++ b/src/synth_setter/pipeline/skypilot_launch.py
@@ -814,16 +814,13 @@ def _cancel_job(job_name: str) -> None:
 def _detect_provider_from_doc(doc: dict[str, object], source: Path) -> str:  # noqa: DOC203
     """Detect the cred-bootstrap provider from an already-parsed YAML mapping.
 
-    Mirrors ``_detect_provider``'s rules (flat ``resources.cloud`` vs.
-    ``resources.any_of[0].cloud``) but operates on an in-memory dict so
-    ``dispatch_via_skypilot`` doesn't re-read the template after the cmd-injection
-    edit.
+    In-memory counterpart of ``_detect_provider``; same rules (flat
+    ``resources.cloud`` vs. ``resources.any_of[0].cloud``) without re-reading
+    the template from disk.
 
     :param doc: Parsed top-level YAML mapping for a SkyPilot Task.
-    :param source: Filesystem path the doc was loaded from, used only in error
-        messages so the operator can locate the offending file.
-    :return: ``"runpod" | "oci" | "local"`` — the ``--provider`` flag to pass to
-        the cred-bootstrap script.
+    :param source: Path the doc was loaded from; used only in error messages.
+    :return: ``--provider`` flag for the cred-bootstrap script.
     :raises ValueError: ``resources`` is missing/malformed or names an
         unsupported cloud.
     """
@@ -867,25 +864,18 @@ _WORKER_CMD_SENTINEL = "${WORKER_CMD}"
 def _load_compute_template_with_cmd(template_path: Path, cmd: str) -> dict[str, object]:  # noqa: DOC203
     """Load ``template_path`` as YAML and inject ``cmd`` into the ``run:`` block.
 
-    Three branches based on the template's existing ``run:`` value:
+    Three branches based on the template's existing ``run:``:
 
-    * **No ``run:``** — set ``run = cmd`` directly (the happy path; templates
-      whose ``run:`` semantics are exactly "exec the worker cmd").
-    * **``run:`` contains** ``${WORKER_CMD}`` — substitute ``cmd`` into the
-      sentinel and keep the template's surrounding shell scaffolding intact
-      (e.g. OCI's ``sudo docker run … bash -c "${WORKER_CMD}"``). Opt-in per
-      template: the author places the sentinel where the worker cmd should
-      land. Caller is responsible for shell-quoting the sentinel context so
-      the substituted string lands as a single bash argv item.
-    * **Non-empty ``run:`` without the sentinel** — refuse. The template
-      author wrote a complete ``run:`` and didn't ask for cmd injection, so
-      silently dropping their ``run:`` (the old behavior) was the wrong call.
-      Strip the YAML's ``run:`` to opt into the no-run injection path or add
-      the sentinel to opt into the substitution path.
+    * **Empty/missing** — set ``run = cmd``.
+    * **Contains** ``${WORKER_CMD}`` — substitute ``cmd`` into the sentinel,
+      preserving surrounding scaffolding (e.g. OCI's ``sudo docker run …
+      bash -c "${WORKER_CMD}"``). Caller must shell-quote the context so the
+      substituted string lands as a single argv item.
+    * **Non-empty without sentinel** — refuse, rather than silently dropping
+      the template's ``run:``. Strip ``run:`` or add the sentinel to opt in.
 
     :param template_path: Path to a SkyPilot Task YAML.
-    :param cmd: Bash command to inject (either as the full ``run:`` body or
-        substituted into the sentinel).
+    :param cmd: Bash command to inject.
     :return: The parsed YAML dict with ``run`` populated.
     :raises FileNotFoundError: ``template_path`` does not point to a file.
     :raises ValueError: top-level YAML is not a mapping, or the template's
@@ -929,11 +919,10 @@ def _launch_one_rank_from_doc(  # noqa: DOC203
     worker_image: str,
     task_doc: dict[str, object],
 ) -> int:
-    """Per-rank submission variant that builds the ``sky.Task`` from a YAML dict.
+    """Submit one rank, building the ``sky.Task`` from an in-memory YAML dict.
 
-    Mirrors ``_launch_one_rank`` but uses ``sky.Task.from_yaml_config`` so the
-    cmd-injected dict from ``dispatch_via_skypilot`` doesn't need a roundtrip
-    through disk. Lives at module level so tests can exercise it directly.
+    Uses ``sky.Task.from_yaml_config`` so a cmd-injected dict skips the
+    disk roundtrip.
 
     :param rank: This rank's index into ``job_names``.
     :param job_names: One managed-job name per rank; ``len()`` defines the world size.
@@ -975,10 +964,9 @@ def _run_workers_from_doc(  # noqa: DOC203
     worker_image_tag: str,
     tail: bool,
 ) -> list[int]:
-    """``_run_workers`` variant that fans out from a pre-built YAML dict.
+    """Fan out one rank per ``job_names`` entry from a pre-built YAML dict.
 
-    Shares the tail / detach runners with the click CLI — only the per-rank
-    launch helper differs (``_launch_one_rank_from_doc`` vs. ``_launch_one_rank``).
+    Shares the tail / detach runners with the click CLI fan-out path.
 
     :param worker_env_base: Env dict forwarded to every rank (rank/world keys added per call).
     :param task_doc: Parsed compute YAML dict (with ``run`` already injected).
@@ -1025,8 +1013,8 @@ def dispatch_via_skypilot(spec: DatasetSpec, sky_cfg: SkypilotLaunchConfig) -> N
 
     env_file_path = Path(sky_cfg.env_file).expanduser() if sky_cfg.env_file else None
 
-    # Mirrors click main()'s mutual-exclusion check, but raises a plain Exception so
-    # Hydra callers don't get a click-formatted message.
+    # api_server and local express opposite dispatch modes — accepting both
+    # would leave the resolved SKYPILOT_API_SERVER_ENDPOINT non-deterministic.
     if sky_cfg.api_server is not None and sky_cfg.local:
         raise ValueError("api_server and local are mutually exclusive")
     if sky_cfg.api_server is not None:

--- a/src/synth_setter/pipeline/skypilot_launch.py
+++ b/src/synth_setter/pipeline/skypilot_launch.py
@@ -60,6 +60,7 @@ from hydra.errors import HydraException
 
 from synth_setter.cli.generate_dataset import spec_from_cfg
 from synth_setter.pipeline.partitioning import NUM_WORKERS_ENV_VAR, WORKER_RANK_ENV_VAR
+from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
 from synth_setter.pipeline.schemas.spec import DatasetSpec
 
 # Per-launch R2 key for the materialized spec (file_mounts blocked by #749).
@@ -808,6 +809,310 @@ def _cancel_job(job_name: str) -> None:
     # SDK-internal); blanket except keeps teardown robust across all of them.
     except Exception as exc:  # noqa: BLE001
         click.echo(f"[{job_name}] cancel failed: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# dispatch_via_skypilot — Hydra-driven entrypoint surface
+#
+# The click ``main`` above stays the operator-facing rich CLI. ``dispatch_via_skypilot``
+# is the parallel entrypoint that ``synth_setter.cli.generate_dataset.main`` calls when
+# ``cfg.skypilot_launch.compute_template`` is set, sharing the launcher's worker-env
+# resolution, R2 spec upload, per-rank fan-out, and provider-aware cred bootstrap — but
+# building each rank's ``sky.Task`` from a YAML dict whose ``run:`` block has been
+# replaced with ``sky_cfg.cmd``. Cmd injection is the only deliberate departure from
+# the click flow: the worker re-enters Hydra via ``synth-setter-generate-dataset-from-hydra``
+# rather than the WORKER_SPEC_URI / docker_entrypoint path the file-based templates use.
+# ---------------------------------------------------------------------------
+
+
+def _detect_provider_from_doc(doc: dict[str, object], source: Path) -> str:  # noqa: DOC203
+    """Detect the cred-bootstrap provider from an already-parsed YAML mapping.
+
+    Mirrors ``_detect_provider``'s rules (flat ``resources.cloud`` vs.
+    ``resources.any_of[0].cloud``) but operates on an in-memory dict so
+    ``dispatch_via_skypilot`` doesn't re-read the template after the cmd-injection
+    edit.
+
+    :param doc: Parsed top-level YAML mapping for a SkyPilot Task.
+    :param source: Filesystem path the doc was loaded from, used only in error
+        messages so the operator can locate the offending file.
+    :return: ``"runpod" | "oci" | "local"`` — the ``--provider`` flag to pass to
+        the cred-bootstrap script.
+    :raises ValueError: ``resources`` is missing/malformed or names an
+        unsupported cloud.
+    """
+    resources = doc.get("resources") or {}
+    if not isinstance(resources, dict):
+        raise ValueError(
+            f"Could not detect cloud from {source}; expected `resources` to be a mapping."
+        )
+    cloud_value = resources.get("cloud")
+    if cloud_value is None:
+        any_of = resources.get("any_of") or []
+        if not isinstance(any_of, list):
+            raise ValueError(
+                f"Could not detect cloud from {source}; expected `resources.any_of` to be a list."
+            )
+        if any_of:
+            first = any_of[0]
+            if not isinstance(first, dict):
+                raise ValueError(
+                    f"Could not detect cloud from {source}; "
+                    "expected `resources.any_of[0]` to be a mapping."
+                )
+            cloud_value = first.get("cloud")
+    if not isinstance(cloud_value, str):
+        raise ValueError(
+            f"Could not detect cloud from {source}; "
+            "expected resources.cloud (str) or resources.any_of[0].cloud (str)."
+        )
+    provider = _CLOUD_TO_PROVIDER.get(cloud_value.strip().lower())
+    if provider is None:
+        raise ValueError(
+            f"Unsupported cloud {cloud_value!r} in {source}; cred bootstrap "
+            "supports runpod, oci, and local (kubernetes) only"
+        )
+    return provider
+
+
+def _load_compute_template_with_cmd(template_path: Path, cmd: str) -> dict[str, object]:  # noqa: DOC203
+    """Load ``template_path`` as YAML and inject ``cmd`` as the ``run:`` block.
+
+    Refuses to silently drop an existing ``run:`` block — if the template
+    already defines one, the caller's ``cmd`` is ambiguous (which one wins?),
+    so raise rather than guess. Strip the YAML's ``run:`` to opt into the
+    Hydra cmd-injection flow.
+
+    :param template_path: Path to a SkyPilot Task YAML.
+    :param cmd: Bash command to use as each ``sky.Task`` ``run:`` block.
+    :return: The parsed YAML dict with ``run`` set to ``cmd``.
+    :raises FileNotFoundError: ``template_path`` does not point to a file.
+    :raises ValueError: top-level YAML is not a mapping, or the template
+        already defines a non-empty ``run:`` block.
+    """
+    if not template_path.is_file():
+        raise FileNotFoundError(f"compute template not found: {template_path}")
+    with template_path.open(encoding="utf-8") as f:
+        doc = yaml.safe_load(f)
+    if doc is None:
+        doc = {}
+    if not isinstance(doc, dict):
+        raise ValueError(
+            f"Top-level YAML in {template_path} must be a mapping, got {type(doc).__name__}"
+        )
+    existing_run = doc.get("run")
+    if existing_run not in (None, ""):
+        raise ValueError(
+            f"compute template {template_path} has a `run:` block, but "
+            "skypilot_launch.cmd is also set — cmd cannot be silently dropped. "
+            "Strip the YAML's `run:` section to use the Hydra cmd-injection flow, "
+            "or unset skypilot_launch.cmd to use the YAML's `run:`."
+        )
+    doc["run"] = cmd
+    return doc
+
+
+def _launch_one_rank_from_doc(  # noqa: DOC203
+    rank: int,
+    *,
+    job_names: list[str],
+    worker_env_base: dict[str, str],
+    worker_image: str,
+    task_doc: dict[str, object],
+) -> int:
+    """Per-rank submission variant that builds the ``sky.Task`` from a YAML dict.
+
+    Mirrors ``_launch_one_rank`` but uses ``sky.Task.from_yaml_config`` so the
+    cmd-injected dict from ``dispatch_via_skypilot`` doesn't need a roundtrip
+    through disk. Lives at module level so tests can exercise it directly.
+
+    :param rank: This rank's index into ``job_names``.
+    :param job_names: One managed-job name per rank; ``len()`` defines the world size.
+    :param worker_env_base: Env dict forwarded to the rank (rank/world keys added here).
+    :param worker_image: Resolved ``repo:tag`` Docker image reference.
+    :param task_doc: Parsed compute YAML dict (with ``run`` already injected).
+    :return: SkyPilot-assigned ``job_id`` for this rank.
+    :raises RuntimeError: ``sky.jobs.launch`` / ``sky.stream_and_get`` yielded
+        no ``job_id``.
+    """
+    num_workers = len(job_names)
+    job_name = job_names[rank]
+    env_for_rank = {
+        **worker_env_base,
+        WORKER_RANK_ENV_VAR: str(rank),
+        NUM_WORKERS_ENV_VAR: str(num_workers),
+        _WORKER_IMAGE_ENV: worker_image,
+    }
+    task = sky.Task.from_yaml_config(task_doc)
+    _override_image_id(task, worker_image)
+    task.update_envs(env_for_rank)
+    click.echo(f"[{job_name}] submitting rank={rank}/{num_workers}")
+    launch_request_id = sky.jobs.launch(task, name=job_name)
+    launch_result = sky.stream_and_get(launch_request_id)
+    if launch_result is None:
+        raise RuntimeError(f"[{job_name}] sky.jobs.launch returned None (no submission handle)")
+    job_ids = launch_result[0]
+    if not job_ids or job_ids[0] is None:
+        raise RuntimeError(
+            f"[{job_name}] sky.jobs.launch returned no job_id (empty/null job_ids list)"
+        )
+    return job_ids[0]
+
+
+def _run_workers_from_doc(  # noqa: DOC203
+    worker_env_base: dict[str, str],
+    task_doc: dict[str, object],
+    job_names: list[str],
+    worker_image_tag: str,
+    tail: bool,
+) -> list[int]:
+    """``_run_workers`` variant that fans out from a pre-built YAML dict.
+
+    Shares the tail / detach runners with the click CLI — only the per-rank
+    launch helper differs (``_launch_one_rank_from_doc`` vs. ``_launch_one_rank``).
+
+    :param worker_env_base: Env dict forwarded to every rank (rank/world keys added per call).
+    :param task_doc: Parsed compute YAML dict (with ``run`` already injected).
+    :param job_names: One managed-job name per rank; ``len()`` defines the world size.
+    :param worker_image_tag: Docker image tag under tinaudio/synth-setter to inject.
+    :param tail: If True, tail logs and cancel all jobs. If False, detach after launch.
+    :return: List with one rc per rank in ``job_names`` order — ``0`` = success,
+        non-zero = failure (``-1`` for a half-submitted launch).
+    """
+    worker_image = f"{_WORKER_IMAGE_REPO}:{worker_image_tag}"
+    launch_get_job_id = functools.partial(
+        _launch_one_rank_from_doc,
+        job_names=job_names,
+        worker_env_base=worker_env_base,
+        worker_image=worker_image,
+        task_doc=task_doc,
+    )
+    if tail:
+        return _run_workers_tail(job_names, launch_get_job_id)
+    return _run_workers_detached(job_names, launch_get_job_id)
+
+
+def dispatch_via_skypilot(spec: DatasetSpec, sky_cfg: SkypilotLaunchConfig) -> None:
+    """Dispatch ``spec`` to the SkyPilot template named in ``sky_cfg``.
+
+    Caller invariants:
+    - ``sky_cfg.compute_template`` is a non-empty path to a SkyPilot Task YAML.
+      ``None`` is the "don't dispatch" sentinel and is the Hydra entrypoint's
+      responsibility; calling this function with ``None`` is a bug.
+    - ``sky_cfg.cmd`` is a non-empty bash command. It is injected as each
+      ``sky.Task`` ``run:`` block. If the YAML at ``compute_template`` already
+      has a ``run:`` block, this function raises rather than silently dropping
+      either value.
+
+    The function:
+    1. Loads the compute YAML and overlays ``cmd`` as its ``run:`` block.
+    2. Resolves worker env from ``sky_cfg.env_file`` and forwards the rclone
+       keys into the process env so the spec upload below picks them up.
+    3. Materializes a per-launch ``base_job_name`` (from ``sky_cfg.job_name`` or
+       the spec's ``task_name``), validates it against ``_JOB_NAME_RE``.
+    4. Bootstraps provider creds (skipped for the kubernetes ``local`` provider
+       and when ``SKYPILOT_API_SERVER_ENDPOINT`` is set).
+    5. Uploads the spec to R2 at ``skypilot-launcher-specs/<base_job_name>.json``
+       and forwards ``WORKER_SPEC_URI`` into the worker env so cmd-side code
+       that wants the spec by URI can still find it.
+    6. Fans out one managed job per rank.
+
+    :param spec: Validated dataset spec to render on the worker(s).
+    :param sky_cfg: Validated launcher configuration (compute_template + cmd required).
+    :raises ValueError: ``sky_cfg`` is missing required fields or has a conflicting
+        ``cmd``/``run:`` pair, or worker env vars are unresolved.
+    :raises RuntimeError: one or more ranks did not reach the SUCCEEDED terminal status.
+    """
+    if not sky_cfg.compute_template:
+        raise ValueError("dispatch_via_skypilot requires sky_cfg.compute_template to be set")
+    if not sky_cfg.cmd:
+        raise ValueError("dispatch_via_skypilot requires sky_cfg.cmd to be set")
+
+    template_path = Path(sky_cfg.compute_template).expanduser().resolve()
+    task_doc = _load_compute_template_with_cmd(template_path, sky_cfg.cmd)
+
+    env_file_path = Path(sky_cfg.env_file).expanduser() if sky_cfg.env_file else None
+
+    # Mirrors click main()'s mutual-exclusion check, but raises a plain Exception so
+    # Hydra callers don't get a click-formatted message.
+    if sky_cfg.api_server is not None and sky_cfg.local:
+        raise ValueError("api_server and local are mutually exclusive")
+    if sky_cfg.api_server is not None:
+        os.environ[_SKYPILOT_API_SERVER_ENV] = sky_cfg.api_server
+    elif sky_cfg.local:
+        os.environ.pop(_SKYPILOT_API_SERVER_ENV, None)
+
+    if sky_cfg.job_name is not None and not _JOB_NAME_RE.fullmatch(sky_cfg.job_name):
+        raise ValueError(
+            f"job_name must match {_JOB_NAME_RE.pattern} (alphanumerics, underscore, dash; "
+            f"≤63 chars; no path separators); got {sky_cfg.job_name!r}"
+        )
+
+    if not _DOCKER_TAG_RE.fullmatch(sky_cfg.worker_image_tag):
+        raise ValueError(
+            f"worker_image_tag must match OCI tag grammar {_DOCKER_TAG_RE.pattern}; "
+            f"got {sky_cfg.worker_image_tag!r}"
+        )
+
+    worker_env = resolve_worker_env(env_file_path)
+    if not any(k in worker_env for k in _SECRET_WORKER_ENV_KEYS):
+        raise ValueError(
+            "No worker env vars resolved. Set the rclone-R2 keys in process env "
+            f"(e.g. via `docker run -e RCLONE_CONFIG_R2_*=...`) or populate "
+            f"{env_file_path if env_file_path is not None else '<env_file not set>'}. "
+            f"Expected at least one of: {', '.join(_SECRET_WORKER_ENV_KEYS)}."
+        )
+
+    # rclone subprocess inherits os.environ; mirror launcher-resolved values so .env wins.
+    for key, value in worker_env.items():
+        if key.startswith("RCLONE_CONFIG_R2_"):
+            os.environ[key] = value
+
+    base_job_name = sky_cfg.job_name or f"synth-setter-smoke-{spec.task_name[:8]}"
+    if not _JOB_NAME_RE.fullmatch(base_job_name):
+        raise ValueError(
+            f"derived job name {base_job_name!r} must match {_JOB_NAME_RE.pattern} "
+            "(spec.task_name contains characters not allowed in a job name; "
+            "set skypilot_launch.job_name explicitly or fix spec.task_name)"
+        )
+
+    provider = _detect_provider_from_doc(task_doc, source=template_path)
+    if provider != "local":
+        _run_cred_bootstrap(provider=provider, env_file_path=env_file_path)
+
+    spec_uri = upload_spec_to_r2(spec, job_name=base_job_name)
+    click.echo(f"Spec uploaded to {spec_uri}")
+    worker_env[_WORKER_SPEC_URI_ENV] = spec_uri
+
+    if provider == "local":
+        import sky.check
+
+        sky.check.check(clouds=["kubernetes"], quiet=False)
+
+    job_names = (
+        [base_job_name]
+        if sky_cfg.num_workers == 1
+        else [f"{base_job_name}-r{i}" for i in range(sky_cfg.num_workers)]
+    )
+
+    rcs = _run_workers_from_doc(
+        worker_env_base=worker_env,
+        task_doc=task_doc,
+        job_names=job_names,
+        worker_image_tag=sky_cfg.worker_image_tag,
+        tail=sky_cfg.tail,
+    )
+
+    failed = [
+        (job_names[i], rcs[i])
+        for i in range(sky_cfg.num_workers)
+        if rcs[i] != _TAIL_LOGS_RC_SUCCESS
+    ]
+    if failed:
+        raise RuntimeError(
+            f"{len(failed)} of {sky_cfg.num_workers} worker(s) failed: "
+            + ", ".join(f"{name}(rc={rc})" for name, rc in failed)
+        )
 
 
 if __name__ == "__main__":

--- a/src/synth_setter/pipeline/skypilot_launch.py
+++ b/src/synth_setter/pipeline/skypilot_launch.py
@@ -861,20 +861,35 @@ def _detect_provider_from_doc(doc: dict[str, object], source: Path) -> str:  # n
     return provider
 
 
-def _load_compute_template_with_cmd(template_path: Path, cmd: str) -> dict[str, object]:  # noqa: DOC203
-    """Load ``template_path`` as YAML and inject ``cmd`` as the ``run:`` block.
+_WORKER_CMD_SENTINEL = "${WORKER_CMD}"
 
-    Refuses to silently drop an existing ``run:`` block — if the template
-    already defines one, the caller's ``cmd`` is ambiguous (which one wins?),
-    so raise rather than guess. Strip the YAML's ``run:`` to opt into the
-    Hydra cmd-injection flow.
+
+def _load_compute_template_with_cmd(template_path: Path, cmd: str) -> dict[str, object]:  # noqa: DOC203
+    """Load ``template_path`` as YAML and inject ``cmd`` into the ``run:`` block.
+
+    Three branches based on the template's existing ``run:`` value:
+
+    * **No ``run:``** — set ``run = cmd`` directly (the happy path; templates
+      whose ``run:`` semantics are exactly "exec the worker cmd").
+    * **``run:`` contains** ``${WORKER_CMD}`` — substitute ``cmd`` into the
+      sentinel and keep the template's surrounding shell scaffolding intact
+      (e.g. OCI's ``sudo docker run … bash -c "${WORKER_CMD}"``). Opt-in per
+      template: the author places the sentinel where the worker cmd should
+      land. Caller is responsible for shell-quoting the sentinel context so
+      the substituted string lands as a single bash argv item.
+    * **Non-empty ``run:`` without the sentinel** — refuse. The template
+      author wrote a complete ``run:`` and didn't ask for cmd injection, so
+      silently dropping their ``run:`` (the old behavior) was the wrong call.
+      Strip the YAML's ``run:`` to opt into the no-run injection path or add
+      the sentinel to opt into the substitution path.
 
     :param template_path: Path to a SkyPilot Task YAML.
-    :param cmd: Bash command to use as each ``sky.Task`` ``run:`` block.
-    :return: The parsed YAML dict with ``run`` set to ``cmd``.
+    :param cmd: Bash command to inject (either as the full ``run:`` body or
+        substituted into the sentinel).
+    :return: The parsed YAML dict with ``run`` populated.
     :raises FileNotFoundError: ``template_path`` does not point to a file.
-    :raises ValueError: top-level YAML is not a mapping, or the template
-        already defines a non-empty ``run:`` block.
+    :raises ValueError: top-level YAML is not a mapping, or the template's
+        ``run:`` is non-empty and lacks the sentinel.
     """
     if not template_path.is_file():
         raise FileNotFoundError(f"compute template not found: {template_path}")
@@ -887,15 +902,23 @@ def _load_compute_template_with_cmd(template_path: Path, cmd: str) -> dict[str, 
             f"Top-level YAML in {template_path} must be a mapping, got {type(doc).__name__}"
         )
     existing_run = doc.get("run")
-    if existing_run not in (None, ""):
+    if existing_run in (None, ""):
+        doc["run"] = cmd
+        return doc
+    if not isinstance(existing_run, str):
         raise ValueError(
-            f"compute template {template_path} has a `run:` block, but "
-            "skypilot_launch.cmd is also set — cmd cannot be silently dropped. "
-            "Strip the YAML's `run:` section to use the Hydra cmd-injection flow, "
-            "or unset skypilot_launch.cmd to use the YAML's `run:`."
+            f"compute template {template_path} `run:` must be a string, "
+            f"got {type(existing_run).__name__}"
         )
-    doc["run"] = cmd
-    return doc
+    if _WORKER_CMD_SENTINEL in existing_run:
+        doc["run"] = existing_run.replace(_WORKER_CMD_SENTINEL, cmd)
+        return doc
+    raise ValueError(
+        f"compute template {template_path} has a non-empty `run:` block, but "
+        "skypilot_launch.cmd is also set — cmd cannot be silently dropped. "
+        f"Strip the YAML's `run:` section, or substitute {_WORKER_CMD_SENTINEL} "
+        "where the worker cmd should land, to opt into the Hydra cmd-injection flow."
+    )
 
 
 def _launch_one_rank_from_doc(  # noqa: DOC203

--- a/src/synth_setter/pipeline/skypilot_launch.py
+++ b/src/synth_setter/pipeline/skypilot_launch.py
@@ -811,18 +811,7 @@ def _cancel_job(job_name: str) -> None:
         click.echo(f"[{job_name}] cancel failed: {exc}")
 
 
-# ---------------------------------------------------------------------------
-# dispatch_via_skypilot — Hydra-driven entrypoint surface
-#
-# The click ``main`` above stays the operator-facing rich CLI. ``dispatch_via_skypilot``
-# is the parallel entrypoint that ``synth_setter.cli.generate_dataset.main`` calls when
-# ``cfg.skypilot_launch.compute_template`` is set, sharing the launcher's worker-env
-# resolution, R2 spec upload, per-rank fan-out, and provider-aware cred bootstrap — but
-# building each rank's ``sky.Task`` from a YAML dict whose ``run:`` block has been
-# replaced with ``sky_cfg.cmd``. Cmd injection is the only deliberate departure from
-# the click flow: the worker re-enters Hydra via ``synth-setter-generate-dataset-from-hydra``
-# rather than the WORKER_SPEC_URI / docker_entrypoint path the file-based templates use.
-# ---------------------------------------------------------------------------
+# --- Hydra-driven dispatch surface (see dispatch_via_skypilot docstring) ---
 
 
 def _detect_provider_from_doc(doc: dict[str, object], source: Path) -> str:  # noqa: DOC203

--- a/src/synth_setter/pipeline/skypilot_launch.py
+++ b/src/synth_setter/pipeline/skypilot_launch.py
@@ -811,9 +811,6 @@ def _cancel_job(job_name: str) -> None:
         click.echo(f"[{job_name}] cancel failed: {exc}")
 
 
-# --- Hydra-driven dispatch surface (see dispatch_via_skypilot docstring) ---
-
-
 def _detect_provider_from_doc(doc: dict[str, object], source: Path) -> str:  # noqa: DOC203
     """Detect the cred-bootstrap provider from an already-parsed YAML mapping.
 

--- a/src/synth_setter/pipeline/skypilot_launch.py
+++ b/src/synth_setter/pipeline/skypilot_launch.py
@@ -984,32 +984,15 @@ def _run_workers_from_doc(  # noqa: DOC203
 def dispatch_via_skypilot(spec: DatasetSpec, sky_cfg: SkypilotLaunchConfig) -> None:
     """Dispatch ``spec`` to the SkyPilot template named in ``sky_cfg``.
 
-    Caller invariants:
-    - ``sky_cfg.compute_template`` is a non-empty path to a SkyPilot Task YAML.
-      ``None`` is the "don't dispatch" sentinel and is the Hydra entrypoint's
-      responsibility; calling this function with ``None`` is a bug.
-    - ``sky_cfg.cmd`` is a non-empty bash command. It is injected as each
-      ``sky.Task`` ``run:`` block. If the YAML at ``compute_template`` already
-      has a ``run:`` block, this function raises rather than silently dropping
-      either value.
-
-    The function:
-    1. Loads the compute YAML and overlays ``cmd`` as its ``run:`` block.
-    2. Resolves worker env from ``sky_cfg.env_file`` and forwards the rclone
-       keys into the process env so the spec upload below picks them up.
-    3. Materializes a per-launch ``base_job_name`` (from ``sky_cfg.job_name`` or
-       the spec's ``task_name``), validates it against ``_JOB_NAME_RE``.
-    4. Bootstraps provider creds (skipped for the kubernetes ``local`` provider
-       and when ``SKYPILOT_API_SERVER_ENDPOINT`` is set).
-    5. Uploads the spec to R2 at ``skypilot-launcher-specs/<base_job_name>.json``
-       and forwards ``WORKER_SPEC_URI`` into the worker env so cmd-side code
-       that wants the spec by URI can still find it.
-    6. Fans out one managed job per rank.
+    ``sky_cfg.compute_template`` and ``sky_cfg.cmd`` must both be set;
+    ``None`` is the Hydra entrypoint's "don't dispatch" sentinel. If the
+    compute YAML already defines ``run:``, this function raises rather than
+    silently dropping either side.
 
     :param spec: Validated dataset spec to render on the worker(s).
     :param sky_cfg: Validated launcher configuration (compute_template + cmd required).
-    :raises ValueError: ``sky_cfg`` is missing required fields or has a conflicting
-        ``cmd``/``run:`` pair, or worker env vars are unresolved.
+    :raises ValueError: degenerate ``sky_cfg``, conflicting ``cmd``/``run:`` pair,
+        or unresolved worker env vars.
     :raises RuntimeError: one or more ranks did not reach the SUCCEEDED terminal status.
     """
     if not sky_cfg.compute_template:

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1004,9 +1004,9 @@ class TestMainDispatchBranches:
     ) -> None:
         """A `+skypilot_launch.cmd=…` override is rejected before any dispatch fires.
 
-        Hydra's struct-mode already rejects `skypilot_launch.cmd=…` (the key isn't in
-        configs/skypilot_launch/default.yaml), so the guard runs on `+skypilot_launch.cmd=…`, which
-        is Hydra's syntax for adding a previously-undeclared key.
+        Uses Hydra's `+key=value` add-syntax because the key isn't in
+        configs/skypilot_launch/default.yaml (struct-mode would otherwise reject it before our
+        guard runs).
         """
         import synth_setter.cli.generate_dataset as gd
         import synth_setter.pipeline.skypilot_launch as sl

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -822,3 +822,133 @@ class TestSpecFromCfg:
 # PROJECT_ROOT-bootstrap behavior is exercised end-to-end by tests/pipeline/test_configs/
 # test_experiment_yamls.py — those tests fail with an InterpolationResolutionError if the
 # module's import-time `rootutils.setup_root(...)` ever stops setting PROJECT_ROOT.
+
+
+# ---------------------------------------------------------------------------
+# _build_worker_cmd — shell-quoted cmd injection for sky.Task.run
+# ---------------------------------------------------------------------------
+
+
+class TestBuildWorkerCmd:
+    """The worker cmd reconstructs the operator's Hydra invocation under bash."""
+
+    def test_cmd_uses_from_hydra_console_script(self) -> None:
+        """The worker reproduces the composition by re-entering the from_hydra entry point."""
+        from synth_setter.cli.generate_dataset import _build_worker_cmd
+
+        cmd = _build_worker_cmd(["experiment=foo"])
+        assert "synth-setter-generate-dataset-from-hydra" in cmd
+        assert "experiment=foo" in cmd
+
+    def test_cmd_shell_quotes_overrides_with_spaces(self) -> None:
+        """Spaces and special chars in an override survive bash interpretation in run:."""
+        from synth_setter.cli.generate_dataset import _build_worker_cmd
+
+        cmd = _build_worker_cmd(["task_name=value with space"])
+        # shlex.quote wraps the whole assignment in single quotes; the bare-word form
+        # would be split into two argv items by bash.
+        assert "'task_name=value with space'" in cmd
+
+    def test_cmd_handles_empty_overrides(self) -> None:
+        """No overrides → no trailing arguments after the entry-point name."""
+        from synth_setter.cli.generate_dataset import _build_worker_cmd
+
+        cmd = _build_worker_cmd([])
+        # No stray whitespace at the end; bash would tolerate it but it's a smell.
+        assert cmd.endswith("synth-setter-generate-dataset-from-hydra")
+
+
+# ---------------------------------------------------------------------------
+# main — dispatching CLI entry: local vs SkyPilot
+# ---------------------------------------------------------------------------
+
+
+class TestMainDispatchBranches:
+    """``main()`` composes the dataset cfg from argv, then dispatches local or via SkyPilot."""
+
+    @pytest.fixture(autouse=True)
+    def _set_default_skypilot_env(self, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: DOC101,DOC103
+        """Set single-worker rank/world env so the local branch's run() succeeds."""
+        monkeypatch.setenv("SYNTH_SETTER_WORKER_RANK", "0")
+        monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "1")
+
+    def test_compute_template_null_calls_run_locally(  # noqa: DOC101,DOC103
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """compute_template=null routes to run(spec); dispatch_via_skypilot stays unused."""
+        import synth_setter.cli.generate_dataset as gd
+
+        # Compose for a real experiment so cfg.skypilot_launch resolves; override the plugin path
+        # to TEST_PLUGIN_VST3 so the version-check in run() (which we will mock out) doesn't matter.
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+
+        recorded: dict[str, object] = {}
+
+        def _fake_run(spec: object) -> None:
+            recorded["spec"] = spec
+
+        monkeypatch.setattr(gd, "run", _fake_run)
+        # Sentinel ensures dispatch_via_skypilot is not even imported on the local branch.
+        import synth_setter.pipeline.skypilot_launch as sl
+
+        def _explode(*args: object, **kwargs: object) -> None:
+            raise AssertionError("dispatch_via_skypilot must not be called on the local branch")
+
+        monkeypatch.setattr(sl, "dispatch_via_skypilot", _explode)
+
+        gd.main()
+
+        assert "spec" in recorded, "run(spec) was not called"
+
+    def test_compute_template_set_calls_dispatch_via_skypilot(  # noqa: DOC101,DOC103
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """compute_template=<path> routes through dispatch_via_skypilot with cmd populated."""
+        import synth_setter.cli.generate_dataset as gd
+        import synth_setter.pipeline.skypilot_launch as sl
+
+        # A bare-minimum compute YAML the loader will accept (resources + envs, no run:).
+        template = tmp_path / "template.yaml"
+        template.write_text("resources:\n  cloud: runpod\nenvs:\n  X: ''\n")
+
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+            f"skypilot_launch.compute_template={template}",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+
+        recorded: dict[str, object] = {}
+
+        def _fake_dispatch(spec: object, sky_cfg: object) -> None:
+            recorded["spec"] = spec
+            recorded["sky_cfg"] = sky_cfg
+
+        monkeypatch.setattr(sl, "dispatch_via_skypilot", _fake_dispatch)
+        # ``run`` must NOT be invoked on the dispatch branch.
+        monkeypatch.setattr(
+            gd,
+            "run",
+            lambda *_a, **_k: (_ for _ in ()).throw(
+                AssertionError("run must not be called on the dispatch branch")
+            ),
+        )
+
+        gd.main()
+
+        assert "sky_cfg" in recorded
+        sky_cfg = recorded["sky_cfg"]
+        # cmd is built by _build_worker_cmd from the same overrides — sanity-check the shape.
+        assert sky_cfg.compute_template == str(template)  # type: ignore[attr-defined]
+        assert sky_cfg.cmd is not None  # type: ignore[attr-defined]
+        assert "synth-setter-generate-dataset-from-hydra" in sky_cfg.cmd  # type: ignore[attr-defined]
+        assert "experiment=generate_dataset/smoke-shard" in sky_cfg.cmd  # type: ignore[attr-defined]

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -840,6 +840,25 @@ class TestBuildWorkerCmd:
         assert "synth-setter-generate-dataset-from-hydra" in cmd
         assert "experiment=foo" in cmd
 
+    def test_cmd_cds_to_worker_repo_root_not_launcher_repo(self) -> None:
+        """Cd target is the worker checkout, not the launcher's path."""
+        from synth_setter.cli.generate_dataset import _WORKER_REPO_ROOT, _build_worker_cmd
+
+        cmd = _build_worker_cmd([])
+        assert cmd.startswith(f"cd {_WORKER_REPO_ROOT}")
+        assert _WORKER_REPO_ROOT == "/home/build/synth-setter"
+
+    def test_cmd_runs_sync_worker_checkout_before_exec(self) -> None:
+        """sync_worker_checkout.sh bypasses dev-snapshot bake-lag when WORKER_GIT_REF is set."""
+        from synth_setter.cli.generate_dataset import _build_worker_cmd
+
+        cmd = _build_worker_cmd([])
+        sync_idx = cmd.find("bash scripts/sync_worker_checkout.sh")
+        exec_idx = cmd.find("exec synth-setter-generate-dataset-from-hydra")
+        assert sync_idx != -1, f"sync step missing from cmd: {cmd!r}"
+        assert exec_idx != -1, f"exec step missing from cmd: {cmd!r}"
+        assert sync_idx < exec_idx, "sync_worker_checkout must run before exec"
+
     def test_cmd_shell_quotes_overrides_with_spaces(self) -> None:
         """Spaces and special chars in an override survive bash interpretation in run:."""
         from synth_setter.cli.generate_dataset import _build_worker_cmd
@@ -850,7 +869,7 @@ class TestBuildWorkerCmd:
         assert "'task_name=value with space'" in cmd
 
     def test_cmd_handles_empty_overrides(self) -> None:
-        """No overrides → bash one-liner is just cd + exec entry-point, no trailing space."""
+        """No overrides → bash one-liner is just cd + sync + exec, no trailing space."""
         from synth_setter.cli.generate_dataset import _build_worker_cmd
 
         cmd = _build_worker_cmd([])

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -832,50 +832,73 @@ class TestSpecFromCfg:
 class TestBuildWorkerCmd:
     """The worker cmd reconstructs the operator's Hydra invocation under bash."""
 
-    def test_cmd_uses_from_hydra_console_script(self) -> None:
+    @pytest.fixture()
+    def spec(self, tmp_path: Path) -> DatasetSpec:  # noqa: DOC101,DOC103,DOC201,DOC203
+        """Reusable DatasetSpec for worker-cmd construction (no I/O — pure kwargs)."""
+        return DatasetSpec(**_base_spec_kwargs(tmp_path))  # type: ignore[arg-type]
+
+    def test_cmd_uses_from_hydra_console_script(self, spec: DatasetSpec) -> None:  # noqa: DOC101,DOC103
         """The worker reproduces the composition by re-entering the from_hydra entry point."""
         from synth_setter.cli.generate_dataset import _build_worker_cmd
 
-        cmd = _build_worker_cmd(["experiment=foo"])
+        cmd = _build_worker_cmd(["experiment=foo"], spec)
         assert "synth-setter-generate-dataset-from-hydra" in cmd
         assert "experiment=foo" in cmd
 
-    def test_cmd_cds_to_worker_repo_root_not_launcher_repo(self) -> None:
+    def test_cmd_cds_to_worker_repo_root_not_launcher_repo(  # noqa: DOC101,DOC103
+        self, spec: DatasetSpec
+    ) -> None:
         """Cd target is the worker checkout, not the launcher's path."""
         from synth_setter.cli.generate_dataset import _WORKER_REPO_ROOT, _build_worker_cmd
 
-        cmd = _build_worker_cmd([])
+        cmd = _build_worker_cmd([], spec)
         assert cmd.startswith(f"cd {_WORKER_REPO_ROOT}")
         assert _WORKER_REPO_ROOT == "/home/build/synth-setter"
 
-    def test_cmd_runs_sync_worker_checkout_before_exec(self) -> None:
+    def test_cmd_runs_sync_worker_checkout_before_exec(  # noqa: DOC101,DOC103
+        self, spec: DatasetSpec
+    ) -> None:
         """sync_worker_checkout.sh bypasses dev-snapshot bake-lag when WORKER_GIT_REF is set."""
         from synth_setter.cli.generate_dataset import _build_worker_cmd
 
-        cmd = _build_worker_cmd([])
+        cmd = _build_worker_cmd([], spec)
         sync_idx = cmd.find("bash scripts/sync_worker_checkout.sh")
         exec_idx = cmd.find("exec synth-setter-generate-dataset-from-hydra")
         assert sync_idx != -1, f"sync step missing from cmd: {cmd!r}"
         assert exec_idx != -1, f"exec step missing from cmd: {cmd!r}"
         assert sync_idx < exec_idx, "sync_worker_checkout must run before exec"
 
-    def test_cmd_shell_quotes_overrides_with_spaces(self) -> None:
+    def test_cmd_pins_spec_created_at_via_hydra_override(  # noqa: DOC101,DOC103
+        self, spec: DatasetSpec
+    ) -> None:
+        """Worker compose must inherit launcher's created_at to land on the same r2_prefix."""
+        from synth_setter.cli.generate_dataset import _build_worker_cmd
+
+        cmd = _build_worker_cmd([], spec)
+        # `+key=value` is Hydra's add-key syntax; spec.created_at.isoformat() goes in verbatim
+        # (no surrounding quotes added by shlex when the value has no shell metachars).
+        assert f"+created_at={spec.created_at.isoformat()}" in cmd
+
+    def test_cmd_shell_quotes_overrides_with_spaces(  # noqa: DOC101,DOC103
+        self, spec: DatasetSpec
+    ) -> None:
         """Spaces and special chars in an override survive bash interpretation in run:."""
         from synth_setter.cli.generate_dataset import _build_worker_cmd
 
-        cmd = _build_worker_cmd(["task_name=value with space"])
+        cmd = _build_worker_cmd(["task_name=value with space"], spec)
         # shlex.quote wraps the whole assignment in single quotes; the bare-word form
         # would be split into two argv items by bash.
         assert "'task_name=value with space'" in cmd
 
-    def test_cmd_handles_empty_overrides(self) -> None:
-        """No overrides → bash one-liner is just cd + sync + exec, no trailing space."""
+    def test_cmd_handles_empty_operator_overrides(  # noqa: DOC101,DOC103
+        self, spec: DatasetSpec
+    ) -> None:
+        """No operator overrides → cmd is just cd + sync + exec + pinned-runtime override."""
         from synth_setter.cli.generate_dataset import _build_worker_cmd
 
-        cmd = _build_worker_cmd([])
+        cmd = _build_worker_cmd([], spec)
         assert cmd.startswith("cd ")
-        assert " && exec synth-setter-generate-dataset-from-hydra" in cmd
-        assert cmd.endswith("synth-setter-generate-dataset-from-hydra")
+        assert " && exec synth-setter-generate-dataset-from-hydra " in cmd
         # No bash-interpretable trailing whitespace that would surface as an empty argv item.
         assert cmd == cmd.rstrip()
 

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -850,12 +850,15 @@ class TestBuildWorkerCmd:
         assert "'task_name=value with space'" in cmd
 
     def test_cmd_handles_empty_overrides(self) -> None:
-        """No overrides → no trailing arguments after the entry-point name."""
+        """No overrides → bash one-liner is just cd + exec entry-point, no trailing space."""
         from synth_setter.cli.generate_dataset import _build_worker_cmd
 
         cmd = _build_worker_cmd([])
-        # No stray whitespace at the end; bash would tolerate it but it's a smell.
+        assert cmd.startswith("cd ")
+        assert " && exec synth-setter-generate-dataset-from-hydra" in cmd
         assert cmd.endswith("synth-setter-generate-dataset-from-hydra")
+        # No bash-interpretable trailing whitespace that would surface as an empty argv item.
+        assert cmd == cmd.rstrip()
 
 
 # ---------------------------------------------------------------------------
@@ -934,21 +937,44 @@ class TestMainDispatchBranches:
             recorded["sky_cfg"] = sky_cfg
 
         monkeypatch.setattr(sl, "dispatch_via_skypilot", _fake_dispatch)
-        # ``run`` must NOT be invoked on the dispatch branch.
-        monkeypatch.setattr(
-            gd,
-            "run",
-            lambda *_a, **_k: (_ for _ in ()).throw(
-                AssertionError("run must not be called on the dispatch branch")
-            ),
-        )
+
+        def _run_must_not_fire(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("run must not be called on the dispatch branch")
+
+        monkeypatch.setattr(gd, "run", _run_must_not_fire)
 
         gd.main()
 
         assert "sky_cfg" in recorded
         sky_cfg = recorded["sky_cfg"]
-        # cmd is built by _build_worker_cmd from the same overrides — sanity-check the shape.
         assert sky_cfg.compute_template == str(template)  # type: ignore[attr-defined]
         assert sky_cfg.cmd is not None  # type: ignore[attr-defined]
-        assert "synth-setter-generate-dataset-from-hydra" in sky_cfg.cmd  # type: ignore[attr-defined]
-        assert "experiment=generate_dataset/smoke-shard" in sky_cfg.cmd  # type: ignore[attr-defined]
+        # Every operator-supplied override (sans argv[0]) round-trips into the worker cmd
+        # so the worker reproduces this composition byte-for-byte.
+        for override in argv[1:]:
+            assert override in sky_cfg.cmd, (  # type: ignore[attr-defined]
+                f"override {override!r} missing from worker cmd: {sky_cfg.cmd!r}"  # type: ignore[attr-defined]
+            )
+
+    def test_operator_supplied_cmd_is_rejected(  # noqa: DOC101,DOC103
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A `+skypilot_launch.cmd=…` override is rejected loudly — cmd is launcher-internal.
+
+        Hydra's struct-mode already rejects `skypilot_launch.cmd=…` (the key isn't in
+        configs/skypilot_launch/default.yaml), so the guard runs on `+skypilot_launch.cmd=…`, which
+        is Hydra's syntax for adding a previously-undeclared key.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+            "+skypilot_launch.cmd=rm -rf /",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+
+        with pytest.raises(ValueError, match="skypilot_launch.cmd is launcher-internal"):
+            gd.main()

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -879,11 +879,12 @@ class TestMainDispatchBranches:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """compute_template=null routes to run(spec); dispatch_via_skypilot stays unused."""
+        """compute_template=null routes to run(spec) with a DatasetSpec; dispatch stays unused."""
         import synth_setter.cli.generate_dataset as gd
+        import synth_setter.pipeline.skypilot_launch as sl
 
-        # Compose for a real experiment so cfg.skypilot_launch resolves; override the plugin path
-        # to TEST_PLUGIN_VST3 so the version-check in run() (which we will mock out) doesn't matter.
+        # Use a real experiment so cfg.skypilot_launch resolves; override the plugin path
+        # to the test VST3 so run() — which we replace below — sees the right spec shape.
         argv = [
             "synth-setter-generate-dataset",
             "experiment=generate_dataset/smoke-shard",
@@ -896,18 +897,17 @@ class TestMainDispatchBranches:
         def _fake_run(spec: object) -> None:
             recorded["spec"] = spec
 
-        monkeypatch.setattr(gd, "run", _fake_run)
-        # Sentinel ensures dispatch_via_skypilot is not even imported on the local branch.
-        import synth_setter.pipeline.skypilot_launch as sl
-
-        def _explode(*args: object, **kwargs: object) -> None:
+        def _dispatch_must_not_fire(*_args: object, **_kwargs: object) -> None:
             raise AssertionError("dispatch_via_skypilot must not be called on the local branch")
 
-        monkeypatch.setattr(sl, "dispatch_via_skypilot", _explode)
+        monkeypatch.setattr(gd, "run", _fake_run)
+        monkeypatch.setattr(sl, "dispatch_via_skypilot", _dispatch_must_not_fire)
 
         gd.main()
 
-        assert "spec" in recorded, "run(spec) was not called"
+        spec = recorded.get("spec")
+        assert isinstance(spec, DatasetSpec)
+        assert spec.render.plugin_path == str(TEST_PLUGIN_VST3)
 
     def test_compute_template_set_calls_dispatch_via_skypilot(  # noqa: DOC101,DOC103
         self,
@@ -960,13 +960,14 @@ class TestMainDispatchBranches:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """A `+skypilot_launch.cmd=…` override is rejected loudly — cmd is launcher-internal.
+        """A `+skypilot_launch.cmd=…` override is rejected before any dispatch fires.
 
         Hydra's struct-mode already rejects `skypilot_launch.cmd=…` (the key isn't in
         configs/skypilot_launch/default.yaml), so the guard runs on `+skypilot_launch.cmd=…`, which
         is Hydra's syntax for adding a previously-undeclared key.
         """
         import synth_setter.cli.generate_dataset as gd
+        import synth_setter.pipeline.skypilot_launch as sl
 
         argv = [
             "synth-setter-generate-dataset",
@@ -975,6 +976,15 @@ class TestMainDispatchBranches:
             "+skypilot_launch.cmd=rm -rf /",
         ]
         monkeypatch.setattr("sys.argv", argv)
+
+        def _run_must_not_fire(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("run must not be called when cmd is rejected")
+
+        def _dispatch_must_not_fire(*_args: object, **_kwargs: object) -> None:
+            raise AssertionError("dispatch_via_skypilot must not be called when cmd is rejected")
+
+        monkeypatch.setattr(gd, "run", _run_must_not_fire)
+        monkeypatch.setattr(sl, "dispatch_via_skypilot", _dispatch_must_not_fire)
 
         with pytest.raises(ValueError, match="skypilot_launch.cmd is launcher-internal"):
             gd.main()

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -2676,26 +2676,27 @@ class TestLoadComputeTemplateWithCmd:
 class TestDetectProviderFromDoc:
     """``_detect_provider_from_doc`` mirrors ``_detect_provider`` but operates on a parsed dict."""
 
-    def test_flat_resources_cloud(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """``resources.cloud: runpod`` → ``runpod`` provider."""
+    @pytest.mark.parametrize(
+        "doc, expected_provider",
+        [
+            ({"resources": {"cloud": "runpod"}}, "runpod"),
+            ({"resources": {"any_of": [{"cloud": "oci"}]}}, "oci"),
+            ({"resources": {"cloud": "kubernetes"}}, "local"),
+            ({"resources": {"cloud": "k8s"}}, "local"),
+            ({"resources": {"cloud": "RunPod"}}, "runpod"),
+        ],
+        ids=["flat-runpod", "any-of-oci", "kubernetes-as-local", "k8s-alias", "case-insensitive"],
+    )
+    def test_supported_clouds_map_to_provider(  # noqa: DOC101,DOC103
+        self,
+        tmp_path: Path,
+        doc: dict[str, object],
+        expected_provider: str,
+    ) -> None:
+        """Each supported `resources.cloud` shape maps to the expected cred-bootstrap provider."""
         from synth_setter.pipeline.skypilot_launch import _detect_provider_from_doc
 
-        doc: dict[str, object] = {"resources": {"cloud": "runpod"}}
-        assert _detect_provider_from_doc(doc, source=tmp_path / "x.yaml") == "runpod"
-
-    def test_any_of_resources(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """``resources.any_of[0].cloud: oci`` → ``oci`` provider."""
-        from synth_setter.pipeline.skypilot_launch import _detect_provider_from_doc
-
-        doc: dict[str, object] = {"resources": {"any_of": [{"cloud": "oci"}]}}
-        assert _detect_provider_from_doc(doc, source=tmp_path / "x.yaml") == "oci"
-
-    def test_kubernetes_maps_to_local(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """``cloud: kubernetes`` collapses to the ``local`` provider — same as the k8s alias."""
-        from synth_setter.pipeline.skypilot_launch import _detect_provider_from_doc
-
-        doc: dict[str, object] = {"resources": {"cloud": "kubernetes"}}
-        assert _detect_provider_from_doc(doc, source=tmp_path / "x.yaml") == "local"
+        assert _detect_provider_from_doc(doc, source=tmp_path / "x.yaml") == expected_provider
 
     def test_unknown_cloud_raises(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
         """An unsupported cloud surfaces as a ValueError naming the offending value."""
@@ -2746,10 +2747,22 @@ class TestDispatchViaSkypilot:
         tmp_path: Path,
         fake_plugin: Path,
         local_spec_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """No rclone creds in env → fail loudly rather than launching a task that can't upload."""
+        """No rclone creds in env → fail loudly rather than launching a task that can't upload.
+
+        The autouse ``clear_worker_env_from_process`` fixture already strips these keys,
+        but re-asserting via ``monkeypatch.delenv`` keeps the contract explicit if that
+        fixture ever changes.
+        """
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
-        from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
+        from synth_setter.pipeline.skypilot_launch import (
+            _SECRET_WORKER_ENV_KEYS,
+            dispatch_via_skypilot,
+        )
+
+        for key in _SECRET_WORKER_ENV_KEYS:
+            monkeypatch.delenv(key, raising=False)
 
         template = _write_runpod_yaml(tmp_path)
         spec = _build_spec(fake_plugin)
@@ -2804,7 +2817,7 @@ class TestDispatchViaSkypilot:
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
         from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 
-        # Even in --no-tail mode, a launch raising → rank gets rc=-1 in the failed list.
+        # Even in --no-tail mode, a launch raising leaves the rank with a failure rc.
         mock_sky.stream_and_get.side_effect = RuntimeError("boom")
 
         template = _write_runpod_yaml(tmp_path)
@@ -2818,3 +2831,110 @@ class TestDispatchViaSkypilot:
 
         with pytest.raises(RuntimeError, match="worker.* failed"):
             dispatch_via_skypilot(spec, sky_cfg)
+
+    def test_multi_worker_fans_out_one_task_per_rank(  # noqa: DOC101,DOC103
+        self,
+        tmp_path: Path,
+        fake_plugin: Path,
+        env_file: Path,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        patch_materialize_io: None,  # noqa: ARG002
+    ) -> None:
+        """`num_workers=N` builds N tasks with -rN job-name suffixes, per the fan-out contract."""
+        from synth_setter.pipeline.partitioning import NUM_WORKERS_ENV_VAR, WORKER_RANK_ENV_VAR
+        from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
+        from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
+
+        template = _write_runpod_yaml(tmp_path)
+        spec = _build_spec(fake_plugin)
+        sky_cfg = SkypilotLaunchConfig(
+            compute_template=str(template),
+            cmd="echo",
+            env_file=str(env_file),
+            job_name="fan-out",
+            num_workers=3,
+        )
+
+        dispatch_via_skypilot(spec, sky_cfg)
+
+        # 3 ranks → 3 sky.Task.from_yaml_config calls with the same cmd-injected doc.
+        assert mock_sky.Task.from_yaml_config.call_count == 3
+        # Job names per rank carry the -rN suffix; submission order isn't guaranteed (threads).
+        submitted_names = sorted(
+            call.kwargs["name"] for call in mock_sky.jobs.launch.call_args_list
+        )
+        assert submitted_names == ["fan-out-r0", "fan-out-r1", "fan-out-r2"]
+        # Each rank's update_envs received its own WORKER_RANK / NUM_WORKERS values.
+        ranks_seen = sorted(
+            call.args[0][WORKER_RANK_ENV_VAR]
+            for call in mock_sky.Task.from_yaml_config.return_value.update_envs.call_args_list
+        )
+        assert ranks_seen == ["0", "1", "2"]
+        for call in mock_sky.Task.from_yaml_config.return_value.update_envs.call_args_list:
+            assert call.args[0][NUM_WORKERS_ENV_VAR] == "3"
+
+    @pytest.mark.parametrize(
+        "field, value, match",
+        [
+            ("job_name", "has/slash", "job_name must match"),
+            ("worker_image_tag", "bad tag", "worker_image_tag must match OCI"),
+        ],
+        ids=["job-name-with-slash", "image-tag-with-space"],
+    )
+    def test_input_validation_raises_before_disk_or_network(  # noqa: DOC101,DOC103
+        self,
+        tmp_path: Path,
+        fake_plugin: Path,
+        env_file: Path,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        patch_materialize_io: None,  # noqa: ARG002
+        field: str,
+        value: str,
+        match: str,
+    ) -> None:
+        """Malformed launcher params surface as ValueError before any SkyPilot submission."""
+        from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
+        from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
+
+        template = _write_runpod_yaml(tmp_path)
+        spec = _build_spec(fake_plugin)
+        kwargs: dict[str, object] = {
+            "compute_template": str(template),
+            "cmd": "echo",
+            "env_file": str(env_file),
+            "job_name": "ok-name",
+            field: value,
+        }
+        sky_cfg = SkypilotLaunchConfig(**kwargs)  # type: ignore[arg-type]
+
+        with pytest.raises(ValueError, match=match):
+            dispatch_via_skypilot(spec, sky_cfg)
+        mock_sky.jobs.launch.assert_not_called()
+
+    def test_api_server_and_local_are_mutually_exclusive(  # noqa: DOC101,DOC103
+        self,
+        tmp_path: Path,
+        fake_plugin: Path,
+        env_file: Path,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        patch_materialize_io: None,  # noqa: ARG002
+    ) -> None:
+        """Setting both api_server and local raises before launch — same as the click CLI guard."""
+        from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
+        from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
+
+        template = _write_runpod_yaml(tmp_path)
+        spec = _build_spec(fake_plugin)
+        sky_cfg = SkypilotLaunchConfig(
+            compute_template=str(template),
+            cmd="echo",
+            env_file=str(env_file),
+            api_server="https://api.example.com",
+            local=True,
+        )
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            dispatch_via_skypilot(spec, sky_cfg)
+        mock_sky.jobs.launch.assert_not_called()

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -2590,3 +2590,231 @@ class TestLaunchOneRank:
         assert envs_passed[WORKER_RANK_ENV_VAR] == "2"
         assert envs_passed[NUM_WORKERS_ENV_VAR] == "4"
         assert envs_passed[_WORKER_IMAGE_ENV] == "repo:tag"
+
+
+# ---------------------------------------------------------------------------
+# dispatch_via_skypilot — Hydra-driven launcher surface
+# ---------------------------------------------------------------------------
+
+
+def _write_runpod_yaml(tmp_path: Path, *, include_run: bool = False) -> Path:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Write a minimal RunPod-shaped compute template; ``include_run=True`` adds a run: block."""
+    yaml_text = (
+        "resources:\n"
+        "  cloud: runpod\n"
+        "  accelerators: {RTX3070: 1}\n"
+        "envs:\n"
+        "  RCLONE_CONFIG_R2_TYPE: ''\n"
+    )
+    if include_run:
+        yaml_text += "run: |\n  echo existing\n"
+    path = tmp_path / "compute.yaml"
+    path.write_text(yaml_text)
+    return path
+
+
+def _build_spec(fake_plugin: Path) -> DatasetSpec:  # noqa: DOC101,DOC103,DOC201,DOC203
+    """Build a DatasetSpec wired to ``fake_plugin`` for the dispatch tests."""
+    return DatasetSpec(
+        task_name="test-dispatch",
+        train_val_test_sizes=(10000, 0, 0),
+        output_format="hdf5",
+        base_seed=42,
+        r2_bucket="intermediate-data",
+        render={  # type: ignore[arg-type]
+            "plugin_path": str(fake_plugin),
+            "preset_path": "presets/surge-base.vstpreset",
+            "param_spec_name": "surge_simple",
+            "renderer_version": "1.3.4",
+            "sample_rate": 16000,
+            "channels": 2,
+            "velocity": 100,
+            "signal_duration_seconds": 4.0,
+            "min_loudness": -55.0,
+            "samples_per_render_batch": 32,
+            "samples_per_shard": 10000,
+        },
+    )
+
+
+class TestLoadComputeTemplateWithCmd:
+    """``_load_compute_template_with_cmd`` injects cmd as run and rejects pre-existing runs."""
+
+    def test_cmd_is_injected_when_yaml_has_no_run(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+        """Without a pre-existing run: block, the loaded doc's run: equals cmd."""
+        from synth_setter.pipeline.skypilot_launch import _load_compute_template_with_cmd
+
+        template = _write_runpod_yaml(tmp_path, include_run=False)
+        doc = _load_compute_template_with_cmd(template, "echo hello")
+        assert doc["run"] == "echo hello"
+
+    def test_existing_run_block_raises(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+        """A pre-existing run: + non-empty cmd is a conflict, not a silent override."""
+        from synth_setter.pipeline.skypilot_launch import _load_compute_template_with_cmd
+
+        template = _write_runpod_yaml(tmp_path, include_run=True)
+        with pytest.raises(ValueError, match="has a `run:` block"):
+            _load_compute_template_with_cmd(template, "echo hello")
+
+    def test_missing_template_raises_file_not_found(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+        """Mistyped path surfaces a FileNotFoundError, not a confusing parse error downstream."""
+        from synth_setter.pipeline.skypilot_launch import _load_compute_template_with_cmd
+
+        with pytest.raises(FileNotFoundError):
+            _load_compute_template_with_cmd(tmp_path / "missing.yaml", "x")
+
+    def test_non_mapping_top_level_raises(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+        """A YAML whose top level is a list, not a mapping, is rejected at load time."""
+        from synth_setter.pipeline.skypilot_launch import _load_compute_template_with_cmd
+
+        path = tmp_path / "bad.yaml"
+        path.write_text("- not\n- a\n- mapping\n")
+        with pytest.raises(ValueError, match="must be a mapping"):
+            _load_compute_template_with_cmd(path, "x")
+
+
+class TestDetectProviderFromDoc:
+    """``_detect_provider_from_doc`` mirrors ``_detect_provider`` but operates on a parsed dict."""
+
+    def test_flat_resources_cloud(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+        """``resources.cloud: runpod`` → ``runpod`` provider."""
+        from synth_setter.pipeline.skypilot_launch import _detect_provider_from_doc
+
+        doc: dict[str, object] = {"resources": {"cloud": "runpod"}}
+        assert _detect_provider_from_doc(doc, source=tmp_path / "x.yaml") == "runpod"
+
+    def test_any_of_resources(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+        """``resources.any_of[0].cloud: oci`` → ``oci`` provider."""
+        from synth_setter.pipeline.skypilot_launch import _detect_provider_from_doc
+
+        doc: dict[str, object] = {"resources": {"any_of": [{"cloud": "oci"}]}}
+        assert _detect_provider_from_doc(doc, source=tmp_path / "x.yaml") == "oci"
+
+    def test_kubernetes_maps_to_local(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+        """``cloud: kubernetes`` collapses to the ``local`` provider — same as the k8s alias."""
+        from synth_setter.pipeline.skypilot_launch import _detect_provider_from_doc
+
+        doc: dict[str, object] = {"resources": {"cloud": "kubernetes"}}
+        assert _detect_provider_from_doc(doc, source=tmp_path / "x.yaml") == "local"
+
+    def test_unknown_cloud_raises(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+        """An unsupported cloud surfaces as a ValueError naming the offending value."""
+        from synth_setter.pipeline.skypilot_launch import _detect_provider_from_doc
+
+        doc: dict[str, object] = {"resources": {"cloud": "aws"}}
+        with pytest.raises(ValueError, match="Unsupported cloud"):
+            _detect_provider_from_doc(doc, source=tmp_path / "x.yaml")
+
+
+class TestDispatchViaSkypilot:
+    """``dispatch_via_skypilot`` rejects degenerate cfgs and threads per-rank fanout through."""
+
+    def test_missing_compute_template_raises(self, fake_plugin: Path) -> None:  # noqa: DOC101,DOC103
+        """``compute_template=None`` is the "don't dispatch" sentinel — calling here is a bug."""
+        from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
+        from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
+
+        spec = _build_spec(fake_plugin)
+        sky_cfg = SkypilotLaunchConfig(compute_template=None, cmd="echo")
+        with pytest.raises(ValueError, match="compute_template"):
+            dispatch_via_skypilot(spec, sky_cfg)
+
+    def test_missing_cmd_raises(self, tmp_path: Path, fake_plugin: Path) -> None:  # noqa: DOC101,DOC103
+        """No cmd → no run block on the worker → we refuse to launch a no-op task."""
+        from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
+        from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
+
+        template = _write_runpod_yaml(tmp_path)
+        spec = _build_spec(fake_plugin)
+        sky_cfg = SkypilotLaunchConfig(compute_template=str(template), cmd=None)
+        with pytest.raises(ValueError, match="cmd"):
+            dispatch_via_skypilot(spec, sky_cfg)
+
+    def test_yaml_run_block_conflicts_with_cmd(self, tmp_path: Path, fake_plugin: Path) -> None:  # noqa: DOC101,DOC103
+        """End-to-end conflict guard: YAML's run: + sky_cfg.cmd both present → raise before any side effect."""
+        from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
+        from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
+
+        template = _write_runpod_yaml(tmp_path, include_run=True)
+        spec = _build_spec(fake_plugin)
+        sky_cfg = SkypilotLaunchConfig(compute_template=str(template), cmd="echo")
+        with pytest.raises(ValueError, match="has a `run:` block"):
+            dispatch_via_skypilot(spec, sky_cfg)
+
+    def test_missing_worker_env_raises(  # noqa: DOC101,DOC103
+        self,
+        tmp_path: Path,
+        fake_plugin: Path,
+        local_spec_dir: Path,
+    ) -> None:
+        """No rclone creds in env → fail loudly rather than launching a task that can't upload."""
+        from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
+        from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
+
+        template = _write_runpod_yaml(tmp_path)
+        spec = _build_spec(fake_plugin)
+        sky_cfg = SkypilotLaunchConfig(
+            compute_template=str(template),
+            cmd="exec synth-setter-generate-dataset-from-hydra experiment=foo",
+            env_file=None,
+        )
+        with pytest.raises(ValueError, match="No worker env vars resolved"):
+            dispatch_via_skypilot(spec, sky_cfg)
+
+    def test_end_to_end_dispatch_uses_cmd_as_run_block(  # noqa: DOC101,DOC103
+        self,
+        tmp_path: Path,
+        fake_plugin: Path,
+        env_file: Path,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        patch_materialize_io: None,  # noqa: ARG002
+    ) -> None:
+        """Happy-path dispatch: sky.Task.from_yaml_config receives a doc whose ``run`` is sky_cfg.cmd."""
+        from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
+        from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
+
+        template = _write_runpod_yaml(tmp_path)
+        spec = _build_spec(fake_plugin)
+        cmd = "exec synth-setter-generate-dataset-from-hydra experiment=foo"
+        sky_cfg = SkypilotLaunchConfig(
+            compute_template=str(template),
+            cmd=cmd,
+            env_file=str(env_file),
+            job_name="dispatch-smoke",
+        )
+
+        dispatch_via_skypilot(spec, sky_cfg)
+
+        # The launcher should have built one Task per rank from a dict whose run: was cmd.
+        mock_sky.Task.from_yaml_config.assert_called()
+        passed_doc = mock_sky.Task.from_yaml_config.call_args.args[0]
+        assert passed_doc["run"] == cmd
+
+    def test_dispatch_failure_raises_runtime_error(  # noqa: DOC101,DOC103
+        self,
+        tmp_path: Path,
+        fake_plugin: Path,
+        env_file: Path,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        patch_materialize_io: None,  # noqa: ARG002
+    ) -> None:
+        """A non-success tail rc surfaces as a RuntimeError naming the failed rank."""
+        from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
+        from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
+
+        # Even in --no-tail mode, a launch raising → rank gets rc=-1 in the failed list.
+        mock_sky.stream_and_get.side_effect = RuntimeError("boom")
+
+        template = _write_runpod_yaml(tmp_path)
+        spec = _build_spec(fake_plugin)
+        sky_cfg = SkypilotLaunchConfig(
+            compute_template=str(template),
+            cmd="echo",
+            env_file=str(env_file),
+            job_name="dispatch-fail",
+        )
+
+        with pytest.raises(RuntimeError, match="worker.* failed"):
+            dispatch_via_skypilot(spec, sky_cfg)

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -2731,8 +2731,13 @@ class TestDispatchViaSkypilot:
         with pytest.raises(ValueError, match="cmd"):
             dispatch_via_skypilot(spec, sky_cfg)
 
-    def test_yaml_run_block_conflicts_with_cmd(self, tmp_path: Path, fake_plugin: Path) -> None:  # noqa: DOC101,DOC103
-        """End-to-end conflict guard: YAML's run: + sky_cfg.cmd both present → raise before any side effect."""
+    def test_yaml_run_block_conflicts_with_cmd(  # noqa: DOC101,DOC103
+        self,
+        tmp_path: Path,
+        fake_plugin: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """End-to-end conflict guard: YAML run + sky_cfg.cmd raises before any SkyPilot side effect."""
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
         from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 
@@ -2741,6 +2746,7 @@ class TestDispatchViaSkypilot:
         sky_cfg = SkypilotLaunchConfig(compute_template=str(template), cmd="echo")
         with pytest.raises(ValueError, match="has a `run:` block"):
             dispatch_via_skypilot(spec, sky_cfg)
+        mock_sky.jobs.launch.assert_not_called()
 
     def test_missing_worker_env_raises(  # noqa: DOC101,DOC103
         self,
@@ -2912,6 +2918,35 @@ class TestDispatchViaSkypilot:
         with pytest.raises(ValueError, match=match):
             dispatch_via_skypilot(spec, sky_cfg)
         mock_sky.jobs.launch.assert_not_called()
+
+    def test_job_name_falls_back_to_task_name_prefix_when_unset(  # noqa: DOC101,DOC103
+        self,
+        tmp_path: Path,
+        fake_plugin: Path,
+        env_file: Path,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        patch_materialize_io: None,  # noqa: ARG002
+    ) -> None:
+        """job_name=None derives the synth-setter-smoke-<task_name[:8]> fallback."""
+        from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
+        from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
+
+        template = _write_runpod_yaml(tmp_path)
+        spec = _build_spec(fake_plugin)
+        sky_cfg = SkypilotLaunchConfig(
+            compute_template=str(template),
+            cmd="echo",
+            env_file=str(env_file),
+            job_name=None,
+        )
+
+        dispatch_via_skypilot(spec, sky_cfg)
+
+        submitted = mock_sky.jobs.launch.call_args.kwargs["name"]
+        assert submitted.startswith("synth-setter-smoke-")
+        # spec.task_name=="test-dispatch" → first 8 chars round-trip into the suffix.
+        assert submitted.endswith(spec.task_name[:8])
 
     def test_api_server_and_local_are_mutually_exclusive(  # noqa: DOC101,DOC103
         self,

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -2711,7 +2711,7 @@ class TestLoadComputeTemplateWithCmd:
 
 
 class TestDetectProviderFromDoc:
-    """``_detect_provider_from_doc`` mirrors ``_detect_provider`` but operates on a parsed dict."""
+    """``_detect_provider_from_doc`` maps a parsed compute YAML to a cred-bootstrap provider."""
 
     @pytest.mark.parametrize(
         "doc, expected_provider",
@@ -2860,7 +2860,7 @@ class TestDispatchViaSkypilot:
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
         from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 
-        # Even in --no-tail mode, a launch raising leaves the rank with a failure rc.
+        # A launch raising leaves the rank with a failure rc even when not tailing logs.
         mock_sky.stream_and_get.side_effect = RuntimeError("boom")
 
         template = _write_runpod_yaml(tmp_path)
@@ -2994,7 +2994,7 @@ class TestDispatchViaSkypilot:
         mock_sky: MagicMock,
         patch_materialize_io: None,  # noqa: ARG002
     ) -> None:
-        """Setting both api_server and local raises before launch — same as the click CLI guard."""
+        """Setting both api_server and local raises before any launch — opposite dispatch modes."""
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
         from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -2597,8 +2597,18 @@ class TestLaunchOneRank:
 # ---------------------------------------------------------------------------
 
 
-def _write_runpod_yaml(tmp_path: Path, *, include_run: bool = False) -> Path:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Write a minimal RunPod-shaped compute template; ``include_run=True`` adds a run: block."""
+def _write_runpod_yaml(  # noqa: DOC101,DOC103,DOC201,DOC203
+    tmp_path: Path,
+    *,
+    include_run: bool = False,
+    run_body: str | None = None,
+) -> Path:
+    """Write a minimal RunPod-shaped compute template.
+
+    ``include_run=True`` adds a default ``run:`` block (``echo existing``).
+    ``run_body`` overrides the run body — pass a multiline string with
+    ``${WORKER_CMD}`` to exercise the sentinel-substitution path.
+    """
     yaml_text = (
         "resources:\n"
         "  cloud: runpod\n"
@@ -2606,8 +2616,10 @@ def _write_runpod_yaml(tmp_path: Path, *, include_run: bool = False) -> Path:  #
         "envs:\n"
         "  RCLONE_CONFIG_R2_TYPE: ''\n"
     )
-    if include_run:
-        yaml_text += "run: |\n  echo existing\n"
+    if include_run or run_body is not None:
+        body = run_body if run_body is not None else "echo existing"
+        indented = "\n".join(f"  {line}" for line in body.splitlines())
+        yaml_text += f"run: |\n{indented}\n"
     path = tmp_path / "compute.yaml"
     path.write_text(yaml_text)
     return path
@@ -2648,13 +2660,38 @@ class TestLoadComputeTemplateWithCmd:
         doc = _load_compute_template_with_cmd(template, "echo hello")
         assert doc["run"] == "echo hello"
 
-    def test_existing_run_block_raises(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """A pre-existing run: + non-empty cmd is a conflict, not a silent override."""
+    def test_existing_run_block_without_sentinel_raises(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+        """A pre-existing run: with no sentinel + non-empty cmd is a conflict, not a silent override."""
         from synth_setter.pipeline.skypilot_launch import _load_compute_template_with_cmd
 
         template = _write_runpod_yaml(tmp_path, include_run=True)
-        with pytest.raises(ValueError, match="has a `run:` block"):
+        with pytest.raises(ValueError, match="has a non-empty `run:` block"):
             _load_compute_template_with_cmd(template, "echo hello")
+
+    def test_sentinel_in_run_block_substitutes_cmd(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+        """A template with ${WORKER_CMD} in run: substitutes cmd; scaffolding survives."""
+        from synth_setter.pipeline.skypilot_launch import _load_compute_template_with_cmd
+
+        template = _write_runpod_yaml(
+            tmp_path,
+            run_body='sudo docker run --rm "$WORKER_IMAGE" bash -c "${WORKER_CMD}"',
+        )
+        doc = _load_compute_template_with_cmd(template, "echo hello && exec foo")
+        assert isinstance(doc["run"], str)
+        # Substituted cmd lands where the sentinel was; surrounding shell scaffolding stays.
+        assert "${WORKER_CMD}" not in doc["run"]
+        assert "echo hello && exec foo" in doc["run"]
+        assert doc["run"].startswith("sudo docker run --rm")
+        assert doc["run"].rstrip().endswith('"echo hello && exec foo"')
+
+    def test_non_string_run_block_raises(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+        """A non-string run: (e.g. a list) is a malformed template, raise before substitute."""
+        from synth_setter.pipeline.skypilot_launch import _load_compute_template_with_cmd
+
+        path = tmp_path / "bad_run.yaml"
+        path.write_text("resources:\n  cloud: runpod\nrun:\n  - echo\n  - bad\n")
+        with pytest.raises(ValueError, match="`run:` must be a string"):
+            _load_compute_template_with_cmd(path, "x")
 
     def test_missing_template_raises_file_not_found(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
         """Mistyped path surfaces a FileNotFoundError, not a confusing parse error downstream."""
@@ -2744,7 +2781,7 @@ class TestDispatchViaSkypilot:
         template = _write_runpod_yaml(tmp_path, include_run=True)
         spec = _build_spec(fake_plugin)
         sky_cfg = SkypilotLaunchConfig(compute_template=str(template), cmd="echo")
-        with pytest.raises(ValueError, match="has a `run:` block"):
+        with pytest.raises(ValueError, match="has a non-empty `run:` block"):
             dispatch_via_skypilot(spec, sky_cfg)
         mock_sky.jobs.launch.assert_not_called()
 

--- a/tests/pipeline/test_schemas/test_skypilot_launch.py
+++ b/tests/pipeline/test_schemas/test_skypilot_launch.py
@@ -39,24 +39,26 @@ class TestDefaults:
 class TestValidation:
     """Pydantic field validators reject invalid combinations early."""
 
-    def test_negative_num_workers_rejected(self) -> None:
-        """Zero or negative worker counts surface as ValidationError."""
+    @pytest.mark.parametrize("bad", [0, -1, -100])
+    def test_non_positive_num_workers_rejected(self, bad: int) -> None:  # noqa: DOC101,DOC103
+        """Any worker count below 1 surfaces as ValidationError naming the offending value."""
         with pytest.raises(ValidationError, match="num_workers must be >= 1"):
-            SkypilotLaunchConfig(num_workers=0)
+            SkypilotLaunchConfig(num_workers=bad)
 
-    def test_blank_api_server_rejected(self) -> None:
-        """Whitespace-only api_server is rejected to surface typos loudly."""
+    @pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
+    def test_blank_api_server_rejected(self, blank: str) -> None:  # noqa: DOC101,DOC103
+        """Empty or whitespace-only api_server is rejected to surface typos loudly."""
         with pytest.raises(ValidationError, match="api_server must be a non-empty URL"):
-            SkypilotLaunchConfig(api_server="   ")
+            SkypilotLaunchConfig(api_server=blank)
 
     def test_api_server_is_stripped(self) -> None:
         """Surrounding whitespace is trimmed so the eventual env-export round-trips cleanly."""
         cfg = SkypilotLaunchConfig(api_server="  https://api.example.com  ")
         assert cfg.api_server == "https://api.example.com"
 
-    def test_extra_fields_rejected(self) -> None:
-        """``extra='forbid'`` catches misspelled Hydra overrides loudly."""
-        with pytest.raises(ValidationError):
+    def test_extra_fields_rejected_naming_the_offender(self) -> None:
+        """``extra='forbid'`` catches misspelled Hydra overrides loudly and names the bad field."""
+        with pytest.raises(ValidationError, match="compute_templat"):
             SkypilotLaunchConfig(compute_templat="typo.yaml")  # type: ignore[call-arg]
 
     def test_frozen_after_construction(self) -> None:

--- a/tests/pipeline/test_schemas/test_skypilot_launch.py
+++ b/tests/pipeline/test_schemas/test_skypilot_launch.py
@@ -24,11 +24,11 @@ class TestDefaults:
         assert SkypilotLaunchConfig().num_workers == 1
 
     def test_default_worker_image_tag_is_dev_snapshot(self) -> None:
-        """Matches the launcher's --worker-image-tag default."""
+        """Worker image tag defaults to the dev-snapshot rolling tag."""
         assert SkypilotLaunchConfig().worker_image_tag == "dev-snapshot"
 
     def test_default_tail_is_false(self) -> None:
-        """Detach by default; --tail is opt-in."""
+        """Detach by default; ``tail`` is opt-in."""
         assert SkypilotLaunchConfig().tail is False
 
     def test_default_local_is_false(self) -> None:

--- a/tests/pipeline/test_schemas/test_skypilot_launch.py
+++ b/tests/pipeline/test_schemas/test_skypilot_launch.py
@@ -1,0 +1,79 @@
+"""Tests for src/synth_setter/pipeline/schemas/skypilot_launch.py — launcher config schema."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
+
+
+class TestDefaults:
+    """All fields default to safe local-only values when no input is given."""
+
+    def test_default_compute_template_is_none(self) -> None:
+        """Compute template defaults to None — the "don't dispatch" sentinel."""
+        assert SkypilotLaunchConfig().compute_template is None
+
+    def test_default_cmd_is_none(self) -> None:
+        """Cmd defaults to None — populated by the Hydra entrypoint at dispatch time."""
+        assert SkypilotLaunchConfig().cmd is None
+
+    def test_default_num_workers_is_one(self) -> None:
+        """Single worker is the default; >1 fans out parallel ranks."""
+        assert SkypilotLaunchConfig().num_workers == 1
+
+    def test_default_worker_image_tag_is_dev_snapshot(self) -> None:
+        """Matches the launcher's --worker-image-tag default."""
+        assert SkypilotLaunchConfig().worker_image_tag == "dev-snapshot"
+
+    def test_default_tail_is_false(self) -> None:
+        """Detach by default; --tail is opt-in."""
+        assert SkypilotLaunchConfig().tail is False
+
+    def test_default_local_is_false(self) -> None:
+        """No dispatch-mode preference by default; honor inherited env."""
+        assert SkypilotLaunchConfig().local is False
+
+
+class TestValidation:
+    """Pydantic field validators reject invalid combinations early."""
+
+    def test_negative_num_workers_rejected(self) -> None:
+        """Zero or negative worker counts surface as ValidationError."""
+        with pytest.raises(ValidationError, match="num_workers must be >= 1"):
+            SkypilotLaunchConfig(num_workers=0)
+
+    def test_blank_api_server_rejected(self) -> None:
+        """Whitespace-only api_server is rejected to surface typos loudly."""
+        with pytest.raises(ValidationError, match="api_server must be a non-empty URL"):
+            SkypilotLaunchConfig(api_server="   ")
+
+    def test_api_server_is_stripped(self) -> None:
+        """Surrounding whitespace is trimmed so the eventual env-export round-trips cleanly."""
+        cfg = SkypilotLaunchConfig(api_server="  https://api.example.com  ")
+        assert cfg.api_server == "https://api.example.com"
+
+    def test_extra_fields_rejected(self) -> None:
+        """``extra='forbid'`` catches misspelled Hydra overrides loudly."""
+        with pytest.raises(ValidationError):
+            SkypilotLaunchConfig(compute_templat="typo.yaml")  # type: ignore[call-arg]
+
+    def test_frozen_after_construction(self) -> None:
+        """Trust-boundary models are frozen so dispatch can't mutate the config mid-launch."""
+        cfg = SkypilotLaunchConfig()
+        with pytest.raises(ValidationError):
+            cfg.compute_template = "anything.yaml"  # type: ignore[misc]
+
+
+class TestModelCopy:
+    """``model_copy(update=...)`` is the path the Hydra entrypoint uses to inject ``cmd``."""
+
+    def test_model_copy_with_cmd_yields_new_instance(self) -> None:
+        """Frozen + model_copy(update=…) is the only way to set cmd post-construction."""
+        original = SkypilotLaunchConfig(compute_template="x.yaml")
+        with_cmd = original.model_copy(update={"cmd": "echo hi"})
+        assert with_cmd.cmd == "echo hi"
+        assert with_cmd.compute_template == "x.yaml"
+        # Original is untouched (frozen invariant).
+        assert original.cmd is None


### PR DESCRIPTION
## Summary

Adds a single user-facing `synth-setter-generate-dataset` entry point that composes the dataset cfg from `sys.argv` Hydra overrides and dispatches the run either in-process (default) or via SkyPilot when `cfg.skypilot_launch.compute_template` is set, **and migrates every provider in `generate-dataset-shards.yaml` to drive it** (skypilot-local + runpod + oci). Worker re-enters the same composition via a new `synth-setter-generate-dataset-from-hydra` console script injected as each `sky.Task`'s `run:` block (or substituted into the template's `${WORKER_CMD}` sentinel for OCI's sub-docker shim).

- New `SkypilotLaunchConfig` Pydantic schema (`compute_template` / `cmd` / `env_file` / `job_name` / `num_workers` / `worker_image_tag` / `tail` / `api_server` / `local`).
- New `configs/skypilot_launch/default.yaml` Hydra group; wired into `configs/dataset.yaml`.
- Split `synth_setter.cli.generate_dataset` into:
  - `main()` — new console script (`synth-setter-generate-dataset`); programmatic compose then branches on `compute_template`.
  - `from_hydra()` — renamed `@hydra.main` entry, exposed as `synth-setter-generate-dataset-from-hydra` and invoked as the worker-side cmd.
- New `dispatch_via_skypilot(spec, sky_cfg)` in `synth_setter.pipeline.skypilot_launch`: loads the compute YAML, applies cmd injection (no-`run:` → set as `run:`; `${WORKER_CMD}` sentinel in `run:` → substitute; non-empty `run:` without sentinel → refuse), and fans out per-rank via `sky.Task.from_yaml_config` + existing helpers.

## CI migration

- `.github/workflows/generate-dataset-shards.yaml` skypilot-local + runpod + oci rows now invoke `synth-setter-generate-dataset` with `skypilot_launch.*` Hydra overrides instead of `python -m synth_setter.pipeline.skypilot_launch`. The runpod and OCI rows share a single docker-run step branched only on `TEMPLATE` (the runpod/oci YAML path).
- `_build_worker_cmd` now `cd`s to a constant `/home/build/synth-setter` (the worker image WORKDIR), not the launcher's `_REPO_ROOT`. The launcher's path only coincides with the worker's when the launcher itself runs inside dev-snapshot; for the skypilot-local row the launcher runs on the bare GH-actions runner.
- Worker cmd now inlines `bash scripts/sync_worker_checkout.sh` between `cd` and `exec`, so PR-CI workers fetch the PR head over the image-baked checkout (the bake-lag bypass existing templates' `run:` blocks did manually).
- Worker cmd pins `+created_at='<launcher_spec.created_at.isoformat()>'` so the worker's `from_hydra` re-compose lands on the same `r2_prefix` as the launcher's spec. Without this, `DatasetSpec.created_at`'s `default_factory=lambda: _utc_now()` fires twice and worker shards land at a different prefix than `validate-shards` looks for. `run_id` and `r2_prefix` derive from `created_at` in `DatasetSpec`'s default factories, so pinning that one field is sufficient.
- `configs/compute/local-template.yaml` and `configs/compute/runpod-template.yaml` had their `run:` blocks stripped (the new dispatch refuses to silently shadow them). `configs/compute/oci-cpu-template.yaml` keeps its outer `run:` (sub-docker shim — OCI backend can't ingest `image_id: docker:<image>`) but its inner `bash -c` body is now `bash -c "${WORKER_CMD}"`; `_load_compute_template_with_cmd` substitutes the launcher's worker cmd into the sentinel, so the surrounding shell scaffolding survives.
- Pre-flight `materialize_spec` step writes `input_spec.json` so the existing `Compute spec_uri output` step still has its `r2_bucket` source.

## Approach vs. PR #1062

This is the successful follow-up to #1062. Differences:

- No `ComputeConfig` schema — the compute YAML stays opaque past parse-time, validated only against the `run:` / `cmd` injection rules (no-run / sentinel / refuse).
- Two-entrypoint design (`main` + `from_hydra`): worker re-enters Hydra cleanly without needing a `WORKER_SPEC_URI` indirection.
- `cmd` injection is the source of truth for `sky.Task.run` — templates that opt into the Hydra flow either strip their `run:` blocks or surface `${WORKER_CMD}` where the cmd should land.
- Click CLI in `skypilot_launch.py` is unchanged at the Python surface; its unit tests still pass. CI no longer drives the click CLI (all three providers in `generate-dataset-shards.yaml` use the new entrypoint).

## Why

`#922` — fold compute config into Hydra so dispatch is selectable from the same `synth-setter-generate-dataset` invocation operators already use for local runs, no separate click CLI to remember.

## Tests

- `tests/pipeline/test_schemas/test_skypilot_launch.py` — `SkypilotLaunchConfig` defaults, validation (`num_workers >= 1`, blank `api_server`, `extra='forbid'`), frozen invariant, `model_copy(update={'cmd': ...})` round-trip.
- `tests/pipeline/test_entrypoints/test_skypilot_launch.py::TestLoadComputeTemplateWithCmd` — no-`run:` injection, `${WORKER_CMD}` substitution, refusal of non-empty `run:` without the sentinel, non-string `run:` rejection, missing-file / non-mapping rejections.
- `tests/pipeline/test_entrypoints/test_skypilot_launch.py::TestDetectProviderFromDoc` — flat `cloud:`, `any_of[0].cloud`, kubernetes→local mapping, unknown-cloud rejection.
- `tests/pipeline/test_entrypoints/test_skypilot_launch.py::TestDispatchViaSkypilot` — happy-path dispatch (asserts `sky.Task.from_yaml_config` receives the cmd-injected doc), missing `compute_template` / `cmd` / worker-env failure modes, end-to-end failure surfaces as `RuntimeError`.
- `tests/pipeline/test_entrypoints/test_generate_dataset.py::TestBuildWorkerCmd` — worker cmd embeds the from-hydra entry point, shell-quotes overrides containing spaces, `cd`s to `_WORKER_REPO_ROOT` (`/home/build/synth-setter`), runs `sync_worker_checkout.sh` before `exec`, and pins `+created_at=` to keep launcher / worker composes deterministic.
- `tests/pipeline/test_entrypoints/test_generate_dataset.py::TestMainDispatchBranches` — `compute_template=null` calls `run()` locally; `compute_template=<path>` calls `dispatch_via_skypilot` with `cmd` populated.

## Test plan

- [x] CI: all required + optional checks green
- [x] CI: `test-dataset-generation` matrix (skypilot-local / hdf5 + wds) green — now exercising the new entry point end-to-end including shard validation
- [x] `/repo-review-full-no-comments` iterated against the CI-migration commit
- [ ] Copilot review addressed

Closes #922