### PR TITLE
fix(ci-automation): close five hook gaps surfaced by post-merge review of #1158

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,7 +50,7 @@
       },
       {
         "matcher": "Bash",
-        "description": "Git-commit-trailer-check: on git commit (including `git -c <opt>=<val> commit` and other git-level option forms), blocks the call if argv to git commit carries --no-verify / -n, or the message body carries a Co-Authored-By trailer or an agent-attribution footer ('Generated with Claude ...', etc.). Tokenizes with shlex so downstream commands chained with && / || / ; / | are not mistakenly scoped. Goal: keep agent-attribution trailers and verification bypasses out of the history at the tool boundary.",
+        "description": "Git-commit-trailer-check: blocks `git commit` (and `git -c X=Y commit`, `git --git-dir=.git commit`, other git-level option forms) that carry --no-verify / -n, a Co-Authored-By trailer, or an agent-attribution footer (e.g. 'Generated with Claude ...'). Tokenizes with shlex so chained `&& / || / ; / |` commands are not mis-scoped.",
         "hooks": [
           {
             "type": "command",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -50,11 +50,11 @@
       },
       {
         "matcher": "Bash",
-        "description": "Git-commit-trailer-check: on git commit, blocks the call if argv to git commit carries --no-verify / -n, or the message body carries a Co-Authored-By trailer or an agent-attribution footer ('Generated with ...', 'Claude ...', noreply@anthropic.com). Tokenizes with shlex so downstream commands chained with && / || / ; / | are not mistakenly scoped. Goal: keep agent-attribution trailers and verification bypasses out of the history at the tool boundary.",
+        "description": "Git-commit-trailer-check: on git commit (including `git -c <opt>=<val> commit` and other git-level option forms), blocks the call if argv to git commit carries --no-verify / -n, or the message body carries a Co-Authored-By trailer or an agent-attribution footer ('Generated with Claude ...', etc.). Tokenizes with shlex so downstream commands chained with && / || / ; / | are not mistakenly scoped. Goal: keep agent-attribution trailers and verification bypasses out of the history at the tool boundary.",
         "hooks": [
           {
             "type": "command",
-            "if": "Bash(git commit *)",
+            "if": "Bash(git*)",
             "timeout": 10,
             "command": "bash agent/hooks/git-commit-trailer-check.sh"
           }

--- a/agent/hooks/git-commit-trailer-check.sh
+++ b/agent/hooks/git-commit-trailer-check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# PreToolUse Bash(git commit *) gate. Exits 0 (clean / not git commit) or 2
+# PreToolUse Bash(git*) gate. Exits 0 (clean / not git commit) or 2
 # (forbidden --no-verify/-n flag or Co-Authored-By / agent-attribution trailer).
 set -euo pipefail
 

--- a/agent/hooks/git-commit-trailer-check.sh
+++ b/agent/hooks/git-commit-trailer-check.sh
@@ -15,10 +15,12 @@ readonly SCRIPT_DIR
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/_lib.sh"
 
-# Re-scope regex: matches `git commit` at command start or after a shell
-# control character. Defensive against the handler-level `if:` filter firing
-# more broadly than expected.
-readonly GIT_COMMIT_RE='(^[[:space:]]*|[;|&`(][[:space:]]*)git[[:space:]]+commit([[:space:]]|$)'
+# Re-scope regex: matches `git ... commit` where the slot between `git` and
+# `commit` is empty or holds only `git`-level option tokens (e.g. `-c key=val`,
+# `--git-dir=.git`). Required because the handler-level `if: "Bash(git commit *)"`
+# is a literal-prefix permission rule that does NOT match `git -c X commit ...`;
+# this hook is broadened to `Bash(git*)` and the wrapper re-scopes here.
+readonly GIT_COMMIT_RE='(^[[:space:]]*|[;|&`(][[:space:]]*)git([[:space:]]+(-[a-zA-Z]|--[a-zA-Z][a-zA-Z0-9_-]*)(=[^[:space:]]*)?([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+commit([[:space:]]|$)'
 
 main() {
   # Any unexpected failure (Python crash, jq parse, etc.) must block — never

--- a/agent/hooks/git-commit-trailer-check.sh
+++ b/agent/hooks/git-commit-trailer-check.sh
@@ -15,13 +15,6 @@ readonly SCRIPT_DIR
 # shellcheck disable=SC1091
 source "${SCRIPT_DIR}/_lib.sh"
 
-# Re-scope regex: matches `git ... commit` where the slot between `git` and
-# `commit` is empty or holds only `git`-level option tokens (e.g. `-c key=val`,
-# `--git-dir=.git`). Required because the handler-level `if: "Bash(git commit *)"`
-# is a literal-prefix permission rule that does NOT match `git -c X commit ...`;
-# this hook is broadened to `Bash(git*)` and the wrapper re-scopes here.
-readonly GIT_COMMIT_RE='(^[[:space:]]*|[;|&`(][[:space:]]*)git([[:space:]]+(-[a-zA-Z]|--[a-zA-Z][a-zA-Z0-9_-]*)(=[^[:space:]]*)?([[:space:]]+[^-[:space:]][^[:space:]]*)?)*[[:space:]]+commit([[:space:]]|$)'
-
 main() {
   # Any unexpected failure (Python crash, jq parse, etc.) must block — never
   # leak a non-2 exit that bypasses the contract documented in the header.
@@ -39,12 +32,11 @@ main() {
     exit 2
   fi
 
-  if ! grep -qE "$GIT_COMMIT_RE" <<<"$cmd"; then
-    exit 0
-  fi
-
-  # Pipe the command on stdin to the Python scanner so argv slicing can
-  # distinguish `git commit -n` from a downstream `grep -n`.
+  # The Python scanner is the authoritative parser — it uses shlex, so it
+  # tracks quoted-value forms like `git -c user.name="A B" commit` that an
+  # ERE pre-filter cannot. Non-commit invocations produce empty stdout (no
+  # commit slice found), so this also serves as the fast-path for
+  # `git status`, `git log`, etc.
   findings=$(printf '%s' "$cmd" | python3 "${SCRIPT_DIR}/git_commit_trailer_check.py")
 
   if [[ -n "$findings" ]]; then

--- a/agent/hooks/git_commit_trailer_check.py
+++ b/agent/hooks/git_commit_trailer_check.py
@@ -23,7 +23,14 @@ from collections.abc import Iterator
 # subject like "feat: docs generated with sphinx-build" does not match. Group
 # 1 captures the trailer key for clean reporting.
 _CO_AUTHORED_BY = re.compile(r"(?:^|\\n|\n)\s*(Co-Authored-By:)", re.IGNORECASE)
-_GENERATED_WITH = re.compile(r"(?:^|\\n|\n)\s*(Generated with)", re.IGNORECASE)
+# ``Generated with`` is only an agent attribution when followed on the same
+# line by an agent-product name. Plain "Generated with sphinx-build" or
+# "Generated with the docs job" is a legitimate body line.
+_GENERATED_WITH = re.compile(
+    r"(?:^|\\n|\n)\s*(Generated with)[^\r\n]{0,80}?"
+    r"\b(Claude|Anthropic|Cursor|Copilot|ChatGPT|GPT-?\d|Codex|Gemini|Bard)\b",
+    re.IGNORECASE,
+)
 _CLAUDE_ATTRIBUTION = re.compile(
     r"(?:^|\\n|\n)\s*[A-Za-z-]+:\s*Claude\s+(?:Code|Opus|Sonnet|Haiku)\b"
 )
@@ -57,28 +64,62 @@ def _tokenize(cmd: str) -> list[str]:
         ]
 
 
+_GIT_LEVEL_OPTION_RE = re.compile(r"^(-[a-zA-Z]|--[a-zA-Z][a-zA-Z0-9_-]*)(=.*)?$")
+_GIT_LEVEL_VALUE_OPTS = frozenset({"-c", "-C", "--git-dir", "--work-tree", "--namespace"})
+
+
+def _find_commit_subcommand(tokens: list[str], git_idx: int) -> int | None:
+    """Return the index of the ``commit`` token following ``git`` at ``git_idx``.
+
+    Skips ``git``-level options between ``git`` and the subcommand (``-c key=val``,
+    ``--git-dir=.git``, ``--work-tree path``, etc.) so ``git -c gpg.sign=false commit``
+    is still recognised. Returns ``None`` if no ``commit`` subcommand is found
+    before a metachar or end-of-tokens.
+
+    :param tokens: Tokenized command.
+    :param git_idx: Index of the ``git`` token.
+    :returns: Index of the ``commit`` subcommand, or ``None``.
+    """
+    j = git_idx + 1
+    while j < len(tokens) and tokens[j] not in _METACHARS:
+        tok = tokens[j]
+        if tok == "commit":
+            return j
+        if not _GIT_LEVEL_OPTION_RE.match(tok):
+            return None
+        if tok in _GIT_LEVEL_VALUE_OPTS and j + 1 < len(tokens):
+            # Space-separated value form (e.g. `-c key=val`, `--git-dir .git`).
+            j += 2
+            continue
+        j += 1
+    return None
+
+
 def _commit_arg_slices(tokens: list[str]) -> Iterator[tuple[int, int]]:
     """Yield each ``[start, end)`` slice of tokens belonging to a ``git commit`` argv.
 
     A slice ends at a shell metachar token (``&&`` / ``||`` / ``;`` / ``|`` /
     ``&``) or at end-of-tokens, so a downstream ``grep -n`` after ``&&`` is not
-    mistaken for ``git commit -n``.
+    mistaken for ``git commit -n``. ``git`` options between ``git`` and
+    ``commit`` (e.g. ``git -c gpg.sign=false commit``) are skipped.
 
     :param tokens: Tokenized command.
     :yields: ``(start, end)`` index pairs into ``tokens``.
     :ytype: tuple[int, int]
     """
     i = 0
-    while i < len(tokens) - 1:
-        if tokens[i] == "git" and tokens[i + 1] == "commit":
-            start = i + 2
-            j = start
-            while j < len(tokens) and tokens[j] not in _METACHARS:
-                j += 1
-            yield start, j
-            i = j
-        else:
-            i += 1
+    while i < len(tokens):
+        if tokens[i] == "git":
+            commit_idx = _find_commit_subcommand(tokens, i)
+            if commit_idx is not None:
+                start = commit_idx + 1
+                j = start
+                while j < len(tokens) and tokens[j] not in _METACHARS:
+                    j += 1
+                yield start, j
+                i = j
+                continue
+        i += 1
 
 
 def _iter_commit_argvs(tokens: list[str]) -> Iterator[list[str]]:
@@ -92,13 +133,22 @@ def _iter_commit_argvs(tokens: list[str]) -> Iterator[list[str]]:
         yield tokens[start:end]
 
 
+# ``git commit`` short flags whose value attaches inline (``-S<keyid>``,
+# ``-C<commit>``, etc.). When the cluster starts with one of these, the
+# remainder is the value — not additional bundled flags — so ``n`` in the
+# value (``-Sandykey``) is not a ``-n``.
+_VALUE_ATTACHING_SHORT_FLAGS = frozenset({"S", "C", "c", "F", "m", "u", "t"})
+
+
 def _has_no_verify_short_flag(argv: list[str]) -> bool:
     """Return True if ``argv`` has ``-n`` or any bundled short flag containing ``n``.
 
     Short flags cluster: ``git commit -nm "msg"`` tokenizes as
     ``["-nm", "msg"]``, so a bare ``"-n" in argv`` misses it. Stops scanning at
     the ``--`` end-of-options marker, and skips long flags (``--no-foo``) and
-    positional args.
+    positional args. When a cluster begins with a value-attaching short flag
+    (``-S<keyid>``, ``-C<commit>``, etc.), only the first letter is treated as
+    a flag — the rest is its value.
 
     :param argv: ``git commit`` argv slice.
     :returns: True if a no-verify-equivalent short flag is present.
@@ -108,7 +158,14 @@ def _has_no_verify_short_flag(argv: list[str]) -> bool:
             return False
         if tok.startswith("--"):
             continue
-        if len(tok) >= 2 and tok[0] == "-" and "n" in tok[1:] and tok[1:].isalpha():
+        if len(tok) < 2 or tok[0] != "-":
+            continue
+        cluster = tok[1:]
+        if not cluster.isalpha():
+            continue
+        if cluster[0] in _VALUE_ATTACHING_SHORT_FLAGS:
+            cluster = cluster[0]
+        if "n" in cluster:
             return True
     return False
 

--- a/agent/hooks/git_commit_trailer_check.py
+++ b/agent/hooks/git_commit_trailer_check.py
@@ -1,13 +1,17 @@
 """Forbidden-flag / trailer scanner for the git-commit-trailer-check hook.
 
-Reads a single ``git commit`` command on stdin; prints one
-``<label>\\t<match>`` line per forbidden finding (``--no-verify`` / bundled
-``-n`` short flags, ``Co-Authored-By:`` trailers, agent-attribution footers).
-Empty stdout means clean.
+Reads a shell command on stdin (any ``git ...`` invocation under the
+``Bash(git*)`` matcher); prints one ``<label>\\t<match>`` line per forbidden
+finding (``--no-verify`` / bundled ``-n`` short flags, ``Co-Authored-By:``
+trailers, agent-attribution footers). Empty stdout means clean — including
+non-``git commit`` invocations, which reach the scanner because the wrapper
+no longer pre-filters.
 
-The .sh wrapper handles JSON parsing, re-scope, and the user-facing BLOCKED
-message; this module is the pure-Python parser so unit-test-style argv slicing
-can avoid confusing ``-n`` on ``git commit`` with a downstream ``grep -n``.
+The .sh wrapper handles JSON parsing and the user-facing BLOCKED message;
+this module is the pure-Python parser and the authoritative scope filter
+(``_find_commit_subcommand`` yields nothing for non-commit ``git`` calls and
+shlex tokenization distinguishes ``-n`` on ``git commit`` from a downstream
+``grep -n``).
 """
 
 from __future__ import annotations

--- a/agent/hooks/git_commit_trailer_check.py
+++ b/agent/hooks/git_commit_trailer_check.py
@@ -227,28 +227,35 @@ def _scan(cmd: str) -> list[tuple[str, str]]:
     tokens = _tokenize(cmd)
     findings: list[tuple[str, str]] = []
 
+    commit_slices = list(_iter_commit_argvs(tokens))
+    if not commit_slices:
+        # No ``git commit`` invocation in this command — nothing to gate.
+        # We must NOT raw-command-fallback the trailer regexes here:
+        # `git log --grep="Co-Authored-By: …"` (and similar diagnostic
+        # invocations) embed trailer-shaped substrings as flag values, not
+        # as outgoing commit body content.
+        return findings
+
     # --no-verify / -n (incl. bundled `-nm` / `-anm` / …) on `git commit` itself.
     # Iterate all argvs so chained invocations are all checked, but record only
     # the first hit per kind to keep the output tight.
-    for argv in _iter_commit_argvs(tokens):
+    for argv in commit_slices:
         if "--no-verify" in argv:
             findings.append(("--no-verify flag", "--no-verify"))
             break
-    for argv in _iter_commit_argvs(tokens):
+    for argv in commit_slices:
         if _has_no_verify_short_flag(argv):
             findings.append(("-n flag (== --no-verify)", "-n"))
             break
 
-    # Forbidden trailers inside -m / -F / heredoc bodies. When we cannot find
-    # any explicit message body (heredoc / shell-substituted), fall back to the
-    # raw command — but with anchored trailer regexes only, since substring
-    # matches against arbitrary command text produce false positives. The
-    # raw_command_fallback flag makes that trust-level shift explicit.
+    # Forbidden trailers inside -m / -F / heredoc bodies. When a commit slice
+    # exists but no explicit message body is recoverable (heredoc /
+    # shell-substituted), fall back to scanning the raw command — anchored
+    # trailer regexes still rule out substring false positives.
     texts: list[str] = []
-    for argv in _iter_commit_argvs(tokens):
+    for argv in commit_slices:
         texts.extend(_collect_message_texts(argv))
-    raw_command_fallback = not texts
-    if raw_command_fallback:
+    if not texts:
         texts = [cmd]
 
     for text in texts:

--- a/agent/hooks/git_commit_trailer_check.py
+++ b/agent/hooks/git_commit_trailer_check.py
@@ -23,9 +23,8 @@ from collections.abc import Iterator
 # subject like "feat: docs generated with sphinx-build" does not match. Group
 # 1 captures the trailer key for clean reporting.
 _CO_AUTHORED_BY = re.compile(r"(?:^|\\n|\n)\s*(Co-Authored-By:)", re.IGNORECASE)
-# ``Generated with`` is only an agent attribution when followed on the same
-# line by an agent-product name. Plain "Generated with sphinx-build" or
-# "Generated with the docs job" is a legitimate body line.
+# Match only when an agent-product name follows ``Generated with`` on the
+# same line, so bodies like "Generated with sphinx-build" stay legitimate.
 _GENERATED_WITH = re.compile(
     r"(?:^|\\n|\n)\s*(Generated with)[^\r\n]{0,80}?"
     r"\b(Claude|Anthropic|Cursor|Copilot|ChatGPT|GPT-?\d|Codex|Gemini|Bard)\b",
@@ -134,10 +133,14 @@ def _iter_commit_argvs(tokens: list[str]) -> Iterator[list[str]]:
 
 
 # ``git commit`` short flags whose value attaches inline (``-S<keyid>``,
-# ``-C<commit>``, etc.). When the cluster starts with one of these, the
-# remainder is the value — not additional bundled flags — so ``n`` in the
-# value (``-Sandykey``) is not a ``-n``.
-_VALUE_ATTACHING_SHORT_FLAGS = frozenset({"S", "C", "c", "F", "m", "u", "t"})
+# ``-C<commit>``, ``-c<commit>``, ``-F<file>``, ``-m<msg>``). When the cluster
+# starts with one of these, the remainder is the value — not additional
+# bundled flags — so ``n`` in the value (``-Sandykey``) is not a ``-n``.
+# ``-u``/``-t`` are intentionally excluded: their value is optional and they
+# are overwhelmingly used bare (``-u`` == ``--untracked-files``), so a
+# hand-typed ``-un`` is far more likely to mean ``-u -n`` than ``-u`` with
+# value ``n`` — better to keep the fail-closed default and block.
+_VALUE_ATTACHING_SHORT_FLAGS = frozenset({"S", "C", "c", "F", "m"})
 
 
 def _has_no_verify_short_flag(argv: list[str]) -> bool:

--- a/agent/hooks/no-baseline-additions.sh
+++ b/agent/hooks/no-baseline-additions.sh
@@ -49,7 +49,8 @@ else:
     old = tool.get("old_string", "")
     new = tool.get("new_string", "")
     if old and old in current:
-        proposed = current.replace(old, new, 1)
+        count = -1 if tool.get("replace_all") else 1
+        proposed = current.replace(old, new, count)
     else:
         print(
             "note: Edit old_string not found in current content; row count unchanged",

--- a/agent/hooks/no_yaml_run_comments.py
+++ b/agent/hooks/no_yaml_run_comments.py
@@ -6,6 +6,10 @@ on stdin and emits one tab-delimited violation per line on stdout:
 the BLOCKED message; this module only locates offenders so the Edit/Write tool
 call is gated before it lands content where a stray ``'``/`` ` ``/``$``/``\\``
 inside a block-scalar comment would trigger shell expansion on the runner.
+
+Violations are reported only when the edit *introduces* them. Pre-existing
+comments in the file are subtracted from the post-edit set so legacy violations
+do not lock the file against unrelated edits or comment-removal edits.
 """
 
 from __future__ import annotations
@@ -59,28 +63,60 @@ def _scan(lines: list[str]) -> list[tuple[int, str, int, str]]:
     return violations
 
 
-def _post_edit_content(payload: dict) -> str | None:
-    """Synthesise the content the tool call would commit.
+def _edit_contents(payload: dict) -> tuple[str, str] | None:
+    """Return ``(pre_edit, post_edit)`` text for the tool call.
 
     :param payload: Parsed PreToolUse JSON envelope.
-    :returns: Post-edit text, or ``None`` when the Edit target file is missing
-        (the Edit tool itself will then reject the call — we just skip scanning).
+    :returns: ``(pre, post)`` strings, or ``None`` when the Edit target file is
+        missing (the Edit tool itself will then reject the call — we just skip
+        scanning). For Write, ``pre`` is the existing file content if any.
     """
     tool_name = payload.get("tool_name", "")
     tool_input = payload.get("tool_input", {})
-    if tool_name == "Write":
-        return tool_input.get("content", "")
     file_path = tool_input.get("file_path", "")
     path = pathlib.Path(file_path)
+    pre = path.read_text() if path.is_file() else ""
+    if tool_name == "Write":
+        return pre, tool_input.get("content", "")
     if not path.is_file():
         sys.stderr.write(f"LOG:Edit target {file_path} not found; skipping scan\n")
         return None
-    content = path.read_text()
     old = tool_input.get("old_string", "")
     new = tool_input.get("new_string", "")
-    if old and old in content:
-        content = content.replace(old, new, 1)
-    return content
+    if old and old in pre:
+        count = -1 if tool_input.get("replace_all") else 1
+        post = pre.replace(old, new, count)
+    else:
+        post = pre
+    return pre, post
+
+
+def _new_violations(
+    pre: list[tuple[int, str, int, str]], post: list[tuple[int, str, int, str]]
+) -> list[tuple[int, str, int, str]]:
+    """Return post-edit violations not accounted for by a matching pre-edit one.
+
+    Multiset diff by ``(block_key, text)`` so line-number shifts don't cause the
+    same comment to look "new". A pre-existing violation with matching key and
+    text consumes one instance from the post-edit set.
+
+    :param pre: Violations found in the file before the edit.
+    :param post: Violations found after the synthesised edit.
+    :returns: Violations attributable to this edit, in document order.
+    """
+    pre_counts: dict[tuple[str, str], int] = {}
+    for _, block_key, _, text in pre:
+        key = (block_key, text)
+        pre_counts[key] = pre_counts.get(key, 0) + 1
+    new: list[tuple[int, str, int, str]] = []
+    for entry in post:
+        _, block_key, _, text = entry
+        key = (block_key, text)
+        if pre_counts.get(key, 0) > 0:
+            pre_counts[key] -= 1
+            continue
+        new.append(entry)
+    return new
 
 
 def main() -> int:
@@ -90,11 +126,14 @@ def main() -> int:
         lines.
     """
     payload = json.loads(sys.stdin.read())
-    content = _post_edit_content(payload)
-    if content is None:
+    contents = _edit_contents(payload)
+    if contents is None:
         return 0
+    pre_text, post_text = contents
+    pre_violations = _scan(pre_text.splitlines())
+    post_violations = _scan(post_text.splitlines())
     out = sys.stdout
-    for lineno, key, header_lineno, text in _scan(content.splitlines()):
+    for lineno, key, header_lineno, text in _new_violations(pre_violations, post_violations):
         out.write(f"{lineno}\t{key}\t{header_lineno}\t{text}\n")
     return 0
 

--- a/agent/hooks/no_yaml_run_comments.py
+++ b/agent/hooks/no_yaml_run_comments.py
@@ -7,9 +7,9 @@ the BLOCKED message; this module only locates offenders so the Edit/Write tool
 call is gated before it lands content where a stray ``'``/`` ` ``/``$``/``\\``
 inside a block-scalar comment would trigger shell expansion on the runner.
 
-Violations are reported only when the edit *introduces* them. Pre-existing
-comments in the file are subtracted from the post-edit set so legacy violations
-do not lock the file against unrelated edits or comment-removal edits.
+Only violations newly introduced by the edit are reported: the scanner
+diffs the pre-edit and post-edit violation multisets so unrelated edits to
+files with existing block-scalar comments pass through.
 """
 
 from __future__ import annotations
@@ -63,6 +63,22 @@ def _scan(lines: list[str]) -> list[tuple[int, str, int, str]]:
     return violations
 
 
+def _safe_read(path: pathlib.Path) -> str:
+    """Return ``path``'s text, or ``""`` on any OSError.
+
+    Permission denied / EISDIR / ENOTDIR turn into "empty pre-edit" rather
+    than a Python traceback that the shell trap would re-format as an
+    opaque internal-error block.
+
+    :param path: File to read.
+    :returns: File contents, or ``""`` if the file is unreadable or missing.
+    """
+    try:
+        return path.read_text()
+    except OSError:
+        return ""
+
+
 def _edit_contents(payload: dict) -> tuple[str, str] | None:
     """Return ``(pre_edit, post_edit)`` text for the tool call.
 
@@ -75,7 +91,7 @@ def _edit_contents(payload: dict) -> tuple[str, str] | None:
     tool_input = payload.get("tool_input", {})
     file_path = tool_input.get("file_path", "")
     path = pathlib.Path(file_path)
-    pre = path.read_text() if path.is_file() else ""
+    pre = _safe_read(path) if path.is_file() else ""
     if tool_name == "Write":
         return pre, tool_input.get("content", "")
     if not path.is_file():

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -146,9 +146,9 @@ def test_handler_if_values_use_permission_rule_syntax() -> None:
 _EXPECTED_HANDLER_SCOPES: tuple[tuple[str, str], ...] = (
     ("Branch safety", "Bash(git commit *)"),
     ("Doc-drift advisory review", "Bash(gh pr create *)"),
-    # Broader than `Bash(git commit *)` so the harness still fires the hook on
-    # `git -c <opt>=<val> commit ...` and other git-level option forms; the hook
-    # wrapper re-scopes to actual commits inside.
+    # `Bash(git*)` so the harness still fires the hook on `git -c X=Y commit
+    # ...` (git-level options before the subcommand); the wrapper defers to
+    # the Python scanner, which re-scopes to actual commit invocations.
     ("Git-commit-trailer-check", "Bash(git*)"),
     ("PR review resolver", "Bash(git push *)"),
     ("Pre-PR review gate", "Bash(gh pr create *)"),
@@ -1074,9 +1074,8 @@ def test_yaml_run_hook_allows_edit_removing_comment(
 ) -> None:
     """An Edit that *removes* a pre-existing block-scalar comment is allowed.
 
-    Earlier the scanner only looked at the post-edit content, so an edit
-    deleting one of three identical comments via ``replace_all=true`` was
-    rejected because two stale comments remained in the synthesised content.
+    Exercises the ``replace_all=true`` path: every matched occurrence must
+    be subtracted from the post-edit violation set before the diff is taken.
 
     :param yaml_run_hook_command: Hook command body fixture.
     :param tmp_path: pytest tmp_path.
@@ -1108,9 +1107,8 @@ def test_yaml_run_hook_allows_edit_removing_comment(
 def test_trailer_hook_catches_dash_c_option_before_commit(trailer_hook_command: str) -> None:
     """``git -c <opt>=<val> commit -n`` is blocked despite the option between git and commit.
 
-    Pre-fix, the wrapper regex required ``git`` immediately followed by
-    ``commit`` and the Python slicer used the same shape, so the entire gate
-    was bypassed by any git-level option (``-c``, ``--git-dir``, ...).
+    The Python slicer walks past git-level option tokens (``-c``, ``--git-dir``,
+    ``--work-tree``, ``--namespace``) before locating the ``commit`` subcommand.
 
     :param trailer_hook_command: Hook command body fixture.
     """
@@ -1125,8 +1123,8 @@ def test_trailer_hook_catches_dash_c_option_before_commit(trailer_hook_command: 
 def test_trailer_hook_catches_dash_c_with_co_authored_by(trailer_hook_command: str) -> None:
     """``git -c X=Y commit -m "...Co-Authored-By: ..."`` is blocked.
 
-    Covers the trailer-scan path of the same bypass; the wrapper must still drill into the message
-    body once the slicer finds the commit subcommand.
+    The trailer-scan path runs once the slicer skips git-level options to
+    find the ``commit`` subcommand.
 
     :param trailer_hook_command: Hook command body fixture.
     """
@@ -1149,8 +1147,7 @@ def test_trailer_hook_allows_dash_S_keyid_with_n(trailer_hook_command: str) -> N
     """``git commit -S<keyid> -m "..."`` with an alpha keyid containing ``n`` is allowed.
 
     The inline gpg-sign keyid is the *value* of ``-S``, not a bundle of
-    additional flags. Pre-fix the bundled-flag check mistook ``Sandykey`` for
-    a ``-n`` cluster and blocked the commit.
+    additional flags.
 
     :param trailer_hook_command: Hook command body fixture.
     """
@@ -1166,9 +1163,8 @@ def test_trailer_hook_still_blocks_bundled_n_after_value_attaching_flag(
 ) -> None:
     """``-anSkey`` (bundled ``-a -n -S<keyid>``) still trips the no-verify check.
 
-    Pins the value-attaching-flag fix: ``-S`` only swallows the *rest* of the
-    cluster when it sits at the start. With ``-a -n`` before it, the ``n``
-    is still a real ``-n`` flag.
+    ``-S`` only consumes the rest of a cluster when it sits at the cluster
+    start; here the leading ``-a -n`` keep their flag meaning.
 
     :param trailer_hook_command: Hook command body fixture.
     """
@@ -1183,9 +1179,8 @@ def test_trailer_hook_still_blocks_bundled_n_after_value_attaching_flag(
 def test_trailer_hook_allows_generated_with_non_agent_tool(trailer_hook_command: str) -> None:
     """A body line ``Generated with sphinx-build manually`` is allowed.
 
-    The attribution rule targets agent-emitted footers like ``Generated with
-    Claude Code``. Pre-fix the regex matched any line starting with
-    ``Generated with``, so legitimate docs commits were blocked.
+    The attribution rule requires an agent-product name (``Claude``,
+    ``Copilot``, ...) on the same line within ~80 chars.
 
     :param trailer_hook_command: Hook command body fixture.
     """
@@ -1224,12 +1219,10 @@ def test_trailer_hook_blocks_generated_with_any_agent_keyword(
 
 
 def test_baseline_hook_honours_replace_all(baseline_hook_command: str, tmp_path: Path) -> None:
-    """An Edit with ``replace_all: true`` is row-counted as if every occurrence is replaced.
+    """An Edit with ``replace_all: true`` is row-counted at every occurrence.
 
-    Pre-fix the inline Python always passed ``count=1`` to ``str.replace``, so
-    a ``replace_all`` edit that introduced one new row per occurrence reported
-    the row delta of a single replacement. The block direction stayed right
-    incidentally, but the reported counts in the BLOCKED message were wrong.
+    The synthesised post-edit content reflects all replacements so the BLOCKED message reports the
+    actual proposed row count.
 
     :param baseline_hook_command: Hook command body fixture.
     :param tmp_path: pytest tmp_path.
@@ -1251,3 +1244,119 @@ def test_baseline_hook_honours_replace_all(baseline_hook_command: str, tmp_path:
     assert result.returncode == 2, (result.returncode, result.stderr)
     assert "Proposed rows: 6" in result.stderr
     assert "Current rows: 3" in result.stderr
+
+
+def test_trailer_hook_passes_non_commit_git_command(trailer_hook_command: str) -> None:
+    """``git status`` (and other non-commit git commands) fast-paths through.
+
+    The handler ``if:`` is broadened to ``Bash(git*)``; the hook must exit 0
+    for any git invocation that is not a commit.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": "git status"}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        pytest.param('git --git-dir=.git commit -n -m "x"', id="git-dir-equals"),
+        pytest.param('git --work-tree /tmp commit -n -m "x"', id="work-tree-space"),
+        pytest.param('git -c user.name="Foo Bar" commit -n -m "x"', id="dash-c-quoted-value"),
+    ],
+)
+def test_trailer_hook_catches_no_verify_through_various_git_level_options(
+    trailer_hook_command: str, command: str
+) -> None:
+    """Other git-level option forms (``--git-dir``, ``--work-tree``, quoted ``-c``) also gate.
+
+    Pins the Python slicer's option-skipping logic across the value-bearing
+    long options and the shlex-quoted short option that an ERE alone cannot
+    parse.
+
+    :param trailer_hook_command: Hook command body fixture.
+    :param command: ``git`` invocation carrying the option form under test.
+    """
+    result = _run_hook_command(trailer_hook_command, {"tool_input": {"command": command}})
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "agent_keyword",
+    ["Codex", "Bard", "GPT-4", "GPT4"],
+)
+def test_trailer_hook_blocks_generated_with_additional_agent_keywords(
+    trailer_hook_command: str, agent_keyword: str
+) -> None:
+    """Additional agents in the ``Generated with`` alternation are blocked.
+
+    :param trailer_hook_command: Hook command body fixture.
+    :param agent_keyword: Agent-product name appended after ``Generated with``.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": f'git commit -m "feat: x\n\nGenerated with {agent_keyword}"'}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+@pytest.mark.parametrize(
+    "cluster",
+    [pytest.param("-un", id="dash-u-n"), pytest.param("-tn", id="dash-t-n")],
+)
+def test_trailer_hook_blocks_un_and_tn_bundles(trailer_hook_command: str, cluster: str) -> None:
+    """``-un`` / ``-tn`` are read as ``-u -n`` / ``-t -n``, not as value-attaching forms.
+
+    ``-u`` and ``-t`` are excluded from the value-attaching short-flag set
+    because their bare form is the common usage; treating their tail as a
+    value would silently bypass ``-n`` detection.
+
+    :param trailer_hook_command: Hook command body fixture.
+    :param cluster: Short-flag cluster under test.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": f'git commit {cluster} -m "feat: x"'}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_yaml_run_hook_blocks_new_comment_when_legacy_one_is_preserved(
+    yaml_run_hook_command: str, tmp_path: Path
+) -> None:
+    """An Edit that preserves a legacy comment AND introduces a new one blocks on the new one.
+
+    Verifies the multiset diff: subtracting one legacy entry must not also
+    consume an unrelated new entry.
+
+    :param yaml_run_hook_command: Hook command body fixture.
+    :param tmp_path: pytest tmp_path.
+    """
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    workflow = workflow_dir / "test.yml"
+    workflow.write_text(
+        "jobs:\n  test:\n    steps:\n      - run: |\n"
+        "          # legacy comment\n          echo hi\n"
+    )
+    result = _run_hook_command(
+        yaml_run_hook_command,
+        {
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": str(workflow),
+                "old_string": "          echo hi\n",
+                "new_string": "          # newly introduced\n          echo hi\n",
+            },
+        },
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+    assert "newly introduced" in result.stderr

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -1328,6 +1328,60 @@ def test_trailer_hook_blocks_un_and_tn_bundles(trailer_hook_command: str, cluste
     assert "BLOCKED" in result.stderr
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        pytest.param('git log --grep="Co-Authored-By: anyone"', id="git-log-grep-coauthor"),
+        pytest.param(
+            'git log --grep="\\nGenerated with Claude Code"',
+            id="git-log-grep-generated-with-claude",
+        ),
+        pytest.param('git log --grep="noreply@anthropic.com"', id="git-log-grep-noreply"),
+        pytest.param(
+            'git show HEAD --format="%B" | grep "Co-Authored-By:"',
+            id="git-show-piped-grep-coauthor",
+        ),
+        pytest.param(
+            'echo "msg\\nCo-Authored-By: x" > /tmp/note',
+            id="non-git-bash-with-trailer-substring",
+        ),
+    ],
+)
+def test_trailer_hook_does_not_false_positive_on_non_commit_with_trailer_substring(
+    trailer_hook_command: str, command: str
+) -> None:
+    """Non-commit invocations that mention a trailer-shaped substring pass through.
+
+    The scanner short-circuits to "no findings" when no ``git commit`` argv
+    slice is present, so the raw-command fallback (used only inside a real
+    commit invocation with a heredoc body) cannot misfire on diagnostic
+    commands like ``git log --grep="Co-Authored-By: ..."`` or on unrelated
+    Bash invocations whose command string happens to contain the substring.
+
+    :param trailer_hook_command: Hook command body fixture.
+    :param command: Non-commit invocation under test.
+    """
+    result = _run_hook_command(trailer_hook_command, {"tool_input": {"command": command}})
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_trailer_hook_still_blocks_heredoc_commit_with_trailer(
+    trailer_hook_command: str,
+) -> None:
+    """Heredoc-bodied ``git commit`` invocations still fall back to raw-command scanning.
+
+    Pins that the raw-command fallback remains active when a commit slice IS
+    found but no ``-m``/``-F`` body is recoverable — removing the fallback
+    entirely would create a different bypass.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    cmd = "git commit <<EOF\nfeat: x\n\nCo-Authored-By: Claude\nEOF"
+    result = _run_hook_command(trailer_hook_command, {"tool_input": {"command": cmd}})
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
 def test_yaml_run_hook_blocks_new_comment_when_legacy_one_is_preserved(
     yaml_run_hook_command: str, tmp_path: Path
 ) -> None:

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -146,7 +146,10 @@ def test_handler_if_values_use_permission_rule_syntax() -> None:
 _EXPECTED_HANDLER_SCOPES: tuple[tuple[str, str], ...] = (
     ("Branch safety", "Bash(git commit *)"),
     ("Doc-drift advisory review", "Bash(gh pr create *)"),
-    ("Git-commit-trailer-check", "Bash(git commit *)"),
+    # Broader than `Bash(git commit *)` so the harness still fires the hook on
+    # `git -c <opt>=<val> commit ...` and other git-level option forms; the hook
+    # wrapper re-scopes to actual commits inside.
+    ("Git-commit-trailer-check", "Bash(git*)"),
     ("PR review resolver", "Bash(git push *)"),
     ("Pre-PR review gate", "Bash(gh pr create *)"),
 )
@@ -1032,3 +1035,219 @@ def test_yaml_run_hook_blocks_comment_in_map_key_run_block(yaml_run_hook_command
     )
     assert result.returncode == 2, (result.returncode, result.stderr)
     assert "BLOCKED" in result.stderr
+
+
+def test_yaml_run_hook_allows_unrelated_edit_to_file_with_preexisting_comment(
+    yaml_run_hook_command: str, tmp_path: Path
+) -> None:
+    """Unrelated edits don't trip on pre-existing block-scalar comments.
+
+    The scanner diffs pre- vs. post-edit violation multisets so legacy comments (or comments
+    inserted by another tool) do not lock the file against unrelated edits.
+
+    :param yaml_run_hook_command: Hook command body fixture.
+    :param tmp_path: pytest tmp_path.
+    """
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    workflow = workflow_dir / "test.yml"
+    workflow.write_text(
+        "jobs:\n  test:\n    steps:\n      - run: |\n"
+        "          # legacy comment\n          echo hi\n"
+    )
+    result = _run_hook_command(
+        yaml_run_hook_command,
+        {
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": str(workflow),
+                "old_string": "echo hi",
+                "new_string": "echo hello",
+            },
+        },
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_yaml_run_hook_allows_edit_removing_comment(
+    yaml_run_hook_command: str, tmp_path: Path
+) -> None:
+    """An Edit that *removes* a pre-existing block-scalar comment is allowed.
+
+    Earlier the scanner only looked at the post-edit content, so an edit
+    deleting one of three identical comments via ``replace_all=true`` was
+    rejected because two stale comments remained in the synthesised content.
+
+    :param yaml_run_hook_command: Hook command body fixture.
+    :param tmp_path: pytest tmp_path.
+    """
+    workflow_dir = tmp_path / ".github" / "workflows"
+    workflow_dir.mkdir(parents=True)
+    workflow = workflow_dir / "test.yml"
+    workflow.write_text(
+        "jobs:\n  test:\n    steps:\n      - run: |\n"
+        "          # stale comment\n          echo a\n"
+        "      - run: |\n"
+        "          # stale comment\n          echo b\n"
+    )
+    result = _run_hook_command(
+        yaml_run_hook_command,
+        {
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": str(workflow),
+                "old_string": "          # stale comment\n",
+                "new_string": "",
+                "replace_all": True,
+            },
+        },
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_trailer_hook_catches_dash_c_option_before_commit(trailer_hook_command: str) -> None:
+    """``git -c <opt>=<val> commit -n`` is blocked despite the option between git and commit.
+
+    Pre-fix, the wrapper regex required ``git`` immediately followed by
+    ``commit`` and the Python slicer used the same shape, so the entire gate
+    was bypassed by any git-level option (``-c``, ``--git-dir``, ...).
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git -c gpg.sign=false commit -n -m "x"'}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_trailer_hook_catches_dash_c_with_co_authored_by(trailer_hook_command: str) -> None:
+    """``git -c X=Y commit -m "...Co-Authored-By: ..."`` is blocked.
+
+    Covers the trailer-scan path of the same bypass; the wrapper must still drill into the message
+    body once the slicer finds the commit subcommand.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {
+            "tool_input": {
+                "command": (
+                    "git -c gpg.sign=false commit "
+                    '-m "feat: x\n\nCo-Authored-By: Claude <noreply@anthropic.com>"'
+                )
+            }
+        },
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_trailer_hook_allows_dash_S_keyid_with_n(trailer_hook_command: str) -> None:
+    """``git commit -S<keyid> -m "..."`` with an alpha keyid containing ``n`` is allowed.
+
+    The inline gpg-sign keyid is the *value* of ``-S``, not a bundle of
+    additional flags. Pre-fix the bundled-flag check mistook ``Sandykey`` for
+    a ``-n`` cluster and blocked the commit.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -Sandykey -m "feat: x"'}},
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+def test_trailer_hook_still_blocks_bundled_n_after_value_attaching_flag(
+    trailer_hook_command: str,
+) -> None:
+    """``-anSkey`` (bundled ``-a -n -S<keyid>``) still trips the no-verify check.
+
+    Pins the value-attaching-flag fix: ``-S`` only swallows the *rest* of the
+    cluster when it sits at the start. With ``-a -n`` before it, the ``n``
+    is still a real ``-n`` flag.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": 'git commit -anSkey -m "feat: x"'}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_trailer_hook_allows_generated_with_non_agent_tool(trailer_hook_command: str) -> None:
+    """A body line ``Generated with sphinx-build manually`` is allowed.
+
+    The attribution rule targets agent-emitted footers like ``Generated with
+    Claude Code``. Pre-fix the regex matched any line starting with
+    ``Generated with``, so legitimate docs commits were blocked.
+
+    :param trailer_hook_command: Hook command body fixture.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {
+            "tool_input": {
+                "command": (
+                    'git commit -m "feat: docs\n\nThis page is auto-generated.\n'
+                    'Generated with sphinx-build manually."'
+                )
+            }
+        },
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr)
+
+
+@pytest.mark.parametrize(
+    "agent_keyword",
+    ["Claude Code", "Anthropic Claude", "ChatGPT", "Copilot", "Cursor", "Gemini"],
+)
+def test_trailer_hook_blocks_generated_with_any_agent_keyword(
+    trailer_hook_command: str, agent_keyword: str
+) -> None:
+    """``Generated with <agent>`` for known agent-product keywords is still blocked.
+
+    :param trailer_hook_command: Hook command body fixture.
+    :param agent_keyword: Agent-product name appended after ``Generated with``.
+    """
+    result = _run_hook_command(
+        trailer_hook_command,
+        {"tool_input": {"command": f'git commit -m "feat: x\n\nGenerated with {agent_keyword}"'}},
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "BLOCKED" in result.stderr
+
+
+def test_baseline_hook_honours_replace_all(baseline_hook_command: str, tmp_path: Path) -> None:
+    """An Edit with ``replace_all: true`` is row-counted as if every occurrence is replaced.
+
+    Pre-fix the inline Python always passed ``count=1`` to ``str.replace``, so
+    a ``replace_all`` edit that introduced one new row per occurrence reported
+    the row delta of a single replacement. The block direction stayed right
+    incidentally, but the reported counts in the BLOCKED message were wrong.
+
+    :param baseline_hook_command: Hook command body fixture.
+    :param tmp_path: pytest tmp_path.
+    """
+    baseline = tmp_path / ".pydoclint-baseline.txt"
+    baseline.write_text("a DOC101\nb DOC101\nc DOC101\n")
+    result = _run_hook_command(
+        baseline_hook_command,
+        {
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": str(baseline),
+                "old_string": "DOC101",
+                "new_string": "DOC101\nEXTRA",
+                "replace_all": True,
+            },
+        },
+    )
+    assert result.returncode == 2, (result.returncode, result.stderr)
+    assert "Proposed rows: 6" in result.stderr
+    assert "Current rows: 3" in result.stderr


### PR DESCRIPTION
## Summary

Post-merge review of #1158 surfaced five independently reproducible behaviour gaps in the new PreToolUse hooks. This PR lands all five fixes and adds **25 regression tests** (76 → 101 in `tests/claude_hooks/`).

## Bugs fixed

### 1. `no-yaml-run-comments` blocked all edits to workflows with pre-existing comments

The scanner inspected the whole post-edit content rather than the diff, so any edit to a workflow with a legacy `#`-comment inside `run: |` was rejected — including edits that *removed* such comments. `_new_violations()` now diffs pre- vs. post-edit violation multisets by `(block_key, text)` so line shifts don't manufacture false positives.

### 2. `git -c <opt>=<val> commit` bypassed the trailer/`-n` gate entirely

Two layers were too tight: the handler-level `if: "Bash(git commit *)"` permission rule never fired for `git -c gpg.sign=false commit ...`, and the wrapper regex required `git` and `commit` adjacent. The `if:` is now `Bash(git*)`, the wrapper drops the regex pre-filter entirely (an ERE can't track shlex-quoted values like `-c user.name="A B"`), and a new `_find_commit_subcommand` walks past `-c`, `--git-dir`, `--work-tree`, `--namespace`, etc. before locating the `commit` subcommand.

### 3. `-S<keyid>` mis-read as a `-n` bundle when keyid is alphabetic and contains `n`

`git commit -Sandykey -m "..."` was wrongly blocked. When a short-flag cluster starts with one of the value-attaching short flags `{S, C, c, F, m}`, only the first letter is kept for the `n` check. `-u`/`-t` are deliberately excluded — their value is optional and bare usage dominates, so `-un` correctly trips `-n` rather than being misread as `-u` with value `n`.

### 4. `Generated with <anything>` at body line-start was blocked

The agent-attribution rule was meant for `Generated with Claude Code`-style footers; in practice any line starting with `Generated with` was flagged. The regex now requires a known agent-product keyword on the same line (Claude / Anthropic / Cursor / Copilot / ChatGPT / GPT-N / Codex / Gemini / Bard, case-insensitive).

### 5. `replace_all=true` ignored by both Edit-scanning hooks

Both helpers passed `count=1` to `str.replace` unconditionally. Now both consult `tool_input.replace_all` and pass `count=-1` when set.

## Files

| File | Change |
| --- | --- |
| `.claude/settings.json` | `if:` for trailer hook widened to `Bash(git*)` |
| `agent/hooks/git-commit-trailer-check.sh` | wrapper drops the ERE pre-filter and defers to the Python scanner |
| `agent/hooks/git_commit_trailer_check.py` | new `_find_commit_subcommand`, tightened `_has_no_verify_short_flag`, narrowed `_GENERATED_WITH` regex |
| `agent/hooks/no-baseline-additions.sh` | inline Python honours `replace_all` |
| `agent/hooks/no_yaml_run_comments.py` | scanner diffs pre/post violation multisets; `_safe_read` swallows OSError |
| `tests/claude_hooks/test_settings_hooks.py` | 25 regression tests + handler-scope fixture update |

## Test plan

- [x] `pytest tests/claude_hooks/ -q` → **101 passed** (was 76; +25 regressions for the five bugs).
- [x] `pre-commit run --files <touched>` → all pass.
- [x] Each bug verified with an explicit `bash agent/hooks/<hook>.sh < payload.json` reproducer before & after the fix.
- [x] `/repo-review-full-no-comments` orchestration run — 0 BLOCK across six skills; all correctness-affecting WARNs addressed in the fixup commit.
- [ ] CI green on this PR.

## Pre-PR review

Ran `/repo-review-full-no-comments` against this branch (six parallel skills: code-health, synth-setter-project-standards, python-style, tdd-implementation, comment-hygiene, shell-style). **0 BLOCK findings, ~25 WARN.** The fixup commit `bdaff41` addresses every correctness-affecting WARN:

- `shell-style #1`: `-c user.name="Foo Bar" commit` bypass — fixed by dropping the bash regex pre-filter.
- `synth-setter #1`: `-u`/`-t` over-broad in value-attaching set — fixed by removing them.
- `synth-setter #4`: `path.read_text()` traceback on permission denied — fixed with `_safe_read`.
- Comment hygiene C11 (historical narrative): 12 occurrences cleaned.
- Test-gap fixes from `tdd-implementation`: 11 new tests added.

The remaining WARNs are polish (constant placement, TypeAlias suggestions, naming-style nits) and have been left for a follow-up.

## Tracking issue

The auto-mode classifier denied filing a tracking issue under Phase 2 (#151) since the user explicitly asked for a PR, not an issue. **Reviewer:** please file a follow-up Task issue (or treat this PR as a direct follow-up to #1158 and waive the metadata gate).

Refs #1158
