### PR TITLE
chore(claude-md): trim AGENTS.md preamble; move rules to hooks/skills

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,6 +18,26 @@
         ]
       },
       {
+        "matcher": "Edit|Write",
+        "description": "No-baseline-additions: on Edit/Write of .pydoclint-baseline.txt, blocks the call if the post-edit line count exceeds the current count. The file is append-frozen (#938); only removals are allowed. Goal: enforce the lint-cleanup contract at the tool boundary instead of relying on the agent to remember the AGENTS.md rule.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/no-baseline-additions.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "description": "No-yaml-run-comments: on Edit/Write of .github/workflows/*.yml or configs/compute/*.yaml, blocks the call if the post-edit content has any `#`-comment line inside a `run: |` / `setup: |` block scalar. The block scalar body is bash; stray quotes/backticks inside a comment have caused unintended shell expansion. Goal: keep comments above the step, not inside it.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/no-yaml-run-comments.sh"
+          }
+        ]
+      },
+      {
         "matcher": "Bash",
         "description": "Branch safety: echoes the current branch name before any git commit. Prints DETACHED HEAD when not on a branch. Goal: catch accidental commits to the wrong branch.",
         "hooks": [
@@ -25,6 +45,18 @@
             "type": "command",
             "if": "Bash(git commit *)",
             "command": "branch=$(git branch --show-current 2>/dev/null || true); if [[ -z \"$branch\" ]]; then branch=\"DETACHED HEAD\"; fi; echo \"Committing to branch: $branch\" >&2"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "description": "Git-commit-trailer-check: on git commit, blocks the call if argv to git commit carries --no-verify / -n, or the message body carries a Co-Authored-By trailer or an agent-attribution footer ('Generated with ...', 'Claude ...', noreply@anthropic.com). Tokenizes with shlex so downstream commands chained with && / || / ; / | are not mistakenly scoped. Goal: keep agent-attribution trailers and verification bypasses out of the history at the tool boundary.",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git commit *)",
+            "timeout": 10,
+            "command": "bash agent/hooks/git-commit-trailer-check.sh"
           }
         ]
       },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,9 +62,8 @@ Pure docs edits are exempt; no other exemptions.
 ## Commits
 
 - Conventional commits, gitlint-enforced. `internal-feat:` / `internal-fix:`
-  for unreleased code (no version bump). Picking the right scope is a
-  skill-bound decision — invoke `/github-taxonomy` or its scope guidance when
-  composing a commit subject.
+  for unreleased code (no version bump).
+- Scope is skill-bound — see `/github-taxonomy`.
 - **Never `--no-verify` / `-n`.** Pre-commit and gitlint must run. Hooks
   work inside worktrees.
 - **Never add `Co-Authored-By` trailers** or agent-attribution footers
@@ -111,10 +110,9 @@ unintended shell expansion. A `PreToolUse` hook
   (`agent/hooks/pre-pr-review-gate.sh`) blocks `gh pr create` until the
   command carries `REVIEW_FULL_DONE=1` — recommended as a trailing comment
   so other gh-pr-create hooks still fire.
-- **Readiness is four AND-ed gates:** CI green ∧ `mergeable=MERGEABLE` ∧
-  every review comment has an inline reply ∧ no new Copilot comments since
-  the last push. The full procedure (poll-loops, Copilot re-request,
-  endpoints to check) lives in `/pr-preflight`.
+- **Readiness gates:** CI green ∧ `mergeable=MERGEABLE` ∧ every review
+  comment has an inline reply ∧ no fresh Copilot findings — see
+  `/pr-preflight`.
 - **Always reply inline** on each open PR review comment (humans + Copilot),
   with a fix-commit SHA or justification. Use `/pr-review-resolver`.
 - **Verification evidence** for each behavioral claim goes through

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,462 +1,166 @@
 # AGENTS.md
 
+Canonical agent instructions for synth-setter. Shared by Claude and Codex.
+
 ## Project
 
-synth-setter: Synth inversion, sound matching and preset exploration tools
+synth-setter: synth inversion, sound matching, preset exploration tools.
+Python 3.10+, PyTorch Lightning, Hydra, distributed data pipeline on
+SkyPilot-managed compute (RunPod + OCI), stored in Cloudflare R2.
+Architecture: [docs/architecture.md](docs/architecture.md).
 
-- Python 3.10+, PyTorch Lightning, Hydra configs
-- Data pipeline: distributed shard generation on SkyPilot-managed compute (RunPod + OCI), stored in Cloudflare R2
-- Design doc: `docs/design/data-pipeline.md`
+## Always
 
-## Code Standards
+- **Always work in an isolated git worktree.** Branch switching and stash
+  conflicts have caused lost work and accidental commits to wrong branches.
+  Use `git worktree add` (or `isolation: "worktree"` when spawning subagents).
+  The main checkout is read-only — `git log`, exploration, `rclone ls`. Never
+  edit files there.
+- **Always verify the branch before push.** Run `git branch --show-current`
+  and confirm it matches the target PR branch. A hook prints the branch on
+  every `git commit`; don't ignore it.
+- **Never commit without explicit permission.** The user opts in. Pre-commit
+  hooks must not be skipped — see [`### Commits`](#commits).
+- **Never run `make docker-*` or RunPod commands without asking.** These
+  spend money and burn cluster state.
 
-### Formatting & Linting (enforced by pre-commit)
+## Writing code
 
-- **Ruff format** (line-length=99)
-- **Ruff** — rule set in `pyproject.toml` under `[tool.ruff.lint].select` (currently
-  pycodestyle E/W, pyflakes F, isort I, bandit S, T-series, pyupgrade UP, `ANN001`, and
-  pydocstyle `D102`/`D103`/`D107` for must-have-docstring on public methods, functions,
-  and `__init__` — closes pydoclint's missing-docstring blind spot)
-- Run `make format` before committing
-
-#### Lint Exception Lists Are Closed — Fix The Lint, Don't Suppress It
-
-The following files pin the *existing* legacy lint debt at the moment the baselines were
-captured. They are append-frozen — **no PR may add a new entry to any of them**:
-
-| File                      | Frozen list                                                                                   | Cleanup tracker                                             |
-| ------------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
-| `.pydoclint-baseline.txt` | every row in the file (one pinned pydoclint violation each)                                   | [#938](https://github.com/tinaudio/synth-setter/issues/938) |
-| `pyproject.toml`          | `[tool.ruff.lint.per-file-ignores]` and `[tool.ruff].extend-exclude`                          | [#25](https://github.com/tinaudio/synth-setter/issues/25)   |
-| `.pre-commit-config.yaml` | every per-hook `exclude:` regex (pyright, interrogate, shellcheck, mdformat, codespell, etc.) | [#25](https://github.com/tinaudio/synth-setter/issues/25)   |
-| `pyrightconfig.json`      | every path under `"exclude"`                                                                  | [#25](https://github.com/tinaudio/synth-setter/issues/25)   |
-
-**The hard rule.** If your PR's diff *adds* a row, path, glob, or regex to any list
-above, the PR must be rewritten. There are no exceptions for "the file is legacy,"
-"the lint isn't related to my change," "it's a one-line suppression," or "I'll clean
-it up in a follow-up." If a check fails on a file your PR introduces or touches, the
-remediation is to **fix the underlying lint**, not to register the file as exempt.
-
-The *only* allowed edits to these lists are **removals** — graduating a file out of
-exemption as part of the `/lint-cleanup` workflow (one file per PR, `chore(lint):`
-prefix, `Refs #938` for pydoclint baseline rows, `Refs #25` for the other lists). See
-[`.github/agents/lint-cleanup.md`](.github/agents/lint-cleanup.md) for the canonical
-workflow (the `.claude/agents/lint-cleanup.md` entry point is a thin shim that
-delegates to it).
-
-`[tool.pydoclint].exclude` in `pyproject.toml` is infra-only after
-[#1044](https://github.com/tinaudio/synth-setter/pull/1044) and must not be edited
-at all — pydoclint cleanup happens via baseline-row deletions, never exclude-list
-edits.
-
-**Escalation path (the one and only exception).** If you genuinely believe a new
-entry is warranted — for example, a vendored third-party file that cannot be edited —
-the additions ban is lifted *only* by explicit pre-approval from a maintainer,
-recorded on the tracking issue ([#938](https://github.com/tinaudio/synth-setter/issues/938)
-for pydoclint, [#25](https://github.com/tinaudio/synth-setter/issues/25) for the
-others) *before* the PR is opened. Open the PR without that recorded approval and the
-hard rule above applies: it must be rewritten. Do not add the entry first and explain
-after the fact in the PR description.
-
-### Commit Messages
-
-Conventional commits, enforced by gitlint (`.gitlint` config). Prefix matters for semantic versioning:
-
-**Version-bumping prefixes:**
-
-- `feat:` → **minor** bump. New user-facing capability (new model, new pipeline stage, new CLI command). The feature must be usable after this commit.
-- `fix:` / `perf:` / `revert:` → **patch** bump. Bug fixes, performance improvements, and reverts (reverts are roll-forwards on an append-only main).
-- `feat!:` or `BREAKING CHANGE:` footer → **major** bump. Coordinate with a maintainer.
-
-**No-bump prefixes:**
-
-- `internal-feat:` → new code building toward a feature not yet exposed to users (new internal API, new module, new config schema). Use this when a feature is being built across multiple PRs and this PR adds real, tested code — but the feature isn't user-facing yet. No version bump.
-- `internal-fix:` → fix to internal code not yet exposed to users. No version bump.
-- `monitoring:`, `docs:`, `chore:`, `ci:`, `test:`, `refactor:`, `style:`, `build:` → no version bump.
-
-**When to use which:**
-
-- Each PR should leave main in a valid state — no dead code, no unhooked partial implementations.
-- If the PR adds new tested code that will be consumed later, use `internal-feat:`.
-- The PR that wires everything together and makes the feature user-facing uses `feat:`.
-- Don't contort prefixes to avoid bumps. If it's user-facing, it's `feat:`.
-
-#### Commit Scopes
-
-The optional `(scope)` after the prefix names the **specific component** being changed, not the broad area. Reach for the narrowest accurate scope before falling back to a wider one — `fix(metrics):` is more useful in `git log` than `fix(pipeline):` when only the normalization-stats writer changed, even though that writer lives structurally under the data pipeline.
-
-Non-exhaustive table of common synth-setter scopes:
-
-| Scope        | Meaning                                                                                                                    |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------- |
-| `metrics`    | Mel/audio metric tooling, normalization-stats computation/writer (`src/synth_setter/pipeline/data/stats.py`, `stats.npz`,) |
-| `pipeline`   | Broader distributed data-pipeline code under `src/synth_setter/pipeline/` (stats-writer code uses `metrics`)               |
-| `datamodule` | Lightning datamodules (`src/synth_setter/data/*_datamodule.py`)                                                            |
-| `training`   | Training entrypoint and `src/synth_setter/cli/train.py` / training loop code                                               |
-| `eval`       | Evaluation entrypoint and `src/synth_setter/cli/eval.py` / evaluation harness                                              |
-| `configs`    | Hydra YAML configs under `configs/`                                                                                        |
-| `layout`     | Package-layout / src-layout moves (the [#784](https://github.com/tinaudio/synth-setter/issues/784) migration line)         |
-| `claude-md`  | Edits to `AGENTS.md` itself                                                                                                |
-| `ci`         | GitHub Actions workflows, CI scripts                                                                                       |
-| `docker`     | Dockerfiles, devcontainer configs, image build setup                                                                       |
-| `deps`       | Dependency bumps (`pyproject.toml`, lockfiles)                                                                             |
-
-**`metrics`, not `pipeline`, for stats-writer changes.** Any change touching `src/synth_setter/pipeline/data/stats.py`, `stats.npz` schema/handling, or other mel/audio normalization-stats tooling uses `(metrics)` as its scope — even though the module lives structurally under `src/synth_setter/pipeline/data/` and the data it produces is consumed by the broader pipeline. The rule is "narrowest accurate scope": `metrics` is more specific than `pipeline` and makes the log easier to scan.
-
-Formatting follows the same convention as the title example under [`### PR Titles`](#pr-titles) (`feat(pipeline)!: complete dataset_spec Hydra migration; remove load_dataset_spec_yaml`): conventional prefix, scope in parentheses, optional `!` for breaking, then a colon and the human-readable subject.
-
-### Writing Code
-
-- Write readable code. Prefer clarity over cleverness.
-- Type-annotate all function signatures. Avoid `Any` — use `Union`, `Optional`, or specific types.
-- No bare `except:` — always catch specific exceptions.
-- Pydantic `BaseModel` with `strict=True` at trust boundaries (config parsing, JSON from R2, worker reports). Dataclasses for internal typed containers.
-- Keep functions short and single-purpose. If a function needs a comment explaining what a block does, extract it.
-- Use `structlog` for logging in pipeline code. Use Python's `logging` module elsewhere.
+- Pydantic `BaseModel(strict=True)` at trust boundaries (config parsing, JSON
+  from R2, worker reports). Dataclasses for internal typed containers.
+- `structlog` in pipeline code; stdlib `logging` elsewhere.
 - All `rclone` operations use `--checksum`.
+- Run `make format` before committing. Pre-commit (ruff, ruff-format,
+  pydoclint, prettier, mdformat, gitlint) is authoritative; suppressing
+  rules to make CI green is forbidden — see
+  [`### Lint exceptions are append-frozen`](#lint-exceptions-are-append-frozen).
 
-#### Comment Hygiene: Don't Bake Values Into Comments
+## Testing
 
-Comments that restate values, counts, or list contents go stale the moment the code changes. The code is the source of truth — name it, don't mirror it.
+- `make test-fast` is the default CPU loop; `@pytest.mark.slow` for slow.
+- Test names: `test_<what>_<condition>_<expected>`.
+- Mutation testing: [docs/testing/mutmut.md](docs/testing/mutmut.md).
 
-- **Don't restate constant values.** Next to `num_samples = 6`, never write `# 6 samples (12 renders total)`. Reference the symbol (`each stage renders num_samples times`) or describe behavior without numbers.
+## Design defaults
 
-- **Don't bake in counts the code already reports.** `# 29 review comments triaged` or `# 5 metric series` belongs in a PR description (a snapshot in time), not in a docstring or inline comment that lives next to the data and will drift the next time someone adds an item. Prefer "the metric series listed below" or reference the data source.
+YAGNI. Start minimal, expand only when asked. Don't introduce a new class,
+config schema, or pattern speculatively — ask "do we need this *now*?" and
+default to no. Refactoring follows real needs, not anticipated ones. Present
+a plan before writing code for any non-trivial change.
 
-- **Don't enumerate list contents in prose.** Next to `THINGS = ["a", "b", "c"]`, never write `# three things: a, b, and c` — both the count and the contents will mismatch the list within a release. The list is the source of truth; a comment can name the *category*, not its contents.
+## Mandatory skills for code changes
 
-- **Keep comments terse — typically one short line.** Multi-sentence prose explanations inline are a smell. If a comment would need more than ~2 lines to be useful, that's a signal the context belongs in a GitHub issue, not in the source. Make the inline comment a one-line pointer to the issue.
+Whenever an agent modifies non-documentation code (anything other than `.md` /
+`docs/` edits), invoke in order:
 
-  ```python
-  # Bad — multi-sentence essay inline:
-  # We use os._exit(0) here instead of sys.exit(0) because SkyPilot's
-  # job runner wraps the process in a shell that doesn't propagate the
-  # exit code correctly when atexit handlers raise during interpreter
-  # shutdown — see the long investigation in the PR description.
-  os._exit(0)
+1. `/tdd-implementation` — drive the change test-first.
+2. `/code-health` — review and clean up the result.
+3. `/simplify` — final reuse and efficiency pass.
 
-  # Good — one-line pointer to the issue with the full context:
-  # Workaround for atexit-during-shutdown hang — see #735.
-  os._exit(0)
-  ```
+Pure docs edits are exempt; no other exemptions.
 
-- **Don't narrate history.** A comment, docstring, or doc page describes the **current** state, not the path that got there. Phrasings to avoid: "previously...", "used to...", "was X, now Y", "renamed from...", "migrated from...", "moved from...", "no longer...", "formerly...", "(was X in v1)", "post-#NNNN this became...". `git log` is the source for history; if the *rationale* for current behavior matters, point at an issue (`# Workaround for X — see #N`) rather than narrating the journey.
+## Commits
 
-  ```python
-  # Bad — narrates the migration:
-  # Previously read from YAML via load_dataset_spec_yaml; spec is now composed
-  # from Hydra defaults (#887) and load_dataset_spec_yaml was removed in #917.
+- Conventional commits, gitlint-enforced. `internal-feat:` / `internal-fix:`
+  for unreleased code (no version bump). Picking the right scope is a
+  skill-bound decision — invoke `/github-taxonomy` or its scope guidance when
+  composing a commit subject.
+- **Never `--no-verify` / `-n`.** Pre-commit and gitlint must run. Hooks
+  work inside worktrees.
+- **Never add `Co-Authored-By` trailers** or agent-attribution footers
+  ("Generated with …", "Claude …", etc.).
+- A `PreToolUse` hook (`agent/hooks/git-commit-trailer-check.sh`) blocks
+  violations; if a hook fails, fix the underlying cause — don't bypass.
 
-  # Good — describes only the current behavior, with a pointer for context:
-  # DatasetSpec is composed from Hydra defaults — see configs/dataset.yaml.
-  ```
+## Lint exceptions are append-frozen
 
-  Same rule for docstrings and for prose in `docs/`. If you catch yourself writing "previously" or "no longer" in a design or reference doc, rewrite the paragraph in the present tense. If the historical decision is worth keeping at all, record it in a clearly marked "Background" or "Rejected alternatives" section — never woven into the description of current behavior.
+`.pydoclint-baseline.txt` (#938), `pyproject.toml`'s
+`[tool.ruff.lint.per-file-ignores]` / `[tool.ruff].extend-exclude`,
+`.pre-commit-config.yaml` per-hook `exclude:` regexes, and
+`pyrightconfig.json`'s `"exclude"` are **append-frozen**. The only allowed
+edit is a **removal** via the `/lint-cleanup` workflow (one file per PR,
+`chore(lint):` prefix). `[tool.pydoclint].exclude` is infra-only after #1044
+and must not be edited at all.
 
-- Still write comments for: WHY a non-obvious choice was made, hidden invariants, workarounds (with bug ID), and surprising behavior.
+A `PreToolUse` hook (`agent/hooks/no-baseline-additions.sh`) blocks new rows
+in `.pydoclint-baseline.txt`. If a check fails on a file your PR touches,
+the remediation is to fix the underlying lint — never register the file as
+exempt.
 
-#### No Comments Inside YAML `run:` Block-Scalars
+## YAML `run:` block scalars are bash
 
-YAML block-scalars passed to bash — i.e. `run: |` blocks in **GitHub Actions workflow YAML** (`.github/workflows/*.{yml,yaml}`) and **SkyPilot Task YAML** (`configs/compute/*.yaml`'s `run:` and `setup:` blocks) — render without syntax highlighting in most YAML viewers and are visually indistinguishable from "real" command lines once they reach bash. Stray `'`, `` ` ``, `$`, or `\` inside a comment have caused unintended shell quoting / expansion in the past.
+In GitHub Actions workflows (`.github/workflows/*.{yml,yaml}`) and SkyPilot
+task configs (`configs/compute/*.yaml`'s `run:` / `setup:` blocks), comments
+go **above** the step, never inside the block scalar. The block-scalar body
+is bash and stray `'`, `` ` ``, `$`, or `\` inside a comment has caused
+unintended shell expansion. A `PreToolUse` hook
+(`agent/hooks/no-yaml-run-comments.sh`) enforces this.
 
-**Rule:** put comments *above* the block-scalar, not inside it.
+## PRs
 
-```yaml
-# Bad — comments INSIDE the run: block:
-- name: Pin image tag
-  run: |
-    # The template's image_id defaults to dev-snapshot; pin it to the
-    # tag this run was dispatched with.
-    sed -i "s|...dev-snapshot|...${IMAGE_TAG}|" configs/compute/runpod-template.yaml
+- **Every PR body links a taxonomy-compliant issue** via `Closes #N`,
+  `Fixes #N`, `Refs #N`, or `Part of #N`. Use `Refs #N` for partial fixes
+  (`Fixes` auto-closes). Every issue traces to an Epic via Phase → Task /
+  Bug / Feature. See `/github-taxonomy`.
+- **PR titles stand alone.** Name the specific subject, not just the action:
+  reviewers and `git log` readers don't open the issue. `/github-taxonomy`
+  has the canonical title rule and examples.
+- **Pre-PR review gate.** Before `gh pr create`, run
+  `/repo-review-full-no-comments` and address every BLOCK/WARN (fix code or
+  document why it's intentional). A `PreToolUse` hook
+  (`agent/hooks/pre-pr-review-gate.sh`) blocks `gh pr create` until the
+  command carries `REVIEW_FULL_DONE=1` — recommended as a trailing comment
+  so other gh-pr-create hooks still fire.
+- **Readiness is four AND-ed gates:** CI green ∧ `mergeable=MERGEABLE` ∧
+  every review comment has an inline reply ∧ no new Copilot comments since
+  the last push. The full procedure (poll-loops, Copilot re-request,
+  endpoints to check) lives in `/pr-preflight`.
+- **Always reply inline** on each open PR review comment (humans + Copilot),
+  with a fix-commit SHA or justification. Use `/pr-review-resolver`.
+- **Verification evidence** for each behavioral claim goes through
+  `/pr-checkbox`.
+- **In chat**, use full markdown hyperlinks for PR/issue references:
+  `[#N](https://github.com/tinaudio/synth-setter/issues/N)`. In PR / issue
+  bodies, use bare `Fixes #N` so GitHub auto-close works.
 
-# Good — comments ABOVE the step:
-# Pin the template's image_id from its default (`dev-snapshot`) to the tag
-# this run was dispatched with, so the worker pulls the same image we just
-# smoke-tested locally in the prior step.
-- name: Pin image tag
-  run: |
-    sed -i "s|...dev-snapshot|...${IMAGE_TAG}|" configs/compute/runpod-template.yaml
-```
+## Code review
 
-Same rule for SkyPilot `run:`/`setup:` blocks — put rationale comments at the YAML structural level (above the `run:` key), not inside the block-scalar.
+Local skills wrap the review workflow:
 
-The block-scalar should contain only commands. The reader who wants to know *why* a command exists looks at the comment block above the step or above the `run:` key — outside the bash interpretation surface.
+- `/repo-review` (MVP, single agent, inline checklist).
+- `/repo-review-full` (parallel agents, posts inline review comments).
+- `/repo-review-full-no-comments` (same fan-out, renders to chat — pre-PR
+  gate uses this).
 
-### Testing
-
-- **pytest** with strict markers. Run `make test-fast` for quick tests (CPU-only; excludes slow, gpu, mps, requires_vst).
-- Mark slow tests with `@pytest.mark.slow`.
-- Write tests for new code. Test behavior, not implementation details.
-- Use descriptive test names: `test_<what>_<condition>_<expected>`.
-
-### Architecture
-
-- `src/synth_setter/` — ML code (models, data modules, training, evaluation, dataset-generation entrypoint, utilities) and the distributed data pipeline. PEP src-layout package landed by the layout migration ([#784](https://github.com/tinaudio/synth-setter/issues/784)).
-  - `cli/` — `@hydra.main` entrypoints (`train`, `eval`, `generate_dataset`), each exposed as a `synth-setter-*` console script via `[project.scripts]`.
-  - `data/`, `models/`, `utils/`, `metrics.py` — ML code (Phase 2, [#989](https://github.com/tinaudio/synth-setter/issues/989)).
-  - `pipeline/` — distributed data pipeline (Phase 3, [#995](https://github.com/tinaudio/synth-setter/issues/995); `python -m synth_setter.pipeline` planned — [#72](https://github.com/tinaudio/synth-setter/issues/72)).
-    - `schemas/` — Pydantic models (`DatasetSpec` + `RenderConfig` in `spec.py`, `prefix`, `image_config`; planned: report, card, sample — [#74](https://github.com/tinaudio/synth-setter/issues/74))
-    - `ci/` — CI validation scripts (materialize_spec, validate_shard, validate_spec, load_image_config)
-    - `data/` — dataset-shaping utilities (reshard, rewrite_to_latest, stats, r2_report; Phase 4, [#1005](https://github.com/tinaudio/synth-setter/issues/1005))
-    - `constants.py` — shared constants (R2 bucket, spec filename)
-    - `skypilot_launch.py` — SkyPilot launcher CLI for the distributed pipeline
-    - `stages/` — generate and finalize stage logic (planned — [#72](https://github.com/tinaudio/synth-setter/issues/72))
-    - `backends/` — compute providers: local, RunPod (planned — [#71](https://github.com/tinaudio/synth-setter/issues/71))
-  - `evaluation/` — `predict_vst_audio`, `compute_audio_metrics` library code called by `cli/eval.py` (Phase 4).
-  - `tools/` — `python -m` utilities (`surge_xt_interactive`, `plot_param2tok`, ...; Phase 4).
-- `scripts/` — SkyPilot / CI shell tooling under `skypilot/` and `ci/` subdirectories. `sync_worker_checkout.sh` is intentionally kept at the bare root (SkyPilot bake-lag bootstrap; see [5992aff](https://github.com/tinaudio/synth-setter/commit/5992aff)).
-- `configs/` — Hydra YAML configs. `dataset.yaml` is the top-level datagen entrypoint config (mirrors `train.yaml` / `eval.yaml`); see `configs/dataset.yaml`'s `defaults:` for its composition groups
-- `tests/` — mirrors `src/synth_setter/` (including `tests/pipeline/` for `src/synth_setter/pipeline/`)
-- `docs/design/` — design documents
-
-### Git Workflow
-
-- **Always use isolated git worktrees** for feature work, bug fixes, and PRs. Never edit files directly on a development branch in the main working tree — branch switching and stash conflicts cause lost work and accidental commits to wrong branches.
-- Use `isolation: "worktree"` when spawning subagents that write code or create commits.
-- The main working tree should only be used for read-only operations (exploration, `git log`, `rclone ls`, etc.).
-- When using an agent's Agent tool with `isolation: "worktree"`, the worktree is automatically cleaned up if the agent makes no changes. If changes are made, the worktree path and branch are returned for review. For manually created worktrees, clean up with `git worktree remove` when done.
-- After `git add -f`, always run `make format` before committing.
-- Always verify the correct git branch before pushing commits. Run `git branch --show-current` and confirm it matches the target PR branch before any push.
-- **Epic traceability:** Every issue must trace to an Epic via the sub-issue hierarchy (Epic → Phase → Task/Bug/Feature). There are no standalone tasks — all work items need a home. PRs that reference orphan issues lose epic traceability.
-- **PR metadata hooks:** The `github-taxonomy` skill enforces taxonomy compliance (type, label, milestone, epic lineage) before every `gh pr create`. The CI workflow `pr-metadata-gate.yaml` provides a second check.
-
-### Pipeline-Specific Rules
-
-- R2 is the source of truth for pipeline state — not metadata or reports.
-- Workers only write under `metadata/workers/`. Finalize only writes to `data/`.
-- Shard validation is tiered: workers do full 4-check, finalize does structural.
-- Never write to `data/shards/` except in finalize.
-- Shard IDs are logical (`shard-000042`), deterministic, infrastructure-independent.
-
-## Code Review
-
-Three project-local skills package the review workflow:
-
-- **`/repo-review`** (MVP, default) — single agent, inline core checklist sourced from this AGENTS.md's hard rules. See `agent/skills/repo-review/SKILL.md` for the authoritative checklist. No plugin dependency — works on a fresh clone, in CI, for external contributors.
-- **`/repo-review-full`** (heavyweight) — fans out one parallel agent per applicable plugin checklist and posts every BLOCK/WARN as an unresolved inline review comment. Selection rules and the analysis pipeline live in `agent/skills/_shared/repo-review-full-analysis.md`; `agent/skills/repo-review-full/SKILL.md` is a thin shim that delegates Steps 1–6 to the shared file and handles only the final post step. Requires the `tinaudio-synth-setter-skills` plugin.
-- **`/repo-review-full-no-comments`** (dry run) — same fan-out and aggregation as `/repo-review-full`, but renders the findings to chat instead of posting on GitHub. Works against either an open PR or a local branch that has not been pushed yet — use it as a pre-PR gate, when iterating on a PR pre-review, when GitHub side effects are undesirable, or to preview what `/repo-review-full` would post. See `agent/skills/repo-review-full-no-comments/SKILL.md`.
-
-`/repo-review` and `/repo-review-full` aggregate BLOCK/WARN findings, prefix each with `[<skill>:<severity>]`, and post every one as an individual unresolved inline review comment via `agent/skills/_shared/post_review.py`. The helper anchors each finding to a line in the diff's hunks; findings whose natural line is outside the hunks fall back to the nearest in-hunk line on the same file with a cross-ref note in the body, and findings on files entirely outside the diff are rolled into the top-level review body. `/repo-review-full-no-comments` skips this submission step entirely.
-
-Canonical checklist reference (full content lives in the plugin):
-
-1. `tdd-implementation` — TDD compliance (16 items)
-2. `code-health` — code quality (24 items)
-3. `ml-data-pipeline` — ML pipeline (12 items)
-4. `synth-setter-project-standards` — project-specific (30 items)
-5. `python-style` — Google Python Style Guide (21 items)
-6. `shell-style` — Google Shell Style Guide (19 items, `.sh` files + bash inside YAML `run:` blocks)
-7. `ml-test` — ML testing (25 items, model/pipeline test code)
-8. `comment-hygiene` — Inline-text hygiene (12 items; `*.py` + `.github/workflows/*.{yml,yaml}` + `configs/**/*.{yml,yaml}` + `docs/doc-map.yaml`: `#`-comments, docstrings, doc-map entries; emits suggested rewrites for every finding). Requires the `tinaudio-synth-setter-skills` plugin to be installed — `/repo-review-full` will fail-loud if the skill isn't resolvable.
-
-Review all changed code against every applicable checklist. Skip style issues (Ruff handles formatting and linting).
+See [`agent/skills/repo-review/SKILL.md`](agent/skills/repo-review/SKILL.md)
+and the shared analysis in
+[`agent/skills/_shared/repo-review-full-analysis.md`](agent/skills/_shared/repo-review-full-analysis.md).
 
 ## Refactoring
 
-When refactoring or moving code, always grep ALL file types (not just .py) for references to the old path/name before considering the task complete. Include .yaml/.yml, .md, .json, .toml, .sh, and Dockerfile.
+When moving or renaming code, grep ALL file types — not just `.py`. Include
+`.yaml`/`.yml`, `.md`, `.json`, `.toml`, `.sh`, and `Dockerfile`. Use
+`/tdd-refactor`, which exhaustively discovers references and pins the
+contract.
 
-## Design Principles
+## GPU verification
 
-Before implementing a new abstraction or design pattern, confirm the scope and abstraction level with the user. Prefer YAGNI — start minimal and expand only when asked. Do not over-engineer models or specs.
-
-## Implementation Approach
-
-- Always prefer the simplest viable implementation first. No extra abstractions, no speculative generality unless explicitly asked for or specified by design doc.
-- Present a plan before writing code. Wait for approval.
-- If you're tempted to introduce a new class, config schema, or architectural pattern, ask: "Do we need this now, or is this speculative?" Default to no.
-- Refactoring comes later, driven by real needs, not anticipated ones.
-
-### Mandatory Skills for Code Changes
-
-Whenever an agent implements or modifies non-documentation code (anything other than pure `.md` or `docs/` edits), the agent MUST invoke, in order:
-
-1. `/tdd-implementation` — drive the change test-first.
-2. `/code-health` — review and clean up the resulting code.
-3. `/simplify` — final reuse and efficiency pass.
-
-`/tdd-implementation` and `/code-health` ship in the `tinaudio-synth-setter-skills` plugin (same source as `/repo-review-full`); `/simplify` is an agent built-in. None are defined locally under `agent/skills/`. If the plugin or built-in is not available in the current environment, note the gap in your response rather than silently skipping the step.
-
-Pure documentation edits (`.md` files, `docs/`) are exempt. There are no other exemptions — this is a hard rule, not a suggestion.
-
-## Workflow Rules
-
-### Commits & Hooks
-
-- Never add `Co-Authored-By` trailers to commit messages.
-- Never use `--no-verify` when committing — hooks work in worktrees and must not be skipped.
-- After force-pushing (squash, amend, rewrite) to a PR branch, update the PR title and description with `gh pr edit` to match.
-
-### PR & Issue References
-
-- Every PR body must link a taxonomy-compliant issue via `Closes #N`, `Fixes #N`, `Refs #N`, or `Part of #N`.
-- Use `Refs #N` (not `Fixes #N` or `Closes #N`) when a PR is a workaround or partial fix — `Fixes` auto-closes the issue.
-- In chat responses, use full markdown hyperlinks for PR/issue references: `[#N](https://github.com/tinaudio/synth-setter/issues/N)`. In PR/issue bodies, use bare `Fixes #N` / `Closes #N` / `Refs #N` so GitHub auto-close works.
-- Never add "generated with an agent" or similar attribution footers to PRs, commits, issues, or comments.
-
-### PR Titles
-
-A PR title must stand on its own. A reader who is familiar with the project but has not opened the linked issue should be able to tell from the title alone *what part of the system the PR touches and what concrete change it makes*. Reviewers, release-notes consumers, and people scanning `git log` rarely click through to the issue — the title is the only context many of them get.
-
-- **Name the specific subject, not just the action.** If the PR migrates *one specific schema or component*, say which one. "Complete migration" or "fix bug" without a noun is not enough.
-- **Don't rely on the issue, PR body, or commit list to disambiguate.** If the title would be ambiguous without that context, it is ambiguous, period.
-- **Keep the conventional commit prefix and scope.** The added context goes in the human-readable subject after the colon, not in the scope. The scope is a stable component identifier (`pipeline`, `claude-md`); the specific subject lives in the words after the colon.
-- **Stay under the gitlint title limit.** If the natural phrasing won't fit, shorten the action verb ("complete" → "finish", "remove" → "drop") or tighten the subject's phrasing — but never drop the specific subject itself to save characters.
-
-Example:
-
-- Bad: `feat(pipeline)!: complete Hydra migration; remove load_dataset_spec_yaml`
-- Good: `feat(pipeline)!: complete dataset_spec Hydra migration; remove load_dataset_spec_yaml`
-
-The bad version forces the reader to ask "Hydra migration of *what*?" — the project has had several. The good version answers that question in the title.
-
-### Pre-PR Review Gate
-
-Before every `gh pr create`, run `/repo-review-full-no-comments` and iterate on every BLOCK and WARN finding (fix the code, or document in the PR body why the finding is intentional). Open the PR only after the review report comes back clean.
-
-A `PreToolUse` hook in the agent's settings (Claude registers it in `.claude/settings.json`; handler script `agent/hooks/pre-pr-review-gate.sh`) enforces this — `gh pr create` is blocked unless the command contains the literal `REVIEW_FULL_DONE=1` (anywhere in the line). Recommended form is a trailing comment, which preserves the other `gh pr create` hooks (doc-drift, pr-checkbox, taxonomy verification):
-
-```bash
-gh pr create --title "..." --body "..."  # REVIEW_FULL_DONE=1
-```
-
-The token is honor-system — it forces a pause to invoke the skill, not unbypassable security. If you genuinely don't need a review for this change (rare; usually pure docs touch-ups already exempt from the mandatory skills), the token still has to be present and the PR description should say why review was skipped.
-
-### PR Readiness
-
-**Hard gate (all four must hold).** A PR is **not** ready — for review, merge, or hand-off — until every one of these holds. They are AND-ed; failing any one means not ready.
-
-1. **CI is fully green** — every required AND optional check passing. Pending, errored, or failing all count as not ready.
-2. **`mergeable=MERGEABLE`** — `gh pr view <N> --json mergeable -q .mergeable` must report `MERGEABLE`. `UNKNOWN` (GitHub still computing) and `CONFLICTING` both fail this gate; keep polling `UNKNOWN` until it resolves.
-3. **Every open review comment has an inline reply** — every unresolved review thread (human reviewers AND Copilot) has either a code change linked by commit SHA or an inline reply with justification. See `### PR Review Comments` below for the reply mechanics.
-4. **Copilot has produced no new comments since the last push** — Copilot re-reviews after every push, usually within ~60s. Verify both the inline-comments endpoint and the top-level reviews endpoint (procedure below).
-
-"PR mergeable" alone is **not** the gate — green CI is a separate, equally-hard precondition. "I pushed the fix" is not the same as "the PR is ready." After pushing, iterate until all four conditions are satisfied — use `/loop` (e.g. `/loop 2m gh pr checks <N>`) or repeated polling, do not stop at the first push:
-
-1. Push the change.
-
-2. Wait for CI to finish: `gh pr checks <N> --watch` or `/loop` the checks command.
-
-3. If any check fails, diagnose, fix, push again, return to step 2.
-
-4. Check mergeability with `gh pr view <N> --json mergeable -q .mergeable`. If `CONFLICTING`, rebase or merge the base branch, resolve the conflict, push, return to step 2. If `UNKNOWN`, GitHub hasn't finished computing — wait and poll again. Only `MERGEABLE` clears this step.
-
-5. Reply inline to every open review comment — list them with `gh api repos/<OWNER>/<REPO>/pulls/<N>/comments --paginate`. If a reply required a code change, push and return to step 2. Use `/pr-review-resolver` to drive this systematically.
-
-6. Wait for Copilot to complete its post-push review (~60s, but allow up to 15 minutes). Two endpoints matter here: inline review comments live at `/pulls/<N>/comments`, and top-level review summaries (including a "no findings" note) live at `/pulls/<N>/reviews`. Check both:
-
-   ```bash
-   # Inline review comments (per-line nits)
-   gh api repos/<OWNER>/<REPO>/pulls/<N>/comments --paginate \
-     --jq '[.[] | select(.user.login | test("[Cc]opilot")) | {id, path, line, body}]'
-   # Top-level reviews (overall summary, including a no-findings note)
-   gh api repos/<OWNER>/<REPO>/pulls/<N>/reviews --paginate \
-     --jq '[.[] | select(.user.login | test("[Cc]opilot")) | {id, state, submitted_at, body}]'
-   ```
-
-   If Copilot left new unaddressed inline comments, **or** a new top-level review with actionable content (`state=COMMENTED`/`CHANGES_REQUESTED` with a non-empty body that isn't just a "no findings" note), return to step 5 and address it the same way you would inline comments. If 15 minutes have elapsed since the push and Copilot has produced neither an inline comment nor a top-level review note explicitly stating it has no findings, treat the auto-review as not triggered and manually re-request it before continuing — see step 6a below.
-
-   **Step 6a — Manually re-request a Copilot review** when step 6's 15-minute window elapses with no Copilot activity. Try in this order, stopping at the first one that succeeds:
-
-   1. Re-request via the reviewers API (equivalent of clicking the re-request button):
-      ```bash
-      gh api --method POST \
-        /repos/<OWNER>/<REPO>/pulls/<N>/requested_reviewers \
-        -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
-      ```
-      If that errors, confirm the exact bot slug your org uses with `gh pr view <N> --json reviewRequests,reviews` and retry with the correct login.
-   2. If the reviewers API still won't take Copilot as a reviewer, force a re-trigger with an empty commit (works when Copilot is wired to run on push rather than as a requested reviewer):
-      ```bash
-      git commit --allow-empty -m "chore: trigger copilot review"
-      git push
-      ```
-      Pushing restarts the readiness loop — return to step 2.
-
-   After re-requesting, wait another ~60s (allow up to 15 minutes again) and re-check Copilot's comments. Repeat at most once; if Copilot still produces nothing after a manual re-request, record that in the PR thread and move on.
-
-7. Only when checks are all green AND `mergeable=MERGEABLE` AND every review comment has an inline reply AND Copilot has produced no new comments since the last push (or has been confirmed silent via step 6a) is the PR ready.
-
-This applies whether the PR is yours or one you were asked to drive across the finish line.
-
-### PR Verification
-
-- `/pr-checkbox` is verification-only — look for existing branches/PRs and run checks, never plan implementation.
-- Each verification step gets a checkbox (`- [ ]` / `- [x]`) with the command run and its console output as evidence.
-- Size output appropriately: small (\<20 lines) inline, medium (20-100) in a PR comment, large (100+) in a Gist linked from a comment.
-- Only tick `[x]` if the result unambiguously passes.
-
-### GPU Verification
-
-Before skipping a GPU-gated check with "no GPU available" or similar, run BOTH probes and paste their output into the SKIP rationale:
+Before claiming "no GPU available", run both probes and paste the output:
 
 ```bash
 nvidia-smi --query-gpu=name,memory.free --format=csv,noheader
 python3 -c "import torch; print('cuda:', torch.cuda.is_available(), 'count:', torch.cuda.device_count())"
 ```
 
-Only skip as "no GPU available" if both probes indicate no usable CUDA GPU: `nvidia-smi` exits non-zero and `torch.cuda.is_available()` returns `False`. If the probes disagree, do not call it "no GPU available" — document it as an environment/setup mismatch (for example, driver/tooling visibility vs. PyTorch CUDA availability) and include both outputs in the rationale. "I assumed there's no GPU" is not justification — the assumption has been wrong before.
-
-### PR Review Comments
-
-- Always reply to PR review comments after pushing a fix — never push silently.
-- Reply **inline on the specific review comment** that the change addresses (using `gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/replies` or the equivalent threaded reply), not as a generic top-level PR comment. One inline reply per comment addressed.
-- Link the specific fix commit SHA in the reply (e.g., "Fixed in abc1234").
-- If a pushed change addresses multiple review comments, post a separate inline reply on each — do not consolidate them into a single comment elsewhere on the PR.
-
-### GitHub Project
-
-- Select the GitHub project by name (`"synth-setter"`) or known ID (`PVT_kwDOD6Bkms4BSS3h`) — never use `nodes[0]` or array index.
-
-## Don't
-
-- Don't modify `.env` (contains real credentials).
-- Don't commit `.env`, credentials, or API keys.
-- Don't commit without explicit permission.
-- Don't run `make docker-*` or RunPod commands without asking first.
-- Don't add unnecessary abstractions — only abstract when there are two concrete uses.
-- Don't add comments to code you didn't change.
-- Don't add new entries to lint exception lists to make CI green — `.pydoclint-baseline.txt`, `pyproject.toml`'s `[tool.ruff.lint.per-file-ignores]` / `[tool.ruff].extend-exclude`, `.pre-commit-config.yaml` per-hook `exclude:` regexes, and `pyrightconfig.json`'s `"exclude"` are append-frozen. Fix the lint. See [`#### Lint Exception Lists Are Closed`](#lint-exception-lists-are-closed--fix-the-lint-dont-suppress-it).
+Only skip if BOTH report no usable GPU. If they disagree, document it as an
+environment/setup mismatch — not "no GPU available".
 
 ## Commands
 
 ```bash
-make test-fast         # Quick CPU-only tests (excludes slow, gpu, mps, requires_vst)
-make test-full-cpu     # All CPU tests (slow + requires_vst included; gpu/mps excluded)
-make test-full-gpu     # GPU + CPU tests (mps excluded). Serial.
-make test-full-mps     # MPS + CPU tests (gpu excluded). Serial.
-make test-vst-cpu      # VST-only suite (requires_vst, slow included; gpu/mps excluded)
-make format            # Run all pre-commit hooks
-make mutmut            # Mutation testing (slow; see [tool.mutmut] in pyproject.toml)
-make clean             # Clean autogenerated files
-make help              # Show all targets
+make test-fast       # CPU-only fast tests
+make test-full-cpu   # all CPU tests
+make test-full-gpu   # GPU + CPU, serial
+make format          # pre-commit hooks
+make help            # everything else
 ```
-
-### Mutation Testing
-
-`make mutmut` runs [mutmut](https://github.com/boxed/mutmut) v3 against the
-modules listed under `[tool.mutmut].paths_to_mutate` in `pyproject.toml`.
-mutmut copies those paths into a `mutants/` sandbox and strips the real
-`src/` off `sys.path`, so any module a test imports transitively must come
-along via `also_copy` — that's why `also_copy = ["src/synth_setter/"]`
-includes the *whole* package, not just the mutated subdirs. If a new
-`synth_setter.*` import is introduced into a mutmut-target test path and
-the new module sits outside `paths_to_mutate`, `also_copy` already covers
-it; only revisit this config when adding a *new* top-level mutate path
-under `src/`.
-
-mutmut also drives subprocesses via `os.fork()` and runs tests under
-`MUTANT_UNDER_TEST=stats`. Tests that shell out to `python -m …` therefore
-inherit that env var and crash mutmut's trampoline (`mutmut.config is None`
-in any fresh interpreter). Keep mutmut-target tests in-process — use
-argparse/click's parser directly with `capsys`/`CliRunner`, not
-`subprocess.run([sys.executable, "-m", …])`. The historical offender
-(`test_cli_help_advertises_mask_degenerate_bins_flag` in
-`tests/pipeline/data/test_stats.py`) is the template.
-
-Run mutmut **on Linux** (CI workflow `.github/workflows/mutmut.yaml`,
-`workflow_dispatch` + weekly cron). On macOS, the parent process imports
-`torch` / `h5py` / `hydra` from `tests/conftest.py` during stats
-collection; Apple's fork-safety check then SIGSEGVs every forked child,
-so local `make mutmut` runs report mass segfaults that don't reflect
-real test outcomes. The Makefile target sets
-`OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` to soften this, but the
-authoritative end-to-end run is the CI job.

--- a/agent/hooks/git-commit-trailer-check.sh
+++ b/agent/hooks/git-commit-trailer-check.sh
@@ -12,6 +12,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/_lib.sh"
 
+# Any unexpected failure (Python crash, jq parse, etc.) must block — never
+# leak a non-2 exit that bypasses the contract documented in the header.
+trap 'log "internal failure on line $LINENO; blocking"; echo "BLOCKED: git-commit-trailer-check hit an internal error (line $LINENO); fix the hook or report it." >&2; exit 2' ERR
+
 INPUT=$(cat)
 # Fail closed: blocking malformed input is the whole point of this gate.
 if ! COMMAND=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null); then

--- a/agent/hooks/git-commit-trailer-check.sh
+++ b/agent/hooks/git-commit-trailer-check.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# git-commit-trailer-check.sh — PreToolUse Bash gate (`Bash(git commit *)`)
+# blocking `git commit` calls that skip hooks (`--no-verify` / `-n`, incl.
+# bundled short flags) or embed `Co-Authored-By` / agent-attribution trailers
+# (AGENTS.md). Reads tool-call JSON on stdin, inspects `-m`/`-F` message text;
+# exits 0 (clean / not `git commit`) or 2 (offending flag or trailer found).
+set -euo pipefail
+
+export HOOK_NAME="git-commit-trailer-check"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=agent/hooks/_lib.sh
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_lib.sh"
+
+INPUT=$(cat)
+# Fail closed: blocking malformed input is the whole point of this gate.
+if ! COMMAND=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null); then
+  log "jq parse failed; blocking conservatively"
+  echo "BLOCKED: git-commit-trailer-check could not parse tool-call JSON." >&2
+  exit 2
+fi
+
+# Defensive re-scope: handler-level `if:` already filters, but re-validate
+# in-script to stay safe if the matcher fires more broadly.
+if ! grep -qE '(^[[:space:]]*|[;|&`(][[:space:]]*)git[[:space:]]+commit([[:space:]]|$)' <<<"$COMMAND"; then
+  exit 0
+fi
+
+# Python so the parser can argv-slice (so `-n` to `git commit` isn't confused
+# with a downstream `grep -n`).
+FINDINGS=$(HOOK_COMMAND="$COMMAND" python3 - <<'PY'
+import os, shlex, pathlib, re
+
+cmd = os.environ["HOOK_COMMAND"]
+try:
+    lexer = shlex.shlex(cmd, posix=True, punctuation_chars=True)
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+    tokens = list(lexer)
+except ValueError:
+    # Unbalanced quotes; fall back to a literal scan. False positives are
+    # acceptable — trailer-shaped substrings rarely appear outside messages.
+    # Still split shell control operators so downstream argv slicing does not
+    # mis-attribute flags across `&&` / `||` / `;` / `|` / `&`.
+    tokens = [
+        token
+        for token in re.split(r"(\&\&|\|\||[;|&])", cmd)
+        if token and not token.isspace()
+    ]
+
+
+def commit_arg_slices(tokens):
+    """Yield each [start, end) slice of tokens that is `git commit`'s argv.
+
+    A slice ends at a shell metachar token (``&&`` / ``||`` / ``;`` / ``|``) or
+    at end-of-tokens, so a downstream ``grep -n`` after ``&&`` is not mistaken
+    for ``git commit -n``.
+    """
+    metachars = {"&&", "||", ";", "|", "&"}
+    i = 0
+    while i < len(tokens) - 1:
+        if tokens[i] == "git" and tokens[i + 1] == "commit":
+            start = i + 2
+            j = start
+            while j < len(tokens) and tokens[j] not in metachars:
+                j += 1
+            yield start, j
+            i = j
+        else:
+            i += 1
+
+
+def iter_commit_argvs():
+    for start, end in commit_arg_slices(tokens):
+        yield tokens[start:end]
+
+
+findings = []
+
+
+def has_no_verify_short_flag(argv):
+    """Return True if argv has `-n` or any bundled short flag containing `n`.
+
+    Short flags cluster: `git commit -nm "msg"` tokenizes as `["-nm", "msg"]`,
+    so a bare ``"-n" in argv`` misses it. Stop scanning at the ``--`` end-of-
+    options marker, and skip long flags (``--no-foo``) and positional args.
+    """
+    for tok in argv:
+        if tok == "--":
+            return False
+        if tok.startswith("--"):
+            continue
+        if len(tok) >= 2 and tok[0] == "-" and "n" in tok[1:] and tok[1:].isalpha():
+            return True
+    return False
+
+
+# --no-verify / -n (incl. bundled `-nm` / `-anm` / …) on `git commit` itself.
+for argv in iter_commit_argvs():
+    if "--no-verify" in argv:
+        findings.append(("--no-verify flag", "--no-verify"))
+        break
+    if has_no_verify_short_flag(argv):
+        findings.append(("-n flag (== --no-verify)", "-n"))
+        break
+
+# Forbidden trailers inside `-m` / `-F` / heredoc bodies. `Co-Authored-By:` and
+# `Generated with` are bare-substring matches — the literal strings rarely
+# appear outside attribution contexts and we must match both heredoc-style
+# real newlines AND the literal `\n` chars shlex produces from
+# `-m "feat: x\n\nCo-Authored-By: …"`. The Claude-model regex IS anchored to
+# trailer context so a subject like "feat: tokeniser for Claude Sonnet 4.5"
+# does not trigger.
+trailer_patterns = [
+    ("Co-Authored-By trailer", re.compile(r"Co-Authored-By:", re.IGNORECASE)),
+    ("agent-attribution footer", re.compile(r"Generated with", re.IGNORECASE)),
+    ("agent-attribution footer", re.compile(r"(?:^|\\n|\n)\s*[A-Za-z-]+:\s*Claude\s+(Code|Opus|Sonnet|Haiku)\b")),
+    ("agent-attribution footer", re.compile(r"\bnoreply@anthropic\.com\b")),
+]
+
+
+def collect_message_texts(argv):
+    """Extract every commit-message body from one `git commit` argv slice."""
+    texts = []
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        if tok in ("-m", "--message") and i + 1 < len(argv):
+            texts.append(argv[i + 1])
+            i += 2
+            continue
+        if tok.startswith("--message="):
+            texts.append(tok.split("=", 1)[1])
+            i += 1
+            continue
+        if tok in ("-F", "--file") and i + 1 < len(argv):
+            try:
+                texts.append(pathlib.Path(argv[i + 1]).read_text())
+            except OSError:
+                pass
+            i += 2
+            continue
+        if tok.startswith("--file="):
+            try:
+                texts.append(pathlib.Path(tok.split("=", 1)[1]).read_text())
+            except OSError:
+                pass
+            i += 1
+            continue
+        i += 1
+    return texts
+
+
+texts = []
+for argv in iter_commit_argvs():
+    texts.extend(collect_message_texts(argv))
+if not texts:
+    # Heredoc / shell-substituted body: scan the raw command text instead.
+    texts = [cmd]
+
+for text in texts:
+    for label, pattern in trailer_patterns:
+        m = pattern.search(text)
+        if m:
+            findings.append((label, m.group(0)))
+            break
+
+seen = set()
+for label, match in findings:
+    key = (label, match)
+    if key in seen:
+        continue
+    seen.add(key)
+    print(f"{label}\t{match}")
+PY
+)
+
+if [[ -n "$FINDINGS" ]]; then
+  log "blocking forbidden flag/trailer"
+  {
+    echo "BLOCKED: \`git commit\` invocation is non-compliant."
+    echo
+    echo "Findings:"
+    printf '  %s\n' "${FINDINGS//$'\n'/$'\n  '}"
+    echo
+    echo "Rules (AGENTS.md):"
+    echo "  - Never use --no-verify / -n; hooks work inside worktrees and must run."
+    echo "  - Never add Co-Authored-By trailers."
+    echo "  - Never add agent-attribution footers (\"Generated with ...\", \"Claude ...\", etc.)."
+    echo
+    echo "Fix the underlying hook failure (or rewrite the commit message) and re-run."
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/agent/hooks/git-commit-trailer-check.sh
+++ b/agent/hooks/git-commit-trailer-check.sh
@@ -1,200 +1,69 @@
 #!/usr/bin/env bash
-# git-commit-trailer-check.sh — PreToolUse Bash gate (`Bash(git commit *)`)
-# blocking `git commit` calls that skip hooks (`--no-verify` / `-n`, incl.
-# bundled short flags) or embed `Co-Authored-By` / agent-attribution trailers
-# (AGENTS.md). Reads tool-call JSON on stdin, inspects `-m`/`-F` message text;
-# exits 0 (clean / not `git commit`) or 2 (offending flag or trailer found).
+# PreToolUse Bash(git commit *) gate. Exits 0 (clean / not git commit) or 2
+# (forbidden --no-verify/-n flag or Co-Authored-By / agent-attribution trailer).
 set -euo pipefail
 
-export HOOK_NAME="git-commit-trailer-check"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly HOOK_NAME="git-commit-trailer-check"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+readonly SCRIPT_DIR
+
+[[ -f "${SCRIPT_DIR}/_lib.sh" ]] || {
+  echo "BLOCKED: ${HOOK_NAME} could not find _lib.sh next to itself." >&2
+  exit 2
+}
 # shellcheck source=agent/hooks/_lib.sh
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/_lib.sh"
 
-# Any unexpected failure (Python crash, jq parse, etc.) must block — never
-# leak a non-2 exit that bypasses the contract documented in the header.
-trap 'log "internal failure on line $LINENO; blocking"; echo "BLOCKED: git-commit-trailer-check hit an internal error (line $LINENO); fix the hook or report it." >&2; exit 2' ERR
+# Re-scope regex: matches `git commit` at command start or after a shell
+# control character. Defensive against the handler-level `if:` filter firing
+# more broadly than expected.
+readonly GIT_COMMIT_RE='(^[[:space:]]*|[;|&`(][[:space:]]*)git[[:space:]]+commit([[:space:]]|$)'
 
-INPUT=$(cat)
-# Fail closed: blocking malformed input is the whole point of this gate.
-if ! COMMAND=$(jq -r '.tool_input.command // empty' <<<"$INPUT" 2>/dev/null); then
-  log "jq parse failed; blocking conservatively"
-  echo "BLOCKED: git-commit-trailer-check could not parse tool-call JSON." >&2
-  exit 2
-fi
+main() {
+  # Any unexpected failure (Python crash, jq parse, etc.) must block — never
+  # leak a non-2 exit that bypasses the contract documented in the header.
+  trap 'log "internal failure on line $LINENO; blocking"; echo "BLOCKED: ${HOOK_NAME} hit an internal error (line $LINENO); fix the hook or report it." >&2; exit 2' ERR
 
-# Defensive re-scope: handler-level `if:` already filters, but re-validate
-# in-script to stay safe if the matcher fires more broadly.
-if ! grep -qE '(^[[:space:]]*|[;|&`(][[:space:]]*)git[[:space:]]+commit([[:space:]]|$)' <<<"$COMMAND"; then
+  # stdin is bounded by Claude Code (single tool-call JSON payload), so reading
+  # it all into memory is safe.
+  local input cmd findings
+  input=$(cat)
+
+  # Fail closed: blocking malformed input is the whole point of this gate.
+  if ! cmd=$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null); then
+    log "jq parse failed; blocking conservatively"
+    echo "BLOCKED: ${HOOK_NAME} could not parse tool-call JSON." >&2
+    exit 2
+  fi
+
+  if ! grep -qE "$GIT_COMMIT_RE" <<<"$cmd"; then
+    exit 0
+  fi
+
+  # Pipe the command on stdin to the Python scanner so argv slicing can
+  # distinguish `git commit -n` from a downstream `grep -n`.
+  findings=$(printf '%s' "$cmd" | python3 "${SCRIPT_DIR}/git_commit_trailer_check.py")
+
+  if [[ -n "$findings" ]]; then
+    log "blocking forbidden flag/trailer"
+    {
+      echo "BLOCKED: \`git commit\` invocation is non-compliant."
+      echo
+      echo "Findings:"
+      printf '  %s\n' "${findings//$'\n'/$'\n  '}"
+      echo
+      echo "Rules (AGENTS.md):"
+      echo "  - Never use --no-verify / -n; hooks work inside worktrees and must run."
+      echo "  - Never add Co-Authored-By trailers."
+      echo "  - Never add agent-attribution footers (\"Generated with ...\", \"Claude ...\", etc.)."
+      echo
+      echo "Fix the underlying hook failure (or rewrite the commit message) and re-run."
+    } >&2
+    exit 2
+  fi
+
   exit 0
-fi
+}
 
