### PR TITLE
feat(pipeline): synth-setter-finalize-dataset entrypoint + wds branch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,7 @@ synth-setter-train = "synth_setter.cli.train:main"
 synth-setter-eval = "synth_setter.cli.eval:main"
 synth-setter-generate-dataset = "synth_setter.cli.generate_dataset:main"
 synth-setter-generate-dataset-from-hydra = "synth_setter.cli.generate_dataset:from_hydra"
+synth-setter-finalize-dataset = "synth_setter.cli.finalize_dataset:main"
 synth-setter-spec-uri = "synth_setter.pipeline.ci.spec_uri:main"
 
 

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -1,0 +1,109 @@
+"""``synth-setter-finalize-dataset`` entrypoint: post-generate finalize stage.
+
+Mirrors ``generate-dataset``'s operator-side shape — programmatic Hydra
+compose, single ``DatasetSpec`` input, dispatch on ``spec.output_format``.
+The ``hdf5`` branch raises ``NotImplementedError`` in this slice; the wds
+branch downloads the train-split shards, computes stats, then writes the
+``dataset.complete`` marker last per ``pipeline/CLAUDE.md`` invariants.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+from typing import NoReturn
+
+import rootutils
+from hydra import compose, initialize_config_dir
+from loguru import logger
+
+# Bootstrap PROJECT_ROOT + sys.path before sibling synth_setter imports.
+rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
+
+from synth_setter.cli.generate_dataset import spec_from_cfg  # noqa: E402
+from synth_setter.pipeline import r2_io  # noqa: E402
+from synth_setter.pipeline.data.stats import get_stats_wds  # noqa: E402
+from synth_setter.pipeline.schemas.spec import DatasetSpec  # noqa: E402
+
+# Resolve repo root from this file so the entrypoint is cwd-independent.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_CONFIG_DIR = _REPO_ROOT / "configs"
+
+_DATASET_COMPLETE_FILENAME = "dataset.complete"
+_STATS_NPZ_FILENAME = "stats.npz"
+
+
+def finalize_wds(spec: DatasetSpec, work_dir: Path) -> None:
+    """Compute stats over the train-split shards and upload ``stats.npz``.
+
+    Per-shard tar files stay in their original R2 location; only the
+    derived ``stats.npz`` is materialized here. The wds brace pattern for
+    each split is available at read time via
+    ``spec.r2.split_wds_brace_uri(spec.split_shard_ranges[split])``.
+
+    :param spec: Validated dataset spec (``output_format == "wds"``).
+    :param work_dir: Scratch directory; train shards land under
+        ``<work_dir>/train_shards/`` and ``stats.npz`` is written next to them.
+    """
+    train_lo, train_hi = spec.split_shard_ranges["train"]
+    train_shards_dir = work_dir / "train_shards"
+    train_shards_dir.mkdir()
+    for shard in spec.shards[train_lo:train_hi]:
+        r2_io.download_to_path(spec.r2.shard_uri(shard), train_shards_dir / shard.filename)
+    get_stats_wds(train_shards_dir)
+    r2_io.upload(train_shards_dir / _STATS_NPZ_FILENAME, spec.r2.stats_uri())
+    logger.info("uploaded stats to {}", spec.r2.stats_uri())
+
+
+def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> NoReturn:
+    """Stub raising ``NotImplementedError``; the hdf5 body lands in Phase 2.
+
+    :param spec: Validated dataset spec (``output_format == "hdf5"``); unused.
+    :param work_dir: Scratch directory; unused.
+    :raises NotImplementedError: Always — the hdf5 branch is deferred.
+    """
+    del spec, work_dir
+    raise NotImplementedError("hdf5 finalize lands in Phase 2")
+
+
+def main() -> None:
+    """Operator CLI: compose dataset cfg from argv, then finalize the run.
+
+    Programmatic compose (not ``@hydra.main``) so the branch decision on
+    ``spec.output_format`` happens before any work runs and the operator
+    surface stays compatible with a future SkyPilot dispatch branch
+    (tracked as #1181). ``dataset.complete`` is uploaded strictly last;
+    its presence is the canonical "this run is ready to train" signal.
+
+    :raises ValueError: ``spec.output_format`` is neither ``"hdf5"`` nor ``"wds"``.
+    """
+    overrides = list(sys.argv[1:])
+    with initialize_config_dir(version_base="1.3", config_dir=str(_CONFIG_DIR)):
+        cfg = compose(config_name="dataset", overrides=overrides)
+
+    # Pin paths.* so spec_from_cfg's resolve step does not trip on
+    # ${hydra:runtime.output_dir} — programmatic compose leaves it unset.
+    cfg.paths.root_dir = str(_REPO_ROOT)
+    cfg.paths.output_dir = str(_REPO_ROOT)
+    cfg.paths.work_dir = str(_REPO_ROOT)
+
+    spec = spec_from_cfg(cfg)
+    r2_io.ensure_r2_env_loaded()
+
+    with tempfile.TemporaryDirectory() as raw_work_dir:
+        work_dir = Path(raw_work_dir)
+        if spec.output_format == "wds":
+            finalize_wds(spec, work_dir)
+        elif spec.output_format == "hdf5":
+            finalize_hdf5(spec, work_dir)
+        else:
+            raise ValueError(f"unsupported output_format: {spec.output_format!r}")
+        marker_local = work_dir / _DATASET_COMPLETE_FILENAME
+        marker_local.touch()
+        r2_io.upload(marker_local, spec.r2.dataset_complete_marker_uri())
+    logger.info("wrote dataset.complete to {}", spec.r2.dataset_complete_marker_uri())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -2,15 +2,16 @@
 
 Mirrors ``generate-dataset``'s operator-side shape — programmatic Hydra
 compose, single ``DatasetSpec`` input, dispatch on ``spec.output_format``.
-The ``hdf5`` branch raises ``NotImplementedError`` in this slice; the wds
-branch downloads the train-split shards, computes stats, then writes the
-``dataset.complete`` marker last per ``pipeline/CLAUDE.md`` invariants.
+The wds branch streams the train shards through Welford row-by-row,
+uploads ``stats.npz``, then writes the ``dataset.complete`` marker last
+per ``pipeline/CLAUDE.md``. hdf5 is not implemented (#1183).
 """
 
 from __future__ import annotations
 
 import sys
 import tempfile
+from collections.abc import Iterator
 from pathlib import Path
 from typing import NoReturn
 
@@ -21,60 +22,81 @@ from loguru import logger
 # Bootstrap PROJECT_ROOT + sys.path before sibling synth_setter imports.
 rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 
+import numpy as np  # noqa: E402
+
 from synth_setter.cli.generate_dataset import spec_from_cfg  # noqa: E402
 from synth_setter.pipeline import r2_io  # noqa: E402
-from synth_setter.pipeline.data.stats import get_stats_wds  # noqa: E402
+from synth_setter.pipeline.constants import (  # noqa: E402
+    DATASET_COMPLETE_FILENAME,
+    STATS_NPZ_FILENAME,
+)
+from synth_setter.pipeline.data.stats import stream_stats_wds  # noqa: E402
 from synth_setter.pipeline.schemas.spec import DatasetSpec  # noqa: E402
 
 # Resolve repo root from this file so the entrypoint is cwd-independent.
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _CONFIG_DIR = _REPO_ROOT / "configs"
 
-_DATASET_COMPLETE_FILENAME = "dataset.complete"
-_STATS_NPZ_FILENAME = "stats.npz"
+
+def _download_train_shards_one_at_a_time(spec: DatasetSpec, work_dir: Path) -> Iterator[Path]:
+    """Yield one downloaded train shard at a time, unlinking after the consumer is done.
+
+    Peak local disk stays at one shard regardless of split size; the
+    ``finally`` clause runs when ``stream_stats_wds`` advances to the next
+    iteration, so the previous shard's bytes are released before the next
+    download starts.
+
+    :param spec: Validated dataset spec.
+    :param work_dir: Scratch directory; shards land here transiently.
+    :yields Path: Local path of the just-downloaded train shard.
+    """
+    train_lo, train_hi = spec.split_shard_ranges["train"]
+    for shard in spec.shards[train_lo:train_hi]:
+        local = work_dir / shard.filename
+        r2_io.download_to_path(spec.r2.shard_uri(shard), local)
+        try:
+            yield local
+        finally:
+            local.unlink(missing_ok=True)
 
 
 def finalize_wds(spec: DatasetSpec, work_dir: Path) -> None:
-    """Compute stats over the train-split shards and upload ``stats.npz``.
+    """Stream stats over the train shards and upload ``stats.npz``.
 
     Per-shard tar files stay in their original R2 location; only the
-    derived ``stats.npz`` is materialized here. The wds brace pattern for
-    each split is available at read time via
+    derived ``stats.npz`` is materialized. Brace patterns for each split
+    are available via
     ``spec.r2.split_wds_brace_uri(spec.split_shard_ranges[split])``.
 
     :param spec: Validated dataset spec (``output_format == "wds"``).
-    :param work_dir: Scratch directory; train shards land under
-        ``<work_dir>/train_shards/`` and ``stats.npz`` is written next to them.
+    :param work_dir: Scratch directory; one shard at a time + the final
+        ``stats.npz`` live here transiently.
     """
-    train_lo, train_hi = spec.split_shard_ranges["train"]
-    train_shards_dir = work_dir / "train_shards"
-    train_shards_dir.mkdir()
-    for shard in spec.shards[train_lo:train_hi]:
-        r2_io.download_to_path(spec.r2.shard_uri(shard), train_shards_dir / shard.filename)
-    get_stats_wds(train_shards_dir)
-    r2_io.upload(train_shards_dir / _STATS_NPZ_FILENAME, spec.r2.stats_uri())
+    mean, std = stream_stats_wds(_download_train_shards_one_at_a_time(spec, work_dir))
+    stats_npz = work_dir / STATS_NPZ_FILENAME
+    np.savez(stats_npz, mean=mean, std=std)
+    r2_io.upload(stats_npz, spec.r2.stats_uri())
     logger.info("uploaded stats to {}", spec.r2.stats_uri())
 
 
 def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> NoReturn:
-    """Stub raising ``NotImplementedError``; the hdf5 body lands in Phase 2.
+    """Reject hdf5 finalize until the writer side is implemented — see #1183.
 
-    :param spec: Validated dataset spec (``output_format == "hdf5"``); unused.
+    :param spec: Validated dataset spec; unused.
     :param work_dir: Scratch directory; unused.
-    :raises NotImplementedError: Always — the hdf5 branch is deferred.
+    :raises NotImplementedError: Always — hdf5 finalize is not implemented yet.
     """
     del spec, work_dir
-    raise NotImplementedError("hdf5 finalize lands in Phase 2")
+    raise NotImplementedError("hdf5 finalize is not implemented yet")
 
 
 def main() -> None:
-    """Operator CLI: compose dataset cfg from argv, then finalize the run.
+    """Operator CLI: compose dataset cfg, dispatch on ``output_format``, write marker last.
 
-    Programmatic compose (not ``@hydra.main``) so the branch decision on
-    ``spec.output_format`` happens before any work runs and the operator
-    surface stays compatible with a future SkyPilot dispatch branch
-    (tracked as #1181). ``dataset.complete`` is uploaded strictly last;
-    its presence is the canonical "this run is ready to train" signal.
+    Skips the body entirely when ``dataset.complete`` already exists at the
+    run prefix — R2 is the source of truth (per ``pipeline/CLAUDE.md``), so a
+    second invocation against a finalized prefix is a no-op rather than a
+    full redo.
 
     :raises ValueError: ``spec.output_format`` is neither ``"hdf5"`` nor ``"wds"``.
     """
@@ -91,6 +113,11 @@ def main() -> None:
     spec = spec_from_cfg(cfg)
     r2_io.ensure_r2_env_loaded()
 
+    marker_uri = spec.r2.dataset_complete_marker_uri()
+    if r2_io.object_size(marker_uri) is not None:
+        logger.info("skip: {} already exists, run is finalized", marker_uri)
+        return
+
     with tempfile.TemporaryDirectory() as raw_work_dir:
         work_dir = Path(raw_work_dir)
         if spec.output_format == "wds":
@@ -99,10 +126,10 @@ def main() -> None:
             finalize_hdf5(spec, work_dir)
         else:
             raise ValueError(f"unsupported output_format: {spec.output_format!r}")
-        marker_local = work_dir / _DATASET_COMPLETE_FILENAME
+        marker_local = work_dir / DATASET_COMPLETE_FILENAME
         marker_local.touch()
-        r2_io.upload(marker_local, spec.r2.dataset_complete_marker_uri())
-    logger.info("wrote dataset.complete to {}", spec.r2.dataset_complete_marker_uri())
+        r2_io.upload(marker_local, marker_uri)
+    logger.info("wrote dataset.complete to {}", marker_uri)
 
 
 if __name__ == "__main__":

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -64,14 +64,26 @@ def finalize_wds(spec: DatasetSpec, work_dir: Path) -> None:
     """Stream stats over the train shards and upload ``stats.npz``.
 
     Per-shard tar files stay in their original R2 location; only the
-    derived ``stats.npz`` is materialized. Brace patterns for each split
-    are available via
-    ``spec.r2.split_wds_brace_uri(spec.split_shard_ranges[split])``.
+    derived ``stats.npz`` is materialized. Brace patterns for non-empty
+    splits are available via
+    ``spec.r2.split_wds_brace_uri(spec.split_shard_ranges[split])``;
+    callers must check ``lo < hi`` first because empty splits raise
+    ``ValueError`` at that helper.
 
     :param spec: Validated dataset spec (``output_format == "wds"``).
     :param work_dir: Scratch directory; one shard at a time + the final
         ``stats.npz`` live here transiently.
+    :raises ValueError: The train split is empty
+        (``spec.split_shard_ranges["train"]`` has ``lo >= hi``); stats
+        cannot be computed without at least one train shard.
     """
+    train_lo, train_hi = spec.split_shard_ranges["train"]
+    if train_lo >= train_hi:
+        raise ValueError(
+            f"train split is empty (split_shard_ranges['train']="
+            f"{spec.split_shard_ranges['train']!r}); cannot compute stats "
+            f"without at least one train shard."
+        )
     mean, std = stream_stats_wds(_download_train_shards_one_at_a_time(spec, work_dir))
     stats_npz = work_dir / STATS_NPZ_FILENAME
     np.savez(stats_npz, mean=mean, std=std)

--- a/src/synth_setter/pipeline/constants.py
+++ b/src/synth_setter/pipeline/constants.py
@@ -7,6 +7,13 @@ Canonical names from docs/design/data-pipeline.md §7.1 (storage layout).
 # JSON serialization, never modified after launch.
 INPUT_SPEC_FILENAME = "input_spec.json"
 
+# Normalization statistics (mel-spec mean / std) written by finalize.
+STATS_NPZ_FILENAME = "stats.npz"
+
+# Zero-byte trust-anchor marker; presence under ``r2.prefix`` is the canonical
+# "this run is ready to consume" signal. Written strictly last by finalize.
+DATASET_COMPLETE_FILENAME = "dataset.complete"
+
 # Env-var name reserved for the worker to locate the materialized DatasetSpec.
 # Today's consumers: the launcher (``dispatch_via_skypilot``) injects the value
 # into each rank's ``task.update_envs``; the CI helper (``pipeline.ci.spec_uri``)

--- a/src/synth_setter/pipeline/data/stats.py
+++ b/src/synth_setter/pipeline/data/stats.py
@@ -3,9 +3,9 @@ import io
 import logging
 import re
 import tarfile
-from collections.abc import Iterator
+from collections.abc import Iterable, Iterator
 from pathlib import Path
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import dask.array as da
 import h5py
@@ -281,6 +281,60 @@ def _iter_mel_batches(shard_path: Path) -> Iterator[np.ndarray]:
             yield np.load(io.BytesIO(extracted.read()))
 
 
+def _fold_shard_into_welford(
+    existing: tuple[int, Any, Any], shard_path: Path
+) -> tuple[int, Any, Any]:
+    """Fold every mel row from one shard into the Welford accumulator.
+
+    :param existing: Welford state ``(count, mean, M2)`` before this shard.
+    :param shard_path: Filesystem path to one ``shard-*.tar``.
+    :returns: Updated Welford state after every readable mel row was folded.
+    :raises ValueError: ``shard_path`` carried no readable ``*.mel_spec.npy``
+        members; raised eagerly so partial stats are never written silently
+        for a truncated/malformed shard.
+    """
+    shard_rows = 0
+    for mel_batch in _iter_mel_batches(shard_path):
+        for row in mel_batch:
+            existing = update(existing, row)
+            shard_rows += 1
+    if shard_rows == 0:
+        raise ValueError(
+            f"shard {shard_path.name} contained no readable "
+            f"'*.{MEL_SPEC_FIELD}.npy' members; aborting so partial stats "
+            f"are never written silently for a truncated/malformed shard"
+        )
+    return existing
+
+
+def stream_stats_wds(
+    shard_paths: Iterable[Path], mask_degenerate: bool = False
+) -> tuple[np.ndarray, np.ndarray]:
+    """Stream Welford mean/std across an iterable of ``shard-*.tar`` paths.
+
+    Lets finalize download a shard, fold it, and ``unlink`` it before pulling
+    the next one — peak disk stays at one shard regardless of split size.
+    The iterable is consumed lazily; a generator that downloads+yields+deletes
+    pairs naturally.
+
+    :param shard_paths: Iterable yielding shard tar paths in the order the
+        caller wants them folded; sorting is the caller's responsibility.
+    :param mask_degenerate: See :func:`get_stats_wds`.
+    :returns: ``(mean, std)`` arrays as produced by :func:`finalize`.
+    :raises FileNotFoundError: ``shard_paths`` yielded zero paths; partial
+        stats are never written silently for an empty input set.
+    """
+    existing: tuple[int, Any, Any] = (0, 0, 0)
+    folded_any = False
+    for shard_path in shard_paths:
+        logger.info(f"Processing {shard_path.name}...")
+        existing = _fold_shard_into_welford(existing, shard_path)
+        folded_any = True
+    if not folded_any:
+        raise FileNotFoundError("stream_stats_wds received no shard paths")
+    return finalize(existing, mask_degenerate=mask_degenerate)
+
+
 def get_stats_wds(directory: str | Path, mask_degenerate: bool = False) -> None:
     """Compute mel-spec mean/std across all ``shard-*.tar`` in ``directory`` and write sibling
     ``stats.npz``.
@@ -294,9 +348,6 @@ def get_stats_wds(directory: str | Path, mask_degenerate: bool = False) -> None:
         on :func:`get_stats_hdf5` / :func:`get_stats_directory` for the
         downstream rationale.
     :raises FileNotFoundError: When ``directory`` contains no shards.
-    :raises ValueError: When a matched shard has zero readable
-        ``mel_spec.npy`` members — raised eagerly so partial stats are
-        never written silently for a truncated/malformed shard.
     :returns: ``None``. Writes ``stats.npz`` to ``directory / "stats.npz"``.
     :rtype: None
     """
@@ -304,25 +355,11 @@ def get_stats_wds(directory: str | Path, mask_degenerate: bool = False) -> None:
     shard_paths = sorted(directory.glob(_SHARD_GLOB))
     if not shard_paths:
         raise FileNotFoundError(f"no {_SHARD_GLOB} files in {directory}")
+    # ``ValueError`` on a malformed shard propagates from
+    # ``stream_stats_wds → _fold_shard_into_welford``; pydoclint's
+    # :raises: section only mirrors local raises.
+    mean, std = stream_stats_wds(shard_paths, mask_degenerate=mask_degenerate)
     out_file = directory / "stats.npz"
-
-    existing = (0, 0, 0)
-    for shard_path in shard_paths:
-        logger.info(f"Processing {shard_path.name}...")
-        shard_rows = 0
-        for mel_batch in _iter_mel_batches(shard_path):
-            for row in mel_batch:
-                existing = update(existing, row)
-                shard_rows += 1
-        if shard_rows == 0:
-            raise ValueError(
-                f"shard {shard_path.name} contained no readable "
-                f"'*.{MEL_SPEC_FIELD}.npy' members; aborting so partial stats "
-                f"are never written silently for a truncated/malformed shard"
-            )
-
-    mean, std = finalize(existing, mask_degenerate=mask_degenerate)
-
     logger.info(f"Saving to {out_file}")
     np.savez(out_file, mean=mean, std=std)
 

--- a/src/synth_setter/pipeline/r2_io.py
+++ b/src/synth_setter/pipeline/r2_io.py
@@ -117,21 +117,22 @@ def ensure_r2_env_loaded(env_file: Path | None = None) -> None:
 
 
 def is_r2_reachable() -> bool:
-    """Return ``True`` iff ``rclone`` is on PATH and ``rclone lsd r2:`` exits 0.
+    """Return ``True`` iff every :func:`ensure_r2_env_loaded` precondition holds.
 
-    Tests gate ``@pytest.mark.integration_r2`` cases on this helper so a
-    contributor's bare clone (no creds), a fork PR (no secrets), or a
-    network-out failure auto-skips rather than failing on the first real
-    rclone call. Mirrors the ``rclone lsd r2:`` auth-ping in
-    :func:`ensure_r2_env_loaded` but swallows the failure into a boolean
-    instead of raising.
+    Tests gate ``@pytest.mark.integration_r2`` cases on this helper. The
+    predicate has to match :func:`ensure_r2_env_loaded`'s contract — if it
+    returns ``True`` only because a user's local rclone config makes
+    ``rclone lsd r2:`` succeed while the secret env keys are unset, the
+    test then calls :func:`ensure_r2_env_loaded` and hits a hard
+    ``RuntimeError`` instead of the intended auto-skip.
 
-    :returns: ``True`` when rclone binary resolves AND a credentialled
-        ``lsd`` of ``r2:`` exits 0; ``False`` otherwise (binary missing,
-        bad/missing creds, network down, etc.).
+    :returns: ``True`` when rclone is on PATH AND all three
+        ``_SECRET_R2_ENV_KEYS`` are present in ``os.environ`` AND a
+        credentialled ``rclone lsd r2:`` exits 0; ``False`` otherwise.
     """
-
     if shutil.which("rclone") is None:
+        return False
+    if not all(key in os.environ for key in _SECRET_R2_ENV_KEYS):
         return False
     try:
         subprocess.run(  # noqa: S603 — args are literal strings

--- a/src/synth_setter/pipeline/r2_io.py
+++ b/src/synth_setter/pipeline/r2_io.py
@@ -25,10 +25,12 @@ __all__ = [
     "download_to_path",
     "downloaded_to_tempfile",
     "ensure_r2_env_loaded",
+    "is_r2_reachable",
     "is_r2_uri",
     "object_size",
     "shard_uri",
     "to_rclone_path",
+    "upload",
     "upload_to_uri",
 ]
 
@@ -113,6 +115,36 @@ def ensure_r2_env_loaded(env_file: Path | None = None) -> None:
         )
 
 
+def is_r2_reachable() -> bool:
+    """Return ``True`` iff ``rclone`` is on PATH and ``rclone lsd r2:`` exits 0.
+
+    Tests gate ``@pytest.mark.integration_r2`` cases on this helper so a
+    contributor's bare clone (no creds), a fork PR (no secrets), or a
+    network-out failure auto-skips rather than failing on the first real
+    rclone call. Mirrors the ``rclone lsd r2:`` auth-ping in
+    :func:`ensure_r2_env_loaded` but swallows the failure into a boolean
+    instead of raising.
+
+    :returns: ``True`` when rclone binary resolves AND a credentialled
+        ``lsd`` of ``r2:`` exits 0; ``False`` otherwise (binary missing,
+        bad/missing creds, network down, etc.).
+    """
+    import shutil
+
+    if shutil.which("rclone") is None:
+        return False
+    try:
+        subprocess.run(  # noqa: S603 — args are literal strings
+            ["rclone", "lsd", "r2:", "--contimeout=10s", "--timeout=30s"],  # noqa: S607
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+    return True
+
+
 def is_r2_uri(uri: str) -> bool:
     """Return True if `uri` is an `r2://bucket/key` URI."""
     return uri.startswith(R2_URI_SCHEME)
@@ -173,6 +205,35 @@ def upload_to_uri(local_path: Path, r2_uri: str) -> None:
         _to_rclone_path(r2_uri),
     ]
     subprocess.check_call(args)  # noqa: S603 — args from validated URI
+
+
+def upload(source: str | Path, destination_uri: str) -> None:
+    """Copy ``source`` to ``destination_uri``; ``source`` may be a local path or ``r2://`` URI.
+
+    Local sources delegate to :func:`upload_to_uri` so the reliability-flag set
+    stays a single-source-of-truth. R2 sources trigger ``rclone copyto`` between
+    two ``r2:`` paths with the same flag set, supporting R2-to-R2 promotion
+    (e.g. ``metadata/workers/<id>/shard-N.h5`` → ``shard-N.h5``) without
+    round-tripping through local disk.
+
+    :param source: Local filesystem path (``str`` or ``Path``) or ``r2://`` URI.
+    :param destination_uri: Destination ``r2://`` URI.
+    """
+    if isinstance(source, str) and is_r2_uri(source):
+        args = [  # noqa: S607 — rclone resolved by image's PATH
+            "rclone",
+            "copyto",
+            "-vv",
+            "--checksum",
+            "--contimeout=30s",
+            "--timeout=300s",
+            "--retries=3",
+            _to_rclone_path(source),
+            _to_rclone_path(destination_uri),
+        ]
+        subprocess.check_call(args)  # noqa: S603 — args from validated URIs
+        return
+    upload_to_uri(Path(source), destination_uri)
 
 
 def shard_uri(bucket: str, prefix: str, shard_filename: str) -> str:

--- a/src/synth_setter/pipeline/r2_io.py
+++ b/src/synth_setter/pipeline/r2_io.py
@@ -10,6 +10,7 @@ when any of these functions runs; ``ensure_r2_env_loaded`` is the load + validat
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import tempfile
 from collections.abc import Iterator
@@ -129,7 +130,6 @@ def is_r2_reachable() -> bool:
         ``lsd`` of ``r2:`` exits 0; ``False`` otherwise (binary missing,
         bad/missing creds, network down, etc.).
     """
-    import shutil
 
     if shutil.which("rclone") is None:
         return False
@@ -208,17 +208,26 @@ def upload_to_uri(local_path: Path, r2_uri: str) -> None:
 
 
 def upload(source: str | Path, destination_uri: str) -> None:
-    """Copy ``source`` to ``destination_uri``; ``source`` may be a local path or ``r2://`` URI.
+    """Copy ``source`` to ``destination_uri``; ``source`` is a local path or ``r2://`` URI.
 
-    Local sources delegate to :func:`upload_to_uri` so the reliability-flag set
-    stays a single-source-of-truth. R2 sources trigger ``rclone copyto`` between
-    two ``r2:`` paths with the same flag set, supporting R2-to-R2 promotion
-    (e.g. ``metadata/workers/<id>/shard-N.h5`` → ``shard-N.h5``) without
-    round-tripping through local disk.
+    R2-source dispatches to ``rclone copyto`` (R2→R2 promotion); local-source
+    delegates to :func:`upload_to_uri` so the reliability-flag set lives in
+    one place.
 
-    :param source: Local filesystem path (``str`` or ``Path``) or ``r2://`` URI.
+    :param source: Local filesystem path (``str`` or ``Path``) or ``r2://`` URI
+        as a ``str`` — a ``Path`` whose text starts with ``r2://`` is rejected
+        because the type signature carries no URI semantics.
     :param destination_uri: Destination ``r2://`` URI.
+    :raises TypeError: ``source`` is a ``Path`` whose textual form begins with
+        ``r2://``; pass the URI as ``str`` so dispatch is unambiguous.
     """
+    if isinstance(source, Path) and str(source).startswith(("r2://", "r2:/")):
+        # ``Path("r2://bucket/key")`` collapses the double slash to ``"r2:/bucket/key"``,
+        # so both forms have to be guarded; either way the caller meant a URI.
+        raise TypeError(
+            f"upload() received Path({str(source)!r}); pass r2:// URIs as str "
+            f"so the source-type dispatch is unambiguous."
+        )
     if isinstance(source, str) and is_r2_uri(source):
         args = [  # noqa: S607 — rclone resolved by image's PATH
             "rclone",

--- a/src/synth_setter/pipeline/schemas/r2_location.py
+++ b/src/synth_setter/pipeline/schemas/r2_location.py
@@ -28,7 +28,13 @@ from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from synth_setter.pipeline.constants import INPUT_SPEC_FILENAME, R2_URI_SCHEME, RCLONE_REMOTE
+from synth_setter.pipeline.constants import (
+    DATASET_COMPLETE_FILENAME,
+    INPUT_SPEC_FILENAME,
+    R2_URI_SCHEME,
+    RCLONE_REMOTE,
+    STATS_NPZ_FILENAME,
+)
 from synth_setter.pipeline.schemas.prefix import DEFAULT_R2_PREFIX_ROOT
 
 if TYPE_CHECKING:
@@ -204,7 +210,7 @@ class R2Location(BaseModel):
 
         :returns: ``r2://<bucket>/<prefix>dataset.complete`` URI string.
         """
-        return self._under_prefix("dataset.complete")
+        return self._under_prefix(DATASET_COMPLETE_FILENAME)
 
     def split_h5_uri(self, split: Split) -> str:
         """R2 URI of a split virtual-dataset file (``train.h5`` / ``val.h5`` / ``test.h5``).
@@ -222,17 +228,24 @@ class R2Location(BaseModel):
     def split_wds_brace_uri(self, shard_range: tuple[int, int]) -> str:
         """R2 URI carrying the webdataset brace pattern for ``[lo, hi)`` shards.
 
-        WebDataset readers expand the ``{LO..HI}`` form natively; ``HI`` here is
-        inclusive (``shard_range[1] - 1``) because that is the contract
-        ``webdataset.WebDataset`` reads.
+        WebDataset readers expand the ``{LO..HI}`` form natively; ``HI`` here
+        is inclusive (``shard_range[1] - 1``) per the
+        ``webdataset.WebDataset`` contract.
 
-        :param shard_range: Half-open shard-index range as produced by
-            ``DatasetSpec.split_shard_ranges[split]``; ``lo == hi`` is not
-            supported (no shards => no brace pattern).
+        :param shard_range: Half-open shard-index range, typically from
+            ``DatasetSpec.split_shard_ranges[split]``.
         :returns: ``r2://<bucket>/<prefix>shard-{LO..HI}.tar`` with zero-padded
             six-digit indices matching ``ShardSpec.filename``'s format.
+        :raises ValueError: ``shard_range`` is empty (``lo >= hi``) — would
+            emit a malformed brace like ``{000003..000002}`` that wds reads
+            as an empty set instead of raising.
         """
         lo, hi = shard_range
+        if lo >= hi:
+            raise ValueError(
+                f"split_wds_brace_uri requires lo < hi (got {shard_range!r}); "
+                f"an empty shard range has no brace pattern."
+            )
         return self._under_prefix(f"shard-{{{lo:06d}..{hi - 1:06d}}}.tar")
 
     def stats_uri(self) -> str:
@@ -243,7 +256,7 @@ class R2Location(BaseModel):
 
         :returns: ``r2://<bucket>/<prefix>stats.npz`` URI string.
         """
-        return self._under_prefix("stats.npz")
+        return self._under_prefix(STATS_NPZ_FILENAME)
 
     def worker_staged_shard_uri(
         self,

--- a/src/synth_setter/pipeline/schemas/r2_location.py
+++ b/src/synth_setter/pipeline/schemas/r2_location.py
@@ -32,7 +32,7 @@ from synth_setter.pipeline.constants import INPUT_SPEC_FILENAME, R2_URI_SCHEME, 
 from synth_setter.pipeline.schemas.prefix import DEFAULT_R2_PREFIX_ROOT
 
 if TYPE_CHECKING:
-    from synth_setter.pipeline.schemas.spec import ShardSpec
+    from synth_setter.pipeline.schemas.spec import ShardSpec, Split
 
 __all__ = ["R2Location"]
 
@@ -206,16 +206,34 @@ class R2Location(BaseModel):
         """
         return self._under_prefix("dataset.complete")
 
-    def split_uri(self, split: str) -> str:
+    def split_h5_uri(self, split: Split) -> str:
         """R2 URI of a split virtual-dataset file (``train.h5`` / ``val.h5`` / ``test.h5``).
 
         Reshard produces these locally today; the URI is where they land once
-        finalize uploads them (#408).
+        finalize uploads them (#408). Paired with :meth:`split_wds_brace_uri`
+        for the wds variant; callers branch on ``DatasetSpec.output_format``.
 
-        :param split: One of ``"train"``, ``"val"``, ``"test"``.
+        :param split: Split name; ``Literal["train","val","test"]`` (see
+            ``synth_setter.pipeline.schemas.spec.Split``).
         :returns: ``r2://<bucket>/<prefix><split>.h5`` URI string.
         """
         return self._under_prefix(f"{split}.h5")
+
+    def split_wds_brace_uri(self, shard_range: tuple[int, int]) -> str:
+        """R2 URI carrying the webdataset brace pattern for ``[lo, hi)`` shards.
+
+        WebDataset readers expand the ``{LO..HI}`` form natively; ``HI`` here is
+        inclusive (``shard_range[1] - 1``) because that is the contract
+        ``webdataset.WebDataset`` reads.
+
+        :param shard_range: Half-open shard-index range as produced by
+            ``DatasetSpec.split_shard_ranges[split]``; ``lo == hi`` is not
+            supported (no shards => no brace pattern).
+        :returns: ``r2://<bucket>/<prefix>shard-{LO..HI}.tar`` with zero-padded
+            six-digit indices matching ``ShardSpec.filename``'s format.
+        """
+        lo, hi = shard_range
+        return self._under_prefix(f"shard-{{{lo:06d}..{hi - 1:06d}}}.tar")
 
     def stats_uri(self) -> str:
         """R2 URI of ``stats.npz`` (normalization statistics).

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -41,6 +41,7 @@ __all__ = [
     "R2Location",
     "RenderConfig",
     "ShardSpec",
+    "Split",
 ]
 
 # Flat-form keys promoted into the nested ``r2`` dict by the back-compat shim.
@@ -269,6 +270,11 @@ class RenderConfig(BaseModel):
 
 # Names paired with ``train_val_test_sizes`` indices in error messages.
 _SPLIT_LABELS: tuple[str, str, str] = ("train", "val", "test")
+
+# Typed alias for split names — narrows the ``str`` parameter on layout helpers
+# (``R2Location.split_h5_uri``, ``DatasetSpec.split_shard_ranges`` keys) so a
+# typo lands as a type error rather than a silent miss at runtime.
+Split = Literal["train", "val", "test"]
 
 
 def _default_run_id(data: dict[str, Any]) -> str:
@@ -709,6 +715,24 @@ class DatasetSpec(BaseModel):
     def num_shards(self) -> int:
         """Total number of shards across all splits."""
         return len(self.shards)
+
+    @computed_field  # type: ignore[prop-decorator]
+    @cached_property
+    def split_shard_ranges(self) -> dict[Split, tuple[int, int]]:
+        """Half-open ``[lo, hi)`` shard-index ranges per split.
+
+        :returns: Mapping from split name to ``(lo, hi)``; ``hi`` is exclusive
+            and ``hi - lo`` equals ``size // render.samples_per_shard``. The
+            ranges concatenate in train→val→test order so their union covers
+            ``[0, num_shards)`` with no gaps.
+        """
+        sps = self.render.samples_per_shard
+        train_n, val_n, test_n = (sz // sps for sz in self.train_val_test_sizes)
+        return {
+            "train": (0, train_n),
+            "val": (train_n, train_n + val_n),
+            "test": (train_n + val_n, train_n + val_n + test_n),
+        }
 
     @computed_field  # type: ignore[prop-decorator]
     @cached_property

--- a/tests/integration/test_finalize_dataset_r2.py
+++ b/tests/integration/test_finalize_dataset_r2.py
@@ -140,6 +140,21 @@ def test_finalize_wds_uploads_stats_and_marker_to_real_r2(
     assert r2_io.object_size(spec.r2.stats_uri()) is not None, (
         f"expected stats.npz at {spec.r2.stats_uri()} after finalize"
     )
-    assert r2_io.object_size(spec.r2.dataset_complete_marker_uri()) is not None, (
-        f"expected dataset.complete marker at {spec.r2.dataset_complete_marker_uri()}"
+    # Marker is a trust anchor, not a payload — 0-byte is the canonical shape.
+    marker_size = r2_io.object_size(spec.r2.dataset_complete_marker_uri())
+    assert marker_size == 0, (
+        f"expected zero-byte marker at {spec.r2.dataset_complete_marker_uri()}; "
+        f"got size={marker_size}"
     )
+    # stats.npz must carry the keys the SurgeXTDataset reader pulls
+    # (surge_datamodule.py:62-64) — pull it back and validate the schema.
+    with tempfile.TemporaryDirectory() as raw_verify_dir:
+        verify_dir = Path(raw_verify_dir)
+        local_stats = verify_dir / "stats.npz"
+        r2_io.download_to_path(spec.r2.stats_uri(), local_stats)
+        with np.load(local_stats) as stats:
+            assert set(stats.files) == {"mean", "std"}, (
+                f"stats.npz keys are {set(stats.files)}, expected {{'mean', 'std'}}"
+            )
+            assert stats["mean"].dtype.kind == "f"
+            assert stats["std"].dtype.kind == "f"

--- a/tests/integration/test_finalize_dataset_r2.py
+++ b/tests/integration/test_finalize_dataset_r2.py
@@ -1,0 +1,145 @@
+"""End-to-end finalize-against-real-R2 tests.
+
+Auto-skips when R2 is unreachable (rclone missing, no creds, network down)
+via ``r2_io.is_r2_reachable``. Stages a single tiny wds shard under a
+unique R2 prefix, runs ``finalize_wds`` + the ``dataset.complete`` upload
+the entrypoint emits last, then asserts both artifacts land at the
+canonical URIs the consumer reads. The prefix is purged on teardown
+regardless of pass/fail.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+import tarfile
+import tempfile
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from synth_setter.cli import finalize_dataset
+from synth_setter.pipeline import r2_io
+from synth_setter.pipeline.schemas.spec import DatasetSpec
+
+pytestmark = [pytest.mark.integration_r2, pytest.mark.r2, pytest.mark.slow]
+
+
+def _write_minimal_wds_shard(dest: Path) -> None:
+    """Write a tar at ``dest`` carrying one ``00000000.mel_spec.npy`` member.
+
+    :param dest: Filesystem path where the tar is written; parents must exist.
+    """
+    payload = np.arange(8, dtype=np.float32).reshape(4, 2)
+    buf = io.BytesIO()
+    np.save(buf, payload)
+    member_bytes = buf.getvalue()
+    with tarfile.open(dest, mode="w") as tar:
+        info = tarfile.TarInfo(name="00000000.mel_spec.npy")
+        info.size = len(member_bytes)
+        tar.addfile(info, io.BytesIO(member_bytes))
+
+
+def _unique_test_prefix_suffix() -> str:
+    """Build a ``ci-finalize/<run_id>/<run_attempt>/<uuid>/`` suffix for ``R2Location.prefix``.
+
+    Matches the layout convention of ``test_local_launcher_roundtrip``'s
+    ``_unique_r2_prefix`` so concurrent CI runs and local dev runs do not
+    collide. Includes the leading ``ci-finalize/`` so a bulk
+    ``rclone purge r2:<bucket>/ci-finalize/`` reclaims stale artifacts.
+
+    :returns: Trailing-slash-terminated R2 prefix string.
+    """
+    run_id = os.environ.get("GITHUB_RUN_ID", "local")
+    run_attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "0")
+    nonce = uuid.uuid4().hex[:8]
+    return f"ci-finalize/{run_id}/{run_attempt}/{nonce}/"
+
+
+@pytest.fixture()
+def staged_wds_spec() -> Iterator[DatasetSpec]:
+    """Yield a 1-shard wds ``DatasetSpec`` with its shard pre-uploaded to R2.
+
+    Pins ``r2.prefix`` to a per-run unique value so the prefix is safe to
+    ``rclone purge`` on teardown without touching neighbours. The shard is
+    materialized locally then ``rclone copyto``'d to ``spec.r2.shard_uri(shard)``
+    so the test exercises the real download path during ``finalize_wds``.
+
+    :yields DatasetSpec: A frozen spec whose train split is one 4-sample wds shard
+        already present on R2 at ``spec.r2.shard_uri(spec.shards[0])``.
+    """
+    if not r2_io.is_r2_reachable():
+        pytest.skip("R2 not reachable (rclone not on PATH or rclone lsd r2: failed)")
+    r2_io.ensure_r2_env_loaded()
+
+    prefix = _unique_test_prefix_suffix()
+    bucket = "intermediate-data"
+    spec_kwargs: dict[str, Any] = {
+        "task_name": "finalize-it-test",
+        "output_format": "wds",
+        "train_val_test_sizes": [4, 0, 0],
+        "base_seed": 42,
+        "r2": {"bucket": bucket, "prefix": prefix},
+        "render": {
+            "plugin_path": "/fake/Plugin.vst3",
+            "preset_path": "presets/surge-base.vstpreset",
+            "param_spec_name": "surge_simple",
+            "renderer_version": "1.0.0-test",
+            "sample_rate": 16000,
+            "channels": 2,
+            "velocity": 100,
+            "signal_duration_seconds": 4.0,
+            "min_loudness": -55.0,
+            "samples_per_render_batch": 4,
+            "samples_per_shard": 4,
+            "gui_toggle_cadence": "never",
+        },
+    }
+    spec = DatasetSpec(**spec_kwargs)  # type: ignore[arg-type]
+
+    with tempfile.TemporaryDirectory() as raw_local:
+        local = Path(raw_local) / spec.shards[0].filename
+        _write_minimal_wds_shard(local)
+        r2_io.upload_to_uri(local, spec.r2.shard_uri(spec.shards[0]))
+    try:
+        yield spec
+    finally:
+        # Best-effort cleanup; a non-zero purge exit leaves test artifacts
+        # behind but never masks a real test failure.
+        subprocess.run(  # noqa: S603 — args are literal strings
+            ["rclone", "purge", f"r2:{bucket}/{prefix}"],  # noqa: S607
+            capture_output=True,
+            check=False,
+        )
+
+
+def test_finalize_wds_uploads_stats_and_marker_to_real_r2(
+    staged_wds_spec: DatasetSpec,
+) -> None:
+    """``finalize_wds`` + marker upload land ``stats.npz`` and ``dataset.complete`` on R2.
+
+    Exercises the production code path end-to-end against the configured
+    ``r2:`` remote: shard download → stats computation → stats upload →
+    marker upload. Replaces the prior plan-doc manual verification step.
+
+    :param staged_wds_spec: Fixture-provided spec whose train shard is already on R2.
+    """
+    spec = staged_wds_spec
+    with tempfile.TemporaryDirectory() as raw_work_dir:
+        work_dir = Path(raw_work_dir)
+        finalize_dataset.finalize_wds(spec, work_dir)
+        marker_local = work_dir / "dataset.complete"
+        marker_local.touch()
+        r2_io.upload(marker_local, spec.r2.dataset_complete_marker_uri())
+
+    assert r2_io.object_size(spec.r2.stats_uri()) is not None, (
+        f"expected stats.npz at {spec.r2.stats_uri()} after finalize"
+    )
+    assert r2_io.object_size(spec.r2.dataset_complete_marker_uri()) is not None, (
+        f"expected dataset.complete marker at {spec.r2.dataset_complete_marker_uri()}"
+    )

--- a/tests/integration/test_local_launcher_roundtrip.py
+++ b/tests/integration/test_local_launcher_roundtrip.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import io
 import json
 import os
-import shutil
 import subprocess
 import sys
 import tarfile
@@ -48,6 +47,7 @@ from synth_setter.data.vst.shapes import (
     mel_dataset_shape,
     param_array_dataset_shape,
 )
+from synth_setter.pipeline import r2_io
 from synth_setter.pipeline.ci.validate_shard import validate_all_shards_from_r2
 from synth_setter.pipeline.ci.validate_spec import validate_structure
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
@@ -74,35 +74,6 @@ TEST_PLUGIN_VERSION = "1.0.0-test"
 # real subprocess.check_call without recursing through any patch that targets
 # the same symbol the production code uses.
 _REAL_CHECK_CALL = subprocess.check_call
-
-
-def _r2_reachable() -> bool:
-    """Return True if rclone is on PATH and ``rclone lsd r2:`` exits cleanly.
-
-    Mirrors the gating pattern in ``tests/pipeline/data/test_r2_report.py`` so
-    a contributor running locally without R2 creds auto-skips this test
-    rather than failing on the first rclone subprocess. The ``r2:`` remote
-    is configured via ``RCLONE_CONFIG_R2_*`` env vars (set by the workflow
-    from repo secrets, or by the contributor's local rclone config); the
-    listing is authenticated and the exit code is what indicates whether
-    those creds are present and valid.
-
-    :returns: ``True`` when rclone resolves and the configured ``r2:`` remote
-        accepts a credentialled ``lsd``; ``False`` if rclone is absent or
-        the listing exits non-zero (no/invalid creds, network down, etc.).
-    """
-    if shutil.which("rclone") is None:
-        return False
-    try:
-        subprocess.run(  # noqa: S603 — args are literal strings
-            ["rclone", "lsd", "r2:", "--contimeout=10s", "--timeout=30s"],  # noqa: S607
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError):
-        return False
-    return True
 
 
 def _write_dummy_h5_shard(output_path: Path, spec: DatasetSpec) -> None:
@@ -251,7 +222,7 @@ def ci_r2_prefix() -> Iterator[str]:
 
     :yields str: Trailing-slash-terminated unique R2 prefix string.
     """
-    if not _r2_reachable():
+    if not r2_io.is_r2_reachable():
         pytest.skip("R2 not reachable (rclone not on PATH or rclone lsd r2: failed)")
     prefix = _unique_r2_prefix()
     try:

--- a/tests/pipeline/ci/test_validate_spec.py
+++ b/tests/pipeline/ci/test_validate_spec.py
@@ -49,6 +49,13 @@ def _make_valid_spec(*, output_format: str = "hdf5", **overrides: object) -> dic
         "shards": [
             {"shard_id": i, "filename": f"shard-{i:06d}{ext}", "seed": 42 + i} for i in range(3)
         ],
+        # Computed field; mirrors DatasetSpec.split_shard_ranges output for
+        # train_val_test_sizes=[32, 32, 32] and samples_per_shard=32.
+        "split_shard_ranges": {
+            "train": [0, 1],
+            "val": [1, 2],
+            "test": [2, 3],
+        },
     }
     if "render" in overrides:
         # Merge nested render overrides instead of replacing the whole sub-dict.

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 import io
 import sys
 import tarfile
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 import numpy as np
 import pytest
@@ -20,19 +20,16 @@ import pytest
 from synth_setter.cli import finalize_dataset
 from synth_setter.pipeline.schemas.spec import DatasetSpec
 
+_FIXED_NOW = datetime(2026, 5, 20, 12, 0, 0, tzinfo=timezone.utc)
+
 
 def _write_minimal_wds_shard(dest: Path) -> None:
     """Write a tar at ``dest`` with one ``00000000.mel_spec.npy`` member.
 
-    ``get_stats_wds`` requires every shard to contain at least one matched
-    ``*.mel_spec.npy`` payload or it raises; the payload's exact shape is
-    irrelevant for the upload-order assertion this test guards.
-
     :param dest: Filesystem path where the tar is written.
     """
     dest.parent.mkdir(parents=True, exist_ok=True)
-    # Welford finalize needs >=2 rows total across shards (zero variance otherwise),
-    # so each shard ships a 4-row batch.
+    # 4 rows so Welford variance is non-degenerate.
     payload = np.arange(8, dtype=np.float32).reshape(4, 2)
     buf = io.BytesIO()
     np.save(buf, payload)
@@ -43,90 +40,21 @@ def _write_minimal_wds_shard(dest: Path) -> None:
         tar.addfile(info, io.BytesIO(member_bytes))
 
 
-def test_wds_finalize_uploads_stats_then_marker_through_main(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``main()`` against the smoke-shard-wds experiment uploads stats then marker.
+def _build_wds_smoke_spec(
+    task_name: str = "finalize-wds-unit",
+    train_val_test_sizes: tuple[int, int, int] = (4, 0, 0),
+) -> DatasetSpec:
+    """Construct a wds ``DatasetSpec`` directly (no Hydra compose).
 
-    :param monkeypatch: Pytest fixture used to stub ``r2_io`` calls and ``sys.argv``.
-    """
-    uploaded: list[str] = []
-
-    def record_upload(source: str | Path, destination_uri: str) -> None:
-        del source
-        uploaded.append(destination_uri)
-
-    def fake_download(r2_uri: str, dest_path: Path) -> None:
-        del r2_uri
-        _write_minimal_wds_shard(dest_path)
-
-    monkeypatch.setattr("synth_setter.pipeline.r2_io.upload", record_upload)
-    monkeypatch.setattr("synth_setter.pipeline.r2_io.download_to_path", fake_download)
-    monkeypatch.setattr(
-        "synth_setter.pipeline.r2_io.ensure_r2_env_loaded",
-        lambda *args, **kwargs: None,
-    )
-    monkeypatch.setattr(sys, "argv", ["finalize", "experiment=generate_dataset/smoke-shard-wds"])
-
-    finalize_dataset.main()
-
-    uploaded_basenames = [Path(urlparse(uri).path).name for uri in uploaded]
-    assert uploaded_basenames == ["stats.npz", "dataset.complete"]
-
-
-def test_hdf5_branch_raises_not_implemented_in_phase_1(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``main()`` raises ``NotImplementedError`` for an hdf5 spec until Phase 2 lands.
-
-    :param monkeypatch: Pytest fixture used to stub ``ensure_r2_env_loaded`` and ``sys.argv``.
-    """
-    monkeypatch.setattr(
-        "synth_setter.pipeline.r2_io.ensure_r2_env_loaded",
-        lambda *args, **kwargs: None,
-    )
-    monkeypatch.setattr(sys, "argv", ["finalize", "experiment=generate_dataset/smoke-shard"])
-
-    with pytest.raises(NotImplementedError, match="hdf5 finalize lands in Phase 2"):
-        finalize_dataset.main()
-
-
-def test_finalize_wds_uploads_stats_npz_to_spec_stats_uri(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """``finalize_wds`` posts ``stats.npz`` at exactly ``spec.r2.stats_uri()``.
-
-    :param monkeypatch: Pytest fixture used to stub ``r2_io`` download / upload.
-    :param tmp_path: Pytest tmp dir used as the in-process scratch work_dir.
-    """
-    monkeypatch.setattr(
-        "synth_setter.pipeline.r2_io.download_to_path",
-        lambda r2_uri, dest_path: _write_minimal_wds_shard(dest_path),
-    )
-    uploads: list[tuple[Any, str]] = []
-    monkeypatch.setattr(
-        "synth_setter.pipeline.r2_io.upload",
-        lambda source, destination_uri: uploads.append((source, destination_uri)),
-    )
-
-    spec = _build_wds_smoke_spec()
-    finalize_dataset.finalize_wds(spec, tmp_path)
-
-    assert len(uploads) == 1
-    source, destination = uploads[0]
-    assert Path(source).name == "stats.npz"
-    assert destination == spec.r2.stats_uri()
-
-
-def _build_wds_smoke_spec() -> DatasetSpec:
-    """Construct a single-shard wds ``DatasetSpec`` without invoking Hydra.
-
-    :returns: A frozen ``DatasetSpec`` whose train split is one 4-sample shard.
+    :param task_name: Unique task name so each test gets a distinct r2.prefix.
+    :param train_val_test_sizes: Three-tuple of sample counts; default is one
+        4-sample shard.
+    :returns: A frozen wds ``DatasetSpec`` whose shards are deterministic.
     """
     kwargs: dict[str, Any] = {
-        "task_name": "finalize-wds-unit",
+        "task_name": task_name,
         "output_format": "wds",
-        "train_val_test_sizes": [4, 0, 0],
+        "train_val_test_sizes": list(train_val_test_sizes),
         "base_seed": 42,
         "r2": {"bucket": "intermediate-data"},
         "render": {
@@ -145,3 +73,172 @@ def _build_wds_smoke_spec() -> DatasetSpec:
         },
     }
     return DatasetSpec(**kwargs)  # type: ignore[arg-type]
+
+
+@pytest.fixture()
+def patch_finalize_io(monkeypatch: pytest.MonkeyPatch) -> tuple[list[str], list[tuple[Path, str]]]:
+    """Patch ``r2_io`` download/upload/auth so finalize never touches real R2.
+
+    :param monkeypatch: Pytest fixture used to install the stubs.
+    :returns:``(downloaded_uris, uploaded)`` — the two recording lists. Tests read these to assert
+        behaviour.
+    """
+    downloaded_uris: list[str] = []
+    uploaded: list[tuple[Path, str]] = []
+
+    def fake_download(r2_uri: str, dest_path: Path) -> None:
+        downloaded_uris.append(r2_uri)
+        _write_minimal_wds_shard(dest_path)
+
+    def record_upload(source: str | Path, destination_uri: str) -> None:
+        uploaded.append((Path(source), destination_uri))
+
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.download_to_path", fake_download)
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.upload", record_upload)
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.ensure_r2_env_loaded",
+        lambda *args, **kwargs: None,
+    )
+    # main() probes the marker URI for the idempotency gate; default is "absent".
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.object_size", lambda uri: None)
+    # Pin runtime fields so DatasetSpec.run_id is reproducible across the
+    # main()-side compose and the assertion-side compose.
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._get_git_sha", lambda: "a" * 40)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._is_repo_dirty", lambda: False)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._utc_now", lambda: _FIXED_NOW)
+    return downloaded_uris, uploaded
+
+
+def test_main_uploads_stats_then_marker_at_canonical_uris(
+    monkeypatch: pytest.MonkeyPatch,
+    patch_finalize_io: tuple[list[str], list[tuple[Path, str]]],
+) -> None:
+    """``main()`` against smoke-shard-wds uploads exactly ``stats.npz`` then ``dataset.complete``.
+
+    :param monkeypatch: Pytest fixture used to patch ``sys.argv``.
+    :param patch_finalize_io: Recording stubs for download / upload / auth.
+    """
+    _downloaded, uploaded = patch_finalize_io
+    monkeypatch.setattr(sys, "argv", ["finalize", "experiment=generate_dataset/smoke-shard-wds"])
+
+    finalize_dataset.main()
+
+    # Reconstruct the spec the same way main() does so we can assert exact URIs.
+    spec = _compose_smoke_wds_spec()
+    upload_destinations = [dst for _, dst in uploaded]
+    assert upload_destinations == [
+        spec.r2.stats_uri(),
+        spec.r2.dataset_complete_marker_uri(),
+    ]
+    assert upload_destinations[-1] == spec.r2.dataset_complete_marker_uri()
+
+
+def test_main_is_idempotent_when_marker_already_exists(
+    monkeypatch: pytest.MonkeyPatch,
+    patch_finalize_io: tuple[list[str], list[tuple[Path, str]]],
+) -> None:
+    """If ``dataset.complete`` already exists at the run prefix, ``main()`` does no work.
+
+    :param monkeypatch: Pytest fixture used to patch ``sys.argv`` and ``object_size``.
+    :param patch_finalize_io: Recording stubs; we override ``object_size`` after
+        the fixture installs the default-absent stub.
+    """
+    downloaded, uploaded = patch_finalize_io
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.object_size", lambda uri: 0)
+    monkeypatch.setattr(sys, "argv", ["finalize", "experiment=generate_dataset/smoke-shard-wds"])
+
+    finalize_dataset.main()
+
+    assert downloaded == []
+    assert uploaded == []
+
+
+def test_main_hdf5_branch_raises_not_implemented_without_uploading_anything(
+    monkeypatch: pytest.MonkeyPatch,
+    patch_finalize_io: tuple[list[str], list[tuple[Path, str]]],
+) -> None:
+    """The hdf5 stub raises before any upload — never strands a spurious marker.
+
+    :param monkeypatch: Pytest fixture used to patch ``sys.argv``.
+    :param patch_finalize_io: Recording stubs; asserted to be empty after the raise.
+    """
+    _downloaded, uploaded = patch_finalize_io
+    monkeypatch.setattr(sys, "argv", ["finalize", "experiment=generate_dataset/smoke-shard"])
+
+    with pytest.raises(NotImplementedError, match="hdf5 finalize is not implemented"):
+        finalize_dataset.main()
+    assert uploaded == []
+
+
+def test_finalize_wds_downloads_every_train_shard_uri(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Multi-shard train split: every ``spec.shards[train_lo:train_hi]`` URI is downloaded.
+
+    :param monkeypatch: Pytest fixture used to install download/upload stubs.
+    :param tmp_path: Pytest tmp dir used as the in-process scratch work_dir.
+    """
+    downloaded_uris: list[str] = []
+    uploaded: list[tuple[Path, str]] = []
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.download_to_path",
+        lambda uri, dest: (downloaded_uris.append(uri), _write_minimal_wds_shard(dest)),
+    )
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.upload",
+        lambda source, destination_uri: uploaded.append((Path(source), destination_uri)),
+    )
+
+    spec = _build_wds_smoke_spec(task_name="multi-shard-train", train_val_test_sizes=(8, 0, 0))
+    finalize_dataset.finalize_wds(spec, tmp_path)
+
+    expected_uris = [spec.r2.shard_uri(shard) for shard in spec.shards]
+    assert downloaded_uris == expected_uris
+    assert len(uploaded) == 1
+    assert uploaded[0][1] == spec.r2.stats_uri()
+
+
+def test_finalize_wds_unlinks_each_shard_after_folding(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Peak-disk invariant: at any moment at most one shard sits in ``work_dir``.
+
+    :param monkeypatch: Pytest fixture used to install the download stub.
+    :param tmp_path: Pytest tmp dir used as the in-process scratch work_dir.
+    """
+    concurrent_shards_seen: list[int] = []
+
+    def fake_download(r2_uri: str, dest_path: Path) -> None:
+        del r2_uri
+        _write_minimal_wds_shard(dest_path)
+        concurrent_shards_seen.append(len(list(tmp_path.glob("shard-*.tar"))))
+
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.download_to_path", fake_download)
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.upload", lambda src, dst: None)
+
+    spec = _build_wds_smoke_spec(task_name="peak-disk", train_val_test_sizes=(8, 0, 0))
+    finalize_dataset.finalize_wds(spec, tmp_path)
+
+    assert concurrent_shards_seen == [1, 1]
+
+
+def _compose_smoke_wds_spec() -> DatasetSpec:
+    """Re-compose the wds smoke spec the same way ``main()`` does, for URI assertions.
+
+    :returns: A ``DatasetSpec`` whose ``r2.prefix`` matches what ``main()``
+        constructs from the ``smoke-shard-wds`` experiment in the same process.
+    """
+    from hydra import compose, initialize_config_dir
+
+    with initialize_config_dir(
+        version_base="1.3",
+        config_dir=str(finalize_dataset._CONFIG_DIR),  # noqa: SLF001 — test mirrors main()
+    ):
+        cfg = compose(
+            config_name="dataset",
+            overrides=["experiment=generate_dataset/smoke-shard-wds"],
+        )
+    cfg.paths.root_dir = str(finalize_dataset._REPO_ROOT)  # noqa: SLF001
+    cfg.paths.output_dir = str(finalize_dataset._REPO_ROOT)  # noqa: SLF001
+    cfg.paths.work_dir = str(finalize_dataset._REPO_ROOT)  # noqa: SLF001
+    return finalize_dataset.spec_from_cfg(cfg)

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -1,0 +1,147 @@
+"""Tests for ``synth_setter.cli.finalize_dataset`` — finalize entrypoint.
+
+End-to-end test invokes ``main()`` against the real ``smoke-shard-wds``
+experiment so the Hydra compose + ``DatasetSpec`` construction stay
+exercised; rclone (download / upload / auth ping) is stubbed.
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import tarfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import numpy as np
+import pytest
+
+from synth_setter.cli import finalize_dataset
+from synth_setter.pipeline.schemas.spec import DatasetSpec
+
+
+def _write_minimal_wds_shard(dest: Path) -> None:
+    """Write a tar at ``dest`` with one ``00000000.mel_spec.npy`` member.
+
+    ``get_stats_wds`` requires every shard to contain at least one matched
+    ``*.mel_spec.npy`` payload or it raises; the payload's exact shape is
+    irrelevant for the upload-order assertion this test guards.
+
+    :param dest: Filesystem path where the tar is written.
+    """
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    # Welford finalize needs >=2 rows total across shards (zero variance otherwise),
+    # so each shard ships a 4-row batch.
+    payload = np.arange(8, dtype=np.float32).reshape(4, 2)
+    buf = io.BytesIO()
+    np.save(buf, payload)
+    member_bytes = buf.getvalue()
+    with tarfile.open(dest, mode="w") as tar:
+        info = tarfile.TarInfo(name="00000000.mel_spec.npy")
+        info.size = len(member_bytes)
+        tar.addfile(info, io.BytesIO(member_bytes))
+
+
+def test_wds_finalize_uploads_stats_then_marker_through_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``main()`` against the smoke-shard-wds experiment uploads stats then marker.
+
+    :param monkeypatch: Pytest fixture used to stub ``r2_io`` calls and ``sys.argv``.
+    """
+    uploaded: list[str] = []
+
+    def record_upload(source: str | Path, destination_uri: str) -> None:
+        del source
+        uploaded.append(destination_uri)
+
+    def fake_download(r2_uri: str, dest_path: Path) -> None:
+        del r2_uri
+        _write_minimal_wds_shard(dest_path)
+
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.upload", record_upload)
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.download_to_path", fake_download)
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.ensure_r2_env_loaded",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(sys, "argv", ["finalize", "experiment=generate_dataset/smoke-shard-wds"])
+
+    finalize_dataset.main()
+
+    uploaded_basenames = [Path(urlparse(uri).path).name for uri in uploaded]
+    assert uploaded_basenames == ["stats.npz", "dataset.complete"]
+
+
+def test_hdf5_branch_raises_not_implemented_in_phase_1(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``main()`` raises ``NotImplementedError`` for an hdf5 spec until Phase 2 lands.
+
+    :param monkeypatch: Pytest fixture used to stub ``ensure_r2_env_loaded`` and ``sys.argv``.
+    """
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.ensure_r2_env_loaded",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(sys, "argv", ["finalize", "experiment=generate_dataset/smoke-shard"])
+
+    with pytest.raises(NotImplementedError, match="hdf5 finalize lands in Phase 2"):
+        finalize_dataset.main()
+
+
+def test_finalize_wds_uploads_stats_npz_to_spec_stats_uri(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``finalize_wds`` posts ``stats.npz`` at exactly ``spec.r2.stats_uri()``.
+
+    :param monkeypatch: Pytest fixture used to stub ``r2_io`` download / upload.
+    :param tmp_path: Pytest tmp dir used as the in-process scratch work_dir.
+    """
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.download_to_path",
+        lambda r2_uri, dest_path: _write_minimal_wds_shard(dest_path),
+    )
+    uploads: list[tuple[Any, str]] = []
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.upload",
+        lambda source, destination_uri: uploads.append((source, destination_uri)),
+    )
+
+    spec = _build_wds_smoke_spec()
+    finalize_dataset.finalize_wds(spec, tmp_path)
+
+    assert len(uploads) == 1
+    source, destination = uploads[0]
+    assert Path(source).name == "stats.npz"
+    assert destination == spec.r2.stats_uri()
+
+
+def _build_wds_smoke_spec() -> DatasetSpec:
+    """Construct a single-shard wds ``DatasetSpec`` without invoking Hydra.
+
+    :returns: A frozen ``DatasetSpec`` whose train split is one 4-sample shard.
+    """
+    kwargs: dict[str, Any] = {
+        "task_name": "finalize-wds-unit",
+        "output_format": "wds",
+        "train_val_test_sizes": [4, 0, 0],
+        "base_seed": 42,
+        "r2": {"bucket": "intermediate-data"},
+        "render": {
+            "plugin_path": "/fake/Plugin.vst3",
+            "preset_path": "presets/surge-base.vstpreset",
+            "param_spec_name": "surge_simple",
+            "renderer_version": "1.0.0-test",
+            "sample_rate": 16000,
+            "channels": 2,
+            "velocity": 100,
+            "signal_duration_seconds": 4.0,
+            "min_loudness": -55.0,
+            "samples_per_render_batch": 4,
+            "samples_per_shard": 4,
+            "gui_toggle_cadence": "never",
+        },
+    }
+    return DatasetSpec(**kwargs)  # type: ignore[arg-type]

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -198,6 +198,29 @@ def test_finalize_wds_downloads_every_train_shard_uri(
     assert uploaded[0][1] == spec.r2.stats_uri()
 
 
+def test_finalize_wds_raises_on_empty_train_split(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An empty train split surfaces as a clear ValueError, not a misleading FileNotFoundError.
+
+    :param monkeypatch: Pytest fixture used to install download/upload stubs.
+    :param tmp_path: Pytest tmp dir used as the in-process scratch work_dir.
+    """
+    # download/upload must never be called — the empty-train guard short-circuits.
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.download_to_path",
+        lambda *a, **kw: pytest.fail("download_to_path should not be reached"),
+    )
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.upload",
+        lambda *a, **kw: pytest.fail("upload should not be reached"),
+    )
+
+    spec = _build_wds_smoke_spec(task_name="empty-train", train_val_test_sizes=(0, 4, 0))
+    with pytest.raises(ValueError, match="train split is empty"):
+        finalize_dataset.finalize_wds(spec, tmp_path)
+
+
 def test_finalize_wds_unlinks_each_shard_after_folding(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/pipeline/test_r2_io.py
+++ b/tests/pipeline/test_r2_io.py
@@ -185,13 +185,15 @@ class TestIsR2Reachable:
     def test_returns_true_when_rclone_lsd_exits_zero(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Happy path: rclone is on PATH and the ``lsd`` probe exits 0.
+        """Happy path: rclone on PATH, env keys present, probe exits 0.
 
-        :param monkeypatch: Pytest fixture used to stub ``shutil.which`` + ``subprocess.run``.
+        :param monkeypatch: Pytest fixture used to stub PATH + env + ``subprocess.run``.
         """
         monkeypatch.setattr(
             "synth_setter.pipeline.r2_io.shutil.which", lambda name: f"/usr/bin/{name}"
         )
+        for key in r2_io._SECRET_R2_ENV_KEYS:  # noqa: SLF001 — test asserts contract
+            monkeypatch.setenv(key, "stub")
 
         class _OK:
             returncode = 0
@@ -204,13 +206,15 @@ class TestIsR2Reachable:
     def test_returns_false_when_rclone_lsd_exits_non_zero(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Auth failure: rclone is on PATH but the probe exits non-zero.
+        """Auth failure: rclone + env keys present but the probe exits non-zero.
 
-        :param monkeypatch: Pytest fixture used to stub ``shutil.which`` + ``subprocess.run``.
+        :param monkeypatch: Pytest fixture used to stub PATH + env + ``subprocess.run``.
         """
         monkeypatch.setattr(
             "synth_setter.pipeline.r2_io.shutil.which", lambda name: f"/usr/bin/{name}"
         )
+        for key in r2_io._SECRET_R2_ENV_KEYS:  # noqa: SLF001 — test asserts contract
+            monkeypatch.setenv(key, "stub")
 
         def fake_run(*args: object, **kwargs: object) -> object:
             del args, kwargs
@@ -226,6 +230,29 @@ class TestIsR2Reachable:
         """
         monkeypatch.setattr("synth_setter.pipeline.r2_io.shutil.which", lambda _name: None)
         # subprocess.run must never be called — short-circuit on PATH miss.
+        monkeypatch.setattr(
+            "synth_setter.pipeline.r2_io.subprocess.run",
+            lambda *a, **kw: pytest.fail("subprocess.run should not be reached"),
+        )
+        assert r2_io.is_r2_reachable() is False
+
+    def test_returns_false_when_secret_env_keys_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Rclone-on-PATH + working local config but no env keys → skip, not hard-fail later.
+
+        Mirrors the contract of ``ensure_r2_env_loaded`` so a test that
+        gates on ``is_r2_reachable`` doesn't pass the gate and then crash
+        on ``RuntimeError`` from the env-key check downstream.
+
+        :param monkeypatch: Pytest fixture used to clear env + stub the probe.
+        """
+        monkeypatch.setattr(
+            "synth_setter.pipeline.r2_io.shutil.which", lambda name: f"/usr/bin/{name}"
+        )
+        for key in r2_io._SECRET_R2_ENV_KEYS:  # noqa: SLF001 — test asserts contract
+            monkeypatch.delenv(key, raising=False)
+        # subprocess.run must never be called — short-circuit on missing env.
         monkeypatch.setattr(
             "synth_setter.pipeline.r2_io.subprocess.run",
             lambda *a, **kw: pytest.fail("subprocess.run should not be reached"),

--- a/tests/pipeline/test_r2_io.py
+++ b/tests/pipeline/test_r2_io.py
@@ -179,6 +179,71 @@ class TestUploadToUri:
         assert "--retries=3" in args
 
 
+class TestUpload:
+    """Tests for ``upload`` — source-type-tolerant wrapper over ``rclone copyto``."""
+
+    def test_local_path_source_lands_at_destination(
+        self, fake_r2_remote: Path, tmp_path: Path
+    ) -> None:
+        """A local ``Path`` source uploads via the same path ``upload_to_uri`` exercises.
+
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        :param tmp_path: Pytest tmp dir used for the upload source file.
+        """
+        src = tmp_path / "in.json"
+        src.write_text('{"payload": 7}')
+
+        r2_io.upload(src, "r2://bucket/key.json")
+
+        assert (fake_r2_remote / "bucket" / "key.json").read_text() == '{"payload": 7}'
+
+    def test_local_str_path_source_lands_at_destination(
+        self, fake_r2_remote: Path, tmp_path: Path
+    ) -> None:
+        """A local path passed as ``str`` is coerced to ``Path`` and uploaded.
+
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        :param tmp_path: Pytest tmp dir used for the upload source file.
+        """
+        src = tmp_path / "in.json"
+        src.write_text("{}")
+
+        r2_io.upload(str(src), "r2://bucket/key.json")
+
+        assert (fake_r2_remote / "bucket" / "key.json").is_file()
+
+    def test_r2_uri_source_copies_remote_to_remote(
+        self, fake_r2_remote: Path, tmp_path: Path
+    ) -> None:
+        """An ``r2://`` source triggers an rclone R2→R2 copy (not a local upload).
+
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        :param tmp_path: Pytest tmp dir (unused but threaded for fixture symmetry).
+        """
+        seed = fake_r2_remote / "bucket" / "src" / "key.json"
+        seed.parent.mkdir(parents=True)
+        seed.write_text('{"seed": true}')
+
+        r2_io.upload("r2://bucket/src/key.json", "r2://bucket/dst/key.json")
+
+        assert (fake_r2_remote / "bucket" / "dst" / "key.json").read_text() == '{"seed": true}'
+
+    def test_r2_uri_source_uses_rclone_copyto_with_reliability_flags(self, tmp_path: Path) -> None:
+        """R2→R2 path carries the same reliability flag set as the local-upload path.
+
+        :param tmp_path: Pytest tmp dir (unused; threaded so fixture isolation is consistent).
+        """
+        with patch.object(r2_io.subprocess, "check_call") as mock_call:
+            r2_io.upload("r2://bucket/src/key.json", "r2://bucket/dst/key.json")
+        args = mock_call.call_args[0][0]
+        assert args[:2] == ["rclone", "copyto"]
+        assert "--checksum" in args
+        assert "--contimeout=30s" in args
+        assert "--timeout=300s" in args
+        assert "--retries=3" in args
+        assert args[-2:] == ["r2:bucket/src/key.json", "r2:bucket/dst/key.json"]
+
+
 class TestDownloadedToTempfile:
     """Tests for the downloaded_to_tempfile context manager."""
 

--- a/tests/pipeline/test_r2_io.py
+++ b/tests/pipeline/test_r2_io.py
@@ -179,6 +179,60 @@ class TestUploadToUri:
         assert "--retries=3" in args
 
 
+class TestIsR2Reachable:
+    """Tests for ``is_r2_reachable`` — boolean auth-probe used as a test-skip gate."""
+
+    def test_returns_true_when_rclone_lsd_exits_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Happy path: rclone is on PATH and the ``lsd`` probe exits 0.
+
+        :param monkeypatch: Pytest fixture used to stub ``shutil.which`` + ``subprocess.run``.
+        """
+        monkeypatch.setattr(
+            "synth_setter.pipeline.r2_io.shutil.which", lambda name: f"/usr/bin/{name}"
+        )
+
+        class _OK:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        monkeypatch.setattr("synth_setter.pipeline.r2_io.subprocess.run", lambda *a, **kw: _OK())
+        assert r2_io.is_r2_reachable() is True
+
+    def test_returns_false_when_rclone_lsd_exits_non_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Auth failure: rclone is on PATH but the probe exits non-zero.
+
+        :param monkeypatch: Pytest fixture used to stub ``shutil.which`` + ``subprocess.run``.
+        """
+        monkeypatch.setattr(
+            "synth_setter.pipeline.r2_io.shutil.which", lambda name: f"/usr/bin/{name}"
+        )
+
+        def fake_run(*args: object, **kwargs: object) -> object:
+            del args, kwargs
+            raise subprocess.CalledProcessError(returncode=1, cmd=["rclone", "lsd", "r2:"])
+
+        monkeypatch.setattr("synth_setter.pipeline.r2_io.subprocess.run", fake_run)
+        assert r2_io.is_r2_reachable() is False
+
+    def test_returns_false_when_rclone_not_on_path(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Bare clone / missing binary: rclone is absent from PATH.
+
+        :param monkeypatch: Pytest fixture used to stub ``shutil.which``.
+        """
+        monkeypatch.setattr("synth_setter.pipeline.r2_io.shutil.which", lambda _name: None)
+        # subprocess.run must never be called — short-circuit on PATH miss.
+        monkeypatch.setattr(
+            "synth_setter.pipeline.r2_io.subprocess.run",
+            lambda *a, **kw: pytest.fail("subprocess.run should not be reached"),
+        )
+        assert r2_io.is_r2_reachable() is False
+
+
 class TestUpload:
     """Tests for ``upload`` — source-type-tolerant wrapper over ``rclone copyto``."""
 
@@ -242,6 +296,11 @@ class TestUpload:
         assert "--timeout=300s" in args
         assert "--retries=3" in args
         assert args[-2:] == ["r2:bucket/src/key.json", "r2:bucket/dst/key.json"]
+
+    def test_rejects_path_whose_text_looks_like_r2_uri(self) -> None:
+        """A ``Path("r2://...")`` is rejected so dispatch is unambiguous between local and R2."""
+        with pytest.raises(TypeError, match=r"upload\(\) received Path.*r2://"):
+            r2_io.upload(Path("r2://bucket/src/key.json"), "r2://bucket/dst/key.json")
 
 
 class TestDownloadedToTempfile:

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -498,6 +498,42 @@ class TestDatasetSpecComputedFields:
         with pytest.raises(KeyError):
             _ = spec.num_params
 
+    def test_split_shard_ranges_partition_shards_in_index_order(
+        self, patch_runtime_io: None
+    ) -> None:
+        """Each half-open range covers ``size // samples_per_shard`` contiguous shards.
+
+        :param patch_runtime_io: Pytest fixture stubbing git/timestamp factories.
+        """
+        spec = DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=[400, 100, 100]))
+        assert spec.split_shard_ranges == {
+            "train": (0, 4),
+            "val": (4, 5),
+            "test": (5, 6),
+        }
+
+    def test_split_shard_ranges_handles_zero_sized_splits(self, patch_runtime_io: None) -> None:
+        """A zero-sized split collapses to an empty range; the next split picks up its index.
+
+        :param patch_runtime_io: Pytest fixture stubbing git/timestamp factories.
+        """
+        spec = DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=[300, 0, 0]))
+        assert spec.split_shard_ranges == {
+            "train": (0, 3),
+            "val": (3, 3),
+            "test": (3, 3),
+        }
+
+    def test_split_shard_ranges_total_matches_num_shards(self, patch_runtime_io: None) -> None:
+        """The union of the three ranges spans exactly ``[0, num_shards)``.
+
+        :param patch_runtime_io: Pytest fixture stubbing git/timestamp factories.
+        """
+        spec = DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=[400, 100, 100]))
+        ranges = spec.split_shard_ranges
+        assert ranges["train"][0] == 0
+        assert ranges["test"][1] == spec.num_shards
+
 
 # ---------------------------------------------------------------------------
 # DatasetSpec — JSON round-trip

