### PR TITLE
fix(eval): predict_vst_audio UnboundLocalError when target params present without -t

### DIFF
--- a/src/synth_setter/evaluation/predict_vst_audio.py
+++ b/src/synth_setter/evaluation/predict_vst_audio.py
@@ -181,6 +181,9 @@ def main(
                 preset_path=preset_path,
             )
 
+            target_synth_params: dict[str, float] | None = None
+            target_note_params: dict[str, float] | None = None
+
             out_target = os.path.join(sample_dir, "target.wav")
             if rerender_target and target_params is not None:
                 target_params_ = target_params[j].numpy()

--- a/tests/evaluation/test_predict_vst_audio.py
+++ b/tests/evaluation/test_predict_vst_audio.py
@@ -360,6 +360,33 @@ def test_main_rerender_target_renders_pred_and_target_per_sample(
         assert bool(df["target"].notna().all())
 
 
+def test_main_target_params_on_disk_without_rerender_does_not_crash(
+    runner: CliRunner, pred_dir: Path, out_dir: Path
+) -> None:
+    """Targets-on-disk + ``rerender_target=False`` must complete without crashing.
+
+    Regression guard for ``UnboundLocalError`` at the ``params_to_csv`` call
+    site: when ``target-params-{i}.pt`` is present but ``--rerender_target``
+    is not passed, ``target_synth_params`` / ``target_note_params`` were never
+    bound but were still referenced by the ``target_params is not None`` arm
+    of the call-site conditional.
+
+    :param runner: Parametrized ``runner`` value under test.
+    :param pred_dir: Parametrized ``pred_dir`` value under test.
+    :param out_dir: Parametrized ``out_dir`` value under test.
+    """
+    _write_batch(pred_dir, index=0, batch_size=2, with_target_params=True)
+
+    result = _invoke_main(runner, pred_dir, out_dir, "--skip-spectrogram")
+
+    assert result.exit_code == 0, result.output
+    for j in range(2):
+        sample_dir = out_dir / f"sample_{j}"
+        assert (sample_dir / "pred.wav").is_file()
+        assert (sample_dir / "target.wav").is_file()
+        assert (sample_dir / "params.csv").is_file()
+
+
 def test_main_multiple_batches_produce_contiguous_sample_indices(
     runner: CliRunner, pred_dir: Path, out_dir: Path
 ) -> None:

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -315,9 +315,7 @@ def test_train_eval_surge_xt(
 
     # Render predicted params through the Surge XT VST to per-sample audio directories.
     # `-t` (`--rerender_target`) re-synthesizes target.wav from the stored target_params instead
-    # of the saved target audio. Also works around an `UnboundLocalError` in
-    # `src/synth_setter/evaluation/predict_vst_audio.py` where `target_synth_params` is referenced in the default
-    # path without being defined outside the `rerender_target` branch (see #672).
+    # of the saved target audio.
     audio_dir = tmp_path / "audio"
     runner = CliRunner()
 


### PR DESCRIPTION
## Summary

Minimal 2-line fix for the `UnboundLocalError` in
`synth_setter.evaluation.predict_vst_audio.main`: when
`target-params-{i}.pt` is present on disk and `--rerender_target` is NOT
passed (the default flow), the `params_to_csv` call site referenced
`target_synth_params` / `target_note_params` via a ternary that fires
the `target_params is not None` arm — but those names are only bound
inside the rerender branch.

Fix: initialize both to `None` at the top of each row iteration. The
existing call-site conditional still evaluates as before (target column
emitted as NaN when `rerender_target=False`); the prior crash was the
*only* observable behavior change.

This PR is intentionally scoped to *just* the bug fix:
- Source: 3 added lines in `predict_vst_audio.py` (2 inits + 1 blank).
- Tests: 1 new regression test (~27 lines) — fails on `main` HEAD with
  the same `UnboundLocalError`; passes with this fix.

Other latent issues in the module (single-panel spectrogram crash,
double dB conversion, `torch.load` without `weights_only`, larger
refactor of `main`) are **not** bundled here — those can ride in
follow-up PRs without conflating bug-fix bisection. Note: a follow-up
worth filing is whether the non-rerender path should *decode*
`target_params[j]` so the CSV target column is populated when target
params are on disk — that's a behavior change beyond fixing the crash.

Replaces (closed) #1076.

Refs #672

## Test plan

- [ ] `make test-fast` — 1190 passed, 2 skipped (verified locally).
- [ ] `tests/evaluation/test_predict_vst_audio.py` — 12 tests pass (was 11; +1 regression test).
- [ ] Revert the source hunk and rerun the new test — fails as expected with `UnboundLocalError` (verified locally).
- [ ] \`pre-commit run --files <changed>\` — all hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)