### PR TITLE
chore(lint): document 15 Pydantic schemas via .. attribute :: blocks

### DIFF
--- a/src/synth_setter/pipeline/schemas/r2_location.py
+++ b/src/synth_setter/pipeline/schemas/r2_location.py
@@ -37,13 +37,29 @@ if TYPE_CHECKING:
 __all__ = ["R2Location"]
 
 
-class R2Location(BaseModel):  # noqa: DOC601,DOC603
+class R2Location(BaseModel):
     """R2 storage location: bucket + prefix_root + materialized prefix.
 
     Strict + frozen at the trust boundary — the same JSON-from-R2 round-trip
     contract that ``DatasetSpec`` honors. Field validators reject blanks and
     enforce the ``prefix`` trailing slash so rclone never receives
     ``r2:bucket/prefixshardname`` (concatenation trap).
+
+    .. attribute :: model_config
+
+        Pydantic config: ``strict=True``, ``frozen=True``, ``extra="forbid"``.
+
+    .. attribute :: bucket
+
+        Cloudflare R2 bucket name where shards and metadata are written.
+
+    .. attribute :: prefix_root
+
+        Top-level prefix segment under the bucket.
+
+    .. attribute :: prefix
+
+        Full R2 object prefix (``<root>/<task_name>/<run_id>/``); must end with ``/``.
     """
 
     model_config = ConfigDict(strict=True, frozen=True, extra="forbid")

--- a/src/synth_setter/pipeline/schemas/r2_location.py
+++ b/src/synth_setter/pipeline/schemas/r2_location.py
@@ -47,7 +47,7 @@ class R2Location(BaseModel):
 
     .. attribute :: model_config
 
-        Pydantic config: ``strict=True``, ``frozen=True``, ``extra="forbid"``.
+        Pydantic model config sentinel — see ``ConfigDict(...)`` below for active settings.
 
     .. attribute :: bucket
 

--- a/src/synth_setter/pipeline/schemas/skypilot_launch.py
+++ b/src/synth_setter/pipeline/schemas/skypilot_launch.py
@@ -16,7 +16,7 @@ class SkypilotLaunchConfig(BaseModel):
 
     .. attribute :: model_config
 
-        Pydantic config: ``strict=True``, ``frozen=True``, ``extra="forbid"``.
+        Pydantic model config sentinel — see ``ConfigDict(...)`` below for active settings.
 
     .. attribute :: compute_template
 

--- a/src/synth_setter/pipeline/schemas/skypilot_launch.py
+++ b/src/synth_setter/pipeline/schemas/skypilot_launch.py
@@ -11,8 +11,49 @@ from __future__ import annotations
 from pydantic import BaseModel, ConfigDict, field_validator
 
 
-class SkypilotLaunchConfig(BaseModel):  # noqa: DOC601,DOC603
-    """Validated SkyPilot launch parameters consumed by dispatch_via_skypilot."""
+class SkypilotLaunchConfig(BaseModel):
+    """Validated SkyPilot launch parameters consumed by dispatch_via_skypilot.
+
+    .. attribute :: model_config
+
+        Pydantic config: ``strict=True``, ``frozen=True``, ``extra="forbid"``.
+
+    .. attribute :: compute_template
+
+        Path to the SkyPilot compute-template YAML.
+
+    .. attribute :: cmd
+
+        Override command passed to the worker entrypoint.
+
+    .. attribute :: env_file
+
+        Path to an ``.env`` file forwarded to workers.
+
+    .. attribute :: job_name
+
+        SkyPilot job name (shown in ``sky status``).
+
+    .. attribute :: num_workers
+
+        Number of worker replicas to launch.
+
+    .. attribute :: worker_image_tag
+
+        Docker image tag pulled by each worker.
+
+    .. attribute :: tail
+
+        Whether to tail logs after launch.
+
+    .. attribute :: api_server
+
+        SkyPilot API server URL override.
+
+    .. attribute :: local
+
+        Run the job on the local SkyPilot context instead of remote.
+    """
 
     model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
 

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -404,7 +404,7 @@ class DatasetSpec(BaseModel):
 
     .. attribute :: model_config
 
-        Pydantic config: ``strict=True``, ``frozen=True``, ``extra="forbid"``, ``validate_default=True``.
+        Pydantic model config sentinel — see ``ConfigDict(...)`` below for active settings.
 
     .. attribute :: task_name
 

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -387,7 +387,7 @@ def _can_derive_prefix(data: dict[str, Any], r2: dict[str, Any]) -> bool:
     return True
 
 