--- a/tests/pipeline/test_schemas/test_r2_location.py
+++ b/tests/pipeline/test_schemas/test_r2_location.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from synth_setter.pipeline.schemas.r2_location import R2Location
-from synth_setter.pipeline.schemas.spec import ShardSpec
+from synth_setter.pipeline.schemas.spec import ShardSpec, Split
 
 
 def _shard(filename: str = "shard-000042.h5") -> ShardSpec:
@@ -172,13 +172,25 @@ class TestR2LocationLayoutHelpers:
         )
 
     @pytest.mark.parametrize("split", ["train", "val", "test"])
-    def test_split_uri(self, split: str) -> None:
-        """``split_uri(<split>)`` returns ``<prefix><split>.h5`` for each split.
+    def test_split_h5_uri(self, split: Split) -> None:
+        """``split_h5_uri(<split>)`` returns ``<prefix><split>.h5`` for each split.
 
         :param split: Parametrized split name (``train``/``val``/``test``).
         """
         loc = R2Location(bucket="intermediate-data", prefix="data/run/")
-        assert loc.split_uri(split) == f"r2://intermediate-data/data/run/{split}.h5"
+        assert loc.split_h5_uri(split) == f"r2://intermediate-data/data/run/{split}.h5"
+
+    def test_split_wds_brace_uri_zero_pads_six_digits_and_inclusive_hi(self) -> None:
+        """``split_wds_brace_uri`` returns the wds brace pattern for the half-open range."""
+        loc = R2Location(bucket="intermediate-data", prefix="data/run/")
+        assert loc.split_wds_brace_uri((0, 3)) == (
+            "r2://intermediate-data/data/run/shard-{000000..000002}.tar"
+        )
+
+    def test_split_wds_brace_uri_single_shard_range(self) -> None:
+        """A single-shard range collapses to a degenerate ``{NNNNNN..NNNNNN}`` brace."""
+        loc = R2Location(bucket="b", prefix="p/")
+        assert loc.split_wds_brace_uri((4, 5)) == "r2://b/p/shard-{000004..000004}.tar"
 
     def test_stats_uri(self) -> None:
         """``stats_uri()`` returns ``<prefix>stats.npz``."""
@@ -222,7 +234,8 @@ class TestR2LocationLayoutHelpers:
         assert loc.config_yaml_uri().startswith(expected_root)
         assert loc.dataset_card_uri().startswith(expected_root)
         assert loc.dataset_complete_marker_uri().startswith(expected_root)
-        assert loc.split_uri("train").startswith(expected_root)
+        assert loc.split_h5_uri("train").startswith(expected_root)
+        assert loc.split_wds_brace_uri((0, 1)).startswith(expected_root)
         assert loc.stats_uri().startswith(expected_root)
         assert loc.worker_staged_shard_uri(
             shard_id=0, worker_id="w", attempt_uuid="u", ext=".h5"

--- a/tests/pipeline/test_schemas/test_r2_location.py
+++ b/tests/pipeline/test_schemas/test_r2_location.py
@@ -192,6 +192,12 @@ class TestR2LocationLayoutHelpers:
         loc = R2Location(bucket="b", prefix="p/")
         assert loc.split_wds_brace_uri((4, 5)) == "r2://b/p/shard-{000004..000004}.tar"
 
+    def test_split_wds_brace_uri_rejects_empty_range(self) -> None:
+        """An empty range (lo == hi) raises rather than silently emitting a malformed brace."""
+        loc = R2Location(bucket="b", prefix="p/")
+        with pytest.raises(ValueError, match=r"requires lo < hi"):
+            loc.split_wds_brace_uri((3, 3))
+
     def test_stats_uri(self) -> None:
         """``stats_uri()`` returns ``<prefix>stats.npz``."""
         loc = R2Location(bucket="intermediate-data", prefix="data/run/")


### PR DESCRIPTION
## Summary

Wave 1 of the finalize-dataset PR series. Wires the post-generate finalize stage as a console script that mirrors `generate-dataset`'s operator-side shape (programmatic Hydra compose, single `DatasetSpec` input). hdf5 branch raises `NotImplementedError` (Phase 2 / #1183).

### What lands

- `synth-setter-finalize-dataset` console script (`src/synth_setter/cli/finalize_dataset.py`)
- `Split = Literal["train","val","test"]` alias + `DatasetSpec.split_shard_ranges` computed property
- `R2Location.split_h5_uri(split)` + `R2Location.split_wds_brace_uri(shard_range)` (raises on empty range)
- `r2_io.upload(source, destination_uri)` source-tolerant helper (rejects `Path("r2://...")`)
- `r2_io.is_r2_reachable()` boolean auth-probe used as the `integration_r2` skip gate; `test_local_launcher_roundtrip._r2_reachable` refactored to use it
- `stats.stream_stats_wds(Iterable[Path])` streaming variant; `get_stats_wds` delegates
- `DATASET_COMPLETE_FILENAME` + `STATS_NPZ_FILENAME` hoisted to `pipeline/constants.py`

### Finalize flow (wds)

1. Idempotency gate: `object_size(spec.r2.dataset_complete_marker_uri()) is not None` → skip.
2. Per-shard download → fold into Welford → unlink (peak local disk = 1 shard regardless of split size).
3. Upload `stats.npz` to `spec.r2.stats_uri()`.
4. Write `dataset.complete` marker last per `pipeline/CLAUDE.md`.

### Why no SkyPilot dispatch in this PR

Tracked as #1181. Operator-side shape (programmatic compose) stays compatible so dispatch lands without breaking callers.

## Test plan

- [x] `pytest tests/pipeline/test_entrypoints/test_finalize_dataset.py` — 5 pass (idempotency, upload order vs full URIs, hdf5 stub, multi-shard download, peak-disk invariant)
- [x] `pytest tests/pipeline/test_schemas/test_r2_location.py tests/pipeline/test_schemas/test_dataset_spec.py` — 5 new tests
- [x] `pytest tests/pipeline/test_r2_io.py` — 7 new tests (`upload` + `is_r2_reachable`)
- [x] `pytest tests/pipeline/data/test_stats.py` — full suite still green after the `stream_stats_wds` extraction
- [x] `pre-commit run --files <touched>` — all hooks green
- [x] `pytest -m integration_r2 tests/integration/test_finalize_dataset_r2.py` — auto-skips when R2 unreachable; runs end-to-end + validates `stats.npz` schema + asserts the marker is zero-byte when creds resolve
- [ ] CI presubmit: `test-dataset-finalization.yml` lands in Phase 3 / #1184
- [ ] `cpu-slow.yml` R2-creds wiring lands in #1185 so `integration_r2` runs post-merge

Closes #1182