### PR TITLE
internal-feat(pipeline): dispatch_via_skypilot injects canonical WORKER_SPEC_URI; promote WORKER_SPEC_URI_ENV constant

### DIFF
--- a/.github/workflows/validate-dataset-shards.yaml
+++ b/.github/workflows/validate-dataset-shards.yaml
@@ -66,15 +66,17 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
 
       # synth_setter.pipeline.ci.validate_spec imports OUTPUT_FORMAT_TO_EXTENSION from
-      # synth_setter.pipeline.schemas.spec, which transitively loads pydantic at module top.
-      # Keep the runner-side env minimal: install the project with --no-deps
-      # (the full [project.dependencies] would drag in torch, skypilot, librosa,
-      # etc.), then add pydantic in a second command so its own required
-      # `pydantic-core` resolves.
+      # synth_setter.pipeline.schemas.spec (transitively pulls pydantic at module
+      # top), and indirectly imports r2_io.py (transitively pulls python-dotenv
+      # at module top via `ensure_r2_env_loaded` in #1120). Keep the runner-side
+      # env minimal: install the project with --no-deps (the full
+      # [project.dependencies] would drag in torch, skypilot, librosa, etc.),
+      # then add the two top-level imports above so their own required
+      # transitive deps resolve. Long-term cleanup tracked at #1139.
       - name: Install validate_spec runtime deps
         run: |
           pip install --no-deps -e .
-          pip install "pydantic>=2,<3"
+          pip install "pydantic>=2,<3" python-dotenv
 
       - name: Validate spec structure
         run: python3 -m synth_setter.pipeline.ci.validate_spec "${{ inputs.spec_uri }}"

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -364,7 +364,10 @@ def main() -> None:
     from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
 
     sky_cfg = sky_cfg.model_copy(update={"cmd": _build_worker_cmd(overrides, spec)})
-    dispatch_via_skypilot(spec, sky_cfg)
+    # ``input_spec_uri()`` (not ``uri(INPUT_SPEC_FILENAME)``) — the former
+    # includes the run's prefix so the worker reads the same canonical object
+    # ``main()`` just uploaded.
+    dispatch_via_skypilot(spec, sky_cfg, spec_uri=spec.r2.input_spec_uri())
 
 
 if __name__ == "__main__":

--- a/src/synth_setter/pipeline/constants.py
+++ b/src/synth_setter/pipeline/constants.py
@@ -11,8 +11,8 @@ INPUT_SPEC_FILENAME = "input_spec.json"
 # Today's consumers: the launcher (``dispatch_via_skypilot``) injects the value
 # into each rank's ``task.update_envs``; the CI helper (``pipeline.ci.spec_uri``)
 # reconstructs the URI for workflow exports. No worker code reads it yet — the
-# dispatched cmd rebuilds the spec from Hydra overrides; PR-3 / PR-4 will swap
-# in a worker that reads this env var directly.
+# dispatched cmd rebuilds the spec from Hydra overrides; #1115 / #1116 will
+# swap in a worker that reads this env var directly.
 WORKER_SPEC_URI_ENV = "WORKER_SPEC_URI"
 
 # Cloudflare R2 remote name used by rclone (``rclone copy <src> r2:bucket/key``).

--- a/src/synth_setter/pipeline/constants.py
+++ b/src/synth_setter/pipeline/constants.py
@@ -7,10 +7,12 @@ Canonical names from docs/design/data-pipeline.md §7.1 (storage layout).
 # JSON serialization, never modified after launch.
 INPUT_SPEC_FILENAME = "input_spec.json"
 
