### PR TITLE
chore(pipeline): clarify skypilot_launch CLI is for ad-hoc commands + reject dispatch-owning entrypoints

### DIFF
--- a/docs/design/skypilot-compute-integration.md
+++ b/docs/design/skypilot-compute-integration.md
@@ -145,7 +145,51 @@ synth-setter-generate-dataset \
     skypilot_launch.compute_template=configs/compute/runpod-template.yaml
 ```
 
-The launcher finds `<repo_root>/.env`, parses it via `python-dotenv`, and resolves all keys from there. Process env is a non-event because `.env` wins per key — useful when you have stale shell exports.
+This is the **standard** local dispatch path: each `synth-setter-*` CLI
+entrypoint that supports SkyPilot carries its own `skypilot_launch` sub-config
+(today `synth-setter-generate-dataset`; more entrypoints are expected to
+follow), and setting `skypilot_launch.compute_template` flips the same command
+from "run in-process" to "materialize the spec, then dispatch via SkyPilot".
+The env-resolution logic described above lives inside
+`dispatch_via_skypilot` and runs the same way regardless of whether the call
+originated from this standard path or from the ad-hoc launcher CLI
+(`python -m synth_setter.pipeline.skypilot_launch`, contrasted against the
+standard path in
+[configuration-reference.md §2.4](../reference/configuration-reference.md#24-cloud-infrastructure))
+— both share one resolver, one `.env` lookup, and one set of failure modes.
+
+The resolver finds `<repo_root>/.env`, parses it via `python-dotenv`, and
+resolves all keys from there. Process env is a non-event because `.env` wins
+per key — useful when you have stale shell exports.
+
+For arbitrary ad-hoc commands that have no `synth-setter-*` entrypoint of
+their own, use the launcher CLI directly:
+
+```bash
+python -m synth_setter.pipeline.skypilot_launch \
+    --template configs/compute/runpod-template.yaml \
+    -- <arbitrary-command-that-materializes-an-input_spec.json>
+```
+
+The launcher's `--` argument is passed verbatim to `subprocess.check_call` and
+re-used as each worker's `run:` command, so the inner command must be safe to
+re-execute identically on the launcher host and on every worker rank. Do
+**not** pass a `synth-setter-*` CLI entrypoint as the inner command — those
+already own their dispatch via the standard path above, and routing them
+through this launcher would either materialize a fresh spec on each worker
+(losing alignment with the canonical `input_spec.json` the launcher just
+discovered) or attempt to dispatch a second time.
+
+To close the misuse loop, the launcher carries a runtime guardrail —
+`_DISPATCH_OWNING_ENTRYPOINTS` (`src/synth_setter/pipeline/skypilot_launch.py`)
+lists the `synth-setter-*` console scripts that own their own dispatch, and
+passing any of them as the inner command (whether as the bare console-script
+name, an absolute-path invocation, or the `python -m <module>` equivalent)
+raises a `click.ClickException` before the inner subprocess is even spawned.
+The check is intentionally narrow: it catches the direct-invocation misuse
+but does not chase shell aliases or wrapper scripts that resolve to a
+dispatching entrypoint by a different name, so the rule still rides on
+operator discipline at the margins.
 
 > **Note on `python -m synth_setter.pipeline.skypilot_launch -- …`.** The launcher CLI accepts an arbitrary inner command via the trailing `--` separator, but the inner command must (a) materialize exactly one canonical `data/<task>/<run>/metadata/input_spec.json`, (b) upload that spec to its canonical R2 URI (the launcher itself does not upload — it only resolves the URI via `synth-setter-spec-uri` and forwards it as `WORKER_SPEC_URI`), and (c) re-enter deterministically on the worker (the same string is threaded into the SkyPilot task's `run:` block via `shlex.join`). The default `synth-setter-generate-dataset` console script does **not** yet satisfy (c) — it re-composes Hydra fresh and would either run the pipeline locally on the worker or recursively dispatch — so it is not currently a valid inner command for this entrypoint. Use the canonical `synth-setter-generate-dataset` path shown above until a materialize-only mode lands (follow-up tracked in #1160).
 

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -83,10 +83,10 @@ docs:
 
   # ── SkyPilot compute integration design doc ─────────────────────
   - doc: docs/design/skypilot-compute-integration.md
-    description: SkyPilot launcher for the data pipeline (RunPod + OCI smoke)
+    description: SkyPilot dispatch for the data pipeline — standard entrypoint path + ad-hoc launcher (RunPod + OCI smoke)
     sources:
       - pattern: "src/synth_setter/pipeline/skypilot_launch.py"
-        covers: "SkyPilot launcher CLI; sky.jobs.launch managed-jobs SDK flow; --tail/--no-tail split (detached prints `sky jobs logs --name` and exits; tail streams via sky.jobs.tail_logs and cancels in finally). WORKER_SPEC_URI sourced from `spec.r2.input_spec_uri()`; file_mounts avoided (#749)."
+        covers: "Ad-hoc SkyPilot launcher CLI for arbitrary operator commands; also hosts `dispatch_via_skypilot`, the shared library the standard `synth-setter-*` dispatch path calls into. sky.jobs.launch managed-jobs SDK flow; --tail/--no-tail split (detached prints `sky jobs logs --name` and exits; tail streams via sky.jobs.tail_logs and cancels in finally). `dispatch_via_skypilot` receives a `spec_uri` from the caller (standard path passes `spec.r2.input_spec_uri()`; ad-hoc launcher resolves it via the `synth-setter-spec-uri` console script in `_resolve_spec_uri`) and forwards it as `WORKER_SPEC_URI`; file_mounts avoided (#749)."
       - pattern: "configs/compute/runpod-template.yaml"
         covers: "SkyPilot Task YAML for RunPod: resources block, image_id injected per-launch by the launcher (`--worker-image-tag`, default `dev-snapshot`) via `_override_image_id`, env-var injection (RCLONE_CONFIG_R2_*), R2-URI spec contract (WORKER_SPEC_URI consumed by load_spec_from_uri in the worker)"
       - pattern: "configs/compute/oci-cpu-template.yaml"

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -83,26 +83,96 @@ Reference: `eval-pipeline.md` §4–5
 
 ### 2.4 Cloud Infrastructure
 
+There are two ways a SkyPilot dispatch enters this codebase, and they should not
+be confused:
+
+1. **Standard path — a `synth-setter-*` CLI entrypoint dispatches itself.** Each
+   project console script that has compute support carries a `skypilot_launch`
+   sub-config (today: `synth-setter-generate-dataset`; more entrypoints are
+   expected to follow). Setting `skypilot_launch.compute_template=<path>` on the
+   entrypoint's Hydra invocation flips that single command from "run in-process"
+   to "materialize the spec, then dispatch via SkyPilot". This is the standard,
+   recommended way to run dataset generation (and any other supported command)
+   on SkyPilot — no separate launcher invocation involved.
+
+2. **Ad-hoc path — `synth_setter.pipeline.skypilot_launch`.** A thin wrapper
+   for running an *arbitrary* operator-supplied command on a SkyPilot worker
+   when no entrypoint in (1) covers the use case. The launcher shells out to
+   the command verbatim, discovers the materialized spec, resolves its URI,
+   and re-executes the same command on every worker rank. Reach for it when
+   you have an ad-hoc command you want to fan out via SkyPilot; do not use it
+   to invoke a `synth-setter-*` entrypoint that already has compute support —
+   that would be either redundant or self-defeating (the inner entrypoint
+   would either run locally a second time or attempt to dispatch on its own).
+
+#### Standard path: entrypoint-owned dispatch
+
 ```