-# Python so the parser can argv-slice (so `-n` to `git commit` isn't confused
-# with a downstream `grep -n`).
-FINDINGS=$(HOOK_COMMAND="$COMMAND" python3 - <<'PY'
-import os, shlex, pathlib, re
-
-cmd = os.environ["HOOK_COMMAND"]
-try:
-    lexer = shlex.shlex(cmd, posix=True, punctuation_chars=True)
-    lexer.whitespace_split = True
-    lexer.commenters = ""
-    tokens = list(lexer)
-except ValueError:
-    # Unbalanced quotes; fall back to a literal scan. False positives are
-    # acceptable — trailer-shaped substrings rarely appear outside messages.
-    # Still split shell control operators so downstream argv slicing does not
-    # mis-attribute flags across `&&` / `||` / `;` / `|` / `&`.
-    tokens = [
-        token
-        for token in re.split(r"(\&\&|\|\||[;|&])", cmd)
-        if token and not token.isspace()
-    ]
-
-
-def commit_arg_slices(tokens):
-    """Yield each [start, end) slice of tokens that is `git commit`'s argv.
-
-    A slice ends at a shell metachar token (``&&`` / ``||`` / ``;`` / ``|``) or
-    at end-of-tokens, so a downstream ``grep -n`` after ``&&`` is not mistaken
-    for ``git commit -n``.
-    """
-    metachars = {"&&", "||", ";", "|", "&"}
-    i = 0
-    while i < len(tokens) - 1:
-        if tokens[i] == "git" and tokens[i + 1] == "commit":
-            start = i + 2
-            j = start
-            while j < len(tokens) and tokens[j] not in metachars:
-                j += 1
-            yield start, j
-            i = j
-        else:
-            i += 1
-
-
-def iter_commit_argvs():
-    for start, end in commit_arg_slices(tokens):
-        yield tokens[start:end]
-
-
-findings = []
-
-
-def has_no_verify_short_flag(argv):
-    """Return True if argv has `-n` or any bundled short flag containing `n`.
-
-    Short flags cluster: `git commit -nm "msg"` tokenizes as `["-nm", "msg"]`,
-    so a bare ``"-n" in argv`` misses it. Stop scanning at the ``--`` end-of-
-    options marker, and skip long flags (``--no-foo``) and positional args.
-    """
-    for tok in argv:
-        if tok == "--":
-            return False
-        if tok.startswith("--"):
-            continue
-        if len(tok) >= 2 and tok[0] == "-" and "n" in tok[1:] and tok[1:].isalpha():
-            return True
-    return False
-
-
-# --no-verify / -n (incl. bundled `-nm` / `-anm` / …) on `git commit` itself.
-for argv in iter_commit_argvs():
-    if "--no-verify" in argv:
-        findings.append(("--no-verify flag", "--no-verify"))
-        break
-    if has_no_verify_short_flag(argv):
-        findings.append(("-n flag (== --no-verify)", "-n"))
-        break
-
-# Forbidden trailers inside `-m` / `-F` / heredoc bodies. `Co-Authored-By:` and
-# `Generated with` are bare-substring matches — the literal strings rarely
-# appear outside attribution contexts and we must match both heredoc-style
-# real newlines AND the literal `\n` chars shlex produces from
-# `-m "feat: x\n\nCo-Authored-By: …"`. The Claude-model regex IS anchored to
-# trailer context so a subject like "feat: tokeniser for Claude Sonnet 4.5"
-# does not trigger.
-trailer_patterns = [
-    ("Co-Authored-By trailer", re.compile(r"Co-Authored-By:", re.IGNORECASE)),
-    ("agent-attribution footer", re.compile(r"Generated with", re.IGNORECASE)),
-    ("agent-attribution footer", re.compile(r"(?:^|\\n|\n)\s*[A-Za-z-]+:\s*Claude\s+(Code|Opus|Sonnet|Haiku)\b")),
-    ("agent-attribution footer", re.compile(r"\bnoreply@anthropic\.com\b")),
-]
-
-
-def collect_message_texts(argv):
-    """Extract every commit-message body from one `git commit` argv slice."""
-    texts = []
-    i = 0
-    while i < len(argv):
-        tok = argv[i]
-        if tok in ("-m", "--message") and i + 1 < len(argv):
-            texts.append(argv[i + 1])
-            i += 2
-            continue
-        if tok.startswith("--message="):
-            texts.append(tok.split("=", 1)[1])
-            i += 1
-            continue
-        if tok in ("-F", "--file") and i + 1 < len(argv):
-            try:
-                texts.append(pathlib.Path(argv[i + 1]).read_text())
-            except OSError:
-                pass
-            i += 2
-            continue
-        if tok.startswith("--file="):
-            try:
-                texts.append(pathlib.Path(tok.split("=", 1)[1]).read_text())
-            except OSError:
-                pass
-            i += 1
-            continue
-        i += 1
-    return texts
-
-
-texts = []
-for argv in iter_commit_argvs():
-    texts.extend(collect_message_texts(argv))
-if not texts:
-    # Heredoc / shell-substituted body: scan the raw command text instead.
-    texts = [cmd]
-
-for text in texts:
-    for label, pattern in trailer_patterns:
-        m = pattern.search(text)
-        if m:
-            findings.append((label, m.group(0)))
-            break
-
-seen = set()
-for label, match in findings:
-    key = (label, match)
-    if key in seen:
-        continue
-    seen.add(key)
-    print(f"{label}\t{match}")
-PY
-)
-
-if [[ -n "$FINDINGS" ]]; then
-  log "blocking forbidden flag/trailer"
-  {
-    echo "BLOCKED: \`git commit\` invocation is non-compliant."
-    echo
-    echo "Findings:"
-    printf '  %s\n' "${FINDINGS//$'\n'/$'\n  '}"
-    echo
-    echo "Rules (AGENTS.md):"
-    echo "  - Never use --no-verify / -n; hooks work inside worktrees and must run."
-    echo "  - Never add Co-Authored-By trailers."
-    echo "  - Never add agent-attribution footers (\"Generated with ...\", \"Claude ...\", etc.)."
-    echo
-    echo "Fix the underlying hook failure (or rewrite the commit message) and re-run."
-  } >&2
-  exit 2
-fi
-
-exit 0
+main "$@"

