### PR TITLE
ci(cpu-slow): inject RCLONE_CONFIG_R2_* secrets so integration_r2 tests run

### DIFF
--- a/.github/workflows/cpu-slow.yml
+++ b/.github/workflows/cpu-slow.yml
@@ -60,9 +60,14 @@ jobs:
       - name: List dependencies
         run: uv pip list --system
 
+      # `RCLONE_CONFIG_R2_*` lets `integration_r2`-marked tests reach real
+      # R2 instead of skipping via `r2_io.is_r2_reachable()` — see #1185.
       - name: Run slow (non-GPU, non-MPS, non-VST) tests
         env:
           HYDRA_FULL_ERROR: "1"
+          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
         run: |
           pytest -vv -s -m "slow and not gpu and not mps and not requires_vst"
 

--- a/.github/workflows/cpu-slow.yml
+++ b/.github/workflows/cpu-slow.yml
@@ -14,6 +14,13 @@ on:
     paths-ignore:
       - "docs/**"
       - "**/*.md"
+  # Self-trigger so PRs that touch the workflow (or its invariant test)
+  # exercise it pre-merge instead of waiting for the post-merge push run
+  # to surface regressions — see #1206.
+  pull_request:
+    paths:
+      - ".github/workflows/cpu-slow.yml"
+      - "tests/infra/test_cpu_slow_workflow_r2_creds.py"
 
 concurrency:
   group: cpu-slow-${{ github.ref }}

--- a/.github/workflows/cpu-slow.yml
+++ b/.github/workflows/cpu-slow.yml
@@ -60,11 +60,20 @@ jobs:
       - name: List dependencies
         run: uv pip list --system
 
+      # `is_r2_reachable()` shells out to `rclone`; without the binary the
+      # `integration_r2` gate short-circuits and the tests skip silently.
+      # Mirrors the install in `test-local-launcher-roundtrip.yml` and
+      # `generate-dataset-shards.yaml`.
+      - name: Install rclone
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
+
       # `RCLONE_CONFIG_R2_*` lets `integration_r2`-marked tests reach real
       # R2 instead of skipping via `r2_io.is_r2_reachable()` — see #1185.
       - name: Run slow (non-GPU, non-MPS, non-VST) tests
         env:
           HYDRA_FULL_ERROR: "1"
+          RCLONE_CONFIG_R2_TYPE: s3
+          RCLONE_CONFIG_R2_PROVIDER: Cloudflare
           RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
           RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
           RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}

--- a/.github/workflows/cpu-slow.yml
+++ b/.github/workflows/cpu-slow.yml
@@ -31,6 +31,12 @@ permissions:
 
 jobs:
   run_slow_tests:
+    # Skip fork-PR runs: forks can't see `secrets.RCLONE_CONFIG_R2_*` and the
+    # 90-min suite would burn a 4-core runner with `integration_r2` skipping
+    # silently. Workflow_dispatch / push / schedule runs are unaffected — only
+    # the `pull_request` trigger checks head-repo identity (see #1206).
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+
     # Larger runner: the slow CPU suite runs PyTorch forward passes on the FFN
     # smoke fixtures, and the standard 2-core/7 GB `ubuntu-latest` OOMs during
     # those passes. `ubuntu-latest-4core` (4 vCPU / 16 GB) is the smallest

--- a/tests/infra/test_cpu_slow_workflow_r2_creds.py
+++ b/tests/infra/test_cpu_slow_workflow_r2_creds.py
@@ -15,15 +15,30 @@ from typing import cast
 import pytest
 import yaml
 
