### PR TITLE
chore(lint): fix DOC10x/20x docstrings across 21 tests/ files

### DIFF
--- a/tests/data/test_surge_datamodule.py
+++ b/tests/data/test_surge_datamodule.py
@@ -56,7 +56,7 @@ _ALL_TENSOR_KEYS = ("audio", "mel_spec", "m2l", "params", "noise")
 
 
 @contextlib.contextmanager
-def _set_up_module(**kwargs: object) -> Iterator[SurgeDataModule]:  # noqa: DOC101,DOC103,DOC404
+def _set_up_module(**kwargs: object) -> Iterator[SurgeDataModule]:
     """Construct a ``SurgeDataModule`` from ``**kwargs``, ``setup``, yield, then ``teardown``.
 
     Encapsulates the setup/teardown try/finally pattern every
@@ -65,7 +65,9 @@ def _set_up_module(**kwargs: object) -> Iterator[SurgeDataModule]:  # noqa: DOC1
     h5py file when one was opened, since ``teardown`` only closes the three
     train/val/test splits.
 
+    :param \\*\\*kwargs: Forwarded to ``SurgeDataModule``.
     :yields: The set-up datamodule for assertion work inside the ``with`` block.
+    :ytype: SurgeDataModule
     """
     module = SurgeDataModule(**kwargs)  # type: ignore[arg-type]
     module.setup()
@@ -214,8 +216,11 @@ def single_h5(tmp_path: Path) -> Path:
 class TestSurgeXTDatasetFakeMode:
     """``fake=True`` skips HDF5 entirely and returns randomly-generated tensors."""
 
