### PR TITLE
refactor(tests): dedupe `_render_cfg` helper across three vst test modules

### DIFF
--- a/tests/data/vst/test_always_on_integration.py
+++ b/tests/data/vst/test_always_on_integration.py
@@ -14,7 +14,6 @@ issue noted in the Wave 3 PR body.
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -28,13 +27,16 @@ from synth_setter.data.vst.writers import make_hdf5_dataset
 
 _ = hdf5plugin  # keep type checkers from flagging the side-effect import
 
+# ``_PLUGIN_PATH`` is imported with the helpers so the ``skip_no_vst`` mark
+# tracks the same path that ``_render_cfg`` embeds in the produced
+# ``RenderConfig`` — a local copy could drift if the canonical default ever
+# changed.
 from tests.data.vst.test_generate_vst_dataset import (  # noqa: E402  pinned canonical patch
     _HARDCODED_NOTE_PARAMS,
     _HARDCODED_SYNTH_PARAMS,
+    _PLUGIN_PATH,
     _render_cfg,
 )
-
-_PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
 
 skip_no_vst = pytest.mark.skipif(
     not Path(_PLUGIN_PATH).exists(),

--- a/tests/data/vst/test_always_on_integration.py
+++ b/tests/data/vst/test_always_on_integration.py
@@ -25,56 +25,21 @@ import pytest
 
 from synth_setter.data.vst import core
 from synth_setter.data.vst.writers import make_hdf5_dataset
-from synth_setter.pipeline.schemas.spec import RenderConfig
 
 _ = hdf5plugin  # keep type checkers from flagging the side-effect import
 
 from tests.data.vst.test_generate_vst_dataset import (  # noqa: E402  pinned canonical patch
     _HARDCODED_NOTE_PARAMS,
     _HARDCODED_SYNTH_PARAMS,
+    _render_cfg,
 )
 
 _PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
-_PRESET_PATH = "presets/surge-base.vstpreset"
-_SAMPLE_RATE = 44100
-_CHANNELS = 2
-_DURATION = 4.0
-_VELOCITY = 100
-_MIN_LOUDNESS = -55.0
-_SPEC_NAME = "surge_xt"
-_RENDERER_VERSION = "1.3.4"
 
 skip_no_vst = pytest.mark.skipif(
     not Path(_PLUGIN_PATH).exists(),
     reason=f"VST plugin not found at {_PLUGIN_PATH}",
 )
-
-
-def _render_cfg(num_samples: int, samples_per_render_batch: int) -> RenderConfig:
-    """Build a held-open ``RenderConfig`` with the integration-test defaults.
-
-    :param num_samples: Total samples in the shard.
-    :param samples_per_render_batch: Per-batch size; setting this smaller than
-        ``num_samples`` forces multiple flush callbacks inside the held-open
-        scope (the cross-flush invariant the test is here to defend).
-    :return: A ``RenderConfig`` pinned to the ``always_on`` + ``once`` pairing
-        required by the schema validator.
-    """
-    return RenderConfig(
-        plugin_path=_PLUGIN_PATH,
-        preset_path=_PRESET_PATH,
-        param_spec_name=_SPEC_NAME,
-        renderer_version=_RENDERER_VERSION,
-        sample_rate=_SAMPLE_RATE,
-        channels=_CHANNELS,
-        velocity=_VELOCITY,
-        signal_duration_seconds=_DURATION,
-        min_loudness=_MIN_LOUDNESS,
-        samples_per_render_batch=samples_per_render_batch,
-        samples_per_shard=num_samples,
-        plugin_reload_cadence="once",
-        gui_toggle_cadence="always_on",
-    )
 
 
 @pytest.mark.slow
@@ -97,7 +62,14 @@ def test_always_on_renders_small_shard_end_to_end(
         is observable (loguru does not propagate to ``caplog``).
     """
     num_samples = 4
-    render_cfg = _render_cfg(num_samples=num_samples, samples_per_render_batch=2)
+    # ``always_on`` requires ``plugin_reload_cadence="once"`` per schema validator;
+    # batch=2 forces a mid-shard flush so the cross-flush invariant is exercised.
+    render_cfg = _render_cfg(
+        num_samples=num_samples,
+        samples_per_render_batch=2,
+        plugin_reload_cadence="once",
+        gui_toggle_cadence="always_on",
+    )
     out = tmp_path / "shard-000000.h5"
     fixed_synth = [_HARDCODED_SYNTH_PARAMS] * num_samples
     fixed_note = [_HARDCODED_NOTE_PARAMS] * num_samples

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -8,6 +8,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 from unittest.mock import MagicMock, patch
 
 import h5py
@@ -49,6 +50,9 @@ def _render_cfg(
     num_samples: int,
     samples_per_render_batch: int | None = None,
     min_loudness: float = _MIN_LOUDNESS,
+    *,
+    plugin_reload_cadence: Literal["once", "render"] = "render",
+    gui_toggle_cadence: Literal["never", "once", "render", "always_on"] = "never",
 ) -> RenderConfig:
     """Build a RenderConfig with this module's test defaults.
 
@@ -56,6 +60,19 @@ def _render_cfg(
     ``samples_per_render_batch`` defaults to the same so each test renders in a single batch.
     ``min_loudness`` defaults to ``_MIN_LOUDNESS`` and can be lowered (e.g. to
     ``-inf``) to disable the loudness gate during replay runs — see #489.
+    ``gui_toggle_cadence`` defaults to ``"never"`` (Darwin-portable, #714);
+    ``"always_on"`` requires ``plugin_reload_cadence="once"`` per schema validator.
+
+    :param num_samples: Total samples to render in the shard.
+    :param samples_per_render_batch: Per-batch sample count; ``None`` selects
+        single-batch behaviour by matching ``num_samples``.
+    :param min_loudness: Loudness-gate floor in dB; lower values disable the
+        gate for replay runs (see #489).
+    :param plugin_reload_cadence: Pinned to ``"once"`` for held-open editor
+        scenarios; defaults to the historical per-render reload.
+    :param gui_toggle_cadence: Editor warm-up cadence; ``"never"`` is the
+        Darwin-portable default, ``"always_on"`` exercises the held-open path.
+    :return: ``RenderConfig`` populated with the module's test defaults.
     """
     return RenderConfig(
         plugin_path=_PLUGIN_PATH,
@@ -71,8 +88,8 @@ def _render_cfg(
         if samples_per_render_batch is not None
         else num_samples,
         samples_per_shard=num_samples,
-        # Darwin-portable: never run the editor warm-up (#714).
-        gui_toggle_cadence="never",
+        plugin_reload_cadence=plugin_reload_cadence,
+        gui_toggle_cadence=gui_toggle_cadence,
     )
 
 

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -12,16 +12,22 @@ from unittest.mock import MagicMock, patch
 
 import h5py
 import hdf5plugin  # noqa: F401  side-effect: registers Blosc2 filter for h5py reads
+
 _ = hdf5plugin  # keep type checkers from flagging the side-effect import
 import numpy as np
 import pytest
 
-from synth_setter.pipeline.schemas.spec import RenderConfig
-from synth_setter.evaluation.compute_audio_metrics import compute_mss, compute_rms, compute_sot, compute_wmfcc
 from synth_setter.data.vst import param_specs
 from synth_setter.data.vst.core import load_plugin, load_preset, render_params
 from synth_setter.data.vst.param_spec import ParamSpec
 from synth_setter.data.vst.writers import make_hdf5_dataset
+from synth_setter.evaluation.compute_audio_metrics import (
+    compute_mss,
+    compute_rms,
+    compute_sot,
+    compute_wmfcc,
+)
+from synth_setter.pipeline.schemas.spec import RenderConfig
 
 log = logging.getLogger(__name__)
 
@@ -61,21 +67,24 @@ def _render_cfg(
         velocity=_VELOCITY,
         signal_duration_seconds=_DURATION,
         min_loudness=min_loudness,
-        samples_per_render_batch=samples_per_render_batch if samples_per_render_batch is not None else num_samples,
+        samples_per_render_batch=samples_per_render_batch
+        if samples_per_render_batch is not None
+        else num_samples,
         samples_per_shard=num_samples,
         # Darwin-portable: never run the editor warm-up (#714).
         gui_toggle_cadence="never",
     )
+
 
 # Phase-robust audio similarity thresholds for replayed-params vs. candidates.
 # Two independent renders of identical params differ at the sample level on main
 # (issue #489 — Surge XT's oscillator phase init is nondeterministic across renders),
 # but should remain perceptually close. Tune downward if the metrics consistently come
 # in tighter than these caps.
-_MSS_MAX = 10.0           # multi-scale log-mel L1 distance (dB)
-_WMFCC_MAX = 18.0         # DTW-aligned MFCC L1 distance
-_SOT_MAX = 0.15          # spectral optimal transport (Wasserstein on STFT mags)
-_RMS_MIN_COSINE = 0.8   # RMS envelope cosine similarity (1.0 = identical)
+_MSS_MAX = 10.0  # multi-scale log-mel L1 distance (dB)
+_WMFCC_MAX = 18.0  # DTW-aligned MFCC L1 distance
+_SOT_MAX = 0.15  # spectral optimal transport (Wasserstein on STFT mags)
+_RMS_MIN_COSINE = 0.8  # RMS envelope cosine similarity (1.0 = identical)
 _MEL_MEAN_ABS_MAX = 5.0  # mean abs diff on stored mel_spec (log-power dB)
 
 # Peak amplitude floor below which a clip is treated as silent.
@@ -323,9 +332,7 @@ def _assert_h5_structure_is_valid(
         assert np.isfinite(params_arr).all()
 
         peak = np.abs(audio_arr).reshape(num_samples, -1).max(axis=1)
-        assert (peak > _AUDIO_PEAK_SILENCE_FLOOR).all(), (
-            f"silent clips: peaks={peak.tolist()}"
-        )
+        assert (peak > _AUDIO_PEAK_SILENCE_FLOOR).all(), f"silent clips: peaks={peak.tolist()}"
 
         return audio_arr, mel_arr, params_arr
 
@@ -359,9 +366,7 @@ def _patched_sample(
     )
 
 
-def _audio_metrics(
-    target: np.ndarray, pred: np.ndarray
-) -> tuple[float, float, float, float]:
+def _audio_metrics(target: np.ndarray, pred: np.ndarray) -> tuple[float, float, float, float]:
     """Compute (mss, wmfcc, sot, rms_cos) for one (target, pred) audio pair."""
     return (
         compute_mss(target, pred),
@@ -540,9 +545,7 @@ def _emit_audio_similarity_benchmark_metrics(
     _emit_benchmark_metrics(entries=entries, bench_filename=f"{prefix}.json")
 
 
-def _emit_benchmark_metrics(
-    entries: list[dict[str, float | str]], bench_filename: str
-) -> None:
+def _emit_benchmark_metrics(entries: list[dict[str, float | str]], bench_filename: str) -> None:
     """Append metrics to ``$BENCHMARK_OUTPUT_DIR/<bench_filename>`` for the trend chart.
 
     No-op when the env var is unset (e.g. local pytest runs). One file per
@@ -613,16 +616,14 @@ def _assert_all_pairs_audio_metrics_within_thresholds(
         *worst_rms_cos,
     )
     assert worst_mss[0] < _MSS_MAX, (
-        f"{label_prefix}: worst mss={worst_mss[0]:.4f} at pair {worst_mss[1:]} "
-        f"exceeds {_MSS_MAX}"
+        f"{label_prefix}: worst mss={worst_mss[0]:.4f} at pair {worst_mss[1:]} exceeds {_MSS_MAX}"
     )
     assert worst_wmfcc[0] < _WMFCC_MAX, (
         f"{label_prefix}: worst wmfcc={worst_wmfcc[0]:.4f} at pair {worst_wmfcc[1:]} "
         f"exceeds {_WMFCC_MAX}"
     )
     assert worst_sot[0] < _SOT_MAX, (
-        f"{label_prefix}: worst sot={worst_sot[0]:.4f} at pair {worst_sot[1:]} "
-        f"exceeds {_SOT_MAX}"
+        f"{label_prefix}: worst sot={worst_sot[0]:.4f} at pair {worst_sot[1:]} exceeds {_SOT_MAX}"
     )
     assert worst_rms_cos[0] > _RMS_MIN_COSINE, (
         f"{label_prefix}: worst rms cosine={worst_rms_cos[0]:.4f} at pair "
@@ -1173,10 +1174,12 @@ def test_generate_sample_retries_when_only_fixed_note_params(
         lambda *a, **kw: next(render_outputs),
     )
 
-    sample_returns = iter([
-        (_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS),
-        (_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS),
-    ])
+    sample_returns = iter(
+        [
+            (_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS),
+            (_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS),
+        ]
+    )
     monkeypatch.setattr(spec, "sample", lambda: next(sample_returns))
 
     sample = generate_vst_dataset.generate_sample(
@@ -1230,9 +1233,7 @@ def _install_fake_render_params(
 
     monkeypatch.setattr(generate_vst_dataset, "render_params", _fake_render_params)
 
-    sample_returns = iter(
-        [(_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS)] * (num_retries + 1)
-    )
+    sample_returns = iter([(_HARDCODED_SYNTH_PARAMS, _HARDCODED_NOTE_PARAMS)] * (num_retries + 1))
     monkeypatch.setattr(spec, "sample", lambda: next(sample_returns))
     return warmup_mock
 
@@ -1383,8 +1384,12 @@ def test_emit_benchmark_skips_when_env_unset(
     _emit_audio_similarity_benchmark_metrics(
         prefix="x",
         round_trip=RoundTripMetrics(
-            mss_max=1.0, wmfcc_max=1.0, sot_max=0.001,
-            rms_cos_min=0.99, mel_mean_abs=0.5, num_samples=4,
+            mss_max=1.0,
+            wmfcc_max=1.0,
+            sot_max=0.001,
+            rms_cos_min=0.99,
+            mel_mean_abs=0.5,
+            num_samples=4,
         ),
     )
     assert list(tmp_path.iterdir()) == []  # nothing written
@@ -1403,8 +1408,12 @@ def test_emit_benchmark_round_trip_only_writes_expected_schema(
     _emit_audio_similarity_benchmark_metrics(
         prefix="bucket-a",
         round_trip=RoundTripMetrics(
-            mss_max=2.5, wmfcc_max=3.5, sot_max=0.02,
-            rms_cos_min=0.97, mel_mean_abs=1.5, num_samples=4,
+            mss_max=2.5,
+            wmfcc_max=3.5,
+            sot_max=0.02,
+            rms_cos_min=0.97,
+            mel_mean_abs=1.5,
+            num_samples=4,
         ),
         total_render_seconds=8.0,  # 8 / (2 × 4) = 1.0 s/render
     )
@@ -1415,9 +1424,8 @@ def test_emit_benchmark_round_trip_only_writes_expected_schema(
     assert by_name["bucket-a/multi-scale-spectral-loss-max"]["value"] == 2.5
     assert by_name["bucket-a/dtw-aligned-mfcc-distance-max"]["value"] == 3.5
     assert by_name["bucket-a/spectral-optimal-transport-max"]["value"] == 0.02
-    assert (
-        by_name["bucket-a/rms-envelope-cosine-distance-max"]["value"]
-        == pytest.approx(1.0 - 0.97)
+    assert by_name["bucket-a/rms-envelope-cosine-distance-max"]["value"] == pytest.approx(
+        1.0 - 0.97
     )
     assert by_name["bucket-a/mel-spectrogram-mean-absolute-error"]["value"] == 1.5
     assert by_name["bucket-a/num-samples"]["value"] == 4
@@ -1436,17 +1444,19 @@ def test_emit_benchmark_all_pairs_only_skips_round_trip_series(
     _emit_audio_similarity_benchmark_metrics(
         prefix="bucket-b",
         all_pairs=AllPairsMetrics(
-            mss_max=4.0, wmfcc_max=6.0, sot_max=0.03,
-            rms_cos_min=0.95, pair_count=66,
+            mss_max=4.0,
+            wmfcc_max=6.0,
+            sot_max=0.03,
+            rms_cos_min=0.95,
+            pair_count=66,
         ),
     )
     entries = json.loads((tmp_path / "bucket-b.json").read_text())
     by_name = {e["name"]: e for e in entries}
     assert by_name["bucket-b/all-pairs-multi-scale-spectral-loss-max"]["value"] == 4.0
-    assert (
-        by_name["bucket-b/all-pairs-rms-envelope-cosine-distance-max"]["value"]
-        == pytest.approx(1.0 - 0.95)
-    )
+    assert by_name["bucket-b/all-pairs-rms-envelope-cosine-distance-max"][
+        "value"
+    ] == pytest.approx(1.0 - 0.95)
     assert by_name["bucket-b/all-pairs-pair-count"]["value"] == 66
     # No round-trip entries when only all_pairs is supplied.
     assert "bucket-b/multi-scale-spectral-loss-max" not in by_name
@@ -1461,12 +1471,19 @@ def test_emit_benchmark_both_structs_writes_both_namespaces(
     _emit_audio_similarity_benchmark_metrics(
         prefix="bucket-c",
         round_trip=RoundTripMetrics(
-            mss_max=1.0, wmfcc_max=1.0, sot_max=0.001,
-            rms_cos_min=0.99, mel_mean_abs=0.5, num_samples=6,
+            mss_max=1.0,
+            wmfcc_max=1.0,
+            sot_max=0.001,
+            rms_cos_min=0.99,
+            mel_mean_abs=0.5,
+            num_samples=6,
         ),
         all_pairs=AllPairsMetrics(
-            mss_max=4.0, wmfcc_max=6.0, sot_max=0.03,
-            rms_cos_min=0.95, pair_count=66,
+            mss_max=4.0,
+            wmfcc_max=6.0,
+            sot_max=0.03,
+            rms_cos_min=0.95,
+            pair_count=66,
         ),
     )
     entries = json.loads((tmp_path / "bucket-c.json").read_text())
@@ -1491,8 +1508,12 @@ def test_emit_benchmark_appends_to_existing_file(
     """Subsequent emissions for the same prefix accumulate in the same file."""
     monkeypatch.setenv("BENCHMARK_OUTPUT_DIR", str(tmp_path))
     rt = RoundTripMetrics(
-        mss_max=1.0, wmfcc_max=1.0, sot_max=0.001,
-        rms_cos_min=0.99, mel_mean_abs=0.5, num_samples=2,
+        mss_max=1.0,
+        wmfcc_max=1.0,
+        sot_max=0.001,
+        rms_cos_min=0.99,
+        mel_mean_abs=0.5,
+        num_samples=2,
     )
     _emit_audio_similarity_benchmark_metrics(prefix="bucket-e", round_trip=rt)
     _emit_audio_similarity_benchmark_metrics(prefix="bucket-e", round_trip=rt)

--- a/tests/data/vst/test_writers_wds_e2e.py
+++ b/tests/data/vst/test_writers_wds_e2e.py
@@ -23,19 +23,10 @@ import webdataset as wds
 
 from synth_setter.data.vst.writers import make_hdf5_dataset, make_wds_dataset
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
-from synth_setter.pipeline.schemas.spec import RenderConfig
 
 _ = hdf5plugin  # keep type checkers from flagging the side-effect import
 
 _PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
-_PRESET_PATH = "presets/surge-base.vstpreset"
-_SAMPLE_RATE = 44100
-_CHANNELS = 2
-_DURATION = 4.0
-_VELOCITY = 100
-_MIN_LOUDNESS = -55.0
-_SPEC_NAME = "surge_xt"
-_RENDERER_VERSION = "1.3.4"
 
 skip_no_vst = pytest.mark.skipif(
     not Path(_PLUGIN_PATH).exists(),
@@ -52,31 +43,8 @@ from tests.data.vst.test_generate_vst_dataset import (
     _HARDCODED_SYNTH_PARAMS,
     _MEL_MEAN_ABS_MAX,
     _assert_audio_metrics_within_thresholds,
+    _render_cfg,
 )
-
-
-def _render_cfg(num_samples: int, samples_per_render_batch: int | None = None) -> RenderConfig:
-    """Build a ``RenderConfig`` with this module's test defaults.
-
-    :param num_samples: Total samples to render per shard.
-    :param samples_per_render_batch: Per-batch sample count (defaults to ``num_samples``).
-    :return: A ``RenderConfig`` populated with the test-defaults.
-    """
-    return RenderConfig(
-        plugin_path=_PLUGIN_PATH,
-        preset_path=_PRESET_PATH,
-        param_spec_name=_SPEC_NAME,
-        renderer_version=_RENDERER_VERSION,
-        sample_rate=_SAMPLE_RATE,
-        channels=_CHANNELS,
-        velocity=_VELOCITY,
-        signal_duration_seconds=_DURATION,
-        min_loudness=_MIN_LOUDNESS,
-        samples_per_render_batch=samples_per_render_batch if samples_per_render_batch is not None else num_samples,
-        samples_per_shard=num_samples,
-        # Darwin-portable: never run the editor warm-up (#714).
-        gui_toggle_cadence="never",
-    )
 
 
 def _tar_members(tar_path: Path) -> dict[str, bytes]:

--- a/tests/data/vst/test_writers_wds_e2e.py
+++ b/tests/data/vst/test_writers_wds_e2e.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import io
 import json
-import os
 import tarfile
 from pathlib import Path
 
@@ -26,24 +25,24 @@ from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
 
 _ = hdf5plugin  # keep type checkers from flagging the side-effect import
 
-_PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
+# Hardcoded loudness-passing patch, h5↔h5 phase-robust comparison helpers, and
+# the canonical ``_PLUGIN_PATH`` are reused verbatim from
+# ``test_generate_vst_dataset.py`` so this module's h5↔wds parity check uses
+# the same thresholds the h5↔h5 round-trip tests already pin, and the
+# ``skip_no_vst`` mark below tracks the same plugin path that ``_render_cfg``
+# embeds in the produced ``RenderConfig``.
+from tests.data.vst.test_generate_vst_dataset import (  # noqa: E402  pinned canonical patch
+    _HARDCODED_NOTE_PARAMS,
+    _HARDCODED_SYNTH_PARAMS,
+    _MEL_MEAN_ABS_MAX,
+    _PLUGIN_PATH,
+    _assert_audio_metrics_within_thresholds,
+    _render_cfg,
+)
 
 skip_no_vst = pytest.mark.skipif(
     not Path(_PLUGIN_PATH).exists(),
     reason=f"VST plugin not found at {_PLUGIN_PATH}",
-)
-
-# Hardcoded loudness-passing patch and h5↔h5 phase-robust comparison helpers
-# are reused verbatim from ``test_generate_vst_dataset.py`` so this module's
-# h5↔wds parity check uses the same thresholds the h5↔h5 round-trip tests
-# already pin. Imported (not copied) on purpose: a future spec change updates
-# the canonical patch in one place, and both test modules track it.
-from tests.data.vst.test_generate_vst_dataset import (
-    _HARDCODED_NOTE_PARAMS,
-    _HARDCODED_SYNTH_PARAMS,
-    _MEL_MEAN_ABS_MAX,
-    _assert_audio_metrics_within_thresholds,
-    _render_cfg,
 )
 
 


### PR DESCRIPTION
## Summary

- Three vst test modules each defined a near-identical `_render_cfg(...)`
  factory: `tests/data/vst/test_generate_vst_dataset.py:42`,
  `tests/data/vst/test_writers_wds_e2e.py:58`, and
  `tests/data/vst/test_always_on_integration.py:53`. The `always_on`
  variant only differed by pinning `plugin_reload_cadence="once"` and
  `gui_toggle_cadence="always_on"`.
- Generalize the canonical helper with keyword-only `plugin_reload_cadence`
  and `gui_toggle_cadence` parameters (defaults preserve existing
  behaviour) and import it from the other two modules — both already
  follow the same pattern for `_HARDCODED_*` constants and
  `_assert_audio_metrics_within_thresholds`.
- The single `always_on` call site passes the held-open pairing inline;
  the local wrapper is no longer needed.

## Refs

- Refs #1208 — sibling test-helper consolidation under data-pipeline /
  testing; same theme (extract a shared factory from near-identical
  per-module helpers). Filed against `test_core.py` rather than the vst
  tests, but the cleanup motivation is identical. If a more specific
  parent exists, reviewers should reassign.

## Commits

- `style(tests): ruff-format catch-up on test_generate_vst_dataset` —
  pre-existing whitespace / line-length drift, kept separate so the
  refactor diff stays small.
- `refactor(tests): dedupe \`_render_cfg\` helper across three vst test
  modules` — the actual dedup.

## Test plan

- [ ] `pytest tests/data/vst/test_generate_vst_dataset.py -k "emit_benchmark or test_generate_sample"` passes (16 tests verified locally — the VST-free unit tests).
- [ ] `pytest tests/data/vst/ --collect-only` collects all 83 tests cleanly across the three touched modules.
- [ ] Pre-commit hooks (ruff, pyright, pydoclint, docformatter, interrogate, codespell) pass on the refactor commit.
- [ ] CI: the VST-required tests run on the slow-VST workflow — the canonical helper now drives all three modules, so the held-open and writer-parity coverage exercises the same defaults.

## Notes

- repo-review-full-no-comments returned 0 BLOCK, 10 WARN — every WARN is either a pre-existing pattern the dedup widens (E402 noqa placement, cross-test imports of `_`-prefixed helpers) or a style refinement (drop "historical" in docstring, lift nested ternary out of kwargs, tighten `:param:` filler). See `.agent-reviews/repo-review-full-no-comments.6ab641531f7ab46fe91bfc2cb989f338a9a73625.md`.