-REQUIRED_R2_ENV_KEYS: frozenset[str] = frozenset(
-    {
-        "RCLONE_CONFIG_R2_ACCESS_KEY_ID",
-        "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY",
-        "RCLONE_CONFIG_R2_ENDPOINT",
-    }
+from synth_setter.pipeline.r2_io import _R2_STRUCTURAL_DEFAULTS, _SECRET_R2_ENV_KEYS
+
+# Union of the secret keys rclone needs to authenticate AND the structural
+# defaults rclone needs to assemble the `r2:` remote. `is_r2_reachable()`
+# does NOT apply the `setdefault` that `ensure_r2_env_loaded()` does, so
+# both sets must be present in the runner env — see #1185.
+REQUIRED_R2_ENV_KEYS: frozenset[str] = frozenset(_SECRET_R2_ENV_KEYS) | frozenset(
+    _R2_STRUCTURAL_DEFAULTS
 )
 
 PYTEST_STEP_NAME = "Run slow (non-GPU, non-MPS, non-VST) tests"
+RCLONE_INSTALL_STEP_NAME = "Install rclone"
+
+
+def _load_workflow_steps(project_root: Path) -> list[dict[str, object]]:
+    """Return the ordered ``steps`` list of the ``run_slow_tests`` job.
+
+    :param project_root: repo root; the workflow is read from
+        ``<project_root>/.github/workflows/cpu-slow.yml``.
+    :returns: the job's ``steps`` list.
+    """
+    workflow_path = project_root / ".github" / "workflows" / "cpu-slow.yml"
+    workflow = yaml.safe_load(workflow_path.read_text())
+    return cast(list[dict[str, object]], workflow["jobs"]["run_slow_tests"]["steps"])
 
 
 def _load_pytest_step_env(project_root: Path) -> dict[str, str]:
@@ -34,16 +49,15 @@ def _load_pytest_step_env(project_root: Path) -> dict[str, str]:
     :returns: the step's ``env`` block, or an empty dict if unset.
     """
     workflow_path = project_root / ".github" / "workflows" / "cpu-slow.yml"
-    workflow = yaml.safe_load(workflow_path.read_text())
-    for step in workflow["jobs"]["run_slow_tests"]["steps"]:
+    for step in _load_workflow_steps(project_root):
         if step.get("name") == PYTEST_STEP_NAME:
-            return cast("dict[str, str]", step.get("env") or {})
+            return cast(dict[str, str], step.get("env") or {})
     pytest.fail(f"Could not find step {PYTEST_STEP_NAME!r} in {workflow_path}")
 
 
 @pytest.mark.infra
 def test_cpu_slow_pytest_step_injects_r2_creds(project_root: Path) -> None:
-    """The pytest step exposes all three ``RCLONE_CONFIG_R2_*`` keys via ``env:``.
+    """The pytest step exposes every ``RCLONE_CONFIG_R2_*`` key ``is_r2_reachable()`` reads.
 
     :param project_root: session fixture from ``tests/infra/conftest.py``.
     """
@@ -56,16 +70,66 @@ def test_cpu_slow_pytest_step_injects_r2_creds(project_root: Path) -> None:
 
 
 @pytest.mark.infra
-def test_cpu_slow_r2_env_values_reference_matching_secrets(project_root: Path) -> None:
-    """Each R2 env key sources from the same-named ``secrets.RCLONE_CONFIG_R2_*``.
+@pytest.mark.parametrize("key", sorted(_SECRET_R2_ENV_KEYS))
+def test_cpu_slow_r2_secret_env_values_reference_matching_secrets(
+    project_root: Path, key: str
+) -> None:
+    """Each secret R2 env key sources from the same-named ``secrets.RCLONE_CONFIG_R2_*``.
+
+    :param project_root: session fixture from ``tests/infra/conftest.py``.
+    :param key: one of ``_SECRET_R2_ENV_KEYS``; parametrized so a missing
+        key fails this case independently with the key name in the output
+        rather than collapsing into a ``KeyError`` from the others.
+    """
+    env = _load_pytest_step_env(project_root)
+    actual = env.get(key)
+    expected = f"${{{{ secrets.{key} }}}}"
+    assert actual == expected, (
+        f"cpu-slow.yml env[{key!r}] = {actual!r}; expected {expected!r} to match the "
+        f"secret-name convention used by generate-dataset-shards.yaml + "
+        f"test-local-launcher-roundtrip.yml"
+    )
+
+
+@pytest.mark.infra
+@pytest.mark.parametrize(("key", "expected"), sorted(_R2_STRUCTURAL_DEFAULTS.items()))
+def test_cpu_slow_r2_structural_env_values_use_canonical_literals(
+    project_root: Path, key: str, expected: str
+) -> None:
+    """Each structural R2 env key uses the canonical literal from ``r2_io``.
+
+    ``is_r2_reachable()`` does not apply ``_R2_STRUCTURAL_DEFAULTS`` via
+    ``setdefault`` the way ``ensure_r2_env_loaded()`` does, so the workflow
+    must export these literals itself or ``rclone lsd r2:`` will fail with
+    ``didn't find section in config file`` and ``integration_r2`` tests
+    skip silently — see #1185.
+
+    :param project_root: session fixture from ``tests/infra/conftest.py``.
+    :param key: one of ``_R2_STRUCTURAL_DEFAULTS``.
+    :param expected: the canonical literal value rclone needs (``s3`` /
+        ``Cloudflare``); drift from ``r2_io._R2_STRUCTURAL_DEFAULTS`` fails
+        this case loudly instead of letting the workflow silently regress.
+    """
+    env = _load_pytest_step_env(project_root)
+    actual = env.get(key)
+    assert actual == expected, (
+        f"cpu-slow.yml env[{key!r}] = {actual!r}; expected literal {expected!r} "
+        f"(canonical value from r2_io._R2_STRUCTURAL_DEFAULTS)"
+    )
+
+
+@pytest.mark.infra
+def test_cpu_slow_installs_rclone_before_pytest(project_root: Path) -> None:
+    """``Install rclone`` runs before the pytest step so ``is_r2_reachable()`` passes.
 
     :param project_root: session fixture from ``tests/infra/conftest.py``.
     """
-    env = _load_pytest_step_env(project_root)
-    for key in sorted(REQUIRED_R2_ENV_KEYS):
-        expected = f"${{{{ secrets.{key} }}}}"
-        assert env[key] == expected, (
-            f"cpu-slow.yml env[{key!r}] = {env[key]!r}; expected {expected!r} to match the "
-            f"secret-name convention used by generate-dataset-shards.yaml + "
-            f"test-local-launcher-roundtrip.yml"
-        )
+    steps = _load_workflow_steps(project_root)
+    names = [step.get("name") for step in steps]
+    assert RCLONE_INSTALL_STEP_NAME in names, (
+        f"cpu-slow.yml missing step {RCLONE_INSTALL_STEP_NAME!r} — "
+        f"`integration_r2` tests skip via r2_io.is_r2_reachable() without the binary"
+    )
+    assert names.index(RCLONE_INSTALL_STEP_NAME) < names.index(PYTEST_STEP_NAME), (
+        f"{RCLONE_INSTALL_STEP_NAME!r} must precede {PYTEST_STEP_NAME!r} in cpu-slow.yml"
+    )

--- a/tests/infra/test_cpu_slow_workflow_r2_creds.py
+++ b/tests/infra/test_cpu_slow_workflow_r2_creds.py
@@ -9,6 +9,7 @@ restructure can't drop the keys unnoticed (see #1185).
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import cast
 
@@ -43,6 +44,18 @@ def _load_workflow(project_root: Path) -> dict[str, object]:
     return cast(dict[str, object], yaml.safe_load(workflow_path.read_text()))
 
 
+def _load_run_slow_tests_job(project_root: Path) -> dict[str, object]:
+    """Return the ``run_slow_tests`` job mapping from ``cpu-slow.yml``.
+
+    :param project_root: repo root; the workflow is read from
+        ``<project_root>/.github/workflows/cpu-slow.yml``.
+    :returns: the job mapping, including ``if``, ``steps``, ``runs-on``, etc.
+    """
+    workflow = _load_workflow(project_root)
+    jobs = cast(dict[str, object], workflow["jobs"])
+    return cast(dict[str, object], jobs["run_slow_tests"])
+
+
 def _load_workflow_steps(project_root: Path) -> list[dict[str, object]]:
     """Return the ordered ``steps`` list of the ``run_slow_tests`` job.
 
@@ -50,10 +63,8 @@ def _load_workflow_steps(project_root: Path) -> list[dict[str, object]]:
         ``<project_root>/.github/workflows/cpu-slow.yml``.
     :returns: the job's ``steps`` list.
     """
-    workflow = _load_workflow(project_root)
-    jobs = cast(dict[str, object], workflow["jobs"])
-    run_slow_tests = cast(dict[str, object], jobs["run_slow_tests"])
-    return cast(list[dict[str, object]], run_slow_tests["steps"])
+    job = _load_run_slow_tests_job(project_root)
+    return cast(list[dict[str, object]], job["steps"])
 
 
 def _load_pytest_step_env(project_root: Path) -> dict[str, str]:
@@ -128,10 +139,11 @@ def test_cpu_slow_r2_secret_env_values_reference_matching_secrets(
     """
     env = _load_pytest_step_env(project_root)
     actual = env.get(key)
-    expected = f"${{{{ secrets.{key} }}}}"
-    assert actual == expected, (
-        f"cpu-slow.yml env[{key!r}] = {actual!r}; expected {expected!r} to match the "
-        f"secret-name convention used by generate-dataset-shards.yaml + "
+    pattern = rf"\$\{{\{{\s*secrets\.{re.escape(key)}\s*\}}\}}"
+    assert isinstance(actual, str) and re.fullmatch(pattern, actual), (
+        f"cpu-slow.yml env[{key!r}] = {actual!r}; expected a "
+        f"`${{{{ secrets.{key} }}}}` expression (any whitespace inside the "
+        f"braces) — secret-name convention used by generate-dataset-shards.yaml + "
         f"test-local-launcher-roundtrip.yml"
     )
 
@@ -201,4 +213,35 @@ def test_cpu_slow_pull_request_self_trigger_present(
         f"cpu-slow.yml `on.pull_request.paths` missing {expected_path!r}; "
         f"got {paths!r} — PRs touching that file must trigger the workflow "
         f"pre-merge (see #1206)"
+    )
+
+
+@pytest.mark.infra
+def test_cpu_slow_job_gated_against_fork_prs(project_root: Path) -> None:
+    """``run_slow_tests.if`` blocks fork-PR runs of the 90-min suite.
+
+    Fork PRs can't see ``secrets.RCLONE_CONFIG_R2_*``, so the
+    ``integration_r2`` surface skips anyway — but the rest of the slow
+    suite still burns a 4-core runner for up to 90 minutes. The job-level
+    ``if`` guard short-circuits ``pull_request`` events whose head repo
+    differs from the workflow repo; ``workflow_dispatch`` / ``push`` /
+    ``schedule`` runs are unaffected.
+
+    :param project_root: session fixture from ``tests/infra/conftest.py``.
+    """
+    job = _load_run_slow_tests_job(project_root)
+    guard = job.get("if")
+    assert isinstance(guard, str), (
+        "cpu-slow.yml `run_slow_tests` missing job-level `if:` guard — "
+        "fork-PR runs of the 90-min slow suite are unrestricted (see #1206)"
+    )
+    fork_guard_pattern = re.compile(
+        r"github\.event\.pull_request\.head\.repo\.full_name"
+        r"\s*==\s*"
+        r"github\.repository"
+    )
+    assert fork_guard_pattern.search(guard), (
+        f"cpu-slow.yml `run_slow_tests.if` = {guard!r}; expected a "
+        "`github.event.pull_request.head.repo.full_name == github.repository` "
+        "clause so fork PRs skip the 90-min slow suite (see #1206)"
     )

--- a/tests/infra/test_cpu_slow_workflow_r2_creds.py
+++ b/tests/infra/test_cpu_slow_workflow_r2_creds.py
@@ -1,0 +1,71 @@
+"""`cpu-slow.yml` injects `RCLONE_CONFIG_R2_*` so `integration_r2` tests run.
+
+`integration_r2`-marked tests also carry `slow`, so they collect into
+`cpu-slow.yml`'s pytest invocation. Without the rclone-prefixed R2 env vars,
+`r2_io.is_r2_reachable()` short-circuits and they skip silently — degrading
+coverage with no signal. This test pins the env-injection so a future
+restructure can't drop the keys unnoticed (see #1185).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import cast
+
+import pytest
+import yaml
+
+REQUIRED_R2_ENV_KEYS: frozenset[str] = frozenset(
+    {
+        "RCLONE_CONFIG_R2_ACCESS_KEY_ID",
+        "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY",
+        "RCLONE_CONFIG_R2_ENDPOINT",
+    }
+)
+
+PYTEST_STEP_NAME = "Run slow (non-GPU, non-MPS, non-VST) tests"
+
+
+def _load_pytest_step_env(project_root: Path) -> dict[str, str]:
+    """Return the ``env`` mapping of the pytest step in ``cpu-slow.yml``.
+
+    :param project_root: repo root; the workflow is read from
+        ``<project_root>/.github/workflows/cpu-slow.yml``.
+    :returns: the step's ``env`` block, or an empty dict if unset.
+    """
+    workflow_path = project_root / ".github" / "workflows" / "cpu-slow.yml"
+    workflow = yaml.safe_load(workflow_path.read_text())
+    for step in workflow["jobs"]["run_slow_tests"]["steps"]:
+        if step.get("name") == PYTEST_STEP_NAME:
+            return cast("dict[str, str]", step.get("env") or {})
+    pytest.fail(f"Could not find step {PYTEST_STEP_NAME!r} in {workflow_path}")
+
+
+@pytest.mark.infra
+def test_cpu_slow_pytest_step_injects_r2_creds(project_root: Path) -> None:
+    """The pytest step exposes all three ``RCLONE_CONFIG_R2_*`` keys via ``env:``.
+
+    :param project_root: session fixture from ``tests/infra/conftest.py``.
+    """
+    env = _load_pytest_step_env(project_root)
+    missing = REQUIRED_R2_ENV_KEYS - env.keys()
+    assert not missing, (
+        f"cpu-slow.yml pytest step missing R2 env keys: {sorted(missing)} — "
+        f"`integration_r2` tests will skip via r2_io.is_r2_reachable() without them"
+    )
+
+
+@pytest.mark.infra
+def test_cpu_slow_r2_env_values_reference_matching_secrets(project_root: Path) -> None:
+    """Each R2 env key sources from the same-named ``secrets.RCLONE_CONFIG_R2_*``.
+
+    :param project_root: session fixture from ``tests/infra/conftest.py``.
+    """
+    env = _load_pytest_step_env(project_root)
+    for key in sorted(REQUIRED_R2_ENV_KEYS):
+        expected = f"${{{{ secrets.{key} }}}}"
+        assert env[key] == expected, (
+            f"cpu-slow.yml env[{key!r}] = {env[key]!r}; expected {expected!r} to match the "
+            f"secret-name convention used by generate-dataset-shards.yaml + "
+            f"test-local-launcher-roundtrip.yml"
+        )

--- a/tests/infra/test_cpu_slow_workflow_r2_creds.py
+++ b/tests/infra/test_cpu_slow_workflow_r2_creds.py
@@ -28,6 +28,20 @@ REQUIRED_R2_ENV_KEYS: frozenset[str] = frozenset(_SECRET_R2_ENV_KEYS) | frozense
 PYTEST_STEP_NAME = "Run slow (non-GPU, non-MPS, non-VST) tests"
 RCLONE_INSTALL_STEP_NAME = "Install rclone"
 
+WORKFLOW_SELF_PATH = ".github/workflows/cpu-slow.yml"
+INVARIANT_TEST_SELF_PATH = "tests/infra/test_cpu_slow_workflow_r2_creds.py"
+
+
+def _load_workflow(project_root: Path) -> dict[str, object]:
+    """Return the parsed ``cpu-slow.yml`` workflow document.
+
+    :param project_root: repo root; the workflow is read from
+        ``<project_root>/.github/workflows/cpu-slow.yml``.
+    :returns: the parsed YAML mapping.
+    """
+    workflow_path = project_root / ".github" / "workflows" / "cpu-slow.yml"
+    return cast(dict[str, object], yaml.safe_load(workflow_path.read_text()))
+
 
 def _load_workflow_steps(project_root: Path) -> list[dict[str, object]]:
     """Return the ordered ``steps`` list of the ``run_slow_tests`` job.
@@ -36,9 +50,10 @@ def _load_workflow_steps(project_root: Path) -> list[dict[str, object]]:
         ``<project_root>/.github/workflows/cpu-slow.yml``.
     :returns: the job's ``steps`` list.
     """
-    workflow_path = project_root / ".github" / "workflows" / "cpu-slow.yml"
-    workflow = yaml.safe_load(workflow_path.read_text())
-    return cast(list[dict[str, object]], workflow["jobs"]["run_slow_tests"]["steps"])
+    workflow = _load_workflow(project_root)
+    jobs = cast(dict[str, object], workflow["jobs"])
+    run_slow_tests = cast(dict[str, object], jobs["run_slow_tests"])
+    return cast(list[dict[str, object]], run_slow_tests["steps"])
 
 
 def _load_pytest_step_env(project_root: Path) -> dict[str, str]:
@@ -53,6 +68,36 @@ def _load_pytest_step_env(project_root: Path) -> dict[str, str]:
         if step.get("name") == PYTEST_STEP_NAME:
             return cast(dict[str, str], step.get("env") or {})
     pytest.fail(f"Could not find step {PYTEST_STEP_NAME!r} in {workflow_path}")
+
+
+def _load_pull_request_paths(project_root: Path) -> list[str]:
+    """Return the ``on.pull_request.paths`` filter list from ``cpu-slow.yml``.
+
+    PyYAML parses the bare ``on`` key as the boolean ``True``, so callers
+    cannot index the document with the string ``"on"``; we resolve whichever
+    key the loader actually produced before reading the trigger block.
+
+    :param project_root: repo root; the workflow is read from
+        ``<project_root>/.github/workflows/cpu-slow.yml``.
+    :returns: the configured ``paths`` list; fails the test if the
+        ``pull_request`` trigger or its ``paths`` filter is missing.
+    """
+    workflow = _load_workflow(project_root)
+    on_key: object = "on" if "on" in workflow else True
+    triggers = cast(dict[str, object], workflow[on_key])  # type: ignore[index]
+    pull_request = triggers.get("pull_request")
+    if not isinstance(pull_request, dict):
+        pytest.fail(
+            "cpu-slow.yml missing `on.pull_request` trigger — PRs that touch the "
+            "workflow must exercise it pre-merge (see #1206)"
+        )
+    paths = pull_request.get("paths")
+    if not isinstance(paths, list):
+        pytest.fail(
+            "cpu-slow.yml `on.pull_request` missing `paths` filter — without it "
+            "every PR would trigger the slow suite (see #1206)"
+        )
+    return cast(list[str], paths)
 
 
 @pytest.mark.infra
@@ -132,4 +177,28 @@ def test_cpu_slow_installs_rclone_before_pytest(project_root: Path) -> None:
     )
     assert names.index(RCLONE_INSTALL_STEP_NAME) < names.index(PYTEST_STEP_NAME), (
         f"{RCLONE_INSTALL_STEP_NAME!r} must precede {PYTEST_STEP_NAME!r} in cpu-slow.yml"
+    )
+
+
+@pytest.mark.infra
+@pytest.mark.parametrize("expected_path", [WORKFLOW_SELF_PATH, INVARIANT_TEST_SELF_PATH])
+def test_cpu_slow_pull_request_self_trigger_present(
+    project_root: Path, expected_path: str
+) -> None:
+    """``on.pull_request.paths`` covers the workflow and its invariant test.
+
+    A PR that edits ``cpu-slow.yml`` (or this test, whose contract pins the
+    env-block shape the workflow promises) must exercise the slow suite
+    pre-merge instead of waiting for the post-merge push run — see #1206.
+
+    :param project_root: session fixture from ``tests/infra/conftest.py``.
+    :param expected_path: a repo-relative path that must appear verbatim in
+        the ``paths`` filter; parametrized so a missing entry names the
+        offending path in the failure output.
+    """
+    paths = _load_pull_request_paths(project_root)
+    assert expected_path in paths, (
+        f"cpu-slow.yml `on.pull_request.paths` missing {expected_path!r}; "
+        f"got {paths!r} — PRs touching that file must trigger the workflow "
+        f"pre-merge (see #1206)"
     )


### PR DESCRIPTION
## Summary

- `integration_r2`-marked tests in `tests/integration/test_finalize_dataset_r2.py` and `tests/integration/test_local_launcher_roundtrip.py` carry both the `slow` and `integration_r2` markers, so they collect into `cpu-slow.yml`'s pytest invocation. Without the rclone-prefixed R2 env vars, `r2_io.is_r2_reachable()` short-circuits and they skip silently — leaving the `integration_r2` surface with **no scheduled coverage**.
- Wire the same `RCLONE_CONFIG_R2_*` secret block that `generate-dataset-shards.yaml` and `test-local-launcher-roundtrip.yml` already use into the `Run slow` step. On fork PRs without secrets the gate still auto-skips cleanly via `r2_io.is_r2_reachable()` — no regression.
- Add `tests/infra/test_cpu_slow_workflow_r2_creds.py` that parses the workflow and pins both (1) the presence of the three `RCLONE_CONFIG_R2_*` env keys and (2) the secret-name convention — so a future workflow restructure can't drop the keys unnoticed.

Closes #1185

## Test plan

- [x] `pytest tests/infra/test_cpu_slow_workflow_r2_creds.py -vv` — 2 passed
- [x] `pre-commit run --files .github/workflows/cpu-slow.yml tests/infra/test_cpu_slow_workflow_r2_creds.py` — all hooks pass (pyright, ruff, pydoclint, prettier, codespell, yaml-check, etc.)
- [x] gha-workflow-validator skill — 7 passed, 0 failures (the three `${{ secrets.RCLONE_CONFIG_R2_* }}` refs are "must be configured as a repo secret", which they are — proven by generate-dataset-shards.yaml + test-local-launcher-roundtrip.yml using the identical names today)
- [x] `actionlint` clean on the new env block (the only warning is the pre-existing `ubuntu-latest-4core` runner-label entry on the unchanged `runs-on:` line)
- [ ] Post-merge: confirm the next `cpu-slow` run on `main` shows the two `integration_r2` tests as **passed** (not skipped) in the test report