### PR TITLE
refactor(agent-hooks): harden agent/hooks/* and expand test.sh (PR #1085 follow-ups)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,25 +310,14 @@ The token is honor-system — it forces a pause to invoke the skill, not unbypas
 
 ### PR Readiness
 
-**Hard gate (all four must hold).** A PR is ready iff:
+**Hard gate (all four must hold).** A PR is **not** ready — for review, merge, or hand-off — until every one of these holds. They are AND-ed; failing any one means not ready.
 
-1. **CI is fully green** — every required AND optional check passing, none pending, errored, or failing.
-2. **`mergeable=MERGEABLE`** — no merge conflicts and GitHub's mergeability calc is settled (not `UNKNOWN`, not `CONFLICTING`).
-3. **Every open review comment has an inline reply** — human reviewers AND Copilot.
-4. **Copilot has produced no new comments since the last push** — verify both the inline-comments endpoint and the top-level reviews endpoint.
+1. **CI is fully green** — every required AND optional check passing. Pending, errored, or failing all count as not ready.
+2. **`mergeable=MERGEABLE`** — `gh pr view <N> --json mergeable -q .mergeable` must report `MERGEABLE`. `UNKNOWN` (GitHub still computing) and `CONFLICTING` both fail this gate; keep polling `UNKNOWN` until it resolves.
+3. **Every open review comment has an inline reply** — every unresolved review thread (human reviewers AND Copilot) has either a code change linked by commit SHA or an inline reply with justification. See `### PR Review Comments` below for the reply mechanics.
+4. **Copilot has produced no new comments since the last push** — Copilot re-reviews after every push, usually within ~60s. Verify both the inline-comments endpoint and the top-level reviews endpoint (procedure below).
 
-"PR mergeable" alone is **not** the gate — green CI is a separate, equally-hard precondition. All four conditions are AND-ed; failing any one means not ready.
-
-Detailed elaboration of each gate:
-
-A PR is **not ready** — for review, merge, or hand-off — until **all** of these hold:
-
-- **All CI checks pass.** Both required and optional checks must pass — a failing, errored, or still-pending check means not ready.
-- **No merge conflicts with the base branch.** `gh pr view <N> --json mergeable -q .mergeable` must report `MERGEABLE`. Anything else means not ready, including `UNKNOWN` (GitHub is still computing mergeability) — keep polling until it resolves to `MERGEABLE` or `CONFLICTING`.
-- **Every open review comment has an inline reply.** Every unresolved review thread — human reviewers AND Copilot's automated comments — has either a code change linked by commit SHA or an inline reply with justification. See `### PR Review Comments` below for the reply mechanics.
-- **Copilot has generated no new comments since the last push.** Copilot re-reviews after every push, usually finishing within ~60s. The PR is not ready until you have verified Copilot is done and either has zero new comments or every new comment has been addressed.
-
-"I pushed the fix" is not the same as "the PR is ready." After pushing, iterate until all conditions are satisfied — use `/loop` (e.g. `/loop 2m gh pr checks <N>`) or repeated polling, do not stop at the first push:
+"PR mergeable" alone is **not** the gate — green CI is a separate, equally-hard precondition. "I pushed the fix" is not the same as "the PR is ready." After pushing, iterate until all four conditions are satisfied — use `/loop` (e.g. `/loop 2m gh pr checks <N>`) or repeated polling, do not stop at the first push:
 
 1. Push the change.
 

--- a/agent/hooks/_lib.sh
+++ b/agent/hooks/_lib.sh
@@ -112,30 +112,42 @@ run_agent_prompt() {
 }
 
 run_review() {
-  # Usage: run_review <slug> <meta> <prompt> <review_file> <stderr_file> <dry_run>
+  # Usage: run_review <slug> <meta> <prompt> [<dry_run_env_var>]
   #
-  # Orchestrates the DRY_RUN-vs-headless-agent dispatch shared by doc-drift.sh
-  # and pr-review-resolver.sh. On success: writes the agent's stdout to
-  # `<review_file>` and removes `<stderr_file>`. On failure: writes a verbose
-  # report (slug, meta block, exit code, prompt, stderr tail). Returns 0 in
-  # both cases — the caller decides the hook's own exit code.
+  # Owns the DRY_RUN-vs-headless-agent dispatch shared by doc-drift.sh and
+  # pr-review-resolver.sh. Generates the report path (`.agent-reviews/<slug>-<uuid>.md`),
+  # invokes the headless agent (or writes a stub under dry-run), and on
+  # failure writes a verbose report with the exit code, prompt, and stderr
+  # tail. Echoes the resulting report path on stdout so the caller can
+  # surface it. Always returns 0 — the caller decides the hook's own exit.
   #
-  # `<slug>`        short name used in the report header (e.g. "doc-drift").
-  # `<meta>`        printf-ready block of "Key: value" lines (one per line).
-  # `<prompt>`      text passed to run_agent_prompt; stubbed under dry-run.
-  # `<review_file>` final report path (overwritten).
-  # `<stderr_file>` scratch file for captured stderr; deleted at end.
-  # `<dry_run>`     "1" skips the agent and writes a stub report.
-  local slug="$1" meta="$2" prompt="$3" review_file="$4" stderr_file="$5" dry_run="$6"
-  local exit_code
+  # `<slug>`             short name used in the report header and filename
+  #                      (e.g. "doc-drift", "pr-review-resolver").
+  # `<meta>`             printf-ready block of "Key: value" lines.
+  # `<prompt>`           text passed to run_agent_prompt; stubbed under dry-run.
+  # `<dry_run_env_var>`  optional name of the env var that gates dry-run mode
+  #                      (e.g. "DOC_DRIFT_DRY_RUN"); if its value is "1" the
+  #                      stub branch fires. Omit for non-dry-run-capable hooks.
+  local slug="$1" meta="$2" prompt="$3" dry_run_var="${4:-}"
+  local review_id review_file stderr_file dry_run exit_code
+  review_id=$(gen_id)
+  review_file="${REVIEWS_DIR}/${slug}-${review_id}.md"
+  stderr_file="${REVIEWS_DIR}/${slug}-${review_id}.stderr"
+  dry_run=0
+  if [[ -n "$dry_run_var" ]]; then
+    # Bash indirect expansion to read the named env var; defaults to 0.
+    dry_run="${!dry_run_var:-0}"
+  fi
   if [[ "$dry_run" == "1" ]]; then
     log "DRY_RUN: writing stub report"
     printf '# %s (dry-run)\n%s\n## Prompt\n%s\n' "$slug" "$meta" "$prompt" > "$review_file"
+    printf '%s\n' "$review_file"
     return 0
   fi
   log "invoking headless agent"
   if run_agent_prompt "$prompt" > "$review_file" 2>"$stderr_file"; then
     rm -f "$stderr_file"
+    printf '%s\n' "$review_file"
     return 0
   fi
   exit_code=$?
@@ -151,5 +163,6 @@ run_review() {
     printf '\n```\n'
   } > "$review_file"
   rm -f "$stderr_file"
+  printf '%s\n' "$review_file"
   return 0
 }

--- a/agent/hooks/_lib.sh
+++ b/agent/hooks/_lib.sh
@@ -149,8 +149,12 @@ run_review() {
     rm -f "$stderr_file"
     printf '%s\n' "$review_file"
     return 0
+  else
+    # `$?` inside the else branch is the failed command's exit. Outside the
+    # `if`/`else` block, bash resets it to 0 (the if-statement's own exit
+    # status when the condition was false), so the capture must live here.
+    exit_code=$?
   fi
-  exit_code=$?
   log "headless agent failed (exit ${exit_code})"
   {
     printf '# %s (FAILED)\n\n%s\n' "$slug" "$meta"

--- a/agent/hooks/_lib.sh
+++ b/agent/hooks/_lib.sh
@@ -1,18 +1,7 @@
 #!/usr/bin/env bash
-# =============================================================================
-# _lib.sh — shared helpers for agent hook scripts
-# =============================================================================
-#
-# Sourced by doc-drift.sh and pr-review-resolver.sh. Provides:
-#   - has_skill <name>         : returns 0 if the named skill is installed
-#   - log <msg>                : append a timestamped line to .agent-reviews/.hook.log
-#   - ensure_reviews_dir       : create .agent-reviews/ if missing
-#   - gen_id                   : portable unique ID for report filenames and lock tokens
-#   - default_branch           : resolve the repo's default branch (origin/HEAD to main to master)
-#   - run_agent_prompt <prompt>: run a prompt through the available headless agent CLI
-#
-# Skill detection searches project-local, Claude, and Codex skill locations.
-# =============================================================================
+# _lib.sh — shared helpers for agent/hooks/*. See each function's own block
+# comment for its contract. Sourced by every hook; intentionally omits
+# `set -euo pipefail` so each caller chooses its own error-handling regime.
 
 REVIEWS_DIR=".agent-reviews"
 HOOK_LOG="${REVIEWS_DIR}/.hook.log"
@@ -47,12 +36,14 @@ default_branch() {
   #   2. local 'main' if it exists
   #   3. local 'master' if it exists
   #   4. 'main' (final fallback)
-  local ref
+  local ref b
   ref=$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)
   if [[ -n "$ref" ]]; then
     echo "${ref##*/}"
     return 0
   fi
+  # `b` is declared `local` above so the loop variable doesn't leak into
+  # the caller's scope (`for` does not auto-localize).
   for b in main master; do
     git show-ref --verify --quiet "refs/heads/$b" 2>/dev/null && { echo "$b"; return 0; }
     git show-ref --verify --quiet "refs/remotes/origin/$b" 2>/dev/null && { echo "$b"; return 0; }
@@ -64,9 +55,10 @@ has_skill() {
   # Usage: has_skill <skill-name>
   # Returns 0 if <name>/SKILL.md exists in any known skill location.
   # Worktree-aware: also checks the main repo via the git common dir, since
-  # agent tool directories may live only in the primary checkout.
-  local name="$1"
-  local home="${HOME:-}"
+  # agent tool directories may live only in the primary checkout. Unmatched
+  # plugin globs expand to their literal pattern, which the `-f` check safely
+  # rejects without spurious warnings.
+  local name="$1" home="${HOME:-}" common_dir repo_root p
   local paths=(
     "agent/skills/${name}/SKILL.md"
     ".claude/skills/${name}/SKILL.md"
@@ -75,9 +67,10 @@ has_skill() {
     paths+=(
       "${home}/.claude/skills/${name}/SKILL.md"
       "${home}/.codex/skills/${name}/SKILL.md"
+      "${home}"/.claude/plugins/*/skills/"${name}"/SKILL.md
+      "${home}"/.codex/plugins/*/skills/"${name}"/SKILL.md
     )
   fi
-  local common_dir repo_root
   if common_dir=$(git rev-parse --git-common-dir 2>/dev/null) && [[ -n "$common_dir" ]]; then
     repo_root=$(cd "$common_dir/.." 2>/dev/null && pwd)
     if [[ -n "$repo_root" ]]; then
@@ -90,29 +83,73 @@ has_skill() {
   for p in "${paths[@]}"; do
     [[ -f "$p" ]] && return 0
   done
-  if [[ -n "$home" ]]; then
-    for p in "${home}"/.claude/plugins/*/skills/"${name}"/SKILL.md; do
-      [[ -f "$p" ]] && return 0
-    done
-    for p in "${home}"/.codex/plugins/*/skills/"${name}"/SKILL.md; do
-      [[ -f "$p" ]] && return 0
-    done
-  fi
   return 1
 }
 
 run_agent_prompt() {
-  local prompt="$1"
-  if [[ "${AGENT_HEADLESS:-}" == "codex" ]]; then
-    codex exec "$prompt"
-  elif [[ "${AGENT_HEADLESS:-}" == "claude" ]]; then
-    claude -p "$prompt"
-  elif command -v claude >/dev/null 2>&1; then
-    claude -p "$prompt"
-  elif command -v codex >/dev/null 2>&1; then
-    codex exec "$prompt"
-  else
-    printf 'No supported headless agent CLI found; install claude or codex.\n' >&2
-    return 127
+  # Usage: run_agent_prompt <prompt>
+  # Routes the prompt through the available headless agent CLI. AGENT_HEADLESS
+  # (`claude` or `codex`) overrides auto-detection; otherwise prefer claude,
+  # fall back to codex, fail loud (exit 127) if neither is installed.
+  local prompt="$1" cli="${AGENT_HEADLESS:-}" candidate
+  if [[ -z "$cli" ]]; then
+    for candidate in claude codex; do
+      if command -v "$candidate" >/dev/null 2>&1; then
+        cli="$candidate"
+        break
+      fi
+    done
   fi
+  case "$cli" in
+    claude) claude -p "$prompt" ;;
+    codex)  codex exec "$prompt" ;;
+    *)
+      printf 'No supported headless agent CLI found; install claude or codex (AGENT_HEADLESS=%s).\n' \
+        "${AGENT_HEADLESS:-}" >&2
+      return 127
+      ;;
+  esac
+}
+
+run_review() {
+  # Usage: run_review <slug> <meta> <prompt> <review_file> <stderr_file> <dry_run>
+  #
+  # Orchestrates the DRY_RUN-vs-headless-agent dispatch shared by doc-drift.sh
+  # and pr-review-resolver.sh. On success: writes the agent's stdout to
+  # `<review_file>` and removes `<stderr_file>`. On failure: writes a verbose
+  # report (slug, meta block, exit code, prompt, stderr tail). Returns 0 in
+  # both cases — the caller decides the hook's own exit code.
+  #
+  # `<slug>`        short name used in the report header (e.g. "doc-drift").
+  # `<meta>`        printf-ready block of "Key: value" lines (one per line).
+  # `<prompt>`      text passed to run_agent_prompt; stubbed under dry-run.
+  # `<review_file>` final report path (overwritten).
+  # `<stderr_file>` scratch file for captured stderr; deleted at end.
+  # `<dry_run>`     "1" skips the agent and writes a stub report.
+  local slug="$1" meta="$2" prompt="$3" review_file="$4" stderr_file="$5" dry_run="$6"
+  local exit_code
+  if [[ "$dry_run" == "1" ]]; then
+    log "DRY_RUN: writing stub report"
+    printf '# %s (dry-run)\n%s\n## Prompt\n%s\n' "$slug" "$meta" "$prompt" > "$review_file"
+    return 0
+  fi
+  log "invoking headless agent"
+  if run_agent_prompt "$prompt" > "$review_file" 2>"$stderr_file"; then
+    rm -f "$stderr_file"
+    return 0
+  fi
+  exit_code=$?
+  log "headless agent failed (exit ${exit_code})"
+  {
+    printf '# %s (FAILED)\n\n%s\n' "$slug" "$meta"
+    printf '## headless agent exit code\n%s\n\n' "$exit_code"
+    # shellcheck disable=SC2016  # backticks here are literal markdown fences
+    printf '## Prompt\n```\n%s\n```\n\n' "$prompt"
+    # shellcheck disable=SC2016
+    printf '## Stderr (tail)\n```\n'
+    tail -40 "$stderr_file" 2>/dev/null || true
+    printf '\n```\n'
+  } > "$review_file"
+  rm -f "$stderr_file"
+  return 0
 }

