### PR TITLE
ci-automation: strip [#N](url) markdown links before extracting issue refs

### DIFF
--- a/.github/workflows/pr-metadata-gate.yaml
+++ b/.github/workflows/pr-metadata-gate.yaml
@@ -27,7 +27,7 @@ jobs:
             echo "::error::Failed to fetch PR body from GitHub API"
             exit 1
           }
-          PR_BODY_SANITIZED=$(printf '%s' "$PR_BODY" | sed -E 's/\[#[0-9]+\]\([^)]*\)//g')
+          PR_BODY_SANITIZED=$(printf '%s' "$PR_BODY" | sed -E -e 's/`[^`]*`//g' -e 's/\[#[0-9]+\]\([^)]*\)//g')
           echo "::endgroup::"
 
           # --- Linked issue check ---
@@ -221,7 +221,7 @@ jobs:
             echo "::error::Failed to fetch PR body; cannot perform epic lineage check."
             exit 1
           }
-          PR_BODY_SANITIZED=$(printf '%s' "$PR_BODY" | sed -E 's/\[#[0-9]+\]\([^)]*\)//g')
+          PR_BODY_SANITIZED=$(printf '%s' "$PR_BODY" | sed -E -e 's/`[^`]*`//g' -e 's/\[#[0-9]+\]\([^)]*\)//g')
 
           ISSUE_NUMBERS=()
 

--- a/.github/workflows/pr-metadata-gate.yaml
+++ b/.github/workflows/pr-metadata-gate.yaml
@@ -27,6 +27,7 @@ jobs:
             echo "::error::Failed to fetch PR body from GitHub API"
             exit 1
           }
+          PR_BODY_SANITIZED=$(printf '%s' "$PR_BODY" | sed -E 's/\[#[0-9]+\]\([^)]*\)//g')
           echo "::endgroup::"
 
           # --- Linked issue check ---
@@ -57,7 +58,7 @@ jobs:
           LINKED_ISSUES=$(( CONNECTED - DISCONNECTED ))
 
           # Check body for any issue/PR references (#N)
