### PR TITLE
feat(pipeline)!: reshard h5 datas with shard size from DatasetSpec

### DIFF
--- a/src/synth_setter/pipeline/data/reshard.py
+++ b/src/synth_setter/pipeline/data/reshard.py
@@ -1,35 +1,73 @@
+"""Reshard a directory of HDF5 shards into train/val/test virtual datasets.
+
+Both the split sizes *and* the exact shard filenames come from
+``<dataset_root>/input_spec.json`` (written once by the launcher at
+``@hydra.main`` and uploaded alongside the shards). The CLI reads
+``spec.shards`` in order and slices into ``{train, val, test}.h5``
+according to ``spec.train_val_test_sizes // spec.render.samples_per_shard``;
+``spec.render.samples_per_shard`` is the single source of truth, so
+there is no shard-size override flag to drift against it.
+"""
+
 from pathlib import Path
 
 import click
 import h5py
 import numpy as np
 
+from synth_setter.cli.generate_dataset import load_spec_from_uri
+from synth_setter.pipeline.constants import INPUT_SPEC_FILENAME
+
 
 @click.command()
-@click.argument("dataset_root", type=str)
-@click.option("--train-samples", "-t", type=int, default=200)
-@click.option("--val-samples", "-v", type=int, default=4)
-@click.option("--test-samples", "-e", type=int, default=1)
-def main(
-    dataset_root: str,
-    train_samples: int = 200,
-    val_samples: int = 4,
-    test_samples: int = 1,
-):
-    dataset_root = Path(dataset_root)
-    files = dataset_root.glob("shard-*.h5")
-    files = sorted(list(files))
-    assert len(files) == train_samples + val_samples + test_samples
+@click.argument("dataset_root", type=click.Path(file_okay=False, path_type=Path))
+@click.option(
+    "--spec",
+    "spec_uri",
+    type=str,
+    default=None,
+    help=(
+        "Local path or ``r2://bucket/key`` URI of the materialized DatasetSpec JSON "
+        "(``r2://`` is downloaded via rclone — ``RCLONE_CONFIG_R2_*`` env vars must be set). "
+        f"Defaults to ``<dataset_root>/{INPUT_SPEC_FILENAME}``."
+    ),
+)
+def main(dataset_root: Path, spec_uri: str | None) -> None:
+    """Split shards under ``dataset_root`` into ``{train,val,test}.h5`` virtual datasets.
 
+    :param dataset_root: Directory containing the shard files named by ``spec.shards``.
+    :param spec_uri: Optional local path or ``r2://`` URI for the DatasetSpec;
+        defaults to ``<dataset_root>/input_spec.json``.
+    :raises click.ClickException: If any ``spec.train_val_test_sizes`` entry is not
+        evenly divisible by ``spec.render.samples_per_shard``.
+    """
+    spec = load_spec_from_uri(spec_uri or str(dataset_root / INPUT_SPEC_FILENAME))
+
+    shard_size = spec.render.samples_per_shard
+    bad = [sz for sz in spec.train_val_test_sizes if sz % shard_size != 0]
+    if bad:
+        # DatasetSpec._split_sizes_must_be_multiples_of_samples_per_shard normally
+        # rejects this at parse time; this guard catches the case where a stale
+        # spec from R2 predates that validator.
+        raise click.ClickException(
+            f"spec.train_val_test_sizes={list(spec.train_val_test_sizes)} contains "
+            f"sizes not divisible by spec.render.samples_per_shard={shard_size}: "
+            f"{bad}"
+        )
+
+    files = [dataset_root / s.filename for s in spec.shards]
+    train_n, val_n, _ = (sz // shard_size for sz in spec.train_val_test_sizes)
     splits = {
-        "train": files[:train_samples],
-        "val": files[train_samples : train_samples + val_samples],
-        "test": files[train_samples + val_samples :],
+        "train": files[:train_n],
+        "val": files[train_n : train_n + val_n],
+        "test": files[train_n + val_n :],
     }
 
     for split, files in splits.items():
-        print(split)
-        split_len = len(files) * 10_000
+        if not files:
+            continue
+        click.echo(f"{split}: {len(files)} shards")
+        split_len = len(files) * shard_size
 
         with h5py.File(files[0], "r") as f:
             audio_shape = f["audio"].shape[1:]
@@ -42,25 +80,23 @@ def main(
 
         for i, file in enumerate(files):
             vs_audio = h5py.VirtualSource(
-                file, "audio", dtype=np.float32, shape=(10_000, *audio_shape)
+                file, "audio", dtype=np.float32, shape=(shard_size, *audio_shape)
             )
             vs_mel = h5py.VirtualSource(
-                file, "mel_spec", dtype=np.float32, shape=(10_000, *mel_shape)
+                file, "mel_spec", dtype=np.float32, shape=(shard_size, *mel_shape)
             )
             vs_param = h5py.VirtualSource(
-                file, "param_array", dtype=np.float32, shape=(10_000, *param_shape)
+                file, "param_array", dtype=np.float32, shape=(shard_size, *param_shape)
             )
 
-            range_start = i * 10_000
-            range_end = (i + 1) * 10_000
+            range_start = i * shard_size
+            range_end = (i + 1) * shard_size
 
-            print(range_start, range_end)
             vl_audio[range_start:range_end, :, :] = vs_audio
             vl_mel[range_start:range_end, :, :, :] = vs_mel
             vl_param[range_start:range_end, :] = vs_param
 
-        split_file = str(dataset_root / f"{split}.h5")
-        with h5py.File(split_file, "w") as f:
+        with h5py.File(dataset_root / f"{split}.h5", "w") as f:
             f.create_virtual_dataset("audio", vl_audio)
             f.create_virtual_dataset("mel_spec", vl_mel)
             f.create_virtual_dataset("param_array", vl_param)

--- a/src/synth_setter/pipeline/data/reshard.py
+++ b/src/synth_setter/pipeline/data/reshard.py
@@ -38,17 +38,36 @@ def main(dataset_root: Path, spec_uri: str | None) -> None:
     :param dataset_root: Directory containing the shard files named by ``spec.shards``.
     :param spec_uri: Optional local path or ``r2://`` URI for the DatasetSpec;
         defaults to ``<dataset_root>/input_spec.json``.
-    :raises click.ClickException: If any ``spec.train_val_test_sizes`` entry is not
-        evenly divisible by ``spec.render.samples_per_shard``.
+    :raises click.ClickException: If the spec cannot be located, parsed, or
+        declares a non-HDF5 ``output_format``; or if any
+        ``spec.train_val_test_sizes`` entry is not divisible by
+        ``spec.render.samples_per_shard``.
     """
-    spec = load_spec_from_uri(spec_uri or str(dataset_root / INPUT_SPEC_FILENAME))
+    resolved_uri = spec_uri or str(dataset_root / INPUT_SPEC_FILENAME)
+    try:
+        spec = load_spec_from_uri(resolved_uri)
+    except FileNotFoundError as exc:
+        raise click.ClickException(f"DatasetSpec not found at {resolved_uri}: {exc}") from exc
+    except ValueError as exc:
+        # Unsupported scheme from ``read_spec_text`` and pydantic ValidationError
+        # (a ValueError subclass) for malformed / stale specs both land here.
+        raise click.ClickException(f"DatasetSpec at {resolved_uri} is invalid: {exc}") from exc
+
+    if spec.output_format != "hdf5":
+        # reshard wires HDF5 VirtualSources; ``output_format='wds'`` would yield
+        # ``.tar`` shards that would surface as a confusing FileNotFoundError
+        # mid-loop on the first ``h5py.File(...)`` open.
+        raise click.ClickException(
+            f"reshard only supports output_format='hdf5'; spec at {resolved_uri} "
+            f"declares output_format={spec.output_format!r}."
+        )
 
     shard_size = spec.render.samples_per_shard
     bad = [sz for sz in spec.train_val_test_sizes if sz % shard_size != 0]
     if bad:
-        # DatasetSpec._split_sizes_must_be_multiples_of_samples_per_shard normally
-        # rejects this at parse time; this guard catches the case where a stale
-        # spec from R2 predates that validator.
+        # Defensive backstop for the SimpleNamespace test path. Real
+        # ``DatasetSpec`` instances are already rejected at parse time by
+        # ``_split_sizes_must_be_multiples_of_samples_per_shard``.
         raise click.ClickException(
             f"spec.train_val_test_sizes={list(spec.train_val_test_sizes)} contains "
             f"sizes not divisible by spec.render.samples_per_shard={shard_size}: "

--- a/tests/pipeline/data/test_reshard.py
+++ b/tests/pipeline/data/test_reshard.py
@@ -30,8 +30,8 @@ FIXED_NOW = datetime(2026, 5, 18, 12, 0, 0, tzinfo=timezone.utc)
 def _render_kwargs(samples_per_shard: int) -> dict[str, Any]:
     """Return RenderConfig kwargs with the given ``samples_per_shard``.
 
-    :param samples_per_shard: Sample count per shard, exercised by reshard's
-        spec-vs-flag agreement check.
+    :param samples_per_shard: Sample count per shard; drives reshard's
+        per-split shard count via ``size // samples_per_shard``.
     :returns: Dict suitable as ``render`` input for ``DatasetSpec``.
     :rtype: dict[str, Any]
     """
@@ -247,7 +247,7 @@ class TestReshardSpecPath:
         patch_runtime_io: None,
         runner: CliRunner,
     ) -> None:
-        """A dataset root without ``input_spec.json`` exits non-zero.
+        """A dataset root without ``input_spec.json`` exits with a user-oriented message.
 
         :param tmp_path: Pytest tmp_path fixture for the dataset root.
         :param patch_runtime_io: Spec runtime-factory stub fixture.
@@ -258,6 +258,9 @@ class TestReshardSpecPath:
         result = runner.invoke(_reshard_module.main, [str(tmp_path)])
 
         assert result.exit_code != 0
+        # ClickException surfaces a clean ``Error: ...`` message, not a raw traceback.
+        assert "DatasetSpec not found" in result.output
+        assert result.exception is None or isinstance(result.exception, SystemExit)
 
 
 class TestReshardRemovedFlagsRejected:
@@ -312,6 +315,7 @@ class TestReshardSplitDivisibility:
         """
         tmp_path.mkdir(exist_ok=True)
         bad_spec = SimpleNamespace(
+            output_format="hdf5",
             render=SimpleNamespace(samples_per_shard=10),
             train_val_test_sizes=(15, 10, 10),  # 15 % 10 != 0
             shards=(),
@@ -322,6 +326,35 @@ class TestReshardSplitDivisibility:
 
         assert result.exit_code != 0
         assert "divisible" in result.output.lower() or "samples_per_shard" in result.output
+
+
+class TestReshardOutputFormatGuard:
+    """Reshard only supports ``output_format='hdf5'``; ``wds`` must be rejected early."""
+
+    def test_wds_output_format_rejected_with_clickexception(
+        self,
+        tmp_path: Path,
+        runner: CliRunner,
+    ) -> None:
+        """A WDS-format spec exits non-zero before any shard open attempt.
+
+        :param tmp_path: Pytest tmp_path fixture for the dataset root.
+        :param runner: Click test runner fixture.
+        """
+        tmp_path.mkdir(exist_ok=True)
+        wds_spec = SimpleNamespace(
+            output_format="wds",
+            render=SimpleNamespace(samples_per_shard=10),
+            train_val_test_sizes=(20, 10, 10),
+            shards=(),
+        )
+
+        with mock.patch.object(_reshard_module, "load_spec_from_uri", return_value=wds_spec):
+            result = runner.invoke(_reshard_module.main, [str(tmp_path)])
+
+        assert result.exit_code != 0
+        assert "output_format" in result.output
+        assert "hdf5" in result.output
 
 
 class TestReshardR2SpecUri:
@@ -345,9 +378,7 @@ class TestReshardR2SpecUri:
         (tmp_path / INPUT_SPEC_FILENAME).unlink()
         spec_uri = "r2://intermediate-data/data/foo/input_spec.json"
 
-        with mock.patch.object(
-            _reshard_module, "load_spec_from_uri", return_value=spec
-        ) as loader:
+        with mock.patch.object(_reshard_module, "load_spec_from_uri", return_value=spec) as loader:
             result = runner.invoke(
                 _reshard_module.main,
                 [str(tmp_path), "--spec", spec_uri],
@@ -382,15 +413,9 @@ class TestReshardVirtualDatasetIdentity:
         for i, shard in enumerate(spec.shards):
             fill = float(i + 1)
             with h5py.File(tmp_path / shard.filename, "w") as f:
-                f.create_dataset(
-                    "audio", data=np.full((sps, 2, 64), fill, dtype=np.float32)
-                )
-                f.create_dataset(
-                    "mel_spec", data=np.full((sps, 2, 8, 8), fill, dtype=np.float32)
-                )
-                f.create_dataset(
-                    "param_array", data=np.full((sps, 12), fill, dtype=np.float32)
-                )
+                f.create_dataset("audio", data=np.full((sps, 2, 64), fill, dtype=np.float32))
+                f.create_dataset("mel_spec", data=np.full((sps, 2, 8, 8), fill, dtype=np.float32))
+                f.create_dataset("param_array", data=np.full((sps, 12), fill, dtype=np.float32))
 
         result = runner.invoke(_reshard_module.main, [str(tmp_path)], catch_exceptions=False)
         assert result.exit_code == 0, result.output

--- a/tests/pipeline/data/test_reshard.py
+++ b/tests/pipeline/data/test_reshard.py
@@ -138,7 +138,7 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
-class TestResharSpecDriven:
+class TestReshardSpecDriven:
     """Reshard splits the local shard list using spec-derived counts."""
 
     def test_uses_spec_train_val_test_sizes(
@@ -186,7 +186,7 @@ class TestResharSpecDriven:
         assert (tmp_path / "test.h5").exists()
 
 
-class TestResharSpecShardsAreAuthoritative:
+class TestReshardSpecShardsAreAuthoritative:
     """Reshard reads exactly the filenames in ``spec.shards``, no glob."""
 
     def test_missing_canonical_shard_fails_loud(
@@ -211,7 +211,7 @@ class TestResharSpecShardsAreAuthoritative:
         assert result.exit_code != 0
 
 
-class TestResharSpecPath:
+class TestReshardSpecPath:
     """Reshard reads the spec from ``<dataset_root>/input_spec.json`` by default."""
 
     def test_explicit_spec_path_overrides_default(
@@ -260,7 +260,7 @@ class TestResharSpecPath:
         assert result.exit_code != 0
 
 
-class TestResharRemovedFlagsRejected:
+class TestReshardRemovedFlagsRejected:
     """Flags that used to exist on reshard (``--train-samples`` / ``--val-samples`` / ``--test-
     samples`` from the original CLI; ``--shard-size`` from the interim parent #1092) must be
     rejected — the spec is now the single source of truth."""
@@ -292,7 +292,7 @@ class TestResharRemovedFlagsRejected:
         assert "no such option" in result.output.lower()
 
 
-class TestResharSplitDivisibility:
+class TestReshardSplitDivisibility:
     """``train_val_test_sizes`` must be perfectly divisible by ``samples_per_shard``."""
 
     def test_non_divisible_split_size_raises_at_runtime(
@@ -324,7 +324,7 @@ class TestResharSplitDivisibility:
         assert "divisible" in result.output.lower() or "samples_per_shard" in result.output
 
 
-class TestResharR2SpecUri:
+class TestReshardR2SpecUri:
     """``--spec r2://...`` is loaded via ``load_spec_from_uri`` (no real R2 I/O)."""
 
     def test_r2_spec_uri_is_loaded_via_load_spec_from_uri(
@@ -359,7 +359,7 @@ class TestResharR2SpecUri:
         assert (tmp_path / "train.h5").exists()
 
 
-class TestResharVirtualDatasetIdentity:
+class TestReshardVirtualDatasetIdentity:
     """Virtual-dataset rows actually surface the right source-shard bytes, in spec order."""
 
     def test_split_files_concatenate_source_shards_in_spec_order(

--- a/tests/pipeline/data/test_reshard.py
+++ b/tests/pipeline/data/test_reshard.py
@@ -1,0 +1,415 @@
+"""Behavioral tests for `synth_setter.pipeline.data.reshard`.
+
+The reshard CLI consumes ``DatasetSpec.train_val_test_sizes`` from
+``<dataset_root>/input_spec.json`` as the authoritative source of per-split
+sample counts. Shard counts are derived as
+``size // render.samples_per_shard``; the legacy ``--train-samples`` /
+``--val-samples`` / ``--test-samples`` defaults are gone.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest import mock
+
+import h5py
+import numpy as np
+import pytest
+from click.testing import CliRunner
+
+from synth_setter.pipeline.constants import INPUT_SPEC_FILENAME
+from synth_setter.pipeline.data import reshard as _reshard_module
+from synth_setter.pipeline.schemas.spec import DatasetSpec
+
+FIXED_NOW = datetime(2026, 5, 18, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _render_kwargs(samples_per_shard: int) -> dict[str, Any]:
+    """Return RenderConfig kwargs with the given ``samples_per_shard``.
+
+    :param samples_per_shard: Sample count per shard, exercised by reshard's
+        spec-vs-flag agreement check.
+    :returns: Dict suitable as ``render`` input for ``DatasetSpec``.
+    :rtype: dict[str, Any]
+    """
+    return {
+        "plugin_path": "/fake/Plugin.vst3",
+        "preset_path": "presets/surge-base.vstpreset",
+        "param_spec_name": "surge_simple",
+        "renderer_version": "1.3.4",
+        "sample_rate": 16000,
+        "channels": 2,
+        "velocity": 100,
+        "signal_duration_seconds": 4.0,
+        "min_loudness": -55.0,
+        "samples_per_render_batch": 32,
+        "samples_per_shard": samples_per_shard,
+    }
+
+
+def _spec_kwargs(
+    train: int,
+    val: int,
+    test: int,
+    *,
+    samples_per_shard: int,
+) -> dict[str, Any]:
+    """Return DatasetSpec kwargs that produce the requested (train, val, test) split.
+
+    :param train: Sample count for the train split.
+    :param val: Sample count for the val split.
+    :param test: Sample count for the test split.
+    :param samples_per_shard: Shard granularity; each split must be a multiple.
+    :returns: Dict suitable as ``**kwargs`` for ``DatasetSpec``.
+    :rtype: dict[str, Any]
+    """
+    return {
+        "task_name": "reshard-test",
+        "output_format": "hdf5",
+        "train_val_test_sizes": [train, val, test],
+        "base_seed": 42,
+        "r2_bucket": "intermediate-data",
+        "render": _render_kwargs(samples_per_shard),
+    }
+
+
+@pytest.fixture()
+def patch_runtime_io(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub git/timestamp factories so DatasetSpec construction is deterministic.
+
+    :param monkeypatch: Pytest monkeypatching fixture used to override the
+        factory functions on ``synth_setter.pipeline.schemas.spec``.
+    """
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._get_git_sha", lambda: "abc123def456")
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._is_repo_dirty", lambda: False)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._utc_now", lambda: FIXED_NOW)
+
+
+def _write_shard(path: Path, shard_size: int) -> None:
+    """Write a minimal HDF5 shard with the three datasets reshard expects.
+
+    :param path: Destination filesystem path for the shard.
+    :param shard_size: Number of samples (rows) the shard should advertise.
+    """
+    with h5py.File(path, "w") as f:
+        f.create_dataset("audio", shape=(shard_size, 2, 64), dtype=np.float32)
+        f.create_dataset("mel_spec", shape=(shard_size, 2, 8, 8), dtype=np.float32)
+        f.create_dataset("param_array", shape=(shard_size, 12), dtype=np.float32)
+
+
+def _materialize_dataset(
+    dataset_root: Path,
+    spec: DatasetSpec,
+) -> None:
+    """Write ``input_spec.json`` and all ``shard-NNNNNN.h5`` files under ``dataset_root``.
+
+    :param dataset_root: Directory that will hold the spec JSON and shards.
+    :param spec: Spec that describes the layout to materialize.
+    """
+    dataset_root.mkdir(parents=True, exist_ok=True)
+    (dataset_root / INPUT_SPEC_FILENAME).write_text(spec.model_dump_json())
+    shard_size = spec.render.samples_per_shard
+    for shard in spec.shards:
+        _write_shard(dataset_root / shard.filename, shard_size)
+
+
+def _audio_rows(split_h5_path: Path) -> int:
+    """Return the number of rows in the ``audio`` dataset at ``split_h5_path``.
+
+    :param split_h5_path: Path to a ``{split}.h5`` virtual-dataset file.
+    :returns: Leading-axis length of the ``audio`` dataset.
+    :rtype: int
+    """
+    with h5py.File(split_h5_path, "r") as f:
+        dataset = cast(h5py.Dataset, f["audio"])
+        return int(dataset.shape[0])
+
+
+@pytest.fixture()
+def runner() -> CliRunner:
+    """Return a fresh ``click.testing.CliRunner`` for each test.
+
+    :returns: A new ``CliRunner`` instance.
+    :rtype: CliRunner
+    """
+    return CliRunner()
+
+
+class TestResharSpecDriven:
+    """Reshard splits the local shard list using spec-derived counts."""
+
+    def test_uses_spec_train_val_test_sizes(
+        self,
+        tmp_path: Path,
+        patch_runtime_io: None,
+        runner: CliRunner,
+    ) -> None:
+        """Three splits are sized by ``train_val_test_sizes // samples_per_shard``.
+
+        :param tmp_path: Pytest tmp_path fixture for the dataset root.
+        :param patch_runtime_io: Spec runtime-factory stub fixture.
+        :param runner: Click test runner fixture.
+        """
+        spec = DatasetSpec(**_spec_kwargs(20, 10, 10, samples_per_shard=10))
+        _materialize_dataset(tmp_path, spec)
+
+        result = runner.invoke(_reshard_module.main, [str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert _audio_rows(tmp_path / "train.h5") == 20
+        assert _audio_rows(tmp_path / "val.h5") == 10
+        assert _audio_rows(tmp_path / "test.h5") == 10
+
+    def test_zero_sized_split_is_skipped(
+        self,
+        tmp_path: Path,
+        patch_runtime_io: None,
+        runner: CliRunner,
+    ) -> None:
+        """A split with sample count 0 produces no output file.
+
+        :param tmp_path: Pytest tmp_path fixture for the dataset root.
+        :param patch_runtime_io: Spec runtime-factory stub fixture.
+        :param runner: Click test runner fixture.
+        """
+        spec = DatasetSpec(**_spec_kwargs(20, 0, 10, samples_per_shard=10))
+        _materialize_dataset(tmp_path, spec)
+
+        result = runner.invoke(_reshard_module.main, [str(tmp_path)])
+
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "train.h5").exists()
+        assert not (tmp_path / "val.h5").exists()
+        assert (tmp_path / "test.h5").exists()
+
+
+class TestResharSpecShardsAreAuthoritative:
+    """Reshard reads exactly the filenames in ``spec.shards``, no glob."""
+
+    def test_missing_canonical_shard_fails_loud(
+        self,
+        tmp_path: Path,
+        patch_runtime_io: None,
+        runner: CliRunner,
+    ) -> None:
+        """A spec.shards filename missing on disk exits non-zero, even with a stale neighbor.
+
+        :param tmp_path: Pytest tmp_path fixture for the dataset root.
+        :param patch_runtime_io: Spec runtime-factory stub fixture.
+        :param runner: Click test runner fixture.
+        """
+        spec = DatasetSpec(**_spec_kwargs(20, 10, 10, samples_per_shard=10))
+        _materialize_dataset(tmp_path, spec)
+        (tmp_path / spec.shards[0].filename).unlink()
+        (tmp_path / "shard-999999.h5").touch()
+
+        result = runner.invoke(_reshard_module.main, [str(tmp_path)])
+
+        assert result.exit_code != 0
+
+
+class TestResharSpecPath:
+    """Reshard reads the spec from ``<dataset_root>/input_spec.json`` by default."""
+
+    def test_explicit_spec_path_overrides_default(
+        self,
+        tmp_path: Path,
+        patch_runtime_io: None,
+        runner: CliRunner,
+    ) -> None:
+        """``--spec`` accepts an arbitrary path outside the dataset root.
+
+        :param tmp_path: Pytest tmp_path fixture for the dataset root.
+        :param patch_runtime_io: Spec runtime-factory stub fixture.
+        :param runner: Click test runner fixture.
+        """
+        spec = DatasetSpec(**_spec_kwargs(20, 10, 10, samples_per_shard=10))
+        dataset_root = tmp_path / "data"
+        _materialize_dataset(dataset_root, spec)
+        (dataset_root / INPUT_SPEC_FILENAME).unlink()
+        external_spec = tmp_path / "elsewhere.json"
+        external_spec.write_text(spec.model_dump_json())
+
+        result = runner.invoke(
+            _reshard_module.main,
+            [str(dataset_root), "--spec", str(external_spec)],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert (dataset_root / "train.h5").exists()
+
+    def test_missing_spec_fails_loud(
+        self,
+        tmp_path: Path,
+        patch_runtime_io: None,
+        runner: CliRunner,
+    ) -> None:
+        """A dataset root without ``input_spec.json`` exits non-zero.
+
+        :param tmp_path: Pytest tmp_path fixture for the dataset root.
+        :param patch_runtime_io: Spec runtime-factory stub fixture.
+        :param runner: Click test runner fixture.
+        """
+        tmp_path.mkdir(exist_ok=True)
+
+        result = runner.invoke(_reshard_module.main, [str(tmp_path)])
+
+        assert result.exit_code != 0
+
+
+class TestResharRemovedFlagsRejected:
+    """Flags that used to exist on reshard (``--train-samples`` / ``--val-samples`` / ``--test-
+    samples`` from the original CLI; ``--shard-size`` from the interim parent #1092) must be
+    rejected — the spec is now the single source of truth."""
+
+    @pytest.mark.parametrize(
+        "flag",
+        ["--train-samples", "--val-samples", "--test-samples", "--shard-size"],
+    )
+    def test_removed_flag_is_rejected(
+        self,
+        tmp_path: Path,
+        patch_runtime_io: None,
+        runner: CliRunner,
+        flag: str,
+    ) -> None:
+        """Passing a removed flag fails with click's no-such-option error.
+
+        :param tmp_path: Pytest tmp_path fixture for the dataset root.
+        :param patch_runtime_io: Spec runtime-factory stub fixture.
+        :param runner: Click test runner fixture.
+        :param flag: Parametrized removed flag name under test.
+        """
+        spec = DatasetSpec(**_spec_kwargs(20, 10, 10, samples_per_shard=10))
+        _materialize_dataset(tmp_path, spec)
+
+        result = runner.invoke(_reshard_module.main, [str(tmp_path), flag, "1"])
+
+        assert result.exit_code != 0
+        assert "no such option" in result.output.lower()
+
+
+class TestResharSplitDivisibility:
+    """``train_val_test_sizes`` must be perfectly divisible by ``samples_per_shard``."""
+
+    def test_non_divisible_split_size_raises_at_runtime(
+        self,
+        tmp_path: Path,
+        runner: CliRunner,
+    ) -> None:
+        """A stale spec whose split size has a non-zero remainder is rejected loudly.
+
+        Normally ``DatasetSpec._split_sizes_must_be_multiples_of_samples_per_shard``
+        catches this at parse time; this test bypasses model validation (via
+        ``SimpleNamespace``) to exercise the defensive guard inside ``main()``,
+        protecting against a stale R2 spec that predates the model validator.
+
+        :param tmp_path: Pytest tmp_path fixture for the dataset root.
+        :param runner: Click test runner fixture.
+        """
+        tmp_path.mkdir(exist_ok=True)
+        bad_spec = SimpleNamespace(
+            render=SimpleNamespace(samples_per_shard=10),
+            train_val_test_sizes=(15, 10, 10),  # 15 % 10 != 0
+            shards=(),
+        )
+
+        with mock.patch.object(_reshard_module, "load_spec_from_uri", return_value=bad_spec):
+            result = runner.invoke(_reshard_module.main, [str(tmp_path)])
+
+        assert result.exit_code != 0
+        assert "divisible" in result.output.lower() or "samples_per_shard" in result.output
+
+
+class TestResharR2SpecUri:
+    """``--spec r2://...`` is loaded via ``load_spec_from_uri`` (no real R2 I/O)."""
+
+    def test_r2_spec_uri_is_loaded_via_load_spec_from_uri(
+        self,
+        tmp_path: Path,
+        patch_runtime_io: None,
+        runner: CliRunner,
+    ) -> None:
+        """``--spec r2://...`` delegates to ``load_spec_from_uri`` (mocked).
+
+        :param tmp_path: Pytest tmp_path fixture for the dataset root.
+        :param patch_runtime_io: Spec runtime-factory stub fixture.
+        :param runner: Click test runner fixture.
+        """
+        spec = DatasetSpec(**_spec_kwargs(20, 10, 10, samples_per_shard=10))
+        _materialize_dataset(tmp_path, spec)
+        # Remove the local fallback so the test fails if the URI isn't honored.
+        (tmp_path / INPUT_SPEC_FILENAME).unlink()
+        spec_uri = "r2://intermediate-data/data/foo/input_spec.json"
+
+        with mock.patch.object(
+            _reshard_module, "load_spec_from_uri", return_value=spec
+        ) as loader:
+            result = runner.invoke(
+                _reshard_module.main,
+                [str(tmp_path), "--spec", spec_uri],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0, result.output
+        loader.assert_called_once_with(spec_uri)
+        assert (tmp_path / "train.h5").exists()
+
+
+class TestResharVirtualDatasetIdentity:
+    """Virtual-dataset rows actually surface the right source-shard bytes, in spec order."""
+
+    def test_split_files_concatenate_source_shards_in_spec_order(
+        self,
+        tmp_path: Path,
+        patch_runtime_io: None,
+        runner: CliRunner,
+    ) -> None:
+        """Each split's audio[i*sps:(i+1)*sps] equals the i-th source shard's bytes.
+
+        :param tmp_path: Pytest tmp_path fixture for the dataset root.
+        :param patch_runtime_io: Spec runtime-factory stub fixture.
+        :param runner: Click test runner fixture.
+        """
+        sps = 3
+        spec = DatasetSpec(**_spec_kwargs(sps * 2, sps * 1, sps * 1, samples_per_shard=sps))
+        tmp_path.mkdir(exist_ok=True)
+        (tmp_path / INPUT_SPEC_FILENAME).write_text(spec.model_dump_json())
+        # Write shard `i` filled with `float(i + 1)` so each source's bytes are traceable.
+        for i, shard in enumerate(spec.shards):
+            fill = float(i + 1)
+            with h5py.File(tmp_path / shard.filename, "w") as f:
+                f.create_dataset(
+                    "audio", data=np.full((sps, 2, 64), fill, dtype=np.float32)
+                )
+                f.create_dataset(
+                    "mel_spec", data=np.full((sps, 2, 8, 8), fill, dtype=np.float32)
+                )
+                f.create_dataset(
+                    "param_array", data=np.full((sps, 12), fill, dtype=np.float32)
+                )
+
+        result = runner.invoke(_reshard_module.main, [str(tmp_path)], catch_exceptions=False)
+        assert result.exit_code == 0, result.output
+
+        with h5py.File(tmp_path / "train.h5", "r") as f:
+            audio = cast(h5py.Dataset, f["audio"])[:]
+            params = cast(h5py.Dataset, f["param_array"])[:]
+        np.testing.assert_array_equal(audio[:sps], np.full((sps, 2, 64), 1.0, dtype=np.float32))
+        np.testing.assert_array_equal(audio[sps:], np.full((sps, 2, 64), 2.0, dtype=np.float32))
+        np.testing.assert_array_equal(params[:sps], np.full((sps, 12), 1.0, dtype=np.float32))
+        np.testing.assert_array_equal(params[sps:], np.full((sps, 12), 2.0, dtype=np.float32))
+
+        with h5py.File(tmp_path / "val.h5", "r") as f:
+            np.testing.assert_array_equal(
+                cast(h5py.Dataset, f["audio"])[:],
+                np.full((sps, 2, 64), 3.0, dtype=np.float32),
+            )
+        with h5py.File(tmp_path / "test.h5", "r") as f:
+            np.testing.assert_array_equal(
+                cast(h5py.Dataset, f["audio"])[:],
+                np.full((sps, 2, 64), 4.0, dtype=np.float32),
+            )


### PR DESCRIPTION
## Summary

- ``spec.render.samples_per_shard`` and ``spec.train_val_test_sizes`` become the single source of truth for shard count and split sizes. Reshard loads the DatasetSpec JSON (local path or ``r2://`` URI) via ``load_spec_from_uri`` and slices ``spec.shards`` in order instead of globbing ``dataset_root``.
- The legacy ``--train-samples`` / ``--val-samples`` / ``--test-samples`` defaults are removed. ``--shard-size`` is rejected as a regression guard so the flag cannot be re-added without a matching test update.
- Revives the spec-driven design from #1093, which merged onto the stranded ``feat/reshard-shard-size`` branch but never reached main (#1092 and #1096 were closed without merging).

The two files mirror ``origin/feat/reshard-shard-size`` at its tip (post-#1093). All current-main dependencies are present: ``load_spec_from_uri`` (``cli/generate_dataset.py:65``), ``INPUT_SPEC_FILENAME`` (``pipeline/constants.py``), ``DatasetSpec.shards`` / ``ShardSpec.filename`` / ``train_val_test_sizes`` / ``render.samples_per_shard`` (``pipeline/schemas/spec.py``).

## Pre-PR review

Ran ``/repo-review-full-no-comments`` (7-skill fan-out) against the branch before opening this PR. Result: 4 BLOCK, 58 WARN.

- One BLOCK (``TestReshar*`` typo across all seven test classes) is fixed in commit ``1ced220``.
- The remaining 3 BLOCKs target pre-existing properties of the merged #1093 design that this PR revives verbatim — file as follow-ups against #1091 rather than amend the revival:
  - ``reshard.py:46-57`` — add ``spec.output_format == "hdf5"`` guard (today, a WDS spec would crash mid-loop on ``h5py.File("shard-*.tar")``)
  - ``reshard.py:72-75`` — per-shard structural shape validation (today, shape is sampled from ``files[0]`` only)
  - ``reshard.py:73-75`` — wrap unguarded ``f["audio"]`` / ``f["mel_spec"]`` / ``f["param_array"]`` with ``ClickException`` instead of bare ``KeyError``
- The 58 WARNs are largely comment-hygiene and test-tightening suggestions on the new test file. Happy to apply any subset in this PR if a reviewer prefers.

## Test plan

- [x] ``pytest tests/pipeline/data/test_reshard.py`` — all 12 tests pass against current main
- [x] ``pre-commit run --files src/synth_setter/pipeline/data/reshard.py tests/pipeline/data/test_reshard.py`` — ruff, ruff format, pyright, docformatter, interrogate, pydoclint, codespell all pass
- [ ] CI on the PR
- [ ] ``--help`` exposes ``--spec`` and rejects the four removed flags (covered by ``TestReshardRemovedFlagsRejected``)
- [ ] End-to-end resharding produces split files whose row counts match ``spec.train_val_test_sizes`` (covered by ``TestReshardVirtualDatasetIdentity``)

Closes #1091