### PR TITLE
docs(claude-md): reintroduce post-push PR-readiness loop directive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,10 +116,11 @@ unintended shell expansion. A `PreToolUse` hook
 - **After every push, drive the readiness loop until all four gates hold.**
   "I pushed the fix" is not "the PR is ready." Watch CI (`gh pr checks <N> --watch` or `/loop`); on red, diagnose, fix, push, repeat. Reply inline on
   every open review comment via `/pr-review-resolver`. Then wait ~60s (allow
-  15 min) for Copilot's post-push review on **both** `/pulls/<N>/comments`
-  and `/pulls/<N>/reviews`; address any new findings and loop. If Copilot
-  is silent past 15 min, manually re-request and repeat at most once. Full
-  procedure (commands, endpoints, traps) in
+  15 min) for Copilot's post-push review on **both**
+  `repos/<OWNER>/<REPO>/pulls/<N>/comments` and
+  `repos/<OWNER>/<REPO>/pulls/<N>/reviews`; address any new findings and
+  loop. If Copilot is silent past 15 min, manually re-request and repeat at
+  most once. Full procedure (commands, endpoints, traps) in
   [`docs/pr-readiness-loop.md`](docs/pr-readiness-loop.md).
 - **Always reply inline** on each open PR review comment (humans + Copilot),
   with a fix-commit SHA or justification. Use `/pr-review-resolver`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,14 @@ unintended shell expansion. A `PreToolUse` hook
 - **Readiness gates:** CI green ∧ `mergeable=MERGEABLE` ∧ every review
   comment has an inline reply ∧ no fresh Copilot findings — see
   `/pr-preflight`.
+- **After every push, drive the readiness loop until all four gates hold.**
+  "I pushed the fix" is not "the PR is ready." Watch CI (`gh pr checks <N> --watch` or `/loop`); on red, diagnose, fix, push, repeat. Reply inline on
+  every open review comment via `/pr-review-resolver`. Then wait ~60s (allow
+  15 min) for Copilot's post-push review on **both** `/pulls/<N>/comments`
+  and `/pulls/<N>/reviews`; address any new findings and loop. If Copilot
+  is silent past 15 min, manually re-request and repeat at most once. Full
+  procedure (commands, endpoints, traps) in
+  [`docs/pr-readiness-loop.md`](docs/pr-readiness-loop.md).
 - **Always reply inline** on each open PR review comment (humans + Copilot),
   with a fix-commit SHA or justification. Use `/pr-review-resolver`.
 - **Verification evidence** for each behavioral claim goes through

--- a/docs/pr-readiness-loop.md
+++ b/docs/pr-readiness-loop.md
@@ -55,10 +55,15 @@ push.
 
    ```bash
    gh api repos/<OWNER>/<REPO>/pulls/<N>/comments --paginate \
-     --jq '[.[] | select(.user.login | test("[Cc]opilot")) | {id, path, line, body}]'
+     --jq '[.[] | select(.user.login | test("[Cc]opilot")) | {id, path, line, created_at, commit_id, body}]'
    gh api repos/<OWNER>/<REPO>/pulls/<N>/reviews --paginate \
-     --jq '[.[] | select(.user.login | test("[Cc]opilot")) | {id, state, submitted_at, body}]'
+     --jq '[.[] | select(.user.login | test("[Cc]opilot")) | {id, state, submitted_at, commit_id, body}]'
    ```
