### PR TITLE
chore(dev): drop obsolete [toml] extra from pytest-cov spec

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
   "pyright==1.1.408",
   "pytest",
   "pytest-benchmark",
-  "pytest-cov[toml]",
+  "pytest-cov",
   "pytest-xdist",
   "ruff",
 ]


### PR DESCRIPTION
## Summary

`pytest-cov` 7.x folded the optional `[toml]` extra (which used to install `tomli`/`tomllib` for `pyproject.toml`-based `[tool.coverage]` config) into the base package. As a result, `pytest-cov[toml]` now emits `WARNING: pytest-cov 7.1.0 does not provide the extra 'toml'` during pip resolution in CI and locally. Drop the suffix — coverage behavior is unchanged.

Surfaced during verification of #1147; see [that PR's verification comment](https://github.com/tinaudio/synth-setter/pull/1147#issuecomment-4490859937) (last paragraph) for the original warning trace.

Closes #1153

## Test plan

- [ ] `pip install -e ".[dev]"` no longer prints `WARNING: pytest-cov 7.1.0 does not provide the extra 'toml'`.
- [ ] CI: `run_tests_ubuntu` and `run_tests_macos` still pass with coverage reporting.