-# Env-var name the worker reads to locate the materialized DatasetSpec — see
-# ``synth_setter.cli.generate_dataset.load_spec_from_uri``. The launcher
-# (`dispatch_via_skypilot`) injects this into each rank's ``task.update_envs``;
-# the CI helper ``pipeline.ci.spec_uri`` reconstructs it for workflow exports.
+# Env-var name reserved for the worker to locate the materialized DatasetSpec.
+# Today's consumers: the launcher (``dispatch_via_skypilot``) injects the value
+# into each rank's ``task.update_envs``; the CI helper (``pipeline.ci.spec_uri``)
+# reconstructs the URI for workflow exports. No worker code reads it yet — the
+# dispatched cmd rebuilds the spec from Hydra overrides; PR-3 / PR-4 will swap
+# in a worker that reads this env var directly.
 WORKER_SPEC_URI_ENV = "WORKER_SPEC_URI"
 
 # Cloudflare R2 remote name used by rclone (``rclone copy <src> r2:bucket/key``).

--- a/src/synth_setter/pipeline/constants.py
+++ b/src/synth_setter/pipeline/constants.py
@@ -7,6 +7,12 @@ Canonical names from docs/design/data-pipeline.md §7.1 (storage layout).
 # JSON serialization, never modified after launch.
 INPUT_SPEC_FILENAME = "input_spec.json"
 
+# Env-var name the worker reads to locate the materialized DatasetSpec — see
+# ``synth_setter.cli.generate_dataset.load_spec_from_uri``. The launcher
+# (`dispatch_via_skypilot`) injects this into each rank's ``task.update_envs``;
+# the CI helper ``pipeline.ci.spec_uri`` reconstructs it for workflow exports.
+WORKER_SPEC_URI_ENV = "WORKER_SPEC_URI"
+
 # Cloudflare R2 remote name used by rclone (``rclone copy <src> r2:bucket/key``).
 # Resolution is the caller's responsibility — the standard ``RCLONE_CONFIG_R2_*``
 # env vars must be set when any rclone subprocess runs.

