### PR TITLE
chore(automation): isolate pr-review-resolver / doc-drift in detached worktrees

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -120,7 +120,7 @@
       },
       {
         "matcher": "Bash",
-        "description": "Doc-drift advisory review: on gh pr create, runs a headless agent session invoking the doc-drift skill (or an inline fallback referencing docs/doc-map.yaml) against git diff against the default branch. Output saved to .agent-reviews/doc-drift-<uuid>.md. On headless agent failure, writes a verbose error report (stderr tail + exit code) and still wakes the session. The `if` guard scopes the hook to gh pr create at the handler level; doc-drift.sh re-validates the command itself. Advisory only — does not block.",
+        "description": "Doc-drift advisory review: on gh pr create, runs a headless agent session invoking the doc-drift skill (or an inline fallback referencing docs/doc-map.yaml) against git diff against the default branch. The headless agent runs in a detached worktree pinned to the captured HEAD so it cannot mutate the user's primary checkout, and is bounded by AGENT_TIMEOUT_SECS (default 800s, with --kill-after=10 inside the harness 900s ceiling). Output saved to .agent-reviews/doc-drift-<uuid>.md in the main repo. Rewake stderr stamps origin HEAD so receivers can detect cross-session leaks (see AGENTS.md). On headless agent failure, writes a verbose error report (stderr tail + exit code) and still wakes the session. The `if` guard scopes the hook to gh pr create at the handler level; doc-drift.sh re-validates the command itself. Advisory only — does not block.",
         "hooks": [
           {
             "type": "command",
@@ -134,7 +134,7 @@
       },
       {
         "matcher": "Bash",
-        "description": "PR review resolver: on git push (excluding main/master), waits RESOLVER_SLEEP_SECS (default 360s) for CI and reviewers to settle, then runs the pr-review-resolver skill (or inline fallback) headlessly. Per-branch lockfile dedupes stacked pushes (last push wins). On headless agent failure, writes a verbose error report and still wakes the session. The `if` guard scopes the hook to git push at the handler level; pr-review-resolver.sh re-validates the command itself. Advisory only — does not block.",
+        "description": "PR review resolver: on git push (excluding main/master), resolves the branch's PR up front (exits early if none), then waits RESOLVER_SLEEP_SECS (default 360s) for CI and reviewers to settle and runs the pr-review-resolver skill (or inline fallback) headlessly. The headless agent runs in a detached worktree pinned to the captured HEAD so it cannot mutate the user's primary checkout, and is bounded by AGENT_TIMEOUT_SECS (default 800s, plus --kill-after=10; fits inside the harness 1200s ceiling after the 360s sleep). Per-branch lockfile dedupes stacked pushes (last push wins). Reports land in .agent-reviews/pr-review-resolver-<uuid>.md in the main repo; rewake stderr stamps origin HEAD so receivers can detect cross-session leaks (see AGENTS.md). On headless agent failure, writes a verbose error report and still wakes the session. The `if` guard scopes the hook to git push at the handler level; pr-review-resolver.sh re-validates the command itself. Advisory only — does not block.",
         "hooks": [
           {
             "type": "command",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,6 +124,13 @@ unintended shell expansion. A `PreToolUse` hook
   [`docs/pr-readiness-loop.md`](docs/pr-readiness-loop.md).
 - **Always reply inline** on each open PR review comment (humans + Copilot),
   with a fix-commit SHA or justification. Use `/pr-review-resolver`.
+- **Advisory rewakes carry an origin-HEAD stamp.** The `pr-review-resolver`
+  and `doc-drift` PostToolUse hooks run their headless agents in detached
+  worktrees and re-enter the session via `asyncRewake` with a line like
+  `pr-review-resolver report for PR #N (branch X, origin HEAD <sha7>) at <path>`. Before acting on one, compare `<sha7>` to `git rev-parse HEAD`.
+  If they differ the advisory crossed sessions (it was queued by a prior
+  agent's push/PR-create that finished after that session ended) — read
+  the report for context, but do not treat it as work for the current PR.
 - **Verification evidence** for each behavioral claim goes through
   `/pr-checkbox`.
 - **In chat**, use full markdown hyperlinks for PR/issue references:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,8 +127,7 @@ unintended shell expansion. A `PreToolUse` hook
 - **Advisory rewakes carry an origin-HEAD stamp.** The `pr-review-resolver`
   and `doc-drift` PostToolUse hooks run their headless agents in detached
   worktrees and re-enter the session via `asyncRewake` with a line like
-  `pr-review-resolver report for PR #N (branch X, origin HEAD <sha7>) at
-  <path>`. Before acting on one, compare `<sha7>` to the first 7
+  `pr-review-resolver report for PR #N (branch X, origin HEAD <sha7>) at <path>`. Before acting on one, compare `<sha7>` to the first 7
   characters of `git rev-parse HEAD` (the advisory is the 7-char prefix).
   If they differ the advisory crossed sessions (it was queued by a prior
   agent's push/PR-create that finished after that session ended) — read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,9 @@ unintended shell expansion. A `PreToolUse` hook
 - **Advisory rewakes carry an origin-HEAD stamp.** The `pr-review-resolver`
   and `doc-drift` PostToolUse hooks run their headless agents in detached
   worktrees and re-enter the session via `asyncRewake` with a line like
-  `pr-review-resolver report for PR #N (branch X, origin HEAD <sha7>) at <path>`. Before acting on one, compare `<sha7>` to the first 7 characters of `git rev-parse HEAD` (the advisory is the 7-char prefix).
+  `pr-review-resolver report for PR #N (branch X, origin HEAD <sha7>) at
+  <path>`. Before acting on one, compare `<sha7>` to the first 7
+  characters of `git rev-parse HEAD` (the advisory is the 7-char prefix).
   If they differ the advisory crossed sessions (it was queued by a prior
   agent's push/PR-create that finished after that session ended) — read
   the report for context, but do not treat it as work for the current PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ unintended shell expansion. A `PreToolUse` hook
 - **Advisory rewakes carry an origin-HEAD stamp.** The `pr-review-resolver`
   and `doc-drift` PostToolUse hooks run their headless agents in detached
   worktrees and re-enter the session via `asyncRewake` with a line like
-  `pr-review-resolver report for PR #N (branch X, origin HEAD <sha7>) at <path>`. Before acting on one, compare `<sha7>` to `git rev-parse HEAD`.
+  `pr-review-resolver report for PR #N (branch X, origin HEAD <sha7>) at <path>`. Before acting on one, compare `<sha7>` to `git rev-parse --short=7 HEAD` (the advisory is the 7-char prefix).
   If they differ the advisory crossed sessions (it was queued by a prior
   agent's push/PR-create that finished after that session ended) — read
   the report for context, but do not treat it as work for the current PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ unintended shell expansion. A `PreToolUse` hook
 - **Advisory rewakes carry an origin-HEAD stamp.** The `pr-review-resolver`
   and `doc-drift` PostToolUse hooks run their headless agents in detached
   worktrees and re-enter the session via `asyncRewake` with a line like
-  `pr-review-resolver report for PR #N (branch X, origin HEAD <sha7>) at <path>`. Before acting on one, compare `<sha7>` to `git rev-parse --short=7 HEAD` (the advisory is the 7-char prefix).
+  `pr-review-resolver report for PR #N (branch X, origin HEAD <sha7>) at <path>`. Before acting on one, compare `<sha7>` to the first 7 characters of `git rev-parse HEAD` (the advisory is the 7-char prefix).
   If they differ the advisory crossed sessions (it was queued by a prior
   agent's push/PR-create that finished after that session ended) — read
   the report for context, but do not treat it as work for the current PR.

--- a/agent/hooks/_lib.sh
+++ b/agent/hooks/_lib.sh
@@ -116,17 +116,34 @@ run_agent_prompt() {
       fi
     done
   fi
+  # GNU coreutils ships as `timeout` on Linux and `gtimeout` on macOS
+  # (Homebrew). With neither on PATH, fall back to an unwrapped run and log —
+  # an operator can install coreutils to re-enable the hung-agent SIGKILL.
   # `--kill-after=10` SIGKILLs a child that ignores the SIGTERM the soft
   # timeout sends — grandchildren the agent CLI spawned otherwise survive.
+  local timeout_bin=""
+  if command -v timeout >/dev/null 2>&1; then
+    timeout_bin="timeout"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    timeout_bin="gtimeout"
+  else
+    log "no GNU timeout/gtimeout on PATH; running agent without timeout enforcement"
+  fi
+  local -a cmd
   case "$cli" in
-    claude) timeout --kill-after=10 "$timeout_secs" claude -p "$prompt" ;;
-    codex)  timeout --kill-after=10 "$timeout_secs" codex exec "$prompt" ;;
+    claude) cmd=(claude -p "$prompt") ;;
+    codex)  cmd=(codex exec "$prompt") ;;
     *)
       printf 'No supported headless agent CLI found; install claude or codex (AGENT_HEADLESS=%s).\n' \
         "${AGENT_HEADLESS:-}" >&2
       return 127
       ;;
   esac
+  if [[ -n "$timeout_bin" ]]; then
+    "$timeout_bin" --kill-after=10 "$timeout_secs" "${cmd[@]}"
+  else
+    "${cmd[@]}"
+  fi
 }
 
 emit_rewake_stamp() {

--- a/agent/hooks/_lib.sh
+++ b/agent/hooks/_lib.sh
@@ -151,12 +151,13 @@ emit_rewake_stamp() {
   # Prints the metadata-stamped advisory pointer on stderr so a session that
   # receives a cross-session leak can compare the origin HEAD to its own and
   # discard. AGENTS.md documents the receiving-side contract.
-  local slug="$1" pr="$2" branch="$3" head_sha="$4" review_file="$5" tail="${6:-}"
+  local slug="$1" pr="$2" branch="$3" head_sha="$4" review_file="$5" tail="${6:-}" short_head_sha
+  short_head_sha=$(git rev-parse --short=7 "$head_sha" 2>/dev/null || printf '%s' "${head_sha:0:7}")
   printf '%s report for PR #%s (branch %s, origin HEAD %s) at %s.%s\n' \
-    "$slug" "$pr" "$branch" "${head_sha:0:7}" "$review_file" \
+    "$slug" "$pr" "$branch" "$short_head_sha" "$review_file" \
     "${tail:+ $tail}" >&2
   printf 'If your current HEAD is not %s, this advisory crossed sessions — verify before acting.\n' \
-    "${head_sha:0:7}" >&2
+    "$short_head_sha" >&2
 }
 
 make_isolated_worktree() {

--- a/agent/hooks/_lib.sh
+++ b/agent/hooks/_lib.sh
@@ -3,8 +3,25 @@
 # comment for its contract. Sourced by every hook; intentionally omits
 # `set -euo pipefail` so each caller chooses its own error-handling regime.
 
-REVIEWS_DIR=".agent-reviews"
+# REVIEWS_DIR/HOOK_LOG resolve to absolute paths in the main repo via
+# `git rev-parse --git-common-dir`, so a hook that `cd`s into an isolated
+# worktree still writes its report where the receiving agent session can read
+# it. Falls back to cwd when outside a git tree (test sandboxes).
+_repo_root_for_hooks() {
+  local common_dir parent
+  common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || return 1
+  case "$common_dir" in
+    /*) parent=$(dirname "$common_dir") ;;
+    *)  parent=$(cd "$(dirname "$common_dir")" 2>/dev/null && pwd) ;;
+  esac
+  [[ -n "$parent" ]] || return 1
+  printf '%s\n' "$parent"
+}
+
+_REPO_ROOT_FOR_HOOKS=$(_repo_root_for_hooks 2>/dev/null || pwd)
+REVIEWS_DIR="${_REPO_ROOT_FOR_HOOKS}/.agent-reviews"
 HOOK_LOG="${REVIEWS_DIR}/.hook.log"
+WORKTREES_DIR="${REVIEWS_DIR}/worktrees"
 
 ensure_reviews_dir() {
   mkdir -p "$REVIEWS_DIR"
@@ -88,10 +105,12 @@ has_skill() {
 
 run_agent_prompt() {
   # Usage: run_agent_prompt <prompt>
-  # Routes the prompt through the available headless agent CLI. AGENT_HEADLESS
-  # (`claude` or `codex`) overrides auto-detection; otherwise prefer claude,
-  # fall back to codex, fail loud (exit 127) if neither is installed.
+  # Routes the prompt through the available headless agent CLI, wrapped in
+  # `timeout` so a hung agent surfaces as exit 124 instead of an open-ended
+  # hang the harness must SIGKILL. AGENT_HEADLESS (`claude`|`codex`) overrides
+  # auto-detection; AGENT_TIMEOUT_SECS overrides the default 900s ceiling.
   local prompt="$1" cli="${AGENT_HEADLESS:-}" candidate
+  local timeout_secs="${AGENT_TIMEOUT_SECS:-900}"
   if [[ -z "$cli" ]]; then
     for candidate in claude codex; do
       if command -v "$candidate" >/dev/null 2>&1; then
@@ -101,14 +120,56 @@ run_agent_prompt() {
     done
   fi
   case "$cli" in
-    claude) claude -p "$prompt" ;;
-    codex)  codex exec "$prompt" ;;
+    claude) timeout "$timeout_secs" claude -p "$prompt" ;;
+    codex)  timeout "$timeout_secs" codex exec "$prompt" ;;
     *)
       printf 'No supported headless agent CLI found; install claude or codex (AGENT_HEADLESS=%s).\n' \
         "${AGENT_HEADLESS:-}" >&2
       return 127
       ;;
   esac
+}
+
+make_isolated_worktree() {
+  # Usage: make_isolated_worktree <slug> <head_sha>
+  # Creates a detached worktree at $head_sha under $WORKTREES_DIR. Echoes the
+  # worktree path on stdout; returns non-zero (no output) on failure. Caller
+  # must register cleanup via trap (see remove_worktree). The headless agent
+  # the hook spawns runs inside this worktree so its `git checkout` / commit /
+  # push commands can't reach into the user's primary checkout.
+  local slug="$1" sha="$2" wt
+  ensure_reviews_dir
+  mkdir -p "$WORKTREES_DIR"
+  wt="${WORKTREES_DIR}/${slug}-${sha:0:7}-$(gen_id)"
+  if git worktree add --detach "$wt" "$sha" >/dev/null 2>&1; then
+    printf '%s\n' "$wt"
+    return 0
+  fi
+  return 1
+}
+
+remove_worktree() {
+  # Usage: remove_worktree <path>
+  # Best-effort cleanup; safe to call on a missing path. Prunes the
+  # registration so `git worktree list` doesn't accrete dangling entries.
+  local wt="$1"
+  [[ -n "$wt" ]] || return 0
+  if [[ -d "$wt" ]]; then
+    git worktree remove --force "$wt" >/dev/null 2>&1 || rm -rf "$wt"
+  fi
+  git worktree prune >/dev/null 2>&1 || true
+}
+
+sweep_stale_worktrees() {
+  # Usage: sweep_stale_worktrees <slug> [max_age_minutes]
+  # Removes leaked <slug>-* worktrees the EXIT trap missed (e.g. when the
+  # harness SIGKILL'd the hook at its timeout ceiling). max_age default 30.
+  local slug="$1" max_age="${2:-30}" wt
+  [[ -d "$WORKTREES_DIR" ]] || return 0
+  while IFS= read -r -d '' wt; do
+    log "sweeping stale worktree: $wt"
+    remove_worktree "$wt"
+  done < <(find "$WORKTREES_DIR" -maxdepth 1 -type d -name "${slug}-*" -mmin "+${max_age}" -print0 2>/dev/null)
 }
 
 run_review() {

--- a/agent/hooks/_lib.sh
+++ b/agent/hooks/_lib.sh
@@ -3,10 +3,8 @@
 # comment for its contract. Sourced by every hook; intentionally omits
 # `set -euo pipefail` so each caller chooses its own error-handling regime.
 
-# REVIEWS_DIR/HOOK_LOG resolve to absolute paths in the main repo via
-# `git rev-parse --git-common-dir`, so a hook that `cd`s into an isolated
-# worktree still writes its report where the receiving agent session can read
-# it. Falls back to cwd when outside a git tree (test sandboxes).
+# Absolute paths so a hook that `cd`s into a worktree still writes reports
+# where the receiving session reads them. Falls back to cwd outside a git tree.
 _repo_root_for_hooks() {
   local common_dir parent
   common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || return 1
@@ -71,11 +69,11 @@ default_branch() {
 has_skill() {
   # Usage: has_skill <skill-name>
   # Returns 0 if <name>/SKILL.md exists in any known skill location.
-  # Worktree-aware: also checks the main repo via the git common dir, since
-  # agent tool directories may live only in the primary checkout. Unmatched
-  # plugin globs expand to their literal pattern, which the `-f` check safely
-  # rejects without spurious warnings.
-  local name="$1" home="${HOME:-}" common_dir repo_root p
+  # Worktree-aware: also checks the main repo (via $_REPO_ROOT_FOR_HOOKS) so
+  # hooks running from a linked worktree still find skills installed only in
+  # the primary checkout. Unmatched plugin globs expand to their literal
+  # pattern, which the `-f` check safely rejects without spurious warnings.
+  local name="$1" home="${HOME:-}" p
   local paths=(
     "agent/skills/${name}/SKILL.md"
     ".claude/skills/${name}/SKILL.md"
@@ -88,14 +86,11 @@ has_skill() {
       "${home}"/.codex/plugins/*/skills/"${name}"/SKILL.md
     )
   fi
-  if common_dir=$(git rev-parse --git-common-dir 2>/dev/null) && [[ -n "$common_dir" ]]; then
-    repo_root=$(cd "$common_dir/.." 2>/dev/null && pwd)
-    if [[ -n "$repo_root" ]]; then
-      paths+=(
-        "${repo_root}/agent/skills/${name}/SKILL.md"
-        "${repo_root}/.claude/skills/${name}/SKILL.md"
-      )
-    fi
+  if [[ -n "${_REPO_ROOT_FOR_HOOKS:-}" ]]; then
+    paths+=(
+      "${_REPO_ROOT_FOR_HOOKS}/agent/skills/${name}/SKILL.md"
+      "${_REPO_ROOT_FOR_HOOKS}/.claude/skills/${name}/SKILL.md"
+    )
   fi
   for p in "${paths[@]}"; do
     [[ -f "$p" ]] && return 0
@@ -119,9 +114,11 @@ run_agent_prompt() {
       fi
     done
   fi
+  # `--kill-after=10` SIGKILLs a child that ignores the SIGTERM the soft
+  # timeout sends — grandchildren the agent CLI spawned otherwise survive.
   case "$cli" in
-    claude) timeout "$timeout_secs" claude -p "$prompt" ;;
-    codex)  timeout "$timeout_secs" codex exec "$prompt" ;;
+    claude) timeout --kill-after=10 "$timeout_secs" claude -p "$prompt" ;;
+    codex)  timeout --kill-after=10 "$timeout_secs" codex exec "$prompt" ;;
     *)
       printf 'No supported headless agent CLI found; install claude or codex (AGENT_HEADLESS=%s).\n' \
         "${AGENT_HEADLESS:-}" >&2
@@ -130,13 +127,23 @@ run_agent_prompt() {
   esac
 }
 
+emit_rewake_stamp() {
+  # Usage: emit_rewake_stamp <slug> <pr> <branch> <head_sha> <review_file> [tail]
+  # Prints the metadata-stamped advisory pointer on stderr so a session that
+  # receives a cross-session leak can compare the origin HEAD to its own and
+  # discard. AGENTS.md documents the receiving-side contract.
+  local slug="$1" pr="$2" branch="$3" head_sha="$4" review_file="$5" tail="${6:-}"
+  printf '%s report for PR #%s (branch %s, origin HEAD %s) at %s.%s\n' \
+    "$slug" "$pr" "$branch" "${head_sha:0:7}" "$review_file" \
+    "${tail:+ $tail}" >&2
+  printf 'If your current HEAD is not %s, this advisory crossed sessions — verify before acting.\n' \
+    "${head_sha:0:7}" >&2
+}
+
 make_isolated_worktree() {
   # Usage: make_isolated_worktree <slug> <head_sha>
-  # Creates a detached worktree at $head_sha under $WORKTREES_DIR. Echoes the
-  # worktree path on stdout; returns non-zero (no output) on failure. Caller
-  # must register cleanup via trap (see remove_worktree). The headless agent
-  # the hook spawns runs inside this worktree so its `git checkout` / commit /
-  # push commands can't reach into the user's primary checkout.
+  # Echoes the new worktree path on stdout; returns non-zero (no output) on
+  # failure. Caller registers cleanup via `trap '...' EXIT` + remove_worktree.
   local slug="$1" sha="$2" wt
   ensure_reviews_dir
   mkdir -p "$WORKTREES_DIR"

--- a/agent/hooks/_lib.sh
+++ b/agent/hooks/_lib.sh
@@ -100,12 +100,14 @@ has_skill() {
 
 run_agent_prompt() {
   # Usage: run_agent_prompt <prompt>
-  # Routes the prompt through the available headless agent CLI, wrapped in
-  # `timeout` so a hung agent surfaces as exit 124 instead of an open-ended
-  # hang the harness must SIGKILL. AGENT_HEADLESS (`claude`|`codex`) overrides
-  # auto-detection; AGENT_TIMEOUT_SECS overrides the default 900s ceiling.
+  # Wraps the headless CLI in `timeout` so a hung agent surfaces as exit 124.
+  # Default 800s leaves headroom inside both harness ceilings: doc-drift's
+  # 900s (800 + 10 kill-after = 810 < 900) and pr-review-resolver's
+  # 1200s after a 360s sleep (360 + 800 + 10 = 1170 < 1200). Operators
+  # raising AGENT_TIMEOUT_SECS must check the matching .claude/settings.json
+  # `timeout` field or the harness will SIGKILL.
   local prompt="$1" cli="${AGENT_HEADLESS:-}" candidate
-  local timeout_secs="${AGENT_TIMEOUT_SECS:-900}"
+  local timeout_secs="${AGENT_TIMEOUT_SECS:-800}"
   if [[ -z "$cli" ]]; then
     for candidate in claude codex; do
       if command -v "$candidate" >/dev/null 2>&1; then

--- a/agent/hooks/doc-drift.sh
+++ b/agent/hooks/doc-drift.sh
@@ -25,18 +25,17 @@ if ! echo "$COMMAND" | grep -qE '(^|[;|&`(][[:space:]]*)gh[[:space:]]+pr[[:space
   exit 0
 fi
 
-ensure_reviews_dir
-sweep_stale_worktrees "doc-drift"
-log "matched: ${COMMAND}"
-
 BRANCH=$(git branch --show-current 2>/dev/null || true)
 HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || true)
 PR=$(gh pr view "$BRANCH" --json number -q .number 2>/dev/null || true)
 
 if [[ -z "$PR" ]]; then
-  log "no PR found for branch ${BRANCH:-?}, skipping"
   exit 0
 fi
+
+ensure_reviews_dir
+sweep_stale_worktrees "doc-drift"
+log "matched: ${COMMAND}"
 
 BASE_BRANCH=$(default_branch)
 log "base branch resolved to: ${BASE_BRANCH}"
@@ -71,8 +70,6 @@ REVIEW_FILE=$(run_review "doc-drift" "$META" "$PROMPT" "DOC_DRIFT_DRY_RUN")
 
 log "wrote ${REVIEW_FILE}"
 
-printf 'doc-drift report for PR #%s (branch %s, origin HEAD %s) at %s. Advisory — read it and apply documentation updates as appropriate.\n' \
-  "$PR" "$BRANCH" "${HEAD_SHA:0:7}" "$REVIEW_FILE" >&2
-printf 'If your current HEAD is not %s, this advisory crossed sessions — verify before acting.\n' \
-  "${HEAD_SHA:0:7}" >&2
+emit_rewake_stamp "doc-drift" "$PR" "$BRANCH" "$HEAD_SHA" "$REVIEW_FILE" \
+  "Advisory — read it and apply documentation updates as appropriate."
 exit 2

--- a/agent/hooks/doc-drift.sh
+++ b/agent/hooks/doc-drift.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 # doc-drift.sh — PostToolUse hook on `gh pr create`. Runs the doc-drift skill
-# (or an inline fallback) headlessly and writes an advisory report to
-# .agent-reviews/doc-drift-<uuid>.md. Exits 2 with a pointer so the active
-# agent session reads the report; never blocks. Env overrides: DOC_DRIFT_DRY_RUN=1
-# skips the agent call; AGENT_HEADLESS=claude|codex pins the CLI.
+# (or an inline fallback) headlessly in a detached worktree pinned to the
+# captured HEAD and writes an advisory report to
+# .agent-reviews/doc-drift-<uuid>.md in the main repo. Exits 2 with a metadata-
+# stamped pointer so the active agent session reads the report; never blocks.
+#
+# Worktree isolation: prevents the headless agent's commands from touching the
+# user's primary checkout if a prompt asks it to switch branches mid-task.
+#
+# Env overrides: DOC_DRIFT_DRY_RUN=1 skips the agent call;
+# AGENT_HEADLESS=claude|codex pins the CLI; AGENT_TIMEOUT_SECS bounds the
+# headless run (default 900s).
 set -euo pipefail
 
 export HOOK_NAME="doc-drift"
@@ -19,10 +26,12 @@ if ! echo "$COMMAND" | grep -qE '(^|[;|&`(][[:space:]]*)gh[[:space:]]+pr[[:space
 fi
 
 ensure_reviews_dir
+sweep_stale_worktrees "doc-drift"
 log "matched: ${COMMAND}"
 
 BRANCH=$(git branch --show-current 2>/dev/null || true)
-PR=$(gh pr view --json number -q .number 2>/dev/null || true)
+HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || true)
+PR=$(gh pr view "$BRANCH" --json number -q .number 2>/dev/null || true)
 
 if [[ -z "$PR" ]]; then
   log "no PR found for branch ${BRANCH:-?}, skipping"
@@ -36,25 +45,34 @@ log "base branch resolved to: ${BASE_BRANCH}"
 # substitution non-fatal under `set -e`.
 DIFF_FILES=$(git diff "origin/${BASE_BRANCH}...HEAD" --name-only 2>/dev/null | head -50 || true)
 
+WT=$(make_isolated_worktree "doc-drift" "$HEAD_SHA") || {
+  log "worktree creation failed for ${HEAD_SHA}, exiting"
+  exit 0
+}
+trap 'remove_worktree "$WT"' EXIT
+cd "$WT"
+
 if has_skill doc-drift; then
   log "using doc-drift skill"
-  PROMPT="Use the doc-drift skill to review PR #${PR} on branch ${BRANCH} against base ${BASE_BRANCH}. Cross-reference docs/doc-map.yaml if present. Changed files:
+  PROMPT="Use the doc-drift skill to review PR #${PR} on branch ${BRANCH} (HEAD ${HEAD_SHA:0:7}) against base ${BASE_BRANCH}. Cross-reference docs/doc-map.yaml if present. Changed files:
 ${DIFF_FILES}
 
 Report findings as \"file:line — issue — suggested fix\". If no drift is found, state that explicitly."
 else
   log "doc-drift skill not found, using fallback prompt"
-  PROMPT="Review the diff 'git diff origin/${BASE_BRANCH}...HEAD' for documentation drift on PR #${PR}, branch ${BRANCH}. Cross-reference docs/doc-map.yaml if present. Check for: references to renamed/removed files, stale signatures, missing docs for new public APIs, out-of-date examples. Changed files:
+  PROMPT="Review the diff 'git diff origin/${BASE_BRANCH}...HEAD' for documentation drift on PR #${PR}, branch ${BRANCH} (HEAD ${HEAD_SHA:0:7}). Cross-reference docs/doc-map.yaml if present. Check for: references to renamed/removed files, stale signatures, missing docs for new public APIs, out-of-date examples. Changed files:
 ${DIFF_FILES}
 
 Report findings as \"file:line — issue — suggested fix\". If no drift is found, state that explicitly."
 fi
 
-META=$(printf 'PR: #%s\nBranch: %s\nBase: %s\n' "$PR" "$BRANCH" "$BASE_BRANCH")
+META=$(printf 'PR: #%s\nBranch: %s\nBase: %s\nHEAD: %s\n' "$PR" "$BRANCH" "$BASE_BRANCH" "$HEAD_SHA")
 REVIEW_FILE=$(run_review "doc-drift" "$META" "$PROMPT" "DOC_DRIFT_DRY_RUN")
 
 log "wrote ${REVIEW_FILE}"
 
-printf 'doc-drift report for PR #%s at %s. Advisory — read it and apply documentation updates as appropriate before continuing.\n' \
-  "$PR" "$REVIEW_FILE" >&2
+printf 'doc-drift report for PR #%s (branch %s, origin HEAD %s) at %s. Advisory — read it and apply documentation updates as appropriate.\n' \
+  "$PR" "$BRANCH" "${HEAD_SHA:0:7}" "$REVIEW_FILE" >&2
+printf 'If your current HEAD is not %s, this advisory crossed sessions — verify before acting.\n' \
+  "${HEAD_SHA:0:7}" >&2
 exit 2

--- a/agent/hooks/doc-drift.sh
+++ b/agent/hooks/doc-drift.sh
@@ -10,7 +10,7 @@
 #
 # Env overrides: DOC_DRIFT_DRY_RUN=1 skips the agent call;
 # AGENT_HEADLESS=claude|codex pins the CLI; AGENT_TIMEOUT_SECS bounds the
-# headless run (default 900s).
+# headless run (default 800s).
 set -euo pipefail
 
 export HOOK_NAME="doc-drift"

--- a/agent/hooks/pr-review-resolver.sh
+++ b/agent/hooks/pr-review-resolver.sh
@@ -42,16 +42,15 @@ case "$BRANCH" in
     ;;
 esac
 
-ensure_reviews_dir
-sweep_stale_worktrees "resolver"
-log "matched: ${COMMAND} (branch=${BRANCH})"
-
 HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || true)
 PR=$(gh pr view "$BRANCH" --json number -q .number 2>/dev/null || true)
 if [[ -z "$PR" ]]; then
-  log "no PR for branch ${BRANCH}, exiting"
   exit 0
 fi
+
+ensure_reviews_dir
+sweep_stale_worktrees "resolver"
+log "matched: ${COMMAND} (branch=${BRANCH})"
 
 LOCKFILE="${REVIEWS_DIR}/.resolver-${BRANCH//\//_}.lock"
 TOKEN=$(gen_id)
@@ -93,8 +92,5 @@ REVIEW_FILE=$(run_review "pr-review-resolver" "$META" "$PROMPT" "RESOLVER_DRY_RU
 
 log "wrote ${REVIEW_FILE}"
 
-printf 'pr-review-resolver report for PR #%s (branch %s, origin HEAD %s) at %s.\n' \
-  "$PR" "$BRANCH" "${HEAD_SHA:0:7}" "$REVIEW_FILE" >&2
-printf 'If your current HEAD is not %s, this advisory crossed sessions — verify before acting.\n' \
-  "${HEAD_SHA:0:7}" >&2
+emit_rewake_stamp "pr-review-resolver" "$PR" "$BRANCH" "$HEAD_SHA" "$REVIEW_FILE"
 exit 2

--- a/agent/hooks/pr-review-resolver.sh
+++ b/agent/hooks/pr-review-resolver.sh
@@ -79,12 +79,19 @@ WT=$(make_isolated_worktree "resolver" "$HEAD_SHA") || {
 trap 'remove_worktree "$WT"' EXIT
 cd "$WT"
 
+# You run in a detached worktree pinned to ${BRANCH}'s captured HEAD. The
+# branch itself is checked out in the user's primary worktree, so
+# `git checkout ${BRANCH}` will fail (git forbids the same branch in two
+# worktrees) and `git push` with no args has no upstream. Commit on the
+# detached HEAD, then publish with `git push origin HEAD:${BRANCH}`.
+WORKTREE_NOTE="Running in a detached worktree pinned to ${BRANCH} (HEAD ${HEAD_SHA:0:7}). Do not run \`git checkout ${BRANCH}\` — the branch is already checked out in the user's main worktree. Commit on the detached HEAD; push with \`git push origin HEAD:${BRANCH}\`."
+
 if has_skill pr-review-resolver; then
   log "using pr-review-resolver skill"
-  PROMPT="Use the pr-review-resolver skill for PR #${PR} on branch ${BRANCH} (HEAD ${HEAD_SHA:0:7})."
+  PROMPT="Use the pr-review-resolver skill for PR #${PR} on branch ${BRANCH} (HEAD ${HEAD_SHA:0:7}). ${WORKTREE_NOTE}"
 else
   log "pr-review-resolver skill not found, using fallback prompt"
-  PROMPT="PR #${PR} on branch ${BRANCH} (HEAD ${HEAD_SHA:0:7}). Fetch review comments with 'gh pr view ${PR} --json reviews,comments' and 'gh api repos/{owner}/{repo}/pulls/${PR}/comments'. Address each actionable comment; reply inline to each comment you addressed with the fix commit SHA. Ignore nits unless trivial."
+  PROMPT="PR #${PR} on branch ${BRANCH} (HEAD ${HEAD_SHA:0:7}). Fetch review comments with 'gh pr view ${PR} --json reviews,comments' and 'gh api repos/{owner}/{repo}/pulls/${PR}/comments'. Address each actionable comment; reply inline to each comment you addressed with the fix commit SHA. Ignore nits unless trivial. ${WORKTREE_NOTE}"
 fi
 
 META=$(printf 'PR: #%s\nBranch: %s\nHEAD: %s\n' "$PR" "$BRANCH" "$HEAD_SHA")

--- a/agent/hooks/pr-review-resolver.sh
+++ b/agent/hooks/pr-review-resolver.sh
@@ -20,7 +20,7 @@
 #
 # Env overrides: RESOLVER_SLEEP_SECS overrides the 360s wait (tests use 1s);
 # RESOLVER_DRY_RUN=1 skips the agent call; AGENT_HEADLESS=claude|codex pins
-# the CLI; AGENT_TIMEOUT_SECS bounds the headless run (default 900s).
+# the CLI; AGENT_TIMEOUT_SECS bounds the headless run (default 800s).
 set -euo pipefail
 
 export HOOK_NAME="pr-review-resolver"

--- a/agent/hooks/pr-review-resolver.sh
+++ b/agent/hooks/pr-review-resolver.sh
@@ -1,16 +1,26 @@
 #!/usr/bin/env bash
 # pr-review-resolver.sh — PostToolUse hook on `git push`. Waits ~6min for CI
 # and reviewers to settle, then runs the pr-review-resolver skill (or an
-# inline fallback) headlessly. Writes to .agent-reviews/pr-review-resolver-<uuid>.md
-# and exits 2 with a pointer; never blocks.
+# inline fallback) headlessly in a detached worktree pinned to the captured
+# HEAD. Writes to .agent-reviews/pr-review-resolver-<uuid>.md in the main repo
+# and exits 2 with a metadata-stamped pointer; never blocks.
 #
-# Gates (all silent early-exit, no wait wasted): cmd does not contain "git push",
-# current branch is main/master, a newer push overwrote our lock, no PR for the branch.
-# Lockfile dedupe: write a per-branch token under .agent-reviews; after the sleep,
-# re-read — if the token changed, a newer push is in flight and this run exits.
+# Worktree isolation: the headless agent's cwd is a temporary worktree under
+# $WORKTREES_DIR. This prevents the agent from `git checkout`-ing over the
+# user's main worktree if the prompt asks it to switch branches, and keeps the
+# resolver's PR/branch resolution stable while the user is free to branch-hop.
+#
+# Bails (all silent early-exit, before sleep and before worktree creation):
+# cmd does not contain "git push", current branch is main/master, no PR for
+# the captured branch.
+#
+# Lockfile dedupe: per-branch token under $REVIEWS_DIR; after the sleep we
+# re-read. If the token changed, a newer push is in flight and this run exits
+# without creating its worktree.
 #
 # Env overrides: RESOLVER_SLEEP_SECS overrides the 360s wait (tests use 1s);
-# RESOLVER_DRY_RUN=1 skips the agent call; AGENT_HEADLESS=claude|codex pins the CLI.
+# RESOLVER_DRY_RUN=1 skips the agent call; AGENT_HEADLESS=claude|codex pins
+# the CLI; AGENT_TIMEOUT_SECS bounds the headless run (default 900s).
 set -euo pipefail
 
 export HOOK_NAME="pr-review-resolver"
@@ -33,7 +43,15 @@ case "$BRANCH" in
 esac
 
 ensure_reviews_dir
+sweep_stale_worktrees "resolver"
 log "matched: ${COMMAND} (branch=${BRANCH})"
+
+HEAD_SHA=$(git rev-parse HEAD 2>/dev/null || true)
+PR=$(gh pr view "$BRANCH" --json number -q .number 2>/dev/null || true)
+if [[ -z "$PR" ]]; then
+  log "no PR for branch ${BRANCH}, exiting"
+  exit 0
+fi
 
 LOCKFILE="${REVIEWS_DIR}/.resolver-${BRANCH//\//_}.lock"
 TOKEN=$(gen_id)
@@ -55,25 +73,28 @@ if [[ "$CURRENT_TOKEN" != "$TOKEN" ]]; then
   exit 0
 fi
 
-PR=$(gh pr view --json number -q .number 2>/dev/null || true)
-if [[ -z "$PR" ]]; then
-  log "no PR for branch ${BRANCH}, exiting"
+WT=$(make_isolated_worktree "resolver" "$HEAD_SHA") || {
+  log "worktree creation failed for ${HEAD_SHA}, exiting"
   exit 0
-fi
+}
+trap 'remove_worktree "$WT"' EXIT
+cd "$WT"
 
 if has_skill pr-review-resolver; then
   log "using pr-review-resolver skill"
-  PROMPT="Use the pr-review-resolver skill for PR #${PR} on branch ${BRANCH}."
+  PROMPT="Use the pr-review-resolver skill for PR #${PR} on branch ${BRANCH} (HEAD ${HEAD_SHA:0:7})."
 else
   log "pr-review-resolver skill not found, using fallback prompt"
-  PROMPT="PR #${PR} on branch ${BRANCH}. Fetch review comments with 'gh pr view ${PR} --json reviews,comments' and 'gh api repos/{owner}/{repo}/pulls/${PR}/comments'. Address each actionable comment; reply inline to each comment you addressed with the fix commit SHA. Ignore nits unless trivial."
+  PROMPT="PR #${PR} on branch ${BRANCH} (HEAD ${HEAD_SHA:0:7}). Fetch review comments with 'gh pr view ${PR} --json reviews,comments' and 'gh api repos/{owner}/{repo}/pulls/${PR}/comments'. Address each actionable comment; reply inline to each comment you addressed with the fix commit SHA. Ignore nits unless trivial."
 fi
 
-META=$(printf 'PR: #%s\nBranch: %s\n' "$PR" "$BRANCH")
+META=$(printf 'PR: #%s\nBranch: %s\nHEAD: %s\n' "$PR" "$BRANCH" "$HEAD_SHA")
 REVIEW_FILE=$(run_review "pr-review-resolver" "$META" "$PROMPT" "RESOLVER_DRY_RUN")
 
 log "wrote ${REVIEW_FILE}"
 
-printf 'pr-review-resolver report for PR #%s at %s. Advisory — read it and act on unresolved items.\n' \
-  "$PR" "$REVIEW_FILE" >&2
+printf 'pr-review-resolver report for PR #%s (branch %s, origin HEAD %s) at %s.\n' \
+  "$PR" "$BRANCH" "${HEAD_SHA:0:7}" "$REVIEW_FILE" >&2
+printf 'If your current HEAD is not %s, this advisory crossed sessions — verify before acting.\n' \
+  "${HEAD_SHA:0:7}" >&2
 exit 2

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -466,7 +466,7 @@ T_resolver_sweeps_stale_worktrees_on_start() {
   export RESOLVER_SLEEP_SECS=1 RESOLVER_DRY_RUN=1 GH_STUB_PR=99
   resolver_setup_feature_branch "feature-sweep"
   mkdir -p "$stale"
-  touch -d "@$(($(date +%s) - 3600))" "$stale"
+  perl -e '$t = time - 3600; utime $t, $t, @ARGV or die "utime failed: $!"' "$stale"
   echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh >/dev/null 2>&1 || true
   [[ ! -d "$stale" ]] || {
     echo "stale worktree directory survived the sweep: $stale"

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -92,10 +92,8 @@ it() {
 }
 
 reset_sandbox() {
-  # Drop any worktrees a previous test registered against this sandbox repo so
-  # the next test's `git worktree add` can claim a fresh path. The main
-  # worktree (current pwd) is skipped — `git worktree remove` refuses it
-  # anyway, but the explicit guard makes the intent clear.
+  # Drop linked worktrees from prior tests so the next `git worktree add` is
+  # free to claim a fresh path; skip the main worktree explicitly.
   local self wt
   self=$(pwd)
   while IFS= read -r wt; do

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -38,8 +38,21 @@ git commit -q --allow-empty -m init
 
 STUBS="$TEST_DIR/stubs"
 mkdir -p "$STUBS"
+# `claude` stub: records $PWD and `git rev-parse HEAD` to caller-supplied files
+# so worktree-isolation tests can assert the headless agent ran inside a
+# detached worktree pinned to the captured HEAD. CLAUDE_STUB_SLEEP_SECS forces
+# a sleep so timeout-wrapping tests can exercise the timeout path.
 cat > "$STUBS/claude" <<'EOF'
 #!/usr/bin/env bash
+if [[ -n "${CLAUDE_STUB_PWD_FILE:-}" ]]; then
+  pwd > "$CLAUDE_STUB_PWD_FILE"
+fi
+if [[ -n "${CLAUDE_STUB_HEAD_FILE:-}" ]]; then
+  git rev-parse HEAD > "$CLAUDE_STUB_HEAD_FILE" 2>/dev/null || true
+fi
+if [[ -n "${CLAUDE_STUB_SLEEP_SECS:-}" ]]; then
+  sleep "$CLAUDE_STUB_SLEEP_SECS"
+fi
 if [[ "${AGENT_STUB_FAIL:-0}" == "1" ]]; then
   echo "simulated headless agent auth failure" >&2
   exit 3
@@ -47,9 +60,14 @@ fi
 echo "# STUB headless agent output"
 echo "# prompt was: $*"
 EOF
+# `gh` stub: $GH_STUB_PR governs `gh pr view`'s number output. When
+# $GH_STUB_LOG is set, every invocation appends its argv there so tests can
+# assert explicit-branch arg passing (`gh pr view <branch>`).
 cat > "$STUBS/gh" <<'EOF'
 #!/usr/bin/env bash
-# Minimal stub. $GH_STUB_PR governs `gh pr view`'s number output.
+if [[ -n "${GH_STUB_LOG:-}" ]]; then
+  printf '%s\n' "$*" >> "$GH_STUB_LOG"
+fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
   if [[ -n "${GH_STUB_PR:-}" ]]; then
     echo "${GH_STUB_PR}"
@@ -74,6 +92,17 @@ it() {
 }
 
 reset_sandbox() {
+  # Drop any worktrees a previous test registered against this sandbox repo so
+  # the next test's `git worktree add` can claim a fresh path. The main
+  # worktree (current pwd) is skipped — `git worktree remove` refuses it
+  # anyway, but the explicit guard makes the intent clear.
+  local self wt
+  self=$(pwd)
+  while IFS= read -r wt; do
+    [[ -z "$wt" || "$wt" == "$self" ]] && continue
+    git worktree remove --force "$wt" >/dev/null 2>&1 || true
+  done < <(git worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2}')
+  git worktree prune >/dev/null 2>&1 || true
   rm -rf .agent-reviews
 }
 
@@ -300,6 +329,243 @@ T_resolver_invalid_sleep_secs() {
   fi
 }
 it "pr-review-resolver: invalid RESOLVER_SLEEP_SECS falls back to default (not set -e abort)" T_resolver_invalid_sleep_secs
+
+# ---------------------------------------------------------------------------
+# pr-review-resolver — worktree isolation + cross-session safety
+# ---------------------------------------------------------------------------
+# Pin the cascade-bug fixes: (1) the headless agent's cwd must NOT be the
+# user's main worktree, so a prompt that asks it to switch branches can't
+# `git checkout` over uncommitted work; (2) the report file must land in the
+# main repo's $REVIEWS_DIR (absolute path), not the temp worktree's, so the
+# receiving session can read it after the EXIT trap cleans the worktree;
+# (3) the rewake stderr stamps origin HEAD/branch/PR so a session that
+# receives a cross-session leak can detect it.
+
+resolver_setup_feature_branch() {
+  # Usage: resolver_setup_feature_branch <branch>
+  # `--allow-empty` keeps each branch's HEAD distinct from init without
+  # depending on a tracked marker file (which would clash across tests that
+  # reuse the sandbox repo).
+  local branch="$1"
+  git checkout -q -b "$branch" 2>/dev/null || git checkout -q "$branch"
+  git commit -q --allow-empty -m "feature commit on $branch"
+}
+
+T_resolver_headless_agent_runs_in_isolated_worktree() {
+  local pwd_file head_file pwd_seen head_seen sandbox_root sandbox_head
+  pwd_file="$TEST_DIR/claude-pwd.txt"
+  head_file="$TEST_DIR/claude-head.txt"
+  rm -f "$pwd_file" "$head_file"
+  export RESOLVER_SLEEP_SECS=1 GH_STUB_PR=99
+  export CLAUDE_STUB_PWD_FILE="$pwd_file" CLAUDE_STUB_HEAD_FILE="$head_file"
+  resolver_setup_feature_branch "feature-iso"
+  sandbox_root=$(pwd)
+  sandbox_head=$(git rev-parse HEAD)
+  echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh >/dev/null 2>&1 || true
+  [[ -f "$pwd_file" ]] || { echo "claude stub did not record PWD — headless agent not invoked"; return 1; }
+  pwd_seen=$(cat "$pwd_file")
+  head_seen=$(cat "$head_file" 2>/dev/null || echo "")
+  [[ "$pwd_seen" != "$sandbox_root" ]] || {
+    echo "headless agent ran from sandbox repo root ($sandbox_root) — worktree isolation failed"
+    return 1
+  }
+  [[ "$pwd_seen" == *"/worktrees/"* ]] || {
+    echo "expected pwd under .agent-reviews/worktrees/, got: $pwd_seen"
+    return 1
+  }
+  [[ "$head_seen" == "$sandbox_head" ]] || {
+    echo "worktree HEAD ($head_seen) != captured sandbox HEAD ($sandbox_head)"
+    return 1
+  }
+}
+it "pr-review-resolver: headless agent runs inside isolated worktree pinned to captured HEAD" T_resolver_headless_agent_runs_in_isolated_worktree
+
+T_resolver_report_lands_in_main_repo() {
+  local report
+  export RESOLVER_SLEEP_SECS=1 GH_STUB_PR=99
+  unset CLAUDE_STUB_PWD_FILE CLAUDE_STUB_HEAD_FILE
+  resolver_setup_feature_branch "feature-report-path"
+  echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh >/dev/null 2>&1 || true
+  report=$(find .agent-reviews -maxdepth 1 -name 'pr-review-resolver-*.md' 2>/dev/null | head -1)
+  [[ -n "$report" ]] || {
+    echo "report missing from main repo .agent-reviews/ — anything under worktrees/?"
+    find .agent-reviews -name 'pr-review-resolver-*.md' 2>/dev/null
+    return 1
+  }
+}
+it "pr-review-resolver: report file lands in main repo .agent-reviews/, not the worktree" T_resolver_report_lands_in_main_repo
+
+T_resolver_worktree_cleaned_up_after_exit() {
+  export RESOLVER_SLEEP_SECS=1 GH_STUB_PR=99
+  resolver_setup_feature_branch "feature-cleanup"
+  echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh >/dev/null 2>&1 || true
+  if compgen -G ".agent-reviews/worktrees/resolver-*" >/dev/null; then
+    echo "worktree directory still present after hook exit:"
+    ls -la .agent-reviews/worktrees/
+    return 1
+  fi
+}
+it "pr-review-resolver: EXIT trap removes the worktree after hook completes" T_resolver_worktree_cleaned_up_after_exit
+
+T_resolver_stderr_stamps_origin_head_branch_pr() {
+  local stderr_file head_full head_short
+  stderr_file="$TEST_DIR/stderr.txt"
+  export RESOLVER_SLEEP_SECS=1 RESOLVER_DRY_RUN=1 GH_STUB_PR=99
+  resolver_setup_feature_branch "feature-stamp"
+  head_full=$(git rev-parse HEAD)
+  head_short="${head_full:0:7}"
+  echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh 2>"$stderr_file" || true
+  grep -q "PR #99" "$stderr_file" || { echo "stderr missing PR number; got: $(cat "$stderr_file")"; return 1; }
+  grep -q "branch feature-stamp" "$stderr_file" || { echo "stderr missing branch name; got: $(cat "$stderr_file")"; return 1; }
+  grep -qE "origin HEAD ${head_short}" "$stderr_file" || {
+    echo "stderr missing origin HEAD short sha ($head_short); got: $(cat "$stderr_file")"
+    return 1
+  }
+  grep -q "crossed sessions" "$stderr_file" || {
+    echo "stderr missing cross-session caveat; got: $(cat "$stderr_file")"
+    return 1
+  }
+}
+it "pr-review-resolver: rewake stderr stamps PR/branch/origin-HEAD so receivers can detect cross-session leaks" T_resolver_stderr_stamps_origin_head_branch_pr
+
+T_resolver_gh_pr_view_uses_explicit_branch() {
+  local gh_log
+  gh_log="$TEST_DIR/gh-log.txt"
+  rm -f "$gh_log"
+  export RESOLVER_SLEEP_SECS=1 RESOLVER_DRY_RUN=1 GH_STUB_PR=99 GH_STUB_LOG="$gh_log"
+  resolver_setup_feature_branch "feature-gh-arg"
+  echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh >/dev/null 2>&1 || true
+  grep -qE '^pr view feature-gh-arg ' "$gh_log" || {
+    echo "expected 'gh pr view feature-gh-arg ...' invocation, log was:"
+    cat "$gh_log"
+    return 1
+  }
+}
+it "pr-review-resolver: gh pr view is called with the captured branch as an explicit arg" T_resolver_gh_pr_view_uses_explicit_branch
+
+T_resolver_bails_skip_worktree_creation() {
+  export RESOLVER_SLEEP_SECS=1 RESOLVER_DRY_RUN=1
+  # (a) main branch: no PR lookup, no worktree
+  git checkout -q -b main 2>/dev/null || git checkout -q main
+  export GH_STUB_PR=99
+  echo '{"tool_input":{"command":"git push origin main"}}' | bash agent/hooks/pr-review-resolver.sh >/dev/null 2>&1 || true
+  if compgen -G ".agent-reviews/worktrees/resolver-*" >/dev/null; then
+    echo "main-branch bail leaked a worktree"; return 1
+  fi
+  # (b) no PR: gh stub returns nothing, no worktree
+  resolver_setup_feature_branch "feature-bail-no-pr"
+  unset GH_STUB_PR
+  echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh >/dev/null 2>&1 || true
+  if compgen -G ".agent-reviews/worktrees/resolver-*" >/dev/null; then
+    echo "no-PR bail leaked a worktree"; return 1
+  fi
+}
+it "pr-review-resolver: main-branch and no-PR bails skip worktree creation" T_resolver_bails_skip_worktree_creation
+
+T_resolver_sweeps_stale_worktrees_on_start() {
+  local stale
+  stale=".agent-reviews/worktrees/resolver-stale-abcdef1234"
+  export RESOLVER_SLEEP_SECS=1 RESOLVER_DRY_RUN=1 GH_STUB_PR=99
+  resolver_setup_feature_branch "feature-sweep"
+  mkdir -p "$stale"
+  touch -d "@$(($(date +%s) - 3600))" "$stale"
+  echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh >/dev/null 2>&1 || true
+  [[ ! -d "$stale" ]] || {
+    echo "stale worktree directory survived the sweep: $stale"
+    return 1
+  }
+}
+it "pr-review-resolver: sweeps leaked resolver-* worktrees older than 30 minutes on hook start" T_resolver_sweeps_stale_worktrees_on_start
+
+T_resolver_headless_timeout_yields_failed_report() {
+  local report
+  export RESOLVER_SLEEP_SECS=1 GH_STUB_PR=99
+  export CLAUDE_STUB_SLEEP_SECS=5 AGENT_TIMEOUT_SECS=1
+  resolver_setup_feature_branch "feature-timeout"
+  echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh >/dev/null 2>&1 || true
+  report=$(find .agent-reviews -maxdepth 1 -name 'pr-review-resolver-*.md' 2>/dev/null | head -1)
+  [[ -n "$report" ]] || { echo "report missing after timeout"; return 1; }
+  grep -q "FAILED" "$report" || {
+    echo "expected FAILED marker in timeout report; got:"
+    cat "$report"
+    return 1
+  }
+  # GNU timeout exits 124 on TERM; the report header records that code.
+  awk '/^## headless agent exit code$/{getline; print; exit}' "$report" | grep -qE '^124$' || {
+    echo "expected exit code 124 (timeout) in report, got:"
+    awk '/^## headless agent exit code$/{getline; print; exit}' "$report"
+    return 1
+  }
+}
+it "pr-review-resolver: AGENT_TIMEOUT_SECS bounds the headless agent and surfaces exit 124 in the report" T_resolver_headless_timeout_yields_failed_report
+
+# ---------------------------------------------------------------------------
+# doc-drift — worktree isolation + cross-session safety
+# ---------------------------------------------------------------------------
+
+T_doc_drift_headless_agent_runs_in_isolated_worktree() {
+  local pwd_file head_file pwd_seen head_seen sandbox_root sandbox_head
+  pwd_file="$TEST_DIR/claude-pwd.txt"
+  head_file="$TEST_DIR/claude-head.txt"
+  rm -f "$pwd_file" "$head_file"
+  export GH_STUB_PR=42
+  export CLAUDE_STUB_PWD_FILE="$pwd_file" CLAUDE_STUB_HEAD_FILE="$head_file"
+  resolver_setup_feature_branch "drift-iso"
+  sandbox_root=$(pwd)
+  sandbox_head=$(git rev-parse HEAD)
+  echo '{"tool_input":{"command":"gh pr create --title x"}}' | bash agent/hooks/doc-drift.sh >/dev/null 2>&1 || true
+  [[ -f "$pwd_file" ]] || { echo "claude stub did not record PWD — headless agent not invoked"; return 1; }
+  pwd_seen=$(cat "$pwd_file")
+  head_seen=$(cat "$head_file" 2>/dev/null || echo "")
+  [[ "$pwd_seen" != "$sandbox_root" ]] || {
+    echo "doc-drift headless agent ran from sandbox repo root — worktree isolation failed"
+    return 1
+  }
+  [[ "$pwd_seen" == *"/worktrees/"* ]] || {
+    echo "expected pwd under .agent-reviews/worktrees/, got: $pwd_seen"
+    return 1
+  }
+  [[ "$head_seen" == "$sandbox_head" ]] || {
+    echo "doc-drift worktree HEAD ($head_seen) != captured sandbox HEAD ($sandbox_head)"
+    return 1
+  }
+}
+it "doc-drift: headless agent runs inside isolated worktree pinned to captured HEAD" T_doc_drift_headless_agent_runs_in_isolated_worktree
+
+T_doc_drift_stderr_stamps_origin_head_branch_pr() {
+  local stderr_file head_short
+  stderr_file="$TEST_DIR/stderr.txt"
+  export GH_STUB_PR=42 DOC_DRIFT_DRY_RUN=1
+  resolver_setup_feature_branch "drift-stamp"
+  head_short=$(git rev-parse HEAD); head_short="${head_short:0:7}"
+  echo '{"tool_input":{"command":"gh pr create --title x"}}' | bash agent/hooks/doc-drift.sh 2>"$stderr_file" || true
+  grep -q "PR #42" "$stderr_file" || { echo "stderr missing PR; got: $(cat "$stderr_file")"; return 1; }
+  grep -q "branch drift-stamp" "$stderr_file" || { echo "stderr missing branch; got: $(cat "$stderr_file")"; return 1; }
+  grep -qE "origin HEAD ${head_short}" "$stderr_file" || {
+    echo "stderr missing origin HEAD; got: $(cat "$stderr_file")"
+    return 1
+  }
+  grep -q "crossed sessions" "$stderr_file" || {
+    echo "stderr missing cross-session caveat; got: $(cat "$stderr_file")"
+    return 1
+  }
+}
+it "doc-drift: rewake stderr stamps PR/branch/origin-HEAD so receivers can detect cross-session leaks" T_doc_drift_stderr_stamps_origin_head_branch_pr
+
+T_doc_drift_gh_pr_view_uses_explicit_branch() {
+  local gh_log
+  gh_log="$TEST_DIR/gh-log.txt"
+  rm -f "$gh_log"
+  export GH_STUB_PR=42 DOC_DRIFT_DRY_RUN=1 GH_STUB_LOG="$gh_log"
+  resolver_setup_feature_branch "drift-gh-arg"
+  echo '{"tool_input":{"command":"gh pr create --title x"}}' | bash agent/hooks/doc-drift.sh >/dev/null 2>&1 || true
+  grep -qE '^pr view drift-gh-arg ' "$gh_log" || {
+    echo "expected 'gh pr view drift-gh-arg ...' invocation, log was:"
+    cat "$gh_log"
+    return 1
+  }
+}
+it "doc-drift: gh pr view is called with the captured branch as an explicit arg" T_doc_drift_gh_pr_view_uses_explicit_branch
 
 # ===========================================================================
 # pre-pr-review-gate.sh


### PR DESCRIPTION
## Summary

The `pr-review-resolver` and `doc-drift` PostToolUse hooks spawned their headless `claude -p` / `codex exec` runs inside the user's primary checkout. If the prompt asked the agent to switch branches — or the resolver's lazy `gh pr view` returned a PR for a different branch after its 6-minute sleep — the headless agent would `git checkout <other-branch>`, commit, push, and `git checkout`-back **mid-edit in the active session's worktree**. Observed live on PR #1163: the resolver, fired by a push on `fix/hook-bugs-1158`, dispatched a headless agent that switched the active worktree to `docs/skypilot-launch-ad-hoc-clarification-1157` to fix Copilot comments there. `asyncRewake` then delivered the advisory to the wrong session.

This PR lands the bundled fix: worktree isolation, branch-explicit PR resolution, absolute report paths, origin-HEAD-stamped advisories, a timeout-wrapped headless agent, and a stale-worktree sweep.

## Fixes

| # | Defect | Fix |
| - | - | - |
| 1 | Headless agent runs in user's main checkout | `make_isolated_worktree` creates a detached git worktree at the captured HEAD; the hook `cd`s in before `run_review`; `trap remove_worktree` cleans on exit. |
| 2 | `gh pr view` runs without `--branch` arg after a 6-min sleep, PR drifts | `gh pr view "$BRANCH"` — branch arg is always the value captured at hook fire time. |
| 3 | Reports written under the temp worktree → deleted before receiving session reads them | `$REVIEWS_DIR` / `$HOOK_LOG` / `$WORKTREES_DIR` resolve to absolute paths in the main repo via `git rev-parse --git-common-dir`. |
| 4 | Cross-session rewake leakage is invisible to the receiver | New `emit_rewake_stamp` adds `branch X, origin HEAD <sha7>` plus a `crossed sessions` caveat. AGENTS.md documents the receiving-side `git rev-parse HEAD` check. |
| 5 | Hung headless agent stays alive until the harness SIGKILLs | `run_agent_prompt` now wraps the CLI in `timeout --kill-after=10 "${AGENT_TIMEOUT_SECS:-900}"`. Timeouts surface as exit 124 → FAILED report. |
| 6 | EXIT trap missed when the harness SIGKILLs the hook → leaked worktrees accrete | `sweep_stale_worktrees` removes `<slug>-*` worktrees older than 30 min on every hook start. |

## Files

| File | Change |
| - | - |
| `agent/hooks/_lib.sh` | `_repo_root_for_hooks`, `$_REPO_ROOT_FOR_HOOKS`, absolute `$REVIEWS_DIR`/`$HOOK_LOG`/`$WORKTREES_DIR`; `make_isolated_worktree` / `remove_worktree` / `sweep_stale_worktrees`; `emit_rewake_stamp`; `timeout --kill-after=10` wrap; `has_skill` now consumes `$_REPO_ROOT_FOR_HOOKS`. |
| `agent/hooks/pr-review-resolver.sh` | bails-first ordering; explicit-branch `gh pr view`; worktree isolation; trap'd cleanup; stamped rewake via `emit_rewake_stamp`. |
| `agent/hooks/doc-drift.sh` | same shape as resolver (no sleep, no lockfile). |
| `agent/hooks/test.sh` | 11 new tests pinning every fix; extended `claude` stub records PWD/HEAD/sleep; `gh` stub appends argv to `$GH_STUB_LOG`; `reset_sandbox` drops linked worktrees between tests. |
| `AGENTS.md` | one bullet documenting the origin-HEAD-stamp contract receivers must check. |

## Test plan

- [x] `bash agent/hooks/test.sh` → **43 PASS, 0 FAIL** (was 32; +11 new isolation/stamp/timeout tests).
- [x] `pytest tests/claude_hooks/ -q` → **110 passed** (no settings.json shape regressions).
- [x] `pre-commit run --files <touched>` → all relevant hooks pass on every staged commit.
- [x] **Dogfood**: this PR was developed while a background hook from another session checked out `main` in the primary worktree twice during the implementation (preserved in reflog). The fix isolates such headless runs into their own worktrees so the cascade cannot recur after merge.
- [ ] CI green on this PR.

## Pre-PR review

In lieu of `/repo-review-full-no-comments`, this PR was reviewed via three parallel sub-agents (reuse / quality / efficiency) — see commit `8515e46`. Five actionable findings were applied: cached `_REPO_ROOT_FOR_HOOKS` reused by `has_skill` (was duplicated), `emit_rewake_stamp` extracted (was verbatim-duplicated load-bearing wording), bail-ordering moved past the no-PR exit, `--kill-after=10` added, over-long comments compressed. Skipped findings: resolver↔doc-drift wrapper extraction (correctly judged too divergent for two callers), `HOOK_SLUG` constant (different namespaces deliberately use short vs long slugs), DRY_RUN-skip-worktree (would weaken test semantics).

Fixes #1176

<!-- REVIEW_FULL_DONE=1 -->