### PR TITLE
ci(pipeline): drop unused pydantic install from r2-auth-probe

### DIFF
--- a/.github/workflows/r2-auth-probe.yaml
+++ b/.github/workflows/r2-auth-probe.yaml
@@ -62,14 +62,14 @@ jobs:
       - name: Install rclone
         run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
 
-      # Mirror `validate-dataset-shards.yaml`'s install step exactly so the
-      # runner-side env is comparable to the existing failing job: project
-      # with --no-deps (skip torch/skypilot/librosa) plus pydantic and
-      # python-dotenv, which `ensure_r2_env_loaded` imports directly.
+      # Mirror `validate-dataset-shards.yaml`'s minimal-install pattern (project
+      # with --no-deps to skip torch/skypilot/librosa), but only add the deps
+      # `ensure_r2_env_loaded` actually imports: python-dotenv. (Unlike
+      # `validate_spec`, this probe's entry point does not pull in pydantic.)
       - name: Install ensure_r2_env_loaded runtime deps
         run: |
           pip install --no-deps -e .
-          pip install "pydantic>=2,<3" "python-dotenv>=1"
+          pip install "python-dotenv>=1"
 
       - name: Probe ensure_r2_env_loaded
         run: |


### PR DESCRIPTION
## Summary

Follow-up to #1145 — addresses two Copilot review comments that landed after the squash merge:

- [discussion_r3268118962](https://github.com/tinaudio/synth-setter/pull/1145#discussion_r3268118962) — install step claimed `ensure_r2_env_loaded` imports pydantic directly. It does not.
- [discussion_r3268163804](https://github.com/tinaudio/synth-setter/pull/1145#discussion_r3268163804) — install step comment said it mirrors `validate-dataset-shards.yaml` "exactly" while differing.

Verified pydantic is not required by blocking it from `sys.meta_path` and importing `ensure_r2_env_loaded` cleanly. `validate-dataset-shards.yaml` needs pydantic because `validate_spec` imports `pipeline.schemas.spec`, which loads pydantic at module top — the probe doesn't traverse that path.

Net change: one extra `pip install` package dropped, install-step comment rewritten so it stops asserting a false dependency and explicitly calls out the intentional diff with `validate-dataset-shards.yaml`.

## Test plan

- [ ] R2 Auth Probe workflow run on this branch completes (same dispatch path as before, with one fewer install on the wheel-resolution step).
- [ ] Probe step's import of `ensure_r2_env_loaded` still succeeds with only `python-dotenv` installed alongside `-e . --no-deps`.

Refs #1143

🤖 Generated with [Claude Code](https://claude.com/claude-code)