-    def test_fake_mode_does_not_open_h5_file(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """``fake=True`` accepts a nonexistent path because ``__init__`` never reads it."""
+    def test_fake_mode_does_not_open_h5_file(self, tmp_path: Path) -> None:
+        """``fake=True`` accepts a nonexistent path because ``__init__`` never reads it.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         missing = tmp_path / "does-not-exist.h5"
         dataset = SurgeXTDataset(missing, batch_size=4, fake=True)
         assert dataset.dataset_file is None
@@ -324,13 +329,19 @@ class TestSurgeXTDatasetFakeMode:
 class TestSurgeXTDatasetH5Mode:
     """HDF5-backed path: indexing, type conversion, OT routing, normalization."""
 
-    def test_len_equals_num_rows_floor_divided_by_batch_size(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """``__len__`` uses integer division — 8 rows / batch_size 3 == 2 batches."""
+    def test_len_equals_num_rows_floor_divided_by_batch_size(self, single_h5: Path) -> None:
+        """``__len__`` uses integer division — 8 rows / batch_size 3 == 2 batches.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         dataset = SurgeXTDataset(single_h5, batch_size=3, ot=False)
         assert len(dataset) == 8 // 3
 
-    def test_getitem_int_returns_batch_size_slice(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """Integer index ``i`` reads rows ``[i*B : i*B+B]`` from each dataset."""
+    def test_getitem_int_returns_batch_size_slice(self, single_h5: Path) -> None:
+        """Integer index ``i`` reads rows ``[i*B : i*B+B]`` from each dataset.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         dataset = SurgeXTDataset(
             single_h5, batch_size=2, ot=False, use_saved_mean_and_variance=False
         )
@@ -338,24 +349,33 @@ class TestSurgeXTDatasetH5Mode:
         assert _unwrap(item["params"]).shape[0] == 2
         assert _unwrap(item["mel_spec"]).shape[0] == 2
 
-    def test_getitem_tuple_returns_explicit_slice(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """A 2-tuple index ``(lo, hi)`` selects rows ``[lo:hi]`` directly."""
+    def test_getitem_tuple_returns_explicit_slice(self, single_h5: Path) -> None:
+        """A 2-tuple index ``(lo, hi)`` selects rows ``[lo:hi]`` directly.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         dataset = SurgeXTDataset(
             single_h5, batch_size=2, ot=False, use_saved_mean_and_variance=False
         )
         item = dataset[(1, 5)]
         assert _unwrap(item["params"]).shape[0] == 4
 
-    def test_getitem_sequence_falls_through_to_ds_fancy_indexing(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """A non-int / non-2-tuple index falls through to ``ds[idx]`` fancy indexing."""
+    def test_getitem_sequence_falls_through_to_ds_fancy_indexing(self, single_h5: Path) -> None:
+        """A non-int / non-2-tuple index falls through to ``ds[idx]`` fancy indexing.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         dataset = SurgeXTDataset(
             single_h5, batch_size=2, ot=False, use_saved_mean_and_variance=False
         )
         item = dataset[[0, 2, 4]]
         assert _unwrap(item["params"]).shape[0] == 3
 
-    def test_repeat_first_batch_ignores_idx(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """``repeat_first_batch=True`` always returns the first ``batch_size`` rows."""
+    def test_repeat_first_batch_ignores_idx(self, single_h5: Path) -> None:
+        """``repeat_first_batch=True`` always returns the first ``batch_size`` rows.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         dataset = SurgeXTDataset(
             single_h5,
             batch_size=3,
@@ -367,8 +387,11 @@ class TestSurgeXTDatasetH5Mode:
         later = dataset[2]
         assert torch.equal(_unwrap(first["params"]), _unwrap(later["params"]))
 
-    def test_returned_tensors_are_float32(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """All numeric tensors come back as ``torch.float32`` for AMP compatibility."""
+    def test_returned_tensors_are_float32(self, single_h5: Path) -> None:
+        """All numeric tensors come back as ``torch.float32`` for AMP compatibility.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         dataset = SurgeXTDataset(
             single_h5,
             batch_size=2,
@@ -382,8 +405,11 @@ class TestSurgeXTDatasetH5Mode:
         for key in _ALL_TENSOR_KEYS:
             assert _unwrap(item[key]).dtype == torch.float32, key
 
-    def test_returned_tensors_are_contiguous(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """Every populated tensor is ``.contiguous()`` so downstream cuda copies are cheap."""
+    def test_returned_tensors_are_contiguous(self, single_h5: Path) -> None:
+        """Every populated tensor is ``.contiguous()`` so downstream cuda copies are cheap.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         dataset = SurgeXTDataset(
             single_h5,
             batch_size=2,
@@ -397,22 +423,31 @@ class TestSurgeXTDatasetH5Mode:
         for key in _ALL_TENSOR_KEYS:
             assert _unwrap(item[key]).is_contiguous(), f"{key} not contiguous"
 
-    def test_read_audio_false_returns_none_audio(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """``read_audio=False`` (default) leaves the ``audio`` slot at ``None``."""
+    def test_read_audio_false_returns_none_audio(self, single_h5: Path) -> None:
+        """``read_audio=False`` (default) leaves the ``audio`` slot at ``None``.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         dataset = SurgeXTDataset(
             single_h5, batch_size=2, ot=False, use_saved_mean_and_variance=False
         )
         item = dataset[0]
         assert item["audio"] is None
 
-    def test_read_mel_false_returns_none_mel(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """``read_mel=False`` drops the ``mel_spec`` slot, even with stats on disk."""
+    def test_read_mel_false_returns_none_mel(self, single_h5: Path) -> None:
+        """``read_mel=False`` drops the ``mel_spec`` slot, even with stats on disk.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         dataset = SurgeXTDataset(single_h5, batch_size=2, ot=False, read_mel=False)
         item = dataset[0]
         assert item["mel_spec"] is None
 
-    def test_read_m2l_true_returns_m2l_tensor(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """``read_m2l=True`` reads the ``music2latent`` dataset under the ``m2l`` key."""
+    def test_read_m2l_true_returns_m2l_tensor(self, single_h5: Path) -> None:
+        """``read_m2l=True`` reads the ``music2latent`` dataset under the ``m2l`` key.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         dataset = SurgeXTDataset(
             single_h5,
             batch_size=2,
@@ -422,8 +457,11 @@ class TestSurgeXTDatasetH5Mode:
         )
         assert _unwrap(dataset[0]["m2l"]).shape == (2, _M2L_DIM_1, _M2L_DIM_2)
 
-    def test_rescale_params_centers_to_minus_one_to_one(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """``rescale_params=True`` applies ``p * 2 - 1`` element-wise before tensor conversion."""
+    def test_rescale_params_centers_to_minus_one_to_one(self, single_h5: Path) -> None:
+        """``rescale_params=True`` applies ``p * 2 - 1`` element-wise before tensor conversion.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         dataset_raw = SurgeXTDataset(
             single_h5,
             batch_size=2,
@@ -442,8 +480,11 @@ class TestSurgeXTDatasetH5Mode:
         rescaled = _unwrap(dataset_rescaled[0]["params"])
         assert torch.allclose(rescaled, raw * 2 - 1)
 
-    def test_mel_spec_normalized_with_loaded_stats(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """When ``stats.npz`` is loaded, mel is returned as ``(mel - mean) / std``."""
+    def test_mel_spec_normalized_with_loaded_stats(self, tmp_path: Path) -> None:
+        """When ``stats.npz`` is loaded, mel is returned as ``(mel - mean) / std``.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         h5_path = tmp_path / "train.h5"
         _write_h5_shard(h5_path, num_rows=4, mel_fill=3.0)
         _write_stats(tmp_path, mean=1.0, std=2.0)
@@ -457,8 +498,11 @@ class TestSurgeXTDatasetH5Mode:
         expected = (3.0 - 1.0) / 2.0
         assert torch.allclose(mel, torch.full_like(mel, expected))
 
-    def test_no_stats_load_when_disabled(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """``use_saved_mean_and_variance=False`` skips the npz read, even if it's missing."""
+    def test_no_stats_load_when_disabled(self, tmp_path: Path) -> None:
+        """``use_saved_mean_and_variance=False`` skips the npz read, even if it's missing.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         h5_path = tmp_path / "train.h5"
         _write_h5_shard(h5_path, num_rows=4)
         dataset = SurgeXTDataset(
@@ -470,15 +514,21 @@ class TestSurgeXTDatasetH5Mode:
         assert dataset.mean is None
         assert dataset.std is None
 
-    def test_missing_stats_file_raises_file_not_found(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """``use_saved_mean_and_variance=True`` with no sibling ``stats.npz`` errors clearly."""
+    def test_missing_stats_file_raises_file_not_found(self, tmp_path: Path) -> None:
+        """``use_saved_mean_and_variance=True`` with no sibling ``stats.npz`` errors clearly.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         h5_path = tmp_path / "train.h5"
         _write_h5_shard(h5_path, num_rows=4)
         with pytest.raises(FileNotFoundError, match="stats.npz"):
             SurgeXTDataset(h5_path, batch_size=2, ot=False, use_saved_mean_and_variance=True)
 
-    def test_get_stats_file_path_is_sibling_of_dataset(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """The static helper returns ``parent_dir / 'stats.npz'`` for any input layout."""
+    def test_get_stats_file_path_is_sibling_of_dataset(self, tmp_path: Path) -> None:
+        """The static helper returns ``parent_dir / 'stats.npz'`` for any input layout.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         # str input
         assert SurgeXTDataset.get_stats_file_path(str(tmp_path / "train.h5")) == (
             tmp_path / "stats.npz"
@@ -489,8 +539,11 @@ class TestSurgeXTDatasetH5Mode:
         nested = tmp_path / "shard0" / "data.h5"
         assert SurgeXTDataset.get_stats_file_path(nested) == tmp_path / "shard0" / "stats.npz"
 
-    def test_no_ot_does_not_call_hungarian_match(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """``ot=False`` short-circuits before ``_hungarian_match`` is invoked."""
+    def test_no_ot_does_not_call_hungarian_match(self, single_h5: Path) -> None:
+        """``ot=False`` short-circuits before ``_hungarian_match`` is invoked.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         with patch("synth_setter.data.surge_datamodule._hungarian_match") as mock_match:
             dataset = SurgeXTDataset(
                 single_h5,
@@ -501,8 +554,11 @@ class TestSurgeXTDatasetH5Mode:
             _ = dataset[0]
         mock_match.assert_not_called()
 
-    def test_ot_true_calls_hungarian_match_with_all_four_tensors(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """``ot=True`` routes through ``_hungarian_match(noise, params, mel_spec, audio)``."""
+    def test_ot_true_calls_hungarian_match_with_all_four_tensors(self, single_h5: Path) -> None:
+        """``ot=True`` routes through ``_hungarian_match(noise, params, mel_spec, audio)``.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         with patch(
             "synth_setter.data.surge_datamodule._hungarian_match",
             side_effect=lambda noise, params, *args: (noise, params, *args),
@@ -536,8 +592,11 @@ class TestSurgeXTDatasetH5Mode:
             _AUDIO_SAMPLES,
         )
 
-    def test_ot_with_disabled_modalities_passes_none_through(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """``_hungarian_match`` still receives ``None`` placeholders when modalities are off."""
+    def test_ot_with_disabled_modalities_passes_none_through(self, single_h5: Path) -> None:
+        """``_hungarian_match`` still receives ``None`` placeholders when modalities are off.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         with patch(
             "synth_setter.data.surge_datamodule._hungarian_match",
             side_effect=lambda noise, params, *args: (noise, params, *args),
@@ -561,8 +620,11 @@ class TestSurgeXTDatasetH5Mode:
         assert item["mel_spec"] is None
         assert item["audio"] is None
 
-    def test_returned_dict_always_exposes_full_key_set(self, single_h5: Path) -> None:  # noqa: DOC101,DOC103
-        """Every ``__getitem__`` return dict exposes the same five-key contract."""
+    def test_returned_dict_always_exposes_full_key_set(self, single_h5: Path) -> None:
+        """Every ``__getitem__`` return dict exposes the same five-key contract.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
         dataset = SurgeXTDataset(
             single_h5,
             batch_size=2,
@@ -748,28 +810,40 @@ class TestShiftedBatchSampler:
 class TestSurgeDataModule:
     """Lightning datamodule: setup / dataloaders / teardown wiring."""
 
-    def test_init_stores_dataset_root_as_path(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """``dataset_root`` is normalized to ``pathlib.Path`` even when passed as a str."""
+    def test_init_stores_dataset_root_as_path(self, tmp_path: Path) -> None:
+        """``dataset_root`` is normalized to ``pathlib.Path`` even when passed as a str.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         module = SurgeDataModule(dataset_root=str(tmp_path))
         assert module.dataset_root == tmp_path
         assert isinstance(module.dataset_root, Path)
 
-    def test_setup_creates_train_val_test_splits(self, dataset_root: Path) -> None:  # noqa: DOC101,DOC103
-        """``setup()`` opens the three required splits and exposes them as attrs."""
+    def test_setup_creates_train_val_test_splits(self, dataset_root: Path) -> None:
+        """``setup()`` opens the three required splits and exposes them as attrs.
+
+        :param dataset_root: Fixture-provided dataset-root directory.
+        """
         with _set_up_module(dataset_root=dataset_root, batch_size=2, ot=False) as module:
             assert isinstance(module.train_dataset, SurgeXTDataset)
             assert isinstance(module.val_dataset, SurgeXTDataset)
             assert isinstance(module.test_dataset, SurgeXTDataset)
 
-    def test_setup_without_predict_file_leaves_predict_none(self, dataset_root: Path) -> None:  # noqa: DOC101,DOC103
-        """``predict_file=None`` leaves ``predict_dataset`` as ``None``."""
+    def test_setup_without_predict_file_leaves_predict_none(self, dataset_root: Path) -> None:
+        """``predict_file=None`` leaves ``predict_dataset`` as ``None``.
+
+        :param dataset_root: Fixture-provided dataset-root directory.
+        """
         with _set_up_module(dataset_root=dataset_root, batch_size=2, ot=False) as module:
             assert module.predict_dataset is None
 
-    def test_setup_with_predict_file_builds_predict_dataset_with_audio(  # noqa: DOC101,DOC103
+    def test_setup_with_predict_file_builds_predict_dataset_with_audio(
         self, dataset_root: Path
     ) -> None:
-        """``predict_file`` set: predict-split dataset opens with ``read_audio=True``."""
+        """``predict_file`` set: predict-split dataset opens with ``read_audio=True``.
+
+        :param dataset_root: Fixture-provided dataset-root directory.
+        """
         with _set_up_module(
             dataset_root=dataset_root,
             batch_size=2,
@@ -779,15 +853,21 @@ class TestSurgeDataModule:
             assert isinstance(module.predict_dataset, SurgeXTDataset)
             assert module.predict_dataset.read_audio is True
 
-    def test_setup_val_and_test_force_ot_false(self, dataset_root: Path) -> None:  # noqa: DOC101,DOC103
-        """``setup`` hard-codes ``ot=False`` on val/test even when the module is ``ot=True``."""
+    def test_setup_val_and_test_force_ot_false(self, dataset_root: Path) -> None:
+        """``setup`` hard-codes ``ot=False`` on val/test even when the module is ``ot=True``.
+
+        :param dataset_root: Fixture-provided dataset-root directory.
+        """
         with _set_up_module(dataset_root=dataset_root, batch_size=2, ot=True) as module:
             assert module.train_dataset.ot is True
             assert module.val_dataset.ot is False
             assert module.test_dataset.ot is False
 
-    def test_conditioning_mel_routes_to_mel_reads(self, dataset_root: Path) -> None:  # noqa: DOC101,DOC103
-        """``conditioning='mel'`` toggles ``read_mel=True`` / ``read_m2l=False`` on every split."""
+    def test_conditioning_mel_routes_to_mel_reads(self, dataset_root: Path) -> None:
+        """``conditioning='mel'`` toggles ``read_mel=True`` / ``read_m2l=False`` on every split.
+
+        :param dataset_root: Fixture-provided dataset-root directory.
+        """
         with _set_up_module(
             dataset_root=dataset_root, batch_size=2, ot=False, conditioning="mel"
         ) as module:
@@ -795,8 +875,11 @@ class TestSurgeDataModule:
                 assert split.read_mel is True
                 assert split.read_m2l is False
 
-    def test_conditioning_m2l_routes_to_m2l_reads(self, dataset_root: Path) -> None:  # noqa: DOC101,DOC103
-        """``conditioning='m2l'`` flips the read flags to the music2latent channel."""
+    def test_conditioning_m2l_routes_to_m2l_reads(self, dataset_root: Path) -> None:
+        """``conditioning='m2l'`` flips the read flags to the music2latent channel.
+
+        :param dataset_root: Fixture-provided dataset-root directory.
+        """
         with _set_up_module(
             dataset_root=dataset_root, batch_size=2, ot=False, conditioning="m2l"
         ) as module:
@@ -804,8 +887,11 @@ class TestSurgeDataModule:
                 assert split.read_mel is False
                 assert split.read_m2l is True
 
-    def test_conditioning_m2l_also_routes_predict_split(self, dataset_root: Path) -> None:  # noqa: DOC101,DOC103
-        """``predict_dataset`` follows the same conditioning routing as train/val/test."""
+    def test_conditioning_m2l_also_routes_predict_split(self, dataset_root: Path) -> None:
+        """``predict_dataset`` follows the same conditioning routing as train/val/test.
+
+        :param dataset_root: Fixture-provided dataset-root directory.
+        """
         with _set_up_module(
             dataset_root=dataset_root,
             batch_size=2,
@@ -817,8 +903,11 @@ class TestSurgeDataModule:
             assert module.predict_dataset.read_mel is False
             assert module.predict_dataset.read_m2l is True
 
-    def test_train_dataloader_uses_shifted_batch_sampler(self, dataset_root: Path) -> None:  # noqa: DOC101,DOC103
-        """``train_dataloader`` wires the ``ShiftedBatchSampler`` (not the global random one)."""
+    def test_train_dataloader_uses_shifted_batch_sampler(self, dataset_root: Path) -> None:
+        """``train_dataloader`` wires the ``ShiftedBatchSampler`` (not the global random one).
+
+        :param dataset_root: Fixture-provided dataset-root directory.
+        """
         with _set_up_module(
             dataset_root=dataset_root,
             batch_size=2,
@@ -832,8 +921,11 @@ class TestSurgeDataModule:
             assert loader.num_workers == 0
             assert loader.pin_memory is False
 
-    def test_val_test_dataloaders_have_no_shuffle_sampler(self, dataset_root: Path) -> None:  # noqa: DOC101,DOC103
-        """Val/test loaders use the default no-shuffle ``SequentialSampler``."""
+    def test_val_test_dataloaders_have_no_shuffle_sampler(self, dataset_root: Path) -> None:
+        """Val/test loaders use the default no-shuffle ``SequentialSampler``.
+
+        :param dataset_root: Fixture-provided dataset-root directory.
+        """
         with _set_up_module(
             dataset_root=dataset_root,
             batch_size=2,
@@ -846,8 +938,11 @@ class TestSurgeDataModule:
             assert isinstance(val_loader.sampler, torch.utils.data.SequentialSampler)
             assert isinstance(test_loader.sampler, torch.utils.data.SequentialSampler)
 
-    def test_dataloader_num_workers_and_pin_memory_propagate(self, dataset_root: Path) -> None:  # noqa: DOC101,DOC103
-        """``num_workers`` / ``pin_memory`` kwargs are passed verbatim to every DataLoader."""
+    def test_dataloader_num_workers_and_pin_memory_propagate(self, dataset_root: Path) -> None:
+        """``num_workers`` / ``pin_memory`` kwargs are passed verbatim to every DataLoader.
+
+        :param dataset_root: Fixture-provided dataset-root directory.
+        """
         with _set_up_module(
             dataset_root=dataset_root,
             batch_size=2,
@@ -863,10 +958,13 @@ class TestSurgeDataModule:
                 assert loader.num_workers == 2
                 assert loader.pin_memory is True
 
-    def test_predict_dataloader_returns_dataloader_when_predict_file_set(  # noqa: DOC101,DOC103
+    def test_predict_dataloader_returns_dataloader_when_predict_file_set(
         self, dataset_root: Path
     ) -> None:
-        """``predict_dataloader`` wraps the predict split in a no-shuffle loader."""
+        """``predict_dataloader`` wraps the predict split in a no-shuffle loader.
+
+        :param dataset_root: Fixture-provided dataset-root directory.
+        """
         with _set_up_module(
             dataset_root=dataset_root,
             batch_size=2,
@@ -877,11 +975,14 @@ class TestSurgeDataModule:
             assert isinstance(loader, torch.utils.data.DataLoader)
             assert isinstance(loader.sampler, torch.utils.data.SequentialSampler)
 
-    def test_predict_dataloader_propagates_num_workers_and_pin_memory(  # noqa: DOC101,DOC103
+    def test_predict_dataloader_propagates_num_workers_and_pin_memory(
         self, dataset_root: Path
     ) -> None:
         """``num_workers`` / ``pin_memory`` reach the predict loader too (separate construction
-        path)."""
+        path).
+
+        :param dataset_root: Fixture-provided dataset-root directory.
+        """
         with _set_up_module(
             dataset_root=dataset_root,
             batch_size=2,
@@ -894,8 +995,11 @@ class TestSurgeDataModule:
             assert loader.num_workers == 2
             assert loader.pin_memory is True
 
-    def test_teardown_closes_open_h5_handles(self, dataset_root: Path) -> None:  # noqa: DOC101,DOC103
-        """``teardown`` closes the three split files so the next setup can reopen them."""
+    def test_teardown_closes_open_h5_handles(self, dataset_root: Path) -> None:
+        """``teardown`` closes the three split files so the next setup can reopen them.
+
+        :param dataset_root: Fixture-provided dataset-root directory.
+        """
         module = SurgeDataModule(dataset_root=dataset_root, batch_size=2, ot=False)
         module.setup()
         module.teardown()
@@ -904,8 +1008,11 @@ class TestSurgeDataModule:
         assert not module.val_dataset.dataset_file
         assert not module.test_dataset.dataset_file
 
-    def test_fake_mode_setup_does_not_require_dataset_files(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """``fake=True`` setup never touches the dataset_root, so a fresh dir is enough."""
+    def test_fake_mode_setup_does_not_require_dataset_files(self, tmp_path: Path) -> None:
+        """``fake=True`` setup never touches the dataset_root, so a fresh dir is enough.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         with _set_up_module(
             dataset_root=tmp_path,
             batch_size=2,
@@ -917,8 +1024,11 @@ class TestSurgeDataModule:
             assert module.val_dataset.fake is True
             assert module.test_dataset.fake is True
 
-    def test_fake_mode_train_dataloader_yields_well_shaped_items(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """End-to-end smoke: fake-mode train loader iterates and produces sane shapes."""
+    def test_fake_mode_train_dataloader_yields_well_shaped_items(self, tmp_path: Path) -> None:
+        """End-to-end smoke: fake-mode train loader iterates and produces sane shapes.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         with _set_up_module(
             dataset_root=tmp_path,
             batch_size=2,

--- a/tests/data/vst/test_core.py
+++ b/tests/data/vst/test_core.py
@@ -65,10 +65,13 @@ class TestExtractRendererVersion:
 class TestLoadPluginNoWarmup:
     """``load_plugin`` is a pure loader — never calls ``show_editor`` by itself."""
 
-    def test_load_plugin_does_not_call_show_editor(  # noqa: DOC101,DOC103
+    def test_load_plugin_does_not_call_show_editor(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """``load_plugin`` only constructs ``VST3Plugin``; warm-up lives in ``warmup_plugin``."""
+        """``load_plugin`` only constructs ``VST3Plugin``; warm-up lives in ``warmup_plugin``.
+
+        :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+        """
         fake_plugin = MagicMock()
         monkeypatch.setattr(core, "VST3Plugin", lambda _path: fake_plugin)
 
@@ -101,10 +104,13 @@ class TestRenderParamsPreloadedPlugin:
         fake.process.side_effect = lambda *a, **kw: np.zeros(audio_shape, dtype=np.float32)
         return fake
 
-    def test_preloaded_plugin_bypasses_load_and_preset(  # noqa: DOC101,DOC103
+    def test_preloaded_plugin_bypasses_load_and_preset(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """When ``plugin`` is supplied, ``load_plugin`` and ``load_preset`` are not called."""
+        """When ``plugin`` is supplied, ``load_plugin`` and ``load_preset`` are not called.
+
+        :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+        """
         load_calls: list[str] = []
         preset_calls: list[tuple[object, str]] = []
         monkeypatch.setattr(
@@ -138,10 +144,13 @@ class TestRenderParamsPreloadedPlugin:
         # The pre-loaded plugin is what ran the render.
         assert preloaded.process.called
 
-    def test_no_plugin_kwarg_reloads_per_call(  # noqa: DOC101,DOC103
+    def test_no_plugin_kwarg_reloads_per_call(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Without ``plugin``, ``render_params`` still loads the plugin and preset per call."""
+        """Without ``plugin``, ``render_params`` still loads the plugin and preset per call.
+
+        :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+        """
         fake_plugin = self._fake_plugin(audio_shape=(2, 16))
         load_calls: list[str] = []
 
@@ -172,10 +181,13 @@ class TestRenderParamsPreloadedPlugin:
         assert load_calls == ["plugins/Surge XT.vst3"]
         assert preset_calls == [(fake_plugin, "presets/surge-base.vstpreset")]
 
-    def test_warmup_kwarg_runs_warmup_plugin_after_load(  # noqa: DOC101,DOC103
+    def test_warmup_kwarg_runs_warmup_plugin_after_load(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """``warmup=True`` calls ``warmup_plugin`` on the freshly-loaded plugin."""
+        """``warmup=True`` calls ``warmup_plugin`` on the freshly-loaded plugin.
+
+        :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+        """
         fake_plugin = self._fake_plugin(audio_shape=(2, 16))
         warmup_calls: list[object] = []
 
@@ -200,10 +212,13 @@ class TestRenderParamsPreloadedPlugin:
 
         assert warmup_calls == [fake_plugin]
 
-    def test_warmup_kwarg_runs_warmup_on_supplied_plugin(  # noqa: DOC101,DOC103
+    def test_warmup_kwarg_runs_warmup_on_supplied_plugin(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """``warmup=True`` with a cached plugin warms the cached instance, not a fresh load."""
+        """``warmup=True`` with a cached plugin warms the cached instance, not a fresh load.
+
+        :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+        """
         cached = self._fake_plugin(audio_shape=(2, 16))
         warmup_calls: list[object] = []
 

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -1196,7 +1196,7 @@ def test_generate_sample_retries_when_only_fixed_note_params(
     assert sample.note_params == _HARDCODED_NOTE_PARAMS
 
 
-def _install_fake_render_params(  # noqa: DOC203
+def _install_fake_render_params(
     monkeypatch: pytest.MonkeyPatch,
     spec: ParamSpec,
     *,
@@ -1238,7 +1238,7 @@ def _install_fake_render_params(  # noqa: DOC203
 
 
 @pytest.mark.parametrize("num_retries", [0, 1, 3])
-def test_generate_sample_warmups_once_regardless_of_retries(  # noqa: DOC101,DOC103
+def test_generate_sample_warmups_once_regardless_of_retries(
     monkeypatch: pytest.MonkeyPatch, num_retries: int
 ) -> None:
     """``warmup=True`` invokes ``warmup_plugin`` exactly once across K loudness retries.
@@ -1249,6 +1249,9 @@ def test_generate_sample_warmups_once_regardless_of_retries(  # noqa: DOC101,DOC
     primitive must still fire at most once across the whole ``generate_sample``
     call — otherwise N retries blow past the ~3-4-calls-per-process budget.
     Asserts behavior (warm-up call count) rather than the ``warmup`` kwarg.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    :param num_retries: Parametrized ``num_retries`` value under test.
     """
     from synth_setter.data.vst import generate_vst_dataset
 
@@ -1272,7 +1275,7 @@ def test_generate_sample_warmups_once_regardless_of_retries(  # noqa: DOC101,DOC
 
 
 @pytest.mark.parametrize("num_retries", [0, 1, 3])
-def test_generate_sample_with_warmup_false_never_warms_across_retries(  # noqa: DOC101,DOC103
+def test_generate_sample_with_warmup_false_never_warms_across_retries(
     monkeypatch: pytest.MonkeyPatch, num_retries: int
 ) -> None:
     """``warmup=False`` is a hard zero: no ``warmup_plugin`` call regardless of retries.
@@ -1280,6 +1283,9 @@ def test_generate_sample_with_warmup_false_never_warms_across_retries(  # noqa: 
     Off-switch invariant — the caller asked for no warm-up, so the loudness
     retry loop must not re-introduce one. This is the symmetrical guarantee to
     ``test_generate_sample_warmups_once_regardless_of_retries``.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    :param num_retries: Parametrized ``num_retries`` value under test.
     """
     from synth_setter.data.vst import generate_vst_dataset
 
@@ -1302,7 +1308,7 @@ def test_generate_sample_with_warmup_false_never_warms_across_retries(  # noqa: 
     assert warmup_mock.call_count == 0
 
 
-def test_generate_sample_with_warmup_true_no_retries_warms_exactly_once(  # noqa: DOC101,DOC103
+def test_generate_sample_with_warmup_true_no_retries_warms_exactly_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Strict equality at zero retries: ``warmup_plugin`` fires once, not at least once.
@@ -1311,6 +1317,8 @@ def test_generate_sample_with_warmup_true_no_retries_warms_exactly_once(  # noqa
     warm-up primitive is invoked exactly once. Without this, a regression that
     silently double-warmed on the success path could slip past the retry tests
     (which only exercise the retry branch).
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
     """
     from synth_setter.data.vst import generate_vst_dataset
 

--- a/tests/data/vst/test_writers.py
+++ b/tests/data/vst/test_writers.py
@@ -21,11 +21,14 @@ from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
 from synth_setter.pipeline.schemas.spec import RenderConfig
 
 
-def _smoke_render_cfg(**overrides: object) -> RenderConfig:  # noqa: DOC101,DOC103,DOC201,DOC203
+def _smoke_render_cfg(**overrides: object) -> RenderConfig:
     """Build a syntactically-valid ``RenderConfig`` for CPU-only tests.
 
     No I/O happens against ``plugin_path`` or ``preset_path`` in these tests
     — they only need to be non-blank strings.
+
+    :param \\*\\*overrides: Per-call overrides merged into the default kwargs.
+    :return: A ``RenderConfig`` ready for the writer tests.
     """
     kwargs: dict[str, object] = {
         "plugin_path": "plugins/Surge XT.vst3",
@@ -80,12 +83,14 @@ def test_shard_metadata_from_render_round_trips_through_json() -> None:
     assert rehydrated == meta
 
 
-def _run_main_with_argv(argv: list[str]) -> None:  # noqa: DOC101,DOC103
+def _run_main_with_argv(argv: list[str]) -> None:
     """Invoke ``generate_vst_dataset.main`` with ``argv`` patched in.
 
     The pydantic-settings CLI reads ``sys.argv`` directly via ``CliApp.run``,
     so tests need to swap the process argv around the call. Imports the entry
     inside the helper so a single import failure doesn't poison the module.
+
+    :param argv: Parametrized ``argv`` value under test.
     """
     from synth_setter.data.vst.generate_vst_dataset import main
 
@@ -96,11 +101,14 @@ def _run_main_with_argv(argv: list[str]) -> None:  # noqa: DOC101,DOC103
 # Shared CLI argv prefix for the dispatcher tests below. Built from the same
 # ``RenderConfig`` field set the CLI binding inherits, so adding a render-config
 # field auto-extends the prefix.
-def _cli_argv(data_file: str) -> list[str]:  # noqa: DOC101,DOC103,DOC201,DOC203
+def _cli_argv(data_file: str) -> list[str]:
     """Build a CLI argv that parses cleanly into a ``RenderConfig`` + ``data_file``.
 
     All values mirror ``_smoke_render_cfg`` so the parsed config is round-trip
     equal to it. The ``argv[0]`` is a stand-in program name (not used).
+
+    :param data_file: Path threaded into argv as the positional data_file arg.
+    :return: A list of argv tokens suitable for ``_run_main_with_argv``.
     """
     return [
         "generate_vst_dataset",
@@ -133,8 +141,11 @@ def _cli_argv(data_file: str) -> list[str]:  # noqa: DOC101,DOC103,DOC201,DOC203
     ]
 
 
-def test_main_dispatches_h5_suffix_to_make_hdf5_dataset(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """``data_file=foo.h5`` routes to ``make_hdf5_dataset`` (not the wds writer)."""
+def test_main_dispatches_h5_suffix_to_make_hdf5_dataset(tmp_path: Path) -> None:
+    """``data_file=foo.h5`` routes to ``make_hdf5_dataset`` (not the wds writer).
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     data_file = tmp_path / "shard-000000.h5"
 
     with (
@@ -150,8 +161,11 @@ def test_main_dispatches_h5_suffix_to_make_hdf5_dataset(tmp_path: Path) -> None:
     assert h5_args[0] == str(data_file)
 
 
-def test_main_dispatches_tar_suffix_to_make_wds_dataset(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """``data_file=foo.tar`` routes to ``make_wds_dataset`` (not the h5 writer)."""
+def test_main_dispatches_tar_suffix_to_make_wds_dataset(tmp_path: Path) -> None:
+    """``data_file=foo.tar`` routes to ``make_wds_dataset`` (not the h5 writer).
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     data_file = tmp_path / "shard-000000.tar"
 
     with (
@@ -166,8 +180,11 @@ def test_main_dispatches_tar_suffix_to_make_wds_dataset(tmp_path: Path) -> None:
     assert wds_args[0] == str(data_file)
 
 
-def test_main_rejects_unknown_suffix(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """``data_file=foo.bin`` raises ``SystemExit`` rather than silently picking a writer."""
+def test_main_rejects_unknown_suffix(tmp_path: Path) -> None:
+    """``data_file=foo.bin`` raises ``SystemExit`` rather than silently picking a writer.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     data_file = tmp_path / "shard-000000.bin"
 
     with (
@@ -181,7 +198,7 @@ def test_main_rejects_unknown_suffix(tmp_path: Path) -> None:  # noqa: DOC101,DO
     mock_wds.assert_not_called()
 
 
-def _stub_render_dependencies(  # noqa: DOC101,DOC103,DOC201,DOC203
+def _stub_render_dependencies(
     monkeypatch: pytest.MonkeyPatch,
     *,
     load_plugin_calls: list[dict[str, object]],
@@ -194,6 +211,12 @@ def _stub_render_dependencies(  # noqa: DOC101,DOC103,DOC201,DOC203
     ``cached_plugin_holder`` is supplied, the MagicMock returned by the fake
     ``load_plugin`` is appended to it so tests can assert identity-equality
     against the instance threaded into per-render calls.
+
+    :param monkeypatch: Pytest fixture used to patch module-level callables.
+    :param load_plugin_calls: List receiving the path argument of each fake ``load_plugin`` call.
+    :param load_preset_calls: List receiving the kwargs of each fake ``load_preset`` call.
+    :param cached_plugin_holder: When supplied, the fake plugin instance is appended to this list.
+    :return: List of kwargs dicts captured from each ``generate_sample`` invocation.
     """
     captured: list[dict[str, object]] = []
 
@@ -217,10 +240,13 @@ def _stub_render_dependencies(  # noqa: DOC101,DOC103,DOC201,DOC203
     return captured
 
 
-def test_render_in_batches_caches_plugin_when_reload_cadence_is_once(  # noqa: DOC101,DOC103
+def test_render_in_batches_caches_plugin_when_reload_cadence_is_once(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``plugin_reload_cadence="once"`` loads the plugin once and reuses the same instance."""
+    """``plugin_reload_cadence="once"`` loads the plugin once and reuses the same instance.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    """
     n = 4
     render_cfg = _smoke_render_cfg(
         samples_per_shard=n,
@@ -258,10 +284,13 @@ def test_render_in_batches_caches_plugin_when_reload_cadence_is_once(  # noqa: D
     assert sum(len(batch) for batch, _ in flushed) == n
 
 
-def test_render_in_batches_reloads_plugin_per_render_when_reload_cadence_is_render(  # noqa: DOC101,DOC103
+def test_render_in_batches_reloads_plugin_per_render_when_reload_cadence_is_render(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``plugin_reload_cadence="render"`` (default) leaves the plugin to be loaded per call."""
+    """``plugin_reload_cadence="render"`` (default) leaves the plugin to be loaded per call.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    """
     n = 3
     render_cfg = _smoke_render_cfg(
         samples_per_shard=n,
@@ -295,10 +324,13 @@ def test_render_in_batches_reloads_plugin_per_render_when_reload_cadence_is_rend
         assert call_kwargs["warmup"] is False
 
 
-def test_render_in_batches_warmup_once_runs_first_render_only(  # noqa: DOC101,DOC103
+def test_render_in_batches_warmup_once_runs_first_render_only(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``gui_toggle_cadence="once"`` sets warmup=True on the first render only."""
+    """``gui_toggle_cadence="once"`` sets warmup=True on the first render only.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    """
     n = 4
     render_cfg = _smoke_render_cfg(
         samples_per_shard=n,
@@ -325,10 +357,13 @@ def test_render_in_batches_warmup_once_runs_first_render_only(  # noqa: DOC101,D
     assert warmup_flags == [True, False, False, False]
 
 
-def test_render_in_batches_warmup_render_runs_every_render(  # noqa: DOC101,DOC103
+def test_render_in_batches_warmup_render_runs_every_render(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``gui_toggle_cadence="render"`` sets warmup=True on every render."""
+    """``gui_toggle_cadence="render"`` sets warmup=True on every render.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    """
     # The Darwin validator rejects gui_toggle_cadence="render" (SIGTRAP, #714);
     # force the non-Darwin path so the schema constructs on macOS CI hosts too.
     monkeypatch.setattr(
@@ -359,10 +394,13 @@ def test_render_in_batches_warmup_render_runs_every_render(  # noqa: DOC101,DOC1
     assert all(c["warmup"] is True for c in captured)
 
 
-def test_render_in_batches_warmup_never_skips_all_renders(  # noqa: DOC101,DOC103
+def test_render_in_batches_warmup_never_skips_all_renders(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``gui_toggle_cadence="never"`` keeps warmup=False on every render."""
+    """``gui_toggle_cadence="never"`` keeps warmup=False on every render.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    """
     n = 3
     render_cfg = _smoke_render_cfg(
         samples_per_shard=n,
@@ -388,10 +426,13 @@ def test_render_in_batches_warmup_never_skips_all_renders(  # noqa: DOC101,DOC10
     assert all(c["warmup"] is False for c in captured)
 
 
-def test_render_in_batches_once_once_warms_once_and_caches_plugin(  # noqa: DOC101,DOC103
+def test_render_in_batches_once_once_warms_once_and_caches_plugin(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``("once","once")`` — load + warm once, reuse the same plugin instance throughout."""
+    """``("once","once")`` — load + warm once, reuse the same plugin instance throughout.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    """
     n = 4
     render_cfg = _smoke_render_cfg(
         samples_per_shard=n,
@@ -426,10 +467,13 @@ def test_render_in_batches_once_once_warms_once_and_caches_plugin(  # noqa: DOC1
         assert call_kwargs["plugin"] is cached
 
 
-def test_render_in_batches_once_render_warms_every_render_with_cached_plugin(  # noqa: DOC101,DOC103
+def test_render_in_batches_once_render_warms_every_render_with_cached_plugin(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``("once","render")`` — cached plugin, warmup on every render across the shard."""
+    """``("once","render")`` — cached plugin, warmup on every render across the shard.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    """
     monkeypatch.setattr(
         "synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux"
     )
@@ -477,17 +521,22 @@ def test_render_in_batches_once_render_warms_every_render_with_cached_plugin(  #
 _RENDERER_FAKE_AUDIO_SHAPE = (2, 16000 * 4)
 
 
-def _silent_render() -> object:  # noqa: DOC201,DOC203
-    """Return a silent stereo render shaped for the test ``_smoke_render_cfg``."""
+def _silent_render() -> object:
+    """Return a silent stereo render shaped for the test ``_smoke_render_cfg``.
+
+    :return: Zero-filled stereo audio array shaped like a real render.
+    """
     import numpy as np
 
     return np.zeros(_RENDERER_FAKE_AUDIO_SHAPE, dtype=np.float32)
 
 
-def _loud_render() -> object:  # noqa: DOC201,DOC203
+def _loud_render() -> object:
     """Return a loud stereo render shaped for the test ``_smoke_render_cfg``.
 
     A 440 Hz sine at half-scale comfortably clears the ``-55 dB`` loudness gate.
+
+    :return: 440 Hz sine wave stereo audio array shaped like a real render.
     """
     import numpy as np
 
@@ -497,7 +546,7 @@ def _loud_render() -> object:  # noqa: DOC201,DOC203
     return np.stack([sine, sine], axis=0)
 
 
-def _install_writer_level_fakes(  # noqa: DOC203
+def _install_writer_level_fakes(
     monkeypatch: pytest.MonkeyPatch,
     *,
     retry_on_first_sample: int,
@@ -553,7 +602,7 @@ def _install_writer_level_fakes(  # noqa: DOC203
     return warmup_mock, fake_spec
 
 
-def test_render_in_batches_once_cadence_survives_intra_sample_retries(  # noqa: DOC101,DOC103
+def test_render_in_batches_once_cadence_survives_intra_sample_retries(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``gui_toggle_cadence="once"`` warms exactly once even when sample 0 retries twice.
@@ -565,6 +614,8 @@ def test_render_in_batches_once_cadence_survives_intra_sample_retries(  # noqa: 
     would re-warm and silently blow past the per-shard budget. Asserts the
     observable side effect (``warmup_plugin`` call count) across the full
     shard, not the kwarg the writer hands to ``generate_sample``.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
     """
     n = 3
     retries = 2
@@ -590,7 +641,7 @@ def test_render_in_batches_once_cadence_survives_intra_sample_retries(  # noqa: 
     assert warmup_mock.call_count == 1
 
 
-def test_render_in_batches_render_cadence_warms_once_per_generate_sample_call(  # noqa: DOC101,DOC103
+def test_render_in_batches_render_cadence_warms_once_per_generate_sample_call(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``gui_toggle_cadence="render"`` warms once per ``generate_sample`` call, not per retry.
@@ -601,6 +652,8 @@ def test_render_in_batches_render_cadence_warms_once_per_generate_sample_call(  
     internal ``warmup = False`` reset (line 129 of ``generate_vst_dataset.py``)
     is cadence-agnostic, so sample 0's silent retries do NOT re-warm — total
     warm-ups equals the sample count, not the render-attempt count.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
     """
     monkeypatch.setattr(
         "synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux"

--- a/tests/data/vst/test_writers_wds_e2e.py
+++ b/tests/data/vst/test_writers_wds_e2e.py
@@ -55,8 +55,13 @@ from tests.data.vst.test_generate_vst_dataset import (
 )
 
 
-def _render_cfg(num_samples: int, samples_per_render_batch: int | None = None) -> RenderConfig:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Build a ``RenderConfig`` with this module's test defaults."""
+def _render_cfg(num_samples: int, samples_per_render_batch: int | None = None) -> RenderConfig:
+    """Build a ``RenderConfig`` with this module's test defaults.
+
+    :param num_samples: Total samples to render per shard.
+    :param samples_per_render_batch: Per-batch sample count (defaults to ``num_samples``).
+    :return: A ``RenderConfig`` populated with the test-defaults.
+    """
     return RenderConfig(
         plugin_path=_PLUGIN_PATH,
         preset_path=_PRESET_PATH,
@@ -74,8 +79,12 @@ def _render_cfg(num_samples: int, samples_per_render_batch: int | None = None) -
     )
 
 
-def _tar_members(tar_path: Path) -> dict[str, bytes]:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Return a mapping of every tar member's name to its raw bytes."""
+def _tar_members(tar_path: Path) -> dict[str, bytes]:
+    """Return a mapping of every tar member's name to its raw bytes.
+
+    :param tar_path: Filesystem path to the tar archive to read.
+    :return: Mapping of tar member name to raw bytes.
+    """
     members: dict[str, bytes] = {}
     with tarfile.open(tar_path, "r") as tar:
         for entry in tar:
@@ -87,16 +96,23 @@ def _tar_members(tar_path: Path) -> dict[str, bytes]:  # noqa: DOC101,DOC103,DOC
     return members
 
 
-def _load_npy_bytes(raw: bytes) -> np.ndarray:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Decode a ``.npy`` payload from raw bytes."""
+def _load_npy_bytes(raw: bytes) -> np.ndarray:
+    """Decode a ``.npy`` payload from raw bytes.
+
+    :param raw: Raw bytes of a ``.npy`` payload.
+    :return: Decoded numpy array.
+    """
     return np.load(io.BytesIO(raw), allow_pickle=False)
 
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
 @skip_no_vst
-def test_make_wds_dataset_writes_per_batch_npy_members(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """A 4-sample shard with batch_size=2 emits two batches of three npy members plus metadata."""
+def test_make_wds_dataset_writes_per_batch_npy_members(tmp_path: Path) -> None:
+    """A 4-sample shard with batch_size=2 emits two batches of three npy members plus metadata.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     out = tmp_path / "shard-000000.tar"
     num_samples = 4
     fixed_synth = [_HARDCODED_SYNTH_PARAMS] * num_samples
@@ -127,9 +143,11 @@ def test_make_wds_dataset_writes_per_batch_npy_members(tmp_path: Path) -> None: 
 @pytest.mark.slow
 @pytest.mark.requires_vst
 @skip_no_vst
-def test_make_wds_dataset_metadata_json_is_strict_shard_metadata(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """The shard's ``metadata.json`` member parses as a strict ``ShardMetadata`` matching the
-    cfg."""
+def test_make_wds_dataset_metadata_json_is_strict_shard_metadata(tmp_path: Path) -> None:
+    """The shard's ``metadata.json`` member parses as a strict ``ShardMetadata`` matching the cfg.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     out = tmp_path / "shard-000000.tar"
     num_samples = 2
     render_cfg = _render_cfg(num_samples)
@@ -153,8 +171,11 @@ def test_make_wds_dataset_metadata_json_is_strict_shard_metadata(tmp_path: Path)
 @pytest.mark.slow
 @pytest.mark.requires_vst
 @skip_no_vst
-def test_make_wds_dataset_audio_is_float16(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """Audio members are ``float16`` so they match the h5 path's storage precision."""
+def test_make_wds_dataset_audio_is_float16(tmp_path: Path) -> None:
+    """Audio members are ``float16`` so they match the h5 path's storage precision.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     out = tmp_path / "shard-000000.tar"
     num_samples = 2
 
@@ -177,7 +198,7 @@ def test_make_wds_dataset_audio_is_float16(tmp_path: Path) -> None:  # noqa: DOC
 @pytest.mark.slow
 @pytest.mark.requires_vst
 @skip_no_vst
-def test_h5_and_wds_outputs_are_equivalent(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+def test_h5_and_wds_outputs_are_equivalent(tmp_path: Path) -> None:
     """Same params written through both writers produce equivalent on-disk arrays.
 
     Load-bearing test from the original #874 acceptance checklist. Pins the
@@ -191,6 +212,8 @@ def test_h5_and_wds_outputs_are_equivalent(tmp_path: Path) -> None:  # noqa: DOC
     of the same params can differ at the sample level even with
     ``fixed_synth_params_list`` pinned, so audio and mel are compared via the
     phase-robust metrics this repo already pins for h5↔h5 round-trips.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
     """
     num_samples = 2
     fixed_synth = [_HARDCODED_SYNTH_PARAMS] * num_samples
@@ -294,12 +317,14 @@ def test_h5_and_wds_outputs_are_equivalent(tmp_path: Path) -> None:  # noqa: DOC
 @pytest.mark.slow
 @pytest.mark.requires_vst
 @skip_no_vst
-def test_make_wds_dataset_metadata_json_strict_rejects_extra(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
+def test_make_wds_dataset_metadata_json_strict_rejects_extra(tmp_path: Path) -> None:
     """The metadata.json member round-trips through strict ``ShardMetadata`` validation.
 
     Mirrors the trust-boundary contract used by the consumer: a corrupt
     sidecar would surface as a pydantic ``ValidationError`` rather than
     silently passing through with wrong values.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
     """
     out = tmp_path / "shard-000000.tar"
     num_samples = 2

--- a/tests/evaluation/test_compute_audio_metrics.py
+++ b/tests/evaluation/test_compute_audio_metrics.py
@@ -43,17 +43,26 @@ def _sine(seconds: float = 1.0, freq: float = 440.0, amplitude: float = 0.5) -> 
     return (amplitude * np.sin(2 * np.pi * freq * t)).astype(np.float32).reshape(1, -1)
 
 
-def _write_wav(path: Path, audio: np.ndarray) -> None:  # noqa: DOC101,DOC103
-    """Write a ``(channels, N)`` array to ``path`` as a 44.1 kHz WAV file."""
+def _write_wav(path: Path, audio: np.ndarray) -> None:
+    """Write a ``(channels, N)`` array to ``path`` as a 44.1 kHz WAV file.
+
+    :param path: Destination filesystem path for the WAV.
+    :param audio: ``(channels, N)`` float32 audio to write.
+    """
     channels = audio.shape[0]
     with AudioFile(str(path), "w", _SR, channels) as f:
         f.write(audio)
 
 
-def _make_sample_dir(  # noqa: DOC101,DOC103,DOC201,DOC203
-    parent: Path, name: str, target: np.ndarray, pred: np.ndarray
-) -> Path:
-    """Create a ``sample_<name>`` directory with ``target.wav`` and ``pred.wav``."""
+def _make_sample_dir(parent: Path, name: str, target: np.ndarray, pred: np.ndarray) -> Path:
+    """Create a ``sample_<name>`` directory with ``target.wav`` and ``pred.wav``.
+
+    :param parent: Parent directory under which the sample directory is created.
+    :param name: Sample identifier (becomes the ``sample_<name>`` directory suffix).
+    :param target: ``target.wav`` audio array.
+    :param pred: ``pred.wav`` audio array.
+    :return: Path of the created sample directory.
+    """
     sample_dir = parent / f"sample_{name}"
     sample_dir.mkdir(parents=True, exist_ok=True)
     _write_wav(sample_dir / "target.wav", target)
@@ -62,8 +71,11 @@ def _make_sample_dir(  # noqa: DOC101,DOC103,DOC201,DOC203
 
 
 @pytest.fixture(autouse=True)
-def _reset_module_caches(monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: DOC101,DOC103
-    """Reset module-level ``scatter`` and ``pesto_model`` caches per test."""
+def _reset_module_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Reset module-level ``scatter`` and ``pesto_model`` caches per test.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    """
     monkeypatch.setattr(cam, "scatter", None, raising=True)
     monkeypatch.setattr(cam, "pesto_model", None, raising=True)
 
@@ -114,27 +126,39 @@ def test_compute_rms_quiet_nonzero_inputs_return_zero() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_subdir_matches_pattern_with_both_files_returns_true(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """Both ``target.wav`` and ``pred.wav`` present → True."""
+def test_subdir_matches_pattern_with_both_files_returns_true(tmp_path: Path) -> None:
+    """Both ``target.wav`` and ``pred.wav`` present → True.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     (tmp_path / "target.wav").touch()
     (tmp_path / "pred.wav").touch()
     assert subdir_matches_pattern(tmp_path) is True
 
 
-def test_subdir_matches_pattern_missing_target_returns_false(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """Missing ``target.wav`` → False."""
+def test_subdir_matches_pattern_missing_target_returns_false(tmp_path: Path) -> None:
+    """Missing ``target.wav`` → False.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     (tmp_path / "pred.wav").touch()
     assert subdir_matches_pattern(tmp_path) is False
 
 
-def test_subdir_matches_pattern_missing_pred_returns_false(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """Missing ``pred.wav`` → False."""
+def test_subdir_matches_pattern_missing_pred_returns_false(tmp_path: Path) -> None:
+    """Missing ``pred.wav`` → False.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     (tmp_path / "target.wav").touch()
     assert subdir_matches_pattern(tmp_path) is False
 
 
-def test_subdir_matches_pattern_empty_dir_returns_false(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """Empty directory → False."""
+def test_subdir_matches_pattern_empty_dir_returns_false(tmp_path: Path) -> None:
+    """Empty directory → False.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     assert subdir_matches_pattern(tmp_path) is False
 
 
@@ -143,8 +167,11 @@ def test_subdir_matches_pattern_empty_dir_returns_false(tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_find_possible_subdirs_returns_only_matching_dirs(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """Returns only subdirectories that contain both ``target.wav`` and ``pred.wav``."""
+def test_find_possible_subdirs_returns_only_matching_dirs(tmp_path: Path) -> None:
+    """Returns only subdirectories that contain both ``target.wav`` and ``pred.wav``.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     good = tmp_path / "sample_0"
     good.mkdir()
     (good / "target.wav").touch()
@@ -158,8 +185,11 @@ def test_find_possible_subdirs_returns_only_matching_dirs(tmp_path: Path) -> Non
     assert result == [good]
 
 
-def test_find_possible_subdirs_skips_files(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """Files in ``audio_dir`` are not considered candidate subdirectories."""
+def test_find_possible_subdirs_skips_files(tmp_path: Path) -> None:
+    """Files in ``audio_dir`` are not considered candidate subdirectories.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     (tmp_path / "stray.wav").touch()
     good = tmp_path / "sample_0"
     good.mkdir()
@@ -170,8 +200,11 @@ def test_find_possible_subdirs_skips_files(tmp_path: Path) -> None:  # noqa: DOC
     assert result == [good]
 
 
-def test_find_possible_subdirs_empty_dir_returns_empty_list(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """No subdirectories → empty list."""
+def test_find_possible_subdirs_empty_dir_returns_empty_list(tmp_path: Path) -> None:
+    """No subdirectories → empty list.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     assert find_possible_subdirs(tmp_path) == []
 
 
@@ -191,10 +224,12 @@ def test_compute_mel_specs_returns_one_spec_per_mel_param() -> None:
     ("idx", "expected_n_mels"),
     [(0, 32), (1, 64), (2, 128)],
 )
-def test_compute_mel_specs_spec_has_expected_n_mels(  # noqa: DOC101,DOC103
-    idx: int, expected_n_mels: int
-) -> None:
-    """Each spec has finite values and the expected number of mel rows."""
+def test_compute_mel_specs_spec_has_expected_n_mels(idx: int, expected_n_mels: int) -> None:
+    """Each spec has finite values and the expected number of mel rows.
+
+    :param idx: Parametrized ``idx`` value under test.
+    :param expected_n_mels: Parametrized ``expected_n_mels`` value under test.
+    """
     audio = _sine(seconds=0.5)
     specs = compute_mel_specs(audio[0])
     assert specs[idx].shape[-2] == expected_n_mels
@@ -356,8 +391,11 @@ def test_compute_sot_different_inputs_is_finite_and_nonnegative() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_compute_metrics_on_dir_returns_expected_keys(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """End-to-end on a single sample dir returns finite ``mss/wmfcc/sot/rms``."""
+def test_compute_metrics_on_dir_returns_expected_keys(tmp_path: Path) -> None:
+    """End-to-end on a single sample dir returns finite ``mss/wmfcc/sot/rms``.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     sample_dir = _make_sample_dir(tmp_path, "0", _sine(seconds=0.5), _sine(seconds=0.5))
     metrics = compute_metrics_on_dir(sample_dir)
     assert set(metrics.keys()) == {"mss", "wmfcc", "sot", "rms"}
@@ -365,8 +403,11 @@ def test_compute_metrics_on_dir_returns_expected_keys(tmp_path: Path) -> None:  
         assert np.isfinite(value)
 
 
-def test_compute_metrics_on_dir_identical_files_yields_perfect_scores(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """Identical target/pred → mss/wmfcc/sot ≈ 0 and rms == 1."""
+def test_compute_metrics_on_dir_identical_files_yields_perfect_scores(tmp_path: Path) -> None:
+    """Identical target/pred → mss/wmfcc/sot ≈ 0 and rms == 1.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     audio = _sine(seconds=0.5)
     sample_dir = _make_sample_dir(tmp_path, "0", audio, audio)
     metrics = compute_metrics_on_dir(sample_dir)
@@ -381,8 +422,11 @@ def test_compute_metrics_on_dir_identical_files_yields_perfect_scores(tmp_path: 
 # ---------------------------------------------------------------------------
 
 
-def test_compute_metrics_writes_csv_with_expected_index_and_columns(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """Writes a ``metrics-<pid>.csv`` with the trailing ``_N`` suffix as the row index."""
+def test_compute_metrics_writes_csv_with_expected_index_and_columns(tmp_path: Path) -> None:
+    """Writes a ``metrics-<pid>.csv`` with the trailing ``_N`` suffix as the row index.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     audio_root = tmp_path / "audio"
     audio_root.mkdir()
     output_dir = tmp_path / "out"
@@ -413,8 +457,11 @@ def test_compute_metrics_writes_csv_with_expected_index_and_columns(tmp_path: Pa
 
 
 @pytest.mark.slow
-def test_main_writes_metrics_and_aggregated_csvs(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """End-to-end Click CLI run produces ``metrics.csv`` and ``aggregated_metrics.csv``."""
+def test_main_writes_metrics_and_aggregated_csvs(tmp_path: Path) -> None:
+    """End-to-end Click CLI run produces ``metrics.csv`` and ``aggregated_metrics.csv``.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     audio_root = tmp_path / "audio"
     audio_root.mkdir()
     metrics_dir = tmp_path / "metrics"

--- a/tests/evaluation/test_predict_vst_audio.py
+++ b/tests/evaluation/test_predict_vst_audio.py
@@ -38,14 +38,27 @@ _CHANNELS = 2
 _SAMPLES = 1024
 
 
-def _noise(channels: int, samples: int, *, seed: int = 0) -> np.ndarray:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Deterministic ``(channels, samples)`` float32 noise — non-silent input for librosa."""
+def _noise(channels: int, samples: int, *, seed: int = 0) -> np.ndarray:
+    """Deterministic ``(channels, samples)`` float32 noise — non-silent input for librosa.
+
+    :param channels: Number of audio channels.
+    :param samples: Number of audio samples per channel.
+    :param seed: Seed for the RNG to keep outputs deterministic.
+    :return: ``(channels, samples)`` float32 noise array.
+    """
     rng = np.random.default_rng(seed)
     return rng.standard_normal((channels, samples)).astype(np.float32)
 
 
-def _sine(channels: int, samples: int, *, freq: float, sr: float) -> np.ndarray:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Constant-amplitude sine, broadcast across all channels — non-silent and band-limited."""
+def _sine(channels: int, samples: int, *, freq: float, sr: float) -> np.ndarray:
+    """Constant-amplitude sine, broadcast across all channels — non-silent and band-limited.
+
+    :param channels: Number of audio channels.
+    :param samples: Number of audio samples per channel.
+    :param freq: Sine frequency in Hz.
+    :param sr: Sample rate in Hz.
+    :return: ``(channels, samples)`` float32 sine array.
+    """
     t = np.arange(samples, dtype=np.float32) / sr
     tone = 0.5 * np.sin(2 * np.pi * freq * t).astype(np.float32)
     return np.broadcast_to(tone, (channels, samples)).copy()
@@ -92,8 +105,11 @@ def test_make_spectrogram_pure_tone_peaks_near_expected_mel_bin() -> None:
 # ---------- write_spectrograms ----------
 
 
-def test_write_spectrograms_writes_png_to_disk(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """A non-empty PNG (PNG magic bytes) should appear at ``save_path``."""
+def test_write_spectrograms_writes_png_to_disk(tmp_path: Path) -> None:
+    """A non-empty PNG (PNG magic bytes) should appear at ``save_path``.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     out = tmp_path / "spec.png"
 
     write_spectrograms(_noise(2, 4096, seed=1), _noise(2, 4096, seed=2), _SR, str(out))
@@ -102,8 +118,11 @@ def test_write_spectrograms_writes_png_to_disk(tmp_path: Path) -> None:  # noqa:
     assert out.read_bytes()[:8] == b"\x89PNG\r\n\x1a\n"
 
 
-def test_write_spectrograms_closes_figure_to_avoid_leaks(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """Each call closes its figure — otherwise the render loop leaks one per sample."""
+def test_write_spectrograms_closes_figure_to_avoid_leaks(tmp_path: Path) -> None:
+    """Each call closes its figure — otherwise the render loop leaks one per sample.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     plt.close("all")
     write_spectrograms(
         _noise(2, 4096, seed=1), _noise(2, 4096, seed=2), _SR, str(tmp_path / "spec.png")
@@ -115,15 +134,22 @@ def test_write_spectrograms_closes_figure_to_avoid_leaks(tmp_path: Path) -> None
 # ---------- params_to_csv ----------
 
 
-def _sample_param_dicts(seed: int = 0) -> tuple[dict[str, float], dict[str, float]]:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Deterministic ``(synth_params, note_params)`` pair via ``_PARAM_SPEC.decode``."""
+def _sample_param_dicts(seed: int = 0) -> tuple[dict[str, float], dict[str, float]]:
+    """Deterministic ``(synth_params, note_params)`` pair via ``_PARAM_SPEC.decode``.
+
+    :param seed: Seed for the per-call RNG.
+    :return: ``(synth_params, note_params)`` dict pair decoded from a random encoding.
+    """
     rng = np.random.default_rng(seed)
     encoded = rng.random(len(_PARAM_SPEC)).astype(np.float32)
     return _PARAM_SPEC.decode(encoded)
 
 
-def test_params_to_csv_writes_pred_and_target_columns(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """Both dicts populated → CSV holds a row per pred key with finite values in both columns."""
+def test_params_to_csv_writes_pred_and_target_columns(tmp_path: Path) -> None:
+    """Both dicts populated → CSV holds a row per pred key with finite values in both columns.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     pred_s, pred_n = _sample_param_dicts(seed=0)
     tgt_s, tgt_n = _sample_param_dicts(seed=1)
     out = tmp_path / "params.csv"
@@ -137,8 +163,11 @@ def test_params_to_csv_writes_pred_and_target_columns(tmp_path: Path) -> None:  
     assert bool(df["target"].notna().all())
 
 
-def test_params_to_csv_none_target_leaves_target_column_nan(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """The CLI's ``--no-params`` path passes ``None`` past the source's stricter annotation."""
+def test_params_to_csv_none_target_leaves_target_column_nan(tmp_path: Path) -> None:
+    """The CLI's ``--no-params`` path passes ``None`` past the source's stricter annotation.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     pred_s, pred_n = _sample_param_dicts()
     out = tmp_path / "params.csv"
 
@@ -152,20 +181,31 @@ def test_params_to_csv_none_target_leaves_target_column_nan(tmp_path: Path) -> N
 # ---------- main (click CLI) ----------
 
 
-def _fake_render(*_args: object, **_kwargs: object) -> np.ndarray:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Stand-in for ``render_params`` — only the ``(channels, samples)`` shape contract matters."""
+def _fake_render(*_args: object, **_kwargs: object) -> np.ndarray:
+    """Stand-in for ``render_params`` — only the ``(channels, samples)`` shape contract matters.
+
+    :param \\*_args: Ignored positional arguments forwarded by callers.
+    :param \\*\\*_kwargs: Ignored keyword arguments forwarded by callers.
+    :return: ``(_CHANNELS, _SAMPLES)`` float32 audio array.
+    """
     rng = np.random.default_rng(42)
     return rng.standard_normal((_CHANNELS, _SAMPLES)).astype(np.float32)
 
 
-def _write_batch(  # noqa: DOC101,DOC103
+def _write_batch(
     pred_dir: Path,
     *,
     index: int,
     batch_size: int,
     with_target_params: bool,
 ) -> None:
-    """Write the ``.pt`` files one ``PredictionWriter`` batch would produce."""
+    """Write the ``.pt`` files one ``PredictionWriter`` batch would produce.
+
+    :param pred_dir: Destination directory for the ``.pt`` files.
+    :param index: Batch index that becomes the ``pred-<index>.pt`` suffix.
+    :param batch_size: Number of rows per batch tensor.
+    :param with_target_params: When True, also write ``target-params-<index>.pt``.
+    """
     rng = np.random.default_rng(index)
     # ``main`` rescales pred params via ``(x + 1) / 2`` — so the fixture must live on [-1, 1].
     encoded = (rng.random((batch_size, len(_PARAM_SPEC))) * 2 - 1).astype(np.float32)
@@ -179,36 +219,56 @@ def _write_batch(  # noqa: DOC101,DOC103
 
 
 @pytest.fixture()
-def runner() -> CliRunner:  # noqa: DOC201,DOC203
-    """Fresh click ``CliRunner`` per test."""
+def runner() -> CliRunner:
+    """Fresh click ``CliRunner`` per test.
+
+    :return: A fresh ``CliRunner`` instance.
+    """
     return CliRunner()
 
 
 @pytest.fixture()
-def pred_dir(tmp_path: Path) -> Path:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Empty ``preds/`` subdirectory ready for ``_write_batch`` calls."""
+def pred_dir(tmp_path: Path) -> Path:
+    """Empty ``preds/`` subdirectory ready for ``_write_batch`` calls.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    :return: Path of the created ``preds/`` directory.
+    """
     d = tmp_path / "preds"
     d.mkdir()
     return d
 
 
 @pytest.fixture()
-def out_dir(tmp_path: Path) -> Path:  # noqa: DOC101,DOC103,DOC201,DOC203
+def out_dir(tmp_path: Path) -> Path:
     """``out/`` path the CLI will create.
 
     Not pre-created — the CLI does that.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    :return: Path of the planned ``out/`` directory.
     """
     return tmp_path / "out"
 
 
 @pytest.fixture(autouse=True)
-def _patch_render_params(monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: DOC101,DOC103
-    """Replace the VST3 render call with the in-process ``_fake_render`` stub."""
+def _patch_render_params(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace the VST3 render call with the in-process ``_fake_render`` stub.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    """
     monkeypatch.setattr(predict_vst_audio, "render_params", _fake_render)
 
 
-def _invoke_main(runner: CliRunner, pred_dir: Path, out_dir: Path, *extra: str) -> Result:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Invoke ``main`` with the standard small-audio test options plus any ``extra`` flags."""
+def _invoke_main(runner: CliRunner, pred_dir: Path, out_dir: Path, *extra: str) -> Result:
+    """Invoke ``main`` with the standard small-audio test options plus any ``extra`` flags.
+
+    :param runner: Click ``CliRunner`` driving the invocation.
+    :param pred_dir: Directory passed as the first CLI positional.
+    :param out_dir: Directory passed as the second CLI positional.
+    :param \\*extra: Additional CLI flags appended verbatim.
+    :return: The ``Result`` produced by ``runner.invoke``.
+    """
     return runner.invoke(
         main,
         [
@@ -224,10 +284,15 @@ def _invoke_main(runner: CliRunner, pred_dir: Path, out_dir: Path, *extra: str) 
     )
 
 
-def test_main_no_params_writes_pred_target_csv_and_spectrogram(  # noqa: DOC101,DOC103
+def test_main_no_params_writes_pred_target_csv_and_spectrogram(
     runner: CliRunner, pred_dir: Path, out_dir: Path
 ) -> None:
-    """``--no-params`` path produces pred.wav, target.wav, spec.png, and params.csv per sample."""
+    """``--no-params`` path produces pred.wav, target.wav, spec.png, and params.csv per sample.
+
+    :param runner: Parametrized ``runner`` value under test.
+    :param pred_dir: Parametrized ``pred_dir`` value under test.
+    :param out_dir: Parametrized ``out_dir`` value under test.
+    """
     _write_batch(pred_dir, index=0, batch_size=2, with_target_params=False)
 
     result = _invoke_main(runner, pred_dir, out_dir, "--no-params")
@@ -239,10 +304,15 @@ def test_main_no_params_writes_pred_target_csv_and_spectrogram(  # noqa: DOC101,
             assert (sample_dir / name).is_file(), f"missing {name} under {sample_dir}"
 
 
-def test_main_skip_spectrogram_suppresses_png(  # noqa: DOC101,DOC103
+def test_main_skip_spectrogram_suppresses_png(
     runner: CliRunner, pred_dir: Path, out_dir: Path
 ) -> None:
-    """``--skip-spectrogram`` keeps the wav/csv outputs but skips the matplotlib render."""
+    """``--skip-spectrogram`` keeps the wav/csv outputs but skips the matplotlib render.
+
+    :param runner: Parametrized ``runner`` value under test.
+    :param pred_dir: Parametrized ``pred_dir`` value under test.
+    :param out_dir: Parametrized ``out_dir`` value under test.
+    """
     _write_batch(pred_dir, index=0, batch_size=1, with_target_params=False)
     plt.close("all")
 
@@ -258,10 +328,16 @@ def test_main_skip_spectrogram_suppresses_png(  # noqa: DOC101,DOC103
     assert plt.get_fignums() == []
 
 
-def test_main_rerender_target_renders_pred_and_target_per_sample(  # noqa: DOC101,DOC103
+def test_main_rerender_target_renders_pred_and_target_per_sample(
     runner: CliRunner, pred_dir: Path, out_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``-t`` triggers a second ``render_params`` call per sample to re-synthesise the target."""
+    """``-t`` triggers a second ``render_params`` call per sample to re-synthesise the target.
+
+    :param runner: Parametrized ``runner`` value under test.
+    :param pred_dir: Parametrized ``pred_dir`` value under test.
+    :param out_dir: Parametrized ``out_dir`` value under test.
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    """
     calls: list[object] = []
 
     def _counting_render(*args: object, **_kwargs: object) -> np.ndarray:
@@ -284,10 +360,15 @@ def test_main_rerender_target_renders_pred_and_target_per_sample(  # noqa: DOC10
         assert bool(df["target"].notna().all())
 
 
-def test_main_multiple_batches_produce_contiguous_sample_indices(  # noqa: DOC101,DOC103
+def test_main_multiple_batches_produce_contiguous_sample_indices(
     runner: CliRunner, pred_dir: Path, out_dir: Path
 ) -> None:
-    """``current_offset`` accumulates across pred files so sample dirs don't collide."""
+    """``current_offset`` accumulates across pred files so sample dirs don't collide.
+
+    :param runner: Parametrized ``runner`` value under test.
+    :param pred_dir: Parametrized ``pred_dir`` value under test.
+    :param out_dir: Parametrized ``out_dir`` value under test.
+    """
     _write_batch(pred_dir, index=0, batch_size=2, with_target_params=False)
     _write_batch(pred_dir, index=1, batch_size=3, with_target_params=False)
 

--- a/tests/pipeline/test_ci/test_spec_uri.py
+++ b/tests/pipeline/test_ci/test_spec_uri.py
@@ -10,10 +10,13 @@ from synth_setter.pipeline.ci.spec_uri import compute_spec_uri, main
 from synth_setter.pipeline.schemas.spec import DatasetSpec
 
 
-def _write_spec(  # noqa: DOC101,DOC103,DOC201,DOC203
-    tmp_path: Path, bucket: str = "intermediate-data"
-) -> Path:
-    """Materialize a minimal DatasetSpec JSON under ``tmp_path/input_spec.json``."""
+def _write_spec(tmp_path: Path, bucket: str = "intermediate-data") -> Path:
+    """Materialize a minimal DatasetSpec JSON under ``tmp_path/input_spec.json``.
+
+    :param tmp_path: Directory under which ``input_spec.json`` is written.
+    :param bucket: R2 bucket name baked into the spec.
+    :return: Path to the written ``input_spec.json``.
+    """
     spec = DatasetSpec(
         task_name="ci-task",
         output_format="hdf5",
@@ -42,16 +45,22 @@ def _write_spec(  # noqa: DOC101,DOC103,DOC201,DOC203
 class TestComputeSpecUri:
     """``compute_spec_uri`` builds the launcher's per-job R2 URI from spec + cluster."""
 
-    def test_returns_canonical_launcher_uri(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """URI matches ``r2://<bucket>/skypilot-launcher-specs/<cluster>.json`` exactly."""
+    def test_returns_canonical_launcher_uri(self, tmp_path: Path) -> None:
+        """URI matches ``r2://<bucket>/skypilot-launcher-specs/<cluster>.json`` exactly.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         spec_path = _write_spec(tmp_path)
         assert (
             compute_spec_uri(spec_path, "my-cluster-7")
             == "r2://intermediate-data/skypilot-launcher-specs/my-cluster-7.json"
         )
 
-    def test_legacy_flat_spec_still_resolves(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """Specs already in R2 with flat ``r2_bucket`` keys still parse + emit URI."""
+    def test_legacy_flat_spec_still_resolves(self, tmp_path: Path) -> None:
+        """Specs already in R2 with flat ``r2_bucket`` keys still parse + emit URI.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         legacy_text = tmp_path / "legacy.json"
         legacy_text.write_text(
             '{"task_name":"t","run_id":"t-20260328T120000000Z",'
@@ -75,33 +84,47 @@ class TestComputeSpecUri:
 class TestMainCli:
     """CLI entrypoint surface: argv handling, error paths, stdout shape."""
 
-    def test_prints_uri_to_stdout(  # noqa: DOC101,DOC103
+    def test_prints_uri_to_stdout(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """Happy path: argv resolves spec + cluster → exactly one URI line on stdout."""
+        """Happy path: argv resolves spec + cluster → exactly one URI line on stdout.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        :param capsys: Pytest fixture capturing stdout/stderr.
+        """
         spec_path = _write_spec(tmp_path)
         monkeypatch.setattr("sys.argv", ["synth-setter-spec-uri", str(spec_path), "cluster-z"])
         main()
         out = capsys.readouterr().out.strip()
         assert out == "r2://intermediate-data/skypilot-launcher-specs/cluster-z.json"
 
-    def test_missing_args_exits_one(  # noqa: DOC101,DOC103
+    def test_missing_args_exits_one(
         self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """Wrong-arity invocation surfaces a one-line usage error + exit 1."""
+        """Wrong-arity invocation surfaces a one-line usage error + exit 1.
+
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        :param capsys: Pytest fixture capturing stdout/stderr.
+        """
         monkeypatch.setattr("sys.argv", ["synth-setter-spec-uri"])
         with pytest.raises(SystemExit) as exc:
             main()
         assert exc.value.code == 1
         assert "Usage:" in capsys.readouterr().err
 
-    def test_missing_spec_file_exits_two(  # noqa: DOC101,DOC103
+    def test_missing_spec_file_exits_two(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """A non-existent spec path exits 2 with a path-named error."""
+        """A non-existent spec path exits 2 with a path-named error.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        :param capsys: Pytest fixture capturing stdout/stderr.
+        """
         missing = tmp_path / "missing.json"
         monkeypatch.setattr("sys.argv", ["synth-setter-spec-uri", str(missing), "cluster-a"])
         with pytest.raises(SystemExit) as exc:
@@ -109,13 +132,18 @@ class TestMainCli:
         assert exc.value.code == 2
         assert str(missing) in capsys.readouterr().err
 
-    def test_invalid_json_exits_three_without_traceback(  # noqa: DOC101,DOC103
+    def test_invalid_json_exits_three_without_traceback(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """Malformed JSON surfaces as exit 3 + one-line stderr (no traceback)."""
+        """Malformed JSON surfaces as exit 3 + one-line stderr (no traceback).
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        :param capsys: Pytest fixture capturing stdout/stderr.
+        """
         bad = tmp_path / "broken.json"
         bad.write_text("{not-json")
         monkeypatch.setattr("sys.argv", ["synth-setter-spec-uri", str(bad), "cluster-b"])
@@ -126,13 +154,18 @@ class TestMainCli:
         assert str(bad) in err
         assert "Traceback" not in err
 
-    def test_schema_violation_exits_three_without_traceback(  # noqa: DOC101,DOC103
+    def test_schema_violation_exits_three_without_traceback(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
         capsys: pytest.CaptureFixture[str],
     ) -> None:
-        """JSON that parses but fails DatasetSpec validation also exits 3."""
+        """JSON that parses but fails DatasetSpec validation also exits 3.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        :param capsys: Pytest fixture capturing stdout/stderr.
+        """
         bad = tmp_path / "invalid.json"
         bad.write_text('{"task_name": "t"}')
         monkeypatch.setattr("sys.argv", ["synth-setter-spec-uri", str(bad), "cluster-c"])

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -800,7 +800,7 @@ class TestSpecFromCfg:
 
         assert spec.task_name == valid_dataset_spec_kwargs["task_name"]
 
-    def test_r2_group_flows_into_nested_r2_field(  # noqa: DOC101,DOC103
+    def test_r2_group_flows_into_nested_r2_field(
         self, valid_dataset_spec_kwargs: dict[str, object]
     ) -> None:
         """The ``r2`` group composes directly into ``DatasetSpec.r2`` (no flat-key indirection).
@@ -809,6 +809,8 @@ class TestSpecFromCfg:
         ``configs/dataset.yaml`` no longer interpolates flat ``r2_bucket`` /
         ``r2_prefix_root`` keys — the group's content lands at ``cfg.r2`` and
         passes through to ``DatasetSpec.r2``.
+
+        :param valid_dataset_spec_kwargs: Baseline spec kwargs from conftest.
         """
         from omegaconf import OmegaConf
 
@@ -837,32 +839,41 @@ class TestBuildWorkerCmd:
     """The worker cmd reconstructs the operator's Hydra invocation under bash."""
 
     @pytest.fixture()
-    def spec(self, tmp_path: Path) -> DatasetSpec:  # noqa: DOC101,DOC103,DOC201,DOC203
-        """Reusable DatasetSpec for worker-cmd construction (no I/O — pure kwargs)."""
+    def spec(self, tmp_path: Path) -> DatasetSpec:
+        """Reusable DatasetSpec for worker-cmd construction (no I/O — pure kwargs).
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :return: A ``DatasetSpec`` built from base kwargs.
+        """
         return DatasetSpec(**_base_spec_kwargs(tmp_path))  # type: ignore[arg-type]
 
-    def test_cmd_uses_from_hydra_console_script(self, spec: DatasetSpec) -> None:  # noqa: DOC101,DOC103
-        """The worker reproduces the composition by re-entering the from_hydra entry point."""
+    def test_cmd_uses_from_hydra_console_script(self, spec: DatasetSpec) -> None:
+        """The worker reproduces the composition by re-entering the from_hydra entry point.
+
+        :param spec: Fixture-provided ``DatasetSpec``.
+        """
         from synth_setter.cli.generate_dataset import _build_worker_cmd
 
         cmd = _build_worker_cmd(["experiment=foo"], spec)
         assert "synth-setter-generate-dataset-from-hydra" in cmd
         assert "experiment=foo" in cmd
 
-    def test_cmd_cds_to_worker_repo_root_not_launcher_repo(  # noqa: DOC101,DOC103
-        self, spec: DatasetSpec
-    ) -> None:
-        """Cd target is the worker checkout, not the launcher's path."""
+    def test_cmd_cds_to_worker_repo_root_not_launcher_repo(self, spec: DatasetSpec) -> None:
+        """Cd target is the worker checkout, not the launcher's path.
+
+        :param spec: Fixture-provided ``DatasetSpec``.
+        """
         from synth_setter.cli.generate_dataset import _WORKER_REPO_ROOT, _build_worker_cmd
 
         cmd = _build_worker_cmd([], spec)
         assert cmd.startswith(f"cd {_WORKER_REPO_ROOT}")
         assert _WORKER_REPO_ROOT == "/home/build/synth-setter"
 
-    def test_cmd_runs_sync_worker_checkout_before_exec(  # noqa: DOC101,DOC103
-        self, spec: DatasetSpec
-    ) -> None:
-        """sync_worker_checkout.sh bypasses dev-snapshot bake-lag when WORKER_GIT_REF is set."""
+    def test_cmd_runs_sync_worker_checkout_before_exec(self, spec: DatasetSpec) -> None:
+        """sync_worker_checkout.sh bypasses dev-snapshot bake-lag when WORKER_GIT_REF is set.
+
+        :param spec: Fixture-provided ``DatasetSpec``.
+        """
         from synth_setter.cli.generate_dataset import _build_worker_cmd
 
         cmd = _build_worker_cmd([], spec)
@@ -872,10 +883,11 @@ class TestBuildWorkerCmd:
         assert exec_idx != -1, f"exec step missing from cmd: {cmd!r}"
         assert sync_idx < exec_idx, "sync_worker_checkout must run before exec"
 
-    def test_cmd_pins_spec_created_at_via_hydra_override(  # noqa: DOC101,DOC103
-        self, spec: DatasetSpec
-    ) -> None:
-        """Worker compose must inherit launcher's created_at to land on the same r2.prefix."""
+    def test_cmd_pins_spec_created_at_via_hydra_override(self, spec: DatasetSpec) -> None:
+        """Worker compose must inherit launcher's created_at to land on the same r2.prefix.
+
+        :param spec: Fixture-provided ``DatasetSpec``.
+        """
         from synth_setter.cli.generate_dataset import _build_worker_cmd
 
         cmd = _build_worker_cmd([], spec)
@@ -883,10 +895,11 @@ class TestBuildWorkerCmd:
         # (no surrounding quotes added by shlex when the value has no shell metachars).
         assert f"+created_at={spec.created_at.isoformat()}" in cmd
 
-    def test_cmd_shell_quotes_overrides_with_spaces(  # noqa: DOC101,DOC103
-        self, spec: DatasetSpec
-    ) -> None:
-        """Spaces and special chars in an override survive bash interpretation in run:."""
+    def test_cmd_shell_quotes_overrides_with_spaces(self, spec: DatasetSpec) -> None:
+        """Spaces and special chars in an override survive bash interpretation in run:.
+
+        :param spec: Fixture-provided ``DatasetSpec``.
+        """
         from synth_setter.cli.generate_dataset import _build_worker_cmd
 
         cmd = _build_worker_cmd(["task_name=value with space"], spec)
@@ -894,10 +907,11 @@ class TestBuildWorkerCmd:
         # would be split into two argv items by bash.
         assert "'task_name=value with space'" in cmd
 
-    def test_cmd_handles_empty_operator_overrides(  # noqa: DOC101,DOC103
-        self, spec: DatasetSpec
-    ) -> None:
-        """No operator overrides → cmd is just cd + sync + exec + pinned-runtime override."""
+    def test_cmd_handles_empty_operator_overrides(self, spec: DatasetSpec) -> None:
+        """No operator overrides → cmd is just cd + sync + exec + pinned-runtime override.
+
+        :param spec: Fixture-provided ``DatasetSpec``.
+        """
         from synth_setter.cli.generate_dataset import _build_worker_cmd
 
         cmd = _build_worker_cmd([], spec)
@@ -916,16 +930,22 @@ class TestMainDispatchBranches:
     """``main()`` composes the dataset cfg from argv, then dispatches local or via SkyPilot."""
 
     @pytest.fixture(autouse=True)
-    def _set_default_skypilot_env(self, monkeypatch: pytest.MonkeyPatch) -> None:  # noqa: DOC101,DOC103
-        """Set single-worker rank/world env so the local branch's run() succeeds."""
+    def _set_default_skypilot_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Set single-worker rank/world env so the local branch's run() succeeds.
+
+        :param monkeypatch: Pytest fixture used to set env vars.
+        """
         monkeypatch.setenv("SYNTH_SETTER_WORKER_RANK", "0")
         monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "1")
 
-    def test_compute_template_null_calls_run_locally(  # noqa: DOC101,DOC103
+    def test_compute_template_null_calls_run_locally(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """compute_template=null routes to run(spec) with a DatasetSpec; dispatch stays unused."""
+        """compute_template=null routes to run(spec) with a DatasetSpec; dispatch stays unused.
+
+        :param monkeypatch: Pytest fixture used to patch argv and module functions.
+        """
         import synth_setter.cli.generate_dataset as gd
         import synth_setter.pipeline.skypilot_launch as sl
 
@@ -955,12 +975,16 @@ class TestMainDispatchBranches:
         assert isinstance(spec, DatasetSpec)
         assert spec.render.plugin_path == str(TEST_PLUGIN_VST3)
 
-    def test_compute_template_set_calls_dispatch_via_skypilot(  # noqa: DOC101,DOC103
+    def test_compute_template_set_calls_dispatch_via_skypilot(
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        """compute_template=<path> routes through dispatch_via_skypilot with cmd populated."""
+        """compute_template=<path> routes through dispatch_via_skypilot with cmd populated.
+
+        :param monkeypatch: Pytest fixture used to patch argv and module functions.
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         import synth_setter.cli.generate_dataset as gd
         import synth_setter.pipeline.skypilot_launch as sl
 
@@ -1002,7 +1026,7 @@ class TestMainDispatchBranches:
                 f"override {override!r} missing from worker cmd: {sky_cfg.cmd!r}"  # type: ignore[attr-defined]
             )
 
-    def test_operator_supplied_cmd_is_rejected(  # noqa: DOC101,DOC103
+    def test_operator_supplied_cmd_is_rejected(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
@@ -1011,6 +1035,8 @@ class TestMainDispatchBranches:
         Uses Hydra's `+key=value` add-syntax because the key isn't in
         configs/skypilot_launch/default.yaml (struct-mode would otherwise reject it before our
         guard runs).
+
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
         """
         import synth_setter.cli.generate_dataset as gd
         import synth_setter.pipeline.skypilot_launch as sl

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -2598,7 +2598,7 @@ class TestLaunchOneRank:
 # ---------------------------------------------------------------------------
 
 
-def _write_runpod_yaml(  # noqa: DOC101,DOC103,DOC201,DOC203
+def _write_runpod_yaml(
     tmp_path: Path,
     *,
     include_run: bool = False,
@@ -2609,6 +2609,11 @@ def _write_runpod_yaml(  # noqa: DOC101,DOC103,DOC201,DOC203
     ``include_run=True`` adds a default ``run:`` block (``echo existing``).
     ``run_body`` overrides the run body — pass a multiline string with
     ``${WORKER_CMD}`` to exercise the sentinel-substitution path.
+
+    :param tmp_path: Directory under which ``compute.yaml`` is written.
+    :param include_run: When ``True``, add a default ``run:`` block.
+    :param run_body: Override the run body verbatim (multiline allowed).
+    :return: Path to the written ``compute.yaml``.
     """
     yaml_text = (
         "resources:\n"
@@ -2626,8 +2631,12 @@ def _write_runpod_yaml(  # noqa: DOC101,DOC103,DOC201,DOC203
     return path
 
 
-def _build_spec(fake_plugin: Path) -> DatasetSpec:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Build a DatasetSpec wired to ``fake_plugin`` for the dispatch tests."""
+def _build_spec(fake_plugin: Path) -> DatasetSpec:
+    """Build a DatasetSpec wired to ``fake_plugin`` for the dispatch tests.
+
+    :param fake_plugin: Path passed through as ``render.plugin_path``.
+    :return: A ``DatasetSpec`` ready for dispatch-path tests.
+    """
     return DatasetSpec(
         task_name="test-dispatch",
         train_val_test_sizes=(10000, 0, 0),
@@ -2653,24 +2662,33 @@ def _build_spec(fake_plugin: Path) -> DatasetSpec:  # noqa: DOC101,DOC103,DOC201
 class TestLoadComputeTemplateWithCmd:
     """``_load_compute_template_with_cmd`` injects cmd as run and rejects pre-existing runs."""
 
-    def test_cmd_is_injected_when_yaml_has_no_run(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """Without a pre-existing run: block, the loaded doc's run: equals cmd."""
+    def test_cmd_is_injected_when_yaml_has_no_run(self, tmp_path: Path) -> None:
+        """Without a pre-existing run: block, the loaded doc's run: equals cmd.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         from synth_setter.pipeline.skypilot_launch import _load_compute_template_with_cmd
 
         template = _write_runpod_yaml(tmp_path, include_run=False)
         doc = _load_compute_template_with_cmd(template, "echo hello")
         assert doc["run"] == "echo hello"
 
-    def test_existing_run_block_without_sentinel_raises(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """A pre-existing run: with no sentinel + non-empty cmd is a conflict, not a silent override."""
+    def test_existing_run_block_without_sentinel_raises(self, tmp_path: Path) -> None:
+        """A pre-existing run: with no sentinel + non-empty cmd is a conflict, not a silent override.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         from synth_setter.pipeline.skypilot_launch import _load_compute_template_with_cmd
 
         template = _write_runpod_yaml(tmp_path, include_run=True)
         with pytest.raises(ValueError, match="has a non-empty `run:` block"):
             _load_compute_template_with_cmd(template, "echo hello")
 
-    def test_sentinel_in_run_block_substitutes_cmd(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """A template with ${WORKER_CMD} in run: substitutes cmd; scaffolding survives."""
+    def test_sentinel_in_run_block_substitutes_cmd(self, tmp_path: Path) -> None:
+        """A template with ${WORKER_CMD} in run: substitutes cmd; scaffolding survives.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         from synth_setter.pipeline.skypilot_launch import _load_compute_template_with_cmd
 
         template = _write_runpod_yaml(
@@ -2685,8 +2703,11 @@ class TestLoadComputeTemplateWithCmd:
         assert doc["run"].startswith("sudo docker run --rm")
         assert doc["run"].rstrip().endswith('"echo hello && exec foo"')
 
-    def test_non_string_run_block_raises(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """A non-string run: (e.g. a list) is a malformed template, raise before substitute."""
+    def test_non_string_run_block_raises(self, tmp_path: Path) -> None:
+        """A non-string run: (e.g. a list) is a malformed template, raise before substitute.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         from synth_setter.pipeline.skypilot_launch import _load_compute_template_with_cmd
 
         path = tmp_path / "bad_run.yaml"
@@ -2694,15 +2715,21 @@ class TestLoadComputeTemplateWithCmd:
         with pytest.raises(ValueError, match="`run:` must be a string"):
             _load_compute_template_with_cmd(path, "x")
 
-    def test_missing_template_raises_file_not_found(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """Mistyped path surfaces a FileNotFoundError, not a confusing parse error downstream."""
+    def test_missing_template_raises_file_not_found(self, tmp_path: Path) -> None:
+        """Mistyped path surfaces a FileNotFoundError, not a confusing parse error downstream.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         from synth_setter.pipeline.skypilot_launch import _load_compute_template_with_cmd
 
         with pytest.raises(FileNotFoundError):
             _load_compute_template_with_cmd(tmp_path / "missing.yaml", "x")
 
-    def test_non_mapping_top_level_raises(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """A YAML whose top level is a list, not a mapping, is rejected at load time."""
+    def test_non_mapping_top_level_raises(self, tmp_path: Path) -> None:
+        """A YAML whose top level is a list, not a mapping, is rejected at load time.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         from synth_setter.pipeline.skypilot_launch import _load_compute_template_with_cmd
 
         path = tmp_path / "bad.yaml"
@@ -2725,19 +2752,27 @@ class TestDetectProviderFromDoc:
         ],
         ids=["flat-runpod", "any-of-oci", "kubernetes-as-local", "k8s-alias", "case-insensitive"],
     )
-    def test_supported_clouds_map_to_provider(  # noqa: DOC101,DOC103
+    def test_supported_clouds_map_to_provider(
         self,
         tmp_path: Path,
         doc: dict[str, object],
         expected_provider: str,
     ) -> None:
-        """Each supported `resources.cloud` shape maps to the expected cred-bootstrap provider."""
+        """Each supported `resources.cloud` shape maps to the expected cred-bootstrap provider.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param doc: Parametrized parsed-YAML mapping under test.
+        :param expected_provider: Parametrized expected provider name.
+        """
         from synth_setter.pipeline.skypilot_launch import _detect_provider_from_doc
 
         assert _detect_provider_from_doc(doc, source=tmp_path / "x.yaml") == expected_provider
 
-    def test_unknown_cloud_raises(self, tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-        """An unsupported cloud surfaces as a ValueError naming the offending value."""
+    def test_unknown_cloud_raises(self, tmp_path: Path) -> None:
+        """An unsupported cloud surfaces as a ValueError naming the offending value.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
         from synth_setter.pipeline.skypilot_launch import _detect_provider_from_doc
 
         doc: dict[str, object] = {"resources": {"cloud": "aws"}}
@@ -2748,8 +2783,11 @@ class TestDetectProviderFromDoc:
 class TestDispatchViaSkypilot:
     """``dispatch_via_skypilot`` rejects degenerate cfgs and threads per-rank fanout through."""
 
-    def test_missing_compute_template_raises(self, fake_plugin: Path) -> None:  # noqa: DOC101,DOC103
-        """``compute_template=None`` is the "don't dispatch" sentinel — calling here is a bug."""
+    def test_missing_compute_template_raises(self, fake_plugin: Path) -> None:
+        """``compute_template=None`` is the "don't dispatch" sentinel — calling here is a bug.
+
+        :param fake_plugin: Fixture-provided fake VST3 plugin path.
+        """
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
         from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 
@@ -2758,8 +2796,12 @@ class TestDispatchViaSkypilot:
         with pytest.raises(ValueError, match="compute_template"):
             dispatch_via_skypilot(spec, sky_cfg)
 
-    def test_missing_cmd_raises(self, tmp_path: Path, fake_plugin: Path) -> None:  # noqa: DOC101,DOC103
-        """No cmd → no run block on the worker → we refuse to launch a no-op task."""
+    def test_missing_cmd_raises(self, tmp_path: Path, fake_plugin: Path) -> None:
+        """No cmd → no run block on the worker → we refuse to launch a no-op task.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param fake_plugin: Fixture-provided fake VST3 plugin path.
+        """
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
         from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 
@@ -2769,13 +2811,18 @@ class TestDispatchViaSkypilot:
         with pytest.raises(ValueError, match="cmd"):
             dispatch_via_skypilot(spec, sky_cfg)
 
-    def test_yaml_run_block_conflicts_with_cmd(  # noqa: DOC101,DOC103
+    def test_yaml_run_block_conflicts_with_cmd(
         self,
         tmp_path: Path,
         fake_plugin: Path,
         mock_sky: MagicMock,
     ) -> None:
-        """End-to-end conflict guard: YAML run + sky_cfg.cmd raises before any SkyPilot side effect."""
+        """End-to-end conflict guard: YAML run + sky_cfg.cmd raises before any SkyPilot side effect.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param fake_plugin: Fixture-provided fake VST3 plugin path.
+        :param mock_sky: Mocked ``sky`` module from fixture.
+        """
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
         from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 
@@ -2786,7 +2833,7 @@ class TestDispatchViaSkypilot:
             dispatch_via_skypilot(spec, sky_cfg)
         mock_sky.jobs.launch.assert_not_called()
 
-    def test_missing_worker_env_raises(  # noqa: DOC101,DOC103
+    def test_missing_worker_env_raises(
         self,
         tmp_path: Path,
         fake_plugin: Path,
@@ -2798,6 +2845,11 @@ class TestDispatchViaSkypilot:
         The autouse ``clear_worker_env_from_process`` fixture already strips these keys,
         but re-asserting via ``monkeypatch.delenv`` keeps the contract explicit if that
         fixture ever changes.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param fake_plugin: Fixture-provided fake VST3 plugin path.
+        :param local_spec_dir: Fixture-provided local spec directory.
+        :param monkeypatch: Pytest fixture used to clear env keys.
         """
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
         from synth_setter.pipeline.skypilot_launch import (
@@ -2818,7 +2870,7 @@ class TestDispatchViaSkypilot:
         with pytest.raises(ValueError, match="No worker env vars resolved"):
             dispatch_via_skypilot(spec, sky_cfg)
 
-    def test_end_to_end_dispatch_uses_cmd_as_run_block(  # noqa: DOC101,DOC103
+    def test_end_to_end_dispatch_uses_cmd_as_run_block(
         self,
         tmp_path: Path,
         fake_plugin: Path,
@@ -2827,7 +2879,15 @@ class TestDispatchViaSkypilot:
         mock_sky: MagicMock,
         patch_materialize_io: None,  # noqa: ARG002
     ) -> None:
-        """Happy-path dispatch: sky.Task.from_yaml_config receives a doc whose ``run`` is sky_cfg.cmd."""
+        """Happy-path dispatch: sky.Task.from_yaml_config receives a doc whose ``run`` is sky_cfg.cmd.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param fake_plugin: Fixture-provided fake VST3 plugin path.
+        :param env_file: Fixture-provided worker env file path.
+        :param local_spec_dir: Fixture-provided local spec directory.
+        :param mock_sky: Mocked ``sky`` module from fixture.
+        :param patch_materialize_io: Fixture stubbing materialize-side IO.
+        """
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
         from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 
@@ -2848,7 +2908,7 @@ class TestDispatchViaSkypilot:
         passed_doc = mock_sky.Task.from_yaml_config.call_args.args[0]
         assert passed_doc["run"] == cmd
 
-    def test_dispatch_failure_raises_runtime_error(  # noqa: DOC101,DOC103
+    def test_dispatch_failure_raises_runtime_error(
         self,
         tmp_path: Path,
         fake_plugin: Path,
@@ -2857,7 +2917,15 @@ class TestDispatchViaSkypilot:
         mock_sky: MagicMock,
         patch_materialize_io: None,  # noqa: ARG002
     ) -> None:
-        """A non-success tail rc surfaces as a RuntimeError naming the failed rank."""
+        """A non-success tail rc surfaces as a RuntimeError naming the failed rank.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param fake_plugin: Fixture-provided fake VST3 plugin path.
+        :param env_file: Fixture-provided worker env file path.
+        :param local_spec_dir: Fixture-provided local spec directory.
+        :param mock_sky: Mocked ``sky`` module from fixture.
+        :param patch_materialize_io: Fixture stubbing materialize-side IO.
+        """
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
         from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 
@@ -2876,7 +2944,7 @@ class TestDispatchViaSkypilot:
         with pytest.raises(RuntimeError, match="worker.* failed"):
             dispatch_via_skypilot(spec, sky_cfg)
 
-    def test_multi_worker_fans_out_one_task_per_rank(  # noqa: DOC101,DOC103
+    def test_multi_worker_fans_out_one_task_per_rank(
         self,
         tmp_path: Path,
         fake_plugin: Path,
@@ -2885,7 +2953,15 @@ class TestDispatchViaSkypilot:
         mock_sky: MagicMock,
         patch_materialize_io: None,  # noqa: ARG002
     ) -> None:
-        """`num_workers=N` builds N tasks with -rN job-name suffixes, per the fan-out contract."""
+        """`num_workers=N` builds N tasks with -rN job-name suffixes, per the fan-out contract.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param fake_plugin: Fixture-provided fake VST3 plugin path.
+        :param env_file: Fixture-provided worker env file path.
+        :param local_spec_dir: Fixture-provided local spec directory.
+        :param mock_sky: Mocked ``sky`` module from fixture.
+        :param patch_materialize_io: Fixture stubbing materialize-side IO.
+        """
         from synth_setter.pipeline.partitioning import NUM_WORKERS_ENV_VAR, WORKER_RANK_ENV_VAR
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
         from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
@@ -2926,7 +3002,7 @@ class TestDispatchViaSkypilot:
         ],
         ids=["job-name-with-slash", "image-tag-with-space"],
     )
-    def test_input_validation_raises_before_disk_or_network(  # noqa: DOC101,DOC103
+    def test_input_validation_raises_before_disk_or_network(
         self,
         tmp_path: Path,
         fake_plugin: Path,
@@ -2938,7 +3014,18 @@ class TestDispatchViaSkypilot:
         value: str,
         match: str,
     ) -> None:
-        """Malformed launcher params surface as ValueError before any SkyPilot submission."""
+        """Malformed launcher params surface as ValueError before any SkyPilot submission.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param fake_plugin: Fixture-provided fake VST3 plugin path.
+        :param env_file: Fixture-provided worker env file path.
+        :param local_spec_dir: Fixture-provided local spec directory.
+        :param mock_sky: Mocked ``sky`` module from fixture.
+        :param patch_materialize_io: Fixture stubbing materialize-side IO.
+        :param field: Parametrized launcher-config field under test.
+        :param value: Parametrized malformed value for ``field``.
+        :param match: Parametrized regex expected in the ValidationError.
+        """
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
         from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 
@@ -2957,7 +3044,7 @@ class TestDispatchViaSkypilot:
             dispatch_via_skypilot(spec, sky_cfg)
         mock_sky.jobs.launch.assert_not_called()
 
-    def test_job_name_falls_back_to_task_name_prefix_when_unset(  # noqa: DOC101,DOC103
+    def test_job_name_falls_back_to_task_name_prefix_when_unset(
         self,
         tmp_path: Path,
         fake_plugin: Path,
@@ -2966,7 +3053,15 @@ class TestDispatchViaSkypilot:
         mock_sky: MagicMock,
         patch_materialize_io: None,  # noqa: ARG002
     ) -> None:
-        """job_name=None derives the synth-setter-smoke-<task_name[:8]> fallback."""
+        """job_name=None derives the synth-setter-smoke-<task_name[:8]> fallback.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param fake_plugin: Fixture-provided fake VST3 plugin path.
+        :param env_file: Fixture-provided worker env file path.
+        :param local_spec_dir: Fixture-provided local spec directory.
+        :param mock_sky: Mocked ``sky`` module from fixture.
+        :param patch_materialize_io: Fixture stubbing materialize-side IO.
+        """
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
         from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 
@@ -2986,7 +3081,7 @@ class TestDispatchViaSkypilot:
         # spec.task_name=="test-dispatch" → first 8 chars round-trip into the suffix.
         assert submitted.endswith(spec.task_name[:8])
 
-    def test_api_server_and_local_are_mutually_exclusive(  # noqa: DOC101,DOC103
+    def test_api_server_and_local_are_mutually_exclusive(
         self,
         tmp_path: Path,
         fake_plugin: Path,
@@ -2995,7 +3090,15 @@ class TestDispatchViaSkypilot:
         mock_sky: MagicMock,
         patch_materialize_io: None,  # noqa: ARG002
     ) -> None:
-        """Setting both api_server and local raises before any launch — opposite dispatch modes."""
+        """Setting both api_server and local raises before any launch — opposite dispatch modes.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param fake_plugin: Fixture-provided fake VST3 plugin path.
+        :param env_file: Fixture-provided worker env file path.
+        :param local_spec_dir: Fixture-provided local spec directory.
+        :param mock_sky: Mocked ``sky`` module from fixture.
+        :param patch_materialize_io: Fixture stubbing materialize-side IO.
+        """
         from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
         from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -124,10 +124,11 @@ class TestRenderConfig:
             cfg = RenderConfig(**{**_valid_render_kwargs(), "velocity": valid})
             assert cfg.velocity == valid
 
-    def test_cadence_defaults_off_darwin(  # noqa: DOC101,DOC103
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Off Darwin: both cadences default to "render" (historical per-render behaviour)."""
+    def test_cadence_defaults_off_darwin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Off Darwin: both cadences default to "render" (historical per-render behaviour).
+
+        :param monkeypatch: Pytest fixture used to stub ``_current_platform``.
+        """
         monkeypatch.setattr(
             "synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux"
         )
@@ -135,10 +136,11 @@ class TestRenderConfig:
         assert cfg.plugin_reload_cadence == "render"
         assert cfg.gui_toggle_cadence == "render"
 
-    def test_gui_toggle_default_is_never_on_darwin(  # noqa: DOC101,DOC103
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Default factory yields "never" on Darwin so bare RenderConfig() constructs (#714)."""
+    def test_gui_toggle_default_is_never_on_darwin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default factory yields "never" on Darwin so bare RenderConfig() constructs (#714).
+
+        :param monkeypatch: Pytest fixture used to stub ``_current_platform``.
+        """
         monkeypatch.setattr(
             "synth_setter.pipeline.schemas.spec._current_platform", lambda: "darwin"
         )
@@ -158,10 +160,11 @@ class TestRenderConfig:
         assert cfg.plugin_reload_cadence == "once"
         assert cfg.gui_toggle_cadence == "never"
 
-    def test_gui_toggle_render_rejected_on_darwin(  # noqa: DOC101,DOC103
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """``gui_toggle_cadence="render"`` on Darwin raises (SIGTRAP after ~3-4 calls — #714)."""
+    def test_gui_toggle_render_rejected_on_darwin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``gui_toggle_cadence="render"`` on Darwin raises (SIGTRAP after ~3-4 calls — #714).
+
+        :param monkeypatch: Pytest fixture used to stub ``_current_platform``.
+        """
         monkeypatch.setattr(
             "synth_setter.pipeline.schemas.spec._current_platform", lambda: "darwin"
         )
@@ -172,10 +175,14 @@ class TestRenderConfig:
             RenderConfig(**{**_valid_render_kwargs(), "gui_toggle_cadence": "render"})
 
     @pytest.mark.parametrize("cadence", ["never", "once"])
-    def test_gui_toggle_never_and_once_accepted_on_darwin(  # noqa: DOC101,DOC103
+    def test_gui_toggle_never_and_once_accepted_on_darwin(
         self, monkeypatch: pytest.MonkeyPatch, cadence: str
     ) -> None:
-        """``"never"`` and ``"once"`` are the only valid gui_toggle settings on Darwin."""
+        """``"never"`` and ``"once"`` are the only valid gui_toggle settings on Darwin.
+
+        :param monkeypatch: Pytest fixture used to stub ``_current_platform``.
+        :param cadence: Parametrized ``gui_toggle_cadence`` value under test.
+        """
         monkeypatch.setattr(
             "synth_setter.pipeline.schemas.spec._current_platform", lambda: "darwin"
         )
@@ -183,10 +190,14 @@ class TestRenderConfig:
         assert cfg.gui_toggle_cadence == cadence
 
     @pytest.mark.parametrize("cadence", ["never", "once", "render"])
-    def test_gui_toggle_all_values_accepted_off_darwin(  # noqa: DOC101,DOC103
+    def test_gui_toggle_all_values_accepted_off_darwin(
         self, monkeypatch: pytest.MonkeyPatch, cadence: str
     ) -> None:
-        """All three gui_toggle values are accepted on Linux/Windows — gate is darwin-only."""
+        """All three gui_toggle values are accepted on Linux/Windows — gate is darwin-only.
+
+        :param monkeypatch: Pytest fixture used to stub ``_current_platform``.
+        :param cadence: Parametrized ``gui_toggle_cadence`` value under test.
+        """
         monkeypatch.setattr(
             "synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux"
         )
@@ -194,10 +205,14 @@ class TestRenderConfig:
         assert cfg.gui_toggle_cadence == cadence
 
     @pytest.mark.parametrize("cadence", ["once", "render"])
-    def test_plugin_reload_cadence_both_values_accepted_on_darwin(  # noqa: DOC101,DOC103
+    def test_plugin_reload_cadence_both_values_accepted_on_darwin(
         self, monkeypatch: pytest.MonkeyPatch, cadence: str
     ) -> None:
-        """``plugin_reload_cadence`` accepts both "once" and "render" on Darwin."""
+        """``plugin_reload_cadence`` accepts both "once" and "render" on Darwin.
+
+        :param monkeypatch: Pytest fixture used to stub ``_current_platform``.
+        :param cadence: Parametrized ``plugin_reload_cadence`` value under test.
+        """
         monkeypatch.setattr(
             "synth_setter.pipeline.schemas.spec._current_platform", lambda: "darwin"
         )
@@ -702,8 +717,12 @@ class TestSpecConstructionStaysPedalboardFree:
 class TestLegacyFlatR2Compat:
     """Legacy flat ``r2_*`` keys on input must promote into the nested ``r2`` model."""
 
-    def _legacy_kwargs(self, **overrides: Any) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
-        """Return spec kwargs that mirror a pre-migration input dict (flat r2_* keys)."""
+    def _legacy_kwargs(self, **overrides: Any) -> dict[str, Any]:
+        """Return spec kwargs that mirror a pre-migration input dict (flat r2_* keys).
+
+        :param \\*\\*overrides: Per-call key overrides merged into the legacy kwargs.
+        :return: Spec-kwargs dict with flat ``r2_*`` keys.
+        """
         kwargs: dict[str, Any] = {
             "task_name": "ci-smoke-test",
             "output_format": "hdf5",
@@ -715,17 +734,23 @@ class TestLegacyFlatR2Compat:
         kwargs.update(overrides)
         return kwargs
 
-    def test_legacy_r2_bucket_only_promotes_and_derives_prefix(  # noqa: DOC101,DOC103
+    def test_legacy_r2_bucket_only_promotes_and_derives_prefix(
         self, patch_runtime_io: None
     ) -> None:
-        """Pre-migration spec with only ``r2_bucket`` → derived prefix lands on ``r2.prefix``."""
+        """Pre-migration spec with only ``r2_bucket`` → derived prefix lands on ``r2.prefix``.
+
+        :param patch_runtime_io: Fixture stubbing git/time/runtime IO.
+        """
         spec = DatasetSpec(**self._legacy_kwargs())
         assert spec.r2.bucket == "intermediate-data"
         assert spec.r2.prefix_root == "data"
         assert spec.r2.prefix == "data/ci-smoke-test/ci-smoke-test-20260328T120000000Z/"
 
-    def test_all_three_legacy_keys_promote_into_nested_r2(self, patch_runtime_io: None) -> None:  # noqa: DOC101,DOC103
-        """Full legacy triple promotes into ``r2`` and preserves explicit ``r2_prefix``."""
+    def test_all_three_legacy_keys_promote_into_nested_r2(self, patch_runtime_io: None) -> None:
+        """Full legacy triple promotes into ``r2`` and preserves explicit ``r2_prefix``.
+
+        :param patch_runtime_io: Fixture stubbing git/time/runtime IO.
+        """
         spec = DatasetSpec(
             **self._legacy_kwargs(
                 r2_prefix_root="experiments",
@@ -736,19 +761,24 @@ class TestLegacyFlatR2Compat:
         assert spec.r2.prefix_root == "experiments"
         assert spec.r2.prefix == "experiments/legacy/custom/"
 
-    def test_mixed_nested_and_legacy_input_raises(self, patch_runtime_io: None) -> None:  # noqa: DOC101,DOC103
-        """Mixing ``r2`` and any legacy key is ambiguous — must fail-fast."""
+    def test_mixed_nested_and_legacy_input_raises(self, patch_runtime_io: None) -> None:
+        """Mixing ``r2`` and any legacy key is ambiguous — must fail-fast.
+
+        :param patch_runtime_io: Fixture stubbing git/time/runtime IO.
+        """
         with pytest.raises(ValidationError, match="both nested 'r2' and legacy flat keys"):
             DatasetSpec(
                 **self._legacy_kwargs(r2={"bucket": "intermediate-data"}),
             )
 
-    def test_legacy_json_specs_round_trip_in_new_form(self, patch_runtime_io: None) -> None:  # noqa: DOC101,DOC103
+    def test_legacy_json_specs_round_trip_in_new_form(self, patch_runtime_io: None) -> None:
         """Old input_spec.json files in R2 parse + re-emit in the new nested shape.
 
         Worker reconstruction contract: an old JSON spec (flat keys) parses
         identically to a freshly-materialized spec; re-serializing produces
         the new nested form so the next round-trip is on the new shape.
+
+        :param patch_runtime_io: Fixture stubbing git/time/runtime IO.
         """
         import json as _json
 

--- a/tests/pipeline/test_schemas/test_r2_location.py
+++ b/tests/pipeline/test_schemas/test_r2_location.py
@@ -9,8 +9,12 @@ from synth_setter.pipeline.schemas.r2_location import R2Location
 from synth_setter.pipeline.schemas.spec import ShardSpec
 
 
-def _shard(filename: str = "shard-000042.h5") -> ShardSpec:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Return a minimal ``ShardSpec`` for URI-construction tests."""
+def _shard(filename: str = "shard-000042.h5") -> ShardSpec:
+    """Return a minimal ``ShardSpec`` for URI-construction tests.
+
+    :param filename: Shard filename to embed in the spec.
+    :return: A ``ShardSpec`` with fixed shard_id/seed.
+    """
     return ShardSpec(shard_id=42, filename=filename, seed=42)
 
 
@@ -170,8 +174,11 @@ class TestR2LocationLayoutHelpers:
         )
 
     @pytest.mark.parametrize("split", ["train", "val", "test"])
-    def test_split_uri(self, split: str) -> None:  # noqa: DOC101,DOC103
-        """``split_uri(<split>)`` returns ``<prefix><split>.h5`` for each split."""
+    def test_split_uri(self, split: str) -> None:
+        """``split_uri(<split>)`` returns ``<prefix><split>.h5`` for each split.
+
+        :param split: Parametrized split name (``train``/``val``/``test``).
+        """
         loc = R2Location(bucket="intermediate-data", prefix="data/run/")
         assert loc.split_uri(split) == f"r2://intermediate-data/data/run/{split}.h5"
 

--- a/tests/pipeline/test_schemas/test_skypilot_launch.py
+++ b/tests/pipeline/test_schemas/test_skypilot_launch.py
@@ -40,14 +40,20 @@ class TestValidation:
     """Pydantic field validators reject invalid combinations early."""
 
     @pytest.mark.parametrize("bad", [0, -1, -100])
-    def test_non_positive_num_workers_rejected(self, bad: int) -> None:  # noqa: DOC101,DOC103
-        """Any worker count below 1 surfaces as ValidationError naming the offending value."""
+    def test_non_positive_num_workers_rejected(self, bad: int) -> None:
+        """Any worker count below 1 surfaces as ValidationError naming the offending value.
+
+        :param bad: Parametrized non-positive worker count.
+        """
         with pytest.raises(ValidationError, match="num_workers must be >= 1"):
             SkypilotLaunchConfig(num_workers=bad)
 
     @pytest.mark.parametrize("blank", ["", "   ", "\t\n"])
-    def test_blank_api_server_rejected(self, blank: str) -> None:  # noqa: DOC101,DOC103
-        """Empty or whitespace-only api_server is rejected to surface typos loudly."""
+    def test_blank_api_server_rejected(self, blank: str) -> None:
+        """Empty or whitespace-only api_server is rejected to surface typos loudly.
+
+        :param blank: Parametrized blank/whitespace-only api_server value.
+        """
         with pytest.raises(ValidationError, match="api_server must be a non-empty URL"):
             SkypilotLaunchConfig(api_server=blank)
 

--- a/tests/schemas/conftest.py
+++ b/tests/schemas/conftest.py
@@ -35,12 +35,16 @@ def clean_global_hydra() -> Iterator[None]:
     )
 
 
-def _to_dict(node: Any) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Resolve an OmegaConf node to ``dict[str, Any]`` for ``model_validate``."""
+def _to_dict(node: Any) -> dict[str, Any]:
+    """Resolve an OmegaConf node to ``dict[str, Any]`` for ``model_validate``.
+
+    :param node: OmegaConf container to resolve.
+    :return: Plain ``dict[str, Any]`` representation.
+    """
     return cast("dict[str, Any]", OmegaConf.to_container(node, resolve=False))
 
 
-def compose_train_cfg(  # noqa: DOC101,DOC103,DOC201,DOC203
+def compose_train_cfg(
     *,
     overrides: list[str] | None = None,
     return_hydra_config: bool = False,
@@ -50,6 +54,10 @@ def compose_train_cfg(  # noqa: DOC101,DOC103,DOC201,DOC203
     Default overrides pin ``data=ksin model=ffn trainer=cpu`` so the suite
     doesn't depend on root-config ``???`` sentinels; caller overrides are
     appended after.
+
+    :param overrides: Extra Hydra overrides appended after the defaults.
+    :param return_hydra_config: Forwarded to ``hydra.compose``.
+    :return: Composed config as a plain ``dict[str, Any]``.
     """
     selected_overrides = list(_DEFAULT_OVERRIDES)
     if overrides is not None:
@@ -63,11 +71,15 @@ def compose_train_cfg(  # noqa: DOC101,DOC103,DOC201,DOC203
     return _to_dict(cfg)
 
 
-def compose_subtree(group: str, name: str) -> dict[str, Any]:  # noqa: DOC101,DOC103,DOC201,DOC203
+def compose_subtree(group: str, name: str) -> dict[str, Any]:
     """Compose ``train.yaml`` with ``<group>=<name>`` selected and return that subtree.
 
     The subtree must be a dict; groups that compose to ``None`` (e.g.
     ``callbacks/none.yaml``) are unsupported and surfaced via assertion.
+
+    :param group: Hydra config group name (e.g. ``data``, ``model``).
+    :param name: Group member to select (e.g. ``ksin``, ``ffn``).
+    :return: The composed subtree at ``group`` as a ``dict[str, Any]``.
     """
     cfg_dict = compose_train_cfg(overrides=[f"{group}={name}"])
     subtree = cfg_dict[group]

--- a/tests/schemas/test_callbacks_config.py
+++ b/tests/schemas/test_callbacks_config.py
@@ -18,8 +18,11 @@ from tests.schemas.conftest import compose_train_cfg
 _CALLBACKS_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "callbacks"
 
 
-def _all_callback_config_names() -> list[str]:  # noqa: DOC201,DOC203
-    """Return every callback YAML stem under ``configs/callbacks/``."""
+def _all_callback_config_names() -> list[str]:
+    """Return every callback YAML stem under ``configs/callbacks/``.
+
+    :return: Sorted list of YAML stems found in ``configs/callbacks/``.
+    """
     names = sorted(p.stem for p in _CALLBACKS_CONFIG_DIR.glob("*.yaml"))
     assert names, (
         f"no callback YAMLs found under {_CALLBACKS_CONFIG_DIR} — "
@@ -28,10 +31,14 @@ def _all_callback_config_names() -> list[str]:  # noqa: DOC201,DOC203
     return names
 
 
-def _compose_callbacks_subtree(  # noqa: DOC101,DOC103,DOC201,DOC203
+def _compose_callbacks_subtree(
     callbacks_name: str,
 ) -> dict[str, object] | None:
-    """Compose with ``callbacks=<name>``; returns dict, or ``None`` for ``none.yaml``."""
+    """Compose with ``callbacks=<name>``; returns dict, or ``None`` for ``none.yaml``.
+
+    :param callbacks_name: Name of the callbacks YAML under ``configs/callbacks/``.
+    :return: Composed ``callbacks`` subtree as a dict, or ``None`` for ``none.yaml``.
+    """
     cfg_dict = compose_train_cfg(overrides=[f"callbacks={callbacks_name}"])
     return cfg_dict["callbacks"]
 
@@ -44,8 +51,11 @@ class TestCallbacksConfigAcceptsEveryComposition:
     """
 
     @pytest.mark.parametrize("callbacks_name", _all_callback_config_names())
-    def test_callbacks_yaml_validates(self, callbacks_name: str) -> None:  # noqa: DOC101,DOC103
-        """The composed ``callbacks`` subtree validates as ``CallbacksConfig``."""
+    def test_callbacks_yaml_validates(self, callbacks_name: str) -> None:
+        """The composed ``callbacks`` subtree validates as ``CallbacksConfig``.
+
+        :param callbacks_name: Parametrized YAML stem under ``configs/callbacks/``.
+        """
         callbacks_subtree = _compose_callbacks_subtree(callbacks_name)
         if not isinstance(callbacks_subtree, dict):
             pytest.skip(

--- a/tests/schemas/test_data_config.py
+++ b/tests/schemas/test_data_config.py
@@ -23,8 +23,11 @@ from tests.schemas.conftest import compose_subtree
 _DATA_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "data"
 
 
-def _all_data_config_names() -> list[str]:  # noqa: DOC201,DOC203
-    """Return the YAML stem of every direct data config under ``configs/data/``."""
+def _all_data_config_names() -> list[str]:
+    """Return the YAML stem of every direct data config under ``configs/data/``.
+
+    :return: Sorted list of YAML stems found in ``configs/data/``.
+    """
     names = sorted(p.stem for p in _DATA_CONFIG_DIR.glob("*.yaml"))
     assert names, f"no data YAMLs found under {_DATA_CONFIG_DIR} — has the layout changed?"
     return names
@@ -34,8 +37,11 @@ class TestDataConfigAcceptsEveryConfig:
     """Every shipped data YAML must validate against ``DataConfig``."""
 
     @pytest.mark.parametrize("data_name", _all_data_config_names())
-    def test_data_yaml_validates(self, data_name: str) -> None:  # noqa: DOC101,DOC103
-        """The composed ``data`` subtree validates as ``DataConfig``."""
+    def test_data_yaml_validates(self, data_name: str) -> None:
+        """The composed ``data`` subtree validates as ``DataConfig``.
+
+        :param data_name: Parametrized YAML stem under ``configs/data/``.
+        """
         data_subtree = compose_subtree("data", data_name)
         parsed = DataConfig.model_validate(data_subtree)
         assert parsed.target_
@@ -50,11 +56,14 @@ class TestDataConfigAcceptsEveryConfig:
 class TestPathsConfigResolvedInterpolation:
     """A real resolved ``PROJECT_ROOT`` must round-trip through ``NonBlankStr``."""
 
-    def test_paths_resolved_with_env_var(  # noqa: DOC101,DOC103
+    def test_paths_resolved_with_env_var(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """``${oc.env:PROJECT_ROOT}`` resolves to a real path and validates as non-blank."""
+        """``${oc.env:PROJECT_ROOT}`` resolves to a real path and validates as non-blank.
+
+        :param monkeypatch: Pytest fixture used to set ``PROJECT_ROOT``.
+        """
         monkeypatch.setenv("PROJECT_ROOT", "/tmp/x")  # noqa: S108
         # output_dir / work_dir overridden because ``${hydra:runtime.*}`` is
         # only populated at fit time, not at compose time.

--- a/tests/schemas/test_logger_config.py
+++ b/tests/schemas/test_logger_config.py
@@ -17,8 +17,11 @@ from tests.schemas.conftest import compose_subtree
 _LOGGER_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "logger"
 
 
-def _all_logger_config_names() -> list[str]:  # noqa: DOC201,DOC203
-    """Return the YAML stem of every direct logger config under ``configs/logger/``."""
+def _all_logger_config_names() -> list[str]:
+    """Return the YAML stem of every direct logger config under ``configs/logger/``.
+
+    :return: Sorted list of YAML stems found in ``configs/logger/``.
+    """
     names = sorted(p.stem for p in _LOGGER_CONFIG_DIR.glob("*.yaml"))
     assert names, f"no logger YAMLs found under {_LOGGER_CONFIG_DIR} — has the layout changed?"
     return names
@@ -28,8 +31,11 @@ class TestLoggerConfigAcceptsEveryComposition:
     """Every shipped logger group must validate against ``LoggerConfig``."""
 
     @pytest.mark.parametrize("logger_name", _all_logger_config_names())
-    def test_logger_yaml_validates(self, logger_name: str) -> None:  # noqa: DOC101,DOC103
-        """The composed ``logger`` subtree validates as ``LoggerConfig``."""
+    def test_logger_yaml_validates(self, logger_name: str) -> None:
+        """The composed ``logger`` subtree validates as ``LoggerConfig``.
+
+        :param logger_name: Parametrized YAML stem under ``configs/logger/``.
+        """
         logger_subtree = compose_subtree("logger", logger_name)
         parsed = LoggerConfig.model_validate(logger_subtree)
         assert parsed.root

--- a/tests/schemas/test_model_config.py
+++ b/tests/schemas/test_model_config.py
@@ -25,8 +25,11 @@ _VALID_OPTIMIZER = {
 }
 
 
-def _all_model_config_names() -> list[str]:  # noqa: DOC201,DOC203
-    """Return YAML stems for every top-level model config (skipping subgroup dirs)."""
+def _all_model_config_names() -> list[str]:
+    """Return YAML stems for every top-level model config (skipping subgroup dirs).
+
+    :return: Sorted list of YAML stems found in ``configs/model/``.
+    """
     names = sorted(p.stem for p in _MODEL_CONFIG_DIR.glob("*.yaml"))
     assert names, f"no model YAMLs found under {_MODEL_CONFIG_DIR} — has the layout changed?"
     return names
@@ -36,8 +39,11 @@ class TestModelConfigAcceptsEveryConfig:
     """Every shipped model YAML must validate against ``ModelConfig``."""
 
     @pytest.mark.parametrize("model_name", _all_model_config_names())
-    def test_model_yaml_validates(self, model_name: str) -> None:  # noqa: DOC101,DOC103
-        """The composed ``model`` subtree validates as ``ModelConfig``."""
+    def test_model_yaml_validates(self, model_name: str) -> None:
+        """The composed ``model`` subtree validates as ``ModelConfig``.
+
+        :param model_name: Parametrized YAML stem under ``configs/model/``.
+        """
         model_subtree = compose_subtree("model", model_name)
         parsed = ModelConfig.model_validate(model_subtree)
         assert parsed.target_

--- a/tests/schemas/test_trainer_config.py
+++ b/tests/schemas/test_trainer_config.py
@@ -17,8 +17,11 @@ from tests.schemas.conftest import compose_subtree
 _TRAINER_CONFIG_DIR = Path(__file__).resolve().parents[2] / "configs" / "trainer"
 
 
-def _all_trainer_config_names() -> list[str]:  # noqa: DOC201,DOC203
-    """Return the YAML stem of every direct trainer config under ``configs/trainer/``."""
+def _all_trainer_config_names() -> list[str]:
+    """Return the YAML stem of every direct trainer config under ``configs/trainer/``.
+
+    :return: Sorted list of YAML stems found in ``configs/trainer/``.
+    """
     names = sorted(p.stem for p in _TRAINER_CONFIG_DIR.glob("*.yaml"))
     assert names, f"no trainer YAMLs found under {_TRAINER_CONFIG_DIR} — has the layout changed?"
     return names
@@ -28,8 +31,11 @@ class TestTrainerConfigAcceptsEveryConfig:
     """Every shipped trainer YAML must validate against ``TrainerConfig``."""
 
     @pytest.mark.parametrize("trainer_name", _all_trainer_config_names())
-    def test_trainer_yaml_validates(self, trainer_name: str) -> None:  # noqa: DOC101,DOC103
-        """The composed ``trainer`` subtree validates as ``TrainerConfig``."""
+    def test_trainer_yaml_validates(self, trainer_name: str) -> None:
+        """The composed ``trainer`` subtree validates as ``TrainerConfig``.
+
+        :param trainer_name: Parametrized YAML stem under ``configs/trainer/``.
+        """
         trainer_subtree = compose_subtree("trainer", trainer_name)
         parsed = TrainerConfig.model_validate(trainer_subtree)
         assert parsed.target_

--- a/tests/scripts/test_check_no_new_funcs_in_pydoclint_excluded.py
+++ b/tests/scripts/test_check_no_new_funcs_in_pydoclint_excluded.py
@@ -45,15 +45,21 @@ PYDOCLINT_EXCLUDE_REGEX = r"""(?x)
 """
 
 
-def test_extract_exclude_regex_reads_pydoclint_table(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """The regex is loaded from the project's pyproject.toml verbatim."""
+def test_extract_exclude_regex_reads_pydoclint_table(tmp_path: Path) -> None:
+    """The regex is loaded from the project's pyproject.toml verbatim.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text("[tool.pydoclint]\nexclude = '''" + PYDOCLINT_EXCLUDE_REGEX + "'''\n")
     assert guard.load_exclude_regex(pyproject).pattern == PYDOCLINT_EXCLUDE_REGEX
 
 
-def test_extract_exclude_regex_errors_when_pyproject_lacks_section(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """A pyproject without the pydoclint section is a configuration error, not a silent pass."""
+def test_extract_exclude_regex_errors_when_pyproject_lacks_section(tmp_path: Path) -> None:
+    """A pyproject without the pydoclint section is a configuration error, not a silent pass.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text("[project]\nname = 'demo'\n")
     with pytest.raises(KeyError):
@@ -211,8 +217,11 @@ def test_find_new_defs_does_not_count_no_newline_marker_toward_line_numbers() ->
     assert findings == [("src/eval.py", "added_after_marker", 11)]
 
 
-def test_main_exits_zero_when_no_findings(tmp_path: Path) -> None:  # noqa: DOC101,DOC103
-    """`main` exits 0 and prints nothing for a clean diff."""
+def test_main_exits_zero_when_no_findings(tmp_path: Path) -> None:
+    """`main` exits 0 and prints nothing for a clean diff.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text("[tool.pydoclint]\nexclude = '''" + PYDOCLINT_EXCLUDE_REGEX + "'''\n")
     clean_diff = (
@@ -227,10 +236,14 @@ def test_main_exits_zero_when_no_findings(tmp_path: Path) -> None:  # noqa: DOC1
     assert exit_code == 0
 
 
-def test_main_exits_one_and_prints_findings_when_violation_present(  # noqa: DOC101,DOC103
+def test_main_exits_one_and_prints_findings_when_violation_present(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """`main` exits 1 and reports each finding with file:line: name."""
+    """`main` exits 1 and reports each finding with file:line: name.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    :param capsys: Pytest fixture capturing stdout/stderr.
+    """
     pyproject = tmp_path / "pyproject.toml"
     pyproject.write_text("[tool.pydoclint]\nexclude = '''" + PYDOCLINT_EXCLUDE_REGEX + "'''\n")
     violation_diff = (

--- a/tests/test_docs_build.py
+++ b/tests/test_docs_build.py
@@ -52,8 +52,11 @@ _PAGE_TO_MODELS: dict[str, tuple[type, ...]] = {
 }
 
 
-def _expected_field_anchors() -> list[tuple[str, type, str]]:  # noqa: DOC201,DOC203
-    """Build ``(page, model, field_name)`` tuples for every typed field on every model."""
+def _expected_field_anchors() -> list[tuple[str, type, str]]:
+    """Build ``(page, model, field_name)`` tuples for every typed field on every model.
+
+    :return: List of ``(page, model, field_name)`` triples for parametrization.
+    """
     triples: list[tuple[str, type, str]] = []
     for page, models in _PAGE_TO_MODELS.items():
         for model in models:
@@ -66,21 +69,29 @@ assert _PAGE_TO_MODELS, "_PAGE_TO_MODELS is empty — config-reference page map 
 assert _expected_field_anchors(), "_expected_field_anchors() is empty — no fields to verify"
 
 
-def _anchor_pattern(model: type, field_name: str) -> re.Pattern[str]:  # noqa: DOC101,DOC103,DOC201,DOC203
+def _anchor_pattern(model: type, field_name: str) -> re.Pattern[str]:
     """Compile a regex for the ``id="<module>.<Class>.<field>"`` anchor mkdocstrings emits.
 
     Matches the structural anchor (not a bare substring) so short field names
     (``lr``, ``test``, ``train``) don't false-positive on HTML/CSS/JS context.
+
+    :param model: Pydantic model class hosting the field.
+    :param field_name: Name of the field being documented.
+    :return: Compiled regex matching the expected mkdocstrings anchor id.
     """
     fqn = re.escape(f"{model.__module__}.{model.__name__}.{field_name}")
     return re.compile(rf'id="{fqn}"')
 
 
 @pytest.fixture(scope="session")
-def built_site(  # noqa: DOC101,DOC103,DOC201,DOC203
+def built_site(
     tmp_path_factory: pytest.TempPathFactory,
 ) -> Path:
-    """Run ``mkdocs build --strict`` once per session and return the site dir."""
+    """Run ``mkdocs build --strict`` once per session and return the site dir.
+
+    :param tmp_path_factory: Pytest session-scoped tmp-path factory.
+    :return: Path to the built mkdocs site directory.
+    """
     site_dir = tmp_path_factory.mktemp("mkdocs-site")
     try:
         subprocess.run(  # noqa: S603
@@ -106,11 +117,15 @@ def built_site(  # noqa: DOC101,DOC103,DOC201,DOC203
     return site_dir
 
 
-def _read_page_html(built_site: Path, page: str) -> str:  # noqa: DOC101,DOC103,DOC201,DOC203
+def _read_page_html(built_site: Path, page: str) -> str:
     """Read ``<built_site>/<page>/index.html`` with an actionable miss message.
 
     Pre-asserts ``is_file()`` so a missing page surfaces as a readable
     assertion instead of a bare ``FileNotFoundError`` from ``read_text``.
+
+    :param built_site: Root directory of the built mkdocs site.
+    :param page: Page subpath under the built site (no trailing slash).
+    :return: HTML text of the page's ``index.html``.
     """
     page_html = built_site / page / "index.html"
     assert page_html.is_file(), (
@@ -121,14 +136,22 @@ def _read_page_html(built_site: Path, page: str) -> str:  # noqa: DOC101,DOC103,
 
 
 @pytest.fixture(scope="session")
-def page_html_cache(built_site: Path) -> dict[str, str]:  # noqa: DOC101,DOC103,DOC201,DOC203
-    """Memoised HTML text for each config-reference page."""
+def page_html_cache(built_site: Path) -> dict[str, str]:
+    """Memoised HTML text for each config-reference page.
+
+    :param built_site: Session-scoped built mkdocs site directory.
+    :return: Mapping ``page -> page_html`` for every documented page.
+    """
     return {page: _read_page_html(built_site, page) for page in _PAGE_TO_MODELS}
 
 
 @pytest.mark.parametrize("page", list(_PAGE_TO_MODELS))
-def test_docs_page_emitted(built_site: Path, page: str) -> None:  # noqa: DOC101,DOC103
-    """Each config-reference page exists in the built site."""
+def test_docs_page_emitted(built_site: Path, page: str) -> None:
+    """Each config-reference page exists in the built site.
+
+    :param built_site: Session-scoped built mkdocs site directory.
+    :param page: Parametrized page subpath under the built site.
+    """
     page_html = built_site / page / "index.html"
     assert page_html.is_file(), f"{page_html} missing from built site"
 
@@ -138,10 +161,16 @@ def test_docs_page_emitted(built_site: Path, page: str) -> None:  # noqa: DOC101
     _expected_field_anchors(),
     ids=lambda v: v if isinstance(v, str) else getattr(v, "__name__", repr(v)),
 )
-def test_docs_page_renders_pydantic_field_anchor(  # noqa: DOC101,DOC103
+def test_docs_page_renders_pydantic_field_anchor(
     page_html_cache: dict[str, str], page: str, model: type, field: str
 ) -> None:
-    """Every typed field on every documented model gets its own anchor heading."""
+    """Every typed field on every documented model gets its own anchor heading.
+
+    :param page_html_cache: Session-cached mapping of page -> rendered HTML.
+    :param page: Parametrized page subpath.
+    :param model: Parametrized pydantic model class.
+    :param field: Parametrized field name on ``model``.
+    """
     assert page in page_html_cache, f"{page} missing from built site — see test_docs_page_emitted"
     page_html = page_html_cache[page]
     pattern = _anchor_pattern(model, field)
@@ -151,10 +180,13 @@ def test_docs_page_renders_pydantic_field_anchor(  # noqa: DOC101,DOC103
     )
 
 
-def test_docs_train_config_renders_field_description(  # noqa: DOC101,DOC103
+def test_docs_train_config_renders_field_description(
     page_html_cache: dict[str, str],
 ) -> None:
-    """``TrainConfig.task_name``'s ``Field(description=...)`` text renders in the page."""
+    """``TrainConfig.task_name``'s ``Field(description=...)`` text renders in the page.
+
+    :param page_html_cache: Session-cached mapping of page -> rendered HTML.
+    """
     description = TrainConfig.model_fields["task_name"].description
     assert description, "TrainConfig.task_name has no Field(description=...) to spot-check"
     page_html = page_html_cache["config_reference/train_config"]


### PR DESCRIPTION
## Summary

Cluster C bulk — fix every remaining inline `# noqa: DOC101/DOC103/DOC201/DOC203` in `tests/` across **21 files** (~140 test functions). Drops the suppressions. Mirrors the template established by pilot PR #1108.

## Convention (from pilot #1108)

- One `:param <name>:` per non-`self`/`cls` arg in the test's signature. Sources: pytest fixtures (`monkeypatch`, `tmp_path`, custom fixtures from `conftest.py`), `@pytest.mark.parametrize("<name>", ...)` argnames.
- `:return:` added when the function actually returns non-None (helpers/fixtures); omitted for tests returning None.
- `:raises:` omitted (tests use `pytest.raises(...)` as an assertion form, not a `:raises:` contract).
- Drop only `DOC101/DOC103/DOC201/DOC203` noqas. Other noqas (e.g. `S101`) stay.
- No `:rtype:` (the `->` annotation is the source of truth — per PR #1109, `check-return-types` is `false`).
- No `:param self:`/`:param cls:` (pydoclint excludes those from the signature).
- `**kwargs` / `*args` documented as `:param \\*\\*kwargs:` / `:param \\*args:` (matches `src/synth_setter/utils/pylogger.py` precedent).

## Out-of-scope DOC404 fix on `_set_up_module`

`tests/data/test_surge_datamodule.py::_set_up_module` previously carried `# noqa: DOC101,DOC103,DOC404`. Stripping the DOC101/103 codes left a lone DOC404. To clear the gate metric (`make count-doc-noqa GATE=1` requires `tests=0` for ALL `noqa: DOC*`, not just the four targeted codes), the helper's docstring now adds an explicit `:ytype: SurgeDataModule` line so pydoclint accepts the yields-section without a suppression. One-line addition; no body change.

## Files (21)

`tests/data/test_surge_datamodule.py`, `tests/data/vst/test_core.py`, `tests/data/vst/test_generate_vst_dataset.py`, `tests/data/vst/test_writers.py`, `tests/data/vst/test_writers_wds_e2e.py`, `tests/evaluation/test_compute_audio_metrics.py`, `tests/evaluation/test_predict_vst_audio.py`, `tests/pipeline/test_ci/test_spec_uri.py`, `tests/pipeline/test_entrypoints/test_generate_dataset.py`, `tests/pipeline/test_entrypoints/test_skypilot_launch.py`, `tests/pipeline/test_schemas/test_dataset_spec.py`, `tests/pipeline/test_schemas/test_r2_location.py`, `tests/pipeline/test_schemas/test_skypilot_launch.py`, `tests/schemas/conftest.py`, `tests/schemas/test_callbacks_config.py`, `tests/schemas/test_data_config.py`, `tests/schemas/test_logger_config.py`, `tests/schemas/test_model_config.py`, `tests/schemas/test_trainer_config.py`, `tests/scripts/test_check_no_new_funcs_in_pydoclint_excluded.py`, `tests/test_docs_build.py`.

## Verification

- [x] `git grep -E 'noqa: DOC' tests/` → no output.
- [x] `pre-commit run pydoclint --files <all 21 files>` → Passed.
- [x] `scripts/ci/count_doc_noqa.sh` → `src=16 tests=0`, exit 0.
- [x] `make test-fast` → 1143 passed, 2 skipped.

## Review note

`/repo-review-full-no-comments` was not invoked because the skill needs an existing PR; this PR is the first artifact to review. Diff is mechanical (signatures unchanged; only docstring `:param:`/`:return:` additions and inline-noqa removals). No business logic touched.

Refs #1106
