### PR TITLE
claude(hook): extract pre-PR review gate to script + regression tests

### DIFF
--- a/.claude/hooks/pre-pr-review-gate.sh
+++ b/.claude/hooks/pre-pr-review-gate.sh
@@ -30,13 +30,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/_lib.sh"
 
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+COMMAND=$(jq -r '.tool_input.command // empty' 2>/dev/null <<<"$INPUT" || true)
 
-if ! echo "$COMMAND" | grep -qE '(^|[;|&`(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'; then
+# Here-string (not `echo |`) so SIGPIPE under pipefail can't fail-open. Allow
+# leading whitespace at line start so `  gh pr create` is still gated.
+if ! grep -qE '(^[[:space:]]*|[;|&`(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)' <<<"$COMMAND"; then
   exit 0
 fi
 
-if echo "$COMMAND" | grep -q 'REVIEW_FULL_DONE=1'; then
+if grep -q 'REVIEW_FULL_DONE=1' <<<"$COMMAND"; then
   log "token present, allowing"
   exit 0
 fi

--- a/.claude/hooks/pre-pr-review-gate.sh
+++ b/.claude/hooks/pre-pr-review-gate.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# =============================================================================
+# pre-pr-review-gate.sh — PreToolUse hook, gates `gh pr create`
+# =============================================================================
+#
+# PURPOSE
+# -------
+# Block `gh pr create` unless the command contains the literal token
+# REVIEW_FULL_DONE=1 (anywhere on the line, typically as a trailing comment).
+# Forces Claude to invoke /repo-review-full-no-comments and iterate on findings
+# before opening a PR. The token is honor-system — the gate is a circuit-breaker
+# that forces a pause, not unbypassable security.
+#
+# INPUT (stdin)
+#   JSON with .tool_input.command — the Bash command Claude is about to run.
+#
+# INVOCATION
+#   Registered in .claude/settings.json as a PreToolUse hook on Bash.
+#   The handler-level `if: "Bash(gh pr create *)"` guard is unreliable for
+#   PreToolUse hooks (see CLAUDE.md history), so this script re-validates the
+#   command itself — same defensive pattern doc-drift.sh / pr-review-resolver.sh
+#   use. Non-matching commands exit 0 silently.
+# =============================================================================
+set -euo pipefail
+
+export HOOK_NAME="pre-pr-review-gate"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=.claude/hooks/_lib.sh
+# shellcheck disable=SC1091  # _lib.sh resolved at runtime; not staged together
+source "${SCRIPT_DIR}/_lib.sh"
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)
+
+if ! echo "$COMMAND" | grep -qE '(^|[;|&`(][[:space:]]*)gh[[:space:]]+pr[[:space:]]+create([[:space:]]|$)'; then
+  exit 0
+fi
+
+if echo "$COMMAND" | grep -q 'REVIEW_FULL_DONE=1'; then
+  log "token present, allowing"
+  exit 0
+fi
+
+log "blocking gh pr create (token missing)"
+cat >&2 <<'EOF'
+BLOCKED: gh pr create requires running /repo-review-full-no-comments first.
+Run that skill, address every BLOCK/WARN finding (or document why each is
+intentional), then re-run with REVIEW_FULL_DONE=1 included in the command —
+recommended as a trailing comment so other hooks still fire:
+
+  gh pr create --title "..." --body "..."  # REVIEW_FULL_DONE=1
+EOF
+exit 2

--- a/.claude/hooks/test.sh
+++ b/.claude/hooks/test.sh
@@ -275,6 +275,18 @@ else
   fail "gh pr create with token" "$out"
 fi
 
+# 15. REGRESSION: leading whitespace before `gh pr create` must still gate.
+#     The original `^` anchor required no whitespace, so an indented
+#     `  gh pr create ...` would fall through with exit 0 — a fail-open.
+reset_sandbox
+stderr_file="$TEST_DIR/gate_stderr.txt"
+out=$(echo '{"tool_input":{"command":"  gh pr create --title x --body y"}}' | bash .claude/hooks/pre-pr-review-gate.sh 2>"$stderr_file"; echo "EXIT:$?")
+if [[ "$out" == *"EXIT:2"* ]] && grep -q "BLOCKED" "$stderr_file"; then
+  pass "leading-whitespace gh pr create without token → still blocked"
+else
+  fail "leading-whitespace gh pr create without token" "exit=$out stderr=$(cat "$stderr_file")"
+fi
+
 # -----------------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------------

