### PR TITLE
feat(data-pipeline): add gui_toggle_cadence="always_on" schema value

### DIFF
--- a/src/synth_setter/data/vst/writers.py
+++ b/src/synth_setter/data/vst/writers.py
@@ -264,7 +264,8 @@ def _render_in_batches(
         # silently downgraded to "never" and persisted to R2 (#1187).
         raise NotImplementedError(
             'gui_toggle_cadence="always_on" is not yet wired into the renderer; '
-            "use one of {'never', 'once', 'render'} until the follow-up PR lands."
+            "pick another gui_toggle_cadence value (see RenderConfig schema for "
+            "the platform-specific allowed set) until the follow-up PR lands."
         )
     # plugin_reload_cadence="once": load + preset once per shard, reuse instance (#705).
     # "render" (default): cached_plugin stays None; each render reloads (#489 historical).

--- a/src/synth_setter/data/vst/writers.py
+++ b/src/synth_setter/data/vst/writers.py
@@ -252,10 +252,20 @@ def _render_in_batches(
     :param fixed_synth_params_list: Optional pre-set synth params, indexed in write order.
     :param fixed_note_params_list: Optional pre-set note params, indexed in write order.
     :param flush_batch: Called with ``(batch, batch_start_idx)`` to persist each batch.
+    :raises NotImplementedError: ``gui_toggle_cadence="always_on"`` — schema-only
+        until the held-open editor wiring lands (#1187).
     """
     num_samples = render_cfg.samples_per_shard
     sample_batch: list[VSTDataSample] = []
     sample_batch_start = start_idx
+    if render_cfg.gui_toggle_cadence == "always_on":
+        # Wave 1 ships the schema literal; the held-open editor wiring lands in
+        # the follow-up PR. Raise here so a spec composed in the gap can't be
+        # silently downgraded to "never" and persisted to R2 (#1187).
+        raise NotImplementedError(
+            'gui_toggle_cadence="always_on" is not yet wired into the renderer; '
+            "use one of {'never', 'once', 'render'} until the follow-up PR lands."
+        )
     # plugin_reload_cadence="once": load + preset once per shard, reuse instance (#705).
     # "render" (default): cached_plugin stays None; each render reloads (#489 historical).
     cached_plugin: VST3Plugin | None = None
@@ -349,15 +359,13 @@ def make_hdf5_dataset(
     param_spec = param_specs[render_cfg.param_spec_name]
     meta = _shard_metadata_from_render(render_cfg)
     with h5py.File(hdf5_file, "a") as h5:
-        audio_dataset, mel_dataset, param_dataset, start_idx = (
-            create_datasets_and_get_start_idx(
-                hdf5_file=h5,
-                num_samples=render_cfg.samples_per_shard,
-                channels=render_cfg.channels,
-                sample_rate=render_cfg.sample_rate,
-                signal_duration_seconds=render_cfg.signal_duration_seconds,
-                num_params=len(param_spec),
-            )
+        audio_dataset, mel_dataset, param_dataset, start_idx = create_datasets_and_get_start_idx(
+            hdf5_file=h5,
+            num_samples=render_cfg.samples_per_shard,
+            channels=render_cfg.channels,
+            sample_rate=render_cfg.sample_rate,
+            signal_duration_seconds=render_cfg.signal_duration_seconds,
+            num_params=len(param_spec),
         )
 
         _validate_fixed_params_lengths(

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -223,10 +223,13 @@ class RenderConfig(BaseModel):
             "before every render (default on non-Darwin, matching historical "
             'per-render warm-up), ``"always_on"`` holds the editor open for the '
             "whole shard render on a background thread (requires "
-            '``plugin_reload_cadence="once"``). Darwin rejects ``"render"`` (SIGTRAP '
-            'after ~3-4 calls, #714); ``"always_on"`` is permitted on Darwin because '
-            "it opens the editor once per shard, not cumulatively. The default "
-            'factory yields ``"never"`` on Darwin.'
+            '``plugin_reload_cadence="once"``; this Wave 1 PR ships the schema '
+            "only — the renderer raises ``NotImplementedError`` for "
+            '``"always_on"`` until the held-open wiring lands in the follow-up '
+            'PR). Darwin rejects ``"render"`` (SIGTRAP after ~3-4 calls, #714); '
+            '``"always_on"`` is permitted on Darwin because it opens the editor '
+            "once per shard, not cumulatively. The default factory yields "
+            '``"never"`` on Darwin.'
         ),
     )
 

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -130,7 +130,7 @@ def _current_platform() -> str:
     return sys.platform
 
 
-_GuiToggleCadence = Literal["never", "once", "render"]
+_GuiToggleCadence = Literal["never", "once", "render", "always_on"]
 _PluginReloadCadence = Literal["once", "render"]
 
 
@@ -218,11 +218,15 @@ class RenderConfig(BaseModel):
     gui_toggle_cadence: _GuiToggleCadence = Field(
         default_factory=_default_gui_toggle_cadence,
         description=(
-            'How often to run the ``show_editor`` warm-up on the plugin: ``"never"`` '
-            'skips it entirely, ``"once"`` runs it once per shard, ``"render"`` runs '
-            "it before every render (default on non-Darwin, matching historical "
-            'per-render warm-up). Darwin rejects ``"render"`` (SIGTRAP after ~3-4 '
-            'calls, #714); the default factory yields ``"never"`` on Darwin.'
+            'How often to realise the plugin editor during the shard: ``"never"`` '
+            'skips it entirely, ``"once"`` warms once per shard, ``"render"`` warms '
+            "before every render (default on non-Darwin, matching historical "
+            'per-render warm-up), ``"always_on"`` holds the editor open for the '
+            "whole shard render on a background thread (requires "
+            '``plugin_reload_cadence="once"``). Darwin rejects ``"render"`` (SIGTRAP '
+            'after ~3-4 calls, #714); ``"always_on"`` is permitted on Darwin because '
+            "it opens the editor once per shard, not cumulatively. The default "
+            'factory yields ``"never"`` on Darwin.'
         ),
     )
 
@@ -263,6 +267,25 @@ class RenderConfig(BaseModel):
                 "show_editor accumulates AppKit/CGS commit-handler state per "
                 "call in unbundled python and triggers SIGTRAP after ~3-4 "
                 'plugin reloads (#714). Use "once" or "never" on Darwin.'
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _always_on_requires_plugin_reload_once(self) -> RenderConfig:
+        """Reject ``gui_toggle_cadence="always_on"`` unless the plugin is loaded once per shard.
+
+        Holding the editor open binds it to a single live ``VST3Plugin`` instance;
+        reloading per render would invalidate the editor handle mid-shard.
+
+        :return: ``self`` unchanged when the combination is permitted.
+        :raises ValueError: ``gui_toggle_cadence="always_on"`` combined with
+            ``plugin_reload_cadence != "once"``.
+        """
+        if self.gui_toggle_cadence == "always_on" and self.plugin_reload_cadence != "once":
+            raise ValueError(
+                'gui_toggle_cadence="always_on" requires plugin_reload_cadence="once" '
+                "so the editor stays bound to a single live plugin instance for the "
+                "whole shard."
             )
         return self
 

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -285,7 +285,7 @@ class RenderConfig(BaseModel):
             raise ValueError(
                 'gui_toggle_cadence="always_on" requires plugin_reload_cadence="once" '
                 "so the editor stays bound to a single live plugin instance for the "
-                "whole shard."
+                'whole shard. Set plugin_reload_cadence="once" to opt in.'
             )
         return self
 

--- a/tests/data/vst/test_writers.py
+++ b/tests/data/vst/test_writers.py
@@ -366,9 +366,7 @@ def test_render_in_batches_warmup_render_runs_every_render(
     """
     # The Darwin validator rejects gui_toggle_cadence="render" (SIGTRAP, #714);
     # force the non-Darwin path so the schema constructs on macOS CI hosts too.
-    monkeypatch.setattr(
-        "synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux"
-    )
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux")
     n = 3
     render_cfg = _smoke_render_cfg(
         samples_per_shard=n,
@@ -426,6 +424,32 @@ def test_render_in_batches_warmup_never_skips_all_renders(
     assert all(c["warmup"] is False for c in captured)
 
 
+def test_render_in_batches_always_on_raises_not_implemented(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``gui_toggle_cadence="always_on"`` raises until the held-open editor wiring lands (#1187).
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    """
+    render_cfg = _smoke_render_cfg(
+        samples_per_shard=1,
+        samples_per_render_batch=1,
+        plugin_reload_cadence="once",
+        gui_toggle_cadence="always_on",
+    )
+    _stub_render_dependencies(monkeypatch, load_plugin_calls=[], load_preset_calls=[])
+
+    with pytest.raises(NotImplementedError, match=r"always_on.*not yet wired"):
+        _render_in_batches(
+            render_cfg=render_cfg,
+            param_spec=MagicMock(name="param_spec"),
+            start_idx=0,
+            fixed_synth_params_list=None,
+            fixed_note_params_list=None,
+            flush_batch=lambda _batch, _start: None,
+        )
+
+
 def test_render_in_batches_once_once_warms_once_and_caches_plugin(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -474,9 +498,7 @@ def test_render_in_batches_once_render_warms_every_render_with_cached_plugin(
 
     :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
     """
-    monkeypatch.setattr(
-        "synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux"
-    )
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux")
     n = 3
     render_cfg = _smoke_render_cfg(
         samples_per_shard=n,
@@ -655,9 +677,7 @@ def test_render_in_batches_render_cadence_warms_once_per_generate_sample_call(
 
     :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
     """
-    monkeypatch.setattr(
-        "synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux"
-    )
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux")
     n = 3
     retries = 2
     render_cfg = _smoke_render_cfg(

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -178,7 +178,7 @@ class TestRenderConfig:
     def test_gui_toggle_never_and_once_accepted_on_darwin(
         self, monkeypatch: pytest.MonkeyPatch, cadence: str
     ) -> None:
-        """``"never"`` and ``"once"`` are the only valid gui_toggle settings on Darwin.
+        """``"never"`` and ``"once"`` are accepted on Darwin (the historical safe pair).
 
         :param monkeypatch: Pytest fixture used to stub ``_current_platform``.
         :param cadence: Parametrized ``gui_toggle_cadence`` value under test.
@@ -224,6 +224,49 @@ class TestRenderConfig:
             }
         )
         assert cfg.plugin_reload_cadence == cadence
+
+    def test_always_on_accepted_with_reload_once(self) -> None:
+        """``gui_toggle_cadence="always_on"`` with ``plugin_reload_cadence="once"`` constructs."""
+        cfg = RenderConfig(
+            **{
+                **_valid_render_kwargs(),
+                "gui_toggle_cadence": "always_on",
+                "plugin_reload_cadence": "once",
+            }
+        )
+        assert cfg.gui_toggle_cadence == "always_on"
+        assert cfg.plugin_reload_cadence == "once"
+
+    def test_always_on_rejected_with_reload_render(self) -> None:
+        """``"always_on"`` rejects ``plugin_reload_cadence="render"`` at validation."""
+        with pytest.raises(
+            ValidationError,
+            match=r'gui_toggle_cadence="always_on" requires plugin_reload_cadence="once"',
+        ):
+            RenderConfig(
+                **{
+                    **_valid_render_kwargs(),
+                    "gui_toggle_cadence": "always_on",
+                    "plugin_reload_cadence": "render",
+                }
+            )
+
+    def test_always_on_accepted_on_darwin(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``"always_on"`` is permitted on Darwin (single open, below #714 threshold).
+
+        :param monkeypatch: Pytest fixture used to stub ``_current_platform``.
+        """
+        monkeypatch.setattr(
+            "synth_setter.pipeline.schemas.spec._current_platform", lambda: "darwin"
+        )
+        cfg = RenderConfig(
+            **{
+                **_valid_render_kwargs(),
+                "gui_toggle_cadence": "always_on",
+                "plugin_reload_cadence": "once",
+            }
+        )
+        assert cfg.gui_toggle_cadence == "always_on"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -189,19 +189,34 @@ class TestRenderConfig:
         cfg = RenderConfig(**{**_valid_render_kwargs(), "gui_toggle_cadence": cadence})
         assert cfg.gui_toggle_cadence == cadence
 
-    @pytest.mark.parametrize("cadence", ["never", "once", "render"])
+    @pytest.mark.parametrize(
+        ("cadence", "reload_cadence"),
+        [
+            ("never", "render"),
+            ("once", "render"),
+            ("render", "render"),
+            ("always_on", "once"),
+        ],
+    )
     def test_gui_toggle_all_values_accepted_off_darwin(
-        self, monkeypatch: pytest.MonkeyPatch, cadence: str
+        self, monkeypatch: pytest.MonkeyPatch, cadence: str, reload_cadence: str
     ) -> None:
-        """All three gui_toggle values are accepted on Linux/Windows — gate is darwin-only.
+        """All four gui_toggle values are accepted on Linux/Windows — gate is Darwin-only.
 
         :param monkeypatch: Pytest fixture used to stub ``_current_platform``.
         :param cadence: Parametrized ``gui_toggle_cadence`` value under test.
+        :param reload_cadence: Required pairing (``always_on`` needs ``once``).
         """
         monkeypatch.setattr(
             "synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux"
         )
-        cfg = RenderConfig(**{**_valid_render_kwargs(), "gui_toggle_cadence": cadence})
+        cfg = RenderConfig(
+            **{
+                **_valid_render_kwargs(),
+                "gui_toggle_cadence": cadence,
+                "plugin_reload_cadence": reload_cadence,
+            }
+        )
         assert cfg.gui_toggle_cadence == cadence
 
     @pytest.mark.parametrize("cadence", ["once", "render"])
@@ -225,8 +240,14 @@ class TestRenderConfig:
         )
         assert cfg.plugin_reload_cadence == cadence
 
-    def test_always_on_accepted_with_reload_once(self) -> None:
-        """``gui_toggle_cadence="always_on"`` with ``plugin_reload_cadence="once"`` constructs."""
+    def test_always_on_accepted_with_reload_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``gui_toggle_cadence="always_on"`` with ``plugin_reload_cadence="once"`` constructs.
+
+        :param monkeypatch: Pytest fixture used to stub ``_current_platform``.
+        """
+        monkeypatch.setattr(
+            "synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux"
+        )
         cfg = RenderConfig(
             **{
                 **_valid_render_kwargs(),
@@ -237,8 +258,14 @@ class TestRenderConfig:
         assert cfg.gui_toggle_cadence == "always_on"
         assert cfg.plugin_reload_cadence == "once"
 
-    def test_always_on_rejected_with_reload_render(self) -> None:
-        """``"always_on"`` rejects ``plugin_reload_cadence="render"`` at validation."""
+    def test_always_on_rejected_with_reload_render(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``"always_on"`` rejects ``plugin_reload_cadence="render"`` at validation.
+
+        :param monkeypatch: Pytest fixture used to stub ``_current_platform``.
+        """
+        monkeypatch.setattr(
+            "synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux"
+        )
         with pytest.raises(
             ValidationError,
             match=r'gui_toggle_cadence="always_on" requires plugin_reload_cadence="once"',
@@ -267,6 +294,7 @@ class TestRenderConfig:
             }
         )
         assert cfg.gui_toggle_cadence == "always_on"
+        assert cfg.plugin_reload_cadence == "once"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Wave 1 of 3 from `thoughts/shared/plans/2026-05-20-gui-open-for-whole-render.md` — strictly additive schema change plus a renderer guard that holds the line until Wave 2 lands.

- Extend `_GuiToggleCadence` with `"always_on"`.
- Add validator `_always_on_requires_plugin_reload_once` — rejects the combo at construction time because holding the editor open binds it to a single live plugin instance.
- No Darwin gate on `"always_on"`; a single sustained open is below the cumulative #714 SIGTRAP threshold.
- Raise `NotImplementedError` from `_render_in_batches` when `gui_toggle_cadence == "always_on"` so a spec composed in the gap between Wave 1 (this PR) and Wave 2 (renderer wiring) cannot be silently downgraded to `"never"` and persisted to R2.
- 4 new tests across `tests/pipeline/test_schemas/test_dataset_spec.py` and `tests/data/vst/test_writers.py`.

Closes #1187 (refs #218).

## What ships next

- Wave 2: `editor_held_open()` context manager in `data/vst/core.py` + wiring in `_render_in_batches` (`data/vst/writers.py`). Replaces the `NotImplementedError` guard with the real held-open editor.
- Wave 3: real-plugin integration test on Linux Xvfb + macOS Cocoa.

## Test plan

- [x] `pytest tests/pipeline/test_schemas/test_dataset_spec.py tests/data/vst/test_writers.py` — 96 pass.
- [x] `pytest tests/pipeline tests/data/vst/test_core.py tests/data/vst/test_writers.py` — full pipeline + VST suite green.
- [x] `pre-commit run` — all hooks clean (ruff, pyright, docformatter, pydoclint, interrogate, codespell).
- [x] Multi-skill review (`repo-review-full-no-comments`) over 7 parallel passes: BLOCK from the initial pass addressed in the follow-up commit; remaining items are out-of-scope WARNs documented in the sentinel at `.agent-reviews/repo-review-full-no-comments.d0d7ecf3313016f4245d9a49deee571e6943f40d.md`.