### PR TITLE
test(pipeline): replace R2 rclone mocks with fake-local fixture

### DIFF
--- a/tests/pipeline/ci/test_validate_shard.py
+++ b/tests/pipeline/ci/test_validate_shard.py
@@ -1,11 +1,16 @@
-"""Tests for synth_setter.pipeline.ci.validate_shard."""
+"""Tests for synth_setter.pipeline.ci.validate_shard.
+
+R2-side tests use the ``fake_r2_remote`` fixture (see ``tests/pipeline/
+conftest.py``) so ``downloaded_to_tempfile`` runs real rclone against a local-
+typed remote rooted at a tmp dir; each test seeds the fake bucket with the
+shard files it expects ``validate_all_shards_from_r2`` to download.
+"""
 
 from __future__ import annotations
 
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from unittest.mock import patch
 
 import h5py
 import numpy as np
@@ -175,42 +180,64 @@ class TestValidateShard:
 # ---------------------------------------------------------------------------
 
 
+def _seed_r2_shards(
+    fake_r2_remote: Path,
+    spec: DatasetSpec,
+    *,
+    contents: bytes | None = None,
+) -> None:
+    """Populate the fake R2 bucket with every shard listed in ``spec.shards``.
+
+    If ``contents`` is None, writes a valid HDF5 shard sized to the spec's
+    ``samples_per_shard``; otherwise writes the literal bytes (used by the
+    invalid-shard tests to seed garbage that fails HDF5 open).
+
+    :param fake_r2_remote: The fake-local R2 root yielded by the fixture.
+    :param spec: Dataset spec whose ``shards`` and ``r2`` drive the seeded paths.
+    :param contents: Optional override bytes. When None, generates valid HDF5.
+    """
+    bucket_dir = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+    bucket_dir.mkdir(parents=True, exist_ok=True)
+    for shard in spec.shards:
+        target = bucket_dir / shard.filename
+        if contents is None:
+            _create_shard(target, shard_size=spec.render.samples_per_shard)
+        else:
+            target.write_bytes(contents)
+
+
 class TestValidateAllShardsFromR2:
     """Tests for validate_all_shards_from_r2 — iterates spec.shards via R2."""
 
-    def test_all_valid_returns_no_errors(self, real_spec: DatasetSpec, tmp_path: Path) -> None:
-        """When every shard downloads valid HDF5, returns []."""
-        spec = real_spec
+    def test_all_valid_returns_no_errors(
+        self, real_spec: DatasetSpec, fake_r2_remote: Path
+    ) -> None:
+        """When every shard downloads valid HDF5, returns [].
 
-        def fake_check_call(args: list[str]) -> None:
-            # Simulate rclone copyto: write a valid shard to dest path
-            _create_shard(Path(args[-1]), shard_size=spec.render.samples_per_shard)
+        :param real_spec: Fixture-provided ``DatasetSpec``.
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        """
+        _seed_r2_shards(fake_r2_remote, real_spec)
 
-        with patch(
-            "synth_setter.pipeline.r2_io.subprocess.check_call", side_effect=fake_check_call
-        ):
-            errors = validate_all_shards_from_r2(spec)
+        errors = validate_all_shards_from_r2(real_spec)
 
         assert errors == []
 
     def test_invalid_shard_error_carries_shard_filename(
-        self, real_spec: DatasetSpec, tmp_path: Path
+        self, real_spec: DatasetSpec, fake_r2_remote: Path
     ) -> None:
-        """Validation errors are prefixed with the shard filename."""
-        spec = real_spec
+        """Validation errors are prefixed with the shard filename.
 
-        def fake_check_call(args: list[str]) -> None:
-            # Write garbage so shard fails HDF5 open
-            Path(args[-1]).write_bytes(b"garbage")
+        :param real_spec: Fixture-provided ``DatasetSpec``.
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        """
+        _seed_r2_shards(fake_r2_remote, real_spec, contents=b"garbage")
 
-        with patch(
-            "synth_setter.pipeline.r2_io.subprocess.check_call", side_effect=fake_check_call
-        ):
-            errors = validate_all_shards_from_r2(spec)
+        errors = validate_all_shards_from_r2(real_spec)
 
         assert errors  # at least one error
         # First spec.shards filename appears in the error string
-        assert any(spec.shards[0].filename in e for e in errors)
+        assert any(real_spec.shards[0].filename in e for e in errors)
 
 
 class TestMain:
