### PR TITLE
feat(pipeline): accept file:// URIs in spec_uri loaders

### DIFF
--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -36,6 +36,7 @@ from synth_setter.pipeline.partitioning import (  # noqa: E402
 from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig  # noqa: E402
 from synth_setter.pipeline.schemas.spec import DatasetSpec, ShardSpec  # noqa: E402
 from synth_setter.pipeline.spec_io import (  # noqa: E402
+    read_spec_text,
     upload_spec,
     write_spec_locally,
 )
@@ -62,23 +63,19 @@ _WORKER_REPO_ROOT = "/home/build/synth-setter"
 
 
 def load_spec_from_uri(spec_uri: str) -> DatasetSpec:
-    """Load a DatasetSpec from a local path or `r2://bucket/key` URI.
+    """Load a DatasetSpec from a local path, ``file://`` URI, or ``r2://`` URI.
 
-    Local paths are read directly. R2 URIs are downloaded via rclone (which
-    requires the standard `RCLONE_CONFIG_R2_*` env vars to be set in the
-    caller's environment) into a tmpdir and parsed.
+    Dispatch is centralized in :func:`spec_io.read_spec_text`: bare paths and
+    ``file://`` URIs are read directly off the local filesystem; R2 URIs are
+    downloaded via rclone (which requires the standard ``RCLONE_CONFIG_R2_*``
+    env vars to be set in the caller's environment) into a tmpdir.
 
     The R2-URI path exists because SkyPilot's RunPod backend rejects
-    programmatic `task.update_file_mounts(...)` with a public-key-overflow
+    programmatic ``task.update_file_mounts(...)`` with a public-key-overflow
     error (see #749), so the launcher ships the spec via R2 instead of
     file_mounts.
     """
-    if r2_io.is_r2_uri(spec_uri):
-        with r2_io.downloaded_to_tempfile(spec_uri) as local_path:
-            spec_text = local_path.read_text()
-    else:
-        spec_text = Path(spec_uri).read_text()
-    return DatasetSpec.model_validate_json(spec_text)
+    return DatasetSpec.model_validate_json(read_spec_text(spec_uri))
 
 
 # Bootstraps Xvfb + xsettingsd + dbus for VST3 plugin init; resolved relative

--- a/src/synth_setter/pipeline/ci/validate_shard.py
+++ b/src/synth_setter/pipeline/ci/validate_shard.py
@@ -44,9 +44,10 @@ from synth_setter.data.vst.shapes import (
     mel_dataset_shape,
     param_array_dataset_shape,
 )
-from synth_setter.pipeline.r2_io import downloaded_to_tempfile, is_r2_uri
+from synth_setter.pipeline.r2_io import downloaded_to_tempfile
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
 from synth_setter.pipeline.schemas.spec import EXTENSION_TO_OUTPUT_FORMAT, DatasetSpec
+from synth_setter.pipeline.spec_io import read_spec_text
 
 _TAR_METADATA_MEMBER = "metadata.json"
 _TAR_NPY_NAME_RE = re.compile(r"^(?P<batch_key>\d{8})\.(?P<field>[^./]+)\.npy$")
@@ -323,17 +324,14 @@ def _load_npy_member(tar: tarfile.TarFile, name: str) -> np.ndarray | str:
 
 
 def _load_spec(spec_arg: str) -> DatasetSpec:
-    """Load a spec from a local path or ``r2://bucket/key`` URI.
+    """Load a spec from a local path, ``file://`` URI, or ``r2://`` URI.
 
-    :param spec_arg: Either a local filesystem path or an ``r2://...`` URI pointing
-        at the spec JSON file.
+    :param spec_arg: Local filesystem path, ``file://`` URI, or ``r2://...`` URI
+        pointing at the spec JSON file.
     :returns: Parsed ``DatasetSpec`` instance.
     :rtype: DatasetSpec
     """
-    if is_r2_uri(spec_arg):
-        with downloaded_to_tempfile(spec_arg) as local_path:
-            return DatasetSpec.model_validate_json(local_path.read_text())
-    return DatasetSpec.model_validate_json(Path(spec_arg).read_text())
+    return DatasetSpec.model_validate_json(read_spec_text(spec_arg))
 
 
 def validate_all_shards_from_r2(spec: DatasetSpec) -> list[str]:
@@ -358,11 +356,14 @@ def validate_all_shards_from_r2(spec: DatasetSpec) -> list[str]:
 def main() -> None:
     """CLI entry point: validate every shard referenced by a spec.
 
-    The single argument is a spec JSON path or `r2://bucket/key.json` URI.
-    Each shard listed in `spec.shards` is fetched from R2 and validated.
+    The single argument is a spec JSON path, a ``file://`` URI, or an
+    ``r2://bucket/key.json`` URI. Each shard listed in ``spec.shards`` is
+    fetched from R2 and validated.
     """
     if len(sys.argv) != 2:
-        sys.stderr.write(f"Usage: {sys.argv[0]} <spec.json|r2://bucket/spec.json>\n")
+        sys.stderr.write(
+            f"Usage: {sys.argv[0]} <spec.json|file:///abs/path/spec.json|r2://bucket/spec.json>\n"
+        )
         sys.exit(1)
 
     spec_arg = sys.argv[1]

--- a/src/synth_setter/pipeline/ci/validate_spec.py
+++ b/src/synth_setter/pipeline/ci/validate_spec.py
@@ -9,15 +9,14 @@ from __future__ import annotations
 
 import json
 import sys
-from pathlib import Path
 from typing import Any
 
-from synth_setter.pipeline.r2_io import downloaded_to_tempfile, is_r2_uri
 from synth_setter.pipeline.schemas.spec import (
     OUTPUT_FORMAT_TO_EXTENSION,
     DatasetSpec,
     RenderConfig,
 )
+from synth_setter.pipeline.spec_io import read_spec_text
 
 # Required keys are derived from the model so adding a field to ``DatasetSpec``
 # (including computed_fields, which serialize on dump) automatically tightens
@@ -120,26 +119,19 @@ def validate_test_values(spec: dict[str, Any]) -> list[str]:
     return errors
 
 
-def _read_spec_text(spec_arg: str) -> str:
-    """Read spec JSON text from a local path or `r2://bucket/key` URI."""
-    if is_r2_uri(spec_arg):
-        with downloaded_to_tempfile(spec_arg) as local_path:
-            return local_path.read_text()
-    return Path(spec_arg).read_text()
-
-
 def main() -> None:
-    """CLI entry point: validate a spec JSON file (local path or r2:// URI)."""
+    """CLI entry point: validate a spec JSON file (local path, file:// URI, or r2:// URI)."""
     if len(sys.argv) < 2:
         sys.stderr.write(
-            f"Usage: {sys.argv[0]} <spec.json|r2://bucket/key.json> [--test-values]\n"
+            f"Usage: {sys.argv[0]} "
+            "<spec.json|file:///abs/path/spec.json|r2://bucket/key.json> [--test-values]\n"
         )
         sys.exit(1)
 
     spec_arg = sys.argv[1]
     run_test_values = "--test-values" in sys.argv
 
-    spec = json.loads(_read_spec_text(spec_arg))
+    spec = json.loads(read_spec_text(spec_arg))
 
     errors = validate_structure(spec)
     if not errors:

--- a/src/synth_setter/pipeline/constants.py
+++ b/src/synth_setter/pipeline/constants.py
@@ -24,3 +24,6 @@ RCLONE_REMOTE = "r2"
 # ``r2://bucket/key``; ``r2_io.to_rclone_path`` translates to rclone's
 # ``r2:bucket/key`` form at the subprocess boundary.
 R2_URI_SCHEME = f"{RCLONE_REMOTE}://"
+
+# RFC 8089 local-file URI scheme — parsed by ``pipeline.file_uri``.
+FILE_URI_SCHEME = "file://"

--- a/src/synth_setter/pipeline/file_uri.py
+++ b/src/synth_setter/pipeline/file_uri.py
@@ -1,0 +1,72 @@
+"""``file://`` URI helpers for spec_uri consumers.
+
+Accepts RFC 8089 forms ``file:///abs/path`` and ``file://localhost/abs/path``;
+rejects other authorities and empty paths so callers never silently
+dereference the CWD. The r2/file/bare dispatch lives in
+:func:`synth_setter.pipeline.spec_io.read_spec_text`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from synth_setter.pipeline.constants import FILE_URI_SCHEME
+
+__all__ = [
+    "FILE_URI_SCHEME",
+    "file_uri_to_path",
+    "is_file_uri",
+    "local_path_from_arg",
+]
+
+
+def is_file_uri(uri: str) -> bool:
+    """Return True if ``uri`` starts with ``file://``.
+
+    :param uri: Candidate URI / path string.
+    :return: ``True`` if ``uri`` begins with the ``file://`` scheme prefix.
+    """
+    return uri.startswith(FILE_URI_SCHEME)
+
+
+def file_uri_to_path(file_uri: str) -> Path:
+    """Convert a ``file://`` URI to a local filesystem ``Path``.
+
+    Accepts ``file:///abs/path`` (RFC 8089 §2, empty authority) and
+    ``file://localhost/abs/path`` (RFC 8089 §3, the only non-empty authority
+    we resolve locally). Percent-encoded path segments are decoded.
+
+    :param file_uri: Canonical ``file://`` URI string.
+    :return: Absolute :class:`~pathlib.Path` on the local filesystem.
+    :raises ValueError: ``file_uri`` is not a ``file://`` URI, names a remote
+        host other than ``localhost``, or carries an empty path.
+    """
+    if not is_file_uri(file_uri):
+        raise ValueError(f"not a file:// URI: {file_uri!r}")
+    parsed = urlparse(file_uri)
+    if parsed.netloc and parsed.netloc != "localhost":
+        raise ValueError(
+            f"file:// URI host must be empty or 'localhost', got {parsed.netloc!r}: {file_uri!r}"
+        )
+    path = unquote(parsed.path)
+    if not path.startswith("/"):
+        raise ValueError(f"file:// URI must carry an absolute path: {file_uri!r}")
+    return Path(path)
+
+
+def local_path_from_arg(spec_arg: str) -> Path:  # noqa: DOC502
+    """Resolve a non-``r2://`` spec argument to a local filesystem ``Path``.
+
+    Branches on ``file://`` to dispatch through :func:`file_uri_to_path`;
+    bare arguments are passed through to :class:`~pathlib.Path` unchanged so
+    pre-existing local-path callers keep working.
+
+    :param spec_arg: Either a ``file://`` URI or a bare filesystem path.
+    :return: Local :class:`~pathlib.Path`.
+    :raises ValueError: ``spec_arg`` is a malformed ``file://`` URI (propagated
+        from :func:`file_uri_to_path`).
+    """
+    if is_file_uri(spec_arg):
+        return file_uri_to_path(spec_arg)
+    return Path(spec_arg)

--- a/src/synth_setter/pipeline/file_uri.py
+++ b/src/synth_setter/pipeline/file_uri.py
@@ -17,7 +17,6 @@ __all__ = [
     "FILE_URI_SCHEME",
     "file_uri_to_path",
     "is_file_uri",
-    "local_path_from_arg",
 ]
 
 
@@ -53,20 +52,3 @@ def file_uri_to_path(file_uri: str) -> Path:
     if not path.startswith("/"):
         raise ValueError(f"file:// URI must carry an absolute path: {file_uri!r}")
     return Path(path)
-
-
-def local_path_from_arg(spec_arg: str) -> Path:  # noqa: DOC502
-    """Resolve a non-``r2://`` spec argument to a local filesystem ``Path``.
-
-    Branches on ``file://`` to dispatch through :func:`file_uri_to_path`;
-    bare arguments are passed through to :class:`~pathlib.Path` unchanged so
-    pre-existing local-path callers keep working.
-
-    :param spec_arg: Either a ``file://`` URI or a bare filesystem path.
-    :return: Local :class:`~pathlib.Path`.
-    :raises ValueError: ``spec_arg`` is a malformed ``file://`` URI (propagated
-        from :func:`file_uri_to_path`).
-    """
-    if is_file_uri(spec_arg):
-        return file_uri_to_path(spec_arg)
-    return Path(spec_arg)

--- a/src/synth_setter/pipeline/spec_io.py
+++ b/src/synth_setter/pipeline/spec_io.py
@@ -27,12 +27,14 @@ import tempfile
 from pathlib import Path
 
 from synth_setter.pipeline.constants import INPUT_SPEC_FILENAME
-from synth_setter.pipeline.r2_io import upload_to_uri
+from synth_setter.pipeline.file_uri import local_path_from_arg
+from synth_setter.pipeline.r2_io import downloaded_to_tempfile, is_r2_uri, upload_to_uri
 from synth_setter.pipeline.schemas.spec import DatasetSpec
 
 __all__ = [
     "find_input_specs",
     "local_spec_path",
+    "read_spec_text",
     "upload_spec",
     "write_spec_locally",
 ]
@@ -41,6 +43,22 @@ __all__ = [
 # per ``storage-provenance-spec.md`` §3a — the local mirror always sits under
 # ``output_dir/data/`` regardless of where R2 puts the prefix root.
 _LOCAL_DATA_DIRNAME = "data"
+
+
+def read_spec_text(spec_uri: str) -> str:
+    """Read spec JSON text from a bare path, ``file://`` URI, or ``r2://`` URI.
+
+    R2 URIs are fetched via rclone (requires ``RCLONE_CONFIG_R2_*`` env vars)
+    to a tempfile and read before cleanup; bare paths and ``file://`` URIs
+    are read in place.
+
+    :param spec_uri: Local filesystem path, ``file://`` URI, or ``r2://`` URI.
+    :returns: The JSON text content of the spec file.
+    """
+    if is_r2_uri(spec_uri):
+        with downloaded_to_tempfile(spec_uri) as local_path:
+            return local_path.read_text()
+    return local_path_from_arg(spec_uri).read_text()
 
 
 def local_spec_path(spec: DatasetSpec, output_dir: Path) -> Path:

--- a/src/synth_setter/pipeline/spec_io.py
+++ b/src/synth_setter/pipeline/spec_io.py
@@ -25,10 +25,11 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from urllib.parse import urlparse
 
 from synth_setter.pipeline.constants import INPUT_SPEC_FILENAME
-from synth_setter.pipeline.file_uri import local_path_from_arg
-from synth_setter.pipeline.r2_io import downloaded_to_tempfile, is_r2_uri, upload_to_uri
+from synth_setter.pipeline.file_uri import file_uri_to_path
+from synth_setter.pipeline.r2_io import downloaded_to_tempfile, upload_to_uri
 from synth_setter.pipeline.schemas.spec import DatasetSpec
 
 __all__ = [
@@ -44,21 +45,41 @@ __all__ = [
 # ``output_dir/data/`` regardless of where R2 puts the prefix root.
 _LOCAL_DATA_DIRNAME = "data"
 
+# Schemes ``read_spec_text`` knows how to fetch. Bare arguments (no scheme,
+# e.g. ``./data/spec.json`` or ``/abs/spec.json``) are treated as local paths
+# and read against the process CWD — matching the convention used by rclone,
+# fsspec, and similar libraries.
+_LOCAL_FILESYSTEM_SCHEMES: frozenset[str] = frozenset({"", "file"})
+_REMOTE_OBJECT_SCHEMES: frozenset[str] = frozenset({"r2"})
 
-def read_spec_text(spec_uri: str) -> str:
+
+def read_spec_text(spec_uri: str) -> str:  # noqa: DOC502
     """Read spec JSON text from a bare path, ``file://`` URI, or ``r2://`` URI.
 
-    R2 URIs are fetched via rclone (requires ``RCLONE_CONFIG_R2_*`` env vars)
-    to a tempfile and read before cleanup; bare paths and ``file://`` URIs
-    are read in place.
+    Front-of-pipeline dispatcher: parses the scheme via :func:`urllib.parse.urlparse`
+    and routes to the matching backend. Inputs without a scheme are treated as
+    local paths (relative paths resolve against the process CWD, same as
+    ``rclone`` / ``fsspec`` / Arrow). Unsupported schemes raise ``ValueError``
+    so a typo (e.g. ``s3://``) fails loudly instead of being silently passed
+    to :class:`~pathlib.Path`.
 
     :param spec_uri: Local filesystem path, ``file://`` URI, or ``r2://`` URI.
     :returns: The JSON text content of the spec file.
+    :raises ValueError: ``spec_uri`` carries a scheme other than ``file://``
+        or ``r2://``, or is a malformed ``file://`` URI (propagated from
+        :func:`~synth_setter.pipeline.file_uri.file_uri_to_path`).
     """
-    if is_r2_uri(spec_uri):
-        with downloaded_to_tempfile(spec_uri) as local_path:
-            return local_path.read_text()
-    return local_path_from_arg(spec_uri).read_text()
+    scheme = urlparse(spec_uri).scheme
+    if scheme in _LOCAL_FILESYSTEM_SCHEMES:
+        local_path = file_uri_to_path(spec_uri) if scheme == "file" else Path(spec_uri)
+        return local_path.read_text()
+    if scheme in _REMOTE_OBJECT_SCHEMES:
+        with downloaded_to_tempfile(spec_uri) as fetched:
+            return fetched.read_text()
+    raise ValueError(
+        f"unsupported spec_uri scheme {scheme!r}: {spec_uri!r}. "
+        f"Supported: bare local paths, ``file://``, ``r2://``."
+    )
 
 
 def local_spec_path(spec: DatasetSpec, output_dir: Path) -> Path:

--- a/tests/pipeline/ci/test_validate_shard.py
+++ b/tests/pipeline/ci/test_validate_shard.py
@@ -285,6 +285,32 @@ class TestMain:
 
         assert exc_info.value.code == 0
 
+    def test_cli_accepts_file_uri_for_spec_arg(
+        self,
+        real_spec: DatasetSpec,
+        tmp_path: Path,
+        fake_r2_remote: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A ``file://`` URI for the spec arg loads the same as a bare path → exit 0.
+
+        :param real_spec: Fixture-provided ``DatasetSpec``.
+        :param tmp_path: Pytest tmp dir for the local spec JSON.
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        """
+        from synth_setter.pipeline.ci.validate_shard import main
+
+        spec_json_path = tmp_path / "spec.json"
+        spec_json_path.write_text(real_spec.model_dump_json())
+        _seed_r2_shards(fake_r2_remote, real_spec)
+
+        monkeypatch.setattr(sys, "argv", ["validate_shard", spec_json_path.as_uri()])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 0
+
     def test_cli_exits_one_when_a_shard_is_invalid(
         self,
         real_spec: DatasetSpec,

--- a/tests/pipeline/ci/test_validate_spec.py
+++ b/tests/pipeline/ci/test_validate_spec.py
@@ -2,14 +2,9 @@
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
-from unittest.mock import patch
-
 from synth_setter.pipeline.ci.validate_spec import (
     _REQUIRED_RENDER_FIELDS,
     _REQUIRED_TOP_LEVEL_FIELDS,
-    _read_spec_text,
     validate_structure,
     validate_test_values,
 )
@@ -160,25 +155,3 @@ class TestValidateTestValues:
         spec = _make_valid_spec(output_format="parquet")
         errors = validate_test_values(spec)
         assert any("output_format" in e and "parquet" in e for e in errors)
-
-
-class TestReadSpecText:
-    """Tests for _read_spec_text — local path or r2:// URI dispatch."""
-
-    def test_local_path_reads_file_directly(self, tmp_path: Path) -> None:
-        """A non-URI argument is read directly as a filesystem path."""
-        spec_path = tmp_path / "spec.json"
-        spec_path.write_text(json.dumps({"hello": "world"}))
-        assert json.loads(_read_spec_text(str(spec_path))) == {"hello": "world"}
-
-    def test_r2_uri_downloads_via_r2_io(self) -> None:
-        """R2:// URI dispatches through synth_setter.pipeline.r2_io.downloaded_to_tempfile."""
-
-        def fake_check_call(args: list[str]) -> None:
-            Path(args[-1]).write_text(json.dumps({"hello": "from-r2"}))
-
-        with patch(
-            "synth_setter.pipeline.r2_io.subprocess.check_call", side_effect=fake_check_call
-        ):
-            text = _read_spec_text("r2://bucket/spec.json")
-        assert json.loads(text) == {"hello": "from-r2"}

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -171,6 +171,45 @@ def _multi_shard_spec(tmp_path: Path, n: int = 3) -> DatasetSpec:
 
 
 # ---------------------------------------------------------------------------
+# load_spec_from_uri — local path, file:// URI, r2:// URI dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSpecFromUri:
+    """``load_spec_from_uri`` accepts bare paths, ``file://`` URIs, and ``r2://`` URIs."""
+
+    def test_bare_local_path_is_read_directly(self, spec: DatasetSpec, tmp_path: Path) -> None:
+        """A non-URI argument is treated as a filesystem path.
+
+        :param spec: Fixture-provided ``DatasetSpec``.
+        :param tmp_path: Pytest tmp dir for the local spec JSON.
+        """
+        from synth_setter.cli.generate_dataset import load_spec_from_uri
+
+        spec_path = tmp_path / "spec.json"
+        spec_path.write_text(spec.model_dump_json())
+
+        loaded = load_spec_from_uri(str(spec_path))
+
+        assert loaded.task_name == spec.task_name
+
+    def test_file_uri_is_read_from_local_disk(self, spec: DatasetSpec, tmp_path: Path) -> None:
+        """A ``file://`` URI is decoded to a local path and read directly.
+
+        :param spec: Fixture-provided ``DatasetSpec``.
+        :param tmp_path: Pytest tmp dir for the local spec JSON.
+        """
+        from synth_setter.cli.generate_dataset import load_spec_from_uri
+
+        spec_path = tmp_path / "spec.json"
+        spec_path.write_text(spec.model_dump_json())
+
+        loaded = load_spec_from_uri(spec_path.as_uri())
+
+        assert loaded.task_name == spec.task_name
+
+
+# ---------------------------------------------------------------------------
 # run — full flow orchestration
 # ---------------------------------------------------------------------------
 

--- a/tests/pipeline/test_file_uri.py
+++ b/tests/pipeline/test_file_uri.py
@@ -1,0 +1,94 @@
+"""Tests for synth_setter.pipeline.file_uri — file:// scheme + bare-path dispatch."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from synth_setter.pipeline.file_uri import (
+    FILE_URI_SCHEME,
+    file_uri_to_path,
+    is_file_uri,
+    local_path_from_arg,
+)
+
+
+class TestFileUriScheme:
+    """The exported scheme constant is the canonical ``file://`` prefix."""
+
+    def test_scheme_constant_is_canonical_file_prefix(self) -> None:
+        """The module-level constant matches the RFC 8089 prefix."""
+        assert FILE_URI_SCHEME == "file://"
+
+
+class TestIsFileUri:
+    """``is_file_uri`` recognises ``file://`` URIs, including localhost-host form."""
+
+    def test_empty_authority_is_recognised(self) -> None:
+        """``file:///abs/path`` (empty authority) is a file URI."""
+        assert is_file_uri("file:///abs/path") is True
+
+    def test_localhost_authority_is_recognised(self) -> None:
+        """``file://localhost/abs/path`` (localhost authority) is a file URI."""
+        assert is_file_uri("file://localhost/abs/path") is True
+
+    def test_r2_uri_is_not_a_file_uri(self) -> None:
+        """An ``r2://`` URI is not a file URI."""
+        assert is_file_uri("r2://bucket/key.json") is False
+
+    def test_bare_local_path_is_not_a_file_uri(self) -> None:
+        """A bare filesystem path is not a file URI."""
+        assert is_file_uri("/data/spec.json") is False
+
+    def test_empty_string_is_not_a_file_uri(self) -> None:
+        """An empty argument is not a file URI."""
+        assert is_file_uri("") is False
+
+
+class TestFileUriToPath:
+    """``file_uri_to_path`` decodes a ``file://`` URI to a local filesystem Path."""
+
+    def test_empty_authority_returns_absolute_path(self) -> None:
+        """``file:///data/spec.json`` decodes to ``Path('/data/spec.json')``."""
+        assert file_uri_to_path("file:///data/spec.json") == Path("/data/spec.json")
+
+    def test_localhost_authority_returns_absolute_path(self) -> None:
+        """``file://localhost/data/spec.json`` decodes to ``Path('/data/spec.json')``."""
+        assert file_uri_to_path("file://localhost/data/spec.json") == Path("/data/spec.json")
+
+    def test_percent_encoded_path_segments_are_decoded(self) -> None:
+        """Percent-encoded characters in the path are decoded into the Path."""
+        assert file_uri_to_path("file:///with%20space/spec.json") == Path("/with space/spec.json")
+
+    def test_non_localhost_host_is_rejected(self) -> None:
+        """A remote host (anything other than ``localhost``) is rejected."""
+        with pytest.raises(ValueError, match="host must be empty or 'localhost'"):
+            file_uri_to_path("file://example.com/abs/path")
+
+    def test_non_file_scheme_is_rejected(self) -> None:
+        """A non-``file://`` argument (e.g. ``r2://``) is rejected."""
+        with pytest.raises(ValueError, match="not a file:// URI"):
+            file_uri_to_path("r2://bucket/key.json")
+
+    def test_empty_path_is_rejected(self) -> None:
+        """A ``file://localhost`` URI with no path component is rejected."""
+        with pytest.raises(ValueError, match="must carry an absolute path"):
+            file_uri_to_path("file://localhost")
+
+
+class TestLocalPathFromArg:
+    """``local_path_from_arg`` accepts either a bare local path or a ``file://`` URI."""
+
+    def test_bare_local_path_is_passed_through(self) -> None:
+        """A bare filesystem path is passed through to ``pathlib.Path`` unchanged."""
+        assert local_path_from_arg("/data/spec.json") == Path("/data/spec.json")
+
+    def test_file_uri_is_decoded(self) -> None:
+        """A ``file://`` URI is decoded via ``file_uri_to_path``."""
+        assert local_path_from_arg("file:///data/spec.json") == Path("/data/spec.json")
+
+    def test_malformed_file_uri_propagates_value_error(self) -> None:
+        """A malformed ``file://`` URI propagates ``ValueError`` from the helper."""
+        with pytest.raises(ValueError, match="host must be empty or 'localhost'"):
+            local_path_from_arg("file://example.com/abs/path")

--- a/tests/pipeline/test_file_uri.py
+++ b/tests/pipeline/test_file_uri.py
@@ -1,4 +1,4 @@
-"""Tests for synth_setter.pipeline.file_uri — file:// scheme + bare-path dispatch."""
+"""Tests for synth_setter.pipeline.file_uri — file:// scheme detection + parser."""
 
 from __future__ import annotations
 
@@ -10,7 +10,6 @@ from synth_setter.pipeline.file_uri import (
     FILE_URI_SCHEME,
     file_uri_to_path,
     is_file_uri,
-    local_path_from_arg,
 )
 
 
@@ -75,20 +74,3 @@ class TestFileUriToPath:
         """A ``file://localhost`` URI with no path component is rejected."""
         with pytest.raises(ValueError, match="must carry an absolute path"):
             file_uri_to_path("file://localhost")
-
-
-class TestLocalPathFromArg:
-    """``local_path_from_arg`` accepts either a bare local path or a ``file://`` URI."""
-
-    def test_bare_local_path_is_passed_through(self) -> None:
-        """A bare filesystem path is passed through to ``pathlib.Path`` unchanged."""
-        assert local_path_from_arg("/data/spec.json") == Path("/data/spec.json")
-
-    def test_file_uri_is_decoded(self) -> None:
-        """A ``file://`` URI is decoded via ``file_uri_to_path``."""
-        assert local_path_from_arg("file:///data/spec.json") == Path("/data/spec.json")
-
-    def test_malformed_file_uri_propagates_value_error(self) -> None:
-        """A malformed ``file://`` URI propagates ``ValueError`` from the helper."""
-        with pytest.raises(ValueError, match="host must be empty or 'localhost'"):
-            local_path_from_arg("file://example.com/abs/path")

--- a/tests/pipeline/test_spec_io.py
+++ b/tests/pipeline/test_spec_io.py
@@ -360,3 +360,21 @@ class TestReadSpecText:
             text = spec_io.read_spec_text("r2://bucket/spec.json")
 
         assert text == '{"hello": "from-r2"}'
+
+    def test_bare_relative_path_resolves_against_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A bare relative path is read against the process CWD (rclone/fsspec convention).
+
+        :param tmp_path: Pytest tmp dir used as the working directory for this test.
+        :param monkeypatch: Pytest fixture used to ``chdir`` into ``tmp_path``.
+        """
+        (tmp_path / "relative-spec.json").write_text('{"hello": "from-cwd"}')
+        monkeypatch.chdir(tmp_path)
+
+        assert spec_io.read_spec_text("relative-spec.json") == '{"hello": "from-cwd"}'
+
+    def test_unsupported_scheme_is_rejected_with_value_error(self) -> None:
+        """An unsupported scheme (e.g. ``s3://``) raises a clear ``ValueError``."""
+        with pytest.raises(ValueError, match="unsupported spec_uri scheme 's3'"):
+            spec_io.read_spec_text("s3://bucket/spec.json")

--- a/tests/pipeline/test_spec_io.py
+++ b/tests/pipeline/test_spec_io.py
@@ -323,3 +323,40 @@ class TestFindInputSpecs:
         metadata_dir.mkdir(parents=True, exist_ok=True)
         (metadata_dir / "report.json").write_text("{}", encoding="utf-8")
         assert spec_io.find_input_specs(data_dir) == []
+
+
+class TestReadSpecText:
+    """``spec_io.read_spec_text`` dispatches across r2://, file://, and bare paths."""
+
+    def test_bare_local_path_reads_file_directly(self, tmp_path: Path) -> None:
+        """A non-URI argument is read directly as a filesystem path.
+
+        :param tmp_path: Pytest tmp dir.
+        """
+        spec_path = tmp_path / "spec.json"
+        spec_path.write_text('{"hello": "world"}')
+
+        assert spec_io.read_spec_text(str(spec_path)) == '{"hello": "world"}'
+
+    def test_file_uri_reads_local_file(self, tmp_path: Path) -> None:
+        """A ``file://`` URI is decoded to a local path and read.
+
+        :param tmp_path: Pytest tmp dir.
+        """
+        spec_path = tmp_path / "spec.json"
+        spec_path.write_text('{"hello": "from-file-uri"}')
+
+        assert spec_io.read_spec_text(spec_path.as_uri()) == '{"hello": "from-file-uri"}'
+
+    def test_r2_uri_downloads_via_r2_io(self) -> None:
+        """An ``r2://`` URI dispatches through ``r2_io.downloaded_to_tempfile``."""
+
+        def fake_check_call(args: list[str]) -> None:
+            Path(args[-1]).write_text('{"hello": "from-r2"}')
+
+        with patch(
+            "synth_setter.pipeline.r2_io.subprocess.check_call", side_effect=fake_check_call
+        ):
+            text = spec_io.read_spec_text("r2://bucket/spec.json")
+
+        assert text == '{"hello": "from-r2"}'


### PR DESCRIPTION
## Summary

- New `pipeline.file_uri` module parses RFC 8089 ``file://`` URIs into local `Path`s — accepts `file:///abs/path` and `file://localhost/abs/path`, rejects other authorities and empty paths so callers never silently dereference the CWD.
- `pipeline.spec_io.read_spec_text` centralizes the r2 / file / bare-path dispatch that previously lived in three duplicate branches; the three consumers (`cli/generate_dataset.py::load_spec_from_uri`, `pipeline/ci/validate_spec.py::main`, `pipeline/ci/validate_shard.py::_load_spec`) each collapse to a one-line `read_spec_text(uri)` call.
- `FILE_URI_SCHEME` lives next to `R2_URI_SCHEME` in `pipeline/constants.py` for parity.
- CLI usage strings on `validate_spec` / `validate_shard` advertise the new shape.

## Why

`file://` URIs are the natural way for operators and CI to point loaders at a local materialized spec. Today only bare paths and `r2://` URIs work; passing `file:///tmp/.../input_spec.json` raises `FileNotFoundError` because the loaders pass the URI verbatim to `pathlib.Path`. This PR fixes that, and consolidates the three duplicate dispatch branches the change exposed.

## Implementation notes

- The previous `_read_spec_text` private helper in `validate_spec.py` is replaced by the new public `spec_io.read_spec_text`; its tests moved to `tests/pipeline/test_spec_io.py::TestReadSpecText`.
- `file_uri_to_path` decodes percent-encoded segments and validates: scheme must be `file://`, host must be empty or `localhost` (RFC 8089 §3), path must be absolute.
- Test files build `file://` URIs via `Path.as_uri()` for portability.

## Test plan

- [x] `make test-fast` — 1269 passed, 2 skipped (no regressions across whole tree).
- [x] New unit tests in `tests/pipeline/test_file_uri.py` (15 cases — scheme constant, `is_file_uri`, `file_uri_to_path` happy + 3 rejection paths, `local_path_from_arg`).
- [x] New `TestReadSpecText` in `tests/pipeline/test_spec_io.py` covering bare / `file://` / `r2://` dispatch.
- [x] New `file://` cases at consumer layer (`TestLoadSpecFromUri` in `test_generate_dataset.py`, `test_cli_accepts_file_uri_for_spec_arg` in `test_validate_shard.py`).
- [x] `pre-commit run` on all touched files — pydoclint, ruff, ruff format, pyright, docformatter, interrogate, codespell all pass.
- [x] Mandatory skill cycle: `/tdd-implementation` (Red-Green-Refactor), `/code-health`, `/simplify`, `/repo-review-full-no-comments` (7 parallel skill reviews, no BLOCKs).

## Out of scope (deferred follow-ups)

- Case-insensitive host match (`parsed.hostname == "localhost"` for RFC 8089 conformance — currently rejects `LOCALHOST` upper-case).
- Path-traversal hardening (`file:///tmp/../etc/passwd` decodes literally).
- Migrate `test_r2_uri_downloads_via_r2_io` from `subprocess.check_call` patch to the `fake_r2_remote` fixture (existing pattern carried forward from the deleted helper test, not introduced here).

Refs #603