+
+   `created_at` (inline) and `submitted_at` (review) let you filter to
+   comments newer than your last push timestamp; `commit_id` lets you filter
+   to comments anchored to the just-pushed SHA (`git rev-parse HEAD`). Use
+   either to distinguish fresh findings from already-addressed ones.
 
    If Copilot left new unaddressed inline comments **or** a new top-level
    review with actionable content (`state=COMMENTED` / `CHANGES_REQUESTED`

--- a/docs/pr-readiness-loop.md
+++ b/docs/pr-readiness-loop.md
@@ -1,0 +1,113 @@
+# PR readiness loop
+
+After every push to a PR branch, drive the readiness loop until the PR clears
+the four gates below. **Do not stop after the first push.** "I pushed the fix"
+is not the same as "the PR is ready." The summary line in
+[`AGENTS.md`](../AGENTS.md#prs) points here for the full procedure.
+
+## The four gates
+
+A PR is **not** ready — for review, merge, or hand-off — until **all four**
+hold. They are AND-ed; failing any one means not ready.
+
+1. **CI is fully green** — every required AND optional check passing. Pending,
+   errored, or failing all count as not ready.
+2. **`mergeable=MERGEABLE`** — `gh pr view <N> --json mergeable -q .mergeable`
+   reports `MERGEABLE`. `UNKNOWN` (GitHub still computing) and `CONFLICTING`
+   both fail this gate; keep polling `UNKNOWN` until it resolves.
+3. **Every open review comment has an inline reply** — every unresolved review
+   thread (human reviewers AND Copilot) has either a code change linked by
+   commit SHA or an inline reply with justification. Drive this with
+   `/pr-review-resolver`.
+4. **Copilot has produced no new comments since the last push** — Copilot
+   re-reviews after every push, usually within ~60s. Both the inline-comments
+   endpoint and the top-level reviews endpoint must be clear.
+
+## The loop
+
+After every push, iterate until all four gates hold. Use `/loop` for the
+waiting steps (e.g. `/loop 2m gh pr checks <N>`) — do not stop at the first
+push.
+
+1. **Push the change.**
+
+2. **Wait for CI to finish:** `gh pr checks <N> --watch` or `/loop` the checks
+   command.
+
+3. **If any check fails:** diagnose, fix, push, return to step 2. Do not move
+   on with red CI.
+
+4. **Check mergeability** with `gh pr view <N> --json mergeable -q .mergeable`:
+
+   - `CONFLICTING` → rebase or merge the base branch, resolve, push, back to 2.
+   - `UNKNOWN` → GitHub hasn't finished computing; poll again.
+   - `MERGEABLE` → continue.
+
+5. **Reply inline to every open review comment.** List them with
+   `gh api repos/<OWNER>/<REPO>/pulls/<N>/comments --paginate`. If a reply
+   required a code change, push and return to step 2. Drive this with
+   `/pr-review-resolver`. The reply endpoint that works is
+   `repos/<OWNER>/<REPO>/pulls/<N>/comments/<id>/replies` — the shorter
+   `pulls/comments/<id>/replies` returns 404.
+
+6. **Wait for Copilot's post-push review** (~60s, allow up to 15 minutes).
+   Check both endpoints:
+
+   ```bash
+   gh api repos/<OWNER>/<REPO>/pulls/<N>/comments --paginate \
+     --jq '[.[] | select(.user.login | test("[Cc]opilot")) | {id, path, line, body}]'
+   gh api repos/<OWNER>/<REPO>/pulls/<N>/reviews --paginate \
+     --jq '[.[] | select(.user.login | test("[Cc]opilot")) | {id, state, submitted_at, body}]'
+   ```
+
+   If Copilot left new unaddressed inline comments **or** a new top-level
+   review with actionable content (`state=COMMENTED` / `CHANGES_REQUESTED`
+   with a body that isn't just a "no findings" note), return to step 5 and
+   address them the same way as human comments. If 15 minutes elapse with no
+   Copilot activity at all, the auto-review didn't fire — go to 6a.
+
+   **6a. Manually re-request Copilot** when the 15-minute window elapses with
+   no activity. Try in this order, stopping at the first that succeeds:
+
+   - Re-request via the reviewers API:
+
+     ```bash
+     gh api --method POST \
+       /repos/<OWNER>/<REPO>/pulls/<N>/requested_reviewers \
+       -f 'reviewers[]=copilot-pull-request-reviewer[bot]'
+     ```
+
+     If that errors, confirm the bot slug your org uses with
+     `gh pr view <N> --json reviewRequests,reviews` and retry.
+
+   - If the reviewers API still won't take Copilot, force a re-trigger with
+     an empty commit (works when Copilot runs on push, not as a requested
+     reviewer):
+
+     ```bash
+     git commit --allow-empty -m "chore: trigger copilot review"
+     git push
+     ```
+
+     Pushing restarts the readiness loop — return to step 2.
+
+   After re-requesting, wait another ~60s (allow up to 15 minutes) and re-check
+   Copilot's comments. Repeat at most once; if Copilot still produces nothing
+   after a manual re-request, record that in the PR thread and move on.
+
+7. **Done** only when all four gates hold: CI green ∧ `mergeable=MERGEABLE`
+   ∧ every review comment has an inline reply ∧ Copilot has produced no new
+   comments since the last push (or has been confirmed silent via 6a).
+
+This applies whether the PR is yours or one you were asked to drive across
+the finish line.
+
+## Traps
+
+- **`gh pr review` HTTP 502 ≠ post failed.** The POST often succeeded
+  server-side. Re-list reviews before re-posting or you'll create a duplicate
+  review.
+- **`mergeable=UNKNOWN` is not a pass.** Only `MERGEABLE` clears gate 2.
+- **A "no findings" Copilot review counts as silence, not a comment.** Only
+  `state=COMMENTED` / `CHANGES_REQUESTED` with substantive body content
+  blocks gate 4.

--- a/docs/pr-readiness-loop.md
+++ b/docs/pr-readiness-loop.md
@@ -2,8 +2,8 @@
 
 After every push to a PR branch, drive the readiness loop until the PR clears
 the four gates below. **Do not stop after the first push.** "I pushed the fix"
-is not the same as "the PR is ready." The summary line in
-[`AGENTS.md`](../AGENTS.md#prs) points here for the full procedure.
+is not the same as "the PR is ready." The summary line in the project's
+`AGENTS.md` (under `## PRs`) points here for the full procedure.
 
 ## The four gates
 


### PR DESCRIPTION
## Summary

- AGENTS.md trim in #1158 moved the detailed post-push readiness-loop procedure into `/pr-preflight` / `/pr-review-resolver` / `/pr-checkbox` skill descriptions. Those descriptions fire when an agent is *already thinking about* preflight or resolving reviews — they don't fire as a self-driving loop after `git push`. Behavioural regression: agents stop after the first push and skip the watch-CI → fix → reply → wait-for-Copilot → re-request cycle.
- New `docs/pr-readiness-loop.md` (~100 lines) carries the full step-by-step procedure (four gates, 7-step loop, dual-endpoint Copilot check, manual re-request fallback, three common traps).
- One new bullet under `## PRs` in AGENTS.md (~10 lines) names the loop discipline, the dual-endpoint Copilot check, and the re-request fallback, then links the doc. Existing `/pr-preflight` / `/pr-review-resolver` / `/pr-checkbox` bullets stay in place.

## Out of scope

- Editing the `/pr-preflight` / `/pr-review-resolver` / `/pr-checkbox` skill descriptions themselves — they live in the `tinaudio-skills` plugin repo, not here.
- `doc-map.yaml` entry — procedural docs without source-file backings don't fit the doc-drift mapping pattern (same call the trim PR made for `src/synth_setter/pipeline/CLAUDE.md`).

## Test plan

- [x] `make format` / pre-commit: mdformat + codespell pass.
- [x] `/repo-review-full-no-comments` run against the branch — PASS (markdown-only diff; applicable code-health and comment-hygiene items clean).
- [ ] CI green on the PR.
- [ ] Copilot post-push review: no actionable findings (or addressed).

Closes #1172
Refs #1158