@@ -233,45 +260,53 @@ class TestMain:
         assert exc_info.value.code == 1
 
     def test_cli_exits_zero_when_all_shards_valid(
-        self, real_spec: DatasetSpec, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        real_spec: DatasetSpec,
+        tmp_path: Path,
+        fake_r2_remote: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Valid spec + R2-served valid shards → exit 0."""
+        """Valid spec + R2-served valid shards → exit 0.
+
+        :param real_spec: Fixture-provided ``DatasetSpec``.
+        :param tmp_path: Pytest tmp dir for the local spec JSON.
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        """
         from synth_setter.pipeline.ci.validate_shard import main
 
-        spec = real_spec
         spec_json_path = tmp_path / "spec.json"
-        spec_json_path.write_text(spec.model_dump_json())
-
-        def fake_check_call(args: list[str]) -> None:
-            _create_shard(Path(args[-1]), shard_size=spec.render.samples_per_shard)
+        spec_json_path.write_text(real_spec.model_dump_json())
+        _seed_r2_shards(fake_r2_remote, real_spec)
 
         monkeypatch.setattr(sys, "argv", ["validate_shard", str(spec_json_path)])
-        with patch(
-            "synth_setter.pipeline.r2_io.subprocess.check_call", side_effect=fake_check_call
-        ):
-            with pytest.raises(SystemExit) as exc_info:
-                main()
+        with pytest.raises(SystemExit) as exc_info:
+            main()
 
         assert exc_info.value.code == 0
 
     def test_cli_exits_one_when_a_shard_is_invalid(
-        self, real_spec: DatasetSpec, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+        self,
+        real_spec: DatasetSpec,
+        tmp_path: Path,
+        fake_r2_remote: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """If any shard in spec.shards fails validation, exit 1."""
+        """If any shard in spec.shards fails validation, exit 1.
+
+        :param real_spec: Fixture-provided ``DatasetSpec``.
+        :param tmp_path: Pytest tmp dir for the local spec JSON.
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        """
         from synth_setter.pipeline.ci.validate_shard import main
 
-        spec = real_spec
         spec_json_path = tmp_path / "spec.json"
-        spec_json_path.write_text(spec.model_dump_json())
-
-        def fake_check_call(args: list[str]) -> None:
-            Path(args[-1]).write_bytes(b"garbage")
+        spec_json_path.write_text(real_spec.model_dump_json())
+        _seed_r2_shards(fake_r2_remote, real_spec, contents=b"garbage")
 
         monkeypatch.setattr(sys, "argv", ["validate_shard", str(spec_json_path)])
-        with patch(
-            "synth_setter.pipeline.r2_io.subprocess.check_call", side_effect=fake_check_call
-        ):
-            with pytest.raises(SystemExit) as exc_info:
-                main()
+        with pytest.raises(SystemExit) as exc_info:
+            main()
 
         assert exc_info.value.code == 1

--- a/tests/pipeline/conftest.py
+++ b/tests/pipeline/conftest.py
@@ -3,9 +3,37 @@
 from __future__ import annotations
 
 import copy
+import shutil
+from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 
 import pytest
+
+
+@pytest.fixture()
+def fake_r2_remote(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Yield a tmp_path that backs the ``r2:`` rclone remote as a local filesystem.
+
+    Sets ``RCLONE_CONFIG_R2_TYPE=local`` so rclone resolves ``r2:`` against the
+    local filesystem, and chdirs into ``tmp_path`` so a URI of the form
+    ``r2://<bucket>/<key>`` materializes at ``<tmp_path>/<bucket>/<key>``. Tests
+    read/write the yielded path to inspect the "uploaded" objects, exercising
+    the real rclone binary end-to-end instead of patching ``subprocess.check_call``.
+
+    Skips the test if ``rclone`` is not on ``PATH`` (the binary is required in
+    the CI image but might be absent on a contributor's bare clone).
+
+    :param tmp_path: Pytest tmp dir used as the fake R2 root.
+    :param monkeypatch: Pytest fixture used to set env vars and cwd.
+    :yields Path: The fake R2 root path (``<tmp_path>``). A URI ``r2://<bucket>/<key>``
+        materializes at ``<root>/<bucket>/<key>``.
+    """
+    if shutil.which("rclone") is None:
+        pytest.skip("rclone binary not available on PATH")
+    monkeypatch.setenv("RCLONE_CONFIG_R2_TYPE", "local")
+    monkeypatch.chdir(tmp_path)
+    yield tmp_path
 
 
 def _make_dataset_spec_kwargs(plugin_path: str = "plugins/Surge XT.vst3") -> dict[str, Any]:

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -14,7 +14,11 @@ The entrypoint's public surface:
 
 Tests monkeypatch ``write_spec_locally`` / ``upload_spec`` /
 ``ensure_r2_env_loaded`` / ``_rclone_copy`` / ``subprocess.check_call`` and
-assert on recorded call args + ordering.
+assert on recorded call args + ordering. The shard-landing test uses the
+``fake_r2_remote`` fixture (see ``tests/pipeline/conftest.py``) so the upload
+goes through real rclone against a local-typed remote; the surrounding
+orchestration tests keep their mock-based call-count + ordering assertions
+since those don't touch the rclone command shape that issue #1124 targets.
 """
 
 from __future__ import annotations
@@ -68,6 +72,30 @@ def _materialize_shard(args: list[str]) -> int:
     output_file.parent.mkdir(parents=True, exist_ok=True)
     output_file.write_bytes(b"")
     return 0
+
+
+# Captured at import time so the rclone-passthrough side-effect below can
+# call the real subprocess.check_call without recursing back through any
+# patch that targets the same symbol the production code uses.
+_REAL_CHECK_CALL = subprocess.check_call
+
+
+def _materialize_or_passthrough_rclone(args: list[str]) -> int:
+    """Dispatch on the first argv element: rclone calls fall through to real subprocess.
+
+    The state-based ``test_uploads_shard_to_r2_after_generation`` patches the
+    same ``subprocess.check_call`` symbol the renderer AND the rclone shard
+    upload both go through, so this side-effect distinguishes them: renderer
+    calls write the expected shard file (as ``_materialize_shard`` does);
+    rclone calls invoke the real binary (via ``_REAL_CHECK_CALL``) so the
+    upload actually lands a file on the fake-local remote.
+
+    :param args: argv list passed to ``subprocess.check_call``.
+    :returns: 0 on renderer simulation; rclone's exit code on the real subprocess.
+    """
+    if args and args[0] == "rclone":
+        return _REAL_CHECK_CALL(args)  # noqa: S603 — test-only passthrough
+    return _materialize_shard(args)
 
 
 def _base_spec_kwargs(tmp_path: Path, **overrides: object) -> dict[str, object]:
@@ -195,23 +223,32 @@ class TestRun:
             assert VST_HEADLESS_WRAPPER not in args
             assert args[1] == "src/synth_setter/data/vst/generate_vst_dataset.py"
 
-    @patch("synth_setter.cli.generate_dataset.subprocess.check_call")
-    @patch("synth_setter.cli.generate_dataset._rclone_copy")
     def test_uploads_shard_to_r2_after_generation(
         self,
-        mock_rclone: MagicMock,
-        mock_check_call: MagicMock,
         spec: DatasetSpec,
+        fake_r2_remote: Path,
     ) -> None:
-        """Rclone is invoked once per shard (run() uploads shards only, not the spec)."""
-        mock_check_call.side_effect = _materialize_shard
-        run(spec)
+        """Shard lands at the R2 URI implied by ``spec.r2`` and the shard's filename.
 
-        rclone_calls = mock_rclone.call_args_list
-        assert len(rclone_calls) == 1
-        shard_src, shard_dest = rclone_calls[0][0]
-        assert "shard-000000.h5" in shard_src
-        assert shard_dest == f"r2:{spec.r2.bucket}/{spec.r2.prefix}"
+        State-based: ``_rclone_copy`` is not patched — the real ``rclone copy`` runs
+        against the fake-local R2 remote rooted at ``fake_r2_remote``, and the test
+        asserts on the materialized object on disk. The renderer subprocess
+        ``check_call`` is still patched so we don't actually shell out to the VST
+        generator; its side effect writes the same empty HDF5 file that the
+        renderer would.
+
+        :param spec: Fixture-provided ``DatasetSpec``.
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        """
+        # Real rclone copies require a real source file; patch only the renderer.
+        with patch(
+            "synth_setter.cli.generate_dataset.subprocess.check_call",
+            side_effect=_materialize_or_passthrough_rclone,
+        ):
+            run(spec)
+
+        landed = fake_r2_remote / spec.r2.bucket / spec.r2.prefix / spec.shards[0].filename
+        assert landed.is_file()
 
     @patch("synth_setter.cli.generate_dataset.subprocess.check_call")
     @patch("synth_setter.cli.generate_dataset._rclone_copy")

--- a/tests/pipeline/test_r2_io.py
+++ b/tests/pipeline/test_r2_io.py
@@ -1,4 +1,12 @@
-"""Tests for synth_setter.pipeline.r2_io — rclone-backed R2 I/O helpers."""
+"""Tests for synth_setter.pipeline.r2_io — rclone-backed R2 I/O helpers.
+
+State-based tests use the ``fake_r2_remote`` fixture (see ``tests/pipeline/
+conftest.py``): rclone runs against a local-typed remote rooted at a tmp dir,
+so each test asserts on the filesystem state after the helper runs instead of
+on the rclone argv list. Two narrow argv-shape tests survive (the reliability-
+flag set on ``upload_to_uri`` and the ``lsf --format=s`` shape on
+``object_size``) to pin invariants state-based tests cannot observe.
+"""
 
 from __future__ import annotations
 
@@ -55,18 +63,49 @@ class TestToRclonePath:
 class TestDownloadToPath:
     """Tests for download_to_path — file→file copy."""
 
-    def test_invokes_rclone_copyto_with_checksum(self, tmp_path: Path) -> None:
-        """Verifies the rclone command shape (copyto + --checksum + URI translation)."""
+    def test_lands_remote_bytes_at_local_path(self, fake_r2_remote: Path, tmp_path: Path) -> None:
+        """Downloading writes the remote object's bytes verbatim to ``dest_path``.
+
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        :param tmp_path: Pytest tmp dir used for the download destination.
+        """
+        remote_obj = fake_r2_remote / "bucket" / "key.json"
+        remote_obj.parent.mkdir(parents=True)
+        remote_obj.write_text('{"ok": true}')
         dest = tmp_path / "out.json"
-        with patch.object(r2_io.subprocess, "check_call") as mock_call:
-            r2_io.download_to_path("r2://bucket/key.json", dest)
-        args = mock_call.call_args[0][0]
-        assert args[:3] == ["rclone", "copyto", "--checksum"]
-        assert args[3] == "r2:bucket/key.json"
-        assert args[4] == str(dest)
+
+        r2_io.download_to_path("r2://bucket/key.json", dest)
+
+        assert dest.read_text() == '{"ok": true}'
+
+    def test_preserves_destination_filename_not_source_basename(
+        self, fake_r2_remote: Path, tmp_path: Path
+    ) -> None:
+        """``copyto`` (not ``copy``) keeps the destination filename as-is.
+
+        ``rclone copy`` would treat ``dest`` as a directory and write the source
+        basename inside it; ``copyto`` preserves the destination filename verbatim.
+        The dest's filename differs from the source's on purpose so the wrong-verb
+        regression would surface as a missing file.
+
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        :param tmp_path: Pytest tmp dir used for the download destination.
+        """
+        remote_obj = fake_r2_remote / "bucket" / "src-name.json"
+        remote_obj.parent.mkdir(parents=True)
+        remote_obj.write_text("{}")
+        dest = tmp_path / "different-name.json"
+
+        r2_io.download_to_path("r2://bucket/src-name.json", dest)
+
+        assert dest.is_file()
+        assert dest.read_text() == "{}"
 
     def test_rejects_non_r2_uri(self, tmp_path: Path) -> None:
-        """A local-path source is rejected — caller must branch on is_r2_uri."""
+        """A local-path source is rejected — caller must branch on is_r2_uri.
+
+        :param tmp_path: Pytest tmp dir used to build a local destination path.
+        """
         with pytest.raises(ValueError, match="not an r2:// URI"):
             r2_io.download_to_path("local-spec.json", tmp_path / "out.json")
 
@@ -74,8 +113,59 @@ class TestDownloadToPath:
 class TestUploadToUri:
     """Tests for upload_to_uri — file→file upload with reliability flags."""
 
-    def test_invokes_rclone_copyto_with_reliability_flags(self, tmp_path: Path) -> None:
-        """Upload command includes -vv, --contimeout, --timeout, --retries, --checksum."""
+    def test_lands_local_bytes_at_remote_uri(self, fake_r2_remote: Path, tmp_path: Path) -> None:
+        """Upload writes the local file's bytes to the URI's path under the bucket.
+
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        :param tmp_path: Pytest tmp dir used for the upload source file.
+        """
+        src = tmp_path / "in.json"
+        src.write_text('{"payload": 42}')
+
+        r2_io.upload_to_uri(src, "r2://bucket/nested/key.json")
+
+        assert (fake_r2_remote / "bucket" / "nested" / "key.json").read_text() == '{"payload": 42}'
+
+    def test_preserves_destination_filename_not_source_basename(
+        self, fake_r2_remote: Path, tmp_path: Path
+    ) -> None:
+        """``copyto`` (not ``copy``) keeps the destination object name as-is.
+
+        ``rclone copy`` would treat the URI as a directory and write the source
+        basename inside it. The dest's last segment differs from the source's
+        so the wrong-verb regression would surface as a missing object.
+
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        :param tmp_path: Pytest tmp dir used for the upload source file.
+        """
+        src = tmp_path / "src-name.json"
+        src.write_text("{}")
+
+        r2_io.upload_to_uri(src, "r2://bucket/different-name.json")
+
+        assert (fake_r2_remote / "bucket" / "different-name.json").is_file()
+        assert not (fake_r2_remote / "bucket" / "different-name.json" / "src-name.json").exists()
+
+    def test_rejects_non_r2_uri(self, tmp_path: Path) -> None:
+        """A local-path destination is rejected.
+
+        :param tmp_path: Pytest tmp dir used to build a local source path.
+        """
+        with pytest.raises(ValueError, match="not an r2:// URI"):
+            r2_io.upload_to_uri(tmp_path / "in.json", "local-dest.json")
+
+    def test_command_carries_rclone_reliability_flags(self, tmp_path: Path) -> None:
+        """Pin the rclone reliability-flag set on upload.
+
+        State-based tests cover the file-landing contract but cannot observe the
+        ``-vv / --checksum / --contimeout / --timeout / --retries`` flags. Losing
+        any of them is a silent correctness regression (e.g. dropping
+        ``--checksum`` would let half-uploaded objects pass; dropping
+        ``--retries`` would surface transient network blips as hard failures).
+        One mock-based argv assertion guards the invariant.
+
+        :param tmp_path: Pytest tmp dir used for the upload source file.
+        """
         src = tmp_path / "in.json"
         src.write_text("{}")
         with patch.object(r2_io.subprocess, "check_call") as mock_call:
@@ -87,45 +177,44 @@ class TestUploadToUri:
         assert "--contimeout=30s" in args
         assert "--timeout=300s" in args
         assert "--retries=3" in args
-        assert args[-2] == str(src)
-        assert args[-1] == "r2:bucket/key.json"
-
-    def test_rejects_non_r2_uri(self, tmp_path: Path) -> None:
-        """A local-path destination is rejected."""
-        with pytest.raises(ValueError, match="not an r2:// URI"):
-            r2_io.upload_to_uri(tmp_path / "in.json", "local-dest.json")
 
 
 class TestDownloadedToTempfile:
     """Tests for the downloaded_to_tempfile context manager."""
 
-    def test_yields_local_path_named_after_uri_basename(self) -> None:
-        """Yielded path name matches URI's last segment; tempdir is cleaned on exit."""
+    def test_yields_local_path_named_after_uri_basename(self, fake_r2_remote: Path) -> None:
+        """Yielded path name matches URI's last segment; tempdir is cleaned on exit.
+
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        """
+        remote_obj = fake_r2_remote / "bucket" / "path" / "spec.json"
+        remote_obj.parent.mkdir(parents=True)
+        remote_obj.write_text('{"ok": true}')
         seen: list[Path] = []
 
-        def fake_check_call(args: list[str]) -> None:
-            Path(args[-1]).write_text('{"ok": true}')
-
-        with patch.object(r2_io.subprocess, "check_call", side_effect=fake_check_call):
-            with r2_io.downloaded_to_tempfile("r2://bucket/path/spec.json") as local:
-                seen.append(local)
-                assert local.name == "spec.json"
-                assert local.read_text() == '{"ok": true}'
+        with r2_io.downloaded_to_tempfile("r2://bucket/path/spec.json") as local:
+            seen.append(local)
+            assert local.name == "spec.json"
+            assert local.read_text() == '{"ok": true}'
 
         assert not seen[0].exists()
 
-    def test_cleanup_runs_even_on_exception(self) -> None:
-        """If the with-block raises, the tempdir is still cleaned up."""
+    def test_cleanup_runs_even_on_exception(self, fake_r2_remote: Path) -> None:
+        """If the with-block raises, the tempdir is still cleaned up.
+
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        :raises RuntimeError: Deliberately raised inside the ``with`` block to
+            exercise the cleanup-on-exception path.
+        """
+        remote_obj = fake_r2_remote / "bucket" / "spec.json"
+        remote_obj.parent.mkdir(parents=True)
+        remote_obj.write_text("{}")
         seen: list[Path] = []
 
-        def fake_check_call(args: list[str]) -> None:
-            Path(args[-1]).write_text("{}")
-
-        with patch.object(r2_io.subprocess, "check_call", side_effect=fake_check_call):
-            with pytest.raises(RuntimeError, match="boom"):
-                with r2_io.downloaded_to_tempfile("r2://bucket/spec.json") as local:
-                    seen.append(local)
-                    raise RuntimeError("boom")
+        with pytest.raises(RuntimeError, match="boom"):
+            with r2_io.downloaded_to_tempfile("r2://bucket/spec.json") as local:
+                seen.append(local)
+                raise RuntimeError("boom")
 
         assert not seen[0].exists()
 
@@ -149,7 +238,15 @@ class TestShardUri:
 
 
 class TestObjectSize:
-    """Tests for object_size — existence + size probe via `rclone lsf --format=s`."""
+    """Tests for object_size — existence + size probe via `rclone lsf --format=s`.
+
+    Present and zero-size cases are state-based against the fake-local remote.
+    Absent and probe-failure cases stay mock-based: on R2 ``lsf`` returns empty
+    stdout for a missing key (the bucket exists, the key does not); on the
+    local backend the parent directory may not exist, so ``lsf`` exits non-zero
+    instead — a behavior divergence the fixture deliberately leaves outside
+    its coverage (see issue #1124's "Out of scope" note).
+    """
 
     @staticmethod
     def _mock_run(stdout: str) -> MagicMock:
@@ -159,20 +256,35 @@ class TestObjectSize:
         completed.returncode = 0
         return completed
 
-    def test_present_returns_int_size(self) -> None:
-        """A non-empty integer stdout means the object exists; return its size in bytes."""
-        with patch.object(r2_io.subprocess, "run", return_value=self._mock_run("12345\n")):
-            assert r2_io.object_size("r2://bucket/key.h5") == 12345
+    def test_present_returns_int_size(self, fake_r2_remote: Path) -> None:
+        """A present object returns its size in bytes.
+
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        """
+        obj = fake_r2_remote / "bucket" / "key.h5"
+        obj.parent.mkdir(parents=True)
+        obj.write_bytes(b"x" * 12345)
+
+        assert r2_io.object_size("r2://bucket/key.h5") == 12345
+
+    def test_zero_size_returns_zero(self, fake_r2_remote: Path) -> None:
+        """A zero-byte object exists; return 0 (callers decide whether to treat as present).
+
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        """
+        obj = fake_r2_remote / "bucket" / "key.h5"
+        obj.parent.mkdir(parents=True)
+        obj.write_bytes(b"")
+
+        assert r2_io.object_size("r2://bucket/key.h5") == 0
 
     def test_absent_returns_none(self) -> None:
-        """Empty stdout means the object is missing; return None."""
+        """Empty stdout means the object is missing; return None.
+
+        R2-specific behavior — see class docstring for why this stays mock-based.
+        """
         with patch.object(r2_io.subprocess, "run", return_value=self._mock_run("")):
             assert r2_io.object_size("r2://bucket/key.h5") is None
-
-    def test_zero_size_returns_zero(self) -> None:
-        """A zero-byte object exists; return 0 (callers decide whether to treat as present)."""
-        with patch.object(r2_io.subprocess, "run", return_value=self._mock_run("0\n")):
-            assert r2_io.object_size("r2://bucket/key.h5") == 0
 
     def test_probe_failure_propagates(self) -> None:
         """Non-zero rclone exit raises CalledProcessError — fail-fast on env issues."""
@@ -182,7 +294,13 @@ class TestObjectSize:
                 r2_io.object_size("r2://bucket/key.h5")
 
     def test_invokes_rclone_lsf_format_s(self) -> None:
-        """Probe argv shape: rclone lsf --format=s <translated path>."""
+        """Probe argv shape: rclone lsf --format=s <translated path>.
+
+        Pins the ``lsf --format=s`` probe shape; the state-based ``present``/
+        ``zero_size`` tests above exercise the happy paths but cannot observe
+        the exact argv, and a wrong flag here would silently break the absent
+        detection (which relies on empty stdout).
+        """
         with patch.object(r2_io.subprocess, "run", return_value=self._mock_run("42")) as mock_run:
             r2_io.object_size("r2://bucket/path/key.h5")
         args = mock_run.call_args[0][0]

--- a/tests/pipeline/test_spec_io.py
+++ b/tests/pipeline/test_spec_io.py
@@ -169,20 +169,30 @@ class TestUploadSpec:
         assert result == spec.r2.input_spec_uri()
 
     def test_cleans_up_tempfile_on_success(self, spec: DatasetSpec, fake_r2_remote: Path) -> None:
-        """No leftover ``spec_io`` tempfile remains in ``tempfile.gettempdir()`` after success.
+        """The exact tempfile passed to rclone is unlinked after a successful copy.
 
-        Stronger guard than the previous mock-based version: the cleanup runs
-        on the production tempfile path with no patching of the subprocess
-        boundary, so a regression that "leaks" the file or accidentally moves
-        cleanup behind the subprocess call would still be caught.
+        Captures the source path via a pass-through wrapper around the real
+        ``subprocess.check_call`` (so the rclone copy still lands the spec on the
+        fake-local remote), then asserts the captured path no longer exists.
+        The capture is per-test so it's safe under ``pytest -n auto`` — unlike a
+        ``tempfile.gettempdir()`` glob, which races with sibling workers writing
+        their own ``tmp*.json`` files in the shared system tempdir.
 
         :param spec: Fixture-provided ``DatasetSpec``.
         :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
         """
-        before = _spec_io_tempfile_count()
-        spec_io.upload_spec(spec)
-        after = _spec_io_tempfile_count()
-        assert after == before
+        captured_src: list[str] = []
+        real_check_call = subprocess.check_call
+
+        def _capture_then_passthrough(args: list[str]) -> None:
+            captured_src.append(args[-2])
+            real_check_call(args)
+
+        with patch.object(r2_io.subprocess, "check_call", side_effect=_capture_then_passthrough):
+            spec_io.upload_spec(spec)
+
+        assert captured_src, "rclone was not invoked"
+        assert not Path(captured_src[0]).exists()
 
     def test_cleans_up_tempfile_on_rclone_failure(self, spec: DatasetSpec) -> None:
         """Tempfile is removed even when rclone raises CalledProcessError.
@@ -227,18 +237,3 @@ class TestUploadSpec:
         assert "--timeout=300s" in args
         assert "--retries=3" in args
         assert args[-1] == r2_io.to_rclone_path(spec.r2.input_spec_uri())
-
-
-def _spec_io_tempfile_count() -> int:
-    """Return the number of ``upload_spec`` tempfiles currently in ``tempfile.gettempdir()``.
-
-    ``upload_spec`` uses ``NamedTemporaryFile(suffix=".json")``, which generates
-    a ``tmpXXXXXXXX.json``-shaped path in the system tempdir. A leak would
-    bump this count after the call.
-
-    :returns: Count of ``tmp*.json`` entries in ``tempfile.gettempdir()``.
-    """
-    import tempfile
-
-    tmpdir = Path(tempfile.gettempdir())
-    return sum(1 for p in tmpdir.glob("tmp*.json"))

--- a/tests/pipeline/test_spec_io.py
+++ b/tests/pipeline/test_spec_io.py
@@ -127,44 +127,70 @@ class TestWriteSpecLocally:
 
 
 class TestUploadSpec:
-    """``upload_spec`` uploads the spec to its R2 URI."""
+    """``upload_spec`` uploads the spec to its R2 URI.
 
-    def test_invokes_rclone_with_input_spec_uri(self, spec: DatasetSpec) -> None:
-        """The rclone destination is the rclone-form of ``spec.r2.input_spec_uri()``.
+    State-based tests run rclone against the ``fake_r2_remote`` fixture (local-
+    typed backend rooted at a tmp dir) and assert on the materialized object's
+    bytes; one mock-based test below pins the rclone reliability-flag set,
+    which state-based tests cannot observe (see issue #1124).
+    """
 
-        :param spec: Fixture-provided ``DatasetSpec``.
-        """
-        with patch.object(r2_io.subprocess, "check_call") as mock_call:
-            spec_io.upload_spec(spec)
-        args = mock_call.call_args[0][0]
-        assert args[0] == "rclone"
-        assert args[1] == "copyto"
-        assert "--checksum" in args
-        assert args[-1] == r2_io.to_rclone_path(spec.r2.input_spec_uri())
-
-    def test_uses_reliability_flags(self, spec: DatasetSpec) -> None:
-        """Rclone command carries the same flag set as ``r2_io.upload_to_uri``.
+    def test_lands_spec_at_input_spec_uri(self, spec: DatasetSpec, fake_r2_remote: Path) -> None:
+        """Upload writes the spec to the path implied by ``spec.r2.input_spec_uri()``.
 
         :param spec: Fixture-provided ``DatasetSpec``.
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
         """
-        with patch.object(r2_io.subprocess, "check_call") as mock_call:
-            spec_io.upload_spec(spec)
-        args = mock_call.call_args[0][0]
-        assert "--contimeout=30s" in args
-        assert "--timeout=300s" in args
-        assert "--retries=3" in args
+        spec_io.upload_spec(spec)
 
-    def test_returns_input_spec_uri(self, spec: DatasetSpec) -> None:
+        landed = fake_r2_remote / spec.r2.bucket / spec.r2.prefix / INPUT_SPEC_FILENAME
+        assert landed.is_file()
+
+    def test_uploaded_content_matches_spec_dump(
+        self, spec: DatasetSpec, fake_r2_remote: Path
+    ) -> None:
+        """The bytes landed at the R2 URI equal ``spec.model_dump_json(indent=2)``.
+
+        :param spec: Fixture-provided ``DatasetSpec``.
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        """
+        spec_io.upload_spec(spec)
+
+        landed = fake_r2_remote / spec.r2.bucket / spec.r2.prefix / INPUT_SPEC_FILENAME
+        assert landed.read_text(encoding="utf-8") == spec.model_dump_json(indent=2)
+
+    def test_returns_input_spec_uri(self, spec: DatasetSpec, fake_r2_remote: Path) -> None:
         """Return value equals ``spec.r2.input_spec_uri()``.
 
         :param spec: Fixture-provided ``DatasetSpec``.
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
         """
-        with patch.object(r2_io.subprocess, "check_call"):
-            result = spec_io.upload_spec(spec)
+        result = spec_io.upload_spec(spec)
         assert result == spec.r2.input_spec_uri()
+
+    def test_cleans_up_tempfile_on_success(self, spec: DatasetSpec, fake_r2_remote: Path) -> None:
+        """No leftover ``spec_io`` tempfile remains in ``tempfile.gettempdir()`` after success.
+
+        Stronger guard than the previous mock-based version: the cleanup runs
+        on the production tempfile path with no patching of the subprocess
+        boundary, so a regression that "leaks" the file or accidentally moves
+        cleanup behind the subprocess call would still be caught.
+
+        :param spec: Fixture-provided ``DatasetSpec``.
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        """
+        before = _spec_io_tempfile_count()
+        spec_io.upload_spec(spec)
+        after = _spec_io_tempfile_count()
+        assert after == before
 
     def test_cleans_up_tempfile_on_rclone_failure(self, spec: DatasetSpec) -> None:
         """Tempfile is removed even when rclone raises CalledProcessError.
+
+        Stays mock-based: ``upload_spec``'s success path covers the cleanup-on-
+        success branch (state-based above), but the error path needs a forced
+        non-zero rclone exit and there's no clean way to make local-backend
+        rclone fail without also breaking the captured tempfile path.
 
         :param spec: Fixture-provided ``DatasetSpec``.
         """
@@ -181,33 +207,38 @@ class TestUploadSpec:
         assert captured_src, "rclone was not invoked"
         assert not Path(captured_src[0]).exists()
 
-    def test_cleans_up_tempfile_on_success(self, spec: DatasetSpec) -> None:
-        """Tempfile is removed after a successful rclone copy.
+    def test_command_carries_rclone_reliability_flags(self, spec: DatasetSpec) -> None:
+        """Pin the rclone reliability-flag set + the input_spec_uri destination.
+
+        State-based tests cover the spec-lands-at-URI contract but cannot
+        observe ``--checksum / --contimeout / --timeout / --retries`` or the
+        ``rclone copyto`` verb. Losing any of those is a silent correctness
+        regression — one mock-based argv assertion guards them all.
 
         :param spec: Fixture-provided ``DatasetSpec``.
         """
-        captured_src: list[str] = []
-
-        def _record(args: list[str]) -> None:
-            captured_src.append(args[-2])
-
-        with patch.object(r2_io.subprocess, "check_call", side_effect=_record):
+        with patch.object(r2_io.subprocess, "check_call") as mock_call:
             spec_io.upload_spec(spec)
+        args = mock_call.call_args[0][0]
+        assert args[0] == "rclone"
+        assert args[1] == "copyto"
+        assert "--checksum" in args
+        assert "--contimeout=30s" in args
+        assert "--timeout=300s" in args
+        assert "--retries=3" in args
+        assert args[-1] == r2_io.to_rclone_path(spec.r2.input_spec_uri())
 
-        assert captured_src, "rclone was not invoked"
-        assert not Path(captured_src[0]).exists()
 
-    def test_uploaded_content_matches_spec_dump(self, spec: DatasetSpec) -> None:
-        """The bytes handed to rclone are ``spec.model_dump_json(indent=2)``.
+def _spec_io_tempfile_count() -> int:
+    """Return the number of ``upload_spec`` tempfiles currently in ``tempfile.gettempdir()``.
 
-        :param spec: Fixture-provided ``DatasetSpec``.
-        """
-        captured: dict[str, str] = {}
+    ``upload_spec`` uses ``NamedTemporaryFile(suffix=".json")``, which generates
+    a ``tmpXXXXXXXX.json``-shaped path in the system tempdir. A leak would
+    bump this count after the call.
 
-        def _record(args: list[str]) -> None:
-            captured["content"] = Path(args[-2]).read_text(encoding="utf-8")
+    :returns: Count of ``tmp*.json`` entries in ``tempfile.gettempdir()``.
+    """
+    import tempfile
 
-        with patch.object(r2_io.subprocess, "check_call", side_effect=_record):
-            spec_io.upload_spec(spec)
-
-        assert captured["content"] == spec.model_dump_json(indent=2)
+    tmpdir = Path(tempfile.gettempdir())
+    return sum(1 for p in tmpdir.glob("tmp*.json"))


### PR DESCRIPTION
## Summary

- Introduce `fake_r2_remote` pytest fixture (`tests/pipeline/conftest.py`) that runs the real rclone binary against a local-typed remote rooted at `tmp_path` — a URI of the form `r2://<bucket>/<key>` materializes at `<tmp_path>/<bucket>/<key>`.
- Migrate R2-side tests in `test_r2_io.py`, `test_spec_io.py`, `test_validate_shard.py`, and one shard-upload test in `test_generate_dataset.py` from `subprocess.check_call` argv-shape assertions to state-based assertions on the materialized filesystem.
- Keep narrow mock-based tests where state-based coverage can't observe the invariant (rclone reliability flags `-vv / --checksum / --contimeout / --timeout / --retries`, the `lsf --format=s` probe shape) or where the local backend's behavior diverges from R2 (absent-key returns non-zero exit instead of empty stdout).

## Scope

- `test_r2_io.py`: download_to_path / upload_to_uri / downloaded_to_tempfile / object_size happy paths are now state-based. Mock-based survivors: one argv test on `upload_to_uri`'s flag set, the `object_size` absent + probe-failure cases (R2-specific empty-stdout-for-missing-key behavior), and the `lsf --format=s` argv pin.
- `test_spec_io.py`: `TestUploadSpec` migrated; the rclone-failure tempfile-cleanup test stays mocked (no clean way to force a non-zero rclone exit on the local backend); one new mock-based argv test pins the reliability flags + the `input_spec_uri` destination.
- `test_validate_shard.py`: `validate_all_shards_from_r2` and the CLI `main()` tests now seed real shards in the fake bucket via the shared `_seed_r2_shards` helper and let real rclone download them.
- `test_generate_dataset.py`: only `test_uploads_shard_to_r2_after_generation` is migrated (it was the lone test asserting on the `r2:bucket/prefix/` destination string). The surrounding orchestration tests keep mock-based call-count + ordering assertions since they don't touch the rclone command shape that #1124 targets.

## Verification

- `make test-fast`: 1152 passed, 2 skipped (no regressions).
- Pipeline subset (598 tests including all touched files): all green.
- Pre-commit on touched files: ruff / pyright / pydoclint / interrogate / docformatter / codespell all green.

## Out of scope (intentionally deferred)

- Migrating the rest of `test_generate_dataset.py`'s `_rclone_copy` mock pattern — those tests verify orchestration (call counts, render-before-upload ordering, partitioning) rather than the rclone command shape #1124 targets. Keeping them as orchestration spies is the natural fit.

Closes #1124
Refs #603