### PR TITLE
chore(lint): pilot — fix DOC101/103 in tests/schemas/test_paths_config.py

### DIFF
--- a/tests/schemas/test_paths_config.py
+++ b/tests/schemas/test_paths_config.py
@@ -41,8 +41,11 @@ class TestPathsConfigRejectsBadInputs:
     """Validators must reject blank overrides on every path field."""
 
     @pytest.mark.parametrize("field", list(_VALID_PATHS))
-    def test_blank_field_rejected(self, field: str) -> None:  # noqa: DOC101,DOC103
-        """Each path field rejects whitespace-only overrides."""
+    def test_blank_field_rejected(self, field: str) -> None:
+        """Each path field rejects whitespace-only overrides.
+
+        :param field: Parametrized name of the ``PathsConfig`` attribute under test.
+        """
         bad = {**_VALID_PATHS, field: "   "}
         with pytest.raises(ValidationError, match="at least 1 character"):
             PathsConfig.model_validate(bad)


### PR DESCRIPTION
## Summary

Pilot fix for the Cluster C inline-DOC-noqa cleanup. One file, one site:

- `tests/schemas/test_paths_config.py:test_blank_field_rejected` — add `:param field:` for the `@pytest.mark.parametrize("field", …)` argname; drop `# noqa: DOC101,DOC103`.

This PR's diff is the **template** the sibling bulk PR (21 remaining files) will mirror.

## Template rules

1. One `:param <name>:` per non-`self`/`cls` arg in the test's signature. Sources: pytest fixtures (`monkeypatch`, `tmp_path`, `capsys`, custom fixtures from `conftest.py`), `@pytest.mark.parametrize("<name>", …)` argnames.
2. `:returns:` is OMITTED for tests returning `None`.
3. `:raises:` is OMITTED unless the test body has an explicit `raise` (rare — `pytest.raises(...)` is an assertion form, not a `:raises:`).
4. Drop ONLY `# noqa: DOC101`/`DOC103`/`DOC201`/`DOC203`. Other noqas (e.g. `S101`) stay.

## Verification

- [x] `pre-commit run pydoclint --files tests/schemas/test_paths_config.py` → Passed.
- [x] `git grep -c 'noqa: DOC' tests/schemas/test_paths_config.py` → 0.
- [x] `pytest tests/schemas/test_paths_config.py` → green.
- [x] `pre-commit run --files tests/schemas/test_paths_config.py` → all Passed.

Refs #1106