-class DatasetSpec(BaseModel):  # noqa: DOC601,DOC603
+class DatasetSpec(BaseModel):
     """Unified dataset specification — config + materialized runtime in one model.
 
     Construction story:
@@ -401,6 +401,55 @@ class DatasetSpec(BaseModel):  # noqa: DOC601,DOC603
     Strict mode is on (the model is a trust boundary for JSON-from-R2);
     ``extra="forbid"`` plus the per-field validators keep the boundary tight.
     Frozen so the materialized artifact is immutable post-construction.
+
+    .. attribute :: model_config
+
+        Pydantic config: ``strict=True``, ``frozen=True``, ``extra="forbid"``, ``validate_default=True``.
+
+    .. attribute :: task_name
+
+        Dataset config identifier; prefix of ``run_id`` and ``r2.prefix``.
+
+    .. attribute :: output_format
+
+        Shard container format (``hdf5`` writes ``.h5``, ``wds`` writes ``.tar``).
+
+    .. attribute :: train_val_test_sizes
+
+        Sample counts per split; each entry must be a multiple of
+        ``render.samples_per_shard``.
+
+    .. attribute :: train_val_test_seeds
+
+        Reserved for per-sample seeding (#884); must be ``None``.
+
+    .. attribute :: base_seed
+
+        Seed used to derive per-shard ``ShardSpec.seed`` values.
+
+    .. attribute :: render
+
+        Nested ``RenderConfig`` carrying every per-shard renderer input.
+
+    .. attribute :: git_sha
+
+        Commit SHA of the launcher's working tree at construction.
+
+    .. attribute :: is_repo_dirty
+
+        Whether the launcher's working tree had uncommitted changes.
+
+    .. attribute :: created_at
+
+        UTC timestamp when the spec was first constructed.
+
+    .. attribute :: run_id
+
+        Deterministic W&B run ID derived from ``task_name`` and ``created_at``.
+
+    .. attribute :: r2
+
+        Nested R2 storage location (bucket + prefix_root + materialized prefix).
     """
 
     model_config = ConfigDict(strict=True, frozen=True, extra="forbid", validate_default=True)

--- a/src/synth_setter/schemas/_types.py
+++ b/src/synth_setter/schemas/_types.py
@@ -16,11 +16,15 @@ __all__ = ["NonBlankStr", "StrictAllowExtraModel"]
 NonBlankStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 
 
-class StrictAllowExtraModel(BaseModel):  # noqa: DOC601,DOC603
+class StrictAllowExtraModel(BaseModel):
     """Trust-boundary base: ``strict=True`` + ``extra="allow"`` + alias-by-name.
 
     Diverges from ``pipeline.schemas``' ``extra="forbid"`` because training
     configs are composed from many Hydra subtrees whose keys vary per variant.
+
+    .. attribute :: model_config
+
+        Pydantic config: ``strict=True``, ``extra="allow"``, ``populate_by_name=True``.
     """
 
     model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)

--- a/src/synth_setter/schemas/_types.py
+++ b/src/synth_setter/schemas/_types.py
@@ -24,7 +24,7 @@ class StrictAllowExtraModel(BaseModel):
 
     .. attribute :: model_config
 
-        Pydantic config: ``strict=True``, ``extra="allow"``, ``populate_by_name=True``.
+        Pydantic model config sentinel — see ``ConfigDict(...)`` below for active settings.
     """
 
     model_config = ConfigDict(strict=True, extra="allow", populate_by_name=True)

--- a/src/synth_setter/schemas/callbacks_config.py
+++ b/src/synth_setter/schemas/callbacks_config.py
@@ -16,8 +16,13 @@ from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 __all__ = ["CallbackInstance", "CallbacksConfig"]
 
 
-class CallbackInstance(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """One entry of ``cfg.callbacks``; callback kwargs pass through via ``extra="allow"``."""
+class CallbackInstance(StrictAllowExtraModel):
+    """One entry of ``cfg.callbacks``; callback kwargs pass through via ``extra="allow"``.
+
+    .. attribute :: target_
+
+        Fully-qualified callback class path.
+    """
 
     target_: NonBlankStr = Field(
         alias="_target_",
@@ -28,11 +33,15 @@ class CallbackInstance(StrictAllowExtraModel):  # noqa: DOC601,DOC603
     )
 
 
-class CallbacksConfig(RootModel[dict[NonBlankStr, CallbackInstance]]):  # noqa: DOC601,DOC603
+class CallbacksConfig(RootModel[dict[NonBlankStr, CallbackInstance]]):
     """Shape of ``cfg.callbacks`` — a ``name → CallbackInstance`` mapping.
 
     ``configs/callbacks/none.yaml`` resolves to ``None``, not ``{}``, and is
     handled by ``instantiate_callbacks`` short-circuiting on a falsy config.
