### PR TITLE
docs(claude-md): inline positive comment-hygiene rules so they always load

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,39 @@ Claude-specific entry point for the shared agent instructions.
 Read and follow [AGENTS.md](AGENTS.md). That file is the canonical project
 instruction source for both Claude and Codex. Keep Claude-only compatibility
 notes in `.claude/`; keep shared hooks and review skills under `agent/`.
+
+## Comment hygiene (do this when writing inline text)
+
+Code says **what**; comments say **why**. Lean on names and types first; add
+prose only when it carries something they can't. Full rules live in the
+`comment-hygiene` skill — these are the load-bearing actions for inline
+writing:
+
+- **Earn each comment.** Before adding one, ask: "would a future reader be
+  confused without this?" If no, skip it. Trust the names and types.
+- **Stay at one line; cap at two.** When you need more context, write a
+  one-line pointer (`# <why> — see #N`) and put the detail in the issue,
+  commit message, or design doc.
+- **Make every line carry new information.** Comments and `:param:` lines
+  should add a constraint (`must be sorted`), a unit (`seconds`), a
+  semantic (`dB, not linear`), or a rationale — never the function name,
+  signature, type, or literal value the reader can already see.
+- **Describe current behavior only.** Write docstrings and comments as if
+  the code has always looked this way. Put renames, migrations, and
+  removals in the commit message; git log carries history.
+- **Open docstrings with the contract.** Lead with what the function
+  promises or constrains. Skip generic openers ("This module provides…",
+  "Helper function that…", "Utility for…", "Wrapper around…") — if the
+  next sentence adds nothing real, the whole docstring goes.
+- **Let blank lines separate sections.** No `# ===== SECTION =====` or
+  `# ----- foo -----` banners.
+- **Put YAML comments above the `- name:` step.** Inside `run: |` /
+  `setup: |` block scalars the body is bash; a `PreToolUse` hook blocks
+  `#`-lines there.
+- **Reach for `:param:` / `:returns:` only when they add what the type
+  hint can't.** Pydoclint still requires field lists for Pydantic classes
+  and validators with `raise` paths — follow the skill's syntax notes
+  (`.. attribute ::`, no `:param cls:` / `:param self:`, no `:rtype:`).
+
+When in doubt, write less. Reviewers will ask for a comment if they need
+one; they rarely ask for fewer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,13 +31,15 @@ writing:
   next sentence adds nothing real, the whole docstring goes.
 - **Let blank lines separate sections.** No `# ===== SECTION =====` or
   `# ----- foo -----` banners.
-- **Put YAML comments above the `- name:` step.** Inside `run: |` /
-  `setup: |` block scalars the body is bash; a `PreToolUse` hook blocks
-  `#`-lines there.
-- **Reach for `:param:` / `:returns:` only when they add what the type
-  hint can't.** Pydoclint still requires field lists for Pydantic classes
-  and validators with `raise` paths — follow the skill's syntax notes
-  (`.. attribute ::`, no `:param cls:` / `:param self:`, no `:rtype:`).
+- **Put YAML comments above the step list item** (the `- ...` entry).
+  Inside `run: |` / `setup: |` block scalars the body is bash; a
+  `PreToolUse` hook blocks `#`-lines there.
+- **Include `:param:` / `:returns:` / `:raises:` whenever pydoclint
+  expects them.** In those field lists, add semantics the signature can't
+  show — constraints, units, invariants, edge cases, or rationale — and
+  do not repeat the parameter name, type, or obvious return details.
+  Follow the skill's syntax notes (`.. attribute ::`, no `:param cls:` /
+  `:param self:`, no `:rtype:`).
 
 When in doubt, write less. Reviewers will ask for a comment if they need
 one; they rarely ask for fewer.


### PR DESCRIPTION
## Summary

- Adds a short **Comment hygiene (do this when writing inline text)** section to `CLAUDE.md` so the load-bearing comment-hygiene rules are in working memory while Claude/Codex are writing, not only at review time.
- Rules are framed as positive actions (earn each comment; stay at one line; make every line carry new information; describe current behavior only; open docstrings with the contract; let blank lines separate sections; put YAML comments above `- name:`; reach for `:param:` only when it adds what the type hint can't).
- Defers the full checklist / `C1`–`C12` schema to the `comment-hygiene` skill — the section is a pointer, not a parallel source of truth.

## Why now

Inline prose drift (multi-line essays in comments, generic docstring openers, name-restating docstrings) had started reappearing in agent-authored diffs. The `comment-hygiene` skill catches these at review time, but the rules weren't surfaced when the agent was *writing*. Hoisting the action list into CLAUDE.md (which is always loaded) addresses the prevention side.

Consistency check against existing instructions:
- YAML-block-scalar bullet matches AGENTS.md's "YAML \`run:\` block scalars are bash" section and the `agent/hooks/no-yaml-run-comments.sh` PreToolUse hook.
- Pydoclint syntax notes (`.. attribute ::`, no `:param cls:` / `:param self:`, no `:rtype:`) match the persisted feedback notes.

## Test plan

- [x] `mdformat` + pre-commit hooks pass on the commit (no trailers added; `git-commit-trailer-check.sh` clean).
- [x] `/repo-review-full-no-comments` ran on the local branch — PASS, no BLOCK/WARN from `code-health` or `synth-setter-project-standards`.
- [ ] CI green on the open PR.

Refs #1074

<!-- REVIEW_FULL_DONE=1 -->