### PR TITLE
feat(data-pipeline): wire editor_held_open into _render_in_batches for always_on

### DIFF
--- a/.pydoclint-baseline.txt
+++ b/.pydoclint-baseline.txt
@@ -81,7 +81,7 @@ src/synth_setter/data/vst/core.py
     DOC201: Function `load_plugin` does not have a return section in docstring
     DOC203: Function `load_plugin` return type(s) in docstring not consistent with the return annotation. Return annotation has 1 type(s); docstring return section has 0 type(s).
     DOC101: Function `render_params`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `render_params`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [channels: int, midi_note: int, note_start_and_end: Tuple[float, float], params: dict[str, float], plugin: Optional[VST3Plugin], plugin_path: str, preset_path: Optional[str], sample_rate: float, signal_duration_seconds: float, velocity: int, warmup: bool].
+    DOC103: Function `render_params`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [channels: int, midi_note: int, note_start_and_end: tuple[float, float], params: dict[str, float], plugin: VST3Plugin | None, plugin_path: str, preset_path: str | None, sample_rate: float, signal_duration_seconds: float, velocity: int, warmup: bool].
     DOC201: Function `render_params` does not have a return section in docstring
     DOC203: Function `render_params` return type(s) in docstring not consistent with the return annotation. Return annotation has 1 type(s); docstring return section has 0 type(s).
 --------------------

--- a/src/synth_setter/data/vst/core.py
+++ b/src/synth_setter/data/vst/core.py
@@ -1,8 +1,9 @@
+import contextlib
 import json
 import plistlib
 import threading
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Optional, Tuple
 
 import mido
 import numpy as np
@@ -12,6 +13,10 @@ from pedalboard.io import AudioFile
 
 # How long the editor stays open before we signal it to close.
 _EDITOR_INIT_DELAY_SECONDS = 0.5
+# Upper bound on how long ``editor_held_open`` waits for the editor thread to
+# drain after the close event is set; a generous safety net for the held-open
+# path (#1187), not a normal-case timing parameter.
+_EDITOR_JOIN_TIMEOUT_SECONDS = 2.0
 
 
 def extract_renderer_version(plugin_path: Path) -> str:
@@ -85,6 +90,42 @@ def warmup_plugin(plugin: VST3Plugin) -> None:
         close_editor.set()  # defensive: ensure show_editor unblocks even if Timer fails
 
 
+@contextlib.contextmanager
+def editor_held_open(plugin: VST3Plugin) -> Iterator[None]:
+    """Hold ``plugin.show_editor`` open on a background thread for the ``with`` body.
+
+    The editor runs on a daemon thread blocking inside ``show_editor(close_event)``.
+    ``__exit__`` sets the event, joins the thread (bounded by
+    ``_EDITOR_JOIN_TIMEOUT_SECONDS``), and re-raises any exception the editor
+    thread raised — already logged at the moment of failure via
+    ``log.exception`` so operators see it in real time, not only at shard end.
+
+    :param plugin: A loaded VST3 plugin whose editor is realised for the block.
+    :raises BaseException: Re-raised from the editor thread at ``__exit__`` if
+        ``plugin.show_editor`` raised.
+    """
+    close_editor = threading.Event()
+    captured: list[BaseException] = []
+
+    def _run_editor() -> None:
+        try:
+            plugin.show_editor(close_editor)
+        except BaseException as exc:  # noqa: BLE001
+            logger.exception("vst-editor-window crashed: {}", exc)
+            captured.append(exc)
+
+    editor_thread = threading.Thread(target=_run_editor, daemon=True, name="vst-editor-window")
+    editor_thread.start()
+    try:
+        yield
+    finally:
+        close_editor.set()
+        editor_thread.join(timeout=_EDITOR_JOIN_TIMEOUT_SECONDS)
+        if captured:
+            exc: BaseException = captured[0]
+            raise exc
+
+
 def load_preset(plugin: VST3Plugin, preset_path: str) -> None:
     logger.info(f"Loading preset {preset_path}")
     plugin.load_preset(preset_path)
