### PR TITLE
ci(data-pipeline): nightly schedule exercises RenderConfig.parallel end-to-end

### DIFF
--- a/.github/workflows/nightly-parallel-datagen.yml
+++ b/.github/workflows/nightly-parallel-datagen.yml
@@ -58,11 +58,9 @@ jobs:
 
     env:
       IMAGE: tinaudio/synth-setter:${{ inputs.image_tag || 'dev-snapshot' }}
-      # ``r2.prefix`` (and therefore the spec's ``input_spec_uri``) is scoped
-      # to a unique nightly leaf so concurrent runs / re-runs cannot collide on
-      # the canonical R2 object. The leaf is computed in the ``Compute R2
-      # prefix`` step and re-exported into ``GITHUB_ENV`` so the cleanup step
-      # can purge the same scope even when the generate step fails.
+      # ``NIGHTLY_TASK_NAME`` is computed below and exported to ``GITHUB_ENV``
+      # so the cleanup step can purge ``data/<task_name>/`` even when an
+      # earlier step fails before the spec_uri step resolves the full prefix.
       R2_BUCKET: intermediate-data
       RCLONE_CONFIG_R2_TYPE: s3
       RCLONE_CONFIG_R2_PROVIDER: Cloudflare
@@ -77,21 +75,20 @@ jobs:
       - name: Pull image
         run: docker pull "$IMAGE"
 
-      # Per-run unique R2 prefix. ``run_attempt`` is part of the path so a
-      # re-run of the same workflow doesn't collide on the canonical
-      # ``input_spec.json`` object the launcher writes. The leaf nonce keeps
-      # local manual dispatches isolated even when ``run_id``/``run_attempt``
-      # repeat. Persisted into ``GITHUB_ENV`` so the cleanup step (which runs
-      # ``if: always()``) can purge the same scope on failure.
-      - name: Compute R2 prefix
-        id: prefix
+      # Per-run unique ``task_name`` so the launcher's auto-filled
+      # ``r2.prefix = <prefix_root>/<task_name>/<run_id>/`` keeps the
+      # canonical ``data/`` prefix invariant while still scoping each
+      # nightly run to its own R2 leaf. The cleanup step purges the
+      # whole ``data/<task_name>/`` slice on ``if: always()``.
+      - name: Compute nightly task_name
+        id: task
         run: |
           set -euo pipefail
           nonce=$(uuidgen | tr -d '-' | cut -c1-8)
-          prefix="nightly-parallel/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${nonce}/"
-          echo "R2_PREFIX=${prefix}" >> "${GITHUB_ENV}"
-          echo "r2_prefix=${prefix}" >> "${GITHUB_OUTPUT}"
-          echo "r2 prefix: ${prefix}"
+          task="nightly-parallel-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${nonce}"
+          echo "NIGHTLY_TASK_NAME=${task}" >> "${GITHUB_ENV}"
+          echo "task_name=${task}" >> "${GITHUB_OUTPUT}"
+          echo "nightly task_name: ${task}"
 
       # Mirrors the headless plugin-load smoke check in ``test-vst-slow.yml``
       # — fails fast if the plugin / image / mount layout is broken before
@@ -143,7 +140,7 @@ jobs:
             -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
             -e RCLONE_CONFIG_R2_ENDPOINT \
             -e EXPERIMENT \
-            -e R2_PREFIX \
+            -e NIGHTLY_TASK_NAME \
             -e HYDRA_FULL_ERROR=1 \
             -e SYNTH_SETTER_WORKER_RANK=0 \
             -e SYNTH_SETTER_NUM_WORKERS=1 \
@@ -156,30 +153,46 @@ jobs:
               synth-setter-generate-dataset \
                 "experiment=${EXPERIMENT}" \
                 "+render.parallel=true" \
-                "+r2.prefix=${R2_PREFIX}"
+                "task_name=${NIGHTLY_TASK_NAME}"
             ' \
             2>&1 | tee "${RUN_METADATA_DIR}/generate.log"
           echo "run_metadata_dir=${RUN_METADATA_DIR}" >> "${GITHUB_OUTPUT}"
 
-      # ``upload_spec`` emits the canonical spec URI on a stdout sentinel line;
-      # ``grep || true`` keeps a missing marker from short-circuiting the step
-      # under ``set -euo pipefail`` so the explicit empty-check below surfaces
-      # a friendly error instead of a confusing pipe-failure.
-      - name: Extract spec_uri from launcher log
+      # The inline ``run(spec)`` path does NOT emit the
+      # ``::synth-setter-spec-uri::`` marker (that's only the SkyPilot
+      # dispatch branch in ``skypilot_launch.py``). Instead, use the local
+      # spec the launcher wrote via ``write_spec_locally`` — it lives under
+      # ``<workspace>/data/<task_name>/<run_id>/metadata/input_spec.json``
+      # and carries ``r2.bucket`` + ``r2.prefix`` so we can synthesise the
+      # canonical R2 URI without a second R2 round-trip.
+      - name: Resolve spec_uri from local materialized spec
         id: spec_uri
         env:
