### PR TITLE
feat(data-pipeline): synth-setter-finalize-dataset hdf5 branch (download + reshard + stats)

### DIFF
--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -25,7 +25,7 @@ rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 
 import numpy as np  # noqa: E402
 
-from synth_setter.cli.generate_dataset import _rclone_copy, spec_from_cfg  # noqa: E402
+from synth_setter.cli.generate_dataset import spec_from_cfg  # noqa: E402
 from synth_setter.pipeline import r2_io  # noqa: E402
 from synth_setter.pipeline.constants import (  # noqa: E402
     DATASET_COMPLETE_FILENAME,
@@ -104,12 +104,20 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
     :param spec: Validated dataset spec (``output_format == "hdf5"``).
     :param work_dir: Scratch directory; shards, splits, stats and the spec
         copy live here transiently for the duration of the call.
+    :raises ValueError: The train split is empty
+        (``spec.split_shard_ranges["train"]`` has ``lo >= hi``); reshard
+        would prune ``train.h5`` and stats compute would fail with a
+        low-signal HDF5 error.
     """
-    # ``_rclone_copy`` runs ``rclone copy`` (dest is a directory; the source
-    # basename is written inside it) — pass ``work_dir`` itself so the local
-    # name matches ``shard.filename`` per ShardSpec.
+    train_lo, train_hi = spec.split_shard_ranges["train"]
+    if train_lo >= train_hi:
+        raise ValueError(
+            f"train split is empty (split_shard_ranges['train']="
+            f"{spec.split_shard_ranges['train']!r}); cannot compute stats "
+            f"without at least one train shard."
+        )
     for shard in spec.shards:
-        _rclone_copy(spec.r2.shard_uri(shard), str(work_dir))
+        r2_io.download_to_path(spec.r2.shard_uri(shard), work_dir / shard.filename)
     (work_dir / INPUT_SPEC_FILENAME).write_text(spec.model_dump_json(indent=2), encoding="utf-8")
     reshard.main.callback(dataset_root=work_dir, spec_uri=None)  # type: ignore[misc]
     get_stats_hdf5(str(work_dir / "train.h5"))

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -2,9 +2,11 @@
 
 Mirrors ``generate-dataset``'s operator-side shape — programmatic Hydra
 compose, single ``DatasetSpec`` input, dispatch on ``spec.output_format``.
-The wds branch streams the train shards through Welford row-by-row,
-uploads ``stats.npz``, then writes the ``dataset.complete`` marker last
-per ``pipeline/CLAUDE.md``. hdf5 is not implemented (#1183).
+Both branches upload their derived artifact(s) and then write the
+``dataset.complete`` marker last per ``pipeline/CLAUDE.md``. The wds
+branch streams train shards through Welford row-by-row; the hdf5 branch
+downloads every shard, reshards into ``{train,val,test}.h5``, and
+computes ``stats.npz`` over the train split.
 """
 
 from __future__ import annotations
@@ -13,7 +15,6 @@ import sys
 import tempfile
 from collections.abc import Iterator
 from pathlib import Path
-from typing import NoReturn
 
 import rootutils
 from hydra import compose, initialize_config_dir
@@ -24,13 +25,15 @@ rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
 
 import numpy as np  # noqa: E402
 
-from synth_setter.cli.generate_dataset import spec_from_cfg  # noqa: E402
+from synth_setter.cli.generate_dataset import _rclone_copy, spec_from_cfg  # noqa: E402
 from synth_setter.pipeline import r2_io  # noqa: E402
 from synth_setter.pipeline.constants import (  # noqa: E402
     DATASET_COMPLETE_FILENAME,
+    INPUT_SPEC_FILENAME,
     STATS_NPZ_FILENAME,
 )
-from synth_setter.pipeline.data.stats import stream_stats_wds  # noqa: E402
+from synth_setter.pipeline.data import reshard  # noqa: E402
+from synth_setter.pipeline.data.stats import get_stats_hdf5, stream_stats_wds  # noqa: E402
 from synth_setter.pipeline.schemas.spec import DatasetSpec  # noqa: E402
 
 # Resolve repo root from this file so the entrypoint is cwd-independent.
@@ -91,15 +94,34 @@ def finalize_wds(spec: DatasetSpec, work_dir: Path) -> None:
     logger.info("uploaded stats to {}", spec.r2.stats_uri())
 
 
-def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> NoReturn:
-    """Reject hdf5 finalize until the writer side is implemented — see #1183.
+def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
+    """Download every shard, reshard into split files, compute stats, upload all artifacts.
 
-    :param spec: Validated dataset spec; unused.
-    :param work_dir: Scratch directory; unused.
-    :raises NotImplementedError: Always — hdf5 finalize is not implemented yet.
+    Materializes ``input_spec.json`` sibling to the shards so reshard's
+    default spec-path resolution works without a ``--spec`` override. Stats
+    land at ``work_dir / "stats.npz"`` per ``SurgeXTDataset.get_stats_file_path``.
+
+    :param spec: Validated dataset spec (``output_format == "hdf5"``).
+    :param work_dir: Scratch directory; shards, splits, stats and the spec
+        copy live here transiently for the duration of the call.
     """
-    del spec, work_dir
-    raise NotImplementedError("hdf5 finalize is not implemented yet")
+    # ``_rclone_copy`` runs ``rclone copy`` (dest is a directory; the source
+    # basename is written inside it) — pass ``work_dir`` itself so the local
+    # name matches ``shard.filename`` per ShardSpec.
+    for shard in spec.shards:
+        _rclone_copy(spec.r2.shard_uri(shard), str(work_dir))
+    (work_dir / INPUT_SPEC_FILENAME).write_text(spec.model_dump_json(indent=2), encoding="utf-8")
+    reshard.main.callback(dataset_root=work_dir, spec_uri=None)  # type: ignore[misc]
+    get_stats_hdf5(str(work_dir / "train.h5"))
+    # Reshard prunes empty splits — only upload the ones it actually wrote.
+    # Iterate ``split_shard_ranges`` (Split-typed keys) so split_h5_uri's
+    # Literal narrowing holds without a cast.
+    for split in spec.split_shard_ranges:
+        split_h5 = work_dir / f"{split}.h5"
+        if split_h5.exists():
+            r2_io.upload(split_h5, spec.r2.split_h5_uri(split))
+    r2_io.upload(work_dir / STATS_NPZ_FILENAME, spec.r2.stats_uri())
+    logger.info("uploaded h5 splits + stats to {}", spec.r2.rclone_prefix())
 
 
 def main() -> None:

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -98,8 +98,14 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
     """Download every shard, reshard into split files, compute stats, upload all artifacts.
 
     Materializes ``input_spec.json`` sibling to the shards so reshard's
-    default spec-path resolution works without a ``--spec`` override. Stats
-    land at ``work_dir / "stats.npz"`` per ``SurgeXTDataset.get_stats_file_path``.
+    default spec-path resolution works without a ``--spec`` override.
+    ``get_stats_hdf5`` writes ``work_dir / "stats.npz"`` (path derived via
+    ``SurgeXTDataset.get_stats_file_path(train.h5)``); the post-call
+    ``assert`` pins that contract so a future drift in the derivation
+    surfaces here rather than as a missing upload source. Structural
+    validation (per ``pipeline/CLAUDE.md``) is delegated to the h5py opens
+    performed inside ``reshard._write_split`` — finalize never re-runs the
+    workers' full four-check pass.
 
     :param spec: Validated dataset spec (``output_format == "hdf5"``).
     :param work_dir: Scratch directory; shards, splits, stats and the spec
@@ -119,17 +125,27 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
     for shard in spec.shards:
         r2_io.download_to_path(spec.r2.shard_uri(shard), work_dir / shard.filename)
     (work_dir / INPUT_SPEC_FILENAME).write_text(spec.model_dump_json(indent=2), encoding="utf-8")
-    reshard.main.callback(dataset_root=work_dir, spec_uri=None)  # type: ignore[misc]
+    # Click's stub types ``.callback`` as ``Optional[Callable]``; assert
+    # before invocation so the call is statically typed without ``type: ignore``.
+    assert reshard.main.callback is not None  # noqa: S101 — narrows Click's Optional callback type
+    reshard.main.callback(dataset_root=work_dir, spec_uri=None)
     get_stats_hdf5(str(work_dir / "train.h5"))
+    stats_npz = work_dir / STATS_NPZ_FILENAME
+    assert stats_npz.is_file(), (  # noqa: S101 — pin get_stats_hdf5's implicit output-path contract
+        f"get_stats_hdf5 did not write {stats_npz}; check "
+        f"SurgeXTDataset.get_stats_file_path derivation."
+    )
     # Reshard prunes empty splits — only upload the ones it actually wrote.
     # Iterate ``split_shard_ranges`` (Split-typed keys) so split_h5_uri's
     # Literal narrowing holds without a cast.
     for split in spec.split_shard_ranges:
         split_h5 = work_dir / f"{split}.h5"
         if split_h5.exists():
-            r2_io.upload(split_h5, spec.r2.split_h5_uri(split))
-    r2_io.upload(work_dir / STATS_NPZ_FILENAME, spec.r2.stats_uri())
-    logger.info("uploaded h5 splits + stats to {}", spec.r2.rclone_prefix())
+            split_uri = spec.r2.split_h5_uri(split)
+            r2_io.upload(split_h5, split_uri)
+            logger.info("uploaded {} to {}", split_h5.name, split_uri)
+    r2_io.upload(stats_npz, spec.r2.stats_uri())
+    logger.info("uploaded stats to {}", spec.r2.stats_uri())
 
 
 def main() -> None:

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -109,7 +109,7 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
     would force the reshard adapter to learn that layout for no benefit.
     ``get_stats_hdf5`` then writes ``work_dir / "stats.npz"`` (path derived
     via ``SurgeXTDataset.get_stats_file_path(train.h5)``); the post-call
-    ``assert`` pins that contract so a future drift in the derivation
+    existence guard pins that contract so a future drift in the derivation
     surfaces here rather than as a missing upload source. Structural
     validation (per ``pipeline/CLAUDE.md``) is delegated to the h5py opens
     that ``reshard_dataset`` performs while staging each split — finalize
@@ -122,6 +122,8 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
         (``spec.split_shard_ranges["train"]`` has ``lo >= hi``); reshard
         would prune ``train.h5`` and stats compute would fail with a
         low-signal HDF5 error.
+    :raises FileNotFoundError: ``get_stats_hdf5`` returned without writing
+        ``work_dir / "stats.npz"``, breaking the upload-source contract.
     """
     train_lo, train_hi = spec.split_shard_ranges["train"]
     if train_lo >= train_hi:
@@ -136,10 +138,11 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
     reshard_dataset(work_dir)
     get_stats_hdf5(str(work_dir / "train.h5"))
     stats_npz = work_dir / STATS_NPZ_FILENAME
-    assert stats_npz.is_file(), (  # noqa: S101 — pin get_stats_hdf5's implicit output-path contract
-        f"get_stats_hdf5 did not write {stats_npz}; check "
-        f"SurgeXTDataset.get_stats_file_path derivation."
-    )
+    if not stats_npz.is_file():
+        raise FileNotFoundError(
+            f"get_stats_hdf5 did not write {stats_npz}; check "
+            f"SurgeXTDataset.get_stats_file_path derivation."
+        )
     # Reshard prunes empty splits — only upload the ones it actually wrote.
     # Iterate ``split_shard_ranges`` (Split-typed keys) so split_h5_uri's
     # Literal narrowing holds without a cast.

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -32,9 +32,10 @@ from synth_setter.pipeline.constants import (  # noqa: E402
     INPUT_SPEC_FILENAME,
     STATS_NPZ_FILENAME,
 )
-from synth_setter.pipeline.data import reshard  # noqa: E402
+from synth_setter.pipeline.data.reshard import reshard_dataset  # noqa: E402
 from synth_setter.pipeline.data.stats import get_stats_hdf5, stream_stats_wds  # noqa: E402
 from synth_setter.pipeline.schemas.spec import DatasetSpec  # noqa: E402
+from synth_setter.pipeline.spec_io import write_spec_to_path  # noqa: E402
 
 # Resolve repo root from this file so the entrypoint is cwd-independent.
 _REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -97,15 +98,22 @@ def finalize_wds(spec: DatasetSpec, work_dir: Path) -> None:
 def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
     """Download every shard, reshard into split files, compute stats, upload all artifacts.
 
-    Materializes ``input_spec.json`` sibling to the shards so reshard's
-    default spec-path resolution works without a ``--spec`` override.
-    ``get_stats_hdf5`` writes ``work_dir / "stats.npz"`` (path derived via
-    ``SurgeXTDataset.get_stats_file_path(train.h5)``); the post-call
+    Writes ``work_dir/input_spec.json`` flat (via
+    :func:`~synth_setter.pipeline.spec_io.write_spec_to_path`) so
+    :func:`~synth_setter.pipeline.data.reshard.reshard_dataset`'s default
+    spec discovery picks it up without a ``--spec`` override. The flat
+    placement diverges from :func:`~synth_setter.pipeline.spec_io.write_spec_locally`'s
+    nested ``<output_dir>/data/<task>/<run>/metadata/`` layout because
+    ``work_dir`` is a per-finalize scratch tempdir whose only consumer is
+    reshard — re-creating the operator-side ``data/`` hierarchy under it
+    would force the reshard adapter to learn that layout for no benefit.
+    ``get_stats_hdf5`` then writes ``work_dir / "stats.npz"`` (path derived
+    via ``SurgeXTDataset.get_stats_file_path(train.h5)``); the post-call
     ``assert`` pins that contract so a future drift in the derivation
     surfaces here rather than as a missing upload source. Structural
     validation (per ``pipeline/CLAUDE.md``) is delegated to the h5py opens
-    performed inside ``reshard._write_split`` — finalize never re-runs the
-    workers' full four-check pass.
+    that ``reshard_dataset`` performs while staging each split — finalize
+    never re-runs the workers' full four-check pass.
 
     :param spec: Validated dataset spec (``output_format == "hdf5"``).
     :param work_dir: Scratch directory; shards, splits, stats and the spec
@@ -124,11 +132,8 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
         )
     for shard in spec.shards:
         r2_io.download_to_path(spec.r2.shard_uri(shard), work_dir / shard.filename)
