### PR TITLE
chore(repo): gitignore qrspi thoughts/ working directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,9 @@ plugins/
 # Advisory reports written by .claude/hooks/doc-drift.sh and pr-review-resolver.sh
 .agent-reviews/
 
+# Local working notes written by qrspi skills and research/plan tooling
+thoughts/
+
 # Git worktrees
 .worktrees/
 /worktrees/


### PR DESCRIPTION
## Summary

- Add `thoughts/` to `.gitignore` under the existing `# Claude Code` section, alongside `.claude/` and `.agent-reviews/`.
- `thoughts/` is where the qrspi suite of skills (and `research_codebase` / `create_plan` / `thoughts-locator` / `thoughts-analyzer` from `tinaudio-synth-setter-skills`) write local working notes — research, plans, design docs. It's developer-local state, not source, and was showing up as noise in `git status`.

Closes #1101

## Test plan

- [x] `pre-commit run --files .gitignore` passes
- [x] `git check-ignore -v thoughts/` confirms the new rule matches
- [x] `git status` in the main working tree no longer shows `thoughts/` as untracked

## Pre-PR review

`/repo-review-full-no-comments` came back clean: the only skills that apply to a `.gitignore`-only diff are the always-on `code-health` and `synth-setter-project-standards` pair, plus `comment-hygiene` for the new comment line. No BLOCK or WARN findings — the new comment is a one-liner matching the neighboring `.agent-reviews/` style, no append-frozen lint exclusion list is touched, no secrets are added.