@@ -106,13 +147,13 @@ def render_params(
     params: dict[str, float],
     midi_note: int,
     velocity: int,
-    note_start_and_end: Tuple[float, float],
+    note_start_and_end: tuple[float, float],
     signal_duration_seconds: float,
     sample_rate: float,
     channels: int,
-    preset_path: Optional[str] = None,
+    preset_path: str | None = None,
     *,
-    plugin: Optional[VST3Plugin] = None,
+    plugin: VST3Plugin | None = None,
     warmup: bool = False,
 ) -> np.ndarray:
     """Render a single audio sample; reuse ``plugin`` if supplied, else load fresh.

--- a/src/synth_setter/data/vst/core.py
+++ b/src/synth_setter/data/vst/core.py
@@ -1,6 +1,7 @@
 import contextlib
 import json
 import plistlib
+import sys
 import threading
 from collections.abc import Iterator
 from pathlib import Path
@@ -98,14 +99,16 @@ def editor_held_open(plugin: VST3Plugin) -> Iterator[None]:
     ``__exit__`` sets the event, joins the thread (bounded by
     ``_EDITOR_JOIN_TIMEOUT_SECONDS``), and re-raises any exception the editor
     thread raised — already logged at the moment of failure via
-    ``logger.exception`` so operators see it in real time. If the join times
-    out (editor refused to drain), ``__exit__`` logs a warning and returns
-    without raising; the daemon thread is reaped at process exit.
+    ``logger.exception``. **Body exceptions always win:** if the ``with`` body
+    raises, that exception propagates and a captured editor-thread exception
+    is logged but not re-raised (it would otherwise mask the original error in
+    the ``finally``-clause raise). If the join times out the daemon thread is
+    left to be reaped at process exit; a warning records the leak.
 
     :param plugin: A loaded VST3 plugin whose editor is realised for the block.
-    :raises Exception: Propagated from the editor thread at ``__exit__``
-        (whatever ``plugin.show_editor`` raised — typically a ``RuntimeError``
-        from the VST3 host).
+    :raises Exception: Propagated from the editor thread at ``__exit__`` only
+        when the ``with`` body itself raised nothing — typically a
+        ``RuntimeError`` from the VST3 host.
     """
     close_editor = threading.Event()
     captured: list[Exception] = []
@@ -130,9 +133,19 @@ def editor_held_open(plugin: VST3Plugin) -> Iterator[None]:
                 "leaks (reaped at process exit)",
                 _EDITOR_JOIN_TIMEOUT_SECONDS,
             )
-        if captured:
+        # sys.exc_info() returns the body's exception if `with` body raised,
+        # else (None, None, None). Only surface the captured editor-thread
+        # exception when the body succeeded — re-raising during an active
+        # body exception would mask the original error (raise-in-finally wins).
+        body_exc_active = sys.exc_info()[0] is not None
+        if captured and not body_exc_active:
             exc: Exception = captured[0]
             raise exc
+        if captured and body_exc_active:
+            logger.error(
+                "vst-editor-window also crashed during body exception: {}",
+                captured[0],
+            )
 
 
 def load_preset(plugin: VST3Plugin, preset_path: str) -> None:

--- a/src/synth_setter/data/vst/core.py
+++ b/src/synth_setter/data/vst/core.py
@@ -98,19 +98,22 @@ def editor_held_open(plugin: VST3Plugin) -> Iterator[None]:
     ``__exit__`` sets the event, joins the thread (bounded by
     ``_EDITOR_JOIN_TIMEOUT_SECONDS``), and re-raises any exception the editor
     thread raised — already logged at the moment of failure via
-    ``log.exception`` so operators see it in real time, not only at shard end.
+    ``logger.exception`` so operators see it in real time. If the join times
+    out (editor refused to drain), ``__exit__`` logs a warning and returns
+    without raising; the daemon thread is reaped at process exit.
 
     :param plugin: A loaded VST3 plugin whose editor is realised for the block.
