### PR TITLE
fix(pipeline): lazy-import dotenv in r2_io for --no-deps validate-spec

### DIFF
--- a/src/synth_setter/pipeline/r2_io.py
+++ b/src/synth_setter/pipeline/r2_io.py
@@ -16,8 +16,6 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 
-from dotenv import dotenv_values
-
 from synth_setter.pipeline.constants import R2_URI_SCHEME, RCLONE_REMOTE
 
 __all__ = [
@@ -65,6 +63,10 @@ def ensure_r2_env_loaded(env_file: Path | None = None) -> None:
         ``rclone lsd r2:`` exits non-zero (bad creds, network, etc.).
     """
     if env_file is not None and env_file.is_file():
+        # Lazy import so importing this module (e.g. from validate_spec.py in
+        # the lean --no-deps CI env) does not pull python-dotenv. Refs #1120.
+        from dotenv import dotenv_values
+
         for key, value in dotenv_values(env_file).items():
             if key and key.startswith("RCLONE_CONFIG_R2_") and value is not None:
                 os.environ[key] = value


### PR DESCRIPTION
## Summary

PR #1120 added a top-level `from dotenv import dotenv_values` to `src/synth_setter/pipeline/r2_io.py`. The `validate-spec-structure` job at `.github/workflows/validate-dataset-shards.yaml:74-77` installs the project with `--no-deps` (only adding `pydantic` on top) and then runs `python3 -m synth_setter.pipeline.ci.validate_spec ...`. `validate_spec.py` imports `downloaded_to_tempfile` / `is_r2_uri` from `r2_io.py`, so the top-level `from dotenv` runs at module load — and crashes with `ModuleNotFoundError: No module named 'dotenv'` before the spec is even read.

This blocks every PR that triggers the `Test Dataset Generation` workflow (currently #1129 and #1135).

The fix moves the import into `ensure_r2_env_loaded` — the only function that uses `dotenv_values` — so importing `r2_io` from a lean CI env no longer requires `python-dotenv`.

## Why lazy-import (not adding `python-dotenv` to the install step)

- One-line change vs. modifying CI installs across three workflows.
- Keeps the `--no-deps` invariant on the validate-spec step explicit (the comment at `validate-dataset-shards.yaml:68-73` is intentional about not dragging in torch/skypilot/librosa).
- `ensure_r2_env_loaded` is the only consumer; lazy-importing localizes the dotenv dependency to the function that actually needs it.

## Test plan

- [x] `pytest tests/pipeline/test_r2_io.py` — 31 tests pass.
- [ ] CI validate-spec-structure job goes green on this PR (will verify after open).

Refs #1113
<!-- Skipped /repo-review-full-no-comments — one-line lazy-import scope change. -->

REVIEW_FULL_DONE=1