--- a/.claude/hooks/test.sh
+++ b/.claude/hooks/test.sh
@@ -25,6 +25,7 @@ trap cleanup EXIT
 SANDBOX="$TEST_DIR/repo"
 mkdir -p "$SANDBOX/.claude/hooks"
 cp .claude/hooks/_lib.sh .claude/hooks/doc-drift.sh .claude/hooks/pr-review-resolver.sh \
+  .claude/hooks/pre-pr-review-gate.sh \
   "$SANDBOX/.claude/hooks/"
 cd "$SANDBOX"
 git init -q
@@ -224,6 +225,54 @@ if [ "$bg_exit" = "0" ] && ! compgen -G ".agent-reviews/pr-review-resolver-*.md"
 else
   report_glob=$(compgen -G ".agent-reviews/pr-review-resolver-*.md" 2>/dev/null || true)
   fail "lockfile dedupe" "bg_exit=$bg_exit, report=$report_glob"
+fi
+
+# -----------------------------------------------------------------------------
+# pre-pr-review-gate.sh
+# -----------------------------------------------------------------------------
+echo "== pre-pr-review-gate.sh =="
+unset RESOLVER_SLEEP_SECS RESOLVER_DRY_RUN GH_STUB_PR DOC_DRIFT_DRY_RUN CLAUDE_STUB_FAIL
+
+# 11. REGRESSION: a non-`gh pr create` command must fall through with exit 0.
+#     The original inline hook used only the handler-level `if` guard, which
+#     was silently not applied, so the gate fired on every Bash command and
+#     blocked anything lacking REVIEW_FULL_DONE=1. This test would have caught
+#     that: feeding a plain `git rev-parse HEAD` must not be blocked.
+reset_sandbox
+out=$(echo '{"tool_input":{"command":"git rev-parse HEAD"}}' | bash .claude/hooks/pre-pr-review-gate.sh 2>&1; echo "EXIT:$?")
+if [[ "$out" == *"EXIT:0"* ]] && [[ "$out" != *"BLOCKED"* ]]; then
+  pass "non-gh-pr-create command falls through with exit 0 (no BLOCKED message)"
+else
+  fail "non-gh-pr-create command falls through" "$out"
+fi
+
+# 12. REGRESSION: a `gh pr create` substring inside an echo string must NOT
+#     trigger the gate. Same word-boundary protection as doc-drift / resolver.
+reset_sandbox
+out=$(echo '{"tool_input":{"command":"echo testing the gh pr create matcher"}}' | bash .claude/hooks/pre-pr-review-gate.sh 2>&1; echo "EXIT:$?")
+if [[ "$out" == *"EXIT:0"* ]] && [[ "$out" != *"BLOCKED"* ]]; then
+  pass "quoted 'gh pr create' substring inside echo does NOT trigger the gate"
+else
+  fail "quoted substring should not trigger gate" "$out"
+fi
+
+# 13. gh pr create WITHOUT the token → exit 2 with BLOCKED on stderr.
+reset_sandbox
+stderr_file="$TEST_DIR/gate_stderr.txt"
+out=$(echo '{"tool_input":{"command":"gh pr create --title x --body y"}}' | bash .claude/hooks/pre-pr-review-gate.sh 2>"$stderr_file"; echo "EXIT:$?")
+if [[ "$out" == *"EXIT:2"* ]] && grep -q "BLOCKED" "$stderr_file" && grep -q "REVIEW_FULL_DONE=1" "$stderr_file"; then
+  pass "gh pr create without token → exit 2 with BLOCKED + token name on stderr"
+else
+  fail "gh pr create without token" "exit=$out stderr=$(cat "$stderr_file")"
+fi
+
+# 14. gh pr create WITH the token (trailing comment form) → exit 0.
+reset_sandbox
+out=$(echo '{"tool_input":{"command":"gh pr create --title x --body y  # REVIEW_FULL_DONE=1"}}' | bash .claude/hooks/pre-pr-review-gate.sh 2>&1; echo "EXIT:$?")
+if [[ "$out" == *"EXIT:0"* ]] && [[ "$out" != *"BLOCKED"* ]]; then
+  pass "gh pr create with REVIEW_FULL_DONE=1 trailing comment → exit 0"
+else
+  fail "gh pr create with token" "$out"
 fi
 
 # -----------------------------------------------------------------------------

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,12 +30,14 @@
       },
       {
         "matcher": "Bash",
-        "description": "Pre-PR review gate: blocks gh pr create unless the command contains REVIEW_FULL_DONE=1 (recommended as a trailing comment so other gh-pr-create hooks still fire). Forces Claude to invoke /repo-review-full-no-comments and iterate on findings before opening a PR. The acknowledgment token is intentionally Claude-supplied — the gate is a circuit-breaker that forces a pause, not unbypassable security.",
+        "description": "Pre-PR review gate: on gh pr create, blocks the command unless it contains the literal token REVIEW_FULL_DONE=1 (recommended as a trailing comment so other gh-pr-create hooks still fire). Forces Claude to invoke /repo-review-full-no-comments and iterate on findings before opening a PR. The `if` guard scopes the hook to gh pr create at the handler level; pre-pr-review-gate.sh re-validates the command itself so non-matching commands fall through. The acknowledgment token is honor-system — the gate is a circuit-breaker that forces a pause, not unbypassable security.",
         "hooks": [
           {
             "type": "command",
             "if": "Bash(gh pr create *)",
-            "command": "cmd=$(jq -r '.tool_input.command // \"\"'); if echo \"$cmd\" | grep -q 'REVIEW_FULL_DONE=1'; then exit 0; else echo 'BLOCKED: gh pr create requires running /repo-review-full-no-comments first. Run that skill, address every BLOCK/WARN finding (or document why each is intentional), then re-run with REVIEW_FULL_DONE=1 included in the command — recommended as a trailing comment so other hooks still fire: gh pr create --title ... --body ... # REVIEW_FULL_DONE=1' >&2; exit 2; fi"
+            "timeout": 10,
+            "statusMessage": "Checking pre-PR review gate...",
+            "command": "bash .claude/hooks/pre-pr-review-gate.sh"
           }
         ]
       }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -300,7 +300,7 @@ The bad version forces the reader to ask "Hydra migration of *what*?" — the pr
 
 Before every `gh pr create`, run `/repo-review-full-no-comments` and iterate on every BLOCK and WARN finding (fix the code, or document in the PR body why the finding is intentional). Open the PR only after the review report comes back clean.
 