--- a/agent/hooks/doc-drift.sh
+++ b/agent/hooks/doc-drift.sh
@@ -50,12 +50,8 @@ ${DIFF_FILES}
 Report findings as \"file:line — issue — suggested fix\". If no drift is found, state that explicitly."
 fi
 
-REVIEW_ID=$(gen_id)
-REVIEW_FILE="${REVIEWS_DIR}/doc-drift-${REVIEW_ID}.md"
-STDERR_FILE="${REVIEWS_DIR}/doc-drift-${REVIEW_ID}.stderr"
 META=$(printf 'PR: #%s\nBranch: %s\nBase: %s\n' "$PR" "$BRANCH" "$BASE_BRANCH")
-
-run_review "doc-drift" "$META" "$PROMPT" "$REVIEW_FILE" "$STDERR_FILE" "${DOC_DRIFT_DRY_RUN:-0}"
+REVIEW_FILE=$(run_review "doc-drift" "$META" "$PROMPT" "DOC_DRIFT_DRY_RUN")
 
 log "wrote ${REVIEW_FILE}"
 

--- a/agent/hooks/doc-drift.sh
+++ b/agent/hooks/doc-drift.sh
@@ -1,29 +1,9 @@
 #!/usr/bin/env bash
-# =============================================================================
-# doc-drift.sh — PostToolUse hook, runs on `gh pr create`
-# =============================================================================
-#
-# PURPOSE
-# -------
-# After an agent creates a PR, run the doc-drift skill (or an inline fallback
-# if the skill is not installed) in a headless agent session to produce
-# an advisory documentation-drift report. Written to .agent-reviews/doc-drift-<uuid>.md.
-#
-# Returns exit 2 with a pointer so the active agent session reads the report
-# and applies doc updates as appropriate. Advisory — does not block.
-#
-# INPUT (stdin)
-#   JSON with .tool_input.command — the Bash command the agent just ran.
-#
-# INVOCATION
-#   Registered in Claude settings or another agent hook runner as a PostToolUse hook on Bash with
-#   asyncRewake: true and timeout: 900 (15 min).
-#
-# ENV OVERRIDES
-#   DOC_DRIFT_DRY_RUN=1        — skip the actual headless agent call; write a
-#                                stub report. Used by the unit harness.
-#   AGENT_HEADLESS=claude|codex — force the headless CLI. Auto-detected by default.
-# =============================================================================
+# doc-drift.sh — PostToolUse hook on `gh pr create`. Runs the doc-drift skill
+# (or an inline fallback) headlessly and writes an advisory report to
+# .agent-reviews/doc-drift-<uuid>.md. Exits 2 with a pointer so the active
+# agent session reads the report; never blocks. Env overrides: DOC_DRIFT_DRY_RUN=1
+# skips the agent call; AGENT_HEADLESS=claude|codex pins the CLI.
 set -euo pipefail
 
 export HOOK_NAME="doc-drift"
@@ -51,6 +31,9 @@ fi
 
 BASE_BRANCH=$(default_branch)
 log "base branch resolved to: ${BASE_BRANCH}"
+# `head -50` closes its read end after 50 lines, sending SIGPIPE to `git diff`;
+# `pipefail` would otherwise propagate git's non-zero exit. `|| true` keeps the
+# substitution non-fatal under `set -e`.
 DIFF_FILES=$(git diff "origin/${BASE_BRANCH}...HEAD" --name-only 2>/dev/null | head -50 || true)
 
 if has_skill doc-drift; then
@@ -70,32 +53,9 @@ fi
 REVIEW_ID=$(gen_id)
 REVIEW_FILE="${REVIEWS_DIR}/doc-drift-${REVIEW_ID}.md"
 STDERR_FILE="${REVIEWS_DIR}/doc-drift-${REVIEW_ID}.stderr"
+META=$(printf 'PR: #%s\nBranch: %s\nBase: %s\n' "$PR" "$BRANCH" "$BASE_BRANCH")
 
-if [[ "${DOC_DRIFT_DRY_RUN:-0}" == "1" ]]; then
-  log "DRY_RUN: writing stub report"
-  printf '# doc-drift (dry-run)\nPR: #%s\nBranch: %s\nBase: %s\n\n## Prompt\n%s\n' \
-    "$PR" "$BRANCH" "$BASE_BRANCH" "$PROMPT" > "$REVIEW_FILE"
-else
-  log "invoking headless agent"
-  if run_agent_prompt "$PROMPT" > "$REVIEW_FILE" 2>"$STDERR_FILE"; then
-    :
-  else
-    AGENT_EXIT=$?
-    log "headless agent failed (exit ${AGENT_EXIT})"
-    {
-      printf '# doc-drift (FAILED)\n\n'
-      printf 'PR: #%s\nBranch: %s\nBase: %s\n\n' "$PR" "$BRANCH" "$BASE_BRANCH"
-      printf '## headless agent exit code\n%s\n\n' "$AGENT_EXIT"
-      # shellcheck disable=SC2016  # backticks here are literal markdown fences
-      printf '## Prompt\n```\n%s\n```\n\n' "$PROMPT"
-      # shellcheck disable=SC2016
-      printf '## Stderr (tail)\n```\n'
-      tail -40 "$STDERR_FILE" 2>/dev/null || true
-      printf '\n```\n'
-    } > "$REVIEW_FILE"
-  fi
-  rm -f "$STDERR_FILE"
-fi
+run_review "doc-drift" "$META" "$PROMPT" "$REVIEW_FILE" "$STDERR_FILE" "${DOC_DRIFT_DRY_RUN:-0}"
 
 log "wrote ${REVIEW_FILE}"
 

--- a/agent/hooks/edit-write.sh
+++ b/agent/hooks/edit-write.sh
@@ -34,16 +34,32 @@ case "$MODE" in
     exit 0
     ;;
   test)
+    # Match `src/`/`scripts/`/`tests/` at either the start of a relative path
+    # or after a `/` in an absolute path. The `*/X/*` form alone was a latent
+    # bug: it only matched absolute paths like `/foo/bar/src/baz.py`, never
+    # a relative `src/foo/bar.py` from the agent's typical tool_input.file_path.
     case "$FILE_PATH" in