-    :raises BaseException: Re-raised from the editor thread at ``__exit__`` if
-        ``plugin.show_editor`` raised.
+    :raises Exception: Propagated from the editor thread at ``__exit__``
+        (whatever ``plugin.show_editor`` raised — typically a ``RuntimeError``
+        from the VST3 host).
     """
     close_editor = threading.Event()
-    captured: list[BaseException] = []
+    captured: list[Exception] = []
 
     def _run_editor() -> None:
         try:
             plugin.show_editor(close_editor)
-        except BaseException as exc:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001 — fan-in for any host-side failure
             logger.exception("vst-editor-window crashed: {}", exc)
             captured.append(exc)
 
@@ -121,8 +124,14 @@ def editor_held_open(plugin: VST3Plugin) -> Iterator[None]:
     finally:
         close_editor.set()
         editor_thread.join(timeout=_EDITOR_JOIN_TIMEOUT_SECONDS)
+        if editor_thread.is_alive():
+            logger.warning(
+                "vst-editor-window did not drain within {}s; daemon thread "
+                "leaks (reaped at process exit)",
+                _EDITOR_JOIN_TIMEOUT_SECONDS,
+            )
         if captured:
-            exc: BaseException = captured[0]
+            exc: Exception = captured[0]
             raise exc
 
 

--- a/src/synth_setter/data/vst/writers.py
+++ b/src/synth_setter/data/vst/writers.py
@@ -253,6 +253,8 @@ def _render_in_batches(
     :param fixed_synth_params_list: Optional pre-set synth params, indexed in write order.
     :param fixed_note_params_list: Optional pre-set note params, indexed in write order.
     :param flush_batch: Called with ``(batch, batch_start_idx)`` to persist each batch.
+    :raises RuntimeError: ``gui_toggle_cadence="always_on"`` reaches the
+        renderer without ``plugin_reload_cadence="once"`` (validator regression).
     """
     num_samples = render_cfg.samples_per_shard
     sample_batch: list[VSTDataSample] = []