--- a/src/synth_setter/pipeline/skypilot_launch.py
+++ b/src/synth_setter/pipeline/skypilot_launch.py
@@ -1004,7 +1004,7 @@ def dispatch_via_skypilot(
     :param spec: Validated dataset spec to render on the worker(s).
     :param sky_cfg: Validated launcher configuration (compute_template + cmd required).
     :param spec_uri: Canonical R2 URI of the materialized spec — injected into each
-        worker's env as ``WORKER_SPEC_URI`` so a future worker (PR-3 / PR-4) can
+        worker's env as ``WORKER_SPEC_URI`` so a future worker (#1115 / #1116) can
         read from the same object ``main()`` just uploaded. The dispatched cmd
         today rebuilds the spec from Hydra overrides and does not yet consume
         this env var. Pass ``spec.r2.input_spec_uri()`` (not
@@ -1071,7 +1071,7 @@ def dispatch_via_skypilot(
         _run_cred_bootstrap(provider=provider, env_file_path=env_file_path)
 
     # Legacy upload still runs for older CI workflows that read its URI;
-    # the worker env is now sourced from the canonical kwarg. Removed in PR-4.
+    # the worker env is now sourced from the canonical kwarg. Removed in #1116.
     legacy_upload_uri = upload_spec_to_r2(spec, job_name=base_job_name)
     click.echo(f"Spec uploaded to {legacy_upload_uri} (legacy)")
     worker_env[WORKER_SPEC_URI_ENV] = spec_uri

--- a/src/synth_setter/pipeline/skypilot_launch.py
+++ b/src/synth_setter/pipeline/skypilot_launch.py
@@ -1004,8 +1004,10 @@ def dispatch_via_skypilot(
     :param spec: Validated dataset spec to render on the worker(s).
     :param sky_cfg: Validated launcher configuration (compute_template + cmd required).
     :param spec_uri: Canonical R2 URI of the materialized spec — injected into each
-        worker's env as ``WORKER_SPEC_URI`` so the worker downloads from the same
-        object ``main()`` just uploaded. Use ``spec.r2.input_spec_uri()`` (not
+        worker's env as ``WORKER_SPEC_URI`` so a future worker (PR-3 / PR-4) can
+        read from the same object ``main()`` just uploaded. The dispatched cmd
+        today rebuilds the spec from Hydra overrides and does not yet consume
+        this env var. Pass ``spec.r2.input_spec_uri()`` (not
         ``spec.r2.uri(INPUT_SPEC_FILENAME)`` — that omits the run prefix).
     :raises ValueError: degenerate ``sky_cfg``, conflicting ``cmd``/``run:`` pair,
         or unresolved worker env vars.

--- a/src/synth_setter/pipeline/skypilot_launch.py
+++ b/src/synth_setter/pipeline/skypilot_launch.py
@@ -59,13 +59,12 @@ from hydra import compose, initialize_config_dir
 from hydra.errors import HydraException
 
 from synth_setter.cli.generate_dataset import spec_from_cfg
-from synth_setter.pipeline.constants import LAUNCHER_SPEC_R2_PREFIX
+from synth_setter.pipeline.constants import LAUNCHER_SPEC_R2_PREFIX, WORKER_SPEC_URI_ENV
 from synth_setter.pipeline.partitioning import NUM_WORKERS_ENV_VAR, WORKER_RANK_ENV_VAR
 from synth_setter.pipeline.r2_io import to_rclone_path
 from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
 from synth_setter.pipeline.schemas.spec import DatasetSpec
 
-_WORKER_SPEC_URI_ENV = "WORKER_SPEC_URI"
 _WORKER_IMAGE_ENV = "WORKER_IMAGE"
 _WORKER_IMAGE_REPO = "tinaudio/synth-setter"
 
@@ -590,7 +589,7 @@ def main(
     # same r2_prefix — this is what makes the partition cohere as one logical dataset.
     spec_uri = upload_spec_to_r2(spec, job_name=base_job_name)
     click.echo(f"Spec uploaded to {spec_uri}")
-    worker_env[_WORKER_SPEC_URI_ENV] = spec_uri
+    worker_env[WORKER_SPEC_URI_ENV] = spec_uri
 
     # Kubernetes-specific: SkyPilot 0.12 caches enabled-clouds in-process; a
     # CLI `sky check` doesn't always populate the cache the SDK reads, and
@@ -989,7 +988,12 @@ def _run_workers_from_doc(
     return _run_workers_detached(job_names, launch_get_job_id)
 
 
-def dispatch_via_skypilot(spec: DatasetSpec, sky_cfg: SkypilotLaunchConfig) -> None:
+def dispatch_via_skypilot(
+    spec: DatasetSpec,
+    sky_cfg: SkypilotLaunchConfig,
+    *,
+    spec_uri: str,
+) -> None:
     """Dispatch ``spec`` to the SkyPilot template named in ``sky_cfg``.
 
     ``sky_cfg.compute_template`` and ``sky_cfg.cmd`` must both be set;
@@ -999,6 +1003,10 @@ def dispatch_via_skypilot(spec: DatasetSpec, sky_cfg: SkypilotLaunchConfig) -> N
 
     :param spec: Validated dataset spec to render on the worker(s).
     :param sky_cfg: Validated launcher configuration (compute_template + cmd required).
+    :param spec_uri: Canonical R2 URI of the materialized spec — injected into each
+        worker's env as ``WORKER_SPEC_URI`` so the worker downloads from the same
+        object ``main()`` just uploaded. Use ``spec.r2.input_spec_uri()`` (not
+        ``spec.r2.uri(INPUT_SPEC_FILENAME)`` — that omits the run prefix).
     :raises ValueError: degenerate ``sky_cfg``, conflicting ``cmd``/``run:`` pair,
         or unresolved worker env vars.
     :raises RuntimeError: one or more ranks did not reach the SUCCEEDED terminal status.
@@ -1060,9 +1068,11 @@ def dispatch_via_skypilot(spec: DatasetSpec, sky_cfg: SkypilotLaunchConfig) -> N
     if provider != "local":
         _run_cred_bootstrap(provider=provider, env_file_path=env_file_path)
 
-    spec_uri = upload_spec_to_r2(spec, job_name=base_job_name)
-    click.echo(f"Spec uploaded to {spec_uri}")
-    worker_env[_WORKER_SPEC_URI_ENV] = spec_uri
+    # Legacy upload still runs for older CI workflows that read its URI;
+    # the worker env is now sourced from the canonical kwarg. Removed in PR-4.
+    legacy_upload_uri = upload_spec_to_r2(spec, job_name=base_job_name)
+    click.echo(f"Spec uploaded to {legacy_upload_uri} (legacy)")
+    worker_env[WORKER_SPEC_URI_ENV] = spec_uri
 
     if provider == "local":
         import sky.check

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1175,7 +1175,7 @@ class TestMainDispatchBranches:
 
         recorded: dict[str, object] = {}
 
-        def _fake_dispatch(spec: object, sky_cfg: object) -> None:
+        def _fake_dispatch(spec: object, sky_cfg: object, **_kwargs: object) -> None:
             recorded["spec"] = spec
             recorded["sky_cfg"] = sky_cfg
 
@@ -1390,3 +1390,38 @@ class TestMainSpecPersistence:
 
         call_names = [c[0] for c in manager.mock_calls]
         assert call_names.index("ensure_env") < call_names.index("upload_spec")
+
+    def test_dispatch_branch_passes_canonical_spec_uri_kwarg(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """``main()`` threads ``spec.r2.input_spec_uri()`` into ``dispatch_via_skypilot``.
+
+        PR-2 contract: the launcher passes the canonical spec URI (including
+        the run's prefix) as a kwarg so the worker reads the same R2 object
+        ``main()`` just uploaded. Uses ``spec.r2.input_spec_uri()`` (not
+        ``spec.r2.uri(INPUT_SPEC_FILENAME)``) — the former includes the prefix.
+
+        :param monkeypatch: Pytest fixture used to patch ``sys.argv`` + dispatch.
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
+        import synth_setter.cli.generate_dataset as gd
+        import synth_setter.pipeline.skypilot_launch as sl
+
+        template = self._write_minimal_template(tmp_path)
+        monkeypatch.setattr("sys.argv", self._dispatch_argv(template))
+
+        recorded: dict[str, object] = {}
+
+        def _fake_dispatch(spec: DatasetSpec, sky_cfg: object, **kwargs: object) -> None:
+            recorded["spec"] = spec
+            recorded["kwargs"] = kwargs
+
+        monkeypatch.setattr(sl, "dispatch_via_skypilot", _fake_dispatch)
+
+        gd.main()
+
+        spec = recorded["spec"]
+        assert isinstance(spec, DatasetSpec)
+        kwargs = recorded["kwargs"]
+        assert isinstance(kwargs, dict)
+        assert kwargs["spec_uri"] == spec.r2.input_spec_uri()

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -19,10 +19,10 @@ import pytest
 import yaml
 from click.testing import CliRunner
 
+from synth_setter.pipeline.constants import WORKER_SPEC_URI_ENV
 from synth_setter.pipeline.schemas.spec import DatasetSpec
 from synth_setter.pipeline.skypilot_launch import (
     _WORKER_ENV_KEYS,
-    _WORKER_SPEC_URI_ENV,
     _override_image_id,
     load_worker_env,
     main,
@@ -550,7 +550,7 @@ class TestMainCli:
         task.update_envs.assert_called_once()
         forwarded = task.update_envs.call_args.args[0]
         assert (
-            forwarded[_WORKER_SPEC_URI_ENV]
+            forwarded[WORKER_SPEC_URI_ENV]
             == "r2://intermediate-data/skypilot-launcher-specs/smoke-job-1.json"
         )
 
@@ -2631,6 +2631,13 @@ def _write_runpod_yaml(
     return path
 
 
+# Canonical-path spec URI used by the dispatch tests. Mirrors what
+# ``spec.r2.input_spec_uri()`` would resolve to for ``_build_spec``'s fixture
+# spec (prefix `data/<task_name>/<created_at>/`); kept as a fixed string in
+# tests because the dispatch function only sees the kwarg, not the spec field.
+_DISPATCH_SPEC_URI = "r2://intermediate-data/data/run/input_spec.json"
+
+
 def _build_spec(fake_plugin: Path) -> DatasetSpec:
     """Build a DatasetSpec wired to ``fake_plugin`` for the dispatch tests.
 
@@ -2780,6 +2787,14 @@ class TestDetectProviderFromDoc:
             _detect_provider_from_doc(doc, source=tmp_path / "x.yaml")
 
 
+class TestWorkerSpecUriEnvConstant:
+    """``WORKER_SPEC_URI_ENV`` is the canonical public env-var name for worker spec URIs."""
+
+    def test_constant_exposed_publicly_from_pipeline_constants(self) -> None:
+        """Public constant matches the legacy env-var name used by the worker."""
+        assert WORKER_SPEC_URI_ENV == "WORKER_SPEC_URI"
+
+
 class TestDispatchViaSkypilot:
     """``dispatch_via_skypilot`` rejects degenerate cfgs and threads per-rank fanout through."""
 
@@ -2794,7 +2809,7 @@ class TestDispatchViaSkypilot:
         spec = _build_spec(fake_plugin)
         sky_cfg = SkypilotLaunchConfig(compute_template=None, cmd="echo")
         with pytest.raises(ValueError, match="compute_template"):
-            dispatch_via_skypilot(spec, sky_cfg)
+            dispatch_via_skypilot(spec, sky_cfg, spec_uri=_DISPATCH_SPEC_URI)
 
     def test_missing_cmd_raises(self, tmp_path: Path, fake_plugin: Path) -> None:
         """No cmd → no run block on the worker → we refuse to launch a no-op task.
@@ -2809,7 +2824,7 @@ class TestDispatchViaSkypilot:
         spec = _build_spec(fake_plugin)
         sky_cfg = SkypilotLaunchConfig(compute_template=str(template), cmd=None)
         with pytest.raises(ValueError, match="cmd"):
-            dispatch_via_skypilot(spec, sky_cfg)
+            dispatch_via_skypilot(spec, sky_cfg, spec_uri=_DISPATCH_SPEC_URI)
 
     def test_yaml_run_block_conflicts_with_cmd(
         self,
@@ -2830,7 +2845,7 @@ class TestDispatchViaSkypilot:
         spec = _build_spec(fake_plugin)
         sky_cfg = SkypilotLaunchConfig(compute_template=str(template), cmd="echo")
         with pytest.raises(ValueError, match="has a non-empty `run:` block"):
-            dispatch_via_skypilot(spec, sky_cfg)
+            dispatch_via_skypilot(spec, sky_cfg, spec_uri=_DISPATCH_SPEC_URI)
         mock_sky.jobs.launch.assert_not_called()
 
     def test_missing_worker_env_raises(
@@ -2868,7 +2883,7 @@ class TestDispatchViaSkypilot:
             env_file=None,
         )
         with pytest.raises(ValueError, match="No worker env vars resolved"):
-            dispatch_via_skypilot(spec, sky_cfg)
+            dispatch_via_skypilot(spec, sky_cfg, spec_uri=_DISPATCH_SPEC_URI)
 
     def test_end_to_end_dispatch_uses_cmd_as_run_block(
         self,
@@ -2901,7 +2916,7 @@ class TestDispatchViaSkypilot:
             job_name="dispatch-smoke",
         )
 
-        dispatch_via_skypilot(spec, sky_cfg)
+        dispatch_via_skypilot(spec, sky_cfg, spec_uri=_DISPATCH_SPEC_URI)
 
         # The launcher should have built one Task per rank from a dict whose run: was cmd.
         mock_sky.Task.from_yaml_config.assert_called()
@@ -2942,7 +2957,7 @@ class TestDispatchViaSkypilot:
         )
 
         with pytest.raises(RuntimeError, match="worker.* failed"):
-            dispatch_via_skypilot(spec, sky_cfg)
+            dispatch_via_skypilot(spec, sky_cfg, spec_uri=_DISPATCH_SPEC_URI)
 
     def test_multi_worker_fans_out_one_task_per_rank(
         self,
@@ -2976,7 +2991,7 @@ class TestDispatchViaSkypilot:
             num_workers=3,
         )
 
-        dispatch_via_skypilot(spec, sky_cfg)
+        dispatch_via_skypilot(spec, sky_cfg, spec_uri=_DISPATCH_SPEC_URI)
 
         # 3 ranks → 3 sky.Task.from_yaml_config calls with the same cmd-injected doc.
         assert mock_sky.Task.from_yaml_config.call_count == 3
@@ -3041,7 +3056,7 @@ class TestDispatchViaSkypilot:
         sky_cfg = SkypilotLaunchConfig(**kwargs)  # type: ignore[arg-type]
 
         with pytest.raises(ValueError, match=match):
-            dispatch_via_skypilot(spec, sky_cfg)
+            dispatch_via_skypilot(spec, sky_cfg, spec_uri=_DISPATCH_SPEC_URI)
         mock_sky.jobs.launch.assert_not_called()
 
     def test_job_name_falls_back_to_task_name_prefix_when_unset(
@@ -3074,7 +3089,7 @@ class TestDispatchViaSkypilot:
             job_name=None,
         )
 
-        dispatch_via_skypilot(spec, sky_cfg)
+        dispatch_via_skypilot(spec, sky_cfg, spec_uri=_DISPATCH_SPEC_URI)
 
         submitted = mock_sky.jobs.launch.call_args.kwargs["name"]
         assert submitted.startswith("synth-setter-smoke-")
@@ -3112,5 +3127,61 @@ class TestDispatchViaSkypilot:
             local=True,
         )
         with pytest.raises(ValueError, match="mutually exclusive"):
-            dispatch_via_skypilot(spec, sky_cfg)
+            dispatch_via_skypilot(spec, sky_cfg, spec_uri=_DISPATCH_SPEC_URI)
         mock_sky.jobs.launch.assert_not_called()
+
+    def test_spec_uri_kwarg_injected_verbatim_into_worker_env(
+        self,
+        tmp_path: Path,
+        fake_plugin: Path,
+        env_file: Path,
+        local_spec_dir: Path,
+        mock_sky: MagicMock,
+        patch_materialize_io: None,  # noqa: ARG002
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The kwarg-supplied ``spec_uri`` lands in worker env verbatim — not upload's return.
+
+        PR-2 contract: ``dispatch_via_skypilot`` derives ``WORKER_SPEC_URI`` from its
+        ``spec_uri`` kwarg, not from ``upload_spec_to_r2``'s return value. The legacy
+        ``upload_spec_to_r2`` call still runs (it's removed in PR-4), so this test forces
+        the upload helper to return a sentinel string and asserts the worker env carries
+        the kwarg-supplied canonical URI instead.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param fake_plugin: Fixture-provided fake VST3 plugin path.
+        :param env_file: Fixture-provided worker env file path.
+        :param local_spec_dir: Fixture-provided local spec directory.
+        :param mock_sky: Mocked ``sky`` module from fixture.
+        :param patch_materialize_io: Fixture stubbing materialize-side IO.
+        :param monkeypatch: Pytest fixture used to patch the upload helper.
+        """
+        from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
+        from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot
+
+        # Make the legacy upload return a value distinct from the kwarg, so the
+        # worker env's WORKER_SPEC_URI can only match one of them — proving the
+        # source is the kwarg, not the upload result.
+        legacy_upload_uri = "r2://intermediate-data/skypilot-launcher-specs/legacy.json"
+        monkeypatch.setattr(
+            "synth_setter.pipeline.skypilot_launch.upload_spec_to_r2",
+            lambda spec, job_name: legacy_upload_uri,
+        )
+
+        template = _write_runpod_yaml(tmp_path)
+        spec = _build_spec(fake_plugin)
+        sky_cfg = SkypilotLaunchConfig(
+            compute_template=str(template),
+            cmd="echo",
+            env_file=str(env_file),
+            job_name="kwarg-spec-uri",
+        )
+
+        dispatch_via_skypilot(spec, sky_cfg, spec_uri=_DISPATCH_SPEC_URI)
+
+        # update_envs is called per rank; this single-worker case has one call.
+        update_envs_calls = mock_sky.Task.from_yaml_config.return_value.update_envs.call_args_list
+        assert len(update_envs_calls) == 1
+        forwarded = update_envs_calls[0].args[0]
+        assert forwarded[WORKER_SPEC_URI_ENV] == _DISPATCH_SPEC_URI
+        assert forwarded[WORKER_SPEC_URI_ENV] != legacy_upload_uri

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -2631,10 +2631,10 @@ def _write_runpod_yaml(
     return path
 
 
-# Canonical-path spec URI used by the dispatch tests. Mirrors what
-# ``spec.r2.input_spec_uri()`` would resolve to for ``_build_spec``'s fixture
-# spec (prefix `data/<task_name>/<created_at>/`); kept as a fixed string in
-# tests because the dispatch function only sees the kwarg, not the spec field.
+# Sentinel spec URI passed as the dispatch kwarg in tests. Shape mirrors
+# ``input_spec_uri()`` (``r2://<bucket>/<prefix>input_spec.json``) but the
+# prefix segment is arbitrary — ``dispatch_via_skypilot`` only sees the kwarg
+# string and never reads it back from the spec.
 _DISPATCH_SPEC_URI = "r2://intermediate-data/data/run/input_spec.json"
 
 


### PR DESCRIPTION
## Summary

PR-2 in the input_spec.json chain rooted at #603. Threads the canonical
``spec.r2.input_spec_uri()`` through to the worker env so dispatched workers
read from the same R2 object ``main()`` just uploaded (PR-1 / #1120).

Three concrete changes:

1. **``src/synth_setter/pipeline/constants.py``** — Promotes the previously
   private ``_WORKER_SPEC_URI_ENV`` from ``skypilot_launch.py`` to public
   ``WORKER_SPEC_URI_ENV`` next to ``INPUT_SPEC_FILENAME``. CI helpers and
   future PR-3 / PR-4 wiring import it from one canonical home.

2. **``src/synth_setter/pipeline/skypilot_launch.py::dispatch_via_skypilot``** —
   Adds a required ``spec_uri: str`` keyword-only kwarg. The worker env's
   ``WORKER_SPEC_URI`` is now sourced from this kwarg rather than from
   ``upload_spec_to_r2``'s return value. The legacy ``upload_spec_to_r2``
   call **intentionally still runs** in PR-2 so older CI workflows that read
   the legacy URI keep working; it is removed in PR-4.

3. **``src/synth_setter/cli/generate_dataset.py::main``** — Threads
   ``spec.r2.input_spec_uri()`` (the canonical accessor that includes the
   run's prefix) into ``dispatch_via_skypilot(..., spec_uri=...)``. Note:
   ``spec.r2.uri(INPUT_SPEC_FILENAME)`` would omit the prefix and is the
   anti-pattern the docstring guards against.

## Test plan

- [x] ``make test-fast`` — 1152 passed, 2 skipped.
- [x] New tests:
  - ``TestWorkerSpecUriEnvConstant`` — verifies the public constant.
  - ``test_spec_uri_kwarg_injected_verbatim_into_worker_env`` — proves the
    worker env's ``WORKER_SPEC_URI`` matches the kwarg, not the legacy
    upload's return (load-bearing assertion for PR-2's contract).
  - ``test_dispatch_branch_passes_canonical_spec_uri_kwarg`` — proves
    ``main()`` threads ``spec.r2.input_spec_uri()`` into the dispatch call.

## Closes

Closes #1114