### PR TITLE
chore(dev): add pytest-cov[toml] to dev extras

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install --system -e ".[torch,dev]"
-          uv pip install --system pytest-cov[toml]
 
       - name: List dependencies
         run: uv pip list --system
@@ -100,7 +99,6 @@ jobs:
       - name: Install dependencies
         run: |
           uv pip install --system -e ".[torch,dev]"
-          uv pip install --system pytest-cov[toml]
 
       - name: List dependencies
         run: uv pip list --system

--- a/Makefile
+++ b/Makefile
@@ -149,8 +149,6 @@ install-surge-xt: ## Download Surge XT VST3 into plugins/ (skipped if already pr
 # coverage runs reproduce CI output (xml report feeds Codecov; html is for
 # local browsing).
 coverage: ## Run tests with coverage report
-	pip install uv
-	uv pip install pytest-cov[toml]
 	pytest --cov=src --cov-branch --cov-report=xml --cov-report=term-missing --cov-report=html -m "not slow and not gpu and not mps"
 
 benchmark: ## Run performance benchmarks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ dev = [
   "pyright==1.1.408",
   "pytest",
   "pytest-benchmark",
+  "pytest-cov[toml]",
   "pytest-xdist",
   "ruff",
 ]


### PR DESCRIPTION
## Summary

- Add `pytest-cov[toml]` to `[project.optional-dependencies].dev` in `pyproject.toml` so `pip install -e ".[dev]"` covers everything coverage runs need.
- Drop the redundant inline `uv pip install --system pytest-cov[toml]` from both jobs in `.github/workflows/test.yml`.
- Drop the inline `pip install uv` / `uv pip install pytest-cov[toml]` from the `coverage` target in `Makefile` so the target stops mutating the environment on every invocation.

The Makefile portion is exactly the cleanup tracked in #211; the workflow and `pyproject.toml` portions extend the same idea so all three call sites stop installing `pytest-cov` ad-hoc.

Closes #211

## Test plan

- [ ] CI: the `test.yml` jobs install via `-e ".[torch,dev]"` only and the `--cov` invocation still succeeds.
- [ ] Local: `pip install -e ".[dev]"` then `make coverage` works without any extra installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)