@@ -263,15 +265,20 @@ def _render_in_batches(
     if render_cfg.plugin_reload_cadence == "once":
         cached_plugin = load_plugin(render_cfg.plugin_path)
         load_preset(cached_plugin, render_cfg.preset_path)
-    # always_on: hold the plugin editor open on a background thread for the
-    # whole shard loop. The validator on RenderConfig pairs this with
-    # plugin_reload_cadence="once", so cached_plugin is guaranteed non-None.
-    hold_open = render_cfg.gui_toggle_cadence == "always_on"
-    gui_scope: contextlib.AbstractContextManager[None] = (
-        editor_held_open(cached_plugin)
-        if hold_open and cached_plugin is not None
-        else contextlib.nullcontext()
-    )
+    # always_on holds the editor open on a background thread for the whole
+    # shard; RenderConfig validator pairs it with plugin_reload_cadence="once"
+    # so cached_plugin is non-None here (#1187).
+    gui_scope: contextlib.AbstractContextManager[None]
+    if render_cfg.gui_toggle_cadence == "always_on":
+        if cached_plugin is None:
+            raise RuntimeError(
+                "always_on reached the renderer without a cached plugin; "
+                "RenderConfig._always_on_requires_plugin_reload_once validator "
+                "should have rejected this combination."
+            )
+        gui_scope = editor_held_open(cached_plugin)
+    else:
+        gui_scope = contextlib.nullcontext()
     warmup_done = False
     with gui_scope:
         for i in trange(start_idx, num_samples):

--- a/src/synth_setter/data/vst/writers.py
+++ b/src/synth_setter/data/vst/writers.py
@@ -8,6 +8,7 @@ writer using ``webdataset.TarWriter``.
 
 from __future__ import annotations
 
+import contextlib
 from collections.abc import Callable
 from pathlib import Path
 from types import TracebackType
@@ -21,7 +22,7 @@ from pedalboard import VST3Plugin
 from tqdm import trange
 
 from synth_setter.data.vst import param_specs
-from synth_setter.data.vst.core import load_plugin, load_preset
+from synth_setter.data.vst.core import editor_held_open, load_plugin, load_preset
 from synth_setter.data.vst.generate_vst_dataset import (
     VSTDataSample,
     create_datasets_and_get_start_idx,
@@ -252,60 +253,59 @@ def _render_in_batches(
     :param fixed_synth_params_list: Optional pre-set synth params, indexed in write order.
     :param fixed_note_params_list: Optional pre-set note params, indexed in write order.
     :param flush_batch: Called with ``(batch, batch_start_idx)`` to persist each batch.
-    :raises NotImplementedError: ``gui_toggle_cadence="always_on"`` — schema-only
-        until the held-open editor wiring lands (#1187).
     """
     num_samples = render_cfg.samples_per_shard
     sample_batch: list[VSTDataSample] = []
     sample_batch_start = start_idx
-    if render_cfg.gui_toggle_cadence == "always_on":
-        # Wave 1 ships the schema literal; the held-open editor wiring lands in
-        # the follow-up PR. Raise here so a spec composed in the gap can't be
-        # silently downgraded to "never" and persisted to R2 (#1187).
-        raise NotImplementedError(
-            'gui_toggle_cadence="always_on" is not yet wired into the renderer; '
-            "pick another gui_toggle_cadence value (see RenderConfig schema for "
-            "the platform-specific allowed set) until the follow-up PR lands."
-        )
     # plugin_reload_cadence="once": load + preset once per shard, reuse instance (#705).
     # "render" (default): cached_plugin stays None; each render reloads (#489 historical).
     cached_plugin: VST3Plugin | None = None
     if render_cfg.plugin_reload_cadence == "once":
         cached_plugin = load_plugin(render_cfg.plugin_path)
         load_preset(cached_plugin, render_cfg.preset_path)
+    # always_on: hold the plugin editor open on a background thread for the
+    # whole shard loop. The validator on RenderConfig pairs this with
+    # plugin_reload_cadence="once", so cached_plugin is guaranteed non-None.
+    hold_open = render_cfg.gui_toggle_cadence == "always_on"
+    gui_scope: contextlib.AbstractContextManager[None] = (
+        editor_held_open(cached_plugin)
+        if hold_open and cached_plugin is not None
+        else contextlib.nullcontext()
+    )
     warmup_done = False
-    for i in trange(start_idx, num_samples):
-        logger.info(f"Making sample {i}")
-        warmup_this_render = render_cfg.gui_toggle_cadence == "render" or (
-            render_cfg.gui_toggle_cadence == "once" and not warmup_done
-        )
-        sample_batch.append(
-            _generate_sample_for_index(
-                i,
-                start_idx,
-                plugin_path=render_cfg.plugin_path,
-                preset_path=render_cfg.preset_path,
-                velocity=render_cfg.velocity,
-                signal_duration_seconds=render_cfg.signal_duration_seconds,
-                sample_rate=render_cfg.sample_rate,
-                channels=render_cfg.channels,
-                min_loudness=render_cfg.min_loudness,
-                param_spec=param_spec,
-                fixed_synth_params_list=fixed_synth_params_list,
-                fixed_note_params_list=fixed_note_params_list,
-                plugin=cached_plugin,
-                warmup=warmup_this_render,
+    with gui_scope:
+        for i in trange(start_idx, num_samples):
+            logger.info(f"Making sample {i}")
+            warmup_this_render = render_cfg.gui_toggle_cadence == "render" or (
+                render_cfg.gui_toggle_cadence == "once" and not warmup_done
             )
-        )
-        if warmup_this_render and render_cfg.gui_toggle_cadence == "once":
-            warmup_done = True
-        if len(sample_batch) == render_cfg.samples_per_render_batch:
-            flush_batch(sample_batch, sample_batch_start)
-            sample_batch = []
-            sample_batch_start += render_cfg.samples_per_render_batch
+            sample_batch.append(
+                _generate_sample_for_index(
+                    i,
+                    start_idx,
+                    plugin_path=render_cfg.plugin_path,
+                    preset_path=render_cfg.preset_path,
+                    velocity=render_cfg.velocity,
+                    signal_duration_seconds=render_cfg.signal_duration_seconds,
+                    sample_rate=render_cfg.sample_rate,
+                    channels=render_cfg.channels,
+                    min_loudness=render_cfg.min_loudness,
+                    param_spec=param_spec,
+                    fixed_synth_params_list=fixed_synth_params_list,
+                    fixed_note_params_list=fixed_note_params_list,
+                    plugin=cached_plugin,
+                    warmup=warmup_this_render,
+                )
+            )
+            if warmup_this_render and render_cfg.gui_toggle_cadence == "once":
+                warmup_done = True
+            if len(sample_batch) == render_cfg.samples_per_render_batch:
+                flush_batch(sample_batch, sample_batch_start)
+                sample_batch = []
+                sample_batch_start += render_cfg.samples_per_render_batch
 
-    if sample_batch:
-        flush_batch(sample_batch, sample_batch_start)
+        if sample_batch:
+            flush_batch(sample_batch, sample_batch_start)
 
 
 def _shard_metadata_from_render(render_cfg: RenderConfig) -> ShardMetadata:

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -223,10 +223,8 @@ class RenderConfig(BaseModel):
             "before every render (default on non-Darwin, matching historical "
             'per-render warm-up), ``"always_on"`` holds the editor open for the '
             "whole shard render on a background thread (requires "
-            '``plugin_reload_cadence="once"``; this Wave 1 PR ships the schema '
-            "only — the renderer raises ``NotImplementedError`` for "
-            '``"always_on"`` until the held-open wiring lands in the follow-up '
-            'PR). Darwin rejects ``"render"`` (SIGTRAP after ~3-4 calls, #714); '
+            '``plugin_reload_cadence="once"``). Darwin rejects ``"render"`` '
+            "(SIGTRAP after ~3-4 calls, #714); "
             '``"always_on"`` is permitted on Darwin because it opens the editor '
             "once per shard, not cumulatively. The default factory yields "
             '``"never"`` on Darwin.'

--- a/tests/data/vst/test_core.py
+++ b/tests/data/vst/test_core.py
@@ -133,6 +133,37 @@ class TestEditorHeldOpen:
         assert fake_logger.exception.call_count == 1
         assert "vst-editor-window crashed" in fake_logger.exception.call_args.args[0]
 
+    def test_body_exception_wins_over_editor_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If both the ``with`` body and the editor thread raise, the body's exception propagates.
+
+        Re-raising the captured editor exception inside the ``finally`` clause
+        would otherwise mask the body exception (raise-in-finally wins). The
+        editor crash still gets a structured error log so it is not lost.
+
+        :param monkeypatch: Stubs ``core.logger`` so the editor crash log can
+            be observed.
+        :raises ValueError: Intentionally raised inside the ``with`` body to
+            exercise the body-wins precedence path under test.
+        """
+        fake_plugin = MagicMock()
+        fake_plugin.show_editor.side_effect = RuntimeError("editor crashed")
+        fake_logger = MagicMock()
+        monkeypatch.setattr(core, "logger", fake_logger)
+
+        with pytest.raises(ValueError, match="body crashed"):
+            with core.editor_held_open(fake_plugin):
+                time.sleep(0.05)  # let the editor thread run + raise
+                raise ValueError("body crashed")
+
+        # editor crash still surfaces via the structured error log so it is
+        # not lost when the body exception takes precedence.
+        assert any(
+            "also crashed during body exception" in str(call.args[0])
+            for call in fake_logger.error.call_args_list
+        )
+
     def test_join_timeout_does_not_deadlock(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """If ``show_editor`` ignores the close event, ``__exit__`` returns within the timeout.
 

--- a/tests/data/vst/test_core.py
+++ b/tests/data/vst/test_core.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import plistlib
+import threading
+import time
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -65,9 +67,7 @@ class TestExtractRendererVersion:
 class TestLoadPluginNoWarmup:
     """``load_plugin`` is a pure loader — never calls ``show_editor`` by itself."""
 
-    def test_load_plugin_does_not_call_show_editor(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_load_plugin_does_not_call_show_editor(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``load_plugin`` only constructs ``VST3Plugin``; warm-up lives in ``warmup_plugin``.
 
         :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
@@ -90,6 +90,64 @@ class TestWarmupPlugin:
         warmup_plugin(fake_plugin)
 
         fake_plugin.show_editor.assert_called_once()
+
+
+class TestEditorHeldOpen:
+    """``editor_held_open`` opens the plugin editor on a background thread for the ``with``
+    body."""
+
+    def test_opens_once_and_closes_on_exit(self) -> None:
+        """``show_editor`` is called once on a background thread; close_event set on
+        ``__exit__``."""
+        fake_plugin = MagicMock()
+        captured_event: list[threading.Event] = []
+
+        def record_event(event: threading.Event) -> None:
+            captured_event.append(event)
+            event.wait(timeout=5.0)
+
+        fake_plugin.show_editor.side_effect = record_event
+
+        with core.editor_held_open(fake_plugin):
+            pass
+
+        fake_plugin.show_editor.assert_called_once()
+        assert len(captured_event) == 1
+        assert captured_event[0].is_set()
+
+    def test_logs_and_reraises_thread_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An exception in ``show_editor`` is logged immediately and re-raised at ``__exit__``.
+
+        :param monkeypatch: Stubs ``core.logger`` so the log call can be observed
+            (loguru does not propagate to ``caplog``'s stdlib handler).
+        """
+        fake_plugin = MagicMock()
+        fake_plugin.show_editor.side_effect = RuntimeError("xserver gone")
+        fake_logger = MagicMock()
+        monkeypatch.setattr(core, "logger", fake_logger)
+
+        with pytest.raises(RuntimeError, match="xserver gone"):
+            with core.editor_held_open(fake_plugin):
+                time.sleep(0.05)  # let the editor thread run + raise
+
+        assert fake_logger.exception.call_count == 1
+        assert "vst-editor-window crashed" in fake_logger.exception.call_args.args[0]
+
+    def test_join_timeout_does_not_deadlock(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If ``show_editor`` ignores the close event, ``__exit__`` returns within the timeout.
+
+        :param monkeypatch: Tightens ``_EDITOR_JOIN_TIMEOUT_SECONDS`` so the test runs quickly.
+        """
+        monkeypatch.setattr(core, "_EDITOR_JOIN_TIMEOUT_SECONDS", 0.1)
+        fake_plugin = MagicMock()
+        fake_plugin.show_editor.side_effect = lambda _event: time.sleep(2.0)
+
+        start = time.monotonic()
+        with core.editor_held_open(fake_plugin):
+            pass
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 1.0
 
 
 class TestRenderParamsPreloadedPlugin:
@@ -144,9 +202,7 @@ class TestRenderParamsPreloadedPlugin:
         # The pre-loaded plugin is what ran the render.
         assert preloaded.process.called
 
-    def test_no_plugin_kwarg_reloads_per_call(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_no_plugin_kwarg_reloads_per_call(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Without ``plugin``, ``render_params`` still loads the plugin and preset per call.
 
         :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
@@ -193,9 +249,7 @@ class TestRenderParamsPreloadedPlugin:
 
         monkeypatch.setattr(core, "load_plugin", lambda _path: fake_plugin)
         monkeypatch.setattr(core, "load_preset", lambda *_a, **_kw: None)
-        monkeypatch.setattr(
-            core, "warmup_plugin", lambda plugin: warmup_calls.append(plugin)
-        )
+        monkeypatch.setattr(core, "warmup_plugin", lambda plugin: warmup_calls.append(plugin))
 
         render_params(
             "plugins/Surge XT.vst3",
@@ -222,9 +276,7 @@ class TestRenderParamsPreloadedPlugin:
         cached = self._fake_plugin(audio_shape=(2, 16))
         warmup_calls: list[object] = []
 
-        monkeypatch.setattr(
-            core, "warmup_plugin", lambda plugin: warmup_calls.append(plugin)
-        )
+        monkeypatch.setattr(core, "warmup_plugin", lambda plugin: warmup_calls.append(plugin))
 
         render_params(
             "plugins/Surge XT.vst3",

--- a/tests/data/vst/test_core.py
+++ b/tests/data/vst/test_core.py
@@ -136,9 +136,12 @@ class TestEditorHeldOpen:
     def test_join_timeout_does_not_deadlock(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """If ``show_editor`` ignores the close event, ``__exit__`` returns within the timeout.
 
-        :param monkeypatch: Tightens ``_EDITOR_JOIN_TIMEOUT_SECONDS`` so the test runs quickly.
+        :param monkeypatch: Tightens ``_EDITOR_JOIN_TIMEOUT_SECONDS`` and stubs
+            ``core.logger`` so the leak-warning assertion is observable.
         """
         monkeypatch.setattr(core, "_EDITOR_JOIN_TIMEOUT_SECONDS", 0.1)
+        fake_logger = MagicMock()
+        monkeypatch.setattr(core, "logger", fake_logger)
         fake_plugin = MagicMock()
         fake_plugin.show_editor.side_effect = lambda _event: time.sleep(2.0)
 
@@ -147,7 +150,12 @@ class TestEditorHeldOpen:
             pass
         elapsed = time.monotonic() - start
 
+        # 1s slack over the 0.1s timeout to absorb CI scheduler jitter; still
+        # an order of magnitude under the 2.0s `show_editor` sleep so a
+        # regression to "wait for the thread" would fail this assertion.
         assert elapsed < 1.0
+        assert fake_logger.warning.call_count == 1
+        assert "did not drain" in fake_logger.warning.call_args.args[0]
 
 
 class TestRenderParamsPreloadedPlugin:

--- a/tests/data/vst/test_writers.py
+++ b/tests/data/vst/test_writers.py
@@ -8,7 +8,10 @@ the new wds e2e tests in ``test_writers_wds_e2e.py``.
 
 from __future__ import annotations
 
+import contextlib
 import sys
+import threading
+from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -424,10 +427,66 @@ def test_render_in_batches_warmup_never_skips_all_renders(
     assert all(c["warmup"] is False for c in captured)
 
 
-def test_render_in_batches_always_on_raises_not_implemented(
+def test_render_in_batches_always_on_holds_editor_open_across_all_renders(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``gui_toggle_cadence="always_on"`` raises until the held-open editor wiring lands (#1187).
+    """``gui_toggle_cadence="always_on"`` wraps the loop in ``editor_held_open(cached_plugin)``.
+
+    Asserts the context manager is entered once with the cached plugin, the loop
+    runs for all samples, ``warmup_plugin`` never fires per render, and the
+    held-open scope closes after the loop.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    """
+    n = 3
+    render_cfg = _smoke_render_cfg(
+        samples_per_shard=n,
+        samples_per_render_batch=n,
+        plugin_reload_cadence="once",
+        gui_toggle_cadence="always_on",
+    )
+    cached_plugin_holder: list[object] = []
+    captured = _stub_render_dependencies(
+        monkeypatch,
+        load_plugin_calls=[],
+        load_preset_calls=[],
+        cached_plugin_holder=cached_plugin_holder,
+    )
+    held_open_calls: list[object] = []
+    close_events: list[threading.Event] = []
+
+    @contextlib.contextmanager
+    def fake_held_open(plugin: object) -> Iterator[None]:
+        held_open_calls.append(plugin)
+        event = threading.Event()
+        close_events.append(event)
+        try:
+            yield
+        finally:
+            event.set()
+
+    monkeypatch.setattr(writers, "editor_held_open", fake_held_open)
+
+    _render_in_batches(
+        render_cfg=render_cfg,
+        param_spec=MagicMock(name="param_spec"),
+        start_idx=0,
+        fixed_synth_params_list=None,
+        fixed_note_params_list=None,
+        flush_batch=lambda _batch, _start: None,
+    )
+
+    assert len(held_open_calls) == 1
+    assert held_open_calls[0] is cached_plugin_holder[0]
+    assert close_events[0].is_set()
+    assert len(captured) == n
+    assert all(c["warmup"] is False for c in captured)
+
+
+def test_render_in_batches_non_always_on_does_not_open_held_open_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The three legacy cadences leave ``editor_held_open`` untouched (nullcontext path).
 
     :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
     """
@@ -435,19 +494,28 @@ def test_render_in_batches_always_on_raises_not_implemented(
         samples_per_shard=1,
         samples_per_render_batch=1,
         plugin_reload_cadence="once",
-        gui_toggle_cadence="always_on",
+        gui_toggle_cadence="never",
     )
     _stub_render_dependencies(monkeypatch, load_plugin_calls=[], load_preset_calls=[])
+    held_open_calls: list[object] = []
 
-    with pytest.raises(NotImplementedError, match=r"always_on.*not yet wired"):
-        _render_in_batches(
-            render_cfg=render_cfg,
-            param_spec=MagicMock(name="param_spec"),
-            start_idx=0,
-            fixed_synth_params_list=None,
-            fixed_note_params_list=None,
-            flush_batch=lambda _batch, _start: None,
-        )
+    @contextlib.contextmanager
+    def fake_held_open(plugin: object) -> Iterator[None]:
+        held_open_calls.append(plugin)
+        yield
+
+    monkeypatch.setattr(writers, "editor_held_open", fake_held_open)
+
+    _render_in_batches(
+        render_cfg=render_cfg,
+        param_spec=MagicMock(name="param_spec"),
+        start_idx=0,
+        fixed_synth_params_list=None,
+        fixed_note_params_list=None,
+        flush_batch=lambda _batch, _start: None,
+    )
+
+    assert held_open_calls == []
 
 
 def test_render_in_batches_once_once_warms_once_and_caches_plugin(

--- a/tests/data/vst/test_writers.py
+++ b/tests/data/vst/test_writers.py
@@ -489,10 +489,13 @@ def test_render_in_batches_non_always_on_does_not_open_held_open_scope(
 ) -> None:
     """Every legacy ``gui_toggle_cadence`` leaves ``editor_held_open`` untouched.
 
-    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    :param monkeypatch: Pins ``_current_platform`` to ``"linux"`` so the
+        ``"render"`` cadence is accepted on Darwin runners (the schema's #714
+        gate rejects it there), and patches the writer's render dependencies.
     :param legacy_cadence: Parametrized over each non-``always_on`` cadence so
         all three nullcontext paths are pinned, not just ``never``.
     """
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux")
     render_cfg = _smoke_render_cfg(
         samples_per_shard=1,
         samples_per_render_batch=1,

--- a/tests/data/vst/test_writers.py
+++ b/tests/data/vst/test_writers.py
@@ -483,18 +483,21 @@ def test_render_in_batches_always_on_holds_editor_open_across_all_renders(
     assert all(c["warmup"] is False for c in captured)
 
 
+@pytest.mark.parametrize("legacy_cadence", ["never", "once", "render"])
 def test_render_in_batches_non_always_on_does_not_open_held_open_scope(
-    monkeypatch: pytest.MonkeyPatch,
+    monkeypatch: pytest.MonkeyPatch, legacy_cadence: str
 ) -> None:
-    """The three legacy cadences leave ``editor_held_open`` untouched (nullcontext path).
+    """Every legacy ``gui_toggle_cadence`` leaves ``editor_held_open`` untouched.
 
     :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    :param legacy_cadence: Parametrized over each non-``always_on`` cadence so
+        all three nullcontext paths are pinned, not just ``never``.
     """
     render_cfg = _smoke_render_cfg(
         samples_per_shard=1,
         samples_per_render_batch=1,
         plugin_reload_cadence="once",
-        gui_toggle_cadence="never",
+        gui_toggle_cadence=legacy_cadence,
     )
     _stub_render_dependencies(monkeypatch, load_plugin_calls=[], load_preset_calls=[])
     held_open_calls: list[object] = []


### PR DESCRIPTION
## Summary

Wave 2 of 3 from `thoughts/shared/plans/2026-05-20-gui-open-for-whole-render.md` — replaces the Wave 1 `NotImplementedError` guard with the real held-open editor.

- Add `editor_held_open(plugin)` context manager in `src/synth_setter/data/vst/core.py`. Runs `plugin.show_editor(close_event)` on a daemon background thread; on `__exit__` sets the event, joins the thread (bounded by `_EDITOR_JOIN_TIMEOUT_SECONDS = 2.0`), logs a `warning` if the thread refused to drain, and re-raises any captured exception (already surfaced via `logger.exception` at the moment of failure).
- Wrap the shard loop in `_render_in_batches` with `editor_held_open(cached_plugin)` for `gui_toggle_cadence == "always_on"`, otherwise `contextlib.nullcontext()`. Legacy cadences (`never` / `once` / `render`) are byte-identical.
- Strip the Wave 1 transient note from the field description; refresh the pydoclint baseline entry for `render_params` whose parameter types were normalised to PEP 604 by ruff's UP autofixer when the legacy `typing` imports came out.
- 5 new tests: 3 in `TestEditorHeldOpen` (open-and-close, log + re-raise on editor crash, join-timeout-no-deadlock + leak-warning), 2 writer tests (always_on enters the held-open scope with the cached plugin; legacy cadences leave it untouched).

Closes #1191 (refs #218).

## What ships next

- Wave 3: real-plugin integration test on Linux Xvfb + macOS Cocoa via the existing CI matrix — the empirical check the design called for re: pedalboard's off-main-thread editor on Cocoa.

## Test plan

- [x] `pytest tests/data/vst/test_core.py tests/data/vst/test_writers.py tests/pipeline/test_schemas/test_dataset_spec.py` — 240 pass.
- [x] `pre-commit run` — all hooks clean.
- [x] Multi-skill review (`repo-review-full-no-comments`) over 7 parallel passes: 1 BLOCK + 3 load-bearing WARNs from the initial pass addressed in the follow-up commit; remaining items documented as deferred in the sentinel.