+
+    .. attribute :: model_config
+
+        Pydantic config: ``strict=True``.
     """
 
     model_config = ConfigDict(strict=True)

--- a/src/synth_setter/schemas/callbacks_config.py
+++ b/src/synth_setter/schemas/callbacks_config.py
@@ -41,7 +41,7 @@ class CallbacksConfig(RootModel[dict[NonBlankStr, CallbackInstance]]):
 
     .. attribute :: model_config
 
-        Pydantic config: ``strict=True``.
+        Pydantic model config sentinel — see ``ConfigDict(...)`` below for active settings.
     """
 
     model_config = ConfigDict(strict=True)

--- a/src/synth_setter/schemas/data_config.py
+++ b/src/synth_setter/schemas/data_config.py
@@ -13,8 +13,13 @@ from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 __all__ = ["DataConfig"]
 
 
-class DataConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """One of the YAMLs under ``configs/data/``; only ``_target_`` is typed."""
+class DataConfig(StrictAllowExtraModel):
+    """One of the YAMLs under ``configs/data/``; only ``_target_`` is typed.
+
+    .. attribute :: target_
+
+        Fully-qualified ``LightningDataModule`` class path.
+    """
 
     target_: NonBlankStr = Field(
         alias="_target_",

--- a/src/synth_setter/schemas/extras_config.py
+++ b/src/synth_setter/schemas/extras_config.py
@@ -20,8 +20,25 @@ __all__ = ["ExtrasConfig"]
 _FLOAT32_MATMUL_PRECISIONS: tuple[str, ...] = ("highest", "high", "medium")
 
 
-class ExtrasConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """Startup toggles consumed by ``synth_setter.utils.extras(cfg)``."""
+class ExtrasConfig(StrictAllowExtraModel):
+    """Startup toggles consumed by ``synth_setter.utils.extras(cfg)``.
+
+    .. attribute :: ignore_warnings
+
+        If ``True``, ``synth_setter.utils.extras`` silences Python ``warnings``.
+
+    .. attribute :: enforce_tags
+
+        If ``True``, ``extras`` prompts on startup when no ``tags`` are set.
+
+    .. attribute :: print_config
+
+        Pretty-print the composed Hydra config tree at startup using Rich.
+
+    .. attribute :: float32_matmul_precision
+
+        Passed to ``torch.set_float32_matmul_precision``.
+    """
 
     ignore_warnings: StrictBool = Field(
         default=False,

--- a/src/synth_setter/schemas/logger_config.py
+++ b/src/synth_setter/schemas/logger_config.py
@@ -40,7 +40,7 @@ class LoggerConfig(RootModel[dict[NonBlankStr, LoggerInstance]]):
 
     .. attribute :: model_config
 
-        Pydantic config: ``strict=True``.
+        Pydantic model config sentinel — see ``ConfigDict(...)`` below for active settings.
     """
 
     model_config = ConfigDict(strict=True)

--- a/src/synth_setter/schemas/logger_config.py
+++ b/src/synth_setter/schemas/logger_config.py
@@ -14,8 +14,13 @@ from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 __all__ = ["LoggerConfig", "LoggerInstance"]
 
 
-class LoggerInstance(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """One entry of ``cfg.logger``; logger kwargs pass through via ``extra="allow"``."""
+class LoggerInstance(StrictAllowExtraModel):
+    """One entry of ``cfg.logger``; logger kwargs pass through via ``extra="allow"``.
+
+    .. attribute :: target_
+
+        Fully-qualified logger class path.
+    """
 
     target_: NonBlankStr = Field(
         alias="_target_",
@@ -27,11 +32,15 @@ class LoggerInstance(StrictAllowExtraModel):  # noqa: DOC601,DOC603
     )
 
 
-class LoggerConfig(RootModel[dict[NonBlankStr, LoggerInstance]]):  # noqa: DOC601,DOC603
+class LoggerConfig(RootModel[dict[NonBlankStr, LoggerInstance]]):
     """Shape of ``cfg.logger`` — a ``name → LoggerInstance`` mapping.
 
     ``instantiate_loggers`` short-circuits on a falsy ``cfg.logger`` (empty
     or ``None``), so that case bypasses this schema.
+
+    .. attribute :: model_config
+
+        Pydantic config: ``strict=True``.
     """
 
     model_config = ConfigDict(strict=True)

--- a/src/synth_setter/schemas/model_config.py
+++ b/src/synth_setter/schemas/model_config.py
@@ -19,8 +19,25 @@ from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 __all__ = ["ModelConfig", "OptimizerConfig", "SchedulerConfig"]
 
 
-class OptimizerConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """Partial torch optimizer; the LightningModule binds model params at call time."""
+class OptimizerConfig(StrictAllowExtraModel):
+    """Partial torch optimizer; the LightningModule binds model params at call time.
+
+    .. attribute :: target_
+
+        Fully-qualified torch optimizer class path.
+
+    .. attribute :: partial_
+
+        Whether Hydra returns a partial.
+
+    .. attribute :: lr
+
+        Learning rate (must be positive).
+
+    .. attribute :: weight_decay
+
+        L2 weight-decay coefficient (must be non-negative).
+    """
 
     target_: NonBlankStr = Field(
         alias="_target_",
@@ -38,8 +55,17 @@ class OptimizerConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
     )
 
 
-class SchedulerConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """Partial torch LR scheduler; ``scheduler: null`` maps to ``None`` instead."""
+class SchedulerConfig(StrictAllowExtraModel):
+    """Partial torch LR scheduler; ``scheduler: null`` maps to ``None`` instead.
+
+    .. attribute :: target_
+
+        Fully-qualified LR-scheduler class path.
+
+    .. attribute :: partial_
+
+        Whether Hydra returns a partial.
+    """
 
     target_: NonBlankStr = Field(
         alias="_target_",
@@ -52,8 +78,25 @@ class SchedulerConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
     )
 
 
-class ModelConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """One of the YAMLs under ``configs/model/``; variant kwargs via ``extra="allow"``."""
+class ModelConfig(StrictAllowExtraModel):
+    """One of the YAMLs under ``configs/model/``; variant kwargs via ``extra="allow"``.
+
+    .. attribute :: target_
+
+        Fully-qualified ``LightningModule`` class path.
+
+    .. attribute :: optimizer
+
+        Partial torch optimizer config (see ``OptimizerConfig``).
+
+    .. attribute :: scheduler
+
+        Partial LR scheduler config, or ``null`` to run without a scheduler.
+
+    .. attribute :: compile
+
+        Whether to wrap the module in ``torch.compile`` at setup time.
+    """
 
     target_: NonBlankStr = Field(
         alias="_target_",

--- a/src/synth_setter/schemas/paths_config.py
+++ b/src/synth_setter/schemas/paths_config.py
@@ -14,8 +14,29 @@ from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 __all__ = ["PathsConfig"]
 
 
-class PathsConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """Path layout consumed via ``${paths.<name>}`` interpolation across configs."""
+class PathsConfig(StrictAllowExtraModel):
+    """Path layout consumed via ``${paths.<name>}`` interpolation across configs.
+
+    .. attribute :: root_dir
+
+        Project root.
+
+    .. attribute :: data_dir
+
+        Default datamodule data root, ``${paths.root_dir}/data/``.
+
+    .. attribute :: log_dir
+
+        Logger root, ``${paths.root_dir}/logs/``.
+
+    .. attribute :: output_dir
+
+        Per-run output dir resolved from ``${hydra:runtime.output_dir}``.
+
+    .. attribute :: work_dir
+
+        Hydra's launch-time working directory, ``${hydra:runtime.cwd}``.
+    """
 
     root_dir: NonBlankStr = Field(
         description=(

--- a/src/synth_setter/schemas/train_config.py
+++ b/src/synth_setter/schemas/train_config.py
@@ -27,12 +27,44 @@ def _default_tags() -> list[str]:
     return ["dev"]
 
 
-class TrainConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
+class TrainConfig(StrictAllowExtraModel):
     """Top-level training config composed from ``configs/train.yaml``.
 
     Defaults below mirror ``configs/train.yaml``. Hydra-managed subtrees
     (``data``, ``model``, ``trainer``, ...) pass through via ``extra="allow"``
     — ``TrainConfig()`` does not reconstruct them on its own.
+
+    .. attribute :: task_name
+
+        Logical name for this training run.
+
+    .. attribute :: tags
+
+        Free-form tags propagated to the logger (wandb / TensorBoard).
+
+    .. attribute :: train
+
+        Run the fit loop.
+
+    .. attribute :: test
+
+        Run the test loop on the best checkpoint after fit.
+
+    .. attribute :: ckpt_path
+
+        Path to a Lightning checkpoint to resume from.
+
+    .. attribute :: seed
+
+        Seed forwarded to ``lightning.seed_everything``.
+
+    .. attribute :: optimized_metric
+
+        Name of the callback metric returned to Hydra for sweeps.
+
+    .. attribute :: watch_gradients
+
+        If truthy, attaches a gradient watcher to the logger.
     """
 
     task_name: NonBlankStr = Field(

--- a/src/synth_setter/schemas/trainer_config.py
+++ b/src/synth_setter/schemas/trainer_config.py
@@ -19,8 +19,45 @@ from synth_setter.schemas._types import NonBlankStr, StrictAllowExtraModel
 __all__ = ["TrainerConfig"]
 
 
-class TrainerConfig(StrictAllowExtraModel):  # noqa: DOC601,DOC603
-    """One of the YAMLs under ``configs/trainer/``; other kwargs ride ``extra="allow"``."""
+class TrainerConfig(StrictAllowExtraModel):
+    """One of the YAMLs under ``configs/trainer/``; other kwargs ride ``extra="allow"``.
+
+    .. attribute :: target_
+
+        Fully-qualified ``lightning.pytorch.trainer.Trainer`` class path.
+
+    .. attribute :: default_root_dir
+
+        Where Lightning writes logs and checkpoints when no logger overrides it.
+
+    .. attribute :: accelerator
+
+        Hardware backend (``cpu``, ``gpu``, ``mps``, ``tpu``, ``auto``).
+
+    .. attribute :: devices
+
+        Number of devices on the chosen accelerator.
+
+    .. attribute :: log_every_n_steps
+
+        Logging cadence (steps) for training metrics.
+
+    .. attribute :: val_check_interval
+
+        Cadence of validation runs.
+
+    .. attribute :: gradient_clip_val
+
+        Maximum gradient L2 norm before clipping.
+
+    .. attribute :: check_val_every_n_epoch
+
+        Run validation every N epochs (``None`` → step-based).
+
+    .. attribute :: deterministic
+
+        Force deterministic ops where Lightning supports it.
+    """
 
     target_: NonBlankStr = Field(
         alias="_target_",


### PR DESCRIPTION
## Summary

Document 15 Pydantic schema classes across 12 files via Sphinx `.. attribute ::` blocks; drop the `# noqa: DOC601,DOC603` suppression on each class line. Brings `src/` inline-DOC-noqa count to **zero**.

| File | Classes |
| --- | --- |
| `src/synth_setter/schemas/_types.py` | 1 |
| `src/synth_setter/schemas/callbacks_config.py` | 2 |
| `src/synth_setter/schemas/data_config.py` | 1 |
| `src/synth_setter/schemas/extras_config.py` | 1 |
| `src/synth_setter/schemas/logger_config.py` | 2 |
| `src/synth_setter/schemas/model_config.py` | 3 |
| `src/synth_setter/schemas/paths_config.py` | 1 |
| `src/synth_setter/schemas/train_config.py` | 1 |
| `src/synth_setter/schemas/trainer_config.py` | 1 |
| `src/synth_setter/pipeline/schemas/r2_location.py` | 1 |
| `src/synth_setter/pipeline/schemas/skypilot_launch.py` | 1 |
| `src/synth_setter/pipeline/schemas/spec.py` | 1 |

## Syntax choice — why `.. attribute ::` and not `:ivar:`

The QRSPI plan originally specified `:ivar <field>: <text>` lines (a common Sphinx alias). Empirically, pydoclint 0.8.3's `check-class-attributes` does **not** recognize `:ivar:` — re-running pydoclint on a file converted from `.. attribute ::` to `:ivar:` re-fires `DOC601`/`DOC603`. So the only working pydoclint-compatible syntax is the `.. attribute :: <name>` directive (with the description indented in the following block).

This introduces a new convention in this codebase — but it matches the [official Sphinx class-attribute directive](https://www.sphinx-doc.org/en/master/usage/domains/python.html#directive-py-attribute), is what pydoclint's own documentation uses, and is what their `check-class-attributes` test fixtures use.

`Field(description=...)` remains the canonical multi-line prose surface for each attribute. The `.. attribute ::` block carries a short, one-clause summary mirroring the first sentence of the `Field(description=...)`.

## Verification

- [x] `git grep -E 'noqa: DOC60(1|3)' src/` → no output.
- [x] `pre-commit run pydoclint --files <all 12 files>` → Passed.
- [x] `pre-commit run --files <all 12 files>` → Passed (ruff/pyright/pydoclint/docformatter/interrogate/codespell).
- [x] `pytest tests/schemas/` → 97 passed (no behavior change).
- [x] `scripts/ci/count_doc_noqa.sh` → `src=0 tests=188` (Cluster A cleared; the 188 tests/ sites are Cluster C, in the sibling PR).

Refs #1106