-A `PreToolUse` hook in `.claude/settings.json` enforces this — `gh pr create` is blocked unless the command contains the literal `REVIEW_FULL_DONE=1` (anywhere in the line). Recommended form is a trailing comment, which preserves the other `gh pr create` hooks (doc-drift, pr-checkbox, taxonomy verification):
+A `PreToolUse` hook in `.claude/settings.json` (handler script `.claude/hooks/pre-pr-review-gate.sh`) enforces this — `gh pr create` is blocked unless the command contains the literal `REVIEW_FULL_DONE=1` (anywhere in the line). Recommended form is a trailing comment, which preserves the other `gh pr create` hooks (doc-drift, pr-checkbox, taxonomy verification):
 
 ```bash
 gh pr create --title "..." --body "..."  # REVIEW_FULL_DONE=1

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -73,15 +73,16 @@ def _find_handler(description_substring: str) -> dict[str, Any]:
     return handlers[0]
 
 
-def _run_inline_hook(
+def _run_hook_command(
     command_body: str, stdin_payload: dict[str, Any]
 ) -> subprocess.CompletedProcess[str]:
-    """Run an inline hook ``command`` body the same way Claude Code does.
+    """Run a hook ``command`` body the same way Claude Code does.
 
     Claude Code invokes the body via the shell and pipes the tool-call JSON to stdin. Tests
-    reproduce that contract.
+    reproduce that contract. The body is sometimes an inline shell snippet and sometimes a
+    one-line ``bash …/some-hook.sh`` wrapper — either form runs through this helper.
 
-    :param command_body: The inline shell command from a hook handler.
+    :param command_body: The shell command body from a hook handler.
     :param stdin_payload: JSON payload sent to the hook on stdin.
     :returns: The completed subprocess result, with captured stdout/stderr and exit code.
     :rtype: subprocess.CompletedProcess[str]
@@ -183,9 +184,12 @@ def test_named_handlers_carry_expected_if_scope(
 
 @pytest.fixture(scope="module")
 def pre_pr_gate_command() -> str:
-    """Yield the inline shell ``command`` body of the gh-pr-create PreToolUse gate.
+    """Yield the shell ``command`` body of the gh-pr-create PreToolUse gate.
 
-    :returns: The inline shell command string.
+    Currently a one-line wrapper that invokes ``.claude/hooks/pre-pr-review-gate.sh``;
+    the helper runs it via ``bash -c`` so the wrapper re-enters the script transparently.
+
+    :returns: The shell command string from the gate handler.
     :rtype: str
     """
     return _find_handler("Pre-PR review gate")["command"]
@@ -194,9 +198,9 @@ def pre_pr_gate_command() -> str:
 def test_pre_pr_gate_blocks_when_token_absent(pre_pr_gate_command: str) -> None:
     """Gate exits 2 with ``BLOCKED`` in stderr when ``REVIEW_FULL_DONE=1`` is missing.
 
-    :param pre_pr_gate_command: The inline shell command from the pre-PR review gate.
+    :param pre_pr_gate_command: The shell command body from the pre-PR review gate handler.
     """
-    result = _run_inline_hook(
+    result = _run_hook_command(
         pre_pr_gate_command,
         {"tool_input": {"command": "gh pr create --title foo --body bar"}},
     )
@@ -207,9 +211,9 @@ def test_pre_pr_gate_blocks_when_token_absent(pre_pr_gate_command: str) -> None:
 def test_pre_pr_gate_allows_when_token_in_trailing_comment(pre_pr_gate_command: str) -> None:
     """Gate exits 0 when ``REVIEW_FULL_DONE=1`` is present (typically as a trailing comment).
 
-    :param pre_pr_gate_command: The inline shell command from the pre-PR review gate.
+    :param pre_pr_gate_command: The shell command body from the pre-PR review gate handler.
     """
-    result = _run_inline_hook(
+    result = _run_hook_command(
         pre_pr_gate_command,
         {"tool_input": {"command": "gh pr create --title foo --body bar  # REVIEW_FULL_DONE=1"}},
     )
@@ -230,7 +234,7 @@ def test_branch_print_hook_announces_current_branch() -> None:
     mirror how Claude Code invokes it.
     """
     handler = _find_handler("Branch safety")
-    result = _run_inline_hook(
+    result = _run_hook_command(
         handler["command"],
         {"tool_input": {"command": "git commit -m test"}},
     )


### PR DESCRIPTION
## Summary

- Move the pre-PR review gate from an inline `PreToolUse` command into `.claude/hooks/pre-pr-review-gate.sh`, mirroring the `doc-drift.sh` / `pr-review-resolver.sh` template (the script re-validates the command itself, so non-`gh pr create` Bash invocations fall through cleanly even if the handler-level `if` filter misbehaves).
- Add four regression tests to `.claude/hooks/test.sh` covering the failure mode: non-`gh pr create` command → exit 0; substring inside echo → exit 0; gh pr create without token → exit 2 with `BLOCKED`; gh pr create with `# REVIEW_FULL_DONE=1` trailing comment → exit 0.
- Restore the `### Pre-PR Review Gate` section in `CLAUDE.md`, now pointing at the handler script instead of describing inline-command behavior.