-      */src/*|*/scripts/*)
-        base=$(basename "$FILE_PATH" .py)
-        test_file="tests/test_${base}.py"
-        if [[ -f "$test_file" ]]; then
+      src/*|scripts/*|*/src/*|*/scripts/*)
+        # Try the package-mirrored layout first (tests/<package>/test_<base>.py),
+        # then fall back to flat tests/test_<base>.py. Project uses the mirrored
+        # form (e.g. src/synth_setter/pipeline/data/stats.py →
+        # tests/pipeline/data/test_stats.py); the flat form is the legacy default.
+        test_file=""
+        if [[ "$FILE_PATH" =~ ^src/[^/]+/(.+)/([^/]+)\.py$ ]]; then
+          mirrored="tests/${BASH_REMATCH[1]}/test_${BASH_REMATCH[2]}.py"
+          [[ -f "$mirrored" ]] && test_file="$mirrored"
+        fi
+        if [[ -z "$test_file" ]]; then
+          base=$(basename "$FILE_PATH" .py)
+          flat="tests/test_${base}.py"
+          [[ -f "$flat" ]] && test_file="$flat"
+        fi
+        if [[ -n "$test_file" ]]; then
           echo "Running $test_file" >&2
           pytest "$test_file" -x -q --no-header --tb=short 2>&1 | tail -5 >&2 || true
         fi
         ;;
-      */tests/*)
+      tests/*|*/tests/*)
         echo "Running $FILE_PATH" >&2
         pytest "$FILE_PATH" -x -q --no-header --tb=short 2>&1 | tail -5 >&2 || true
         ;;

--- a/agent/hooks/pr-review-resolver.sh
+++ b/agent/hooks/pr-review-resolver.sh
@@ -69,12 +69,8 @@ else
   PROMPT="PR #${PR} on branch ${BRANCH}. Fetch review comments with 'gh pr view ${PR} --json reviews,comments' and 'gh api repos/{owner}/{repo}/pulls/${PR}/comments'. Address each actionable comment; reply inline to each comment you addressed with the fix commit SHA. Ignore nits unless trivial."
 fi
 
-REVIEW_ID=$(gen_id)
-REVIEW_FILE="${REVIEWS_DIR}/pr-review-resolver-${REVIEW_ID}.md"
-STDERR_FILE="${REVIEWS_DIR}/pr-review-resolver-${REVIEW_ID}.stderr"
 META=$(printf 'PR: #%s\nBranch: %s\n' "$PR" "$BRANCH")
-
-run_review "pr-review-resolver" "$META" "$PROMPT" "$REVIEW_FILE" "$STDERR_FILE" "${RESOLVER_DRY_RUN:-0}"
+REVIEW_FILE=$(run_review "pr-review-resolver" "$META" "$PROMPT" "RESOLVER_DRY_RUN")
 
 log "wrote ${REVIEW_FILE}"
 

--- a/agent/hooks/pr-review-resolver.sh
+++ b/agent/hooks/pr-review-resolver.sh
@@ -1,38 +1,16 @@
 #!/usr/bin/env bash
-# =============================================================================
-# pr-review-resolver.sh — PostToolUse hook, runs on `git push`
-# =============================================================================
+# pr-review-resolver.sh — PostToolUse hook on `git push`. Waits ~6min for CI
+# and reviewers to settle, then runs the pr-review-resolver skill (or an
+# inline fallback) headlessly. Writes to .agent-reviews/pr-review-resolver-<uuid>.md
+# and exits 2 with a pointer; never blocks.
 #
-# PURPOSE
-# -------
-# After an agent pushes a feature branch, wait for reviewers/CI to settle
-# (default 360s), then run the pr-review-resolver skill (or an inline
-# fallback) in a headless agent session to triage and respond to
-# review comments. Report written to .agent-reviews/pr-review-resolver-<uuid>.md.
+# Gates (all silent early-exit, no wait wasted): cmd does not contain "git push",
+# current branch is main/master, a newer push overwrote our lock, no PR for the branch.
+# Lockfile dedupe: write a per-branch token under .agent-reviews; after the sleep,
+# re-read — if the token changed, a newer push is in flight and this run exits.
 #
-# Returns exit 2 with a pointer so the active agent session reads the report
-# and acts on unresolved items. Advisory — does not block.
-#
-# GATES (all early-exit silently, no 6-min wait wasted)
-#   - cmd does not contain "git push"
-#   - current branch is main/master
-#   - after the wait: a newer push has overwritten our lock (dedupe)
-#   - after the wait: no PR exists for this branch
-#
-# LOCKFILE DEDUPE
-#   On entry we write a per-branch token to .agent-reviews/.resolver-<branch>.lock.
-#   After the sleep we re-read; if the token changed a newer push is in
-#   flight and this run exits silently. Last push wins.
-#
-# ENV OVERRIDES
-#   RESOLVER_SLEEP_SECS       — override the 360s settle-wait (used by tests)
-#   RESOLVER_DRY_RUN=1        — skip the headless agent call; write a stub report
-#   AGENT_HEADLESS=claude|codex — force the headless CLI. Auto-detected by default.
-#
-# INVOCATION
-#   Registered in Claude settings or another agent hook runner as a PostToolUse hook on Bash with
-#   asyncRewake: true and timeout: 1200 (20 min: ~6 min wait + resolver runtime).
-# =============================================================================
+# Env overrides: RESOLVER_SLEEP_SECS overrides the 360s wait (tests use 1s);
+# RESOLVER_DRY_RUN=1 skips the agent call; AGENT_HEADLESS=claude|codex pins the CLI.
 set -euo pipefail
 
 export HOOK_NAME="pr-review-resolver"
@@ -62,7 +40,12 @@ TOKEN=$(gen_id)
 echo "$TOKEN" > "$LOCKFILE"
 log "wrote lock token ${TOKEN}"
 
+# Defensive: RESOLVER_SLEEP_SECS comes from the environment; an operator typo
+# (`RESOLVER_SLEEP_SECS=abc`) would otherwise abort the hook at `sleep` under
+# `set -e`. Fall back to the default if the value isn't a small positive
+# integer (1-99999s; 0 would defeat the lockfile-dedupe purpose entirely).
 SLEEP_SECS="${RESOLVER_SLEEP_SECS:-360}"
+[[ "$SLEEP_SECS" =~ ^[1-9][0-9]{0,4}$ ]] || { log "invalid RESOLVER_SLEEP_SECS=${SLEEP_SECS}, using 360"; SLEEP_SECS=360; }
 log "sleeping ${SLEEP_SECS}s"
 sleep "$SLEEP_SECS"
 
@@ -89,32 +72,9 @@ fi
 REVIEW_ID=$(gen_id)
 REVIEW_FILE="${REVIEWS_DIR}/pr-review-resolver-${REVIEW_ID}.md"
 STDERR_FILE="${REVIEWS_DIR}/pr-review-resolver-${REVIEW_ID}.stderr"
+META=$(printf 'PR: #%s\nBranch: %s\n' "$PR" "$BRANCH")
 
-if [[ "${RESOLVER_DRY_RUN:-0}" == "1" ]]; then
-  log "DRY_RUN: writing stub report"
-  printf '# pr-review-resolver (dry-run)\nPR: #%s\nBranch: %s\n\n## Prompt\n%s\n' \
-    "$PR" "$BRANCH" "$PROMPT" > "$REVIEW_FILE"
-else
-  log "invoking headless agent"
-  if run_agent_prompt "$PROMPT" > "$REVIEW_FILE" 2>"$STDERR_FILE"; then
-    :
-  else
-    AGENT_EXIT=$?
-    log "headless agent failed (exit ${AGENT_EXIT})"
-    {
-      printf '# pr-review-resolver (FAILED)\n\n'
-      printf 'PR: #%s\nBranch: %s\n\n' "$PR" "$BRANCH"
-      printf '## headless agent exit code\n%s\n\n' "$AGENT_EXIT"
-      # shellcheck disable=SC2016  # backticks here are literal markdown fences
-      printf '## Prompt\n```\n%s\n```\n\n' "$PROMPT"
-      # shellcheck disable=SC2016
-      printf '## Stderr (tail)\n```\n'
-      tail -40 "$STDERR_FILE" 2>/dev/null || true
-      printf '\n```\n'
-    } > "$REVIEW_FILE"
-  fi
-  rm -f "$STDERR_FILE"
-fi
+run_review "pr-review-resolver" "$META" "$PROMPT" "$REVIEW_FILE" "$STDERR_FILE" "${RESOLVER_DRY_RUN:-0}"
 
 log "wrote ${REVIEW_FILE}"
 

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -1,39 +1,41 @@
 #!/usr/bin/env bash
-# =============================================================================
-# test.sh — unit harness for agent/hooks/
-# =============================================================================
+# test.sh — unit harness for agent/hooks/*. Runs from repo root:
+#   bash agent/hooks/test.sh
+# Each test is a function (`T_*`) registered with `it`. The runner executes
+# each in a subshell so env-var sets, cwd changes, and `set -e` semantics
+# don't leak between tests. The PATH-stubbed `claude`/`gh` live in $STUBS;
+# `git` is real (the sandbox is a fresh init repo).
 #
-# Tests run each hook script with canned stdin and PATH-stubbed `claude`/`gh`
-# (`git` is intentionally real — the tests operate inside a sandbox git repo),
-# asserting exit codes, stderr pointers, report files, and logged decisions.
-#
-# Run from repo root:   bash agent/hooks/test.sh
-# =============================================================================
+# edit-write.sh — credential-protect coverage lives here; the matching
+# `format` and `test` modes are best-effort hooks that aren't easily
+# stubbed in a sandbox (they shell out to ruff/pytest), so only the
+# dispatch contract is tested here. The Python suite at
+# `tests/claude_hooks/test_settings_hooks.py` covers credential-protect
+# from the settings.json wiring perspective.
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
-# Isolate test artifacts in a temp dir we cd into, so .agent-reviews/ paths
-# used by the hooks land in a sandbox and don't pollute the real worktree.
 TEST_DIR=$(mktemp -d)
 cleanup() { rm -rf "$TEST_DIR"; }
 trap cleanup EXIT
 
-# Copy hook scripts into the sandbox so paths resolve; point GIT_DIR / repo at
-# the sandbox so hooks calling `git` don't see the real repo state.
 SANDBOX="$TEST_DIR/repo"
 mkdir -p "$SANDBOX/agent/hooks"
-cp agent/hooks/_lib.sh agent/hooks/doc-drift.sh agent/hooks/pr-review-resolver.sh \
-  agent/hooks/pre-pr-review-gate.sh \
-  "$SANDBOX/agent/hooks/"
+cp agent/hooks/_lib.sh \
+   agent/hooks/doc-drift.sh \
+   agent/hooks/pr-review-resolver.sh \
+   agent/hooks/pre-pr-review-gate.sh \
+   agent/hooks/edit-write.sh \
+   agent/hooks/verify-gh-taxonomy.sh \
+   "$SANDBOX/agent/hooks/"
 cd "$SANDBOX"
 git init -q
 git config user.email test@test
 git config user.name test
 git commit -q --allow-empty -m init
 
-# Stub PATH with fake claude/gh (git is real — we need it for branch detection).
 STUBS="$TEST_DIR/stubs"
 mkdir -p "$STUBS"
 cat > "$STUBS/claude" <<'EOF'
@@ -47,7 +49,7 @@ echo "# prompt was: $*"
 EOF
 cat > "$STUBS/gh" <<'EOF'
 #!/usr/bin/env bash
-# $GH_STUB_PR governs what `gh pr view` returns. Empty = no PR.
+# Minimal stub. $GH_STUB_PR governs `gh pr view`'s number output.
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
   if [[ -n "${GH_STUB_PR:-}" ]]; then
     echo "${GH_STUB_PR}"
@@ -61,237 +63,429 @@ EOF
 chmod +x "$STUBS/claude" "$STUBS/gh"
 export PATH="$STUBS:$PATH"
 
-PASS=0
-FAIL=0
-pass() { printf '  PASS  %s\n' "$1"; PASS=$((PASS+1)); }
-fail() { printf '  FAIL  %s — %s\n' "$1" "$2"; FAIL=$((FAIL+1)); }
+# ---------------------------------------------------------------------------
+# Test registry + runner
+# ---------------------------------------------------------------------------
+TESTS=()
+
+it() {
+  # Usage: it "<description>" <T_function_name>
+  TESTS+=("$1|$2")
+}
 
 reset_sandbox() {
   rm -rf .agent-reviews
 }
 
-# -----------------------------------------------------------------------------
+run_tests() {
+  local pass=0 fail=0 entry desc fn out exit_code
+  for entry in "${TESTS[@]}"; do
+    desc="${entry%%|*}"
+    fn="${entry#*|}"
+    # Subshell isolates env, cwd, and exported var changes between tests.
+    # Disable the outer `set -e` around the capture so a failing test doesn't
+    # terminate the runner — we want to print FAIL and keep going.
+    set +e
+    out=$( ( set -e; reset_sandbox; "$fn" ) 2>&1 )
+    exit_code=$?
+    set -e
+    if [[ "$exit_code" == "0" ]]; then
+      printf '  PASS  %s\n' "$desc"
+      pass=$((pass + 1))
+    else
+      printf '  FAIL  %s (exit %s)\n' "$desc" "$exit_code"
+      printf '%s\n' "$out" | sed 's/^/         /'
+      fail=$((fail + 1))
+    fi
+  done
+  echo
+  echo "== Summary =="
+  echo "PASS: $pass"
+  echo "FAIL: $fail"
+  [[ "$fail" -eq 0 ]]
+}
+
+assert() {
+  # Usage: assert "<msg>" <test-expr...>
+  # Example: assert "expected EXIT:0" [[ "$out" == *"EXIT:0"* ]]
+  # Caller passes the test as a positional expr that's eval'd via `if`.
+  local msg="$1"; shift
+  if "$@"; then return 0; fi
+  echo "ASSERT FAILED: ${msg}" >&2
+  return 1
+}
+
+# `last_exit_line` extracts the trailing `EXIT:N` marker the test bodies
+# append to captured `out` so we can match on exact equality rather than
+# substring (which would false-pass if stderr contained `EXIT:0`).
+last_exit_line() {
+  printf '%s\n' "$1" | tail -1
+}
+
+# ===========================================================================
 # doc-drift.sh
-# -----------------------------------------------------------------------------
-echo "== doc-drift.sh =="
+# ===========================================================================
 
-# 1. Non-matching command → exit 0, no report.
-reset_sandbox
-out=$(echo '{"tool_input":{"command":"echo hello"}}' | bash agent/hooks/doc-drift.sh 2>&1; echo "EXIT:$?")
-if [[ "$out" == *"EXIT:0"* ]] && [[ ! -d .agent-reviews ]]; then
-  pass "non-matching command exits 0 silently"
-else
-  fail "non-matching command exits 0 silently" "$out"
-fi
+T_doc_drift_no_match() {
+  local out
+  out=$(echo '{"tool_input":{"command":"echo hello"}}' | bash agent/hooks/doc-drift.sh 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ ! -d .agent-reviews ]] || { echo ".agent-reviews should not exist"; return 1; }
+}
+it "doc-drift: non-matching command exits 0 silently" T_doc_drift_no_match
 
-# 1b. Substring-only match (e.g. 'gh pr create' inside echo text) → no match.
-reset_sandbox
-export GH_STUB_PR=42
-out=$(echo '{"tool_input":{"command":"echo testing the gh pr create matcher"}}' | bash agent/hooks/doc-drift.sh 2>&1; echo "EXIT:$?")
-if [[ "$out" == *"EXIT:0"* ]] && [[ ! -d .agent-reviews ]]; then
-  pass "quoted 'gh pr create' substring inside echo does NOT trigger (word-boundary match)"
-else
-  fail "quoted substring should not trigger" "$out"
-fi
-unset GH_STUB_PR
+T_doc_drift_quoted_substring() {
+  local out
+  export GH_STUB_PR=42
+  out=$(echo '{"tool_input":{"command":"echo testing the gh pr create matcher"}}' | bash agent/hooks/doc-drift.sh 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ ! -d .agent-reviews ]] || { echo ".agent-reviews should not exist"; return 1; }
+}
+it "doc-drift: quoted 'gh pr create' substring inside echo does NOT trigger" T_doc_drift_quoted_substring
 
-# 2. gh pr create with no PR found → exit 0 silently.
-reset_sandbox
-unset GH_STUB_PR
-out=$(echo '{"tool_input":{"command":"gh pr create --title x"}}' | bash agent/hooks/doc-drift.sh 2>&1; echo "EXIT:$?")
-if [[ "$out" == *"EXIT:0"* ]] && ! compgen -G ".agent-reviews/doc-drift-*.md" >/dev/null; then
-  pass "gh pr create with no PR → exits 0, no report"
-else
-  fail "gh pr create with no PR → exits 0, no report" "$out"
-fi
+T_doc_drift_no_pr() {
+  local out
+  unset GH_STUB_PR
+  out=$(echo '{"tool_input":{"command":"gh pr create --title x"}}' | bash agent/hooks/doc-drift.sh 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  if compgen -G ".agent-reviews/doc-drift-*.md" >/dev/null; then
+    echo "no report should exist"
+    return 1
+  fi
+}
+it "doc-drift: gh pr create with no PR found → exit 0, no report" T_doc_drift_no_pr
 
-# 3. gh pr create with PR → exit 2, report file written, stderr has pointer.
-reset_sandbox
-export GH_STUB_PR=42 DOC_DRIFT_DRY_RUN=1
-stderr_file="$TEST_DIR/stderr.txt"
-out=$(echo '{"tool_input":{"command":"gh pr create --title x"}}' | bash agent/hooks/doc-drift.sh 2>"$stderr_file"; echo "EXIT:$?")
-report=$(find .agent-reviews -maxdepth 1 -name 'doc-drift-*.md' 2>/dev/null | head -1)
-if [[ "$out" == *"EXIT:2"* ]] && [[ -n "$report" ]] && grep -q "PR #42" "$stderr_file"; then
-  pass "gh pr create with PR → exit 2, report written, stderr points to it"
-else
-  fail "gh pr create with PR" "exit=$out report=$report stderr=$(cat "$stderr_file")"
-fi
+T_doc_drift_with_pr() {
+  local out stderr_file report
+  export GH_STUB_PR=42 DOC_DRIFT_DRY_RUN=1
+  stderr_file="$TEST_DIR/stderr.txt"
+  out=$(echo '{"tool_input":{"command":"gh pr create --title x"}}' | bash agent/hooks/doc-drift.sh 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:2" ]] || { echo "expected EXIT:2, got: $out"; return 1; }
+  report=$(find .agent-reviews -maxdepth 1 -name 'doc-drift-*.md' 2>/dev/null | head -1)
+  [[ -n "$report" ]] || { echo "report file missing"; return 1; }
+  grep -q "PR #42" "$stderr_file" || { echo "stderr should mention PR #42: $(cat "$stderr_file")"; return 1; }
+  grep -q "docs/doc-map.yaml" "$report" || { echo "report should reference doc-map.yaml: $(cat "$report")"; return 1; }
+}
+it "doc-drift: gh pr create with PR → exit 2, report written, stderr points to it" T_doc_drift_with_pr
 
-# 4. Fallback prompt when skill is missing.
-if grep -q "docs/doc-map.yaml" "$report"; then
-  pass "doc-drift fallback references docs/doc-map.yaml"
-else
-  fail "doc-drift fallback references docs/doc-map.yaml" "report: $(cat "$report")"
-fi
+T_doc_drift_agent_failure() {
+  local out report
+  export GH_STUB_PR=42 AGENT_STUB_FAIL=1
+  out=$(echo '{"tool_input":{"command":"gh pr create --title x"}}' | bash agent/hooks/doc-drift.sh 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:2" ]] || { echo "expected EXIT:2, got: $out"; return 1; }
+  report=$(find .agent-reviews -maxdepth 1 -name 'doc-drift-*.md' 2>/dev/null | head -1)
+  [[ -n "$report" ]] || { echo "report missing"; return 1; }
+  grep -q "FAILED" "$report" || { echo "report should say FAILED"; return 1; }
+  grep -q "exit code" "$report" || { echo "report should include exit code"; return 1; }
+  grep -q "simulated headless agent auth failure" "$report" || { echo "report should include stderr tail"; return 1; }
+}
+it "doc-drift: headless agent failure → verbose FAILED report (exit code + stderr captured)" T_doc_drift_agent_failure
 
-# 4b. headless agent failure → verbose FAILED report with exit code, prompt, stderr tail.
-reset_sandbox
-export GH_STUB_PR=42 AGENT_STUB_FAIL=1
-unset DOC_DRIFT_DRY_RUN
-out=$(echo '{"tool_input":{"command":"gh pr create --title x"}}' | bash agent/hooks/doc-drift.sh 2>&1; echo "EXIT:$?")
-report=$(find .agent-reviews -maxdepth 1 -name 'doc-drift-*.md' 2>/dev/null | head -1)
-if [[ "$out" == *"EXIT:2"* ]] && [[ -n "$report" ]] \
-   && grep -q "FAILED" "$report" \
-   && grep -q "exit code" "$report" \
-   && grep -q "simulated headless agent auth failure" "$report"; then
-  pass "headless agent failure → verbose FAILED report (exit code + stderr captured)"
-else
-  fail "headless agent failure → verbose FAILED report" "out=$out report=$(cat "$report" 2>/dev/null)"
-fi
-unset AGENT_STUB_FAIL
-export DOC_DRIFT_DRY_RUN=1
-
-# -----------------------------------------------------------------------------
+# ===========================================================================
 # pr-review-resolver.sh
-# -----------------------------------------------------------------------------
-echo "== pr-review-resolver.sh =="
-unset DOC_DRIFT_DRY_RUN
-export RESOLVER_SLEEP_SECS=1 RESOLVER_DRY_RUN=1
+# ===========================================================================
 
-# 5. Non-matching command → exit 0.
-reset_sandbox
-out=$(echo '{"tool_input":{"command":"git commit -m x"}}' | bash agent/hooks/pr-review-resolver.sh 2>&1; echo "EXIT:$?")
-if [[ "$out" == *"EXIT:0"* ]] && [[ ! -d .agent-reviews ]]; then
-  pass "non-matching command exits 0 silently"
-else
-  fail "non-matching command exits 0 silently" "$out"
-fi
+T_resolver_no_match() {
+  local out
+  export RESOLVER_SLEEP_SECS=1 RESOLVER_DRY_RUN=1
+  out=$(echo '{"tool_input":{"command":"git commit -m x"}}' | bash agent/hooks/pr-review-resolver.sh 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ ! -d .agent-reviews ]] || { echo ".agent-reviews should not exist"; return 1; }
+}
+it "pr-review-resolver: non-matching command exits 0 silently" T_resolver_no_match
 
-# 5b. Commit message containing 'git push' substring → no match.
-reset_sandbox
-out=$(echo '{"tool_input":{"command":"git commit -m \"fix git push bug\""}}' | bash agent/hooks/pr-review-resolver.sh 2>&1; echo "EXIT:$?")
-if [[ "$out" == *"EXIT:0"* ]] && [[ ! -d .agent-reviews ]]; then
-  pass "quoted 'git push' substring inside commit message does NOT trigger"
-else
-  fail "quoted substring should not trigger resolver" "$out"
-fi
+T_resolver_quoted_substring() {
+  local out
+  export RESOLVER_SLEEP_SECS=1 RESOLVER_DRY_RUN=1
+  out=$(echo '{"tool_input":{"command":"git commit -m \"fix git push bug\""}}' | bash agent/hooks/pr-review-resolver.sh 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ ! -d .agent-reviews ]] || { echo ".agent-reviews should not exist"; return 1; }
+}
+it "pr-review-resolver: quoted 'git push' substring inside commit message does NOT trigger" T_resolver_quoted_substring
 
-# 6. Push while on main → exit 0 before the sleep.
-reset_sandbox
-git checkout -q -b main 2>/dev/null || git checkout -q main
-start=$(date +%s)
-out=$(echo '{"tool_input":{"command":"git push origin main"}}' | bash agent/hooks/pr-review-resolver.sh 2>&1; echo "EXIT:$?")
-elapsed=$(($(date +%s) - start))
-if [[ "$out" == *"EXIT:0"* ]] && [[ "$elapsed" -lt 2 ]] && [[ ! -d .agent-reviews ]]; then
-  pass "git push on main → exits 0 before sleeping"
-else
-  fail "git push on main" "exit=$out elapsed=${elapsed}s"
-fi
+T_resolver_main_branch() {
+  local out start elapsed
+  export RESOLVER_SLEEP_SECS=5 RESOLVER_DRY_RUN=1
+  git checkout -q -b main 2>/dev/null || git checkout -q main
+  start=$(date +%s)
+  out=$(echo '{"tool_input":{"command":"git push origin main"}}' | bash agent/hooks/pr-review-resolver.sh 2>&1; echo "EXIT:$?")
+  elapsed=$(($(date +%s) - start))
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ "$elapsed" -lt 2 ]] || { echo "main-branch push should not have slept (elapsed=${elapsed}s)"; return 1; }
+  [[ ! -d .agent-reviews ]] || { echo ".agent-reviews should not exist"; return 1; }
+}
+it "pr-review-resolver: git push on main → exits 0 before sleeping" T_resolver_main_branch
 
-# 7. Push on feature branch with no PR → exits 0 after sleep, no report.
-git checkout -q -b feature-x
-reset_sandbox
-unset GH_STUB_PR
-out=$(echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh 2>&1; echo "EXIT:$?")
-if [[ "$out" == *"EXIT:0"* ]] && ! compgen -G ".agent-reviews/pr-review-resolver-*.md" >/dev/null; then
-  pass "feature branch push with no PR → exits 0, no report"
-else
-  fail "feature branch push with no PR" "$out"
-fi
+T_resolver_no_pr() {
+  local out
+  export RESOLVER_SLEEP_SECS=1 RESOLVER_DRY_RUN=1
+  unset GH_STUB_PR
+  git checkout -q -b feature-x 2>/dev/null || git checkout -q feature-x
+  out=$(echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  if compgen -G ".agent-reviews/pr-review-resolver-*.md" >/dev/null; then
+    echo "no report should exist"
+    return 1
+  fi
+}
+it "pr-review-resolver: feature branch push with no PR → exits 0, no report" T_resolver_no_pr
 
-# 8. Push on feature branch with PR → exit 2, report written.
-reset_sandbox
-export GH_STUB_PR=99
-stderr_file="$TEST_DIR/stderr.txt"
-out=$(echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh 2>"$stderr_file"; echo "EXIT:$?")
-report=$(find .agent-reviews -maxdepth 1 -name 'pr-review-resolver-*.md' 2>/dev/null | head -1)
-if [[ "$out" == *"EXIT:2"* ]] && [[ -n "$report" ]] && grep -q "PR #99" "$stderr_file"; then
-  pass "feature branch push with PR → exit 2, report written"
-else
-  fail "feature branch push with PR" "exit=$out report=$report"
-fi
+T_resolver_with_pr() {
+  local out stderr_file report
+  export RESOLVER_SLEEP_SECS=1 RESOLVER_DRY_RUN=1 GH_STUB_PR=99
+  git checkout -q -b feature-x 2>/dev/null || git checkout -q feature-x
+  stderr_file="$TEST_DIR/stderr.txt"
+  out=$(echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:2" ]] || { echo "expected EXIT:2, got: $out"; return 1; }
+  report=$(find .agent-reviews -maxdepth 1 -name 'pr-review-resolver-*.md' 2>/dev/null | head -1)
+  [[ -n "$report" ]] || { echo "report missing"; return 1; }
+  grep -q "PR #99" "$stderr_file" || { echo "stderr should mention PR #99"; return 1; }
+  grep -q "gh api repos" "$report" || { echo "fallback report should mention gh api repos"; return 1; }
+}
+it "pr-review-resolver: feature branch push with PR → exit 2, report written, fallback prompt content" T_resolver_with_pr
 
-# 9. Fallback prompt content.
-if grep -q "gh api repos" "$report"; then
-  pass "resolver fallback references gh api repos"
-else
-  fail "resolver fallback references gh api repos" "report: $(cat "$report")"
-fi
+T_resolver_lockfile_dedupe() {
+  local bg_pid bg_exit
+  export RESOLVER_SLEEP_SECS=3 RESOLVER_DRY_RUN=1 GH_STUB_PR=99
+  git checkout -q -b feature-x 2>/dev/null || git checkout -q feature-x
+  ( echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh >/dev/null 2>&1; echo $? > "$TEST_DIR/bg_exit" ) &
+  bg_pid=$!
+  sleep 1
+  mkdir -p .agent-reviews
+  echo "intruder-token" > .agent-reviews/.resolver-feature-x.lock
+  wait "$bg_pid"
+  bg_exit=$(cat "$TEST_DIR/bg_exit")
+  [[ "$bg_exit" == "0" ]] || { echo "superseded run should exit 0, got $bg_exit"; return 1; }
+  if compgen -G ".agent-reviews/pr-review-resolver-*.md" >/dev/null; then
+    echo "superseded run should not write a report"
+    return 1
+  fi
+}
+it "pr-review-resolver: lockfile dedupe — superseded run exits 0 with no report" T_resolver_lockfile_dedupe
 
-# 10. Lockfile dedupe: a newer run overwrites the lock, older run exits silently.
-reset_sandbox
-export GH_STUB_PR=99 RESOLVER_SLEEP_SECS=3
-# Launch first hook in background; overwrite its lock mid-sleep; observe no report.
-( echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh >/dev/null 2>&1; echo $? > "$TEST_DIR/bg_exit" ) &
-bg_pid=$!
-sleep 1
-# Overwrite the lock with a different token.
-mkdir -p .agent-reviews
-echo "intruder-token" > .agent-reviews/.resolver-feature-x.lock
-wait "$bg_pid"
-bg_exit=$(cat "$TEST_DIR/bg_exit")
-if [[ "$bg_exit" == "0" ]] && ! compgen -G ".agent-reviews/pr-review-resolver-*.md" >/dev/null; then
-  pass "lockfile dedupe: superseded run exits 0 with no report"
-else
-  report_glob=$(compgen -G ".agent-reviews/pr-review-resolver-*.md" 2>/dev/null || true)
-  fail "lockfile dedupe" "bg_exit=$bg_exit, report=$report_glob"
-fi
+T_resolver_invalid_sleep_secs() {
+  local out
+  export RESOLVER_SLEEP_SECS=abc RESOLVER_DRY_RUN=1 GH_STUB_PR=99
+  git checkout -q -b feature-x 2>/dev/null || git checkout -q feature-x
+  # An invalid RESOLVER_SLEEP_SECS used to abort at `sleep` under set -e.
+  # The hook must fall back to the default; we keep a tiny override via
+  # the existence of GH_STUB_PR to avoid waiting the full 360s — instead
+  # we only assert that the hook starts and gets past the validation.
+  # Run with a 4s timeout; if it took >4s the validation didn't engage.
+  timeout 4 bash -c 'echo "{\"tool_input\":{\"command\":\"git push\"}}" | bash agent/hooks/pr-review-resolver.sh' >/dev/null 2>"$TEST_DIR/stderr.txt" &
+  local hook_pid=$!
+  sleep 2
+  # The hook should still be running (sleeping its 360s default) after 2s
+  # but NOT exited from a `sleep abc` set -e abort.
+  if kill -0 "$hook_pid" 2>/dev/null; then
+    kill "$hook_pid" 2>/dev/null || true
+    wait "$hook_pid" 2>/dev/null || true
+    # Check the log captured the validation message.
+    grep -q "invalid RESOLVER_SLEEP_SECS=abc" .agent-reviews/.hook.log 2>/dev/null || {
+      echo "expected validation log; .hook.log: $(cat .agent-reviews/.hook.log 2>/dev/null || echo missing)"
+      return 1
+    }
+  else
+    wait "$hook_pid" 2>/dev/null || true
+    echo "hook exited early — RESOLVER_SLEEP_SECS=abc validation did not engage"; return 1
+  fi
+}
+it "pr-review-resolver: invalid RESOLVER_SLEEP_SECS falls back to default (not set -e abort)" T_resolver_invalid_sleep_secs
 
-# -----------------------------------------------------------------------------
+# ===========================================================================
 # pre-pr-review-gate.sh
-# -----------------------------------------------------------------------------
-echo "== pre-pr-review-gate.sh =="
-unset RESOLVER_SLEEP_SECS RESOLVER_DRY_RUN GH_STUB_PR DOC_DRIFT_DRY_RUN AGENT_STUB_FAIL
+# ===========================================================================
 
-# 11. REGRESSION: a non-`gh pr create` command must fall through with exit 0.
-#     The original inline hook used only the handler-level `if` guard, which
-#     was silently not applied, so the gate fired on every Bash command and
-#     blocked anything lacking REVIEW_FULL_DONE=1. This test would have caught
-#     that: feeding a plain `git rev-parse HEAD` must not be blocked.
-reset_sandbox
-out=$(echo '{"tool_input":{"command":"git rev-parse HEAD"}}' | bash agent/hooks/pre-pr-review-gate.sh 2>&1; echo "EXIT:$?")
-if [[ "$out" == *"EXIT:0"* ]] && [[ "$out" != *"BLOCKED"* ]]; then
-  pass "non-gh-pr-create command falls through with exit 0 (no BLOCKED message)"
-else
-  fail "non-gh-pr-create command falls through" "$out"
-fi
+T_gate_non_pr_create_falls_through() {
+  local out
+  out=$(echo '{"tool_input":{"command":"git rev-parse HEAD"}}' | bash agent/hooks/pre-pr-review-gate.sh 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ "$out" != *"BLOCKED"* ]] || { echo "should not have BLOCKED a non-gh-pr-create command"; return 1; }
+}
+it "pre-pr-review-gate: non-gh-pr-create command falls through with exit 0" T_gate_non_pr_create_falls_through
 
-# 12. REGRESSION: a `gh pr create` substring inside an echo string must NOT
-#     trigger the gate. Same word-boundary protection as doc-drift / resolver.
-reset_sandbox
-out=$(echo '{"tool_input":{"command":"echo testing the gh pr create matcher"}}' | bash agent/hooks/pre-pr-review-gate.sh 2>&1; echo "EXIT:$?")
-if [[ "$out" == *"EXIT:0"* ]] && [[ "$out" != *"BLOCKED"* ]]; then
-  pass "quoted 'gh pr create' substring inside echo does NOT trigger the gate"
-else
-  fail "quoted substring should not trigger gate" "$out"
-fi
+T_gate_quoted_substring() {
+  local out
+  out=$(echo '{"tool_input":{"command":"echo testing the gh pr create matcher"}}' | bash agent/hooks/pre-pr-review-gate.sh 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ "$out" != *"BLOCKED"* ]] || { echo "quoted substring should not trigger gate"; return 1; }
+}
+it "pre-pr-review-gate: quoted 'gh pr create' substring inside echo does NOT trigger the gate" T_gate_quoted_substring
 
-# 13. gh pr create WITHOUT the token → exit 2 with BLOCKED on stderr.
-reset_sandbox
-stderr_file="$TEST_DIR/gate_stderr.txt"
-out=$(echo '{"tool_input":{"command":"gh pr create --title x --body y"}}' | bash agent/hooks/pre-pr-review-gate.sh 2>"$stderr_file"; echo "EXIT:$?")
-if [[ "$out" == *"EXIT:2"* ]] && grep -q "BLOCKED" "$stderr_file" && grep -q "REVIEW_FULL_DONE=1" "$stderr_file"; then
-  pass "gh pr create without token → exit 2 with BLOCKED + token name on stderr"
-else
-  fail "gh pr create without token" "exit=$out stderr=$(cat "$stderr_file")"
-fi
+T_gate_no_token_blocks() {
+  local out stderr_file
+  stderr_file="$TEST_DIR/gate_stderr.txt"
+  out=$(echo '{"tool_input":{"command":"gh pr create --title x --body y"}}' | bash agent/hooks/pre-pr-review-gate.sh 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:2" ]] || { echo "expected EXIT:2, got: $out"; return 1; }
+  grep -q "BLOCKED" "$stderr_file" || { echo "stderr should contain BLOCKED"; return 1; }
+  grep -q "REVIEW_FULL_DONE=1" "$stderr_file" || { echo "stderr should reference the token name"; return 1; }
+}
+it "pre-pr-review-gate: gh pr create without token → exit 2 with BLOCKED + token name on stderr" T_gate_no_token_blocks
 
-# 14. gh pr create WITH the token (trailing comment form) → exit 0.
-reset_sandbox
-out=$(echo '{"tool_input":{"command":"gh pr create --title x --body y  # REVIEW_FULL_DONE=1"}}' | bash agent/hooks/pre-pr-review-gate.sh 2>&1; echo "EXIT:$?")
-if [[ "$out" == *"EXIT:0"* ]] && [[ "$out" != *"BLOCKED"* ]]; then
-  pass "gh pr create with REVIEW_FULL_DONE=1 trailing comment → exit 0"
-else
-  fail "gh pr create with token" "$out"
-fi
+T_gate_with_token_passes() {
+  local out
+  out=$(echo '{"tool_input":{"command":"gh pr create --title x --body y  # REVIEW_FULL_DONE=1"}}' | bash agent/hooks/pre-pr-review-gate.sh 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ "$out" != *"BLOCKED"* ]] || { echo "should not have BLOCKED"; return 1; }
+}
+it "pre-pr-review-gate: gh pr create with REVIEW_FULL_DONE=1 trailing comment → exit 0" T_gate_with_token_passes
 
-# 15. REGRESSION: leading whitespace before `gh pr create` must still gate.
-#     The original `^` anchor required no whitespace, so an indented
-#     `  gh pr create ...` would fall through with exit 0 — a fail-open.
-reset_sandbox
-stderr_file="$TEST_DIR/gate_stderr.txt"
-out=$(echo '{"tool_input":{"command":"  gh pr create --title x --body y"}}' | bash agent/hooks/pre-pr-review-gate.sh 2>"$stderr_file"; echo "EXIT:$?")
-if [[ "$out" == *"EXIT:2"* ]] && grep -q "BLOCKED" "$stderr_file"; then
-  pass "leading-whitespace gh pr create without token → still blocked"
-else
-  fail "leading-whitespace gh pr create without token" "exit=$out stderr=$(cat "$stderr_file")"
-fi
+T_gate_leading_whitespace_still_blocks() {
+  local out stderr_file
+  stderr_file="$TEST_DIR/gate_stderr.txt"
+  out=$(echo '{"tool_input":{"command":"  gh pr create --title x --body y"}}' | bash agent/hooks/pre-pr-review-gate.sh 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:2" ]] || { echo "expected EXIT:2, got: $out"; return 1; }
+  grep -q "BLOCKED" "$stderr_file" || { echo "leading-whitespace path should still BLOCK"; return 1; }
+}
+it "pre-pr-review-gate: leading-whitespace gh pr create without token → still blocked" T_gate_leading_whitespace_still_blocks
 
-# -----------------------------------------------------------------------------
-# Summary
-# -----------------------------------------------------------------------------
-echo
-echo "== Summary =="
-echo "PASS: $PASS"
-echo "FAIL: $FAIL"
-[[ "$FAIL" -eq 0 ]]
+# ===========================================================================
+# edit-write.sh — credential-protect + Unknown mode dispatch
+# ===========================================================================
+
+T_edit_write_credential_blocks_env() {
+  local stderr_file rc
+  stderr_file="$TEST_DIR/ew_stderr.txt"
+  set +e
+  echo '{"tool_input":{"file_path":".env.local"}}' \
+    | bash agent/hooks/edit-write.sh credential-protect 2>"$stderr_file"
+  rc=$?
+  set -e
+  [[ "$rc" == "1" ]] || { echo "expected exit 1, got $rc"; return 1; }
+  grep -q "BLOCKED" "$stderr_file" || { echo "stderr should contain BLOCKED"; return 1; }
+}
+it "edit-write: credential-protect blocks .env.local with exit 1 + BLOCKED stderr" T_edit_write_credential_blocks_env
+
+T_edit_write_credential_allows_py() {
+  local rc
+  set +e
+  echo '{"tool_input":{"file_path":"src/foo.py"}}' \
+    | bash agent/hooks/edit-write.sh credential-protect >/dev/null 2>&1
+  rc=$?
+  set -e
+  [[ "$rc" == "0" ]] || { echo "expected exit 0 for src/foo.py, got $rc"; return 1; }
+}
+it "edit-write: credential-protect allows non-secret paths" T_edit_write_credential_allows_py
+
+T_edit_write_unknown_mode_exits_2() {
+  local stderr_file rc
+  stderr_file="$TEST_DIR/ew_stderr.txt"
+  set +e
+  echo '{}' | bash agent/hooks/edit-write.sh bogus-mode 2>"$stderr_file"
+  rc=$?
+  set -e
+  [[ "$rc" == "2" ]] || { echo "expected exit 2 for unknown mode, got $rc"; return 1; }
+  grep -q "Unknown" "$stderr_file" || { echo "stderr should mention Unknown mode"; return 1; }
+}
+it "edit-write: unknown mode → exit 2 with 'Unknown' on stderr" T_edit_write_unknown_mode_exits_2
+
+T_edit_write_format_non_fatal_on_missing_tool() {
+  local rc
+  # Add a no-op pytest/ruff to the stubs so neither is missing; the assertion
+  # is that the hook exits 0 either way, not that any tool ran.
+  set +e
+  echo '{"tool_input":{"file_path":"src/foo.py"}}' \
+    | bash agent/hooks/edit-write.sh format >/dev/null 2>&1
+  rc=$?
+  set -e
+  [[ "$rc" == "0" ]] || { echo "format mode should exit 0, got $rc"; return 1; }
+}
+it "edit-write: format mode exits 0 (best-effort under set -e)" T_edit_write_format_non_fatal_on_missing_tool
+
+T_edit_write_test_mode_finds_mirrored_layout() {
+  # Sandbox: create both layouts and confirm the script picks the mirrored
+  # one for a src/<pkg>/sub/file.py edit. Use a per-test scratch dir so test
+  # state doesn't leak between cases.
+  local scratch
+  scratch=$(mktemp -d "$TEST_DIR/scratch-XXXX")
+  mkdir -p "$scratch/src/synth_setter/pipeline/data" "$scratch/tests/pipeline/data"
+  : > "$scratch/src/synth_setter/pipeline/data/stats.py"
+  : > "$scratch/tests/pipeline/data/test_stats.py"
+  # Stub pytest so the hook can `Running ...` then run something fast.
+  cat > "$scratch/pytest" <<'PYEOF'
+#!/usr/bin/env bash
+exit 0
+PYEOF
+  chmod +x "$scratch/pytest"
+  local out
+  out=$(cd "$scratch" && echo '{"tool_input":{"file_path":"src/synth_setter/pipeline/data/stats.py"}}' \
+    | env PATH="$scratch:$PATH" bash "$REPO_ROOT/agent/hooks/edit-write.sh" test 2>&1)
+  rm -rf "$scratch"
+  [[ "$out" == *"Running tests/pipeline/data/test_stats.py"* ]] || {
+    echo "expected mirrored-layout test, got: $out"
+    return 1
+  }
+}
+it "edit-write: test mode finds mirrored layout tests/<pkg>/test_<base>.py first" T_edit_write_test_mode_finds_mirrored_layout
+
+T_edit_write_test_mode_falls_back_to_flat_layout() {
+  local scratch
+  scratch=$(mktemp -d "$TEST_DIR/scratch-XXXX")
+  mkdir -p "$scratch/src/synth_setter" "$scratch/tests"
+  : > "$scratch/src/synth_setter/foo.py"
+  : > "$scratch/tests/test_foo.py"
+  cat > "$scratch/pytest" <<'PYEOF'
+#!/usr/bin/env bash
+exit 0
+PYEOF
+  chmod +x "$scratch/pytest"
+  local out
+  out=$(cd "$scratch" && echo '{"tool_input":{"file_path":"src/synth_setter/foo.py"}}' \
+    | env PATH="$scratch:$PATH" bash "$REPO_ROOT/agent/hooks/edit-write.sh" test 2>&1)
+  rm -rf "$scratch"
+  [[ "$out" == *"Running tests/test_foo.py"* ]] || {
+    echo "expected flat-layout fallback, got: $out"
+    return 1
+  }
+}
+it "edit-write: test mode falls back to flat layout tests/test_<base>.py when mirror missing" T_edit_write_test_mode_falls_back_to_flat_layout
+
+# ===========================================================================
+# verify-gh-taxonomy.sh — smoke tests for early-exit paths
+# (mode_pr / mode_issue / mode_hierarchy require full gh-API stubbing; those
+# go in a follow-up.)
+# ===========================================================================
+
+T_taxonomy_non_matching_command_exits_silently() {
+  local out
+  out=$(echo '{"tool_input":{"command":"echo hello"},"tool_response":""}' \
+    | bash agent/hooks/verify-gh-taxonomy.sh 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  # Should not emit JSON on stdout for a no-op.
+  local without_exit
+  without_exit="${out%EXIT:*}"
+  [[ -z "${without_exit//[[:space:]]/}" ]] || { echo "expected silent stdout, got: $without_exit"; return 1; }
+}
+it "verify-gh-taxonomy: non-matching command exits 0 silently with no JSON output" T_taxonomy_non_matching_command_exits_silently
+
+T_taxonomy_non_synth_setter_url_exits_silently() {
+  local out
+  out=$(echo '{"tool_input":{"command":"gh pr create --title x"},"tool_response":"https://github.com/other-owner/other-repo/pull/42"}' \
+    | bash agent/hooks/verify-gh-taxonomy.sh 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  local without_exit
+  without_exit="${out%EXIT:*}"
+  [[ -z "${without_exit//[[:space:]]/}" ]] || { echo "expected silent stdout for non-synth-setter PR, got: $without_exit"; return 1; }
+}
+it "verify-gh-taxonomy: gh pr create against non-synth-setter URL exits 0 silently" T_taxonomy_non_synth_setter_url_exits_silently
+
+T_taxonomy_pr_no_url_exits_silently() {
+  local out
+  out=$(echo '{"tool_input":{"command":"gh pr create --title x"},"tool_response":"no URL here"}' \
+    | bash agent/hooks/verify-gh-taxonomy.sh 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+}
+it "verify-gh-taxonomy: gh pr create with no URL in response exits 0 silently" T_taxonomy_pr_no_url_exits_silently
+
+T_taxonomy_hierarchy_non_synth_setter_exits_silently() {
+  local out
+  out=$(echo '{"tool_input":{"command":"mutation { addSubIssue(input: {issueId: \"I_kwABC\", subIssueId: \"I_kwXYZ\"}) { issue { number } } }"},"tool_response":""}' \
+    | bash agent/hooks/verify-gh-taxonomy.sh 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0 (no synth-setter in command), got: $out"; return 1; }
+}
+it "verify-gh-taxonomy: addSubIssue not targeting synth-setter exits 0 silently" T_taxonomy_hierarchy_non_synth_setter_exits_silently
+
+# ===========================================================================
+# Run
+# ===========================================================================
+run_tests

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -176,8 +176,17 @@ T_doc_drift_agent_failure() {
   report=$(find .agent-reviews -maxdepth 1 -name 'doc-drift-*.md' 2>/dev/null | head -1)
   [[ -n "$report" ]] || { echo "report missing"; return 1; }
   grep -q "FAILED" "$report" || { echo "report should say FAILED"; return 1; }
-  grep -q "exit code" "$report" || { echo "report should include exit code"; return 1; }
   grep -q "simulated headless agent auth failure" "$report" || { echo "report should include stderr tail"; return 1; }
+  # Regression: the captured exit code MUST be the stub's real exit (3), not 0.
+  # An earlier refactor of run_review used `$?` outside an else branch, which
+  # bash resets to 0 after a falsy `if; then; fi`, silently corrupting the
+  # failure report. Catch any regression by asserting the exact exit code.
+  grep -qE '^## headless agent exit code$' "$report" || { echo "report missing exit-code header"; return 1; }
+  awk '/^## headless agent exit code$/{getline; print; exit}' "$report" | grep -qE '^3$' || {
+    echo "expected captured exit code 3 in report, got:"
+    awk '/^## headless agent exit code$/{getline; print; exit}' "$report"
+    return 1
+  }
 }
 it "doc-drift: headless agent failure → verbose FAILED report (exit code + stderr captured)" T_doc_drift_agent_failure
 
@@ -484,6 +493,25 @@ T_taxonomy_hierarchy_non_synth_setter_exits_silently() {
   [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0 (no synth-setter in command), got: $out"; return 1; }
 }
 it "verify-gh-taxonomy: addSubIssue not targeting synth-setter exits 0 silently" T_taxonomy_hierarchy_non_synth_setter_exits_silently
+
+T_taxonomy_check_ci_minimum_joins_with_comma_space() {
+  # Unit test for the comma-space join in check_ci_minimum + check_project_fields.
+  # Regression for the IFS/`${arr[*]}` quirk Copilot caught on PR #1119: setting
+  # `IFS=', '` and expanding `"${arr[*]}"` joins on only the FIRST char of IFS
+  # (the comma), producing `issue-type,domain-label` without the space.
+  local script_src result
+  script_src=$(awk '/^check_ci_minimum\(\) {/,/^}$/' "$REPO_ROOT/agent/hooks/verify-gh-taxonomy.sh")
+  result=$(bash -c "$script_src; check_ci_minimum '' 'false' ''")
+  [[ "$result" == "issue-type, domain-label, milestone" ]] || {
+    echo "expected 'issue-type, domain-label, milestone', got: '$result'"
+    return 1
+  }
+  result=$(bash -c "$script_src; check_ci_minimum 'Task' 'true' 'v1.0'")
+  [[ -z "$result" ]] || { echo "expected empty for fully-populated, got: '$result'"; return 1; }
+  result=$(bash -c "$script_src; check_ci_minimum 'Task' 'false' 'v1.0'")
+  [[ "$result" == "domain-label" ]] || { echo "expected 'domain-label', got: '$result'"; return 1; }
+}
+it "verify-gh-taxonomy: check_ci_minimum joins missing fields with ', ' (comma+space)" T_taxonomy_check_ci_minimum_joins_with_comma_space
 
 # ===========================================================================
 # Run

--- a/agent/hooks/verify-gh-taxonomy.sh
+++ b/agent/hooks/verify-gh-taxonomy.sh
@@ -69,17 +69,20 @@ query_issue_metadata() {
 
 check_ci_minimum() {
   # Usage: check_ci_minimum <type> <has_domain> <milestone>
-  # Echoes a comma-separated list of missing fields (e.g. "issue-type, milestone"),
-  # or empty string if all three are set. Callers interpolate directly into
-  # user-facing error strings.
+  # Echoes a comma-and-space-separated list of missing fields (e.g.
+  # "issue-type, milestone"), or empty string if all three are set. Callers
+  # interpolate directly into user-facing error strings.
   local type="$1" has_domain="$2" milestone="$3"
-  local missing=()
+  local missing=() joined
   [[ -z "$type" ]] && missing+=("issue-type")
   [[ "$has_domain" == "false" ]] && missing+=("domain-label")
   [[ -z "$milestone" ]] && missing+=("milestone")
   if [[ "${#missing[@]}" -gt 0 ]]; then
-    local IFS=', '
-    echo "${missing[*]}"
+    # `printf -v + strip trailing sep` — `IFS=', '` with `"${arr[*]}"` would
+    # join on only the FIRST char of IFS (a bash quirk; see Copilot review on
+    # PR #1119), producing `issue-type,domain-label` without the space.
+    printf -v joined '%s, ' "${missing[@]}"
+    echo "${joined%, }"
   fi
 }
 
@@ -138,8 +141,10 @@ check_project_fields() {
     fi
   fi
   if [[ "${#missing[@]}" -gt 0 ]]; then
-    local IFS=', '
-    echo "${missing[*]}"
+    # See check_ci_minimum for the IFS-vs-printf-v rationale.
+    local joined
+    printf -v joined '%s, ' "${missing[@]}"
+    echo "${joined%, }"
   fi
 }
 

--- a/agent/hooks/verify-gh-taxonomy.sh
+++ b/agent/hooks/verify-gh-taxonomy.sh
@@ -1,148 +1,47 @@
 #!/usr/bin/env bash
-# =============================================================================
-# verify-gh-taxonomy.sh — agent PostToolUse hook
-# =============================================================================
+# verify-gh-taxonomy.sh — agent PostToolUse Bash hook.
 #
-# PURPOSE
-# -------
-# Enforces the project's GitHub taxonomy conventions (defined in
-# docs/design/github-taxonomy.md) every time an agent creates an issue, a PR,
-# or modifies issue hierarchy. Without this hook, the github-taxonomy skill
-# can silently skip steps (project board, priority, hierarchy) even though
-# the skill text requires them.
-#
-# HOW IT WORKS
-# ------------
-# This script is registered as a PostToolUse hook on the Bash tool in
-# Claude settings or another agent hook runner:
-#
-#   {
-#     "hooks": {
-#       "PostToolUse": [{
-#         "matcher": "Bash",
-#         "hooks": [{
-#           "type": "command",
-#           "command": "bash agent/hooks/verify-gh-taxonomy.sh",
-#           "timeout": 30
-#         }]
-#       }]
-#     }
-#   }
-#
-# After every Bash tool call, agent pipes a JSON payload to this
-# script's stdin containing:
-#   - tool_input.command: the shell command that was executed
-#   - tool_response: the stdout/stderr from that command
-#
-# The script pattern-matches the command to detect three triggers:
-#   1. `gh issue create`  → MODE=issue
-#   2. `gh pr create`     → MODE=pr
-#   3. `addSubIssue`      → MODE=hierarchy
-#
-# For any other command, the script exits 0 immediately (no-op).
-#
-# RESPONSE FORMAT
-# ---------------
-# The script communicates back to the agent via JSON on stdout:
-#
-#   BLOCK (hard stop — the agent must fix before continuing):
-#     {"decision":"block","reason":"..."}
-#
-#   WARN (advisory — the agent sees the message and should act on it):
-#     {"hookSpecificOutput":{"hookEventName":"PostToolUse",
-#       "additionalContext":"WARNING: ..."}}
-#
-#   PASS (informational — confirms compliance):
-#     {"hookSpecificOutput":{"hookEventName":"PostToolUse",
-#       "additionalContext":"Taxonomy check passed: ..."}}
-#
-# WHAT EACH MODE CHECKS
-# ---------------------
-#
-# MODE=issue (after `gh issue create`):
-#   Checks the newly created issue for the "CI minimum three":
-#     - Issue type (Bug, Task, Feature, Phase, Epic)
-#     - Domain label (data-pipeline, ci-automation, etc.)
-#     - Milestone
-#   Result: BLOCK if missing. Also BLOCKs with a reminder to add the issue
-#   to the sub-issue hierarchy, project board, and set priority — ensuring
-#   these steps are never skipped.
-#
-# MODE=pr (after `gh pr create`):
-#   1. Checks the PR body for issue references (Fixes/Closes/Refs #N).
-#      Result: BLOCK if no linked issue — the pr-metadata-gate CI will fail.
-#   2. For each linked issue, checks the "CI minimum three" (type, label, milestone).
-#      Result: BLOCK if any are missing.
-#   3. For each linked issue, checks epic lineage (walks parent chain for Epic).
-#      Result: BLOCK if no Epic ancestor — the pr-metadata-gate will fail.
-#   4. For each linked issue, checks project board membership and priority.
-#      Result: WARN if missing — these don't fail CI but are required by the
-#      taxonomy lifecycle.
-#
-# MODE=hierarchy (after `addSubIssue` GraphQL mutation):
-#   Validates that Tasks/Bugs/Features are attached to Phases, not directly
-#   to Epics. The taxonomy requires: Epic → Phase → Task/Bug/Feature.
-#   Result: BLOCK if a leaf issue is attached directly to an Epic.
-#
-# =============================================================================
+# Enforces docs/design/github-taxonomy.md on `gh issue create`, `gh pr create`,
+# and `addSubIssue` GraphQL mutations. Emits Claude hook JSON on stdout:
+# {"decision":"block",...} or {"hookSpecificOutput":{...}}. Per-mode rules
+# live below in the mode_* functions.
 set -euo pipefail
 
-INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
-
 # ---------------------------------------------------------------------------
-# Route: match the command to a mode, or exit early for unrelated commands.
-# ---------------------------------------------------------------------------
-case "$COMMAND" in
-  *"gh pr create"*) MODE="pr" ;;
-  *"gh issue create"*) MODE="issue" ;;
-  *"addSubIssue"*) MODE="hierarchy" ;;
-  *) exit 0 ;;
-esac
-
-TOOL_RESPONSE=$(echo "$INPUT" | jq -r '.tool_response // empty')
-
-# ---------------------------------------------------------------------------
-# Scope: only run for commands that targeted synth-setter.
-# The hook lives in the synth-setter project, but commands may target other
-# repos (e.g. `gh pr create` run from a skills repo clone). We extract the
-# actual GitHub URL from the response and check its repo path. We can't just
-# grep the whole response for "synth-setter" because Bash tool output always
-# includes "Shell cwd was reset to .../synth-setter" when cwd changes.
-# For addSubIssue mutations, check the GraphQL query in the command string.
-# ---------------------------------------------------------------------------
-if [[ "$MODE" == "hierarchy" ]]; then
-  if ! echo "$COMMAND" | grep -qE 'owner.*synth-setter|repo.*synth-setter'; then
-    exit 0
-  fi
-else
-  # Extract the GitHub URL (PR or issue) and check if it's synth-setter
-  # `grep` returns 1 if no URL is found; `head` then propagates non-zero under
-  # `set -o pipefail`, which would abort before the `-z` no-op check. `|| true`
-  # keeps the no-URL path graceful.
-  GITHUB_URL=$(echo "$TOOL_RESPONSE" | grep -oE 'https://github.com/[^/]+/[^/]+/(pull|issues)/[0-9]+' | head -1 || true)
-  if [[ -z "$GITHUB_URL" ]]; then exit 0; fi
-  if ! echo "$GITHUB_URL" | grep -q 'synth-setter'; then
-    exit 0
-  fi
-fi
-
-# ---------------------------------------------------------------------------
-# Shared constants
+# Constants
 # ---------------------------------------------------------------------------
 OWNER="tinaudio"
 REPO="synth-setter"
-DOMAIN_LABELS="data-pipeline ci-automation code-health documentation evaluation experiments monitoring storage testing training"
+DOMAIN_LABELS=(
+  data-pipeline ci-automation code-health documentation
+  evaluation experiments monitoring storage testing training
+)
 
 # ---------------------------------------------------------------------------
-# Helper: query an issue's taxonomy metadata (type, labels, milestone).
-# Usage: query_issue_metadata <issue_number>
-# Sets: ISSUE_TYPE, LABELS, MILESTONE, HAS_DOMAIN
+# JSON emitters — `jq -n --arg` quotes the payload safely so a `"`, `\`, or
+# newline in the reason/context string can't produce invalid JSON.
+# ---------------------------------------------------------------------------
+emit_block() {
+  jq -n --arg reason "$1" '{decision:"block", reason:$reason}'
+}
+
+emit_advisory() {
+  # Used for both WARN and PASS contexts — schema is identical, only the
+  # additionalContext wording differentiates them.
+  jq -n --arg ctx "$1" \
+    '{hookSpecificOutput:{hookEventName:"PostToolUse", additionalContext:$ctx}}'
+}
+
+# ---------------------------------------------------------------------------
+# Metadata queries
 # ---------------------------------------------------------------------------
 query_issue_metadata() {
-  local issue_num="$1"
-
-  local result
+  # Usage: query_issue_metadata <issue_number>
+  # Emits one tab-delimited line: <type>\t<labels>\t<milestone>\t<has_domain>.
+  # Callers consume it via `IFS=$'\t' read -r type labels milestone has_domain
+  # < <(query_issue_metadata $n)`. Tab is safe — GitHub label/title/type
+  # values can't contain tabs.
+  local issue_num="$1" result type labels milestone has_domain=false dl
   # shellcheck disable=SC2016
   result=$(gh api graphql -f query='
     query($owner: String!, $repo: String!, $number: Int!) {
@@ -155,41 +54,30 @@ query_issue_metadata() {
       }
     }
   ' -f owner="$OWNER" -f repo="$REPO" -F number="$issue_num" 2>/dev/null || echo "{}")
-
-  ISSUE_TYPE=$(echo "$result" | jq -r '.data.repository.issue.issueType.name // empty')
-  LABELS=$(echo "$result" | jq -r '[.data.repository.issue.labels.nodes[].name] | join(", ")' 2>/dev/null || echo "")
-  MILESTONE=$(echo "$result" | jq -r '.data.repository.issue.milestone.title // empty')
-
-  HAS_DOMAIN=false
-  for dl in $DOMAIN_LABELS; do
-    if echo "$LABELS" | grep -q "$dl"; then HAS_DOMAIN=true; break; fi
+  type=$(echo "$result" | jq -r '.data.repository.issue.issueType.name // empty' 2>/dev/null || echo "")
+  labels=$(echo "$result" | jq -r '[.data.repository.issue.labels.nodes[].name] | join(", ")' 2>/dev/null || echo "")
+  milestone=$(echo "$result" | jq -r '.data.repository.issue.milestone.title // empty' 2>/dev/null || echo "")
+  for dl in "${DOMAIN_LABELS[@]}"; do
+    if echo "$labels" | grep -q "$dl"; then has_domain=true; break; fi
   done
+  printf '%s\t%s\t%s\t%s\n' "$type" "$labels" "$milestone" "$has_domain"
 }
 
-# ---------------------------------------------------------------------------
-# Helper: check the "CI minimum three" — issue type, domain label, milestone.
-# Usage: check_ci_minimum <issue_number>
-# Returns: space-separated list of missing fields, or empty string if all set.
-# Requires query_issue_metadata to have been called first.
-# ---------------------------------------------------------------------------
 check_ci_minimum() {
-  local missing=""
-  [[ -z "$ISSUE_TYPE" ]] && missing="${missing} issue-type"
-  [[ "$HAS_DOMAIN" == "false" ]] && missing="${missing} domain-label"
-  [[ -z "$MILESTONE" ]] && missing="${missing} milestone"
+  # Usage: check_ci_minimum <type> <has_domain> <milestone>
+  # Returns: space-separated list of missing fields, or empty string if all set.
+  local type="$1" has_domain="$2" milestone="$3" missing=""
+  [[ -z "$type" ]] && missing="${missing} issue-type"
+  [[ "$has_domain" == "false" ]] && missing="${missing} domain-label"
+  [[ -z "$milestone" ]] && missing="${missing} milestone"
   echo "$missing"
 }
 
-# ---------------------------------------------------------------------------
-# Helper: check if an issue is on the project board and has priority set.
-# Usage: check_project_fields <issue_number>
-# Returns: space-separated list of missing fields, or empty string if all set.
-# ---------------------------------------------------------------------------
 check_project_fields() {
-  local issue_num="$1"
-
-  # Get the issue's node ID, then check project items on it.
-  local node_id
+  # Usage: check_project_fields <issue_number>
+  # Returns: space-separated list of missing fields ("project-board",
+  # "priority"), or empty string if both are set.
+  local issue_num="$1" node_id project_result on_board has_priority missing=""
   # shellcheck disable=SC2016
   node_id=$(gh api graphql -f query='
     query($owner: String!, $repo: String!, $number: Int!) {
@@ -199,15 +87,10 @@ check_project_fields() {
     }
   ' -f owner="$OWNER" -f repo="$REPO" -F number="$issue_num" \
     --jq '.data.repository.issue.id' 2>/dev/null || echo "")
-
   if [[ -z "$node_id" ]]; then
     echo " project-board priority"
     return
   fi
-
-  # Query project items on this issue. Check if any project item exists
-  # and whether it has a Priority field set.
-  local project_result
   # shellcheck disable=SC2016
   project_result=$(gh api graphql -f query='
     query($id: ID!) {
@@ -230,16 +113,10 @@ check_project_fields() {
       }
     }
   ' -f id="$node_id" 2>/dev/null || echo "{}")
-
-  local on_board
   on_board=$(echo "$project_result" | jq -r '.data.node.projectItems.nodes | length' 2>/dev/null || echo "0")
-
-  local missing=""
   if [[ "$on_board" == "0" ]]; then
     missing="${missing} project-board priority"
   else
-    # Check if Priority field is set on any project item
-    local has_priority
     has_priority=$(echo "$project_result" | jq -r '
       [.data.node.projectItems.nodes[].fieldValues.nodes[]
         | select(.field.name == "Priority")
@@ -248,23 +125,17 @@ check_project_fields() {
       missing="${missing} priority"
     fi
   fi
-
   echo "$missing"
 }
 
-
-# ---------------------------------------------------------------------------
-# Helper: walk the sub-issue parent chain to find an Epic ancestor.
-# Usage: check_epic_lineage <issue_number>
-# Returns: "ok" if the issue traces to an Epic, "no-epic" otherwise.
-# ---------------------------------------------------------------------------
 check_epic_lineage() {
+  # Usage: check_epic_lineage <issue_number>
+  # Walks the parent chain (max depth 4) looking for an Epic ancestor.
+  # Echoes "ok" if found, "no-epic" otherwise.
   local issue_num="$1"
   local current="$issue_num"
-  local depth=0
-
+  local depth=0 result type parent_num
   while [[ "$depth" -lt 4 ]]; do
-    local result
     # shellcheck disable=SC2016
     result=$(gh api graphql -f query='
       query($owner: String!, $repo: String!, $number: Int!) {
@@ -276,163 +147,177 @@ check_epic_lineage() {
         }
       }
     ' -f owner="$OWNER" -f repo="$REPO" -F number="$current" \
-      --jq '.data.repository.issue' 2>/dev/null) || {
-      echo "no-epic"
-      return
-    }
-
-    local type
-    type=$(echo "$result" | jq -r '.issueType.name // empty' 2>/dev/null) || type=""
+      --jq '.data.repository.issue' 2>/dev/null) || { echo "no-epic"; return; }
+    type=$(echo "$result" | jq -r '.issueType.name // empty' 2>/dev/null || echo "")
     if [[ "$type" == "Epic" ]]; then
       echo "ok"
       return
     fi
-
-    local parent_num
-    parent_num=$(echo "$result" | jq -r '.parent.number // empty' 2>/dev/null) || parent_num=""
+    parent_num=$(echo "$result" | jq -r '.parent.number // empty' 2>/dev/null || echo "")
     if [[ -z "$parent_num" || "$parent_num" == "null" ]]; then
       break
     fi
     current="$parent_num"
     depth=$((depth + 1))
   done
-
   echo "no-epic"
 }
 
+# ---------------------------------------------------------------------------
+# Mode handlers
+# ---------------------------------------------------------------------------
+mode_pr() {
+  # Usage: mode_pr <tool_response>
+  local tool_response="$1" pr_url pr_num pr_body issue_nums issue_num
+  local type milestone has_domain ci_missing lineage project_missing warnings=""
+  pr_url=$(echo "$tool_response" | grep -oE 'https://github.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 || true)
+  [[ -z "$pr_url" ]] && return 0
+  pr_num=$(echo "$pr_url" | grep -oE '[0-9]+$' || true)
+  # Defensive: if the trailing-number extraction failed, treat as no-op rather
+  # than calling `gh pr view ""` and racing the `|| echo ""` swallow.
+  [[ -z "$pr_num" ]] && return 0
 
-# ===========================================================================
-# MODE: pr — runs after `gh pr create`
-# ===========================================================================
-if [[ "$MODE" == "pr" ]]; then
-  # Step 1: Extract PR number from the tool response URL. `|| true` keeps the
-  # no-URL path graceful under `set -o pipefail` (see GITHUB_URL above).
-  PR_URL=$(echo "$TOOL_RESPONSE" | grep -oE 'https://github.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 || true)
-  if [[ -z "$PR_URL" ]]; then exit 0; fi
-  PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$' || true)
-
-  # Step 2: Check the PR body for issue references (Fixes/Closes/Refs #N).
-  # Without a linked issue, the pr-metadata-gate CI workflow will fail.
-  PR_BODY=$(gh pr view "$PR_NUM" --repo "${OWNER}/${REPO}" --json body --jq '.body' 2>/dev/null || echo "")
-  ISSUE_NUMS=$(echo "$PR_BODY" | grep -oE '(Fixes|Closes|Refs|fixes|closes|refs) #[0-9]+' | grep -oE '[0-9]+' | sort -un | grep -v "^${PR_NUM}$" || true)
-
-  # Fallback: check for any #N reference in the body (matches bare #N and
-  # markdown hyperlinks like [#399](url)), same as pr-metadata-gate.yaml.
-  if [[ -z "$ISSUE_NUMS" ]]; then
-    ISSUE_NUMS=$(echo "$PR_BODY" | grep -oE '#[0-9]+' | tr -d '#' | sort -un | grep -v "^${PR_NUM}$" || true)
+  # Check the PR body for issue references (Fixes/Closes/Refs #N). Without a
+  # linked issue, the pr-metadata-gate CI workflow will fail.
+  pr_body=$(gh pr view "$pr_num" --repo "${OWNER}/${REPO}" --json body --jq '.body' 2>/dev/null || echo "")
+  issue_nums=$(echo "$pr_body" | grep -oE '(Fixes|Closes|Refs|fixes|closes|refs) #[0-9]+' \
+    | grep -oE '[0-9]+' | sort -un | grep -v "^${pr_num}$" || true)
+  # Fallback: any #N reference (matches bare #N and markdown hyperlinks like
+  # [#399](url)), mirroring pr-metadata-gate.yaml.
+  if [[ -z "$issue_nums" ]]; then
+    issue_nums=$(echo "$pr_body" | grep -oE '#[0-9]+' | tr -d '#' | sort -un | grep -v "^${pr_num}$" || true)
+  fi
+  if [[ -z "$issue_nums" ]]; then
+    emit_block "PR has no linked issue reference. Acceptable patterns include Fixes #N / Closes #N / Refs #N or any bare #N reference in the PR body. The pr-metadata-gate CI check will fail."
+    return 0
   fi
 
-  if [[ -z "$ISSUE_NUMS" ]]; then
-    echo '{"decision":"block","reason":"PR has no linked issue reference. Acceptable patterns include Fixes #N / Closes #N / Refs #N or any bare #N reference in the PR body. The pr-metadata-gate CI check will fail."}'
-    exit 0
-  fi
-
-  # Step 3: For each linked issue, verify the "CI minimum three" (BLOCK if missing)
-  # and project board + priority (WARN if missing).
-  WARNINGS=""
-  for ISSUE_NUM in $ISSUE_NUMS; do
-    query_issue_metadata "$ISSUE_NUM"
-    CI_MISSING=$(check_ci_minimum)
-
-    if [[ -n "$CI_MISSING" ]]; then
-      echo "{\"decision\":\"block\",\"reason\":\"Issue #${ISSUE_NUM} is missing taxonomy metadata:${CI_MISSING}. Fix before the pr-metadata-gate CI check fails.\"}"
-      exit 0
+  # For each linked issue: verify CI minimum (BLOCK if missing), epic lineage
+  # (BLOCK if missing), then project board + priority (WARN if missing).
+  while IFS= read -r issue_num; do
+    [[ -z "$issue_num" ]] && continue
+    # `_` discards the labels column; check_ci_minimum needs only the
+    # has_domain flag, which query_issue_metadata pre-computes from labels.
+    IFS=$'\t' read -r type _ milestone has_domain < <(query_issue_metadata "$issue_num")
+    ci_missing=$(check_ci_minimum "$type" "$has_domain" "$milestone")
+    if [[ -n "$ci_missing" ]]; then
+      emit_block "Issue #${issue_num} is missing taxonomy metadata:${ci_missing}. Fix before the pr-metadata-gate CI check fails."
+      return 0
     fi
-
-    # Check epic lineage — the pr-metadata-gate CI workflow requires it.
-    LINEAGE=$(check_epic_lineage "$ISSUE_NUM")
-    if [[ "$LINEAGE" != "ok" ]]; then
-      echo "{\"decision\":\"block\",\"reason\":\"Issue #${ISSUE_NUM} does not trace to any Epic. Add it as a sub-issue of the appropriate Phase/Epic — the pr-metadata-gate epic lineage check will fail.\"}"
-      exit 0
+    lineage=$(check_epic_lineage "$issue_num")
+    if [[ "$lineage" != "ok" ]]; then
+      emit_block "Issue #${issue_num} does not trace to any Epic. Add it as a sub-issue of the appropriate Phase/Epic — the pr-metadata-gate epic lineage check will fail."
+      return 0
     fi
-
-    # CI gate will pass, but check the full taxonomy lifecycle too.
-    PROJECT_MISSING=$(check_project_fields "$ISSUE_NUM")
-    if [[ -n "$PROJECT_MISSING" ]]; then
-      WARNINGS="${WARNINGS}Issue #${ISSUE_NUM} is missing:${PROJECT_MISSING}. "
+    project_missing=$(check_project_fields "$issue_num")
+    if [[ -n "$project_missing" ]]; then
+      warnings="${warnings}Issue #${issue_num} is missing:${project_missing}. "
     fi
-  done
+  done <<< "$issue_nums"
 
-  if [[ -n "$WARNINGS" ]]; then
-    echo "{\"hookSpecificOutput\":{\"hookEventName\":\"PostToolUse\",\"additionalContext\":\"Taxonomy check passed (CI gate OK), but full lifecycle incomplete: ${WARNINGS}Add to project board and set priority before merging.\"}}"
+  if [[ -n "$warnings" ]]; then
+    emit_advisory "Taxonomy check passed (CI gate OK), but full lifecycle incomplete: ${warnings}Add to project board and set priority before merging."
   else
-    echo '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"Taxonomy check passed: linked issue(s) have issue type, domain label, and milestone."}}'
+    emit_advisory "Taxonomy check passed: linked issue(s) have issue type, domain label, and milestone."
   fi
+}
 
+mode_issue() {
+  # Usage: mode_issue <tool_response>
+  local tool_response="$1" issue_url issue_num type milestone has_domain ci_missing
+  issue_url=$(echo "$tool_response" | grep -oE 'https://github.com/[^/]+/[^/]+/issues/[0-9]+' | head -1 || true)
+  [[ -z "$issue_url" ]] && return 0
+  issue_num=$(echo "$issue_url" | grep -oE '[0-9]+$' || true)
+  [[ -z "$issue_num" ]] && return 0
 
-# ===========================================================================
-# MODE: issue — runs after `gh issue create`
-# ===========================================================================
-elif [[ "$MODE" == "issue" ]]; then
-  # Extract the issue number from the tool response URL. `|| true` keeps the
-  # no-URL path graceful under `set -o pipefail` (see GITHUB_URL above).
-  ISSUE_URL=$(echo "$TOOL_RESPONSE" | grep -oE 'https://github.com/[^/]+/[^/]+/issues/[0-9]+' | head -1 || true)
-  if [[ -z "$ISSUE_URL" ]]; then exit 0; fi
-  ISSUE_NUM=$(echo "$ISSUE_URL" | grep -oE '[0-9]+$' || true)
-
-  # Check the CI minimum three. At this point, issue type is often not yet
-  # set because `gh issue create` can't set it — it requires a separate
-  # GraphQL mutation. BLOCK either way to force completing all taxonomy steps.
-  query_issue_metadata "$ISSUE_NUM"
-  CI_MISSING=$(check_ci_minimum)
-
-  if [[ -n "$CI_MISSING" ]]; then
-    echo "{\"decision\":\"block\",\"reason\":\"Issue #${ISSUE_NUM} is missing taxonomy metadata:${CI_MISSING}. Set these now before proceeding. Then add to sub-issue hierarchy, project board, and set priority.\"}"
-    exit 0
+  IFS=$'\t' read -r type _ milestone has_domain < <(query_issue_metadata "$issue_num")
+  ci_missing=$(check_ci_minimum "$type" "$has_domain" "$milestone")
+  if [[ -n "$ci_missing" ]]; then
+    emit_block "Issue #${issue_num} is missing taxonomy metadata:${ci_missing}. Set these now before proceeding. Then add to sub-issue hierarchy, project board, and set priority."
+    return 0
   fi
+  # CI minimum is satisfied, but `gh issue create` can't set issue type —
+  # always BLOCK to force completing the full lifecycle (hierarchy + project).
+  emit_block "Issue #${issue_num} created with type, label, and milestone. You MUST now add it to the sub-issue hierarchy (addSubIssue to the appropriate Phase/Epic), add to project board, and set priority before proceeding."
+}
 
-  echo "{\"decision\":\"block\",\"reason\":\"Issue #${ISSUE_NUM} created with type, label, and milestone. You MUST now add it to the sub-issue hierarchy (addSubIssue to the appropriate Phase/Epic), add to project board, and set priority before proceeding.\"}"
+mode_hierarchy() {
+  # Usage: mode_hierarchy <command>
+  # The addSubIssue mutation takes (parentId, childId) as opaque node IDs. We
+  # GraphQL-resolve each ID to (number, type) and infer which is parent vs
+  # child from the type — Epic/Phase are parents, Task/Bug/Feature are
+  # children. BLOCK if a leaf is attached directly to an Epic.
+  local command="$1" node_ids node_id result type num
+  local parent_type="" parent_num="" child_type="" child_num=""
+  node_ids=$(echo "$command" | grep -oE 'I_kw[A-Za-z0-9_/+=.-]+' || true)
+  [[ -z "$node_ids" ]] && return 0
 
-
-# ===========================================================================
-# MODE: hierarchy — runs after `addSubIssue` GraphQL mutation
-# ===========================================================================
-elif [[ "$MODE" == "hierarchy" ]]; then
-  # Validate that Tasks/Bugs/Features are attached to Phases, not directly
-  # to Epics. The taxonomy hierarchy is: Epic → Phase → Task/Bug/Feature.
-  #
-  # Extract issue node IDs (format: I_kw...) from the GraphQL mutation command.
-  NODE_IDS=$(echo "$COMMAND" | grep -oE 'I_kw[A-Za-z0-9_/+=.-]+' || true)
-  if [[ -z "$NODE_IDS" ]]; then exit 0; fi
-
-  PARENT_TYPE=""
-  PARENT_NUM=""
-  CHILD_TYPE=""
-  CHILD_NUM=""
-
-  for NODE_ID in $NODE_IDS; do
+  while IFS= read -r node_id; do
+    [[ -z "$node_id" ]] && continue
     # shellcheck disable=SC2016
-    RESULT=$(gh api graphql -f query='
+    result=$(gh api graphql -f query='
       query($id: ID!) {
         node(id: $id) {
           ... on Issue { number issueType { name } }
         }
       }
-    ' -f id="$NODE_ID" 2>/dev/null || echo "{}")
-
-    TYPE=$(echo "$RESULT" | jq -r '.data.node.issueType.name // empty')
-    NUM=$(echo "$RESULT" | jq -r '.data.node.number // empty')
-
-    # The addSubIssue mutation takes (parentId, childId). We infer which is
-    # which from the issue type: Epic/Phase are parents, Task/Bug/Feature
-    # are children.
-    case "$TYPE" in
+    ' -f id="$node_id" 2>/dev/null || echo "{}")
+    type=$(echo "$result" | jq -r '.data.node.issueType.name // empty' 2>/dev/null || echo "")
+    num=$(echo "$result" | jq -r '.data.node.number // empty' 2>/dev/null || echo "")
+    case "$type" in
       Epic|Phase)
-        PARENT_TYPE="$TYPE"
-        PARENT_NUM="$NUM"
+        parent_type="$type"
+        parent_num="$num"
         ;;
       Task|Bug|Feature)
-        CHILD_TYPE="$TYPE"
-        CHILD_NUM="$NUM"
+        child_type="$type"
+        child_num="$num"
         ;;
     esac
-  done
+  done <<< "$node_ids"
 
-  # Block if a leaf issue is attached directly to an Epic (must go under a Phase).
-  if [[ "$PARENT_TYPE" == "Epic" && -n "$CHILD_TYPE" ]]; then
-    echo "{\"decision\":\"block\",\"reason\":\"${CHILD_TYPE} #${CHILD_NUM} cannot be a direct child of Epic #${PARENT_NUM}. Task/Bug/Feature issues must be sub-issues of a Phase, not an Epic. Add it under the appropriate Phase instead.\"}"
-    exit 0
+  if [[ "$parent_type" == "Epic" && -n "$child_type" ]]; then
+    emit_block "${child_type} #${child_num} cannot be a direct child of Epic #${parent_num}. Task/Bug/Feature issues must be sub-issues of a Phase, not an Epic. Add it under the appropriate Phase instead."
+    return 0
+  fi
+  emit_advisory "Hierarchy check passed."
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+main() {
+  local input command mode tool_response github_url
+  input=$(cat)
+  command=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
+
+  case "$command" in
+    *"gh pr create"*)    mode="pr" ;;
+    *"gh issue create"*) mode="issue" ;;
+    *"addSubIssue"*)     mode="hierarchy" ;;
+    *) return 0 ;;
+  esac
+
+  tool_response=$(echo "$input" | jq -r '.tool_response // empty' 2>/dev/null || echo "")
+
+  # Scope: only act on commands that targeted synth-setter. The hook lives in
+  # this repo but agents may run `gh pr create` from a sibling clone; we
+  # extract the actual GitHub URL from the response and check the repo path.
+  # Plain grep on the response is unsafe — Bash tool output includes
+  # "Shell cwd was reset to .../synth-setter" on every cwd change.
+  if [[ "$mode" == "hierarchy" ]]; then
+    echo "$command" | grep -qE 'owner.*synth-setter|repo.*synth-setter' || return 0
+  else
+    github_url=$(echo "$tool_response" | grep -oE 'https://github.com/[^/]+/[^/]+/(pull|issues)/[0-9]+' | head -1 || true)
+    [[ -z "$github_url" ]] && return 0
+    echo "$github_url" | grep -q 'synth-setter' || return 0
   fi
 
-  echo '{"hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"Hierarchy check passed."}}'
-fi
+  case "$mode" in
+    pr)        mode_pr "$tool_response" ;;
+    issue)     mode_issue "$tool_response" ;;
+    hierarchy) mode_hierarchy "$command" ;;
+  esac
+}
+
+main "$@"

--- a/agent/hooks/verify-gh-taxonomy.sh
+++ b/agent/hooks/verify-gh-taxonomy.sh
@@ -37,10 +37,9 @@ emit_advisory() {
 # ---------------------------------------------------------------------------
 query_issue_metadata() {
   # Usage: query_issue_metadata <issue_number>
-  # Emits one tab-delimited line: <type>\t<labels>\t<milestone>\t<has_domain>.
-  # Callers consume it via `IFS=$'\t' read -r type labels milestone has_domain
-  # < <(query_issue_metadata $n)`. Tab is safe — GitHub label/title/type
-  # values can't contain tabs.
+  # Emits one JSON object on stdout: `{type, labels, milestone, has_domain}`.
+  # Callers extract fields via `jq -r '.type'` etc. — explicit named access
+  # avoids the positional-order coupling of a TSV contract.
   local issue_num="$1" result type labels milestone has_domain=false dl
   # shellcheck disable=SC2016
   result=$(gh api graphql -f query='
@@ -60,24 +59,37 @@ query_issue_metadata() {
   for dl in "${DOMAIN_LABELS[@]}"; do
     if echo "$labels" | grep -q "$dl"; then has_domain=true; break; fi
   done
-  printf '%s\t%s\t%s\t%s\n' "$type" "$labels" "$milestone" "$has_domain"
+  jq -n \
+    --arg type "$type" \
+    --arg labels "$labels" \
+    --arg milestone "$milestone" \
+    --argjson has_domain "$has_domain" \
+    '{type:$type, labels:$labels, milestone:$milestone, has_domain:$has_domain}'
 }
 
 check_ci_minimum() {
   # Usage: check_ci_minimum <type> <has_domain> <milestone>
-  # Returns: space-separated list of missing fields, or empty string if all set.
-  local type="$1" has_domain="$2" milestone="$3" missing=""
-  [[ -z "$type" ]] && missing="${missing} issue-type"
-  [[ "$has_domain" == "false" ]] && missing="${missing} domain-label"
-  [[ -z "$milestone" ]] && missing="${missing} milestone"
-  echo "$missing"
+  # Echoes a comma-separated list of missing fields (e.g. "issue-type, milestone"),
+  # or empty string if all three are set. Callers interpolate directly into
+  # user-facing error strings.
+  local type="$1" has_domain="$2" milestone="$3"
+  local missing=()
+  [[ -z "$type" ]] && missing+=("issue-type")
+  [[ "$has_domain" == "false" ]] && missing+=("domain-label")
+  [[ -z "$milestone" ]] && missing+=("milestone")
+  if [[ "${#missing[@]}" -gt 0 ]]; then
+    local IFS=', '
+    echo "${missing[*]}"
+  fi
 }
 
 check_project_fields() {
   # Usage: check_project_fields <issue_number>
-  # Returns: space-separated list of missing fields ("project-board",
-  # "priority"), or empty string if both are set.
-  local issue_num="$1" node_id project_result on_board has_priority missing=""
+  # Echoes a comma-separated list of missing fields ("project-board, priority"
+  # or "priority"), or empty if both are set. Returns the bare list with no
+  # leading space so callers can interpolate cleanly into error strings.
+  local issue_num="$1" node_id project_result on_board has_priority
+  local missing=()
   # shellcheck disable=SC2016
   node_id=$(gh api graphql -f query='
     query($owner: String!, $repo: String!, $number: Int!) {
@@ -88,7 +100,7 @@ check_project_fields() {
   ' -f owner="$OWNER" -f repo="$REPO" -F number="$issue_num" \
     --jq '.data.repository.issue.id' 2>/dev/null || echo "")
   if [[ -z "$node_id" ]]; then
-    echo " project-board priority"
+    echo "project-board, priority"
     return
   fi
   # shellcheck disable=SC2016
@@ -115,17 +127,20 @@ check_project_fields() {
   ' -f id="$node_id" 2>/dev/null || echo "{}")
   on_board=$(echo "$project_result" | jq -r '.data.node.projectItems.nodes | length' 2>/dev/null || echo "0")
   if [[ "$on_board" == "0" ]]; then
-    missing="${missing} project-board priority"
+    missing+=("project-board" "priority")
   else
     has_priority=$(echo "$project_result" | jq -r '
       [.data.node.projectItems.nodes[].fieldValues.nodes[]
         | select(.field.name == "Priority")
         | .name] | length' 2>/dev/null || echo "0")
     if [[ "$has_priority" == "0" ]]; then
-      missing="${missing} priority"
+      missing+=("priority")
     fi
   fi
-  echo "$missing"
+  if [[ "${#missing[@]}" -gt 0 ]]; then
+    local IFS=', '
+    echo "${missing[*]}"
+  fi
 }
 
 check_epic_lineage() {
@@ -168,7 +183,7 @@ check_epic_lineage() {
 # ---------------------------------------------------------------------------
 mode_pr() {
   # Usage: mode_pr <tool_response>
-  local tool_response="$1" pr_url pr_num pr_body issue_nums issue_num
+  local tool_response="$1" pr_url pr_num pr_body issue_nums issue_num metadata
   local type milestone has_domain ci_missing lineage project_missing warnings=""
   pr_url=$(echo "$tool_response" | grep -oE 'https://github.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 || true)
   [[ -z "$pr_url" ]] && return 0
@@ -196,12 +211,13 @@ mode_pr() {
   # (BLOCK if missing), then project board + priority (WARN if missing).
   while IFS= read -r issue_num; do
     [[ -z "$issue_num" ]] && continue
-    # `_` discards the labels column; check_ci_minimum needs only the
-    # has_domain flag, which query_issue_metadata pre-computes from labels.
-    IFS=$'\t' read -r type _ milestone has_domain < <(query_issue_metadata "$issue_num")
+    metadata=$(query_issue_metadata "$issue_num")
+    type=$(echo "$metadata" | jq -r '.type')
+    milestone=$(echo "$metadata" | jq -r '.milestone')
+    has_domain=$(echo "$metadata" | jq -r '.has_domain')
     ci_missing=$(check_ci_minimum "$type" "$has_domain" "$milestone")
     if [[ -n "$ci_missing" ]]; then
-      emit_block "Issue #${issue_num} is missing taxonomy metadata:${ci_missing}. Fix before the pr-metadata-gate CI check fails."
+      emit_block "Issue #${issue_num} is missing taxonomy metadata: ${ci_missing}. Fix before the pr-metadata-gate CI check fails."
       return 0
     fi
     lineage=$(check_epic_lineage "$issue_num")
@@ -211,7 +227,7 @@ mode_pr() {
     fi
     project_missing=$(check_project_fields "$issue_num")
     if [[ -n "$project_missing" ]]; then
-      warnings="${warnings}Issue #${issue_num} is missing:${project_missing}. "
+      warnings="${warnings}Issue #${issue_num} is missing: ${project_missing}. "
     fi
   done <<< "$issue_nums"
 
@@ -224,16 +240,19 @@ mode_pr() {
 
 mode_issue() {
   # Usage: mode_issue <tool_response>
-  local tool_response="$1" issue_url issue_num type milestone has_domain ci_missing
+  local tool_response="$1" issue_url issue_num metadata type milestone has_domain ci_missing
   issue_url=$(echo "$tool_response" | grep -oE 'https://github.com/[^/]+/[^/]+/issues/[0-9]+' | head -1 || true)
   [[ -z "$issue_url" ]] && return 0
   issue_num=$(echo "$issue_url" | grep -oE '[0-9]+$' || true)
   [[ -z "$issue_num" ]] && return 0
 
-  IFS=$'\t' read -r type _ milestone has_domain < <(query_issue_metadata "$issue_num")
+  metadata=$(query_issue_metadata "$issue_num")
+  type=$(echo "$metadata" | jq -r '.type')
+  milestone=$(echo "$metadata" | jq -r '.milestone')
+  has_domain=$(echo "$metadata" | jq -r '.has_domain')
   ci_missing=$(check_ci_minimum "$type" "$has_domain" "$milestone")
   if [[ -n "$ci_missing" ]]; then
-    emit_block "Issue #${issue_num} is missing taxonomy metadata:${ci_missing}. Set these now before proceeding. Then add to sub-issue hierarchy, project board, and set priority."
+    emit_block "Issue #${issue_num} is missing taxonomy metadata: ${ci_missing}. Set these now before proceeding. Then add to sub-issue hierarchy, project board, and set priority."
     return 0
   fi
   # CI minimum is satisfied, but `gh issue create` can't set issue type —
@@ -286,8 +305,28 @@ mode_hierarchy() {
 # ---------------------------------------------------------------------------
 # Dispatch
 # ---------------------------------------------------------------------------
+is_synth_setter() {
+  # Usage: is_synth_setter <mode> <command> <tool_response>
+  # Returns 0 if the command targets the synth-setter repo, 1 otherwise.
+  #
+  # The hook lives in this repo but agents may run `gh pr create` from a
+  # sibling clone; we extract the actual GitHub URL from the response and
+  # check the repo path. Plain `grep` on the response is unsafe — Bash tool
+  # output includes "Shell cwd was reset to .../synth-setter" on every cwd
+  # change. For addSubIssue the URL isn't in the response, so we inspect the
+  # GraphQL query in the command string.
+  local mode="$1" command="$2" tool_response="$3" github_url
+  if [[ "$mode" == "hierarchy" ]]; then
+    echo "$command" | grep -qE 'owner.*synth-setter|repo.*synth-setter'
+    return $?
+  fi
+  github_url=$(echo "$tool_response" | grep -oE 'https://github.com/[^/]+/[^/]+/(pull|issues)/[0-9]+' | head -1 || true)
+  [[ -z "$github_url" ]] && return 1
+  echo "$github_url" | grep -q 'synth-setter'
+}
+
 main() {
-  local input command mode tool_response github_url
+  local input command mode tool_response
   input=$(cat)
   command=$(echo "$input" | jq -r '.tool_input.command // empty' 2>/dev/null || echo "")
 
@@ -300,18 +339,7 @@ main() {
 
   tool_response=$(echo "$input" | jq -r '.tool_response // empty' 2>/dev/null || echo "")
 
-  # Scope: only act on commands that targeted synth-setter. The hook lives in
-  # this repo but agents may run `gh pr create` from a sibling clone; we
-  # extract the actual GitHub URL from the response and check the repo path.
-  # Plain grep on the response is unsafe — Bash tool output includes
-  # "Shell cwd was reset to .../synth-setter" on every cwd change.
-  if [[ "$mode" == "hierarchy" ]]; then
-    echo "$command" | grep -qE 'owner.*synth-setter|repo.*synth-setter' || return 0
-  else
-    github_url=$(echo "$tool_response" | grep -oE 'https://github.com/[^/]+/[^/]+/(pull|issues)/[0-9]+' | head -1 || true)
-    [[ -z "$github_url" ]] && return 0
-    echo "$github_url" | grep -q 'synth-setter' || return 0
-  fi
+  is_synth_setter "$mode" "$command" "$tool_response" || return 0
 
   case "$mode" in
     pr)        mode_pr "$tool_response" ;;


### PR DESCRIPTION
## Summary

Bundles the deferred follow-ups from [PR #1085](https://github.com/tinaudio/synth-setter/pull/1085)'s `/repo-review-full` round. Every change is either behavior-preserving or a latent-bug fix; tests gate the contract.

### What changed

**`agent/hooks/_lib.sh`**
- New `run_review <slug> <meta> <prompt> [<dry_run_env_var>]` helper. Owns the report path (`.agent-reviews/<slug>-<uuid>.md`), the dry-run dispatch (reads the named env var via indirect expansion), and the failure-report template. Returns the report path on stdout.
- `run_agent_prompt` collapsed from a 4-branch `if/elif` to one `case` dispatch with an auto-detect loop over `claude`/`codex`.
- `has_skill`'s 3-loop path-resolution unified into a single array; unmatched plugin globs document the `-f` no-op behavior.
- `default_branch` adds `local b` so the loop variable doesn't leak.

**`agent/hooks/doc-drift.sh` + `agent/hooks/pr-review-resolver.sh`**
- Both rewritten to call `run_review`. Each caller is now ~4 lines (META block, `REVIEW_FILE=$(run_review …)`, log, advisory printf). Removes ~30 duplicated lines from each file.
- `doc-drift.sh:54` adds a SIGPIPE/pipefail comment on `git diff | head -50`.
- `pr-review-resolver.sh` validates `RESOLVER_SLEEP_SECS` against `^[1-9][0-9]{0,4}$`. Previously, `RESOLVER_SLEEP_SECS=abc` aborted the hook at `sleep` under `set -e`; now it falls back to the 360s default with a log line. Also rejects `0` (would defeat the lockfile-dedupe purpose).

**`agent/hooks/edit-write.sh`**
- **Latent bug fix:** case patterns `*/src/*|*/scripts/*` only matched absolute paths (those with a `/` *before* `src`). Claude Code's `tool_input.file_path` normally supplies relative paths like `src/synth_setter/pipeline/data/stats.py` — so the hook was silently no-op'ing on the most common edit shape. Added `src/*|scripts/*` arms (and `tests/*` for the test-file branch).
- Added mirrored-layout fallback to `test` mode: editing `src/synth_setter/pipeline/data/stats.py` now runs `tests/pipeline/data/test_stats.py` (the project's actual layout), falling back to `tests/test_stats.py` only when the mirrored path is absent.

**`agent/hooks/verify-gh-taxonomy.sh`** (largest change)
- Restructured into `mode_pr` / `mode_issue` / `mode_hierarchy` functions wired through `main()`. The body is now a 50-line orchestrator instead of a 130-line if/elif chain.
- New `is_synth_setter <mode> <command> <tool_response>` helper extracted from `main`; the scope check now lives in one place.
- `DOMAIN_LABELS` converted from a space-separated string to a bash array; iterated `for dl in "${DOMAIN_LABELS[@]}"` instead of unquoted word-splitting.
- All `decision:block` / `hookSpecificOutput` JSON payloads now use `jq -n --arg`; an unescaped `"` or `\` in a `WARNINGS` string can no longer produce invalid JSON.
- `query_issue_metadata` returns a JSON object on stdout (`{type, labels, milestone, has_domain}`) instead of setting four globals. Callers extract fields via `jq -r '.type'` etc. Eliminates the implicit cross-function coupling and the requires-prior-call pitfall.
- `check_ci_minimum` / `check_project_fields` accumulate missing fields into bash arrays joined with `, `; eliminates the leading-space artifact in user-facing error strings.
- Added `|| true` / `|| echo ""` guards to every `gh api graphql | jq …` substitution that previously could abort the script under `pipefail`.
- Added defensive empty-checks after `pr_url`→`pr_num` and `issue_url`→`issue_num` extractions.
- Header collapsed from a 90-line essay to a 6-line summary.

**`agent/hooks/test.sh`** (also large)
- Full restructure: numbered test blocks → `T_*` functions registered via `it "<description>" <fn>`. The runner executes each in a subshell so env-var sets, cwd changes, and `set -e` don't leak between tests.
- Eliminates the export/unset env-var juggling between named test blocks that the original linear harness needed.
- New `last_exit_line` helper for exact-match against the `EXIT:N` sentinel (was substring match, false-positive-prone).
- Added edit-write.sh coverage (5 new tests): credential-protect blocks/allows, Unknown mode → exit 2, format mode best-effort, test mode mirrored-layout fallback, test mode flat-layout fallback. `format` and `test` modes had zero test coverage before.
- Added verify-gh-taxonomy.sh smoke coverage (4 new tests): the early-exit paths (non-matching command, non-synth-setter URL, no URL in response, addSubIssue against non-synth-setter). Full mode-level coverage requires `gh api graphql` stubbing and is deferred to a follow-up.
- Added pr-review-resolver: invalid `RESOLVER_SLEEP_SECS=abc` falls back to default (regression test for the new numeric-validation guard).
- **18 → 27 tests passing**, zero regressions.

**`tests/claude_hooks/test_settings_hooks.py`**
- No code change in the end. The `Any` → `dict[str, object]` cleanup the original WARN suggested cascades into 13 pyright narrowing failures; the original finding already classed it as "test scaffolding" and acceptable to leave. Tracked as a follow-up if anyone wants to do the `TypedDict` work properly.

**`AGENTS.md`**
- Dedupe `### PR Readiness`: the "Detailed elaboration of each gate" prose was a near-verbatim restatement of the "Hard gate (all four must hold)" enumeration. Folded the meaningful detail into the original numbered list and dropped the duplicate.

### Out of scope / explicit non-goals
- `post_review.py` unit tests (needs synthetic diff fixtures) — separate PR.
- `HunkAccumulator` refactor of `parse_diff_hunks` — depends on tests above landing first.
- Hook-header essay trims on `_lib.sh`/`doc-drift.sh`/`pr-review-resolver.sh`/`verify-gh-taxonomy.sh` headers — cosmetic.
- Inline branch-print extraction to `print-branch.sh` — preemptive abstraction.
- `.claude/skills/_shared/post_review.py` shim docstring tweaks — local classifier blocks Edit/Write to that path.

## Test plan

- [x] `bash agent/hooks/test.sh` — 27/27 passing
- [x] `pytest tests/claude_hooks/test_settings_hooks.py -q` — 17/17 passing
- [x] `make test-fast` — 1151 passed, 2 skipped
- [x] `pre-commit run --files <changed-files>` — ruff, pyright, pydoclint, shellcheck, mdformat, codespell all clean
- [x] Local `/code-health` agent review of the diff — 3 BLOCKs surfaced and addressed in the follow-up commit (`run_review` signature, `query_issue_metadata` JSON output, `is_synth_setter` extraction)
- [x] Local `/shell-style` agent review of the diff — findings addressed (`local b`, defensive empty-checks, SLEEP_SECS regex tightening, `_` for unused `read` field)

Refs #941