-          BODY_REFS=$(echo "$PR_BODY" | grep -coE '#[0-9]+') || {
+          BODY_REFS=$(echo "$PR_BODY_SANITIZED" | grep -coE '#[0-9]+') || {
             rc=$?
             if [ "$rc" -eq 1 ]; then
               BODY_REFS=0  # No matches found — expected case
@@ -86,7 +87,7 @@ jobs:
           done
 
           # From PR body: extract #N references (exclude the PR's own number)
-          BODY_ISSUE_NUMS=$(echo "$PR_BODY" | grep -oE '#[0-9]+' | tr -d '#' | sort -un) || true
+          BODY_ISSUE_NUMS=$(echo "$PR_BODY_SANITIZED" | grep -oE '#[0-9]+' | tr -d '#' | sort -un) || true
           for num in $BODY_ISSUE_NUMS; do
             if [ "$num" != "$PR_NUMBER" ]; then
               ISSUE_NUMBERS+=("$num")
@@ -220,6 +221,7 @@ jobs:
             echo "::error::Failed to fetch PR body; cannot perform epic lineage check."
             exit 1
           }
+          PR_BODY_SANITIZED=$(printf '%s' "$PR_BODY" | sed -E 's/\[#[0-9]+\]\([^)]*\)//g')
 
           ISSUE_NUMBERS=()
 
@@ -229,7 +231,7 @@ jobs:
             ISSUE_NUMBERS+=("$num")
           done
 
-          BODY_ISSUE_NUMS=$(echo "$PR_BODY" | grep -oE '#[0-9]+' | tr -d '#' | sort -un) || true
+          BODY_ISSUE_NUMS=$(echo "$PR_BODY_SANITIZED" | grep -oE '#[0-9]+' | tr -d '#' | sort -un) || true
           for num in $BODY_ISSUE_NUMS; do
             if [ "$num" != "$PR_NUMBER" ]; then
               ISSUE_NUMBERS+=("$num")

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -494,6 +494,59 @@ T_taxonomy_hierarchy_non_synth_setter_exits_silently() {
 }
 it "verify-gh-taxonomy: addSubIssue not targeting synth-setter exits 0 silently" T_taxonomy_hierarchy_non_synth_setter_exits_silently
 
+T_taxonomy_strip_markdown_issue_links_drops_review_comment_refs() {
+  # Regression for the PR #1163 CI failure (run 26126477593): the PR body
+  # cited four Copilot review comments as `[#3269588963](.../discussion_r…)`
+  # markdown links; the `#[0-9]+` extraction matched those 10-digit *comment*
+  # IDs as if they were issue numbers and fed them to `gh api .../issues/N`,
+  # which 404'd and failed the gate. The fix is to strip `[#N](url)` before
+  # extraction. The same regex is inlined in pr-metadata-gate.yaml — this
+  # test pins the bash version; if you tweak one, tweak the other.
+  local script_src body result
+  script_src=$(awk '/^strip_markdown_issue_links\(\) {/,/^}$/' "$REPO_ROOT/agent/hooks/verify-gh-taxonomy.sh")
+  body=$'Closes #1157.\n- [#3269588963](https://github.com/x/y/pull/1#discussion_r3269588963)\n- [#3269589023](https://github.com/x/y/pull/1#discussion_r3269589023)\nRefs #42'
+  result=$(bash -c "$script_src"$'\n''strip_markdown_issue_links "$1"' _ "$body" \
+    | grep -oE '#[0-9]+' | sort -u | tr '\n' ' ')
+  [[ "$result" == "#1157 #42 " ]] || {
+    echo "expected '#1157 #42 ' (markdown-linked review-comment IDs stripped), got: '$result'"
+    return 1
+  }
+}
+it "verify-gh-taxonomy: strip_markdown_issue_links removes [#N](url) review-comment refs (PR #1163 regression)" T_taxonomy_strip_markdown_issue_links_drops_review_comment_refs
+
+T_taxonomy_strip_markdown_issue_links_preserves_bare_refs() {
+  # Counter-test: bare `#N` references and `Closes #N` / `Refs #N` patterns
+  # must survive sanitization so the gate keeps enforcing linked issues.
+  local script_src body result
+  script_src=$(awk '/^strip_markdown_issue_links\(\) {/,/^}$/' "$REPO_ROOT/agent/hooks/verify-gh-taxonomy.sh")
+  body=$'## Summary\n\nFollow-up to PR #1157.\nCloses #42\nRefs #99'
+  result=$(bash -c "$script_src"$'\n''strip_markdown_issue_links "$1"' _ "$body" \
+    | grep -oE '#[0-9]+' | sort -u | tr '\n' ' ')
+  [[ "$result" == "#1157 #42 #99 " ]] || {
+    echo "expected '#1157 #42 #99 ' (all bare refs preserved), got: '$result'"
+    return 1
+  }
+}
+it "verify-gh-taxonomy: strip_markdown_issue_links preserves bare #N references" T_taxonomy_strip_markdown_issue_links_preserves_bare_refs
+
+T_taxonomy_workflow_inlines_same_sanitize_regex_as_hook() {
+  # Drift guard: the bash hook and pr-metadata-gate.yaml each carry their own
+  # copy of the `[#N](url)` strip regex, and the hook's docstring claims they
+  # stay in sync. Pin the workflow to have the exact `sed` expression in both
+  # jobs so a unilateral edit to one side gets caught here.
+  local workflow="$REPO_ROOT/.github/workflows/pr-metadata-gate.yaml"
+  local expected count
+  expected="sed -E 's/\\[#[0-9]+\\]\\([^)]*\\)//g'"
+  count=$(grep -cF "$expected" "$workflow") || count=0
+  # Two jobs (check-pr-metadata + epic-lineage step) each call sanitize once.
+  [[ "$count" -eq 2 ]] || {
+    echo "expected pr-metadata-gate.yaml to contain the strip-[#N](url) sed expression exactly 2x (once per job), found ${count}."
+    echo "If you intentionally changed the workflow regex, mirror the change in strip_markdown_issue_links() in verify-gh-taxonomy.sh and update this test."
+    return 1
+  }
+}
+it "verify-gh-taxonomy: pr-metadata-gate.yaml inlines the same [#N](url) strip regex (drift guard)" T_taxonomy_workflow_inlines_same_sanitize_regex_as_hook
+
 T_taxonomy_check_ci_minimum_joins_with_comma_space() {
   # Unit test for the comma-space join in check_ci_minimum + check_project_fields.
   # Regression for the IFS/`${arr[*]}` quirk Copilot caught on PR #1119: setting

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -531,21 +531,38 @@ T_taxonomy_strip_markdown_issue_links_preserves_bare_refs() {
 }
 it "verify-gh-taxonomy: strip_markdown_issue_links preserves bare #N references" T_taxonomy_strip_markdown_issue_links_preserves_bare_refs
 
+T_taxonomy_strip_markdown_issue_links_drops_code_span_refs() {
+  # Regression for PR #1171 run 26127785920: the PR body cited comment IDs
+  # inside backticked code spans (e.g. `#3269588963` in prose, `#1157, #1165,
+  # #3269588963, ...` in an enum), not in `[#N](url)` markdown links. The
+  # markdown-only strip from #1163 missed those, so the gate re-failed.
+  # Inline code spans are prose-as-text, never the way a real issue ref is
+  # written — strip the whole span before extraction.
+  local body result
+  body=$'## Summary\n\nCloses #42. Comment IDs like `#3269588963` are not issues.\n`enum: #1157, #3269588963, #3269589002`\nRefs #99'
+  result=$(run_strip_markdown_issue_links "$body" | grep -oE '#[0-9]+' | sort -u | tr '\n' ' ')
+  [[ "$result" == "#42 #99 " ]] || {
+    echo "expected '#42 #99 ' (refs in code spans stripped), got: '$result'"
+    return 1
+  }
+}
+it "verify-gh-taxonomy: strip_markdown_issue_links removes #N refs inside backticked code spans (PR #1171 regression)" T_taxonomy_strip_markdown_issue_links_drops_code_span_refs
+
 T_taxonomy_workflow_inlines_same_sanitize_regex_as_hook() {
   # Drift guard: the bash hook and pr-metadata-gate.yaml each carry their own
-  # copy of the `[#N](url)` strip regex. Pin the workflow to have the exact
-  # `sed` expression once per job; a unilateral edit to either side fails here.
+  # copy of the sanitization sed pipeline. Pin the workflow to have the exact
+  # expression once per job; a unilateral edit to either side fails here.
   local workflow="$REPO_ROOT/.github/workflows/pr-metadata-gate.yaml"
   local expected count
-  expected="sed -E 's/\\[#[0-9]+\\]\\([^)]*\\)//g'"
+  expected="sed -E -e 's/\`[^\`]*\`//g' -e 's/\\[#[0-9]+\\]\\([^)]*\\)//g'"
   count=$(grep -cF "$expected" "$workflow") || count=0
   [[ "$count" -eq 2 ]] || {
-    echo "expected pr-metadata-gate.yaml to contain the strip-[#N](url) sed expression exactly 2x (once per job), found ${count}."
+    echo "expected pr-metadata-gate.yaml to contain the sanitize sed pipeline exactly 2x (once per job), found ${count}."
     echo "If you intentionally changed the workflow regex, mirror the change in strip_markdown_issue_links() in verify-gh-taxonomy.sh and update this test."
     return 1
   }
 }
-it "verify-gh-taxonomy: pr-metadata-gate.yaml inlines the same [#N](url) strip regex (drift guard)" T_taxonomy_workflow_inlines_same_sanitize_regex_as_hook
+it "verify-gh-taxonomy: pr-metadata-gate.yaml inlines the same sanitize sed pipeline (drift guard)" T_taxonomy_workflow_inlines_same_sanitize_regex_as_hook
 
 T_taxonomy_check_ci_minimum_joins_with_comma_space() {
   # Unit test for the comma-space join in check_ci_minimum + check_project_fields.

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -494,19 +494,23 @@ T_taxonomy_hierarchy_non_synth_setter_exits_silently() {
 }
 it "verify-gh-taxonomy: addSubIssue not targeting synth-setter exits 0 silently" T_taxonomy_hierarchy_non_synth_setter_exits_silently
 
+# Helper: extract strip_markdown_issue_links from verify-gh-taxonomy.sh and
+# invoke it on $1, printing the sanitized output. Slices the function with
+# awk anchored on `^}$` — the function's docstring documents this coupling.
+run_strip_markdown_issue_links() {
+  local script_src
+  script_src=$(awk '/^strip_markdown_issue_links\(\) {/,/^}$/' \
+    "$REPO_ROOT/agent/hooks/verify-gh-taxonomy.sh")
+  bash -c "$script_src"$'\n''strip_markdown_issue_links "$1"' _ "$1"
+}
+
 T_taxonomy_strip_markdown_issue_links_drops_review_comment_refs() {
-  # Regression for the PR #1163 CI failure (run 26126477593): the PR body
-  # cited four Copilot review comments as `[#3269588963](.../discussion_r…)`
-  # markdown links; the `#[0-9]+` extraction matched those 10-digit *comment*
-  # IDs as if they were issue numbers and fed them to `gh api .../issues/N`,
-  # which 404'd and failed the gate. The fix is to strip `[#N](url)` before
-  # extraction. The same regex is inlined in pr-metadata-gate.yaml — this
-  # test pins the bash version; if you tweak one, tweak the other.
-  local script_src body result
-  script_src=$(awk '/^strip_markdown_issue_links\(\) {/,/^}$/' "$REPO_ROOT/agent/hooks/verify-gh-taxonomy.sh")
+  # Regression for PR #1163 run 26126477593: Copilot review-comment
+  # `[#3269588963](.../discussion_r…)` markdown links were matched by
+  # `#[0-9]+` and fetched as bogus issue numbers, 404'ing the gate.
+  local body result
   body=$'Closes #1157.\n- [#3269588963](https://github.com/x/y/pull/1#discussion_r3269588963)\n- [#3269589023](https://github.com/x/y/pull/1#discussion_r3269589023)\nRefs #42'
-  result=$(bash -c "$script_src"$'\n''strip_markdown_issue_links "$1"' _ "$body" \
-    | grep -oE '#[0-9]+' | sort -u | tr '\n' ' ')
+  result=$(run_strip_markdown_issue_links "$body" | grep -oE '#[0-9]+' | sort -u | tr '\n' ' ')
   [[ "$result" == "#1157 #42 " ]] || {
     echo "expected '#1157 #42 ' (markdown-linked review-comment IDs stripped), got: '$result'"
     return 1
@@ -515,13 +519,11 @@ T_taxonomy_strip_markdown_issue_links_drops_review_comment_refs() {
 it "verify-gh-taxonomy: strip_markdown_issue_links removes [#N](url) review-comment refs (PR #1163 regression)" T_taxonomy_strip_markdown_issue_links_drops_review_comment_refs
 
 T_taxonomy_strip_markdown_issue_links_preserves_bare_refs() {
-  # Counter-test: bare `#N` references and `Closes #N` / `Refs #N` patterns
-  # must survive sanitization so the gate keeps enforcing linked issues.
-  local script_src body result
-  script_src=$(awk '/^strip_markdown_issue_links\(\) {/,/^}$/' "$REPO_ROOT/agent/hooks/verify-gh-taxonomy.sh")
+  # Counter-test: bare `#N` and `Closes #N` / `Refs #N` patterns must survive
+  # sanitization so the gate keeps enforcing linked issues.
+  local body result
   body=$'## Summary\n\nFollow-up to PR #1157.\nCloses #42\nRefs #99'
-  result=$(bash -c "$script_src"$'\n''strip_markdown_issue_links "$1"' _ "$body" \
-    | grep -oE '#[0-9]+' | sort -u | tr '\n' ' ')
+  result=$(run_strip_markdown_issue_links "$body" | grep -oE '#[0-9]+' | sort -u | tr '\n' ' ')
   [[ "$result" == "#1157 #42 #99 " ]] || {
     echo "expected '#1157 #42 #99 ' (all bare refs preserved), got: '$result'"
     return 1
@@ -531,14 +533,12 @@ it "verify-gh-taxonomy: strip_markdown_issue_links preserves bare #N references"
 
 T_taxonomy_workflow_inlines_same_sanitize_regex_as_hook() {
   # Drift guard: the bash hook and pr-metadata-gate.yaml each carry their own
-  # copy of the `[#N](url)` strip regex, and the hook's docstring claims they
-  # stay in sync. Pin the workflow to have the exact `sed` expression in both
-  # jobs so a unilateral edit to one side gets caught here.
+  # copy of the `[#N](url)` strip regex. Pin the workflow to have the exact
+  # `sed` expression once per job; a unilateral edit to either side fails here.
   local workflow="$REPO_ROOT/.github/workflows/pr-metadata-gate.yaml"
   local expected count
   expected="sed -E 's/\\[#[0-9]+\\]\\([^)]*\\)//g'"
   count=$(grep -cF "$expected" "$workflow") || count=0
-  # Two jobs (check-pr-metadata + epic-lineage step) each call sanitize once.
   [[ "$count" -eq 2 ]] || {
     echo "expected pr-metadata-gate.yaml to contain the strip-[#N](url) sed expression exactly 2x (once per job), found ${count}."
     echo "If you intentionally changed the workflow regex, mirror the change in strip_markdown_issue_links() in verify-gh-taxonomy.sh and update this test."

--- a/agent/hooks/verify-gh-taxonomy.sh
+++ b/agent/hooks/verify-gh-taxonomy.sh
@@ -200,12 +200,15 @@ mode_pr() {
   # Check the PR body for issue references (Fixes/Closes/Refs #N). Without a
   # linked issue, the pr-metadata-gate CI workflow will fail.
   pr_body=$(gh pr view "$pr_num" --repo "${OWNER}/${REPO}" --json body --jq '.body' 2>/dev/null || echo "")
-  issue_nums=$(echo "$pr_body" | grep -oE '(Fixes|Closes|Refs|fixes|closes|refs) #[0-9]+' \
+  # Strip [#N](url) markdown links before extracting refs: those typically point
+  # at review-comment IDs (10-digit `discussion_r…` URLs), not real issues, and
+  # would otherwise be fetched as bogus issue numbers. Mirrors pr-metadata-gate.yaml.
+  pr_body_sanitized=$(printf '%s' "$pr_body" | sed -E 's/\[#[0-9]+\]\([^)]*\)//g')
+  issue_nums=$(echo "$pr_body_sanitized" | grep -oE '(Fixes|Closes|Refs|fixes|closes|refs) #[0-9]+' \
     | grep -oE '[0-9]+' | sort -un | grep -v "^${pr_num}$" || true)
-  # Fallback: any #N reference (matches bare #N and markdown hyperlinks like
-  # [#399](url)), mirroring pr-metadata-gate.yaml.
+  # Fallback: any bare #N reference (markdown-linked refs were stripped above).
   if [[ -z "$issue_nums" ]]; then
-    issue_nums=$(echo "$pr_body" | grep -oE '#[0-9]+' | tr -d '#' | sort -un | grep -v "^${pr_num}$" || true)
+    issue_nums=$(echo "$pr_body_sanitized" | grep -oE '#[0-9]+' | tr -d '#' | sort -un | grep -v "^${pr_num}$" || true)
   fi
   if [[ -z "$issue_nums" ]]; then
     emit_block "PR has no linked issue reference. Acceptable patterns include Fixes #N / Closes #N / Refs #N or any bare #N reference in the PR body. The pr-metadata-gate CI check will fail."

--- a/agent/hooks/verify-gh-taxonomy.sh
+++ b/agent/hooks/verify-gh-taxonomy.sh
@@ -69,15 +69,20 @@ query_issue_metadata() {
 
 strip_markdown_issue_links() {
   # Usage: strip_markdown_issue_links "<pr-body>"
-  # Outputs: sanitized body on stdout. Removes `[#N](url)` markdown links so
-  # the surrounding `#[0-9]+` regex doesn't pick up 10-digit review-comment
-  # IDs (GitHub's "Copy link" UI on a Copilot review comment yields
-  # `[#3269588963](https://.../discussion_r3269588963)`); bare `#N` refs
-  # survive. Same regex is inlined in .github/workflows/pr-metadata-gate.yaml;
-  # keep them in sync. Regression: PR #1163 failing run 26126477593.
+  # Outputs: sanitized body on stdout. Strips two classes of pattern so the
+  # surrounding `#[0-9]+` regex doesn't fetch them as bogus issues:
+  #   1. Inline code spans `\`...\`` — refs cited inside backticks are part
+  #      of prose ("comment IDs like \`#3269588963\`"), not links.
+  #   2. `[#N](url)` markdown links — GitHub's "Copy link" UI on a Copilot
+  #      review comment yields `[#3269588963](.../discussion_r3269588963)`.
+  # Bare `#N` references outside code spans survive.
+  # Same regexes are inlined in .github/workflows/pr-metadata-gate.yaml;
+  # keep them in sync. Regressions: PR #1163 failing run 26126477593 (case
+  # 2), PR #1171 failing run 26127785920 (case 1).
   # NOTE: agent/hooks/test.sh slices this function with awk anchored on
   # `^}$` — preserve the bare brace style or update the awk slice.
-  printf '%s' "$1" | sed -E 's/\[#[0-9]+\]\([^)]*\)//g'
+  # shellcheck disable=SC2016  # backticks are literal sed delimiters, not subshells
+  printf '%s' "$1" | sed -E -e 's/`[^`]*`//g' -e 's/\[#[0-9]+\]\([^)]*\)//g'
 }
 
 check_ci_minimum() {

--- a/agent/hooks/verify-gh-taxonomy.sh
+++ b/agent/hooks/verify-gh-taxonomy.sh
@@ -67,6 +67,18 @@ query_issue_metadata() {
     '{type:$type, labels:$labels, milestone:$milestone, has_domain:$has_domain}'
 }
 
+strip_markdown_issue_links() {
+  # Usage: strip_markdown_issue_links "<pr-body>"
+  # Removes `[#N](url)` markdown links from a PR body and prints the result.
+  # GitHub's "Copy link" UI on a review comment yields
+  # `[#3269588963](https://.../discussion_r3269588963)` — the bracket text is
+  # a 10-digit *comment* ID, not an issue number, and the surrounding regex
+  # would otherwise fetch it as a bogus issue. Bare `#N` references survive.
+  # The same regex is inlined in .github/workflows/pr-metadata-gate.yaml;
+  # keep them in sync. Regression: PR #1163 failing run 26126477593.
+  printf '%s' "$1" | sed -E 's/\[#[0-9]+\]\([^)]*\)//g'
+}
+
 check_ci_minimum() {
   # Usage: check_ci_minimum <type> <has_domain> <milestone>
   # Echoes a comma-and-space-separated list of missing fields (e.g.
@@ -200,10 +212,7 @@ mode_pr() {
   # Check the PR body for issue references (Fixes/Closes/Refs #N). Without a
   # linked issue, the pr-metadata-gate CI workflow will fail.
   pr_body=$(gh pr view "$pr_num" --repo "${OWNER}/${REPO}" --json body --jq '.body' 2>/dev/null || echo "")
-  # Strip [#N](url) markdown links before extracting refs: those typically point
-  # at review-comment IDs (10-digit `discussion_r…` URLs), not real issues, and
-  # would otherwise be fetched as bogus issue numbers. Mirrors pr-metadata-gate.yaml.
-  pr_body_sanitized=$(printf '%s' "$pr_body" | sed -E 's/\[#[0-9]+\]\([^)]*\)//g')
+  pr_body_sanitized=$(strip_markdown_issue_links "$pr_body")
   issue_nums=$(echo "$pr_body_sanitized" | grep -oE '(Fixes|Closes|Refs|fixes|closes|refs) #[0-9]+' \
     | grep -oE '[0-9]+' | sort -un | grep -v "^${pr_num}$" || true)
   # Fallback: any bare #N reference (markdown-linked refs were stripped above).

--- a/agent/hooks/verify-gh-taxonomy.sh
+++ b/agent/hooks/verify-gh-taxonomy.sh
@@ -69,13 +69,14 @@ query_issue_metadata() {
 
 strip_markdown_issue_links() {
   # Usage: strip_markdown_issue_links "<pr-body>"
-  # Removes `[#N](url)` markdown links from a PR body and prints the result.
-  # GitHub's "Copy link" UI on a review comment yields
-  # `[#3269588963](https://.../discussion_r3269588963)` — the bracket text is
-  # a 10-digit *comment* ID, not an issue number, and the surrounding regex
-  # would otherwise fetch it as a bogus issue. Bare `#N` references survive.
-  # The same regex is inlined in .github/workflows/pr-metadata-gate.yaml;
+  # Outputs: sanitized body on stdout. Removes `[#N](url)` markdown links so
+  # the surrounding `#[0-9]+` regex doesn't pick up 10-digit review-comment
+  # IDs (GitHub's "Copy link" UI on a Copilot review comment yields
+  # `[#3269588963](https://.../discussion_r3269588963)`); bare `#N` refs
+  # survive. Same regex is inlined in .github/workflows/pr-metadata-gate.yaml;
   # keep them in sync. Regression: PR #1163 failing run 26126477593.
+  # NOTE: agent/hooks/test.sh slices this function with awk anchored on
+  # `^}$` — preserve the bare brace style or update the awk slice.
   printf '%s' "$1" | sed -E 's/\[#[0-9]+\]\([^)]*\)//g'
 }
 
@@ -200,7 +201,7 @@ check_epic_lineage() {
 # ---------------------------------------------------------------------------
 mode_pr() {
   # Usage: mode_pr <tool_response>
-  local tool_response="$1" pr_url pr_num pr_body issue_nums issue_num metadata
+  local tool_response="$1" pr_url pr_num pr_body pr_body_sanitized issue_nums issue_num metadata
   local type milestone has_domain ci_missing lineage project_missing warnings=""
   pr_url=$(echo "$tool_response" | grep -oE 'https://github.com/[^/]+/[^/]+/pull/[0-9]+' | head -1 || true)
   [[ -z "$pr_url" ]] && return 0


### PR DESCRIPTION
## Summary

- `pr-metadata-gate` was failing on PR bodies that cited review comments via GitHub's "Copy link" UI (e.g. `[#3269588963](.../discussion_r3269588963)`). The bracket text is a 10-digit *comment* ID, not an issue number, but the workflow's `grep -oE '#[0-9]+'` matched it anyway, then `gh api repos/.../issues/3269588963` 404'd and failed the build. See [the failing run on #1163](https://github.com/tinaudio/synth-setter/actions/runs/26126477593/job/76841637556?pr=1163).
- Strip `[#N](url)` markdown link patterns from the PR body before extracting issue references — both jobs in `.github/workflows/pr-metadata-gate.yaml` and the local `agent/hooks/verify-gh-taxonomy.sh` mirror.
- Bare references (`Closes #N` / `Refs #N` / "PR #N") still match, so the gate continues to enforce a linked taxonomy-compliant issue.

## Regression coverage

Three new tests in `agent/hooks/test.sh`:

1. `strip_markdown_issue_links` strips a PR-#1163-shaped body (four `[#3269…](...)` review-comment refs + two bare refs) down to just the bare refs.
2. Counter-test that bare `Closes #N` / `Refs #N` / "PR #N" references survive sanitization, so the gate keeps catching PRs with no linked issue.
3. Drift guard: greps `.github/workflows/pr-metadata-gate.yaml` for the exact `sed` expression twice (once per job). A unilateral edit to either the bash helper or the YAML inline trips the test and tells the next editor where the mirror lives.

## Test plan

- [x] `bash agent/hooks/test.sh` — 31/31 PASS locally, including the three new regression tests.
- [x] Verified the sanitizer against #1163's actual body — before: `#1157, #1165, #3269588963, #3269589002, #3269589023, #3269589051`; after: `#1157, #1165`.
- [ ] CI on this PR should pass `check-pr-metadata` and `Check epic lineage` (linked to #1169, which has Bug type / ci-automation / milestone / Phase #151 parent set).
- [ ] After this lands, re-run `pr-metadata-gate` on #1163 to confirm it goes green.

Refs #1169