### PR TITLE
ci(testing): cleanup coverage config + add slow-cpu Codecov flag

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,9 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        threshold: 1% # fail if coverage drops by more than 1%
-
-    patch:
-      default:
-        threshold: 1% # fail if new code has >1% less coverage than target

--- a/.github/workflows/cpu-slow.yml
+++ b/.github/workflows/cpu-slow.yml
@@ -67,9 +67,8 @@ jobs:
           pytest -vv -s -m "slow and not gpu and not mps and not requires_vst" \
             --cov=src --cov-branch --cov-report=xml --cov-report=term
 
-      # Slow CPU tests exercise PyTorch forward passes and pipeline code paths
-      # that the fast suite skips. Uploading under a dedicated `slow-cpu` flag
-      # keeps that signal separable from `unit-cpu` in Codecov.
+      # Dedicated `slow-cpu` flag keeps this signal separable from `unit-cpu`
+      # in Codecov — the fast suite skips these PyTorch forward passes.
       - name: Upload coverage to Codecov
         if: always() && hashFiles('coverage.xml') != ''
         uses: codecov/codecov-action@v5

--- a/.github/workflows/cpu-slow.yml
+++ b/.github/workflows/cpu-slow.yml
@@ -64,7 +64,20 @@ jobs:
         env:
           HYDRA_FULL_ERROR: "1"
         run: |
-          pytest -vv -s -m "slow and not gpu and not mps and not requires_vst"
+          pytest -vv -s -m "slow and not gpu and not mps and not requires_vst" \
+            --cov=src --cov-branch --cov-report=xml --cov-report=term
+
+      # Slow CPU tests exercise PyTorch forward passes and pipeline code paths
+      # that the fast suite skips. Uploading under a dedicated `slow-cpu` flag
+      # keeps that signal separable from `unit-cpu` in Codecov.
+      - name: Upload coverage to Codecov
+        if: always() && hashFiles('coverage.xml') != ''
+        uses: codecov/codecov-action@v5
+        with:
+          files: coverage.xml
+          flags: slow-cpu
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false
 
       # Auto-file a bug ticket on post-merge failure so CPU regressions in
       # main don't go silently stale. Runs only when the run failed AND the

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,6 +23,10 @@ flag_management:
       paths:
         - src/synth_setter/
         - scripts/ci/
+    - name: slow-cpu
+      paths:
+        - src/synth_setter/
+        - scripts/ci/
 
 component_management:
   default_rules:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,7 +338,7 @@ scripts = ["scripts/ci", "*/scripts/ci"]
 
 [tool.coverage.report]
 exclude_lines = [
-    "pragma: nocover",
+    "pragma: no cover",
     "raise NotImplementedError",
     "raise NotImplementedError()",
     "if __name__ == .__main__.:",


### PR DESCRIPTION
## Summary

Small cleanup pass on the Codecov integration to remove silent footguns and start counting the slow CPU suite as coverage. Four self-contained changes:

- **Delete `.github/codecov.yml`** — a 10-line threshold stub that Codecov's precedence silently ignored in favor of the root `codecov.yml`. Having two configs invited drift.
- **Fix the `pragma: nocover` typo in `pyproject.toml`** — coverage.py's default exclude token is `pragma: no cover` (with a space). The old spelling was non-standard and never matched anything (the lone in-tree user, `scripts/ci/job_queue.py:302`, was only being excluded by coverage.py's built-in default pattern). Grep across `src/`, `tests/`, `scripts/` confirmed no other usages.
- **Upload coverage from `cpu-slow.yml`** under a new `slow-cpu` Codecov flag. The slow CPU suite exercises PyTorch forward passes and pipeline integration paths that the fast `unit-cpu` suite skips, so those lines were reading as 0% covered — perversely incentivizing not testing the hard paths.
- **Register `slow-cpu` in `codecov.yml`'s `flag_management`** so carryforward and path scoping match `unit-cpu`.

No enforcement changes — `informational: true` stays as-is, per the existing roadmap on #14.

## Review

Self-review via `/repo-review-full-no-comments` returned 0 BLOCK / 3 WARN across 5 skills (code-health, synth-setter-project-standards, gha-workflow-validator, comment-hygiene, shell-style). The comment-hygiene WARN (3-line YAML preamble exceeded the 2-line cap from CLAUDE.md) is fixed in c241b75. Remaining two WARNs are non-blocking observations:

- `cpu-slow.yml` upload step uses `if: always() && hashFiles('coverage.xml') != ''` while `test.yml` has no guard. Defensible asymmetry (slow suite can OOM mid-run) — left as-is.
- `codecov.yml` `slow-cpu` `paths:` block duplicates `unit-cpu`. Worth a YAML anchor only if a third CPU flag lands. No action.

## Test plan

- [ ] Workflow YAML and `codecov.yml` parse via `yaml.safe_load` (verified locally during edit).
- [ ] `gh workflow run cpu-slow.yml` (or normal post-merge fire) uploads to Codecov under the `slow-cpu` flag — confirm a `slow-cpu` row appears in the Codecov PR comment / project view after the next slow-CPU run on `main`.
- [ ] CI passes on this PR. The coverage upload step uses `if: always() && hashFiles('coverage.xml') != ''` so a missing xml doesn't fail the job.

Refs #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)