-configs/compute/{provider}-template.yaml (SkyPilot Task YAML — no `run:` block)
-  → inner generator command (operator-supplied; the spec-materializer step)
-    writes data/<task>/<run>/metadata/input_spec.json AND uploads it to R2
-    (the launcher itself does not upload — see the inner-command contract below)
-  → launcher script (synth_setter.pipeline.skypilot_launch)
-    discovers that local spec, asks `synth-setter-spec-uri` for its canonical R2 URI,
-    forwards the same command verbatim into the SkyPilot task `run:`, and hands off
-    to dispatch_via_skypilot
-    → SkyPilot provisions pod (RunPod, Vast.ai planned, …)
-      → pod runs the same inner command, which **should** read `WORKER_SPEC_URI` to
-        skip re-materialization and reuse the canonical spec uploaded above
-        (aspirational — see contract bullet (c) and #1160 for why the default
-        `synth-setter-generate-dataset` does not yet honor this)
+synth-setter-generate-dataset experiment=… skypilot_launch.compute_template=configs/compute/runpod-template.yaml
+  → @hydra.main composes DictConfig → spec_from_cfg → DatasetSpec
+    → write_spec_locally(spec, _REPO_ROOT)
+    → upload_spec(spec) → R2 at {r2.prefix}input_spec.json
+    → dispatch_via_skypilot(spec, sky_cfg, spec_uri=spec.r2.input_spec_uri())
+      → SkyPilot provisions pod (RunPod, OCI, kubernetes via `sky local up`)
+        → pod runs: cd /home/build/synth-setter
+                    && bash scripts/sync_worker_checkout.sh
+                    && exec synth-setter-generate-dataset-from-hydra <pinned hydra overrides>
 ```
 
-- Separate from Hydra in *consumer* (SkyPilot's `Task.from_yaml` reads the compute template), not in *composition* — Hydra composition lives in the inner generator command, not in the launcher.
-- The launcher's CLI is a thin passthrough: it takes the task template plus an inner generator command (passed after `--`), runs that command via `subprocess.check_call`, then discovers the unique materialized spec via `find_input_specs(<repo_root>/data)`, resolves its canonical R2 URI via the `synth-setter-spec-uri` console script, and forwards that `r2://` URI to each worker via `task.update_envs(WORKER_SPEC_URI=...)`. The same command string is threaded into the SkyPilot task's `run:` block (via `shlex.join`) so the worker re-enters the same code path. `task.update_file_mounts` is avoided because the SkyPilot RunPod backend rejects programmatic file_mounts with a pubkey-overflow error (see [#749](https://github.com/tinaudio/synth-setter/issues/749)).
-- **Inner-command contract**: the operator's command must (a) materialize exactly one canonical `data/<task>/<run>/metadata/input_spec.json`, (b) upload that spec to its canonical R2 URI (the launcher does not upload — it only resolves the URI via `synth-setter-spec-uri` and forwards it as `WORKER_SPEC_URI`), and (c) re-enter deterministically when executed on the worker (e.g. by reading `WORKER_SPEC_URI` to skip re-composition / re-upload). The default `synth-setter-generate-dataset` console script does **not** yet satisfy (c) — it re-composes Hydra and runs the local pipeline or dispatches recursively — so it is not currently a valid inner command for `python -m synth_setter.pipeline.skypilot_launch`. The production path that uses it directly (`cli/generate_dataset.py::main()` → `dispatch_via_skypilot`) is the canonical entry point until a materialize-only mode lands; see the launcher-CLI follow-up issue tracked in #1160.
-- Invoked via: `python -m synth_setter.pipeline.skypilot_launch --template <yaml> -- <inner generator command>`. The launcher's options precede `--`; everything after is the operator-supplied inner command, passed through verbatim to `subprocess.check_call`.
+- Hydra composition lives in the entrypoint itself; the launcher module is not
+  on this path beyond `dispatch_via_skypilot`.
+- `_build_worker_cmd` (in `synth_setter.cli.generate_dataset`) pins the same
+  Hydra overrides the operator composed with, and the `from_hydra` entrypoint
+  on the worker rebuilds the spec from those — so worker re-execution is
+  deterministic regardless of operator argv.
+- The canonical `WORKER_SPEC_URI` is forwarded via `task.update_envs(...)`
+  primarily for downstream validate-time consumers (validate-spec /
+  validate-shard CI jobs read it off the workflow output). The worker itself
+  doesn't fetch the JSON. `task.update_file_mounts` is avoided because
+  SkyPilot's RunPod backend rejects programmatic file_mounts with a
+  pubkey-overflow error (see [#749](https://github.com/tinaudio/synth-setter/issues/749)).
+
+#### Ad-hoc path: `python -m synth_setter.pipeline.skypilot_launch`
+
+```
+configs/compute/{provider}-template.yaml (SkyPilot Task YAML — either no `run:`
+block, or a `run:` containing the `${WORKER_CMD}` sentinel where the worker
+cmd should land; see `_load_compute_template_with_cmd`. RunPod uses the
+former; OCI (`oci-cpu-template.yaml`) uses the latter so the launcher's cmd
+can be substituted into the host-side `sudo docker run … bash -c "${WORKER_CMD}"`
+scaffolding.)
+  → ad-hoc launcher: python -m synth_setter.pipeline.skypilot_launch
+                       --template <yaml> -- <arbitrary operator command>
+    runs the command via subprocess.check_call so it materializes
+    data/<task>/<run>/metadata/input_spec.json and uploads it to R2
+    → discovers the unique materialized spec via find_input_specs(<repo_root>/data)
+    → resolves its canonical R2 URI via the `synth-setter-spec-uri` console script
+    → hands off to dispatch_via_skypilot, which forwards the URI as WORKER_SPEC_URI
+      and re-executes the same operator command verbatim on each worker rank
+```
+
+- Invoked via: `python -m synth_setter.pipeline.skypilot_launch --template <yaml> -- <arbitrary command>`. The launcher's options precede `--`; everything after is the operator-supplied inner command, passed through verbatim to `subprocess.check_call` and to each worker's `run:` block.
+- **Inner-command contract** (the operator-supplied command must satisfy all
+  three): (a) materialize exactly one canonical
+  `data/<task>/<run>/metadata/input_spec.json`; (b) upload that spec to its
+  canonical R2 URI (the launcher itself does not upload — it only resolves the
+  URI via `synth-setter-spec-uri` and forwards it as `WORKER_SPEC_URI`);
+  (c) re-enter deterministically on each worker (the same command string is
+  threaded into the SkyPilot task's `run:` block via `shlex.join`, so it must
+  be safe to run identically on the launcher host and every worker rank).
+- **Do not pass a `synth-setter-*` CLI entrypoint here** — those entrypoints
+  already own their dispatch via the standard path above, and invoking one
+  through the ad-hoc launcher would either re-materialize a fresh spec on
+  each worker or attempt to dispatch a second time.
+- The launcher enforces this with a runtime guardrail:
+  `synth_setter.pipeline.skypilot_launch._DISPATCH_OWNING_ENTRYPOINTS` lists
+  the `synth-setter-*` console scripts that own their own dispatch (today:
+  `synth-setter-generate-dataset`; extended as new dispatching entrypoints
+  land), and passing one of them as the inner command (bare, absolute-path,
+  or `python -m <module>`) raises a `click.ClickException` with a pointer to
+  the standard-path invocation. The guardrail covers the common misuse only —
+  shell aliases or wrapper scripts that resolve to a dispatching entrypoint
+  by a different name will not be caught.
 
 Reference: `training-pipeline.md` Appendix D
 

--- a/src/synth_setter/pipeline/skypilot_launch.py
+++ b/src/synth_setter/pipeline/skypilot_launch.py
@@ -1,12 +1,39 @@
-"""Launch a `generate_dataset` run on RunPod, OCI, or local kind via SkyPilot managed jobs.
+"""Ad-hoc SkyPilot launcher for arbitrary operator-supplied commands.
 
-Provider-neutral entrypoint: the same binary launches against
+**This is not the standard dispatch path for the project's CLI entrypoints.**
+The `synth-setter-*` console scripts (currently `synth-setter-generate-dataset`,
+with more to follow) already carry their own `skypilot_launch.compute_template`
+configuration — point that field at a `configs/compute/*.yaml` and the
+entrypoint dispatches via SkyPilot on its own (see
+`synth_setter.cli.generate_dataset.main` and
+`configs/skypilot_launch/default.yaml`). Use this module only when no such
+entrypoint exists for the command you want to run on a SkyPilot worker.
+
+Concretely, this CLI:
+
+1. Shells out (via `subprocess.check_call`) to whatever inner command the
+   operator passes after `--`. That command is expected to materialize a
+   canonical `data/<task>/<run>/metadata/input_spec.json` and upload it to
+   R2 — anything else is fine, but discovery in step 2 will fail without it.
+2. Discovers the unique materialized `input_spec.json` under `<repo_root>/data`
+   and asks the `synth-setter-spec-uri` console script for its canonical R2 URI.
+3. Hands the spec + URI off to ``dispatch_via_skypilot``, which provisions
+   workers via `sky.jobs.launch`, forwards the URI as `WORKER_SPEC_URI`, and
+   re-executes the same inner command verbatim on each worker.
+
+Because step 3 re-uses the operator's argv verbatim, the inner command must
+be safe to run identically on the launcher host and on every worker rank.
+The set of ``synth-setter-*`` entry points listed in
+``_DISPATCH_OWNING_ENTRYPOINTS`` is rejected at the CLI surface — they own
+their own ``cfg.skypilot_launch.compute_template`` config and would
+self-recursively dispatch.
+
+Provider-neutral: the same binary launches against
 `configs/compute/runpod-template.yaml`, `configs/compute/oci-cpu-template.yaml`,
 or `configs/compute/local-template.yaml` (kubernetes-via-`sky local up`).
-Forwards worker env via `task.update_envs` — including the canonical spec
-URI as `WORKER_SPEC_URI` — and submits each rank's task to the SkyPilot
-managed-jobs controller via `sky.jobs.launch` (#749 explains why
-`task.update_file_mounts` is avoided). See
+Worker env is forwarded via `task.update_envs` (#749 explains why
+`task.update_file_mounts` is avoided), and each rank's task is submitted to
+the SkyPilot managed-jobs controller — see
 https://docs.skypilot.co/en/stable/reference/api.html#sky.jobs.launch
 
 By default the launcher waits for `sky.jobs.launch` + `sky.stream_and_get` to
@@ -23,8 +50,7 @@ Managed jobs differ from cluster-level launches:
   There's no per-job autostop window or explicit `down=True` to set — terminal
   status (success / failure / cancel) releases the underlying compute.
 - The user-facing identifier is the managed-job *name* (passed to `sky.jobs.*`
-  via `name=`), not a cluster name. The launcher's `--cluster-name` flag is the
-  job name in this mode.
+  via `name=`), not a cluster name.
 
 Per-backend image handling (driven by `--worker-image-tag`):
 - RunPod: each Resources entry's `image_id` is pinned to `docker:<image>` before the
@@ -128,6 +154,30 @@ DEFAULT_ENV_FILE = REPO_ROOT / ".env"
 _LOCAL_DATA_DIR = REPO_ROOT / "data"
 
 _SPEC_URI_CLI = "synth-setter-spec-uri"
+
+# ``synth-setter-*`` console scripts that already own SkyPilot dispatch via
+# ``cfg.skypilot_launch.compute_template``. Routing one of these through the
+# ad-hoc launcher would either re-materialize a fresh spec on each worker
+# (losing alignment with the canonical ``input_spec.json`` this launcher just
+# discovered) or attempt to dispatch a second time, so reject the misuse early
+# with a pointer to the standard path.
+#
+# Keep this set in sync with ``[project.scripts]`` in ``pyproject.toml``: every
+# entry here must correspond to a console script whose ``main()`` calls
+# ``dispatch_via_skypilot``. The worker-side ``-from-hydra`` siblings do not
+# dispatch and are intentionally absent.
+_DISPATCH_OWNING_ENTRYPOINTS: frozenset[str] = frozenset(
+    {
+        "synth-setter-generate-dataset",
+    }
+)
+
+# ``python -m <module>`` equivalents of the entries above. The value is the
+# console-script name we recommend in the error message; keep the value in
+# sync with ``_DISPATCH_OWNING_ENTRYPOINTS``.
+_DISPATCH_OWNING_MODULES: dict[str, str] = {
+    "synth_setter.cli.generate_dataset": "synth-setter-generate-dataset",
+}
 
 # `sky local up` uses the kubernetes backend; map both spellings.
 _CLOUD_TO_PROVIDER: dict[str, str] = {
@@ -319,19 +369,20 @@ def main(
     local: bool,
     command: tuple[str, ...],
 ) -> None:
-    """Run an inner generator ``command`` then dispatch its spec to SkyPilot.
+    """Run an arbitrary inner ``command`` then dispatch its spec to SkyPilot.
 
-    Shells out to ``command`` (typically the ``synth-setter-generate-dataset``
-    console script), which writes the canonical
-    ``data/<task>/<run>/metadata/input_spec.json`` and uploads it to R2. The
-    launcher then discovers that local spec, asks ``synth-setter-spec-uri``
-    for its canonical R2 URI, and hands both off to ``dispatch_via_skypilot``
-    for the SkyPilot fan-out.
+    Shells out to ``command`` so it materializes the canonical
+    ``data/<task>/<run>/metadata/input_spec.json`` and uploads it to R2; the
+    launcher then resolves the spec's R2 URI via ``synth-setter-spec-uri`` and
+    hands off to ``dispatch_via_skypilot``, which re-executes ``command``
+    verbatim on each worker. See the module docstring for when an
+    entrypoint-owned ``skypilot_launch.compute_template`` is the right tool
+    instead.
 
     Pass the inner command after the launcher's own options::
 
         python -m synth_setter.pipeline.skypilot_launch --template ... -- \\
-            synth-setter-generate-dataset experiment=foo
+            <arbitrary-command-that-materializes-an-input_spec.json>
 
     :param template_path: Path to the SkyPilot task YAML template.
     :param env_file_path: Path to a KEY=VALUE env file for worker env resolution.
@@ -340,10 +391,19 @@ def main(
     :param tail: When True, tail managed-job logs and cancel every job on exit.
     :param api_server: Remote SkyPilot API server URL; mutually exclusive with ``local``.
     :param local: Force local SDK dispatch; mutually exclusive with ``api_server``.
-    :param command: The inner generator command to run before dispatch.
+    :param command: The inner command to run before dispatch. Must materialize
+        a canonical ``input_spec.json`` and be safe to re-execute verbatim on
+        each worker. ``synth-setter-*`` entry points that own their own
+        SkyPilot dispatch (listed in ``_DISPATCH_OWNING_ENTRYPOINTS``) are
+        rejected with a pointer to the standard path.
+    :raises click.ClickException: ``command`` is empty, names a
+        dispatch-owning ``synth-setter-*`` entry point, or the inner
+        subprocess fails / does not materialize exactly one spec.
     """
     if not command:
         raise click.ClickException("an inner command is required (pass it after `--`)")
+
+    _reject_dispatch_owning_inner_command(command)
 
     # cwd=REPO_ROOT pins the inner command's relative-path lookups (e.g. the
     # default `.env`) to the same anchor _LOCAL_DATA_DIR uses for spec discovery,
@@ -357,10 +417,10 @@ def main(
 
     sky_cfg = SkypilotLaunchConfig(
         compute_template=str(template_path),
-        # cmd is the inner worker command; threaded through ``dispatch_via_skypilot``
-        # into the YAML run: block on each rank. shlex.join preserves argv
-        # boundaries so paths with spaces or shell metacharacters survive the
-        # single-string round-trip into the worker's bash invocation.
+        # shlex.join preserves argv boundaries so paths with spaces or shell
+        # metacharacters survive the single-string round-trip into the
+        # worker's bash ``run:`` block. See the module docstring for why the
+        # operator's argv is reused verbatim rather than rebuilt from spec.
         cmd=shlex.join(command),
         env_file=str(env_file_path),
         num_workers=num_workers,
@@ -423,6 +483,46 @@ def _resolve_spec_uri(spec_path: Path) -> str:
         [_SPEC_URI_CLI, str(spec_path)]  # noqa: S607 — entry-point on PATH after `pip install -e .`
     )
     return raw.decode().strip()
+
+
+def _reject_dispatch_owning_inner_command(command: tuple[str, ...]) -> None:
+    """Reject inner commands that own their own SkyPilot dispatch.
+
+    See ``_DISPATCH_OWNING_ENTRYPOINTS`` for the motivation. Recognizes both
+    bare-console-script invocations (``synth-setter-generate-dataset ...``,
+    matched by ``Path(argv[0]).name`` so absolute-path invocations are caught
+    too) and ``python[3] -m synth_setter.cli.<module>`` invocations (matched
+    against ``_DISPATCH_OWNING_MODULES``).
+
+    :param command: The operator-supplied inner command tuple.
+    :raises click.ClickException: ``command`` invokes a known dispatch-owning
+        console script or module; the message names the standard path.
+    """
+    head = Path(command[0]).name
+    if head in _DISPATCH_OWNING_ENTRYPOINTS:
+        raise click.ClickException(
+            f"{head!r} already owns its own SkyPilot dispatch via "
+            "`cfg.skypilot_launch.compute_template` — running it through this "
+            "ad-hoc launcher would either re-materialize a fresh spec on each "
+            "worker or attempt to dispatch a second time. Invoke it directly "
+            f"with that field set instead: `{head} ... "
+            "skypilot_launch.compute_template=<path-to-compute-template.yaml>`. "
+            "See the module docstring for the standard-vs-ad-hoc boundary."
+        )
+    if head in {"python", "python3"} and len(command) >= 3 and command[1] == "-m":
+        module = command[2]
+        if module in _DISPATCH_OWNING_MODULES:
+            recommended = _DISPATCH_OWNING_MODULES[module]
+            raise click.ClickException(
+                f"`python -m {module}` is the same entry point as "
+                f"{recommended!r}, which already owns its own SkyPilot "
+                "dispatch via `cfg.skypilot_launch.compute_template` — running "
+                "it through this ad-hoc launcher would either re-materialize a "
+                "fresh spec on each worker or attempt to dispatch a second "
+                f"time. Invoke `{recommended}` directly with that field set "
+                "instead. See the module docstring for the standard-vs-ad-hoc "
+                "boundary."
+            )
 
 
 def _override_image_id(task: sky.Task, worker_image: str) -> None:

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -382,6 +382,117 @@ class TestCli:
         assert result.exit_code != 0
         mock_sky.jobs.launch.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "inner",
+        [
+            ["synth-setter-generate-dataset", "experiment=foo"],
+            ["/venv/main/bin/synth-setter-generate-dataset", "experiment=foo"],
+            ["python", "-m", "synth_setter.cli.generate_dataset", "experiment=foo"],
+            ["python3", "-m", "synth_setter.cli.generate_dataset", "experiment=foo"],
+        ],
+        ids=[
+            "bare-console-script",
+            "absolute-path-to-console-script",
+            "python -m module",
+            "python3 -m module",
+        ],
+    )
+    def test_rejects_dispatch_owning_inner_command(
+        self,
+        inner: list[str],
+        env_file: Path,
+        template_yaml: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_sky: MagicMock,
+    ) -> None:
+        """Reject ``synth-setter-generate-dataset`` (and its python -m form) before subprocess.
+
+        The launcher's verbatim worker re-execution would otherwise either
+        re-materialize a fresh spec on each worker or attempt to dispatch a
+        second time. Catching the misuse at the CLI surface is cheaper than
+        debugging it from a failed managed-job run.
+
+        :param inner: Parametrized inner-command argv covering bare console
+            script, absolute-path console script, and ``python(3) -m`` forms.
+        :param env_file: Fixture-provided worker env file path.
+        :param template_yaml: Fixture-provided compute template path.
+        :param monkeypatch: Used to pin ``subprocess.check_call`` so an
+            accidental fall-through to subprocess execution would be visible
+            as a test failure rather than running the real entrypoint.
+        :param mock_sky: Mocked ``sky`` module from fixture.
+        """
+        check_call_calls: list[list[str]] = []
+        monkeypatch.setattr(
+            "synth_setter.pipeline.skypilot_launch.subprocess.check_call",
+            lambda args, **_kwargs: (check_call_calls.append(list(args)), 0)[1],
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "--template",
+                str(template_yaml),
+                "--env-file",
+                str(env_file),
+                "--",
+                *inner,
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "synth-setter-generate-dataset" in result.output
+        assert "skypilot_launch.compute_template" in result.output
+        assert check_call_calls == []
+        mock_sky.jobs.launch.assert_not_called()
+
+    def test_allows_non_dispatch_owning_inner_command(
+        self,
+        cwd_with_spec: tuple[Path, Path, DatasetSpec],
+        env_file: Path,
+        template_yaml: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_sky: MagicMock,
+    ) -> None:
+        """A ``synth-setter-*`` entry point that does NOT own dispatch is accepted.
+
+        ``synth-setter-spec-uri`` is a read-only console script (it emits the
+        canonical R2 URI for an input_spec and does not call
+        ``dispatch_via_skypilot``), so it must pass the guardrail. This pins
+        the guardrail to the actual ``_DISPATCH_OWNING_ENTRYPOINTS`` set
+        rather than the broader ``synth-setter-*`` prefix.
+
+        :param cwd_with_spec: Fixture providing a CWD pre-populated with a
+            canonical input_spec.json.
+        :param env_file: Fixture-provided worker env file path.
+        :param template_yaml: Fixture-provided compute template path.
+        :param monkeypatch: Pytest fixture for env/attribute mocking.
+        :param mock_sky: Mocked ``sky`` module from fixture.
+        """
+        check_call_calls: list[list[str]] = []
+        monkeypatch.setattr(
+            "synth_setter.pipeline.skypilot_launch.subprocess.check_call",
+            lambda args, **_kwargs: (check_call_calls.append(list(args)), 0)[1],
+        )
+        _stub_check_output_returns_uri(monkeypatch, "r2://intermediate-data/run/input_spec.json")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            main,
+            [
+                "--template",
+                str(template_yaml),
+                "--env-file",
+                str(env_file),
+                "--",
+                "synth-setter-spec-uri",
+                "some-arg",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert check_call_calls == [["synth-setter-spec-uri", "some-arg"]]
+
     def test_runs_inner_command_via_subprocess(
         self,
         cwd_with_spec: tuple[Path, Path, DatasetSpec],
@@ -417,12 +528,12 @@ class TestCli:
                 "--env-file",
                 str(env_file),
                 "--",
-                "synth-setter-generate-dataset",
+                "materialize-input-spec",
                 "experiment=foo",
             ],
         )
         assert result.exit_code == 0, result.output
-        assert check_call_calls == [["synth-setter-generate-dataset", "experiment=foo"]]
+        assert check_call_calls == [["materialize-input-spec", "experiment=foo"]]
 
     def test_invokes_spec_uri_cli_with_discovered_path(
         self,
@@ -458,7 +569,7 @@ class TestCli:
                 "--env-file",
                 str(env_file),
                 "--",
-                "synth-setter-generate-dataset",
+                "materialize-input-spec",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -498,7 +609,7 @@ class TestCli:
                 "--env-file",
                 str(env_file),
                 "--",
-                "synth-setter-generate-dataset",
+                "materialize-input-spec",
             ],
         )
         assert result.exit_code == 0, result.output
@@ -541,7 +652,7 @@ class TestCli:
                 "--env-file",
                 str(env_file),
                 "--",
-                "synth-setter-generate-dataset",
+                "materialize-input-spec",
             ],
         )
         assert result.exit_code != 0
@@ -586,7 +697,7 @@ class TestCli:
                 "--env-file",
                 str(env_file),
                 "--",
-                "synth-setter-generate-dataset",
+                "materialize-input-spec",
             ],
         )
         assert result.exit_code != 0
@@ -626,7 +737,7 @@ class TestCli:
                 "--env-file",
                 str(env_file),
                 "--",
-                "synth-setter-generate-dataset",
+                "materialize-input-spec",
             ],
         )
         assert result.exit_code != 0
@@ -685,7 +796,7 @@ class TestCli:
                 "--env-file",
                 str(env_file),
                 "--",
-                "synth-setter-generate-dataset",
+                "materialize-input-spec",
             ],
         )
 


### PR DESCRIPTION
## Summary

Follow-up to PR #1157. Clarifies the boundary between (a) the **standard**
SkyPilot dispatch path owned by `synth-setter-*` CLI entrypoints via
`skypilot_launch.compute_template`, and (b) the **ad-hoc** `python -m
synth_setter.pipeline.skypilot_launch` launcher for arbitrary operator
commands that are safe to re-execute verbatim on each worker rank.

- The **standard** path is the `synth-setter-*` CLI entrypoints' own
  `skypilot_launch.compute_template` config (today
  `synth-setter-generate-dataset`; more entrypoints will follow). Those
  entrypoints materialize the spec and dispatch via SkyPilot themselves
  — no separate launcher invocation needed.
- `python -m synth_setter.pipeline.skypilot_launch` is the **ad-hoc**
  path for arbitrary operator-supplied commands that have no
  `synth-setter-*` entrypoint of their own. It shells out to the
  command verbatim, then re-executes the same command on every worker
  rank — so the inner command must be safe to run identically on the
  launcher host and on each worker.
- Passing a `synth-setter-*` entrypoint as the launcher's inner command
  is the wrong tool for the job: that entrypoint would either
  re-materialize a fresh spec on each worker or attempt to dispatch a
  second time.

## Changes

- `docs/reference/configuration-reference.md` §2.4 rewritten to split
  the standard-path and ad-hoc-path stories side by side, each with its
  own diagram and contract bullets. Calls out that the launcher
  must not be invoked with a `synth-setter-*` entrypoint as its inner
  command.
- `docs/design/skypilot-compute-integration.md` "Local dev story"
  switched from the launcher invocation to the standard
  `synth-setter-generate-dataset … skypilot_launch.compute_template=…`
  form. A follow-up paragraph documents the ad-hoc form for arbitrary
  commands and the misuse caveat.
- `docs/doc-map.yaml` entry for `skypilot_launch.py` updated to reflect
  the file's dual role (ad-hoc CLI plus shared `dispatch_via_skypilot`
  library) and the correct `spec_uri` source per path (standard:
  `spec.r2.input_spec_uri()`; ad-hoc: `synth-setter-spec-uri`).
- `src/synth_setter/pipeline/skypilot_launch.py` module + `main()`
  docstrings rewritten around the ad-hoc passthrough contract; inline
  comment block above `cmd=shlex.join(command)` rewritten.
- **New runtime guardrail** (functional change):
  `_reject_dispatch_owning_inner_command()` raises
  `click.ClickException` if the inner command is one of the
  `synth-setter-*` console scripts listed in
  `_DISPATCH_OWNING_ENTRYPOINTS` (today: `synth-setter-generate-dataset`),
  whether passed as the bare console-script name, an absolute-path
  invocation, or the `python -m <module>` equivalent. The error
  message points the operator at the standard path.
- Tests in `tests/pipeline/test_entrypoints/test_skypilot_launch.py`
  cover the guardrail across both invocation forms and a happy-path
  inner command, and the pre-existing dispatch-error parametrize is
  updated to use a non-dispatch-owning inner command (the old
  `synth-setter-generate-dataset` argv now hits the guardrail first).

## Scope note

Originally framed as docs-only, but Copilot review correctly flagged
the guardrail + its tests as a real functional change. The PR scope is
now: docs + a defensive guardrail with full test coverage.

## Test plan

- [ ] CI green (pre-commit and the full test suite — touched-file
  `pre-commit run` is clean locally; `pytest tests/pipeline/test_entrypoints/test_skypilot_launch.py`
  is 66/66 passing locally).
- [ ] Rebased onto `main` after #1162 / #1166 / #1171 landed; merge
  conflict on `configuration-reference.md` and
  `skypilot-compute-integration.md` resolved in favor of the
  standard/ad-hoc split (the prior single-section text in those files
  is superseded by the explicit two-path layout).

Closes #1165
Refs #1157
Refs #1162

# REVIEW_FULL_DONE=1