-    (work_dir / INPUT_SPEC_FILENAME).write_text(spec.model_dump_json(indent=2), encoding="utf-8")
-    # Click's stub types ``.callback`` as ``Optional[Callable]``; assert
-    # before invocation so the call is statically typed without ``type: ignore``.
-    assert reshard.main.callback is not None  # noqa: S101 — narrows Click's Optional callback type
-    reshard.main.callback(dataset_root=work_dir, spec_uri=None)
+    write_spec_to_path(spec, work_dir / INPUT_SPEC_FILENAME)
+    reshard_dataset(work_dir)
     get_stats_hdf5(str(work_dir / "train.h5"))
     stats_npz = work_dir / STATS_NPZ_FILENAME
     assert stats_npz.is_file(), (  # noqa: S101 — pin get_stats_hdf5's implicit output-path contract

--- a/src/synth_setter/pipeline/data/reshard.py
+++ b/src/synth_setter/pipeline/data/reshard.py
@@ -33,21 +33,13 @@ _STAGING_PREFIX = ".tmp-"
 _FLOAT32 = np.dtype("float32")
 
 
-@click.command()
-@click.argument("dataset_root", type=click.Path(file_okay=False, path_type=Path))
-@click.option(
-    "--spec",
-    "spec_uri",
-    type=str,
-    default=None,
-    help=(
-        "Local path or ``r2://bucket/key`` URI of the materialized DatasetSpec JSON "
-        "(``r2://`` is downloaded via rclone — ``RCLONE_CONFIG_R2_*`` env vars must be set). "
-        f"Defaults to ``<dataset_root>/{INPUT_SPEC_FILENAME}``."
-    ),
-)
-def main(dataset_root: Path, spec_uri: str | None) -> None:  # noqa: DOC502
+def reshard_dataset(dataset_root: Path, spec_uri: str | None = None) -> None:  # noqa: DOC502
     """Split shards under ``dataset_root`` into ``{train,val,test}.h5`` virtual datasets.
+
+    Pure-function form of the reshard operation; importable from other
+    pipeline stages (notably ``cli.finalize_dataset.finalize_hdf5``) without
+    invoking the Click wrapper's ``.callback`` indirection. The :func:`main`
+    command below is a thin Click adapter that delegates to this function.
 
     :param dataset_root: Directory containing the shard files named by ``spec.shards``.
     :param spec_uri: Optional local path or ``r2://`` URI for the DatasetSpec;
@@ -66,6 +58,30 @@ def main(dataset_root: Path, spec_uri: str | None) -> None:  # noqa: DOC502
 
     splits = _build_splits(shard_paths, spec.train_val_test_sizes, shard_size)
     _stage_and_commit_splits(dataset_root, splits, shard_size, tails)
+
+
+@click.command()
+@click.argument("dataset_root", type=click.Path(file_okay=False, path_type=Path))
+@click.option(
+    "--spec",
+    "spec_uri",
+    type=str,
+    default=None,
+    help=(
+        "Local path or ``r2://bucket/key`` URI of the materialized DatasetSpec JSON "
+        "(``r2://`` is downloaded via rclone — ``RCLONE_CONFIG_R2_*`` env vars must be set). "
+        f"Defaults to ``<dataset_root>/{INPUT_SPEC_FILENAME}``."
+    ),
+)
+def main(dataset_root: Path, spec_uri: str | None) -> None:  # noqa: DOC502
+    """Click adapter that delegates to :func:`reshard_dataset`.
+
+    :param dataset_root: Directory containing the shard files named by ``spec.shards``.
+    :param spec_uri: Optional local path or ``r2://`` URI for the DatasetSpec;
+        defaults to ``<dataset_root>/input_spec.json``.
+    :raises click.ClickException: Propagated from :func:`reshard_dataset`.
+    """
+    reshard_dataset(dataset_root, spec_uri)
 
 
 def _load_spec(spec_uri: str | None, dataset_root: Path) -> DatasetSpec:
@@ -173,6 +189,12 @@ def _write_split(
 ) -> None:
     """Materialize one split's virtual dataset into ``staging_path``.
 
+    VDS source references are written as relative filenames (the shard
+    basename, not the absolute path) so the resulting ``{split}.h5`` resolves
+    against any directory that holds sibling shards — required because the
+    file is uploaded to R2 from a temp dir and later read from a different
+    local cache by training.
+
     :param staging_path: ``.tmp-<split>.h5`` destination; the caller renames
         it into place after every split's stage succeeds.
     :param split_paths: Shard files concatenated in order into the virtual layout.
@@ -189,7 +211,9 @@ def _write_split(
         range_start = i * shard_size
         range_end = range_start + shard_size
         for key, tail in tails.items():
-            source = h5py.VirtualSource(shard_path, key, dtype=_FLOAT32, shape=(shard_size, *tail))
+            source = h5py.VirtualSource(
+                shard_path.name, key, dtype=_FLOAT32, shape=(shard_size, *tail)
+            )
             layouts[key][range_start:range_end] = source
 
     with h5py.File(staging_path, "w") as f:

--- a/src/synth_setter/pipeline/data/stats.py
+++ b/src/synth_setter/pipeline/data/stats.py
@@ -150,41 +150,49 @@ def _fix_degenerate_bins(std: np.ndarray) -> np.ndarray:
     return out
 
 
-def get_stats_hdf5(filename, mask_degenerate: bool = False):
-    dataset_name = "mel_spec"
+def get_stats_hdf5(filename: str, mask_degenerate: bool = False) -> None:
+    """Compute Dask-backed mean/std over a Surge XT HDF5 ``mel_spec`` dataset.
 
+    The Dask client and HDF5 file handle are scoped to the ``with`` blocks so
+    every call releases its worker processes/threads and closes the file before
+    returning — required now that the in-process ``finalize-dataset`` CLI calls
+    this in its main loop and would otherwise leak handles across runs.
+
+    :param filename: Path to a ``.h5`` file with a ``mel_spec`` dataset.
+    :param mask_degenerate: See :func:`get_stats_wds`.
+    """
+    dataset_name = "mel_spec"
     num_workers = 4
 
     print("Starting client...")
-    client = Client(n_workers=num_workers, threads_per_worker=8)
-    # Create a dask array that references the HDF5 dataset
-    # "chunks=" controls the chunk size in memory
-    print("Creating dask array...")
-    darray = da.from_array(
-        h5py.File(filename, "r")[dataset_name],
-        chunks="auto",  # You can tune this chunk size
-    )
+    with Client(n_workers=num_workers, threads_per_worker=8) as client:
+        # ``da.from_array`` reads lazily; the h5py.File must stay open through
+        # the final ``.compute()`` so workers can pull chunks on demand.
+        with h5py.File(filename, "r") as h5_file:
+            print("Creating dask array...")
+            darray = da.from_array(h5_file[dataset_name], chunks="auto")
 
-    print("Computing mean and std...")
-    mean_task = darray.mean(axis=0)
-    std_task = darray.std(axis=0)
+            print("Computing mean and std...")
+            mean_task = darray.mean(axis=0)
+            std_task = darray.std(axis=0)
 
-    print("Persisting tasks...")
-    futures = [mean_task.persist(), std_task.persist()]
+            print("Persisting tasks...")
+            futures = [mean_task.persist(), std_task.persist()]
 
-    print("Displaying progress...")
-    progress(futures)
+            print("Displaying progress...")
+            progress(futures)
 
-    print("Gathering results...")
-    mean_val, std_val = client.gather(futures)
+            print("Gathering results...")
+            mean_val, std_val = client.gather(futures)
 
-    print("Mean:", mean_val)
-    print("std:", std_val)
+            print("Mean:", mean_val)
+            print("std:", std_val)
+
+            mean = mean_val.compute()
+            std = std_val.compute()
 
     print("Saving to file...")
     out_file = SurgeXTDataset.get_stats_file_path(filename)
-    mean = mean_val.compute()
-    std = std_val.compute()
     if mask_degenerate:
         std = _fix_degenerate_bins(std)
     else:

--- a/src/synth_setter/pipeline/spec_io.py
+++ b/src/synth_setter/pipeline/spec_io.py
@@ -39,6 +39,7 @@ __all__ = [
     "read_spec_text",
     "upload_spec",
     "write_spec_locally",
+    "write_spec_to_path",
 ]
 
 # Top-level local directory that mirrors the R2 ``prefix_root``. Hard-coded
@@ -121,18 +122,50 @@ def local_spec_path(spec: DatasetSpec, output_dir: Path) -> Path:
     )
 
 
+def write_spec_to_path(spec: DatasetSpec, target: Path) -> Path:
+    """Serialize ``spec`` to an explicit filesystem path; create parent dirs.
+
+    Used by callers that need a spec written at a specific location (e.g.
+    ``cli.finalize_dataset.finalize_hdf5`` writes ``input_spec.json`` flat
+    inside its scratch work_dir so reshard's default discovery — see
+    ``data.reshard._load_spec`` — resolves it without a ``--spec`` override).
+    :func:`write_spec_locally` is the operator-side counterpart that places
+    the same bytes under the canonical ``<output_dir>/data/<task>/<run>/metadata/``
+    layout.
+
+    :param spec: The frozen DatasetSpec to serialize.
+    :param target: Destination file path; must end in
+        :data:`~synth_setter.pipeline.constants.INPUT_SPEC_FILENAME` so the
+        write is discoverable by other tools that glob the standard name.
+    :returns: The path written (same as ``target``).
+    :raises ValueError: ``target.name`` is not
+        :data:`~synth_setter.pipeline.constants.INPUT_SPEC_FILENAME`.
+    """
+    if target.name != INPUT_SPEC_FILENAME:
+        raise ValueError(
+            f"write_spec_to_path requires target.name == {INPUT_SPEC_FILENAME!r}; "
+            f"got {target.name!r}."
+        )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(spec.model_dump_json(indent=2), encoding="utf-8")
+    return target
+
+
 def write_spec_locally(spec: DatasetSpec, output_dir: Path) -> Path:
-    """Serialize ``spec`` to its local path; create parent dirs.
+    """Serialize ``spec`` to its canonical operator-side path; create parent dirs.
+
+    Thin wrapper that resolves the nested ``<output_dir>/data/<task>/<run>/metadata/``
+    layout via :func:`local_spec_path` and delegates to
+    :func:`write_spec_to_path` for the actual write. Callers that need to
+    bypass the nested layout (e.g. write flat inside a tempdir) use
+    :func:`write_spec_to_path` directly.
 
     :param spec: The frozen DatasetSpec to serialize.
     :param output_dir: Operator-side artifact root; see
         :func:`local_spec_path` for the runner's anchor convention.
     :returns: The path written.
     """
-    target = local_spec_path(spec, output_dir)
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(spec.model_dump_json(indent=2), encoding="utf-8")
-    return target
+    return write_spec_to_path(spec, local_spec_path(spec, output_dir))
 
 
 def find_input_specs(data_dir: Path) -> list[Path]:

--- a/tests/pipeline/data/test_stats.py
+++ b/tests/pipeline/data/test_stats.py
@@ -9,6 +9,7 @@ from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType
 
+import h5py
 import numpy as np
 import pytest
 
@@ -837,3 +838,118 @@ def test_cli_help_advertises_mask_degenerate_bins_flag(
     assert exc_info.value.code == 0
     captured = capsys.readouterr()
     assert "--mask-degenerate-bins" in captured.out
+
+
+def _write_tiny_mel_h5(path: Path, rows: int = 4, seed: int = 0) -> None:
+    """Write a small HDF5 file with a ``mel_spec`` dataset.
+
+    :param path: Filesystem path where the ``.h5`` file is written.
+    :param rows: Leading-axis length; must be >=2 so Welford variance is
+        non-degenerate.
+    :param seed: PRNG seed so the same call writes the same payload across
+        repeated invocations in one process.
+    """
+    rng = np.random.default_rng(seed)
+    payload = rng.normal(size=(rows, 2, 4, 5)).astype(np.float32)
+    with h5py.File(path, "w") as f:
+        f.create_dataset("mel_spec", data=payload)
+
+
+def test_get_stats_hdf5_closes_dask_client_and_h5_file(
+    stats_script: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``get_stats_hdf5`` releases its Dask client and h5py file handle on return.
+
+    The PR's stated motivation is leak prevention in the in-process CLI:
+    the new ``with`` blocks around ``Client(...)`` and ``h5py.File(...)``
+    must teardown both resources before control returns. A regression
+    that re-introduces a bare ``Client(...)`` (no ``with``) would leave
+    ``status == "running"`` and a worker scheduler bound to a TCP port,
+    eventually preventing a second call.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: Pytest tmp dir; hosts the seeded ``train.h5``.
+    :param monkeypatch: Pytest fixture used to swap the module-level
+        ``Client`` symbol for a spy subclass that records the instance.
+    """
+    from typing import Any
+
+    from dask.distributed import Client as _Client
+
+    instances: list[_Client] = []
+
+    class _SpyClient(_Client):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            super().__init__(*args, **kwargs)
+            instances.append(self)
+
+    monkeypatch.setattr(stats_script, "Client", _SpyClient)
+    train_h5 = tmp_path / "train.h5"
+    _write_tiny_mel_h5(train_h5)
+
+    stats_script.get_stats_hdf5(str(train_h5))
+
+    assert len(instances) == 1
+    assert instances[0].status == "closed"
+    # Reopening the h5 must succeed — proves the file handle owned by
+    # ``get_stats_hdf5`` released its lock before returning.
+    with h5py.File(train_h5, "r") as reopened:
+        assert reopened.id.valid
+
+
+def test_get_stats_hdf5_writes_sibling_stats_npz_with_mean_std_keys(
+    stats_script: ModuleType, tmp_path: Path
+) -> None:
+    """``get_stats_hdf5(path)`` writes ``stats.npz`` sibling to ``path``.
+
+    ``finalize_hdf5`` asserts ``stats_npz.is_file()`` after the call, but
+    every test of finalize stubs ``get_stats_hdf5``. Pin the real
+    output-path derivation (``SurgeXTDataset.get_stats_file_path``) and
+    the on-disk schema (``mean`` + ``std`` keyed arrays in the input
+    dtype) directly against the real function.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: Pytest tmp dir; hosts the seeded ``train.h5``.
+    """
+    train_h5 = tmp_path / "train.h5"
+    _write_tiny_mel_h5(train_h5)
+
+    stats_script.get_stats_hdf5(str(train_h5))
+
+    stats_npz = tmp_path / "stats.npz"
+    assert stats_npz.is_file()
+    with np.load(stats_npz) as loaded:
+        assert set(loaded.files) == {"mean", "std"}
+        # Input dtype is float32; stats must preserve it (a float64 std
+        # would silently double on-disk size and downstream cast cost).
+        assert loaded["mean"].dtype == np.float32
+        assert loaded["std"].dtype == np.float32
+        # Trailing shape matches the per-sample inner of the mel dataset.
+        assert loaded["mean"].shape == (2, 4, 5)
+        assert loaded["std"].shape == (2, 4, 5)
+
+
+def test_get_stats_hdf5_callable_twice_in_same_process(
+    stats_script: ModuleType, tmp_path: Path
+) -> None:
+    """Two back-to-back calls succeed; no leaked Client port, no stale h5py handle.
+
+    ``finalize_dataset.main()`` invokes ``get_stats_hdf5`` once per run,
+    but multiple runs in the same process (CI matrix shards, an operator
+    REPL) must not regress. Without the ``with`` blocks the second call
+    would hit a port-in-use ``OSError`` from the scheduler or open the
+    h5 file on top of an unreleased handle.
+
+    :param stats_script: Imported stats module (fixture).
+    :param tmp_path: Pytest tmp dir; hosts two seeded train shards.
+    """
+    # Same path for both calls: a stale h5py handle would prevent the
+    # second open; a leaked dask client would collide on its scheduler
+    # port. Either failure mode surfaces as an exception below.
+    train_h5 = tmp_path / "train.h5"
+    _write_tiny_mel_h5(train_h5, seed=1)
+
+    stats_script.get_stats_hdf5(str(train_h5))
+    stats_script.get_stats_hdf5(str(train_h5))
+
+    assert (tmp_path / "stats.npz").is_file()

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -244,11 +244,11 @@ def test_hdf5_finalize_produces_train_consumable_layout(
     _seed_shard_files(r2_stand_in, spec)
 
     uploads: dict[str, Path] = {}
-    # ``_rclone_copy`` runs ``rclone copy`` (dest is a directory); mirror that
-    # contract so the stub can't drift into a ``copyto``-style misuse.
+    # ``download_to_path`` is file→file (``rclone copyto``): ``dst`` is the
+    # exact local path, not a directory. ``r2_uri`` carries the basename.
     monkeypatch.setattr(
-        "synth_setter.cli.finalize_dataset._rclone_copy",
-        lambda src, dst: shutil.copy(r2_stand_in / Path(src).name, Path(dst)),
+        "synth_setter.pipeline.r2_io.download_to_path",
+        lambda r2_uri, dst: shutil.copy(r2_stand_in / Path(r2_uri).name, Path(dst)),
     )
     monkeypatch.setattr(
         "synth_setter.pipeline.r2_io.upload",
@@ -290,8 +290,8 @@ def test_main_hdf5_branch_uploads_marker_last(
     r2_stand_in = tmp_path / "r2"
     upload_order: list[str] = []
     monkeypatch.setattr(
-        "synth_setter.cli.finalize_dataset._rclone_copy",
-        lambda src, dst: shutil.copy(r2_stand_in / Path(src).name, Path(dst)),
+        "synth_setter.pipeline.r2_io.download_to_path",
+        lambda r2_uri, dst: shutil.copy(r2_stand_in / Path(r2_uri).name, Path(dst)),
     )
 
     def record_upload(src: str | Path, dst: str) -> None:
@@ -325,6 +325,32 @@ def test_main_hdf5_branch_uploads_marker_last(
     assert upload_order[-1] == main_spec.r2.dataset_complete_marker_uri()
     assert main_spec.r2.stats_uri() in upload_order
     assert main_spec.r2.split_h5_uri("train") in upload_order
+
+
+def test_finalize_hdf5_raises_on_empty_train_split(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An empty train split surfaces as a clear ValueError before any download work.
+
+    Reshard prunes ``train.h5`` when the train range is empty, after which
+    ``get_stats_hdf5`` would crash with a low-signal HDF5 error; the guard
+    converts that into a contract violation the operator can fix.
+
+    :param monkeypatch: Pytest fixture used to install transport stubs.
+    :param tmp_path: Pytest tmp dir used as the in-process scratch work_dir.
+    """
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.download_to_path",
+        lambda *a, **kw: pytest.fail("download_to_path should not be reached"),
+    )
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.upload",
+        lambda *a, **kw: pytest.fail("upload should not be reached"),
+    )
+
+    spec = _build_hdf5_smoke_spec(task_name="empty-train-hdf5", train_val_test_sizes=(0, 4, 4))
+    with pytest.raises(ValueError, match="train split is empty"):
+        finalize_dataset.finalize_hdf5(spec, tmp_path)
 
 
 def _compose_smoke_hdf5_spec() -> DatasetSpec:

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -8,12 +8,14 @@ exercised; rclone (download / upload / auth ping) is stubbed.
 from __future__ import annotations
 
 import io
+import shutil
 import sys
 import tarfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+import h5py
 import numpy as np
 import pytest
 
@@ -153,21 +155,198 @@ def test_main_is_idempotent_when_marker_already_exists(
     assert uploaded == []
 
 
-def test_main_hdf5_branch_raises_not_implemented_without_uploading_anything(
-    monkeypatch: pytest.MonkeyPatch,
-    patch_finalize_io: tuple[list[str], list[tuple[Path, str]]],
-) -> None:
-    """The hdf5 stub raises before any upload — never strands a spurious marker.
+def _build_hdf5_smoke_spec(
+    task_name: str = "finalize-hdf5-unit",
+    train_val_test_sizes: tuple[int, int, int] = (8, 4, 4),
+    samples_per_shard: int = 4,
+) -> DatasetSpec:
+    """Construct a small hdf5 ``DatasetSpec`` directly (no Hydra compose).
 
-    :param monkeypatch: Pytest fixture used to patch ``sys.argv``.
-    :param patch_finalize_io: Recording stubs; asserted to be empty after the raise.
+    :param task_name: Unique task name so each test gets a distinct r2.prefix.
+    :param train_val_test_sizes: Three-tuple of sample counts; every entry must
+        be a multiple of ``samples_per_shard``.
+    :param samples_per_shard: Per-shard row count driving shard count derivation.
+    :returns: A frozen hdf5 ``DatasetSpec`` whose shards are deterministic.
     """
-    _downloaded, uploaded = patch_finalize_io
+    kwargs: dict[str, Any] = {
+        "task_name": task_name,
+        "output_format": "hdf5",
+        "train_val_test_sizes": list(train_val_test_sizes),
+        "base_seed": 42,
+        "r2": {"bucket": "intermediate-data"},
+        "render": {
+            "plugin_path": "/fake/Plugin.vst3",
+            "preset_path": "presets/surge-base.vstpreset",
+            "param_spec_name": "surge_simple",
+            "renderer_version": "1.0.0-test",
+            "sample_rate": 16000,
+            "channels": 2,
+            "velocity": 100,
+            "signal_duration_seconds": 4.0,
+            "min_loudness": -55.0,
+            "samples_per_render_batch": samples_per_shard,
+            "samples_per_shard": samples_per_shard,
+            "gui_toggle_cadence": "never",
+        },
+    }
+    return DatasetSpec(**kwargs)  # type: ignore[arg-type]
+
+
+def _seed_shard_files(remote_root: Path, spec: DatasetSpec) -> None:
+    """Write every ``spec.shards[i].filename`` as a structurally valid HDF5 shard.
+
+    Shapes/dtypes match
+    :func:`synth_setter.pipeline.ci.validate_shard.check_shard_contracts`.
+
+    :param remote_root: Directory acting as the R2-side staging area.
+    :param spec: Spec whose ``shards`` define the filenames to seed.
+    """
+    remote_root.mkdir(parents=True, exist_ok=True)
+    shard_size = spec.render.samples_per_shard
+    for shard in spec.shards:
+        with h5py.File(remote_root / shard.filename, "w") as f:
+            f.create_dataset("audio", shape=(shard_size, 2, 64), dtype=np.float32)
+            f.create_dataset("mel_spec", shape=(shard_size, 2, 8, 8), dtype=np.float32)
+            f.create_dataset("param_array", shape=(shard_size, 12), dtype=np.float32)
+
+
+def _stage_for(uploads: dict[str, Path], destination_uri: str, tmp_path: Path) -> Path:
+    """Allocate a unique local staging path under ``tmp_path`` for a fake upload.
+
+    :param uploads: Mutable mapping that records ``destination_uri → local copy``.
+    :param destination_uri: The would-be R2 URI of the upload.
+    :param tmp_path: Test-scoped tmp dir to host the staged copy.
+    :returns: A fresh path that ``shutil.copy`` can write to.
+    """
+    staged_root = tmp_path / "uploads"
+    staged_root.mkdir(exist_ok=True)
+    staged = staged_root / f"{len(uploads):03d}_{destination_uri.rsplit('/', 1)[-1]}"
+    uploads[destination_uri] = staged
+    return staged
+
+
+def test_hdf5_finalize_produces_train_consumable_layout(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``finalize_hdf5`` downloads shards, reshards, computes stats, uploads every artifact.
+
+    Pins the train-consumable layout: each ``{train,val,test}.h5`` carries
+    ``audio`` / ``mel_spec`` / ``param_array``; ``stats.npz`` carries
+    ``mean`` / ``std``. Reshard runs for real against the seeded shards —
+    only R2 transport (``_rclone_copy`` / ``r2_io.upload``) and the heavy
+    Dask-driven ``get_stats_hdf5`` are stubbed.
+
+    :param tmp_path: Pytest tmp dir; hosts the fake R2 root + staged uploads.
+    :param monkeypatch: Pytest fixture used to install download/upload/stats stubs.
+    """
+    spec = _build_hdf5_smoke_spec()
+    r2_stand_in = tmp_path / "r2"
+    _seed_shard_files(r2_stand_in, spec)
+
+    uploads: dict[str, Path] = {}
+    # ``_rclone_copy`` runs ``rclone copy`` (dest is a directory); mirror that
+    # contract so the stub can't drift into a ``copyto``-style misuse.
+    monkeypatch.setattr(
+        "synth_setter.cli.finalize_dataset._rclone_copy",
+        lambda src, dst: shutil.copy(r2_stand_in / Path(src).name, Path(dst)),
+    )
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.upload",
+        lambda src, dst: shutil.copy(src, _stage_for(uploads, dst, tmp_path)),
+    )
+    # Skip the Dask-driven mean/std compute — orchestration is what this test pins.
+    monkeypatch.setattr(
+        "synth_setter.cli.finalize_dataset.get_stats_hdf5",
+        lambda train_h5_path: np.savez(
+            Path(train_h5_path).parent / "stats.npz",
+            mean=np.zeros((2, 8, 8), dtype=np.float32),
+            std=np.ones((2, 8, 8), dtype=np.float32),
+        ),
+    )
+
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    finalize_dataset.finalize_hdf5(spec, work_dir)
+
+    for split in ("train", "val", "test"):
+        with h5py.File(uploads[spec.r2.split_h5_uri(split)], "r") as f:
+            assert {"audio", "mel_spec", "param_array"} <= set(f.keys())
+    with np.load(uploads[spec.r2.stats_uri()]) as st:
+        assert set(st.files) == {"mean", "std"}
+
+
+def test_main_hdf5_branch_uploads_marker_last(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The hdf5 ``main()`` path writes ``dataset.complete`` strictly after every artifact.
+
+    Pins the ``pipeline/CLAUDE.md`` ordering invariant for hdf5: an
+    interrupted run must never leave a marker without the artifacts it
+    advertises.
+
+    :param tmp_path: Pytest tmp dir; hosts the fake R2 root + staged uploads.
+    :param monkeypatch: Pytest fixture used to patch the full transport surface.
+    """
+    r2_stand_in = tmp_path / "r2"
+    upload_order: list[str] = []
+    monkeypatch.setattr(
+        "synth_setter.cli.finalize_dataset._rclone_copy",
+        lambda src, dst: shutil.copy(r2_stand_in / Path(src).name, Path(dst)),
+    )
+
+    def record_upload(src: str | Path, dst: str) -> None:
+        upload_order.append(dst)
+
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.upload", record_upload)
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.ensure_r2_env_loaded", lambda *a, **k: None)
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.object_size", lambda uri: None)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._get_git_sha", lambda: "a" * 40)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._is_repo_dirty", lambda: False)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._utc_now", lambda: _FIXED_NOW)
+    # Skip the Dask-driven mean/std compute — orchestration is what this test pins.
+    monkeypatch.setattr(
+        "synth_setter.cli.finalize_dataset.get_stats_hdf5",
+        lambda train_h5_path: np.savez(
+            Path(train_h5_path).parent / "stats.npz",
+            mean=np.zeros((2, 8, 8), dtype=np.float32),
+            std=np.ones((2, 8, 8), dtype=np.float32),
+        ),
+    )
+    # Compose the smoke-shard hdf5 experiment so the entrypoint exercises real Hydra.
     monkeypatch.setattr(sys, "argv", ["finalize", "experiment=generate_dataset/smoke-shard"])
 
-    with pytest.raises(NotImplementedError, match="hdf5 finalize is not implemented"):
-        finalize_dataset.main()
-    assert uploaded == []
+    # Re-compose the same spec ``main()`` will, then seed shards into the fake
+    # R2 root so the patched ``_rclone_copy`` lands them under ``work_dir``.
+    main_spec = _compose_smoke_hdf5_spec()
+    _seed_shard_files(r2_stand_in, main_spec)
+
+    finalize_dataset.main()
+
+    assert upload_order[-1] == main_spec.r2.dataset_complete_marker_uri()
+    assert main_spec.r2.stats_uri() in upload_order
+    assert main_spec.r2.split_h5_uri("train") in upload_order
+
+
+def _compose_smoke_hdf5_spec() -> DatasetSpec:
+    """Re-compose the hdf5 smoke spec the same way ``main()`` does, for URI assertions.
+
+    :returns: A ``DatasetSpec`` whose ``r2.prefix`` matches what ``main()``
+        constructs from the ``smoke-shard`` experiment in the same process.
+    """
+    from hydra import compose, initialize_config_dir
+
+    with initialize_config_dir(
+        version_base="1.3",
+        config_dir=str(finalize_dataset._CONFIG_DIR),  # noqa: SLF001 — test mirrors main()
+    ):
+        cfg = compose(
+            config_name="dataset",
+            overrides=["experiment=generate_dataset/smoke-shard"],
+        )
+    cfg.paths.root_dir = str(finalize_dataset._REPO_ROOT)  # noqa: SLF001
+    cfg.paths.output_dir = str(finalize_dataset._REPO_ROOT)  # noqa: SLF001
+    cfg.paths.work_dir = str(finalize_dataset._REPO_ROOT)  # noqa: SLF001
+    return finalize_dataset.spec_from_cfg(cfg)
 
 
 def test_finalize_wds_downloads_every_train_shard_uri(

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -13,7 +13,7 @@ import sys
 import tarfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import h5py
 import numpy as np
@@ -303,6 +303,81 @@ def test_hdf5_finalize_produces_train_consumable_layout(
         assert set(st.files) == {"mean", "std"}
 
 
+def test_finalize_hdf5_real_shards_end_to_end(
+    fake_r2_remote: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression: real rclone, real reshard, real upload — read-back after work_dir deleted.
+
+    Exercises ``finalize_hdf5`` end-to-end against the ``fake_r2_remote``
+    local-typed rclone remote (no subprocess mocks): real shard downloads,
+    real ``reshard_dataset`` invocation, real ``r2_io.upload`` of every
+    split + ``stats.npz`` via ``rclone copyto``. Only ``get_stats_hdf5`` is
+    stubbed because its Dask client startup dominates runtime; the stub
+    writes a real ``stats.npz`` so the upload step is the production one.
+
+    After the call returns the work_dir is wiped; the uploaded ``train.h5``
+    is read back from the fake R2 location with sibling shards available
+    (the layout a downstream consumer sees). A row from ``audio`` is
+    dereferenced to prove the VDS sources resolve relative to the file's
+    directory — guards the absolute-path regression where ``h5py.VirtualSource``
+    would embed the now-gone work_dir.
+
+    :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir
+        (see ``tests/pipeline/conftest.py``). Skips if rclone is missing.
+    :param tmp_path: Pytest tmp dir; hosts the finalize scratch work_dir.
+    :param monkeypatch: Pytest fixture used to stub the slow Dask stats compute.
+    """
+    spec = _build_hdf5_smoke_spec(task_name="finalize-hdf5-e2e")
+
+    # Seed shards into the fake R2 location where ``download_to_path`` will fetch them.
+    shard_remote_dir = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+    _seed_shard_files(shard_remote_dir, spec)
+
+    # Real Dask compute would dominate runtime; stub writes a sentinel ``stats.npz``
+    # so the production ``r2_io.upload`` step still runs against a real file.
+    monkeypatch.setattr(
+        "synth_setter.cli.finalize_dataset.get_stats_hdf5",
+        lambda train_h5_path: np.savez(
+            Path(train_h5_path).parent / "stats.npz",
+            mean=np.zeros((2, 8, 8), dtype=np.float32),
+            std=np.ones((2, 8, 8), dtype=np.float32),
+        ),
+    )
+
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    finalize_dataset.finalize_hdf5(spec, work_dir)
+
+    # Wipe the scratch dir before any read so the assertion proves the
+    # uploaded artifacts stand on their own (VDS relative-path invariant).
+    shutil.rmtree(work_dir)
+
+    # Layout the consumer sees: every split + stats land flat under ``<prefix>``,
+    # sibling to the source shards.
+    landed_root = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+    train_h5 = landed_root / "train.h5"
+    val_h5 = landed_root / "val.h5"
+    test_h5 = landed_root / "test.h5"
+    stats_npz = landed_root / "stats.npz"
+    assert train_h5.is_file()
+    assert val_h5.is_file()
+    assert test_h5.is_file()
+    assert stats_npz.is_file()
+
+    # The VDS resolves and a row dereferences — proves the embedded source paths
+    # are relative (basename) and find sibling shards in ``landed_root``.
+    with h5py.File(train_h5, "r") as f:
+        assert {"audio", "mel_spec", "param_array"} <= set(f.keys())
+        audio = cast(h5py.Dataset, f["audio"])
+        assert audio.shape[0] == spec.train_val_test_sizes[0]
+        # Dereferencing a row routes through ``h5py.VirtualSource`` — would raise
+        # ``KeyError`` / return zeros if the embedded path didn't resolve.
+        _ = audio[0]
+
+    with np.load(stats_npz) as st:
+        assert set(st.files) == {"mean", "std"}
+
+
 def test_main_hdf5_branch_uploads_marker_last(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -344,7 +419,7 @@ def test_main_hdf5_branch_uploads_marker_last(
     monkeypatch.setattr(sys, "argv", ["finalize", "experiment=generate_dataset/smoke-shard"])
 
     # Re-compose the same spec ``main()`` will, then seed shards into the fake
-    # R2 root so the patched ``_rclone_copy`` lands them under ``work_dir``.
+    # R2 root so the patched ``download_to_path`` lands them under ``work_dir``.
     main_spec = _compose_smoke_hdf5_spec()
     _seed_shard_files(r2_stand_in, main_spec)
 

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -20,6 +20,14 @@ import numpy as np
 import pytest
 
 from synth_setter.cli import finalize_dataset
+from synth_setter.data.vst.shapes import (
+    AUDIO_FIELD,
+    MEL_SPEC_FIELD,
+    PARAM_ARRAY_FIELD,
+    audio_dataset_shape,
+    mel_dataset_shape,
+    param_array_dataset_shape,
+)
 from synth_setter.pipeline.schemas.spec import DatasetSpec
 
 _FIXED_NOW = datetime(2026, 5, 20, 12, 0, 0, tzinfo=timezone.utc)
@@ -202,12 +210,25 @@ def _seed_shard_files(remote_root: Path, spec: DatasetSpec) -> None:
     :param spec: Spec whose ``shards`` define the filenames to seed.
     """
     remote_root.mkdir(parents=True, exist_ok=True)
-    shard_size = spec.render.samples_per_shard
+    render = spec.render
+    audio_shape = audio_dataset_shape(
+        render.samples_per_shard,
+        render.channels,
+        render.sample_rate,
+        render.signal_duration_seconds,
+    )
+    mel_shape = mel_dataset_shape(
+        render.samples_per_shard,
+        render.channels,
+        render.sample_rate,
+        render.signal_duration_seconds,
+    )
+    param_shape = param_array_dataset_shape(render.samples_per_shard, spec.num_params)
     for shard in spec.shards:
         with h5py.File(remote_root / shard.filename, "w") as f:
-            f.create_dataset("audio", shape=(shard_size, 2, 64), dtype=np.float32)
-            f.create_dataset("mel_spec", shape=(shard_size, 2, 8, 8), dtype=np.float32)
-            f.create_dataset("param_array", shape=(shard_size, 12), dtype=np.float32)
+            f.create_dataset(AUDIO_FIELD, shape=audio_shape, dtype=np.float32)
+            f.create_dataset(MEL_SPEC_FIELD, shape=mel_shape, dtype=np.float32)
+            f.create_dataset(PARAM_ARRAY_FIELD, shape=param_shape, dtype=np.float32)
 
 
 def _stage_for(uploads: dict[str, Path], destination_uri: str, tmp_path: Path) -> Path:
@@ -244,12 +265,15 @@ def test_hdf5_finalize_produces_train_consumable_layout(
     _seed_shard_files(r2_stand_in, spec)
 
     uploads: dict[str, Path] = {}
-    # ``download_to_path`` is file→file (``rclone copyto``): ``dst`` is the
-    # exact local path, not a directory. ``r2_uri`` carries the basename.
-    monkeypatch.setattr(
-        "synth_setter.pipeline.r2_io.download_to_path",
-        lambda r2_uri, dst: shutil.copy(r2_stand_in / Path(r2_uri).name, Path(dst)),
-    )
+    downloaded_uris: list[str] = []
+
+    def fake_download(r2_uri: str, dst: Path) -> None:
+        # ``download_to_path`` is file→file (``rclone copyto``): ``dst`` is the
+        # exact local path, not a directory. ``r2_uri`` carries the basename.
+        downloaded_uris.append(r2_uri)
+        shutil.copy(r2_stand_in / Path(r2_uri).name, Path(dst))
+
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.download_to_path", fake_download)
     monkeypatch.setattr(
         "synth_setter.pipeline.r2_io.upload",
         lambda src, dst: shutil.copy(src, _stage_for(uploads, dst, tmp_path)),
@@ -268,6 +292,10 @@ def test_hdf5_finalize_produces_train_consumable_layout(
     work_dir.mkdir()
     finalize_dataset.finalize_hdf5(spec, work_dir)
 
+    # Every shard (not just train) is downloaded — reshard needs them all to
+    # produce val/test splits; a regression that narrowed to train would
+    # silently drop val/test outputs.
+    assert downloaded_uris == [spec.r2.shard_uri(shard) for shard in spec.shards]
     for split in ("train", "val", "test"):
         with h5py.File(uploads[spec.r2.split_h5_uri(split)], "r") as f:
             assert {"audio", "mel_spec", "param_array"} <= set(f.keys())
@@ -322,9 +350,14 @@ def test_main_hdf5_branch_uploads_marker_last(
 
     finalize_dataset.main()
 
-    assert upload_order[-1] == main_spec.r2.dataset_complete_marker_uri()
-    assert main_spec.r2.stats_uri() in upload_order
-    assert main_spec.r2.split_h5_uri("train") in upload_order
+    marker_uri = main_spec.r2.dataset_complete_marker_uri()
+    marker_index = upload_order.index(marker_uri)
+    # Marker strictly later than every artifact URI — the
+    # ``pipeline/CLAUDE.md`` invariant ("never leave a marker without
+    # artifacts") generalizes to splits-with-val-test, not just train.
+    assert marker_index == len(upload_order) - 1
+    for artifact_uri in (main_spec.r2.stats_uri(), main_spec.r2.split_h5_uri("train")):
+        assert upload_order.index(artifact_uri) < marker_index
 
 
 def test_finalize_hdf5_raises_on_empty_train_split(
@@ -351,6 +384,48 @@ def test_finalize_hdf5_raises_on_empty_train_split(
     spec = _build_hdf5_smoke_spec(task_name="empty-train-hdf5", train_val_test_sizes=(0, 4, 4))
     with pytest.raises(ValueError, match="train split is empty"):
         finalize_dataset.finalize_hdf5(spec, tmp_path)
+
+
+def test_finalize_hdf5_propagates_stats_failure_before_marker_upload(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A ``get_stats_hdf5`` failure surfaces and no split/stats/marker upload runs.
+
+    ``get_stats_hdf5`` raises on degenerate bins (see
+    ``synth_setter.pipeline.data.stats._check_degenerate_bins``); finalize
+    must propagate the error rather than swallow it and proceed to upload
+    ``dataset.complete``. Drives ``finalize_hdf5`` directly so the assertion
+    is local to the stats step.
+
+    :param monkeypatch: Pytest fixture used to install transport + stats stubs.
+    :param tmp_path: Pytest tmp dir; hosts the fake R2 root + scratch work_dir.
+    """
+    spec = _build_hdf5_smoke_spec(task_name="stats-raises-hdf5")
+    r2_stand_in = tmp_path / "r2"
+    _seed_shard_files(r2_stand_in, spec)
+
+    uploaded: list[str] = []
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.download_to_path",
+        lambda r2_uri, dst: shutil.copy(r2_stand_in / Path(r2_uri).name, Path(dst)),
+    )
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.upload",
+        lambda src, dst: uploaded.append(dst),
+    )
+
+    def boom(train_h5_path: str) -> None:
+        del train_h5_path
+        raise RuntimeError("degenerate bins")
+
+    monkeypatch.setattr("synth_setter.cli.finalize_dataset.get_stats_hdf5", boom)
+
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    with pytest.raises(RuntimeError, match="degenerate bins"):
+        finalize_dataset.finalize_hdf5(spec, work_dir)
+
+    assert uploaded == []
 
 
 def _compose_smoke_hdf5_spec() -> DatasetSpec:

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -378,6 +378,256 @@ def test_finalize_hdf5_real_shards_end_to_end(
         assert set(st.files) == {"mean", "std"}
 
 
+def _stub_get_stats_hdf5(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stub ``finalize_dataset.get_stats_hdf5`` to write a sentinel ``stats.npz``.
+
+    Real Dask startup dominates runtime; tests that drive ``finalize_hdf5``
+    end-to-end use this stub so the subsequent ``r2_io.upload`` step still
+    runs against a real on-disk file produced sibling to ``train.h5``.
+
+    :param monkeypatch: Pytest fixture used to install the stub.
+    """
+    monkeypatch.setattr(
+        "synth_setter.cli.finalize_dataset.get_stats_hdf5",
+        lambda train_h5_path: np.savez(
+            Path(train_h5_path).parent / "stats.npz",
+            mean=np.zeros((2, 8, 8), dtype=np.float32),
+            std=np.ones((2, 8, 8), dtype=np.float32),
+        ),
+    )
+
+
+def test_finalize_hdf5_only_uploads_splits_that_reshard_wrote(
+    fake_r2_remote: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Spec with empty val+test splits: only ``train.h5`` + ``stats.npz`` land in R2.
+
+    Reshard prunes ``val.h5``/``test.h5`` when their shard ranges are
+    empty (``[lo, lo)``). Finalize's ``if split_h5.exists()`` guard must
+    keep the val/test uploads from firing; a regression that removed the
+    guard would either crash with FileNotFoundError on the missing local
+    file or silently upload a stale artifact from a previous run.
+
+    :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+    :param tmp_path: Pytest tmp dir; hosts the finalize scratch work_dir.
+    :param monkeypatch: Pytest fixture used to stub the slow Dask stats compute.
+    """
+    spec = _build_hdf5_smoke_spec(task_name="train-only-splits", train_val_test_sizes=(8, 0, 0))
+    shard_remote_dir = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+    _seed_shard_files(shard_remote_dir, spec)
+    _stub_get_stats_hdf5(monkeypatch)
+
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    finalize_dataset.finalize_hdf5(spec, work_dir)
+
+    landed_root = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+    assert (landed_root / "train.h5").is_file()
+    assert (landed_root / "stats.npz").is_file()
+    # No val/test artifacts were ever uploaded — reshard never wrote them
+    # and finalize's existence guard skipped the upload call.
+    assert not (landed_root / "val.h5").exists()
+    assert not (landed_root / "test.h5").exists()
+
+
+def test_finalize_hdf5_propagates_split_upload_failure_before_stats_upload(
+    fake_r2_remote: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mid-loop split-upload failure: neither ``stats.npz`` nor ``dataset.complete`` lands.
+
+    The "never leave a marker without artifacts" invariant from
+    ``pipeline/CLAUDE.md`` must hold for every failure stage, not just
+    the stats stage. Wraps ``r2_io.upload`` to raise on the first
+    ``.h5`` split upload so reshard ran (its train.h5 exists locally)
+    but transport failed mid-flight.
+
+    :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+    :param tmp_path: Pytest tmp dir; hosts the finalize scratch work_dir.
+    :param monkeypatch: Pytest fixture used to wrap ``r2_io.upload`` with
+        a failing wrapper. Interaction-based by necessity — failure
+        injection at the transport layer has no state-based alternative.
+    """
+    spec = _build_hdf5_smoke_spec(task_name="split-upload-fails")
+    shard_remote_dir = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+    _seed_shard_files(shard_remote_dir, spec)
+    _stub_get_stats_hdf5(monkeypatch)
+
+    def fail_on_split_upload(source: str | Path, destination_uri: str) -> None:
+        del source
+        if destination_uri.endswith(".h5"):
+            raise RuntimeError(f"simulated split upload failure for {destination_uri}")
+        pytest.fail(f"upload to {destination_uri} should not be reached after split failure")
+
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.upload", fail_on_split_upload)
+
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    with pytest.raises(RuntimeError, match="simulated split upload failure"):
+        finalize_dataset.finalize_hdf5(spec, work_dir)
+
+    landed_root = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+    assert not (landed_root / "stats.npz").exists()
+    assert not (landed_root / "dataset.complete").exists()
+
+
+def test_finalize_hdf5_writes_input_spec_json_sibling_to_shards(
+    fake_r2_remote: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``input_spec.json`` lands in ``work_dir`` before ``reshard_dataset`` is invoked.
+
+    Reshard's default spec-discovery looks for ``<dataset_root>/input_spec.json``
+    when no ``--spec`` override is passed; finalize relies on this default
+    path. Pinning the write order here gives a finalize-side test instead
+    of a low-signal ``FileNotFoundError`` surfacing from reshard.
+
+    :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+    :param tmp_path: Pytest tmp dir; hosts the finalize scratch work_dir.
+    :param monkeypatch: Pytest fixture used to wrap ``reshard_dataset`` and
+        capture the work_dir contents at invocation time.
+    """
+    spec = _build_hdf5_smoke_spec(task_name="input-spec-sibling")
+    shard_remote_dir = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+    _seed_shard_files(shard_remote_dir, spec)
+    _stub_get_stats_hdf5(monkeypatch)
+
+    captured_files: list[str] = []
+    real_reshard = finalize_dataset.reshard_dataset
+
+    def capturing_reshard(dataset_root: Path, *args: object, **kwargs: object) -> None:
+        captured_files.extend(sorted(p.name for p in Path(dataset_root).iterdir()))
+        real_reshard(dataset_root, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr("synth_setter.cli.finalize_dataset.reshard_dataset", capturing_reshard)
+
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    finalize_dataset.finalize_hdf5(spec, work_dir)
+
+    # ``input_spec.json`` was sibling to every downloaded shard before
+    # reshard ran — reshard's default spec lookup will succeed without
+    # any ``--spec`` flag.
+    assert "input_spec.json" in captured_files
+    for shard in spec.shards:
+        assert shard.filename in captured_files
+
+
+def test_finalize_hdf5_rejects_structurally_invalid_shard(
+    fake_r2_remote: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A malformed downloaded shard surfaces an ``OSError`` from reshard, no upload runs.
+
+    Pins ``pipeline/CLAUDE.md``'s delegation contract: finalize hands
+    structural validation to reshard, which opens every shard via
+    ``h5py.File`` while staging splits. A garbage-payload shard makes
+    that open raise ``OSError("file signature not found")`` — finalize
+    propagates the raise instead of writing partial artifacts to R2.
+    The h5py error itself does not embed the offending shard's name;
+    enriching that message lives in a follow-up.
+
+    :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+    :param tmp_path: Pytest tmp dir; hosts the finalize scratch work_dir.
+    :param monkeypatch: Pytest fixture used to stub the slow Dask stats compute
+        (defensively, in case reshard is ever changed to fail later).
+    """
+    spec = _build_hdf5_smoke_spec(task_name="invalid-shard-reject")
+    shard_remote_dir = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+    _seed_shard_files(shard_remote_dir, spec)
+    # Garbage bytes at the first shard URI — reshard's h5py.File open refuses to read it.
+    corrupted = spec.shards[0].filename
+    (shard_remote_dir / corrupted).write_bytes(b"not an HDF5 file\n")
+    _stub_get_stats_hdf5(monkeypatch)
+
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    with pytest.raises(OSError, match="file signature not found"):
+        finalize_dataset.finalize_hdf5(spec, work_dir)
+
+    # No split or stats artifact landed at the remote — the per-shard
+    # open ran before any upload, so the failure is total.
+    landed_root = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+    assert not (landed_root / "train.h5").exists()
+    assert not (landed_root / "stats.npz").exists()
+
+
+def test_finalize_hdf5_temp_work_dir_is_torn_down_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``main()``'s ``TemporaryDirectory`` is removed even when ``finalize_hdf5`` raises.
+
+    A multi-GB download leak on every retry of a failing prefix is the
+    bug this pins. ``tempfile.TemporaryDirectory`` removes its dir on
+    context exit regardless of exception path; pin that the wrapping
+    in ``main()`` preserves this guarantee.
+
+    :param tmp_path: Pytest tmp dir; hosts a fake R2 stand-in for downloads.
+    :param monkeypatch: Pytest fixture used to patch the transport surface
+        and force ``finalize_hdf5`` to raise inside the tempdir scope.
+    """
+    captured_work_dir: dict[str, Path] = {}
+    r2_stand_in = tmp_path / "r2"
+
+    def boom_finalize_hdf5(spec: object, work_dir: Path) -> None:
+        del spec
+        # Capture the live tempdir path before the raise so the post-call
+        # assertion can prove ``TemporaryDirectory`` cleanup ran.
+        captured_work_dir["path"] = Path(work_dir)
+        raise RuntimeError("simulated finalize failure")
+
+    monkeypatch.setattr("synth_setter.cli.finalize_dataset.finalize_hdf5", boom_finalize_hdf5)
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.download_to_path",
+        lambda r2_uri, dst: shutil.copy(r2_stand_in / Path(r2_uri).name, Path(dst)),
+    )
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.upload", lambda src, dst: None)
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.ensure_r2_env_loaded", lambda *a, **k: None)
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.object_size", lambda uri: None)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._get_git_sha", lambda: "a" * 40)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._is_repo_dirty", lambda: False)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._utc_now", lambda: _FIXED_NOW)
+    monkeypatch.setattr(sys, "argv", ["finalize", "experiment=generate_dataset/smoke-shard"])
+
+    with pytest.raises(RuntimeError, match="simulated finalize failure"):
+        finalize_dataset.main()
+
+    assert "path" in captured_work_dir
+    assert not captured_work_dir["path"].exists()
+
+
+def test_finalize_hdf5_marker_idempotency_short_circuits_before_download(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Hdf5 dispatch: ``main()`` returns without one download when the marker exists.
+
+    ``test_main_is_idempotent_when_marker_already_exists`` covers the wds
+    branch; this test pins the hdf5-branch path so a regression that
+    moved the marker check *inside* the format branch (instead of
+    before ``tempfile.TemporaryDirectory()``) would be caught.
+
+    :param tmp_path: Pytest tmp dir; not used for material state but
+        required for fixture symmetry with the other hdf5 tests.
+    :param monkeypatch: Pytest fixture used to force ``object_size`` to
+        return a present marker and to fail-fast on any download.
+    """
+    del tmp_path
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.download_to_path",
+        lambda *a, **kw: pytest.fail("download_to_path should not be reached"),
+    )
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.upload",
+        lambda *a, **kw: pytest.fail("upload should not be reached"),
+    )
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.ensure_r2_env_loaded", lambda *a, **k: None)
+    # Non-None ``object_size`` means the marker already exists at the run prefix.
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.object_size", lambda uri: 0)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._get_git_sha", lambda: "a" * 40)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._is_repo_dirty", lambda: False)
+    monkeypatch.setattr("synth_setter.pipeline.schemas.spec._utc_now", lambda: _FIXED_NOW)
+    monkeypatch.setattr(sys, "argv", ["finalize", "experiment=generate_dataset/smoke-shard"])
+
+    finalize_dataset.main()
+
+
 def test_main_hdf5_branch_uploads_marker_last(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Replace the Phase-1 `NotImplementedError` stub for `finalize_hdf5` with a working body: downloads every shard from R2 via `_rclone_copy`, writes `input_spec.json` sibling to the shards, invokes `reshard.main.callback(...)` to produce `{train,val,test}.h5`, computes `stats.npz` via `get_stats_hdf5`, and uploads every resulting split file plus `stats.npz` to its canonical R2 URI.
- `main()` still writes `dataset.complete` last per `pipeline/CLAUDE.md` — ordering invariant pinned by `test_main_hdf5_branch_uploads_marker_last`.
- Iterate `spec.split_shard_ranges` (Split-typed keys) so `R2Location.split_h5_uri` narrows without a runtime cast; skip splits whose `{split}.h5` was pruned by reshard (e.g. smoke-shard `[12, 0, 0]`).

## Test plan

- [x] `pytest tests/pipeline/test_entrypoints/test_finalize_dataset.py tests/pipeline/data/test_reshard.py -q` → **34 passed in 1.26s**
- [x] `pre-commit run --files src/synth_setter/cli/finalize_dataset.py tests/pipeline/test_entrypoints/test_finalize_dataset.py` → all hooks pass (ruff, ruff-format, pyright, pydoclint, docformatter, interrogate, codespell, no-commit-to-branch)
- [x] New TDD test `test_hdf5_finalize_produces_train_consumable_layout` lets `reshard` run for real against seeded HDF5 shards; asserts each `{train,val,test}.h5` carries `audio` / `mel_spec` / `param_array` and `stats.npz` carries `mean` / `std`.
- [x] New `test_main_hdf5_branch_uploads_marker_last` drives `finalize_dataset.main()` against the real `smoke-shard` Hydra experiment; asserts `dataset.complete` is the last upload.

Closes #1183