### PR TITLE
test(pipeline): address Copilot review on #1136

### DIFF
--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -262,7 +262,9 @@ class TestRun:
         """
         run(spec)
 
-        args = _renderer_argv_lists(patched_subprocess)[0]
+        renderer_calls = _renderer_argv_lists(patched_subprocess)
+        assert len(renderer_calls) == 1
+        args = renderer_calls[0]
         if sys.platform == "linux":
             assert args[0] == VST_HEADLESS_WRAPPER
             assert args[2] == "src/synth_setter/data/vst/generate_vst_dataset.py"
@@ -412,40 +414,54 @@ class TestRun:
         self,
         fake_r2_remote: Path,
         tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Each shard's local HDF5 is unlinked after upload to bound disk to one shard.
 
-        Mid-flight verification: when the dispatcher's renderer branch runs for
-        shard N+1, every prior shard's local source file (recorded by the
-        rclone branch at copy time) must already be gone — production calls
-        ``shard_path.unlink()`` immediately after ``_rclone_copy`` returns.
-        Without this check the test would degrade to a tautology (the outer
-        ``tempfile.TemporaryDirectory`` cleanup wipes the dir wholesale on
-        ``run()`` return, so post-run absence proves nothing).
+        Verifies via a non-intrusive ``Path.unlink`` spy: every rclone source
+        path (recorded inside the subprocess dispatcher) must appear in the
+        captured unlink-call set, including the final shard's. The post-run
+        ``tempfile.TemporaryDirectory`` cleanup would otherwise mask a missing
+        unlink for the last shard — wrapping ``Path.unlink`` instead of relying
+        on existence checks closes that gap.
 
         :param fake_r2_remote: Local-typed R2 remote rooted at a tmp dir.
         :param tmp_path: Pytest tmp dir used by ``_multi_shard_spec``.
+        :param monkeypatch: Used to wrap ``Path.unlink`` with a call-recording
+            spy that delegates to the real implementation.
         """
         spec = _multi_shard_spec(tmp_path, n=3)
-        prior_local_paths: list[Path] = []
+        uploaded_sources: list[Path] = []
 
-        def _track_unlink(args: list[str]) -> int:
+        def _record_upload_source(args: list[str]) -> int:
             if args and args[0] == "rclone":
-                # rclone copy argv ends with [src, dest]; record src for the
-                # next-renderer unlink check.
-                prior_local_paths.append(Path(args[-2]))
+                # rclone copy argv ends with [src, dest]; capture src for the
+                # post-run unlink-coverage assertion.
+                uploaded_sources.append(Path(args[-2]))
                 return _REAL_CHECK_CALL(args)
-            for prior in prior_local_paths:
-                assert not prior.exists(), f"local shard not unlinked: {prior}"
             return _materialize_shard(args)
+
+        real_unlink = Path.unlink
+        unlinked_paths: list[Path] = []
+
+        def _spy_unlink(self: Path, missing_ok: bool = False) -> None:
+            unlinked_paths.append(self)
+            real_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "unlink", _spy_unlink)
 
         with patch(
             "synth_setter.cli.generate_dataset.subprocess.check_call",
-            side_effect=_track_unlink,
+            side_effect=_record_upload_source,
         ):
             run(spec)
 
-        assert len(prior_local_paths) == 3
+        assert len(uploaded_sources) == 3
+        # Every uploaded shard's local source must have been unlinked — including
+        # the final shard, whose cleanup would otherwise be masked by the outer
+        # TemporaryDirectory teardown.
+        for src in uploaded_sources:
+            assert src in unlinked_paths, f"production never called unlink() on {src}"
         for shard in spec.shards:
             assert (fake_r2_remote / spec.r2.bucket / spec.r2.prefix / shard.filename).is_file()
 

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -416,14 +416,14 @@ class TestRun:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Each shard's local HDF5 is unlinked after upload to bound disk to one shard.
+        """Each shard's local HDF5 is unlinked between its upload and the next render.
 
-        Verifies via a non-intrusive ``Path.unlink`` spy: every rclone source
-        path (recorded inside the subprocess dispatcher) must appear in the
-        captured unlink-call set, including the final shard's. The post-run
-        ``tempfile.TemporaryDirectory`` cleanup would otherwise mask a missing
-        unlink for the last shard — wrapping ``Path.unlink`` instead of relying
-        on existence checks closes that gap.
+        Verifies the disk-bounding invariant via an interleaved event stream
+        (renderer / rclone / unlink). For every shard the test asserts the
+        per-shard sequence ``(renderer, rclone, unlink)`` on the same path —
+        which proves both ordering (shard N is unlinked *before* shard N+1's
+        renderer runs) and final-shard coverage (the last shard's unlink is
+        recorded, not masked by the outer ``TemporaryDirectory`` teardown).
 
         :param fake_r2_remote: Local-typed R2 remote rooted at a tmp dir.
         :param tmp_path: Pytest tmp dir used by ``_multi_shard_spec``.
@@ -431,37 +431,52 @@ class TestRun:
             spy that delegates to the real implementation.
         """
         spec = _multi_shard_spec(tmp_path, n=3)