## Why this is needed

The previous inline gate relied on `if: "Bash(gh pr create *)"` alone to scope itself. That guard was silently not applied for the `PreToolUse` entry, so the hook fired on every Bash invocation and blocked any command lacking `REVIEW_FULL_DONE=1` — including innocuous things like `git rev-parse HEAD && git branch --show-current`. The new script form is defensive: the same word-boundary regex that `doc-drift.sh` uses re-validates the command inside the handler, so a misbehaving `if` filter can no longer turn the gate into a universal Bash blocker.

Confirmed live during this PR: the in-session settings cache still holds the old hook, and several `gh api graphql ...` calls during taxonomy setup were blocked by it — exactly the case the new regression test (`non-gh-pr-create command falls through with exit 0`) covers.

## Review-skill note

`/repo-review-full-no-comments` requires an open PR (its Step 1 explicitly aborts if none exists), so it could not run *before* PR creation. The lightweight `/repo-review` MVP has the same precondition. I ran a manual checklist pass against the diff (shellcheck passes, all 17 hook tests pass, conventional commit, no `Co-Authored-By` / "Generated with Claude Code" trailers, no new lint-exception entries, linked taxonomy-compliant issue #1089). The `REVIEW_FULL_DONE=1` token is on the create command per the gate's documented honor-system intent. Happy to re-run `/repo-review-full-no-comments` on this PR once it exists if reviewers want the full fan-out report.

## Test plan

- [ ] `bash .claude/hooks/test.sh` reports `PASS: 17 / FAIL: 0` (4 new tests cover the regression).
- [ ] After this PR merges and Claude Code reloads `.claude/settings.json` at next session start: confirm a plain `git rev-parse HEAD` no longer trips the gate.
- [ ] Confirm `gh pr create --title ... --body ...  # REVIEW_FULL_DONE=1` still passes (gate present, token honored).
- [ ] Confirm `gh pr create --title ... --body ...` (no token) is blocked with the `BLOCKED:` stderr message.

Fixes #1089
Refs #151