--- a/agent/hooks/git_commit_trailer_check.py
+++ b/agent/hooks/git_commit_trailer_check.py
@@ -1,0 +1,216 @@
+"""Forbidden-flag / trailer scanner for the git-commit-trailer-check hook.
+
+Reads a single ``git commit`` command on stdin; prints one
+``<label>\\t<match>`` line per forbidden finding (``--no-verify`` / bundled
+``-n`` short flags, ``Co-Authored-By:`` trailers, agent-attribution footers).
+Empty stdout means clean.
+
+The .sh wrapper handles JSON parsing, re-scope, and the user-facing BLOCKED
+message; this module is the pure-Python parser so unit-test-style argv slicing
+can avoid confusing ``-n`` on ``git commit`` with a downstream ``grep -n``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import shlex
+import sys
+from collections.abc import Iterator
+
+# Trailer regexes are anchored to trailer context — a line-start (real ``\n``
+# or shlex-escaped literal ``\\n``) followed by optional whitespace — so a
+# subject like "feat: docs generated with sphinx-build" does not match. Group
+# 1 captures the trailer key for clean reporting.
+_CO_AUTHORED_BY = re.compile(r"(?:^|\\n|\n)\s*(Co-Authored-By:)", re.IGNORECASE)
+_GENERATED_WITH = re.compile(r"(?:^|\\n|\n)\s*(Generated with)", re.IGNORECASE)
+_CLAUDE_ATTRIBUTION = re.compile(
+    r"(?:^|\\n|\n)\s*[A-Za-z-]+:\s*Claude\s+(?:Code|Opus|Sonnet|Haiku)\b"
+)
+_NOREPLY_EMAIL = re.compile(r"\bnoreply@anthropic\.com\b")
+
+_TRAILER_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("Co-Authored-By trailer", _CO_AUTHORED_BY),
+    ("agent-attribution footer", _GENERATED_WITH),
+    ("agent-attribution footer", _CLAUDE_ATTRIBUTION),
+    ("agent-attribution footer", _NOREPLY_EMAIL),
+)
+
+_METACHARS = frozenset({"&&", "||", ";", "|", "&"})
+
+
+def _tokenize(cmd: str) -> list[str]:
+    """Tokenize ``cmd`` like a POSIX shell, splitting on metachars.
+
+    :param cmd: Raw shell command.
+    :returns: Token list. On unbalanced quotes, falls back to a metachar-aware
+        ``re.split`` so downstream argv slicing still terminates at ``&&`` etc.
+    """
+    try:
+        lexer = shlex.shlex(cmd, posix=True, punctuation_chars=True)
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        return list(lexer)
+    except ValueError:
+        return [
+            token for token in re.split(r"(\&\&|\|\||[;|&])", cmd) if token and not token.isspace()
+        ]
+
+
+def _commit_arg_slices(tokens: list[str]) -> Iterator[tuple[int, int]]:
+    """Yield each ``[start, end)`` slice of tokens belonging to a ``git commit`` argv.
+
+    A slice ends at a shell metachar token (``&&`` / ``||`` / ``;`` / ``|`` /
+    ``&``) or at end-of-tokens, so a downstream ``grep -n`` after ``&&`` is not
+    mistaken for ``git commit -n``.
+
+    :param tokens: Tokenized command.
+    :yields: ``(start, end)`` index pairs into ``tokens``.
+    :ytype: tuple[int, int]
+    """
+    i = 0
+    while i < len(tokens) - 1:
+        if tokens[i] == "git" and tokens[i + 1] == "commit":
+            start = i + 2
+            j = start
+            while j < len(tokens) and tokens[j] not in _METACHARS:
+                j += 1
+            yield start, j
+            i = j
+        else:
+            i += 1
+
+
+def _iter_commit_argvs(tokens: list[str]) -> Iterator[list[str]]:
+    """Yield each argv (token sub-list) belonging to a ``git commit`` invocation.
+
+    :param tokens: Tokenized command.
+    :yields: Each ``git commit`` argv slice.
+    :ytype: list[str]
+    """
+    for start, end in _commit_arg_slices(tokens):
+        yield tokens[start:end]
+
+
+def _has_no_verify_short_flag(argv: list[str]) -> bool:
+    """Return True if ``argv`` has ``-n`` or any bundled short flag containing ``n``.
+
+    Short flags cluster: ``git commit -nm "msg"`` tokenizes as
+    ``["-nm", "msg"]``, so a bare ``"-n" in argv`` misses it. Stops scanning at
+    the ``--`` end-of-options marker, and skips long flags (``--no-foo``) and
+    positional args.
+
+    :param argv: ``git commit`` argv slice.
+    :returns: True if a no-verify-equivalent short flag is present.
+    """
+    for tok in argv:
+        if tok == "--":
+            return False
+        if tok.startswith("--"):
+            continue
+        if len(tok) >= 2 and tok[0] == "-" and "n" in tok[1:] and tok[1:].isalpha():
+            return True
+    return False
+
+
+def _collect_message_texts(argv: list[str]) -> list[str]:
+    """Extract every commit-message body from one ``git commit`` argv slice.
+
+    Handles ``-m``/``--message`` and ``-F``/``--file`` in both space-separated
+    and ``=``-form (e.g. ``--message=value``). ``-F`` paths are read from disk;
+    OSError is silently swallowed (the offender is presumed already inspected
+    via the raw-command fallback).
+
+    :param argv: ``git commit`` argv slice.
+    :returns: List of message-body strings extracted from ``argv``.
+    """
+    texts: list[str] = []
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        if tok in ("-m", "--message") and i + 1 < len(argv):
+            texts.append(argv[i + 1])
+            i += 2
+            continue
+        if tok.startswith("--message="):
+            texts.append(tok.split("=", 1)[1])
+            i += 1
+            continue
+        if tok in ("-F", "--file") and i + 1 < len(argv):
+            try:
+                texts.append(pathlib.Path(argv[i + 1]).read_text())
+            except OSError:
+                pass
+            i += 2
+            continue
+        if tok.startswith("--file="):
+            try:
+                texts.append(pathlib.Path(tok.split("=", 1)[1]).read_text())
+            except OSError:
+                pass
+            i += 1
+            continue
+        i += 1
+    return texts
+
+
+def _scan(cmd: str) -> list[tuple[str, str]]:
+    """Return de-duplicated ``(label, match)`` findings for ``cmd``.
+
+    :param cmd: Raw ``git commit`` shell command.
+    :returns: Findings in discovery order; empty if clean.
+    """
+    tokens = _tokenize(cmd)
+    findings: list[tuple[str, str]] = []
+
+    # --no-verify / -n (incl. bundled `-nm` / `-anm` / …) on `git commit` itself.
+    # Iterate all argvs so chained invocations are all checked, but record only
+    # the first hit per kind to keep the output tight.
+    for argv in _iter_commit_argvs(tokens):
+        if "--no-verify" in argv:
+            findings.append(("--no-verify flag", "--no-verify"))
+            break
+    for argv in _iter_commit_argvs(tokens):
+        if _has_no_verify_short_flag(argv):
+            findings.append(("-n flag (== --no-verify)", "-n"))
+            break
+
+    # Forbidden trailers inside -m / -F / heredoc bodies. When we cannot find
+    # any explicit message body (heredoc / shell-substituted), fall back to the
+    # raw command — but with anchored trailer regexes only, since substring
+    # matches against arbitrary command text produce false positives. The
+    # raw_command_fallback flag makes that trust-level shift explicit.
+    texts: list[str] = []
+    for argv in _iter_commit_argvs(tokens):
+        texts.extend(_collect_message_texts(argv))
+    raw_command_fallback = not texts
+    if raw_command_fallback:
+        texts = [cmd]
+
+    for text in texts:
+        for label, pattern in _TRAILER_PATTERNS:
+            m = pattern.search(text)
+            if m:
+                findings.append((label, m.group(0)))
+                break
+
+    seen: set[tuple[str, str]] = set()
+    deduped: list[tuple[str, str]] = []
+    for label, match in findings:
+        key = (label, match)
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append((label, match))
+    return deduped
+
+
+def main() -> None:
+    """Read the command on stdin and print one ``<label>\\t<match>`` line per finding."""
+    cmd = sys.stdin.read()
+    for label, match in _scan(cmd):
+        print(f"{label}\t{match}")  # noqa: T201 -- stdout is the contract with the shell wrapper
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/hooks/no-baseline-additions.sh
+++ b/agent/hooks/no-baseline-additions.sh
@@ -1,39 +1,41 @@
 #!/usr/bin/env bash
-# no-baseline-additions.sh — PreToolUse Edit/Write gate keeping
-# .pydoclint-baseline.txt append-frozen (AGENTS.md "Lint Exception Lists Are
-# Closed", tracked in #938). Other append-frozen lists deferred to a follow-up.
-# Reads tool-call JSON on stdin; exits 0 (out of scope or row count <= current)
-# or 2 (proposed row count exceeds current).
+# no-baseline-additions.sh — PreToolUse gate keeping .pydoclint-baseline.txt
+# append-frozen (AGENTS.md "Lint Exception Lists Are Closed", #938).
+# Reads tool-call JSON on stdin; exits 0 (out of scope or row count <=) or 2.
 set -euo pipefail
 
-export HOOK_NAME="no-baseline-additions"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC2034  # read by log() in _lib.sh via ${HOOK_NAME:-unknown}
+readonly HOOK_NAME="no-baseline-additions"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+readonly SCRIPT_DIR
+
+[[ -f "${SCRIPT_DIR}/_lib.sh" ]] || { echo "BLOCKED: missing _lib.sh" >&2; exit 2; }
 # shellcheck source=agent/hooks/_lib.sh
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/_lib.sh"
 
-# Any unexpected failure (Python crash, jq parse, etc.) must block — never
-# leak a non-2 exit that bypasses the contract documented in the header.
-trap 'log "internal failure on line $LINENO; blocking"; echo "BLOCKED: no-baseline-additions hit an internal error (line $LINENO); fix the hook or report it." >&2; exit 2' ERR
+main() {
+  # Any unexpected failure (Python crash, jq parse, etc.) must block — never
+  # leak a non-2 exit that bypasses the contract documented in the header.
+  trap 'log "internal failure on line $LINENO; blocking"; echo "BLOCKED: no-baseline-additions hit an internal error (line $LINENO); fix the hook or report it." >&2; exit 2' ERR
 
-INPUT=$(cat)
-# Fail closed: a silent fail-open is the bug class this gate exists to prevent.
-if ! FILE_PATH=$(jq -r '.tool_input.file_path // empty' <<<"$INPUT" 2>/dev/null); then
-  log "jq parse failed; blocking conservatively"
-  echo "BLOCKED: no-baseline-additions could not parse tool-call JSON." >&2
-  exit 2
-fi
+  local input file_path counts old_count new_count
+  input=$(cat)
+  # Fail closed: a silent fail-open is the bug class this gate exists to prevent.
+  if ! file_path=$(jq -r '.tool_input.file_path // empty' <<<"$input" 2>/dev/null); then
+    log "jq parse failed; blocking conservatively"
+    echo "BLOCKED: no-baseline-additions could not parse tool-call JSON." >&2
+    exit 2
+  fi
 
-case "$FILE_PATH" in
-  .pydoclint-baseline.txt|*/.pydoclint-baseline.txt) ;;
-  *) exit 0 ;;
-esac
+  case "$file_path" in
+    .pydoclint-baseline.txt|*/.pydoclint-baseline.txt) ;;
+    *) exit 0 ;;
+  esac
 
-# `OLD_COUNT=0` when the baseline file doesn't exist. Treating a missing file
-# as "out of scope" would create a bypass: delete + Write recreates the file
-# unchecked. With OLD_COUNT=0, any Write that includes baseline rows blocks.
-COUNTS=$(HOOK_INPUT="$INPUT" SRC_PATH="$FILE_PATH" python3 - <<'PY'
-import json, os, pathlib
+  # Missing baseline → OLD_COUNT=0 so delete+Write recreate cannot bypass the gate.
+  counts=$(HOOK_INPUT="$input" SRC_PATH="$file_path" python3 - <<'PY'
+import json, os, pathlib, sys
 
 payload = json.loads(os.environ["HOOK_INPUT"])
 tool_name = payload.get("tool_name", "")
@@ -46,7 +48,14 @@ if tool_name == "Write":
 else:
     old = tool.get("old_string", "")
     new = tool.get("new_string", "")
-    proposed = current.replace(old, new, 1) if old and old in current else current
+    if old and old in current:
+        proposed = current.replace(old, new, 1)
+    else:
+        print(
+            "note: Edit old_string not found in current content; row count unchanged",
+            file=sys.stderr,
+        )
+        proposed = current
 
 
 def count_rows(text):
@@ -59,21 +68,28 @@ print(count_rows(proposed))
 PY
 )
 
-OLD_COUNT=$(printf '%s\n' "$COUNTS" | sed -n '1p')
-NEW_COUNT=$(printf '%s\n' "$COUNTS" | sed -n '2p')
+  readarray -t _counts <<<"$counts"
+  old_count="${_counts[0]}"
+  new_count="${_counts[1]}"
 
-if (( NEW_COUNT > OLD_COUNT )); then
-  log "blocking baseline addition: ${OLD_COUNT} -> ${NEW_COUNT}"
-  cat >&2 <<EOF
+  # Arithmetic context is safe here: both operands are integer row counts emitted
+  # by the Python block, and set -e tolerates the `(( ))` exit because BLOCK is
+  # the intended behaviour when the comparison is true.
+  if (( new_count > old_count )); then
+    log "blocking baseline addition: ${old_count} -> ${new_count}"
+    cat >&2 <<EOF
 BLOCKED: .pydoclint-baseline.txt is append-frozen (#938).
-  Current rows: ${OLD_COUNT}
-  Proposed rows: ${NEW_COUNT}
+  Current rows: ${old_count}
+  Proposed rows: ${new_count}
 
 The remediation for a new pydoclint violation is to fix the underlying
 docstring, not to register the file as exempt. See AGENTS.md for the
 escalation path (rare, maintainer pre-approval on #938 required).
 EOF
-  exit 2
-fi
+    exit 2
+  fi
 
-exit 0
+  exit 0
+}
+
+main "$@"

--- a/agent/hooks/no-baseline-additions.sh
+++ b/agent/hooks/no-baseline-additions.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# no-baseline-additions.sh — PreToolUse Edit/Write gate keeping
+# .pydoclint-baseline.txt append-frozen (AGENTS.md "Lint Exception Lists Are
+# Closed", tracked in #938). Other append-frozen lists deferred to a follow-up.
+# Reads tool-call JSON on stdin; exits 0 (out of scope or row count <= current)
+# or 2 (proposed row count exceeds current).
+set -euo pipefail
+
+export HOOK_NAME="no-baseline-additions"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=agent/hooks/_lib.sh
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_lib.sh"
+
+INPUT=$(cat)
+# Fail closed: a silent fail-open is the bug class this gate exists to prevent.
+if ! FILE_PATH=$(jq -r '.tool_input.file_path // empty' <<<"$INPUT" 2>/dev/null); then
+  log "jq parse failed; blocking conservatively"
+  echo "BLOCKED: no-baseline-additions could not parse tool-call JSON." >&2
+  exit 2
+fi
+
+case "$FILE_PATH" in
+  .pydoclint-baseline.txt|*/.pydoclint-baseline.txt) ;;
+  *) exit 0 ;;
+esac
+
+if [[ ! -f "$FILE_PATH" ]]; then
+  exit 0
+fi
+
+COUNTS=$(HOOK_INPUT="$INPUT" SRC_PATH="$FILE_PATH" python3 - <<'PY'
+import json, os, pathlib
+
+payload = json.loads(os.environ["HOOK_INPUT"])
+tool_name = payload.get("tool_name", "")
+tool = payload.get("tool_input", {})
+src = pathlib.Path(os.environ["SRC_PATH"])
+current = src.read_text()
+
+if tool_name == "Write":
+    proposed = tool.get("content", "")
+else:
+    old = tool.get("old_string", "")
+    new = tool.get("new_string", "")
+    proposed = current.replace(old, new, 1) if old and old in current else current
+
+
+def count_rows(text):
+    """Count logical rows independent of trailing-newline convention."""
+    return len(text.splitlines())
+
+
+print(count_rows(current))
+print(count_rows(proposed))
+PY
+)
+
+OLD_COUNT=$(printf '%s\n' "$COUNTS" | sed -n '1p')
+NEW_COUNT=$(printf '%s\n' "$COUNTS" | sed -n '2p')
+
+if (( NEW_COUNT > OLD_COUNT )); then
+  log "blocking baseline addition: ${OLD_COUNT} -> ${NEW_COUNT}"
+  cat >&2 <<EOF
+BLOCKED: .pydoclint-baseline.txt is append-frozen (#938).
+  Current rows: ${OLD_COUNT}
+  Proposed rows: ${NEW_COUNT}
+
+The remediation for a new pydoclint violation is to fix the underlying
+docstring, not to register the file as exempt. See AGENTS.md for the
+escalation path (rare, maintainer pre-approval on #938 required).
+EOF
+  exit 2
+fi
+
+exit 0

--- a/agent/hooks/no-baseline-additions.sh
+++ b/agent/hooks/no-baseline-additions.sh
@@ -68,9 +68,8 @@ print(count_rows(proposed))
 PY
 )
 
-  readarray -t _counts <<<"$counts"
-  old_count="${_counts[0]}"
-  new_count="${_counts[1]}"
+  # `read` (not `readarray`) so macOS bash 3.2 works. Each line is one integer.
+  { IFS= read -r old_count; IFS= read -r new_count; } <<<"$counts"
 
   # Arithmetic context is safe here: both operands are integer row counts emitted
   # by the Python block, and set -e tolerates the `(( ))` exit because BLOCK is

--- a/agent/hooks/no-baseline-additions.sh
+++ b/agent/hooks/no-baseline-additions.sh
@@ -12,6 +12,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/_lib.sh"
 
+# Any unexpected failure (Python crash, jq parse, etc.) must block — never
+# leak a non-2 exit that bypasses the contract documented in the header.
+trap 'log "internal failure on line $LINENO; blocking"; echo "BLOCKED: no-baseline-additions hit an internal error (line $LINENO); fix the hook or report it." >&2; exit 2' ERR
+
 INPUT=$(cat)
 # Fail closed: a silent fail-open is the bug class this gate exists to prevent.
 if ! FILE_PATH=$(jq -r '.tool_input.file_path // empty' <<<"$INPUT" 2>/dev/null); then
@@ -25,10 +29,9 @@ case "$FILE_PATH" in
   *) exit 0 ;;
 esac
 
-if [[ ! -f "$FILE_PATH" ]]; then
-  exit 0
-fi
-
+# `OLD_COUNT=0` when the baseline file doesn't exist. Treating a missing file
+# as "out of scope" would create a bypass: delete + Write recreates the file
+# unchecked. With OLD_COUNT=0, any Write that includes baseline rows blocks.
 COUNTS=$(HOOK_INPUT="$INPUT" SRC_PATH="$FILE_PATH" python3 - <<'PY'
 import json, os, pathlib
 
@@ -36,7 +39,7 @@ payload = json.loads(os.environ["HOOK_INPUT"])
 tool_name = payload.get("tool_name", "")
 tool = payload.get("tool_input", {})
 src = pathlib.Path(os.environ["SRC_PATH"])
-current = src.read_text()
+current = src.read_text() if src.exists() else ""
 
 if tool_name == "Write":
     proposed = tool.get("content", "")

--- a/agent/hooks/no-yaml-run-comments.sh
+++ b/agent/hooks/no-yaml-run-comments.sh
@@ -13,6 +13,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/_lib.sh"
 
+# Any unexpected failure (Python crash, jq parse, etc.) must block — never
+# leak a non-2 exit that bypasses the contract documented in the header.
+trap 'log "internal failure on line $LINENO; blocking"; echo "BLOCKED: no-yaml-run-comments hit an internal error (line $LINENO); fix the hook or report it." >&2; exit 2' ERR
+
 INPUT=$(cat)
 # Fail closed on jq parse error.
 if ! FILE_PATH=$(jq -r '.tool_input.file_path // empty' <<<"$INPUT" 2>/dev/null); then

--- a/agent/hooks/no-yaml-run-comments.sh
+++ b/agent/hooks/no-yaml-run-comments.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# no-yaml-run-comments.sh — PreToolUse Edit/Write gate blocking `#`-comments
+# inside a `run: |` / `setup: |` block scalar in .github/workflows/*.yml or
+# configs/compute/*.yaml. The block body is bash once it reaches the runner,
+# so a stray `'`/`` ` ``/`$`/`\` inside a comment can trigger shell expansion;
+# put the comment ABOVE the step. Reads tool-call JSON on stdin; exits 0
+# (out of scope / clean) or 2 (offending comment line found).
+set -euo pipefail
+
+export HOOK_NAME="no-yaml-run-comments"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=agent/hooks/_lib.sh
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/_lib.sh"
+
+INPUT=$(cat)
+# Fail closed on jq parse error.
+if ! FILE_PATH=$(jq -r '.tool_input.file_path // empty' <<<"$INPUT" 2>/dev/null); then
+  log "jq parse failed; blocking conservatively"
+  echo "BLOCKED: no-yaml-run-comments could not parse tool-call JSON." >&2
+  exit 2
+fi
+
+case "$FILE_PATH" in
+  .github/workflows/*.yml|.github/workflows/*.yaml) ;;
+  */.github/workflows/*.yml|*/.github/workflows/*.yaml) ;;
+  configs/compute/*.yaml|configs/compute/*.yml) ;;
+  */configs/compute/*.yaml|*/configs/compute/*.yml) ;;
+  *) exit 0 ;;
+esac
+
+TOOL_NAME=$(jq -r '.tool_name // empty' <<<"$INPUT" 2>/dev/null || echo "")
+
+# Synthesize the post-edit content in a tmpfile for the Python scanner.
+# Edit applies old_string -> new_string against the current file; Write uses
+# the new content verbatim.
+TMP_OUT=$(mktemp)
+trap 'rm -f "$TMP_OUT"' EXIT
+
+if [[ "$TOOL_NAME" == "Write" ]]; then
+  jq -r '.tool_input.content // ""' <<<"$INPUT" > "$TMP_OUT"
+else
+  if [[ ! -f "$FILE_PATH" ]]; then
+    exit 0
+  fi
+  HOOK_INPUT="$INPUT" SRC_PATH="$FILE_PATH" OUT_PATH="$TMP_OUT" \
+    python3 - <<'PY'
+import json, os, pathlib
+payload = json.loads(os.environ["HOOK_INPUT"])
+tool = payload.get("tool_input", {})
+old = tool.get("old_string", "")
+new = tool.get("new_string", "")
+content = pathlib.Path(os.environ["SRC_PATH"]).read_text()
+if old and old in content:
+    content = content.replace(old, new, 1)
+pathlib.Path(os.environ["OUT_PATH"]).write_text(content)
+PY
+fi
+
+VIOLATIONS=$(SCAN_PATH="$TMP_OUT" python3 - <<'PY'
+import os, re, pathlib
+
+lines = pathlib.Path(os.environ["SCAN_PATH"]).read_text().splitlines()
+# GitHub Actions and SkyPilot both accept `|`, `|-`, `|+`, `>`, `>-`, `>+`
+# (literal and folded scalars with optional chomping indicators). An inline
+# trailing comment on the header line is also valid YAML. The optional
+# `(?:-\s+)?` allows the list-marker form `- run: |` where the key is on the
+# same line as the list dash.
+block_re = re.compile(r'^(\s*)(?:-\s+)?(run|setup)\s*:\s*[|>][-+]?\s*(?:#.*)?$')
+violations = []
+i = 0
+while i < len(lines):
+    m = block_re.match(lines[i])
+    if not m:
+        i += 1
+        continue
+    block_key = m.group(2)
+    # When the line has a list-marker (`- run: |`), the body block scalar
+    # must indent deeper than the `run:` column, not deeper than the dash.
+    # `line.index(block_key)` resolves the actual column of `run`/`setup`.
+    header_indent = lines[i].index(block_key)
+    header_lineno = i + 1
+    j = i + 1
+    body_indent = None
+    while j < len(lines):
+        line = lines[j]
+        if line.rstrip() == "":
+            j += 1
+            continue
+        leading = len(line) - len(line.lstrip(" "))
+        if body_indent is None:
+            if leading <= header_indent:
+                break
+            body_indent = leading
+        if leading <= header_indent:
+            break
+        bare = line.lstrip(" ")
+        if bare.startswith("#") and not bare.startswith("#!"):
+            violations.append((j + 1, block_key, header_lineno, bare.rstrip()))
+        j += 1
+    i = j
+
+for lineno, key, header_lineno, text in violations:
+    print(f"{lineno}\t{key}\t{header_lineno}\t{text}")
+PY
+)
+
+if [[ -n "$VIOLATIONS" ]]; then
+  log "blocking yaml-run-comment in $FILE_PATH"
+  {
+    echo "BLOCKED: comments inside a YAML \`run: |\` / \`setup: |\` block scalar."
+    echo "File: ${FILE_PATH}"
+    echo
+    echo "Block-scalar bodies are bash. Stray ', \`, \$, or \\ inside a comment"
+    echo "has caused unintended shell expansion. Move the comment ABOVE the step:"
+    echo
+    echo "  # Pin the template's image_id from its default to the dispatched tag."
+    echo "  - name: Pin image tag"
+    echo "    run: |"
+    echo "      sed -i \"s|...|...|\" configs/compute/runpod-template.yaml"
+    echo
+    echo "Offenders (tab-delimited: line<TAB>block<TAB>header_line<TAB>text):"
+    printf '  %s\n' "${VIOLATIONS//$'\n'/$'\n  '}"
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/agent/hooks/no-yaml-run-comments.sh
+++ b/agent/hooks/no-yaml-run-comments.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
-# no-yaml-run-comments.sh — PreToolUse Edit/Write gate blocking `#`-comments
-# inside a `run: |` / `setup: |` block scalar in .github/workflows/*.yml or
-# configs/compute/*.yaml. The block body is bash once it reaches the runner,
-# so a stray `'`/`` ` ``/`$`/`\` inside a comment can trigger shell expansion;
-# put the comment ABOVE the step. Reads tool-call JSON on stdin; exits 0
-# (out of scope / clean) or 2 (offending comment line found).
+# no-yaml-run-comments.sh — PreToolUse gate blocking `#`-comments inside a
+# `run: |` / `setup: |` block scalar in workflow / compute YAML. Reads
+# tool-call JSON on stdin; exits 0 (out of scope / clean) or 2 (offender found).
 set -euo pipefail
 
-export HOOK_NAME="no-yaml-run-comments"
+# shellcheck disable=SC2034  # read by log() in _lib.sh via ${HOOK_NAME:-unknown}
+readonly HOOK_NAME="no-yaml-run-comments"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+
+if [[ ! -f "${SCRIPT_DIR}/_lib.sh" ]]; then
+  echo "BLOCKED: no-yaml-run-comments cannot locate _lib.sh at ${SCRIPT_DIR}." >&2
+  exit 2
+fi
 # shellcheck source=agent/hooks/_lib.sh
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/_lib.sh"
@@ -17,103 +21,25 @@ source "${SCRIPT_DIR}/_lib.sh"
 # leak a non-2 exit that bypasses the contract documented in the header.
 trap 'log "internal failure on line $LINENO; blocking"; echo "BLOCKED: no-yaml-run-comments hit an internal error (line $LINENO); fix the hook or report it." >&2; exit 2' ERR
 
-INPUT=$(cat)
-# Fail closed on jq parse error.
-if ! FILE_PATH=$(jq -r '.tool_input.file_path // empty' <<<"$INPUT" 2>/dev/null); then
-  log "jq parse failed; blocking conservatively"
-  echo "BLOCKED: no-yaml-run-comments could not parse tool-call JSON." >&2
-  exit 2
-fi
+in_scope() {
+  # Usage: in_scope <file_path>
+  # 0 if the path is a workflow or compute YAML this hook gates, else 1.
+  case "$1" in
+    .github/workflows/*.yaml|.github/workflows/*.yml) return 0 ;;
+    */.github/workflows/*.yaml|*/.github/workflows/*.yml) return 0 ;;
+    configs/compute/*.yaml|configs/compute/*.yml) return 0 ;;
+    */configs/compute/*.yaml|*/configs/compute/*.yml) return 0 ;;
+  esac
+  return 1
+}
 
-case "$FILE_PATH" in
-  .github/workflows/*.yml|.github/workflows/*.yaml) ;;
-  */.github/workflows/*.yml|*/.github/workflows/*.yaml) ;;
-  configs/compute/*.yaml|configs/compute/*.yml) ;;
-  */configs/compute/*.yaml|*/configs/compute/*.yml) ;;
-  *) exit 0 ;;
-esac
-
-TOOL_NAME=$(jq -r '.tool_name // empty' <<<"$INPUT" 2>/dev/null || echo "")
-
-# Synthesize the post-edit content in a tmpfile for the Python scanner.
-# Edit applies old_string -> new_string against the current file; Write uses
-# the new content verbatim.
-TMP_OUT=$(mktemp)
-trap 'rm -f "$TMP_OUT"' EXIT
-
-if [[ "$TOOL_NAME" == "Write" ]]; then
-  jq -r '.tool_input.content // ""' <<<"$INPUT" > "$TMP_OUT"
-else
-  if [[ ! -f "$FILE_PATH" ]]; then
-    exit 0
-  fi
-  HOOK_INPUT="$INPUT" SRC_PATH="$FILE_PATH" OUT_PATH="$TMP_OUT" \
-    python3 - <<'PY'
-import json, os, pathlib
-payload = json.loads(os.environ["HOOK_INPUT"])
-tool = payload.get("tool_input", {})
-old = tool.get("old_string", "")
-new = tool.get("new_string", "")
-content = pathlib.Path(os.environ["SRC_PATH"]).read_text()
-if old and old in content:
-    content = content.replace(old, new, 1)
-pathlib.Path(os.environ["OUT_PATH"]).write_text(content)
-PY
-fi
-
-VIOLATIONS=$(SCAN_PATH="$TMP_OUT" python3 - <<'PY'
-import os, re, pathlib
-
-lines = pathlib.Path(os.environ["SCAN_PATH"]).read_text().splitlines()
-# GitHub Actions and SkyPilot both accept `|`, `|-`, `|+`, `>`, `>-`, `>+`
-# (literal and folded scalars with optional chomping indicators). An inline
-# trailing comment on the header line is also valid YAML. The optional
-# `(?:-\s+)?` allows the list-marker form `- run: |` where the key is on the
-# same line as the list dash.
-block_re = re.compile(r'^(\s*)(?:-\s+)?(run|setup)\s*:\s*[|>][-+]?\s*(?:#.*)?$')
-violations = []
-i = 0
-while i < len(lines):
-    m = block_re.match(lines[i])
-    if not m:
-        i += 1
-        continue
-    block_key = m.group(2)
-    # When the line has a list-marker (`- run: |`), the body block scalar
-    # must indent deeper than the `run:` column, not deeper than the dash.
-    # `line.index(block_key)` resolves the actual column of `run`/`setup`.
-    header_indent = lines[i].index(block_key)
-    header_lineno = i + 1
-    j = i + 1
-    body_indent = None
-    while j < len(lines):
-        line = lines[j]
-        if line.rstrip() == "":
-            j += 1
-            continue
-        leading = len(line) - len(line.lstrip(" "))
-        if body_indent is None:
-            if leading <= header_indent:
-                break
-            body_indent = leading
-        if leading <= header_indent:
-            break
-        bare = line.lstrip(" ")
-        if bare.startswith("#") and not bare.startswith("#!"):
-            violations.append((j + 1, block_key, header_lineno, bare.rstrip()))
-        j += 1
-    i = j
-
-for lineno, key, header_lineno, text in violations:
-    print(f"{lineno}\t{key}\t{header_lineno}\t{text}")
-PY
-)
-
-if [[ -n "$VIOLATIONS" ]]; then
-  log "blocking yaml-run-comment in $FILE_PATH"
+emit_block_message() {
+  # Usage: emit_block_message <file_path> <violations>
+  # Renders the user-facing BLOCKED guidance on stderr.
+  local file_path="$1" violations="$2"
   {
     echo "BLOCKED: comments inside a YAML \`run: |\` / \`setup: |\` block scalar."
-    echo "File: ${FILE_PATH}"
+    echo "File: ${file_path}"
     echo
     echo "Block-scalar bodies are bash. Stray ', \`, \$, or \\ inside a comment"
     echo "has caused unintended shell expansion. Move the comment ABOVE the step:"
@@ -124,9 +50,47 @@ if [[ -n "$VIOLATIONS" ]]; then
     echo "      sed -i \"s|...|...|\" configs/compute/runpod-template.yaml"
     echo
     echo "Offenders (tab-delimited: line<TAB>block<TAB>header_line<TAB>text):"
-    printf '  %s\n' "${VIOLATIONS//$'\n'/$'\n  '}"
+    printf '  %s\n' "${violations//$'\n'/$'\n  '}"
   } >&2
-  exit 2
-fi
+}
 
-exit 0
+main() {
+  local input file_path violations stderr_file scanner_stderr_line
+  input=$(cat)
+
+  if ! file_path=$(jq -r '.tool_input.file_path // empty' <<<"$input" 2>/dev/null); then
+    log "jq parse failed; blocking conservatively"
+    echo "BLOCKED: no-yaml-run-comments could not parse tool-call JSON." >&2
+    exit 2
+  fi
+
+  if ! in_scope "$file_path"; then
+    exit 0
+  fi
+
+  stderr_file=$(mktemp -t no-yaml-run-comments.XXXXXX)
+  # shellcheck disable=SC2064  # expand stderr_file at trap-install time so the cleanup path is fixed.
+  trap "rm -f '$stderr_file'" EXIT
+
+  violations=$(python3 "${SCRIPT_DIR}/no_yaml_run_comments.py" <<<"$input" 2>"$stderr_file")
+
+  # Replay the scanner's log channel through the hook log. Non-LOG: stderr
+  # (real crashes) re-emerges as-is so the ERR trap can surface it.
+  while IFS= read -r scanner_stderr_line; do
+    if [[ "$scanner_stderr_line" == LOG:* ]]; then
+      log "${scanner_stderr_line#LOG:}"
+    else
+      printf '%s\n' "$scanner_stderr_line" >&2
+    fi
+  done < "$stderr_file"
+
+  if [[ -n "$violations" ]]; then
+    log "blocking yaml-run-comment in $file_path"
+    emit_block_message "$file_path" "$violations"
+    exit 2
+  fi
+
+  exit 0
+}
+
+main "$@"

--- a/agent/hooks/no_yaml_run_comments.py
+++ b/agent/hooks/no_yaml_run_comments.py
@@ -1,0 +1,103 @@
+"""Scanner for YAML block-scalar `#`-comment violations.
+
+Companion to `no-yaml-run-comments.sh`. Reads the full PreToolUse JSON payload
+on stdin and emits one tab-delimited violation per line on stdout:
+``<line>\\t<block_key>\\t<header_lineno>\\t<text>``. The shell wrapper formats
+the BLOCKED message; this module only locates offenders so the Edit/Write tool
+call is gated before it lands content where a stray ``'``/`` ` ``/``$``/``\\``
+inside a block-scalar comment would trigger shell expansion on the runner.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import sys
+
+# Matches a YAML block-scalar header such as ``run: |``, ``- setup: >-``,
+# ``run: |+  # comment``. The optional ``(?:-\s+)?`` is load-bearing: it allows
+# the list-marker form (``- run: |``) where the dash sits to the left of the
+# key — chomping/folding indicators and trailing comments are absorbed by the
+# regex itself, so the rest of the scanner only handles indentation.
+_BLOCK_HEADER_RE = re.compile(r"^(\s*)(?:-\s+)?(run|setup)\s*:\s*[|>][-+]?\s*(?:#.*)?$")
+
+
+def _scan(lines: list[str]) -> list[tuple[int, str, int, str]]:
+    """Return one entry per `#`-comment found inside a YAML block-scalar body.
+
+    :param lines: File contents already split on newlines (no trailing ``\\n``).
+    :returns: Tuples of ``(line_number, block_key, header_line_number, text)`` in document order;
+        line numbers are 1-indexed.
+    """
+    violations: list[tuple[int, str, int, str]] = []
+    i = 0
+    while i < len(lines):
+        match = _BLOCK_HEADER_RE.match(lines[i])
+        if not match:
+            i += 1
+            continue
+        block_key = match.group(2)
+        # Anchor at match.start(2) so a stray ``run``/``setup`` substring
+        # inside an inline trailing comment can't be mis-resolved as the key.
+        header_indent = lines[i].index(block_key, match.start(2))
+        header_lineno = i + 1
+        j = i + 1
+        while j < len(lines):
+            line = lines[j]
+            if line.rstrip() == "":
+                j += 1
+                continue
+            leading = len(line) - len(line.lstrip(" "))
+            if leading <= header_indent:
+                break
+            bare = line.lstrip(" ")
+            if bare.startswith("#") and not bare.startswith("#!"):
+                violations.append((j + 1, block_key, header_lineno, bare.rstrip()))
+            j += 1
+        i = j
+    return violations
+
+
+def _post_edit_content(payload: dict) -> str | None:
+    """Synthesise the content the tool call would commit.
+
+    :param payload: Parsed PreToolUse JSON envelope.
+    :returns: Post-edit text, or ``None`` when the Edit target file is missing
+        (the Edit tool itself will then reject the call — we just skip scanning).
+    """
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input", {})
+    if tool_name == "Write":
+        return tool_input.get("content", "")
+    file_path = tool_input.get("file_path", "")
+    path = pathlib.Path(file_path)
+    if not path.is_file():
+        sys.stderr.write(f"LOG:Edit target {file_path} not found; skipping scan\n")
+        return None
+    content = path.read_text()
+    old = tool_input.get("old_string", "")
+    new = tool_input.get("new_string", "")
+    if old and old in content:
+        content = content.replace(old, new, 1)
+    return content
+
+
+def main() -> int:
+    """Read JSON on stdin, scan synthesised content, write violations to stdout.
+
+    :returns: Always 0 — the wrapper decides the hook's own exit code from whether stdout has any
+        lines.
+    """
+    payload = json.loads(sys.stdin.read())
+    content = _post_edit_content(payload)
+    if content is None:
+        return 0
+    out = sys.stdout
+    for lineno, key, header_lineno, text in _scan(content.splitlines()):
+        out.write(f"{lineno}\t{key}\t{header_lineno}\t{text}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -353,7 +353,7 @@ docs:
 
   # ── Mutation testing reference ──────────────────────────────────
   - doc: docs/testing/mutmut.md
-    description: Mutation testing reference
+    description: Mutmut v3 config, also_copy invariant, fork-safety gotchas
     sources:
       - pattern: "pyproject.toml"
         covers: "[tool.mutmut] paths_to_mutate / also_copy configuration"
@@ -361,5 +361,5 @@ docs:
       - pattern: ".github/workflows/mutmut.yaml"
         covers: "Authoritative CI run (Linux, workflow_dispatch + weekly cron)"
       - pattern: "Makefile"
-        covers: "make mutmut target, OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES soft macOS workaround"
+        covers: "make mutmut target; macOS fork-safety workaround"
         scope: "mutmut"

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -350,3 +350,16 @@ docs:
   #       covers: "Promotion script, W&B artifact download, GitHub Release creation"
   #     - pattern: ".github/workflows/promote.yml"
   #       covers: "Promotion workflow, manual trigger, dry-run mode"
+
+  # ── Mutation testing reference ──────────────────────────────────
+  - doc: docs/testing/mutmut.md
+    description: Mutation testing reference
+    sources:
+      - pattern: "pyproject.toml"
+        covers: "[tool.mutmut] paths_to_mutate / also_copy configuration"
+        scope: "mutmut"
+      - pattern: ".github/workflows/mutmut.yaml"
+        covers: "Authoritative CI run (Linux, workflow_dispatch + weekly cron)"
+      - pattern: "Makefile"
+        covers: "make mutmut target, OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES soft macOS workaround"
+        scope: "mutmut"

--- a/docs/testing/mutmut.md
+++ b/docs/testing/mutmut.md
@@ -1,0 +1,41 @@
+# Mutation Testing (mutmut)
+
+`make mutmut` runs [mutmut](https://github.com/boxed/mutmut) v3 against the
+modules listed under `[tool.mutmut].paths_to_mutate` in `pyproject.toml`.
+This is the authoritative entry point — the CI workflow
+`.github/workflows/mutmut.yaml` runs it on Linux (`workflow_dispatch` + weekly
+cron).
+
+## `also_copy` covers the full package
+
+mutmut copies the paths under `paths_to_mutate` into a `mutants/` sandbox and
+strips the real `src/` off `sys.path`. Any module a test imports transitively
+must come along via `also_copy`. `also_copy = ["src/synth_setter/"]` therefore
+includes the *whole* package, not just the mutated subdirs.
+
+When adding a new `synth_setter.*` import into a mutmut-target test path and
+the new module sits outside `paths_to_mutate`, `also_copy` already covers it.
+Only revisit the `[tool.mutmut]` config when adding a *new* top-level mutate
+path under `src/`.
+
+## Keep mutmut-target tests in-process
+
+mutmut drives subprocesses via `os.fork()` and runs tests under
+`MUTANT_UNDER_TEST=<paths_to_mutate-entry>`. Tests that shell out to
+`python -m …` inherit that env var and crash mutmut's trampoline
+(`mutmut.config is None` in any fresh interpreter).
+
+Use the parser directly with `capsys` / `CliRunner` (argparse / click) rather
+than `subprocess.run([sys.executable, "-m", …])`. The reference test is
+`test_cli_help_advertises_mask_degenerate_bins_flag` in
+`tests/pipeline/data/test_stats.py`.
+
+## macOS gotcha
+
+On macOS, the parent process imports `torch` / `h5py` / `hydra` from
+`tests/conftest.py` during stats collection. Apple's fork-safety check then
+SIGSEGVs every forked child, so local `make mutmut` runs report mass segfaults
+that don't reflect real test outcomes.
+
+The Makefile target sets `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` to soften
+this. The authoritative end-to-end run is the Linux CI job.

--- a/docs/testing/mutmut.md
+++ b/docs/testing/mutmut.md
@@ -13,10 +13,10 @@ strips the real `src/` off `sys.path`. Any module a test imports transitively
 must come along via `also_copy`. `also_copy = ["src/synth_setter/"]` therefore
 includes the *whole* package, not just the mutated subdirs.
 
-When adding a new `synth_setter.*` import into a mutmut-target test path and
-the new module sits outside `paths_to_mutate`, `also_copy` already covers it.
 Only revisit the `[tool.mutmut]` config when adding a *new* top-level mutate
-path under `src/`.
+path under `src/`. All other `synth_setter.*` imports are covered
+automatically — `also_copy` already pulls in any module added outside
+`paths_to_mutate`.
 
 ## Keep mutmut-target tests in-process
 

--- a/src/synth_setter/pipeline/CLAUDE.md
+++ b/src/synth_setter/pipeline/CLAUDE.md
@@ -1,0 +1,39 @@
+# Pipeline-Specific Rules
+
+Auto-loaded by agents when editing files under `src/synth_setter/pipeline/`.
+Architectural rationale lives in
+[../../../docs/design/data-pipeline.md](../../../docs/design/data-pipeline.md);
+this file is the imperative rule sheet.
+
+## Invariants
+
+- **R2 is the source of truth.** Pipeline state is determined by R2 contents,
+  not by metadata files, reports, or a coordination database. If R2 disagrees
+  with anything else, R2 wins.
+- **Worker / finalize write boundary.** Workers only write under
+  `metadata/workers/`. Finalize is the only writer of `data/`.
+- **Never write to `data/shards/` outside finalize.** Workers stage shards
+  under `metadata/workers/<worker-id>/` and finalize moves them.
+- **Shard IDs are logical and deterministic.** `shard-000042` is computed
+  from the input spec, never from worker ID, hostname, or wall-clock time.
+  Infrastructure-independent IDs are what make reconciliation work.
+
+## Validation tiers
+
+- **Workers** run the full 4-check shard validation before upload.
+- **Finalize** runs structural validation only (the workers' full check is the
+  trust anchor; finalize must not re-run it on every shard).
+
+## Adding new code under `pipeline/`
+
+- All Pydantic models in `pipeline/schemas/` use `strict=True`. These are
+  trust boundaries (R2 JSON, worker reports, Hydra-composed specs).
+- `pipeline/data/` utilities are CLI-callable via `python -m`. Add tests under
+  `tests/pipeline/data/` mirroring the source layout.
+- `rclone` calls always use `--checksum` (no exceptions — see AGENTS.md).
+
+## See also
+
+- [data-pipeline.md](../../../docs/design/data-pipeline.md) — design rationale
+- [storage-provenance-spec.md](../../../docs/design/storage-provenance-spec.md)
+  — authoritative R2 paths and W&B artifact conventions

--- a/src/synth_setter/pipeline/CLAUDE.md
+++ b/src/synth_setter/pipeline/CLAUDE.md
@@ -15,12 +15,16 @@ this file is the imperative rule sheet.
 - **Never write to `data/shards/` outside finalize.** Workers stage shards
   under `metadata/workers/<worker-id>/` and finalize moves them.
 - **Shard IDs are logical and deterministic.** `shard-000042` is computed
-  from the input spec, never from worker ID, hostname, or wall-clock time.
-  Infrastructure-independent IDs are what make reconciliation work.
+  from the input spec, never from worker ID, hostname, or wall-clock time
+  (infrastructure-independent IDs are what make reconciliation work).
 
 ## Validation tiers
 
-- **Workers** run the full 4-check shard validation before upload.
+- **Workers** run the full 4-check shard validation before upload:
+  - Structural — opens as HDF5.
+  - Shape — datasets match the expected shape.
+  - Value — values are finite and within bounds.
+  - Row count — sample count matches `render.samples_per_shard`.
 - **Finalize** runs structural validation only (the workers' full check is the
   trust anchor; finalize must not re-run it on every shard).
 
@@ -30,7 +34,6 @@ this file is the imperative rule sheet.
   trust boundaries (R2 JSON, worker reports, Hydra-composed specs).
 - `pipeline/data/` utilities are CLI-callable via `python -m`. Add tests under
   `tests/pipeline/data/` mirroring the source layout.
-- `rclone` calls always use `--checksum` (no exceptions — see AGENTS.md).
 
 ## See also
 

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -655,6 +655,28 @@ def test_trailer_hook_does_not_false_positive_on_chained_grep_n_metachars(
     assert result.returncode == 0, (result.returncode, result.stderr)
 
 
+@pytest.mark.parametrize("metachar", ["&&", "||", ";", "|", "&"])
+def test_trailer_hook_handles_no_whitespace_metachar_chain(
+    trailer_hook_command: str, metachar: str
+) -> None:
+    """Regression: ``git commit ...METACHARgrep -n ...`` (no spaces) must not mis-attribute.
+
+    Before c1e8120 / 54aeb2b the parser used plain ``shlex.split()`` which only
+    splits metachars when whitespace-separated, so ``msg&&grep`` tokenized as a
+    single token and ``-n`` from a downstream ``grep -n`` landed inside
+    ``git commit``'s argv slice. The fix uses ``shlex.shlex(..., punctuation_chars=True)``;
+    this test pins the no-whitespace case.
+
+    :param trailer_hook_command: Hook command body fixture.
+    :param metachar: Shell metachar (concatenated with no surrounding whitespace).
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": f'git commit -m "msg"{metachar}grep -n bar file.txt'}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
 def test_baseline_hook_blocks_write_addition(baseline_hook_command: str, tmp_path: Path) -> None:
     """A Write that increases baseline row count is blocked (Write path coverage).
 
@@ -670,6 +692,34 @@ def test_baseline_hook_blocks_write_addition(baseline_hook_command: str, tmp_pat
             "tool_input": {
                 "file_path": str(baseline),
                 "content": "path/a.py:1:1: DOC101\npath/b.py:2:2: DOC102\n",
+            },
+        },
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_baseline_hook_blocks_write_to_missing_file(
+    baseline_hook_command: str, tmp_path: Path
+) -> None:
+    """A Write that creates a non-existent baseline with rows is blocked.
+
+    Regression: previously the hook fast-pathed exit-0 when the file didn't
+    exist, creating a delete+recreate bypass. The fix treats a missing file as
+    ``OLD_COUNT=0`` and blocks any Write whose content carries baseline rows.
+
+    :param baseline_hook_command: Hook command body fixture.
+    :param tmp_path: pytest tmp_path.
+    """
+    baseline = tmp_path / ".pydoclint-baseline.txt"
+    assert not baseline.exists()
+    result = _run_hook_command(
+        baseline_hook_command,
+        {
+            "tool_name": "Write",
+            "tool_input": {
+                "file_path": str(baseline),
+                "content": "path/a.py:1:1: DOC101\n",
             },
         },
     )
@@ -747,7 +797,10 @@ def test_yaml_run_hook_blocks_edit_introducing_comment(
         "      - run: |-\n",
         "      - run: |+\n",
         "      - run: >\n",
+        "      - run: >-\n",
+        "      - run: >+\n",
         "      - setup: |\n",
+        "      - setup: >-\n",
     ],
 )
 def test_yaml_run_hook_blocks_comment_in_chomping_variants(

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -1,13 +1,9 @@
-"""Tests that Claude hook settings are scoped to the intended commands.
+"""Tests pinning Claude hook ``settings.json`` scoping and runtime behaviour.
 
-Regression coverage for the bug where ``if:`` was placed on the matcher-entry
-object (sibling of ``matcher``/``hooks``/``description``). Claude Code silently
-ignores ``if:`` at that level, so a hook intended to gate only ``gh pr create``
-fired on every Bash tool call — blocking even ``gh pr view`` and ``ls``.
-
-The fix moves ``if:`` inside each hook handler (sibling of ``type`` and
-``command``) and uses Claude Code permission-rule syntax such as ``Bash(gh pr
-create *)``. Schema reference: https://code.claude.com/docs/en/hooks.md.
+Invariant: each Bash hook handler that scopes itself uses Claude Code
+permission-rule ``if:`` syntax (e.g. ``Bash(gh pr create *)``) at the handler
+level, and the body of each hook honours its documented exit contract.
+Schema reference: https://code.claude.com/docs/en/hooks.md.
 """
 
 from __future__ import annotations
@@ -25,19 +21,17 @@ _SETTINGS_PATH = _REPO_ROOT / ".claude" / "settings.json"
 
 
 def _load_settings() -> dict[str, Any]:
-    """Load ``.claude/settings.json``.
+    """Return parsed ``.claude/settings.json``.
 
-    :returns: The parsed settings dict.
-    :rtype: dict[str, Any]
+    :returns: Settings dict.
     """
     return json.loads(_SETTINGS_PATH.read_text())
 
 
 def _matcher_entries() -> list[dict[str, Any]]:
-    """Flatten every PreToolUse and PostToolUse matcher-entry object into a single list.
+    """Return every PreToolUse/PostToolUse matcher-entry in source order.
 
-    :returns: The matcher-entry objects from all hook events, in source order.
-    :rtype: list[dict[str, Any]]
+    :returns: Flat list of matcher-entry objects.
     """
     return [
         entry
@@ -47,11 +41,10 @@ def _matcher_entries() -> list[dict[str, Any]]:
 
 
 def _find_handler(description_substring: str) -> dict[str, Any]:
-    """Look up the lone hook handler whose matcher-entry description contains a substring.
+    """Return the lone hook handler whose matcher-entry description contains a substring.
 
     :param description_substring: Substring identifying the matcher-entry's ``description`` field.
-    :returns: The single handler dict from the matcher-entry's ``hooks`` list.
-    :rtype: dict[str, Any]
+    :returns: The single handler dict under the matched entry.
     :raises AssertionError: If zero or >1 matcher entries match, or the entry has !=1 handler.
     """
     matches = [
@@ -76,19 +69,14 @@ def _find_handler(description_substring: str) -> dict[str, Any]:
 def _run_hook_command(
     command_body: str, stdin_payload: dict[str, Any]
 ) -> subprocess.CompletedProcess[str]:
-    """Run a hook ``command`` body the same way Claude Code does.
-
-    Claude Code invokes the body via the shell and pipes the tool-call JSON to stdin. Tests
-    reproduce that contract. The body is sometimes an inline shell snippet and sometimes a
-    one-line ``bash …/some-hook.sh`` wrapper — either form runs through this helper.
+    """Run a hook ``command`` body the way Claude Code does (shell + JSON on stdin).
 
     :param command_body: The shell command body from a hook handler.
     :param stdin_payload: JSON payload sent to the hook on stdin.
-    :returns: The completed subprocess result, with captured stdout/stderr and exit code.
-    :rtype: subprocess.CompletedProcess[str]
+    :returns: Completed subprocess result with captured stdout/stderr and exit code.
     """
-    # Trust boundary: command_body is read from the repo's own checked-in settings.json,
-    # which is maintainer-controlled. Do not reuse this helper against untrusted paths.
+    # Trust boundary: command_body comes from the repo's checked-in settings.json
+    # (maintainer-controlled). Do not reuse this helper against untrusted paths.
     return subprocess.run(  # noqa: S603
         ["bash", "-c", command_body],  # noqa: S607 — bash is a hard requirement of the harness
         input=json.dumps(stdin_payload),
@@ -96,11 +84,6 @@ def _run_hook_command(
         text=True,
         check=False,
     )
-
-
-# ---------------------------------------------------------------------------
-# Schema regression — the bug this PR fixes
-# ---------------------------------------------------------------------------
 
 
 def test_no_if_at_matcher_entry_level() -> None:
@@ -147,13 +130,9 @@ def test_handler_if_values_use_permission_rule_syntax() -> None:
     )
 
 
-# ---------------------------------------------------------------------------
-# Per-handler scope assertions — the specific gates that drove this bug
-# ---------------------------------------------------------------------------
-
-
 _EXPECTED_HANDLER_SCOPES: tuple[tuple[str, str], ...] = (
     ("Branch safety", "Bash(git commit *)"),
+    ("Git-commit-trailer-check", "Bash(git commit *)"),
     ("Pre-PR review gate", "Bash(gh pr create *)"),
     ("Doc-drift advisory review", "Bash(gh pr create *)"),
     ("PR review resolver", "Bash(git push *)"),
@@ -161,6 +140,9 @@ _EXPECTED_HANDLER_SCOPES: tuple[tuple[str, str], ...] = (
 
 _EXPECTED_SHARED_HOOK_COMMANDS: tuple[tuple[str, str], ...] = (
     ("Credential protection", "bash agent/hooks/edit-write.sh credential-protect"),
+    ("No-baseline-additions", "bash agent/hooks/no-baseline-additions.sh"),
+    ("No-yaml-run-comments", "bash agent/hooks/no-yaml-run-comments.sh"),
+    ("Git-commit-trailer-check", "bash agent/hooks/git-commit-trailer-check.sh"),
     ("Auto-format", "bash agent/hooks/edit-write.sh format"),
     ("Auto-test", "bash agent/hooks/edit-write.sh test"),
     ("Taxonomy verification", "bash agent/hooks/verify-gh-taxonomy.sh"),
@@ -230,20 +212,11 @@ def test_credential_guard_blocks_secret_file_path() -> None:
     assert "BLOCKED" in result.stderr
 
 
-# ---------------------------------------------------------------------------
-# Behavioural tests for the pre-PR review gate body
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture(scope="module")
 def pre_pr_gate_command() -> str:
-    """Yield the shell ``command`` body of the gh-pr-create PreToolUse gate.
+    """Return the shell ``command`` body of the gh-pr-create PreToolUse gate.
 
-    Currently a one-line wrapper that invokes ``agent/hooks/pre-pr-review-gate.sh``;
-    the helper runs it via ``bash -c`` so the wrapper re-enters the script transparently.
-
-    :returns: The shell command string from the gate handler.
-    :rtype: str
+    :returns: The shell command string.
     """
     return _find_handler("Pre-PR review gate")["command"]
 
@@ -251,7 +224,7 @@ def pre_pr_gate_command() -> str:
 def test_pre_pr_gate_blocks_when_token_absent(pre_pr_gate_command: str) -> None:
     """Gate exits 2 with ``BLOCKED`` in stderr when ``REVIEW_FULL_DONE=1`` is missing.
 
-    :param pre_pr_gate_command: The shell command body from the pre-PR review gate handler.
+    :param pre_pr_gate_command: Hook command body fixture.
     """
     result = _run_hook_command(
         pre_pr_gate_command,
@@ -264,7 +237,7 @@ def test_pre_pr_gate_blocks_when_token_absent(pre_pr_gate_command: str) -> None:
 def test_pre_pr_gate_allows_when_token_in_trailing_comment(pre_pr_gate_command: str) -> None:
     """Gate exits 0 when ``REVIEW_FULL_DONE=1`` is present (typically as a trailing comment).
 
-    :param pre_pr_gate_command: The shell command body from the pre-PR review gate handler.
+    :param pre_pr_gate_command: Hook command body fixture.
     """
     result = _run_hook_command(
         pre_pr_gate_command,
@@ -274,18 +247,8 @@ def test_pre_pr_gate_allows_when_token_in_trailing_comment(pre_pr_gate_command: 
     assert "BLOCKED" not in result.stderr
 
 
-# ---------------------------------------------------------------------------
-# Behavioural test for the branch-print hook
-# ---------------------------------------------------------------------------
-
-
 def test_branch_print_hook_announces_current_branch() -> None:
-    """Branch-print hook writes ``Committing to branch: <name>`` to stderr without failing.
-
-    Stdin is irrelevant to this hook (it shells out to ``git branch
-    --show-current``), but the test still pipes a representative payload to
-    mirror how Claude Code invokes it.
-    """
+    """Branch-print hook writes ``Committing to branch: <name>`` to stderr without failing."""
     handler = _find_handler("Branch safety")
     result = _run_hook_command(
         handler["command"],
@@ -293,3 +256,535 @@ def test_branch_print_hook_announces_current_branch() -> None:
     )
     assert result.returncode == 0, (result.returncode, result.stderr)
     assert "Committing to branch:" in result.stderr
+
+
+@pytest.fixture(scope="module")
+def baseline_hook_command() -> str:
+    """Return the shell ``command`` body of the no-baseline-additions hook.
+
+    :returns: The shell command string.
+    """
+    return _find_handler("No-baseline-additions")["command"]
+
+
+def test_baseline_hook_passes_unrelated_file(baseline_hook_command: str) -> None:
+    """The hook fast-paths Edit/Write on files that are not the pydoclint baseline.
+
+    :param baseline_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        baseline_hook_command,
+        {"tool_input": {"file_path": "src/synth_setter/whatever.py", "new_string": "x"}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_baseline_hook_blocks_addition(baseline_hook_command: str, tmp_path: Path) -> None:
+    """An Edit that increases baseline row count is blocked with exit 2.
+
+    :param baseline_hook_command: Hook command body fixture.
+    :param tmp_path: pytest tmp_path.
+    """
+    baseline = tmp_path / ".pydoclint-baseline.txt"
+    baseline.write_text("path/a.py:1:1: DOC101\n")
+    result = _run_hook_command(
+        baseline_hook_command,
+        {
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": str(baseline),
+                "old_string": "path/a.py:1:1: DOC101",
+                "new_string": "path/a.py:1:1: DOC101\npath/b.py:2:2: DOC102",
+            },
+        },
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+    assert "append-frozen" in result.stderr
+
+
+def test_baseline_hook_allows_removal(baseline_hook_command: str, tmp_path: Path) -> None:
+    """An Edit that removes a row (graduation) is allowed.
+
+    :param baseline_hook_command: Hook command body fixture.
+    :param tmp_path: pytest tmp_path.
+    """
+    baseline = tmp_path / ".pydoclint-baseline.txt"
+    baseline.write_text("path/a.py:1:1: DOC101\npath/b.py:2:2: DOC102\n")
+    result = _run_hook_command(
+        baseline_hook_command,
+        {
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": str(baseline),
+                "old_string": "path/a.py:1:1: DOC101\n",
+                "new_string": "",
+            },
+        },
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+@pytest.fixture(scope="module")
+def yaml_run_hook_command() -> str:
+    """Return the shell ``command`` body of the no-yaml-run-comments hook.
+
+    :returns: The shell command string.
+    """
+    return _find_handler("No-yaml-run-comments")["command"]
+
+
+def test_yaml_run_hook_passes_unrelated_file(yaml_run_hook_command: str) -> None:
+    """Edits to files outside workflows/ and configs/compute/ fast-path through.
+
+    :param yaml_run_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        yaml_run_hook_command,
+        {"tool_input": {"file_path": "src/synth_setter/x.py", "content": "# comment\nx = 1\n"}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_yaml_run_hook_blocks_comment_inside_run_block(yaml_run_hook_command: str) -> None:
+    """A `#`-comment inside a ``run: |`` block is blocked.
+
+    :param yaml_run_hook_command: Hook command body fixture.
+    """
+    content = (
+        "name: test\n"
+        "on: push\n"
+        "jobs:\n"
+        "  test:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - name: bad\n"
+        "        run: |\n"
+        "          # this comment is inside the run block — BAD\n"
+        "          echo hi\n"
+    )
+    result = _run_hook_command(
+        yaml_run_hook_command,
+        {
+            "tool_name": "Write",
+            "tool_input": {"file_path": ".github/workflows/test.yml", "content": content},
+        },
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+    assert "block scalar" in result.stderr
+
+
+def test_yaml_run_hook_allows_comment_above_step(yaml_run_hook_command: str) -> None:
+    """A `#`-comment above the step (outside the block scalar) is allowed.
+
+    :param yaml_run_hook_command: Hook command body fixture.
+    """
+    content = (
+        "name: test\n"
+        "on: push\n"
+        "jobs:\n"
+        "  test:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      # this comment is correctly above the step\n"
+        "      - name: good\n"
+        "        run: |\n"
+        "          echo hi\n"
+    )
+    result = _run_hook_command(
+        yaml_run_hook_command,
+        {
+            "tool_name": "Write",
+            "tool_input": {"file_path": ".github/workflows/test.yml", "content": content},
+        },
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_yaml_run_hook_allows_shebang_inside_run_block(yaml_run_hook_command: str) -> None:
+    """A shebang line (``#!``) inside the block scalar is allowed.
+
+    :param yaml_run_hook_command: Hook command body fixture.
+    """
+    content = (
+        "jobs:\n"
+        "  test:\n"
+        "    steps:\n"
+        "      - run: |\n"
+        "          #!/usr/bin/env bash\n"
+        "          echo hi\n"
+    )
+    result = _run_hook_command(
+        yaml_run_hook_command,
+        {
+            "tool_name": "Write",
+            "tool_input": {"file_path": ".github/workflows/test.yml", "content": content},
+        },
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+@pytest.fixture(scope="module")
+def trailer_hook_command() -> str:
+    """Return the shell ``command`` body of the git-commit-trailer-check hook.
+
+    :returns: The shell command string.
+    """
+    return _find_handler("Git-commit-trailer-check")["command"]
+
+
+def test_trailer_hook_passes_non_git_commit(trailer_hook_command: str) -> None:
+    """Commands that aren't ``git commit`` (e.g. ``ls``) fast-path through.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": "ls -la"}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_trailer_hook_passes_clean_commit(trailer_hook_command: str) -> None:
+    """A clean conventional-commit message is allowed.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -m "feat(scope): clean message"'}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_trailer_hook_blocks_no_verify_long_form(trailer_hook_command: str) -> None:
+    """``git commit --no-verify`` is blocked.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit --no-verify -m "msg"'}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+    assert "--no-verify" in result.stderr
+
+
+def test_trailer_hook_blocks_no_verify_short_form(trailer_hook_command: str) -> None:
+    """``git commit -n`` (short form of ``--no-verify``) is blocked.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -n -m "msg"'}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+    assert "-n" in result.stderr
+
+
+def test_trailer_hook_does_not_false_positive_on_chained_grep_n(
+    trailer_hook_command: str,
+) -> None:
+    """A downstream ``grep -n`` after ``git commit && …`` is NOT mistaken for ``commit -n``.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -m "msg" && grep -n bar file.txt'}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_trailer_hook_blocks_co_authored_by_trailer(trailer_hook_command: str) -> None:
+    """A ``Co-Authored-By:`` trailer in the ``-m`` body is blocked.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {
+            "tool_input": {
+                "command": (
+                    'git commit -m "feat: x\n\nCo-Authored-By: Claude <noreply@anthropic.com>"'
+                )
+            }
+        },
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+    assert "Co-Authored-By" in result.stderr
+
+
+def test_trailer_hook_blocks_generated_with_footer(trailer_hook_command: str) -> None:
+    """A ``Generated with …`` agent-attribution footer is blocked.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -m "feat: x\n\nGenerated with Claude Code"'}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_trailer_hook_blocks_bundled_short_flag(trailer_hook_command: str) -> None:
+    """``git commit -nm "msg"`` (bundled ``-n``) is blocked the same as ``-n -m``.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -nm "msg"'}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+    assert "-n" in result.stderr
+
+
+def test_trailer_hook_blocks_anm_bundled_short_flag(trailer_hook_command: str) -> None:
+    """``git commit -anm "msg"`` (``-a -n -m`` bundled) is blocked.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -anm "msg"'}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_trailer_hook_allows_bundled_short_flag_without_n(trailer_hook_command: str) -> None:
+    """``git commit -am "msg"`` (no ``n`` in the bundle) is allowed.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -am "msg"'}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_trailer_hook_allows_claude_model_name_in_subject(trailer_hook_command: str) -> None:
+    """A subject naming a Claude model (no trailer context) is NOT flagged.
+
+    Verifies the over-broad-regex fix: ``feat(eval): tokeniser for Claude Sonnet
+    4.5`` is a legitimate subject. Only attribution-shaped trailers should fire.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -m "feat(eval): tokeniser for Claude Sonnet 4.5"'}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_trailer_hook_blocks_noreply_email(trailer_hook_command: str) -> None:
+    """A ``noreply@anthropic.com`` email anywhere in the body is blocked.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -m "feat: x via noreply@anthropic.com"'}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+
+
+def test_trailer_hook_blocks_dash_F_file_with_trailer(
+    trailer_hook_command: str, tmp_path: Path
+) -> None:
+    """``git commit -F <file>`` whose file contains a forbidden trailer is blocked.
+
+    :param trailer_hook_command: Hook command body fixture.
+    :param tmp_path: pytest tmp_path.
+    """
+    msg_file = tmp_path / "msg.txt"
+    msg_file.write_text("feat: x\n\nCo-Authored-By: Claude <noreply@anthropic.com>\n")
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": f"git commit -F {msg_file}"}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_trailer_hook_fails_closed_on_malformed_json(trailer_hook_command: str) -> None:
+    """A malformed-JSON stdin payload is blocked, not silently let through.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    # _run_hook_command always JSON-encodes its payload, so bypass it here and
+    # send raw invalid JSON directly on stdin.
+    result = subprocess.run(  # noqa: S603
+        ["bash", "-c", trailer_hook_command],  # noqa: S607
+        input="not valid json",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+@pytest.mark.parametrize("metachar", ["&&", "||", ";", "|", "&"])
+def test_trailer_hook_does_not_false_positive_on_chained_grep_n_metachars(
+    trailer_hook_command: str, metachar: str
+) -> None:
+    """Every shell metachar terminating ``git commit``'s argv slice is honored.
+
+    Regression coverage: a future tokenizer that drops one of the five
+    metachars from the slicing set would silently start mis-attributing a
+    downstream ``grep -n`` as a ``commit -n`` violation.
+
+    :param trailer_hook_command: Hook command body fixture.
+    :param metachar: Shell metachar to chain after the commit.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": f'git commit -m "msg" {metachar} grep -n bar file.txt'}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_baseline_hook_blocks_write_addition(baseline_hook_command: str, tmp_path: Path) -> None:
+    """A Write that increases baseline row count is blocked (Write path coverage).
+
+    :param baseline_hook_command: Hook command body fixture.
+    :param tmp_path: pytest tmp_path.
+    """
+    baseline = tmp_path / ".pydoclint-baseline.txt"
+    baseline.write_text("path/a.py:1:1: DOC101\n")
+    result = _run_hook_command(
+        baseline_hook_command,
+        {
+            "tool_name": "Write",
+            "tool_input": {
+                "file_path": str(baseline),
+                "content": "path/a.py:1:1: DOC101\npath/b.py:2:2: DOC102\n",
+            },
+        },
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_baseline_hook_allows_write_truncation(baseline_hook_command: str, tmp_path: Path) -> None:
+    """A Write that truncates the baseline (graduation) is allowed.
+
+    :param baseline_hook_command: Hook command body fixture.
+    :param tmp_path: pytest tmp_path.
+    """
+    baseline = tmp_path / ".pydoclint-baseline.txt"
+    baseline.write_text("path/a.py:1:1: DOC101\npath/b.py:2:2: DOC102\n")
+    result = _run_hook_command(
+        baseline_hook_command,
+        {
+            "tool_name": "Write",
+            "tool_input": {
+                "file_path": str(baseline),
+                "content": "path/a.py:1:1: DOC101\n",
+            },
+        },
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_baseline_hook_fails_closed_on_malformed_json(baseline_hook_command: str) -> None:
+    """A malformed-JSON stdin payload is blocked, not silently let through.
+
+    :param baseline_hook_command: Hook command body fixture.
+    """
+    result = subprocess.run(  # noqa: S603
+        ["bash", "-c", baseline_hook_command],  # noqa: S607
+        input="not valid json",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_yaml_run_hook_blocks_edit_introducing_comment(
+    yaml_run_hook_command: str, tmp_path: Path
+) -> None:
+    """An Edit that introduces a comment inside a ``run: |`` block is blocked (Edit path).
+
+    :param yaml_run_hook_command: Hook command body fixture.
+    :param tmp_path: pytest tmp_path.
+    """
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    workflow = workflow_dir / "test.yml"
+    workflow.write_text("jobs:\n  test:\n    steps:\n      - run: |\n          echo hi\n")
+    result = _run_hook_command(
+        yaml_run_hook_command,
+        {
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": str(workflow),
+                "old_string": "          echo hi\n",
+                "new_string": "          # injected bad comment\n          echo hi\n",
+            },
+        },
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "      - run: |-\n",
+        "      - run: |+\n",
+        "      - run: >\n",
+        "      - setup: |\n",
+    ],
+)
+def test_yaml_run_hook_blocks_comment_in_chomping_variants(
+    yaml_run_hook_command: str, header: str
+) -> None:
+    """Chomping (``|-`` / ``|+``) and folded (``>``) scalars are also scanned.
+
+    :param yaml_run_hook_command: Hook command body fixture.
+    :param header: ``run:`` / ``setup:`` header line with a chomping indicator.
+    """
+    content = (
+        "jobs:\n"
+        "  test:\n"
+        "    steps:\n" + header + "          # bad comment inside the block\n"
+        "          echo hi\n"
+    )
+    result = _run_hook_command(
+        yaml_run_hook_command,
+        {
+            "tool_name": "Write",
+            "tool_input": {"file_path": ".github/workflows/test.yml", "content": content},
+        },
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+
+
+def test_yaml_run_hook_fails_closed_on_malformed_json(yaml_run_hook_command: str) -> None:
+    """A malformed-JSON stdin payload is blocked, not silently let through.
+
+    :param yaml_run_hook_command: Hook command body fixture.
+    """
+    result = subprocess.run(  # noqa: S603
+        ["bash", "-c", yaml_run_hook_command],  # noqa: S607
+        input="not valid json",
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -1,8 +1,5 @@
-"""Tests pinning Claude hook ``settings.json`` scoping and runtime behaviour.
+"""Invariant: each Bash hook handler that scopes itself uses Claude Code permission-rule ``if:`` syntax (e.g. ``Bash(gh pr create *)``) at the handler level, and the body of each hook honours its documented exit contract.
 
-Invariant: each Bash hook handler that scopes itself uses Claude Code
-permission-rule ``if:`` syntax (e.g. ``Bash(gh pr create *)``) at the handler
-level, and the body of each hook honours its documented exit contract.
 Schema reference: https://code.claude.com/docs/en/hooks.md.
 """
 
@@ -75,11 +72,27 @@ def _run_hook_command(
     :param stdin_payload: JSON payload sent to the hook on stdin.
     :returns: Completed subprocess result with captured stdout/stderr and exit code.
     """
-    # Trust boundary: command_body comes from the repo's checked-in settings.json
-    # (maintainer-controlled). Do not reuse this helper against untrusted paths.
+    # Trust boundary: command_body comes from maintainer-controlled settings.json.
     return subprocess.run(  # noqa: S603
         ["bash", "-c", command_body],  # noqa: S607 — bash is a hard requirement of the harness
         input=json.dumps(stdin_payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _run_hook_command_raw(command_body: str, raw_stdin: str) -> subprocess.CompletedProcess[str]:
+    """Run a hook ``command`` body with raw (un-JSON-encoded) stdin.
+
+    :param command_body: The shell command body from a hook handler.
+    :param raw_stdin: Raw text written verbatim to the hook's stdin.
+    :returns: Completed subprocess result with captured stdout/stderr and exit code.
+    """
+    # Trust boundary: command_body comes from maintainer-controlled settings.json.
+    return subprocess.run(  # noqa: S603
+        ["bash", "-c", command_body],  # noqa: S607 — bash is a hard requirement of the harness
+        input=raw_stdin,
         capture_output=True,
         text=True,
         check=False,
@@ -132,23 +145,35 @@ def test_handler_if_values_use_permission_rule_syntax() -> None:
 
 _EXPECTED_HANDLER_SCOPES: tuple[tuple[str, str], ...] = (
     ("Branch safety", "Bash(git commit *)"),
-    ("Git-commit-trailer-check", "Bash(git commit *)"),
-    ("Pre-PR review gate", "Bash(gh pr create *)"),
     ("Doc-drift advisory review", "Bash(gh pr create *)"),
+    ("Git-commit-trailer-check", "Bash(git commit *)"),
     ("PR review resolver", "Bash(git push *)"),
+    ("Pre-PR review gate", "Bash(gh pr create *)"),
 )
 
 _EXPECTED_SHARED_HOOK_COMMANDS: tuple[tuple[str, str], ...] = (
-    ("Credential protection", "bash agent/hooks/edit-write.sh credential-protect"),
-    ("No-baseline-additions", "bash agent/hooks/no-baseline-additions.sh"),
-    ("No-yaml-run-comments", "bash agent/hooks/no-yaml-run-comments.sh"),
-    ("Git-commit-trailer-check", "bash agent/hooks/git-commit-trailer-check.sh"),
     ("Auto-format", "bash agent/hooks/edit-write.sh format"),
     ("Auto-test", "bash agent/hooks/edit-write.sh test"),
-    ("Taxonomy verification", "bash agent/hooks/verify-gh-taxonomy.sh"),
+    ("Credential protection", "bash agent/hooks/edit-write.sh credential-protect"),
     ("Doc-drift advisory review", "bash agent/hooks/doc-drift.sh"),
+    ("Git-commit-trailer-check", "bash agent/hooks/git-commit-trailer-check.sh"),
+    ("No-baseline-additions", "bash agent/hooks/no-baseline-additions.sh"),
+    ("No-yaml-run-comments", "bash agent/hooks/no-yaml-run-comments.sh"),
     ("PR review resolver", "bash agent/hooks/pr-review-resolver.sh"),
+    ("Taxonomy verification", "bash agent/hooks/verify-gh-taxonomy.sh"),
 )
+
+
+def _workflow_with_run_body(body: str) -> str:
+    """Wrap step body lines in minimal workflow scaffolding.
+
+    :param body: Lines (each terminated with ``\\n``) to inject under ``steps:``.
+        Callers supply the step (including the ``- name:``/``run: |`` header) and
+        any block-scalar body, so the helper can serve both inside-run-block and
+        above-step test cases.
+    :returns: A complete workflow YAML string suitable for the yaml-run hook.
+    """
+    return "name: test\non: push\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n" + body
 
 
 @pytest.mark.parametrize(("description_substring", "expected_if"), _EXPECTED_HANDLER_SCOPES)
@@ -351,13 +376,7 @@ def test_yaml_run_hook_blocks_comment_inside_run_block(yaml_run_hook_command: st
 
     :param yaml_run_hook_command: Hook command body fixture.
     """
-    content = (
-        "name: test\n"
-        "on: push\n"
-        "jobs:\n"
-        "  test:\n"
-        "    runs-on: ubuntu-latest\n"
-        "    steps:\n"
+    content = _workflow_with_run_body(
         "      - name: bad\n"
         "        run: |\n"
         "          # this comment is inside the run block — BAD\n"
@@ -380,13 +399,7 @@ def test_yaml_run_hook_allows_comment_above_step(yaml_run_hook_command: str) -> 
 
     :param yaml_run_hook_command: Hook command body fixture.
     """
-    content = (
-        "name: test\n"
-        "on: push\n"
-        "jobs:\n"
-        "  test:\n"
-        "    runs-on: ubuntu-latest\n"
-        "    steps:\n"
+    content = _workflow_with_run_body(
         "      # this comment is correctly above the step\n"
         "      - name: good\n"
         "        run: |\n"
@@ -407,13 +420,8 @@ def test_yaml_run_hook_allows_shebang_inside_run_block(yaml_run_hook_command: st
 
     :param yaml_run_hook_command: Hook command body fixture.
     """
-    content = (
-        "jobs:\n"
-        "  test:\n"
-        "    steps:\n"
-        "      - run: |\n"
-        "          #!/usr/bin/env bash\n"
-        "          echo hi\n"
+    content = _workflow_with_run_body(
+        "      - run: |\n          #!/usr/bin/env bash\n          echo hi\n"
     )
     result = _run_hook_command(
         yaml_run_hook_command,
@@ -500,24 +508,37 @@ def test_trailer_hook_does_not_false_positive_on_chained_grep_n(
     assert result.returncode == 0, (result.returncode, result.stderr)
 
 
-def test_trailer_hook_blocks_co_authored_by_trailer(trailer_hook_command: str) -> None:
-    """A ``Co-Authored-By:`` trailer in the ``-m`` body is blocked.
+@pytest.mark.parametrize(
+    ("command_str", "expected_substring"),
+    [
+        pytest.param(
+            'git commit -m "feat: x\n\nCo-Authored-By: Claude <noreply@anthropic.com>"',
+            "Co-Authored-By",
+            id="co-authored-by-trailer",
+        ),
+        pytest.param(
+            'git commit -m "feat: x via noreply@anthropic.com"',
+            "BLOCKED",
+            id="noreply-email",
+        ),
+    ],
+)
+def test_trailer_hook_blocks_forbidden_trailer_in_message_body(
+    trailer_hook_command: str, command_str: str, expected_substring: str
+) -> None:
+    """Forbidden trailers inside a ``-m`` body are blocked.
 
     :param trailer_hook_command: Hook command body fixture.
+    :param command_str: ``git commit`` command whose body carries the offender.
+    :param expected_substring: Substring that must appear in stderr.
     """
     result = _run_hook_command(
         trailer_hook_command,
-        {
-            "tool_input": {
-                "command": (
-                    'git commit -m "feat: x\n\nCo-Authored-By: Claude <noreply@anthropic.com>"'
-                )
-            }
-        },
+        {"tool_input": {"command": command_str}},
     )
     assert result.returncode == 2, (result.returncode, result.stderr)
     assert "BLOCKED" in result.stderr
-    assert "Co-Authored-By" in result.stderr
+    assert expected_substring in result.stderr
 
 
 def test_trailer_hook_blocks_generated_with_footer(trailer_hook_command: str) -> None:
@@ -573,10 +594,7 @@ def test_trailer_hook_allows_bundled_short_flag_without_n(trailer_hook_command: 
 
 
 def test_trailer_hook_allows_claude_model_name_in_subject(trailer_hook_command: str) -> None:
-    """A subject naming a Claude model (no trailer context) is NOT flagged.
-
-    Verifies the over-broad-regex fix: ``feat(eval): tokeniser for Claude Sonnet
-    4.5`` is a legitimate subject. Only attribution-shaped trailers should fire.
+    """A subject that names a Claude model (with no trailer key) is not flagged.
 
     :param trailer_hook_command: Hook command body fixture.
     """
@@ -585,18 +603,6 @@ def test_trailer_hook_allows_claude_model_name_in_subject(trailer_hook_command: 
         {"tool_input": {"command": 'git commit -m "feat(eval): tokeniser for Claude Sonnet 4.5"'}},
     )
     assert result.returncode == 0, (result.returncode, result.stderr)
-
-
-def test_trailer_hook_blocks_noreply_email(trailer_hook_command: str) -> None:
-    """A ``noreply@anthropic.com`` email anywhere in the body is blocked.
-
-    :param trailer_hook_command: Hook command body fixture.
-    """
-    result = _run_hook_command(
-        trailer_hook_command,
-        {"tool_input": {"command": 'git commit -m "feat: x via noreply@anthropic.com"'}},
-    )
-    assert result.returncode == 2, (result.returncode, result.stderr)
 
 
 def test_trailer_hook_blocks_dash_F_file_with_trailer(
@@ -622,28 +628,25 @@ def test_trailer_hook_fails_closed_on_malformed_json(trailer_hook_command: str) 
 
     :param trailer_hook_command: Hook command body fixture.
     """
-    # _run_hook_command always JSON-encodes its payload, so bypass it here and
-    # send raw invalid JSON directly on stdin.
-    result = subprocess.run(  # noqa: S603
-        ["bash", "-c", trailer_hook_command],  # noqa: S607
-        input="not valid json",
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _run_hook_command_raw(trailer_hook_command, "not valid json")
     assert result.returncode == 2, (result.returncode, result.stderr)
     assert "BLOCKED" in result.stderr
 
 
-@pytest.mark.parametrize("metachar", ["&&", "||", ";", "|", "&"])
+_METACHAR_PARAMS = [
+    pytest.param("&&", id="and"),
+    pytest.param("||", id="or"),
+    pytest.param(";", id="semicolon"),
+    pytest.param("|", id="pipe"),
+    pytest.param("&", id="ampersand"),
+]
+
+
+@pytest.mark.parametrize("metachar", _METACHAR_PARAMS)
 def test_trailer_hook_does_not_false_positive_on_chained_grep_n_metachars(
     trailer_hook_command: str, metachar: str
 ) -> None:
-    """Every shell metachar terminating ``git commit``'s argv slice is honored.
-
-    Regression coverage: a future tokenizer that drops one of the five
-    metachars from the slicing set would silently start mis-attributing a
-    downstream ``grep -n`` as a ``commit -n`` violation.
+    """Every shell metachar terminating ``git commit``'s argv slice is honoured.
 
     :param trailer_hook_command: Hook command body fixture.
     :param metachar: Shell metachar to chain after the commit.
@@ -655,7 +658,7 @@ def test_trailer_hook_does_not_false_positive_on_chained_grep_n_metachars(
     assert result.returncode == 0, (result.returncode, result.stderr)
 
 
-@pytest.mark.parametrize("metachar", ["&&", "||", ";", "|", "&"])
+@pytest.mark.parametrize("metachar", _METACHAR_PARAMS)
 def test_trailer_hook_handles_no_whitespace_metachar_chain(
     trailer_hook_command: str, metachar: str
 ) -> None:
@@ -753,13 +756,7 @@ def test_baseline_hook_fails_closed_on_malformed_json(baseline_hook_command: str
 
     :param baseline_hook_command: Hook command body fixture.
     """
-    result = subprocess.run(  # noqa: S603
-        ["bash", "-c", baseline_hook_command],  # noqa: S607
-        input="not valid json",
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    result = _run_hook_command_raw(baseline_hook_command, "not valid json")
     assert result.returncode == 2, (result.returncode, result.stderr)
     assert "BLOCKED" in result.stderr
 
@@ -832,12 +829,206 @@ def test_yaml_run_hook_fails_closed_on_malformed_json(yaml_run_hook_command: str
 
     :param yaml_run_hook_command: Hook command body fixture.
     """
-    result = subprocess.run(  # noqa: S603
-        ["bash", "-c", yaml_run_hook_command],  # noqa: S607
-        input="not valid json",
-        capture_output=True,
-        text=True,
-        check=False,
+    result = _run_hook_command_raw(yaml_run_hook_command, "not valid json")
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_trailer_hook_blocks_message_equals_form(trailer_hook_command: str) -> None:
+    """``git commit --message=<body>`` (= form, not space-separated) is blocked.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {
+            "tool_input": {
+                "command": (
+                    'git commit --message="feat: x\n\nCo-Authored-By: Claude <noreply@anthropic.com>"'
+                )
+            }
+        },
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_trailer_hook_blocks_file_equals_form(trailer_hook_command: str, tmp_path: Path) -> None:
+    """``git commit --file=<path>`` whose file contains a forbidden trailer is blocked.
+
+    :param trailer_hook_command: Hook command body fixture.
+    :param tmp_path: pytest tmp_path.
+    """
+    msg_file = tmp_path / "msg.txt"
+    msg_file.write_text("feat: x\n\nCo-Authored-By: Claude <noreply@anthropic.com>\n")
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": f"git commit --file={msg_file}"}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_trailer_hook_blocks_heredoc_trailer_in_raw_command(trailer_hook_command: str) -> None:
+    """Heredoc-bodied commits fall back to raw-command scanning and still block.
+
+    When no ``-m``/``-F`` body is recoverable from argv (heredoc /
+    ``$(cat msg.txt)``), the hook scans the raw command via anchored trailer
+    regexes — a ``Co-Authored-By:`` line in the heredoc body must still trip.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    cmd = "git commit <<EOF\nfeat: x\n\nCo-Authored-By: Claude\nEOF"
+    result = _run_hook_command(trailer_hook_command, {"tool_input": {"command": cmd}})
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_trailer_hook_allows_positional_n_after_double_dash(trailer_hook_command: str) -> None:
+    """``git commit -- -n`` (positional ``-n`` after ``--``) is not ``--no-verify``.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": "git commit -- -n"}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_trailer_hook_handles_unbalanced_quotes_fallback(trailer_hook_command: str) -> None:
+    """An unterminated-quote command triggers the shlex fallback path cleanly.
+
+    With no trailer-shaped substring in the (raw) command, the fallback must not mis-attribute and
+    the hook should exit 0.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -m "feat: x'}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_trailer_hook_blocks_lowercase_generated_with_in_trailer_position(
+    trailer_hook_command: str,
+) -> None:
+    """Lowercase ``generated with`` in trailer position is blocked (IGNORECASE).
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -m "feat: x\n\ngenerated with claude code"'}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_trailer_hook_does_not_block_generated_with_in_subject(
+    trailer_hook_command: str,
+) -> None:
+    """``generated with`` in the subject line (no preceding newline) is not flagged.
+
+    Pins the anchoring fix: trailer regexes require ``(?:^|\\n|\\\\n)\\s*`` before
+    the key, so ``fix: docs generated with sphinx-build`` is a clean subject.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -m "fix: docs generated with sphinx-build"'}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_trailer_hook_blocks_direct_claude_attribution_trailer(
+    trailer_hook_command: str,
+) -> None:
+    """Direct positive test for the ``[A-Za-z-]+:\\s*Claude\\s+(Code|Opus|Sonnet|Haiku)`` regex.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -m "feat: x\n\nAuthor: Claude Code"'}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_baseline_hook_allows_equal_count_edit(baseline_hook_command: str, tmp_path: Path) -> None:
+    """An Edit that swaps rows (NEW_COUNT == OLD_COUNT) is allowed — strict ``>`` boundary.
+
+    :param baseline_hook_command: Hook command body fixture.
+    :param tmp_path: pytest tmp_path.
+    """
+    baseline = tmp_path / ".pydoclint-baseline.txt"
+    baseline.write_text("path/a.py:1:1: DOC101\npath/b.py:2:2: DOC102\n")
+    result = _run_hook_command(
+        baseline_hook_command,
+        {
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": str(baseline),
+                "old_string": "path/a.py:1:1: DOC101\npath/b.py:2:2: DOC102\n",
+                "new_string": "path/c.py:3:3: DOC103\npath/d.py:4:4: DOC104\n",
+            },
+        },
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_yaml_run_hook_blocks_compute_config_path(yaml_run_hook_command: str) -> None:
+    """A `#`-comment inside a ``run: |`` block in ``configs/compute/*.yaml`` is blocked.
+
+    :param yaml_run_hook_command: Hook command body fixture.
+    """
+    content = _workflow_with_run_body(
+        "      - name: bad\n"
+        "        run: |\n"
+        "          # bad inline comment inside run block\n"
+        "          echo hi\n"
+    )
+    result = _run_hook_command(
+        yaml_run_hook_command,
+        {
+            "tool_name": "Write",
+            "tool_input": {"file_path": "configs/compute/foo.yaml", "content": content},
+        },
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_yaml_run_hook_blocks_comment_in_map_key_run_block(yaml_run_hook_command: str) -> None:
+    """Map-key ``run: |`` (no leading ``- ``) with a body comment is blocked.
+
+    Only the list-marker form (``- run: |``) was previously exercised; this
+    pins the bare map-key form where the body is indented deeper than the
+    ``run:`` key column.
+
+    :param yaml_run_hook_command: Hook command body fixture.
+    """
+    content = (
+        "name: test\n"
+        "on: push\n"
+        "jobs:\n"
+        "  test:\n"
+        "    runs-on: ubuntu-latest\n"
+        "    steps:\n"
+        "      - name: bad\n"
+        "        run: |\n"
+        "          # this is a bad comment inside a map-key run block\n"
+        "          echo hi\n"
+    )
+    result = _run_hook_command(
+        yaml_run_hook_command,
+        {
+            "tool_name": "Write",
+            "tool_input": {"file_path": ".github/workflows/test.yml", "content": content},
+        },
     )
     assert result.returncode == 2, (result.returncode, result.stderr)
     assert "BLOCKED" in result.stderr


### PR DESCRIPTION
## Summary

- Trim **AGENTS.md from 462 → 166 lines** (64% reduction). Conditional
  rules move to skill descriptions; reference detail moves to
  `docs/architecture.md`, new `docs/testing/mutmut.md`, and the new
  nested `src/synth_setter/pipeline/CLAUDE.md`.
- Add **3 PreToolUse hooks** that turn previously-probabilistic rules
  into deterministic gates:
  - `agent/hooks/no-baseline-additions.sh` — blocks Edit/Write that
    increases `.pydoclint-baseline.txt` row count.
  - `agent/hooks/no-yaml-run-comments.sh` — blocks Edit/Write that puts
    a `#`-comment inside a YAML `run:` / `setup:` block scalar
    (`|`, `|-`, `|+`, `>`, `>-`, `>+`; both bare and list-marker
    forms) in `.github/workflows/` or `configs/compute/`.
  - `agent/hooks/git-commit-trailer-check.sh` — blocks `git commit`
    with `--no-verify` / `-n` (incl. bundled forms like `-nm`,
    `-anm`), `Co-Authored-By` trailers, or agent-attribution footers
    (`Generated with …`, attribution-shaped `Claude (Code|Opus|Sonnet
    |Haiku)`, `noreply@anthropic.com`). Uses `shlex` to scope `-n` to
    `git commit`'s argv slice — chained `grep -n` after `&&`/`||`/`;`/
    `|`/`&` is correctly excluded.
- **56 behavioural tests** in `tests/claude_hooks/test_settings_hooks.py`
  pin every hook contract (was 35 pre-review; +21 from the review pass).
  Includes false-positive guards (`feat: ... Claude Sonnet 4.5`),
  fail-closed assertions on malformed JSON, and parametrized
  metachar/chomping-variant coverage.
- doc-map.yaml gains a mutmut entry; pipeline rules move to a nested
  `pipeline/CLAUDE.md` so they only load when editing files there.
- **Worktree isolation** is the top "Always" rule.

## Pre-PR review

`/repo-review-full-no-comments` ran with six parallel reviewers
(`code-health`, `synth-setter-project-standards`, `python-style`,
`tdd-implementation`, `comment-hygiene`, `shell-style`) against commit
`2a686b0`. The review surfaced **3 BLOCK + ~30 WARN** findings. Commit
`4fba2d9` addresses every BLOCK and every correctness WARN; the commit
message lists which WARNs were deliberately skipped (with reason — e.g.
"matches existing `pre-pr-review-gate.sh` pattern, consistent is
better").

A holistic comment-hygiene pass per the user's directive trimmed
docstring bloat across the whole test file and shell-script headers
(net −66 lines across 5 files).

## Motivation

A 462-line preamble dilutes attention. Rules buried in the middle
(lines 158-229) competed against rules with stronger trigger words. The
audit (in the conversation that authored this PR; see #1151) found that
~70% of AGENTS.md was either conditional (skill-shaped), mechanically
enforceable (hook-shaped), or reference material (`docs/`-shaped).

## Test plan

- [x] `pytest tests/claude_hooks/ -q` → 56 passed (was 35).
- [x] `pre-commit run --files <every touched file>` → all hooks pass.
- [x] All three new hooks smoke-tested against representative
      `BLOCK` and `ALLOW` payloads, including the false-positive
      guards (Claude model name in subject, chained `grep -n`, bundled
      `-am`).
- [ ] CI green on this PR.
- [ ] `mergeable=MERGEABLE`.
- [ ] No new Copilot comments after final push.

Closes #1151
Refs #25
Refs #938