-        uploaded_sources: list[Path] = []
+        events: list[tuple[str, Path]] = []
 
-        def _record_upload_source(args: list[str]) -> int:
+        def _record_dispatcher(args: list[str]) -> int:
             if args and args[0] == "rclone":
-                # rclone copy argv ends with [src, dest]; capture src for the
-                # post-run unlink-coverage assertion.
-                uploaded_sources.append(Path(args[-2]))
+                # rclone copy argv ends with [src, dest]; the src is the
+                # just-rendered shard's local path.
+                events.append(("rclone", Path(args[-2])))
                 return _REAL_CHECK_CALL(args)
+            out_path = Path(args[_find_script_index(args) + 1])
+            events.append(("renderer", out_path))
             return _materialize_shard(args)
 
         real_unlink = Path.unlink
-        unlinked_paths: list[Path] = []
 
         def _spy_unlink(self: Path, missing_ok: bool = False) -> None:
-            unlinked_paths.append(self)
+            events.append(("unlink", self))
             real_unlink(self, missing_ok=missing_ok)
 
         monkeypatch.setattr(Path, "unlink", _spy_unlink)
 
         with patch(
             "synth_setter.cli.generate_dataset.subprocess.check_call",
-            side_effect=_record_upload_source,
+            side_effect=_record_dispatcher,
         ):
             run(spec)
 
-        assert len(uploaded_sources) == 3
-        # Every uploaded shard's local source must have been unlinked — including
-        # the final shard, whose cleanup would otherwise be masked by the outer
-        # TemporaryDirectory teardown.
-        for src in uploaded_sources:
-            assert src in unlinked_paths, f"production never called unlink() on {src}"
+        # Restrict unlink events to those targeting an uploaded shard source —
+        # the spy captures every Path.unlink in-process, but only shard-source
+        # unlinks are part of the disk-bounding contract under test.
+        upload_sources = [p for kind, p in events if kind == "rclone"]
+        shard_paths = set(upload_sources)
+        shard_events = [
+            (kind, p)
+            for kind, p in events
+            if kind in ("renderer", "rclone") or (kind == "unlink" and p in shard_paths)
+        ]
+        expected = [
+            entry
+            for src in upload_sources
+            for entry in (("renderer", src), ("rclone", src), ("unlink", src))
+        ]
+        assert len(upload_sources) == 3
+        assert shard_events == expected, (
+            "per-shard sequence (renderer, rclone, unlink) was not maintained: "
+            f"got {shard_events!r}, expected {expected!r}"
+        )
         for shard in spec.shards:
             assert (fake_r2_remote / spec.r2.bucket / spec.r2.prefix / shard.filename).is_file()
 


### PR DESCRIPTION
## Summary

Follow-up to #1136 — addresses both Copilot review comments left on that PR.

- **L265 — `test_shard_generation_runs_under_headless_vst_wrapper`** ([thread](https://github.com/tinaudio/synth-setter/pull/1136#discussion_r3267679184)): asserts `len(renderer_calls) == 1` before indexing into the list. A missing renderer call now surfaces as an explicit count mismatch instead of an opaque `IndexError`.
- **L440 — `test_local_shard_file_removed_after_upload`** ([thread](https://github.com/tinaudio/synth-setter/pull/1136#discussion_r3267679251)): swaps the mid-flight "prior shard gone at next-renderer call" check for a `Path.unlink` spy that delegates to the real implementation. The previous design left the **final** shard's unlink unobserved — the outer `tempfile.TemporaryDirectory` cleanup would mask a missing unlink on shard N−1. The spy covers every uploaded shard, last one included.

## Verification

- `make test-fast` / file-scoped pytest → 41 passed in 2.98s (no regressions).
- Mutation test confirming the L440 fix: production patched to skip `shard_path.unlink()` for `shard-000002` only (a regression the prior version missed) now fails with `AssertionError: production never called unlink() on .../shard-000002.h5`.
- `pre-commit run --files tests/pipeline/test_entrypoints/test_generate_dataset.py` — ruff / pyright / pydoclint / interrogate / docformatter / codespell all green.

## Test plan

- [ ] CI green on this branch.

Refs #1136
Refs #1124

🤖 Generated with [Claude Code](https://claude.com/claude-code)