-          GENERATE_LOG: ${{ steps.generate.outputs.run_metadata_dir }}/generate.log
+          NIGHTLY_TASK_NAME: ${{ steps.task.outputs.task_name }}
         run: |
           set -euo pipefail
-          SPEC_URI=$(grep -m1 -oE '::synth-setter-spec-uri::r2://[^[:space:]]+' \
-            "${GENERATE_LOG}" \
-            | sed 's|^::synth-setter-spec-uri::||' || true)
-          if [[ -z "${SPEC_URI}" ]]; then
-            echo "::error::launcher did not emit a ::synth-setter-spec-uri:: marker; see generate.log"
+          shopt -s nullglob
+          specs=("${GITHUB_WORKSPACE}/data/${NIGHTLY_TASK_NAME}"/*/metadata/input_spec.json)
+          if [[ "${#specs[@]}" -ne 1 ]]; then
+            echo "::error::expected exactly one materialized spec under data/${NIGHTLY_TASK_NAME}/*/metadata/, found ${#specs[@]}"
+            printf '%s\n' "${specs[@]}"
             exit 1
           fi
+          SPEC_PATH="${specs[0]}"
+          SPEC_URI=$(python3 -c '
+          import json, sys
+          spec = json.load(open(sys.argv[1]))
+          r2 = spec["r2"]
+          print(f"r2://{r2[\"bucket\"]}/{r2[\"prefix\"]}input_spec.json")
+          ' "${SPEC_PATH}")
+          R2_PREFIX=$(python3 -c '
+          import json, sys
+          print(json.load(open(sys.argv[1]))["r2"]["prefix"])
+          ' "${SPEC_PATH}")
           echo "spec_uri=${SPEC_URI}" >> "${GITHUB_OUTPUT}"
+          echo "R2_PREFIX=${R2_PREFIX}" >> "${GITHUB_ENV}"
           echo "spec_uri: ${SPEC_URI}"
+          echo "r2 prefix (for cleanup): ${R2_PREFIX}"
 
       # Validate the spec + every shard against R2 using the same CI helpers
       # invoked by ``validate-dataset-shards.yaml``. Runs inside the same
@@ -216,18 +229,24 @@ jobs:
           if-no-files-found: warn
 
       # Always purge the ephemeral R2 prefix so failed runs do not leak
-      # objects. ``rclone purge`` exits non-zero on a missing remote prefix
-      # (which is fine — nothing to clean); a non-zero exit here must not
-      # mask a real test failure, hence the ``|| true``.
+      # objects. Prefer the spec-derived R2_PREFIX; fall back to the
+      # task-scoped ``data/<task>/`` when generate failed before the spec_uri
+      # step ran. ``rclone purge`` exits non-zero on a missing remote prefix
+      # (fine — nothing to clean); ``|| true`` keeps cleanup from masking a
+      # real test failure.
       - name: Cleanup ephemeral R2 prefix
         if: always()
         run: |
           set -euo pipefail
-          if [[ -z "${R2_PREFIX:-}" ]]; then
-            echo "no R2_PREFIX set; nothing to purge"
+          target_prefix="${R2_PREFIX:-}"
+          if [[ -z "${target_prefix}" && -n "${NIGHTLY_TASK_NAME:-}" ]]; then
+            target_prefix="data/${NIGHTLY_TASK_NAME}/"
+          fi
+          if [[ -z "${target_prefix}" ]]; then
+            echo "no R2_PREFIX or NIGHTLY_TASK_NAME set; nothing to purge"
             exit 0
           fi
-          target="r2:${R2_BUCKET}/${R2_PREFIX}"
+          target="r2:${R2_BUCKET}/${target_prefix}"
           docker run --rm \
             -e RCLONE_CONFIG_R2_TYPE \
             -e RCLONE_CONFIG_R2_PROVIDER \
@@ -241,9 +260,9 @@ jobs:
       # Auto-file a Bug ticket on scheduled-run failure so nightly regressions
       # don't go silently stale. Mirrors ``cpu-slow.yml``'s pattern: dedupe on
       # a title fragment, comment on the existing issue on a repeat, otherwise
-      # open a fresh issue with type=Bug + parent=Phase 6 (#73). Best-effort
+      # open a fresh issue with type=Bug + parent=Phase 1 (#150). Best-effort
       # GraphQL mutations — if either call fails the issue still has label +
-      # milestone, enough for triage.
+      # milestone + assignee, enough for triage.
       - name: Auto-file failure ticket
         if: failure() && github.event_name == 'schedule'
         env:
@@ -285,6 +304,7 @@ jobs:
             --body "${body}" \
             --label ci-automation \
             --label data-pipeline \
+            --assignee ktinubu \
             --milestone "ci-automation v1.0.0")
           echo "Filed: ${new_issue_url}"
 
@@ -317,7 +337,7 @@ jobs:
             -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){issue(number:$number){id}}}' \
             -f owner="${GITHUB_REPOSITORY%/*}" \
             -f repo="${GITHUB_REPOSITORY#*/}" \
-            -F number=73 \
+            -F number=150 \
             --jq '.data.repository.issue.id')
 
           if [ -n "${phase_node_id}" ] && [ -n "${new_node_id}" ]; then
@@ -325,5 +345,5 @@ jobs:
               -f query='mutation($parentId:ID!,$childId:ID!){addSubIssue(input:{issueId:$parentId,subIssueId:$childId}){subIssue{number}}}' \
               -f parentId="${phase_node_id}" \
               -f childId="${new_node_id}" \
-              || echo "WARN: failed to parent under Phase 6 (#73); reparent manually"
+              || echo "WARN: failed to parent under Phase 1 (#150); reparent manually"
           fi

--- a/.github/workflows/nightly-parallel-datagen.yml
+++ b/.github/workflows/nightly-parallel-datagen.yml
@@ -114,16 +114,20 @@ jobs:
       #     directly on this runner.
       #   * ``SYNTH_SETTER_WORKER_RANK=0`` / ``SYNTH_SETTER_NUM_WORKERS=1`` so
       #     the single in-process worker owns every shard.
-      #   * ``+render.parallel=true`` overrides the default ``parallel=false``
+      #   * ``++render.parallel=true`` overrides the default ``parallel=false``
       #     even though the experiment YAML already sets it — the explicit
       #     override keeps the production-path coverage signal in the workflow
       #     itself (a future config tweak can't silently disable it).
-      #   * ``+r2.prefix=${R2_PREFIX}`` redirects shards + canonical spec away
-      #     from production prefixes into the ephemeral nightly scope.
+      #   * ``task_name=${NIGHTLY_TASK_NAME}`` scopes the launcher-derived
+      #     ``r2.prefix`` to ``data/<task_name>/<run_id>/``, keeping ephemeral
+      #     nightly artifacts off production prefixes without an explicit
+      #     ``r2.prefix`` override.
       #   * ``rclone copy`` runs inside the container; secrets are forwarded
       #     via ``-e``.
-      #   * tee'd to ``${RUN_METADATA_DIR}/generate.log`` so the spec_uri
-      #     marker is extracted in the next step.
+      #   * tee'd to ``${RUN_METADATA_DIR}/generate.log`` for the
+      #     upload-artifact step (post-failure triage); ``spec_uri`` is
+      #     resolved from the local materialized spec in the next step, not
+      #     grepped out of this log.
       - name: Run synth-setter-generate-dataset (parallel=true)
         id: generate
         env:

--- a/.github/workflows/nightly-parallel-datagen.yml
+++ b/.github/workflows/nightly-parallel-datagen.yml
@@ -134,7 +134,6 @@ jobs:
           mkdir -p "${RUN_METADATA_DIR}"
           docker run --rm \
             -v "${{ github.workspace }}:/home/build/synth-setter" \
-            -v "${RUN_METADATA_DIR}:/run-metadata" \
             -e RCLONE_CONFIG_R2_TYPE \
             -e RCLONE_CONFIG_R2_PROVIDER \
             -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \

--- a/.github/workflows/nightly-parallel-datagen.yml
+++ b/.github/workflows/nightly-parallel-datagen.yml
@@ -1,0 +1,329 @@
+name: Nightly Parallel Datagen
+
+# Nightly end-to-end exercise of ``RenderConfig.parallel=true`` (#1189) against
+# the real Surge XT VST3 (baked into the ``dev-snapshot`` image) and real
+# Cloudflare R2. Complements:
+#   * ``tests/integration/test_parallel_shard_render_linux.py`` — gated by
+#     ``slow + requires_vst + skipif(linux)`` so it never runs in default CI.
+#   * ``tests/integration/test_parallel_shard_dispatch.py`` (#1195) — drives
+#     the real ``subprocess.check_call`` boundary with a fake renderer script,
+#     no real VST and no real R2.
+#
+# This workflow is the missing surface: real Xvfb wrapper, real plugin, real
+# R2 writes under ``ThreadPoolExecutor`` dispatch — so a regression in the
+# concurrency model surfaces overnight rather than in a manual investigation.
+#
+# Sized for nightly cost: 32 samples / 4 shards / 8 samples per shard. Pool
+# size on an ``ubuntu-latest-4core`` runner = ``min(max(1, 4//2), 4)`` = 2,
+# enough to bootstrap the headless Xvfb wrapper concurrently.
+#
+# Required secrets:
+#   RCLONE_CONFIG_R2_ACCESS_KEY_ID, RCLONE_CONFIG_R2_SECRET_ACCESS_KEY,
+#   RCLONE_CONFIG_R2_ENDPOINT — used both by the launcher's spec upload and
+#   by the in-container ``rclone copy`` per shard.
+
+on:
+  # 05:00 UTC daily — picked to avoid colliding with nightly.yml (06:00),
+  # check-auth (06:00 Mon), test-dataset-generation hourly (top of hour), or
+  # unsnooze (08:00). The cron string is paired with the schedule branch in
+  # the auto-issue dedupe filter below.
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Docker image tag (e.g. dev-snapshot, dev-snapshot-<sha>)"
+        required: false
+        default: "dev-snapshot"
+
+concurrency:
+  group: nightly-parallel-datagen-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  nightly-parallel-datagen:
+    name: Generate + validate parallel smoke dataset
+    runs-on: ubuntu-latest-4core
+    timeout-minutes: 30
+
+    # ``issues: write`` is needed by the auto-issue step below. Workflow
+    # default is ``contents: read``; widening here keeps the elevated scope
+    # job-local rather than workflow-wide.
+    permissions:
+      contents: read
+      issues: write
+
+    env:
+      IMAGE: tinaudio/synth-setter:${{ inputs.image_tag || 'dev-snapshot' }}
+      # ``r2.prefix`` (and therefore the spec's ``input_spec_uri``) is scoped
+      # to a unique nightly leaf so concurrent runs / re-runs cannot collide on
+      # the canonical R2 object. The leaf is computed in the ``Compute R2
+      # prefix`` step and re-exported into ``GITHUB_ENV`` so the cleanup step
+      # can purge the same scope even when the generate step fails.
+      R2_BUCKET: intermediate-data
+      RCLONE_CONFIG_R2_TYPE: s3
+      RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+      RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+      RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+      RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Pull image
+        run: docker pull "$IMAGE"
+
+      # Per-run unique R2 prefix. ``run_attempt`` is part of the path so a
+      # re-run of the same workflow doesn't collide on the canonical
+      # ``input_spec.json`` object the launcher writes. The leaf nonce keeps
+      # local manual dispatches isolated even when ``run_id``/``run_attempt``
+      # repeat. Persisted into ``GITHUB_ENV`` so the cleanup step (which runs
+      # ``if: always()``) can purge the same scope on failure.
+      - name: Compute R2 prefix
+        id: prefix
+        run: |
+          set -euo pipefail
+          nonce=$(uuidgen | tr -d '-' | cut -c1-8)
+          prefix="nightly-parallel/${GITHUB_RUN_ID}/${GITHUB_RUN_ATTEMPT}/${nonce}/"
+          echo "R2_PREFIX=${prefix}" >> "${GITHUB_ENV}"
+          echo "r2_prefix=${prefix}" >> "${GITHUB_OUTPUT}"
+          echo "r2 prefix: ${prefix}"
+
+      # Mirrors the headless plugin-load smoke check in ``test-vst-slow.yml``
+      # — fails fast if the plugin / image / mount layout is broken before
+      # the longer generate-dataset run.
+      - name: Smoke-test Surge XT plugin load
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/home/build/synth-setter" \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              git config --global --add safe.directory /home/build/synth-setter
+              docker/ubuntu22_04/run-linux-vst-headless.sh \
+                python -X faulthandler -c "from synth_setter.data.vst.core import load_plugin; load_plugin(\"/usr/lib/vst3/Surge XT.vst3\")"
+            '
+
+      # Run the operator CLI end-to-end inside the dev-snapshot image:
+      #   * ``compute_template`` stays unset (configs/skypilot_launch/default.yaml
+      #     keeps it null), so ``main()`` runs ``run(spec)`` inline rather than
+      #     dispatching via SkyPilot — exercises ``_dispatch_shards_parallel``
+      #     directly on this runner.
+      #   * ``SYNTH_SETTER_WORKER_RANK=0`` / ``SYNTH_SETTER_NUM_WORKERS=1`` so
+      #     the single in-process worker owns every shard.
+      #   * ``+render.parallel=true`` overrides the default ``parallel=false``
+      #     even though the experiment YAML already sets it — the explicit
+      #     override keeps the production-path coverage signal in the workflow
+      #     itself (a future config tweak can't silently disable it).
+      #   * ``+r2.prefix=${R2_PREFIX}`` redirects shards + canonical spec away
+      #     from production prefixes into the ephemeral nightly scope.
+      #   * ``rclone copy`` runs inside the container; secrets are forwarded
+      #     via ``-e``.
+      #   * tee'd to ``${RUN_METADATA_DIR}/generate.log`` so the spec_uri
+      #     marker is extracted in the next step.
+      - name: Run synth-setter-generate-dataset (parallel=true)
+        id: generate
+        env:
+          RUN_METADATA_DIR: ${{ runner.temp }}/nightly-parallel-run-metadata
+          EXPERIMENT: generate_dataset/nightly-parallel-smoke
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUN_METADATA_DIR}"
+          docker run --rm \
+            -v "${{ github.workspace }}:/home/build/synth-setter" \
+            -v "${RUN_METADATA_DIR}:/run-metadata" \
+            -e RCLONE_CONFIG_R2_TYPE \
+            -e RCLONE_CONFIG_R2_PROVIDER \
+            -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
+            -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
+            -e RCLONE_CONFIG_R2_ENDPOINT \
+            -e EXPERIMENT \
+            -e R2_PREFIX \
+            -e HYDRA_FULL_ERROR=1 \
+            -e SYNTH_SETTER_WORKER_RANK=0 \
+            -e SYNTH_SETTER_NUM_WORKERS=1 \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              git config --global --add safe.directory /home/build/synth-setter
+              bash docker/ubuntu22_04/ensure_plugin_symlinks.sh
+              synth-setter-generate-dataset \
+                "experiment=${EXPERIMENT}" \
+                "+render.parallel=true" \
+                "+r2.prefix=${R2_PREFIX}"
+            ' \
+            2>&1 | tee "${RUN_METADATA_DIR}/generate.log"
+          echo "run_metadata_dir=${RUN_METADATA_DIR}" >> "${GITHUB_OUTPUT}"
+
+      # ``upload_spec`` emits the canonical spec URI on a stdout sentinel line;
+      # ``grep || true`` keeps a missing marker from short-circuiting the step
+      # under ``set -euo pipefail`` so the explicit empty-check below surfaces
+      # a friendly error instead of a confusing pipe-failure.
+      - name: Extract spec_uri from launcher log
+        id: spec_uri
+        env:
+          GENERATE_LOG: ${{ steps.generate.outputs.run_metadata_dir }}/generate.log
+        run: |
+          set -euo pipefail
+          SPEC_URI=$(grep -m1 -oE '::synth-setter-spec-uri::r2://[^[:space:]]+' \
+            "${GENERATE_LOG}" \
+            | sed 's|^::synth-setter-spec-uri::||' || true)
+          if [[ -z "${SPEC_URI}" ]]; then
+            echo "::error::launcher did not emit a ::synth-setter-spec-uri:: marker; see generate.log"
+            exit 1
+          fi
+          echo "spec_uri=${SPEC_URI}" >> "${GITHUB_OUTPUT}"
+          echo "spec_uri: ${SPEC_URI}"
+
+      # Validate the spec + every shard against R2 using the same CI helpers
+      # invoked by ``validate-dataset-shards.yaml``. Runs inside the same
+      # ``dev-snapshot`` image so ``h5py`` is available without a host install.
+      - name: Validate spec + every shard via R2
+        env:
+          SPEC_URI: ${{ steps.spec_uri.outputs.spec_uri }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "${{ github.workspace }}:/home/build/synth-setter:ro" \
+            -e RCLONE_CONFIG_R2_TYPE \
+            -e RCLONE_CONFIG_R2_PROVIDER \
+            -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
+            -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
+            -e RCLONE_CONFIG_R2_ENDPOINT \
+            -e SPEC_URI \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              git config --global --add safe.directory /home/build/synth-setter
+              python3 -m synth_setter.pipeline.ci.validate_spec "$SPEC_URI"
+              python3 -m synth_setter.pipeline.ci.validate_shard "$SPEC_URI"
+            '
+
+      - name: Upload run metadata
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-parallel-run-metadata
+          path: ${{ runner.temp }}/nightly-parallel-run-metadata/
+          retention-days: 7
+          if-no-files-found: warn
+
+      # Always purge the ephemeral R2 prefix so failed runs do not leak
+      # objects. ``rclone purge`` exits non-zero on a missing remote prefix
+      # (which is fine — nothing to clean); a non-zero exit here must not
+      # mask a real test failure, hence the ``|| true``.
+      - name: Cleanup ephemeral R2 prefix
+        if: always()
+        run: |
+          set -euo pipefail
+          if [[ -z "${R2_PREFIX:-}" ]]; then
+            echo "no R2_PREFIX set; nothing to purge"
+            exit 0
+          fi
+          target="r2:${R2_BUCKET}/${R2_PREFIX}"
+          docker run --rm \
+            -e RCLONE_CONFIG_R2_TYPE \
+            -e RCLONE_CONFIG_R2_PROVIDER \
+            -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
+            -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
+            -e RCLONE_CONFIG_R2_ENDPOINT \
+            "$IMAGE" \
+            rclone purge "$target" --contimeout=10s --timeout=60s || true
+          echo "purged ${target}"
+
+      # Auto-file a Bug ticket on scheduled-run failure so nightly regressions
+      # don't go silently stale. Mirrors ``cpu-slow.yml``'s pattern: dedupe on
+      # a title fragment, comment on the existing issue on a repeat, otherwise
+      # open a fresh issue with type=Bug + parent=Phase 6 (#73). Best-effort
+      # GraphQL mutations — if either call fails the issue still has label +
+      # milestone, enough for triage.
+      - name: Auto-file failure ticket
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          dedupe_search='nightly-parallel-datagen scheduled failure'
+          existing=$(gh issue list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --label ci-automation \
+            --state open \
+            --search "${dedupe_search} in:title" \
+            --json number,title \
+            --jq '.[0].number // empty')
+
+          comment_body=$(printf '%s\n\n%s\n' \
+            "Another nightly-parallel-datagen scheduled failure." \
+            "Failed run: ${RUN_URL}")
+
+          if [ -n "${existing}" ]; then
+            echo "Dedup hit: commenting on existing issue #${existing}"
+            gh issue comment "${existing}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --body "${comment_body}"
+            exit 0
+          fi
+
+          title="bug(ci-automation): nightly-parallel-datagen scheduled failure"
+          body=$(printf '%s\n\n%s\n%s\n' \
+            "The nightly-parallel-datagen workflow failed on its scheduled cron. Auto-opened by .github/workflows/nightly-parallel-datagen.yml so the regression in the parallel-dispatch path (or its Xvfb / R2 dependencies) does not go silently stale." \
+            "- Failed run: ${RUN_URL}" \
+            "- Refs #1189 (parallel feature), #1197 (this workflow)")
+
+          new_issue_url=$(gh issue create \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${title}" \
+            --body "${body}" \
+            --label ci-automation \
+            --label data-pipeline \
+            --milestone "ci-automation v1.0.0")
+          echo "Filed: ${new_issue_url}"
+
+          new_issue_number="${new_issue_url##*/}"
+
+          new_node_id=$(gh api graphql \
+            -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){issue(number:$number){id}}}' \
+            -f owner="${GITHUB_REPOSITORY%/*}" \
+            -f repo="${GITHUB_REPOSITORY#*/}" \
+            -F number="${new_issue_number}" \
+            --jq '.data.repository.issue.id')
+
+          bug_type_id=$(gh api graphql \
+            -f query='query($owner:String!,$repo:String!){repository(owner:$owner,name:$repo){issueTypes(first:20){nodes{id name}}}}' \
+            -f owner="${GITHUB_REPOSITORY%/*}" \
+            -f repo="${GITHUB_REPOSITORY#*/}" \
+            --jq '.data.repository.issueTypes.nodes[]|select(.name=="Bug")|.id')
+
+          if [ -n "${bug_type_id}" ] && [ -n "${new_node_id}" ]; then
+            gh api graphql \
+              -f query='mutation($issueId:ID!,$issueTypeId:ID!){updateIssueIssueType(input:{issueId:$issueId,issueTypeId:$issueTypeId}){issue{number}}}' \
+              -f issueId="${new_node_id}" \
+              -f issueTypeId="${bug_type_id}" \
+              || echo "WARN: failed to set issue type=Bug; triage manually"
+          else
+            echo "WARN: missing node_id or bug_type_id; skipping issue-type set"
+          fi
+
+          phase_node_id=$(gh api graphql \
+            -f query='query($owner:String!,$repo:String!,$number:Int!){repository(owner:$owner,name:$repo){issue(number:$number){id}}}' \
+            -f owner="${GITHUB_REPOSITORY%/*}" \
+            -f repo="${GITHUB_REPOSITORY#*/}" \
+            -F number=73 \
+            --jq '.data.repository.issue.id')
+
+          if [ -n "${phase_node_id}" ] && [ -n "${new_node_id}" ]; then
+            gh api graphql \
+              -f query='mutation($parentId:ID!,$childId:ID!){addSubIssue(input:{issueId:$parentId,subIssueId:$childId}){subIssue{number}}}' \
+              -f parentId="${phase_node_id}" \
+              -f childId="${new_node_id}" \
+              || echo "WARN: failed to parent under Phase 6 (#73); reparent manually"
+          fi

--- a/.github/workflows/nightly-parallel-datagen.yml
+++ b/.github/workflows/nightly-parallel-datagen.yml
@@ -152,7 +152,7 @@ jobs:
               bash docker/ubuntu22_04/ensure_plugin_symlinks.sh
               synth-setter-generate-dataset \
                 "experiment=${EXPERIMENT}" \
-                "+render.parallel=true" \
+                "++render.parallel=true" \
                 "task_name=${NIGHTLY_TASK_NAME}"
             ' \
             2>&1 | tee "${RUN_METADATA_DIR}/generate.log"

--- a/.github/workflows/nightly-parallel-datagen.yml
+++ b/.github/workflows/nightly-parallel-datagen.yml
@@ -3,8 +3,9 @@ name: Nightly Parallel Datagen
 # Nightly end-to-end exercise of ``RenderConfig.parallel=true`` (#1189) against
 # the real Surge XT VST3 (baked into the ``dev-snapshot`` image) and real
 # Cloudflare R2. Complements:
-#   * ``tests/integration/test_parallel_shard_render_linux.py`` — gated by
-#     ``slow + requires_vst + skipif(linux)`` so it never runs in default CI.
+#   * ``tests/integration/test_parallel_shard_render_linux.py`` — Linux-only
+#     stress test (``slow + requires_vst`` + ``skipif(sys.platform != "linux")``);
+#     never runs in default CI.
 #   * ``tests/integration/test_parallel_shard_dispatch.py`` (#1195) — drives
 #     the real ``subprocess.check_call`` boundary with a fake renderer script,
 #     no real VST and no real R2.

--- a/configs/experiment/generate_dataset/nightly-parallel-smoke.yaml
+++ b/configs/experiment/generate_dataset/nightly-parallel-smoke.yaml
@@ -1,0 +1,27 @@
+# @package _global_
+
+# Nightly smoke for ``RenderConfig.parallel=true`` against the real Surge XT
+# VST3 + real R2. 32 total samples → 4 shards at samples_per_shard=8, sized so
+# the headless Xvfb wrapper bootstraps at least twice concurrently
+# (pool size = ``min(max(1, cpus // 2), len(my_range))``) while staying inside
+# the workflow's step budget. ``max_retries=1`` keeps a transient Xvfb hiccup
+# from failing the nightly outright — the integration test in
+# ``tests/integration/test_parallel_shard_render_linux.py`` retains strict
+# fail-fast for the local stress signal.
+
+defaults:
+  - override /data: surge_simple
+  - override /render: surge_simple
+  - _self_
+
+task_name: nightly-parallel-smoke
+
+train_val_test_sizes: [32, 0, 0]
+
+render:
+  sample_rate: 16000
+  min_loudness: -50.0
+  samples_per_render_batch: 8
+  samples_per_shard: 8
+  parallel: true
+  max_retries: 1

--- a/configs/experiment/generate_dataset/nightly-parallel-smoke.yaml
+++ b/configs/experiment/generate_dataset/nightly-parallel-smoke.yaml
@@ -1,13 +1,9 @@
 # @package _global_
 
-# Nightly smoke for ``RenderConfig.parallel=true`` against the real Surge XT
-# VST3 + real R2. 32 total samples → 4 shards at samples_per_shard=8, sized so
-# the headless Xvfb wrapper bootstraps at least twice concurrently
-# (pool size = ``min(max(1, cpus // 2), len(my_range))``) while staying inside
-# the workflow's step budget. ``max_retries=1`` keeps a transient Xvfb hiccup
-# from failing the nightly outright — the integration test in
-# ``tests/integration/test_parallel_shard_render_linux.py`` retains strict
-# fail-fast for the local stress signal.
+# Nightly smoke for RenderConfig.parallel=true: 32 samples → 4 shards at
+# samples_per_shard=8, sized so Xvfb bootstraps ≥2 wrappers concurrently.
+# max_retries stays at 0 (default fail-fast) — the nightly's purpose is to
+# catch parallel-dispatch regressions, which a retry budget would mask.
 
 defaults:
   - override /data: surge_simple
@@ -24,4 +20,3 @@ render:
   samples_per_render_batch: 8
   samples_per_shard: 8
   parallel: true
-  max_retries: 1

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -63,7 +63,7 @@ docs:
       - pattern: ".github/workflows/validate-dataset-shards.yaml"
         covers: "Reusable spec + shard validation downstream of generate-dataset-shards; takes the `spec_uri` (r2://) emitted by generate-dataset-shards as its `spec_uri` input"
       - pattern: ".github/workflows/nightly-parallel-datagen.yml"
-        covers: "Nightly schedule (05:00 UTC) + workflow_dispatch that runs `synth-setter-generate-dataset` inline in the dev-snapshot image with `+render.parallel=true` against real Surge XT VST3 + real R2; validates the produced spec + every shard via `pipeline.ci.validate_spec` / `validate_shard`. The missing CI surface for `RenderConfig.parallel` (#1189): the Linux Xvfb stress test (`tests/integration/test_parallel_shard_render_linux.py`) is gated by `slow + requires_vst` and never runs in default CI; this workflow exercises the parallel-dispatch path end-to-end overnight. Ephemeral R2 prefix scoped to `nightly-parallel/<run_id>/<run_attempt>/<nonce>/` with always-on rclone purge."
+        covers: "Nightly + workflow_dispatch running generate-dataset with `++render.parallel=true` against real Surge XT + real R2, then validating spec + shards via `pipeline.ci.{validate_spec,validate_shard}`. Per-run unique `task_name` scopes the ephemeral R2 prefix to `data/<task_name>/<run_id>/` (preserves the `data/` invariant); always-on rclone purge on cleanup. Fills the CI gap left by the slow + requires_vst Linux Xvfb integration test."
       - pattern: "src/synth_setter/pipeline/ci/**"
         covers: "CI validation scripts, spec materialization, shard validation, and spec-URI extraction (`spec_uri.py` / `synth-setter-spec-uri`)"
       - pattern: "src/synth_setter/pipeline/r2_io.py"

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -62,6 +62,8 @@ docs:
         covers: "Reusable launcher fan-out across providers (skypilot-local kind, runpod, oci); per-provider artifact upload; emits a `spec_uri` workflow output (the materialized spec's canonical under-prefix `input_spec.json` URI, computed by the `synth-setter-spec-uri` console script — see `src/synth_setter/pipeline/ci/spec_uri.py`) consumed by validate-dataset-shards"
       - pattern: ".github/workflows/validate-dataset-shards.yaml"
         covers: "Reusable spec + shard validation downstream of generate-dataset-shards; takes the `spec_uri` (r2://) emitted by generate-dataset-shards as its `spec_uri` input"
+      - pattern: ".github/workflows/nightly-parallel-datagen.yml"
+        covers: "Nightly schedule (05:00 UTC) + workflow_dispatch that runs `synth-setter-generate-dataset` inline in the dev-snapshot image with `+render.parallel=true` against real Surge XT VST3 + real R2; validates the produced spec + every shard via `pipeline.ci.validate_spec` / `validate_shard`. The missing CI surface for `RenderConfig.parallel` (#1189): the Linux Xvfb stress test (`tests/integration/test_parallel_shard_render_linux.py`) is gated by `slow + requires_vst` and never runs in default CI; this workflow exercises the parallel-dispatch path end-to-end overnight. Ephemeral R2 prefix scoped to `nightly-parallel/<run_id>/<run_attempt>/<nonce>/` with always-on rclone purge."
       - pattern: "src/synth_setter/pipeline/ci/**"
         covers: "CI validation scripts, spec materialization, shard validation, and spec-URI extraction (`spec_uri.py` / `synth-setter-spec-uri`)"
       - pattern: "src/synth_setter/pipeline/r2_io.py"

--- a/tests/pipeline/test_configs/test_experiment_yamls.py
+++ b/tests/pipeline/test_configs/test_experiment_yamls.py
@@ -32,6 +32,7 @@ DATASET_EXPERIMENTS: tuple[str, ...] = (
     "generate_dataset/10-1k-shards",
     "generate_dataset/ci-materialize-test",
     "generate_dataset/ci-materialize-test-wds",
+    "generate_dataset/nightly-parallel-smoke",
     "generate_dataset/smoke-shard",
     "generate_dataset/smoke-shard-wds",
     "generate_dataset/surge-simple-480k-10k",


### PR DESCRIPTION
## Summary

Adds `.github/workflows/nightly-parallel-datagen.yml` — a scheduled workflow (cron `0 5 * * *` UTC + `workflow_dispatch`) that runs `synth-setter-generate-dataset` inline in the `dev-snapshot` Docker image with `+render.parallel=true` against the real Surge XT VST3 + real Cloudflare R2, then validates the produced spec + every shard via `synth_setter.pipeline.ci.validate_spec` / `validate_shard`.

This is the missing CI surface for the parallel-dispatch feature (PR #1189, merged):

- The Linux Xvfb stress integration test (`tests/integration/test_parallel_shard_render_linux.py`) is gated `slow + requires_vst + skipif(linux)` and never runs in default CI.
- The cross-platform integration test (`tests/integration/test_parallel_shard_dispatch.py` from PR #1195) drives a fake renderer script, not the real VST3.
- This workflow stitches them together: real Xvfb wrapper + real plugin + real R2 writes under `ThreadPoolExecutor` dispatch, overnight, so regressions surface in a daily-checked place rather than a one-off manual investigation.

## What this PR contains

1. `.github/workflows/nightly-parallel-datagen.yml` — the new scheduled workflow.
2. `configs/experiment/generate_dataset/nightly-parallel-smoke.yaml` — 32 samples × 4 shards × 8 samples per shard, sized so the headless Xvfb wrapper bootstraps ≥2 concurrent invocations on a 4-core runner. `max_retries=0` (default fail-fast) so transient Xvfb hiccups don't mask a real regression.
3. `docs/doc-map.yaml` — covers entry for the new workflow.

## Design choices already settled (from pre-PR review)

- **Spec-URI resolution** uses the local materialized spec (`data/<task>/<run_id>/metadata/input_spec.json` — written by `write_spec_locally`), not the `::synth-setter-spec-uri::` log marker — that sentinel is only emitted by the SkyPilot dispatch branch, and the nightly takes the inline `run(spec)` path. Same pattern as `generate-dataset-shards.yaml:491-498`.
- **R2 layout** uses `task_name=nightly-parallel-<run_id>-<attempt>-<nonce>` so the launcher's auto-filled `r2.prefix = data/<task_name>/<run_id>/` preserves the canonical `data/` invariant while still giving each nightly run its own ephemeral leaf.
- **Cleanup** purges `data/<task_name>/` on `if: always()`. Falls back to the task-scoped prefix when the spec_uri step never resolved the full prefix (i.e. when generate failed early).
- **Auto-issue on scheduled failure** mirrors `cpu-slow.yml` exactly: dedupe on title fragment, `--assignee ktinubu`, `--milestone "ci-automation v1.0.0"`, parent under Phase 1 (#150) so milestone-parent alignment honours the taxonomy.

## Open follow-up (not blocking this PR)

The 80-line `Auto-file failure ticket` block is a near-verbatim copy of `cpu-slow.yml:87-180`. Extracting it to a composite action (`.github/actions/auto-file-ci-bug`) is its own PR-shaped change — landing it here would expand scope. Filed as a follow-up.

## Verification

- [x] `pre-commit run --files .github/workflows/nightly-parallel-datagen.yml configs/experiment/generate_dataset/nightly-parallel-smoke.yaml` — all hooks green (Validate GitHub Workflows, prettier, codespell).
- [x] `gha-workflow-validator` skill report — 9/9 passed, 0 warnings, 0 failures.
- [x] Pre-PR multi-skill review (4 parallel passes, sentinel at `.agent-reviews/repo-review-full-no-comments.082f3e6e500730b39bd451b1b82054863058cfce.md`) — both correctness BLOCKs from the initial pass resolved in HEAD `082f3e6`.
- [ ] **Manual / post-merge:** `gh workflow run nightly-parallel-datagen.yml --ref main` after this lands to validate the workflow against the live cron environment. (Cannot dispatch from a feature branch without first merging.)

Closes #1197