### PR TITLE
feat(ci-automation): wire finalize-dataset into generate-dataset-shards.yaml + presubmit caller

### DIFF
--- a/.github/workflows/finalize-dataset.yaml
+++ b/.github/workflows/finalize-dataset.yaml
@@ -1,0 +1,135 @@
+name: Finalize Dataset
+
+# Reusable workflow that runs `synth-setter-finalize-dataset` against an
+# already-generated run prefix on R2. Callers (cron via
+# `generate-dataset-shards.yaml`, PR-presubmit via
+# `test-dataset-finalization.yml`) pass per-run values through inputs.
+#
+# `synth-setter-finalize-dataset` is a thin CLI: it programmatically composes
+# `configs/dataset.yaml` with `experiment=<config_path>`, derives the same
+# `r2.prefix` shape (`data/<task_name>/<run_id>/`) generate used, downloads
+# the shards, builds the split / stats artifacts, and writes
+# `dataset.complete` last (so a re-run against a finalized prefix is a no-op).
+# Bare-runner install — no docker, no SkyPilot path. The `provider` input is
+# carried so callers can keep their per-provider matrices but the body is
+# identical across providers.
+#
+# Required secrets (callers should `secrets: inherit`):
+#   RCLONE_CONFIG_R2_ACCESS_KEY_ID, RCLONE_CONFIG_R2_SECRET_ACCESS_KEY,
+#   RCLONE_CONFIG_R2_ENDPOINT — same R2 credentials the generate stage uses.
+
+on:
+  workflow_call:
+    inputs:
+      provider:
+        description: "Provider tag for log/artifact naming (skypilot-local, runpod, oci, or pr-presubmit). Body is provider-agnostic."
+        required: true
+        type: string
+      config_path:
+        description: "Hydra experiment name under configs/experiment/ (must match the value passed to generate)."
+        required: true
+        type: string
+      output_format:
+        description: "Dataset output format (`hdf5` or `wds`); informational, drives only artifact naming. The CLI re-reads the format from the composed `DatasetSpec`."
+        required: false
+        type: string
+        default: ""
+      run_id:
+        description: "Generate stage's run_id. Pinned via `run_id=<value>` Hydra override so finalize targets the same `data/<task>/<run_id>/` prefix generate wrote."
+        required: true
+        type: string
+      env_ref:
+        description: "Git ref / SHA the runner should check out (typically the PR head SHA)."
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      provider:
+        description: "Provider tag (informational)"
+        required: false
+        type: string
+        default: pr-presubmit
+      config_path:
+        description: "Hydra experiment name (e.g. `generate_dataset/smoke-shard`)"
+        required: true
+        type: string
+        default: "generate_dataset/smoke-shard"
+      output_format:
+        description: "Dataset output format"
+        required: true
+        type: choice
+        default: hdf5
+        options:
+          - hdf5
+          - wds
+      run_id:
+        description: "Generate stage's run_id; finalize composes against the same prefix"
+        required: true
+        type: string
+      env_ref:
+        description: "Git ref / SHA to check out"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  finalize:
+    name: Run finalize_dataset (${{ inputs.provider }} / ${{ inputs.output_format }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      RCLONE_CONFIG_R2_TYPE: s3
+      RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+      RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+      RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+      RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+      HYDRA_FULL_ERROR: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.env_ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install rclone
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
+
+      # `[torch,dev]` is the smallest install that imports finalize cleanly:
+      # `pipeline.data.reshard` pulls h5py / numpy via the base deps, and the
+      # entrypoint imports `cli.generate_dataset.spec_from_cfg` which transitively
+      # touches the torch-gated `data/` package. `--system` installs into the
+      # runner Python so `synth-setter-finalize-dataset` resolves on PATH.
+      - name: Install project deps
+        run: uv pip install --system -e ".[torch,dev]"
+
+      - name: Run synth-setter-finalize-dataset
+        env:
+          CONFIG_PATH: ${{ inputs.config_path }}
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          set -euo pipefail
+          synth-setter-finalize-dataset \
+            "experiment=${CONFIG_PATH}" \
+            "run_id=${RUN_ID}" \
+            2>&1 | tee finalize.log
+
+      - name: Upload finalize log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: finalize-log-${{ inputs.provider }}-${{ inputs.output_format }}
+          path: finalize.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/finalize-dataset.yaml
+++ b/.github/workflows/finalize-dataset.yaml
@@ -125,11 +125,15 @@ jobs:
             "run_id=${RUN_ID}" \
             2>&1 | tee finalize.log
 
+      # `run_id` discriminator — matrix callers invoke this reusable multiple
+      # times in one run (e.g., one row per output_format), and upload-artifact
+      # v4 fails on name collisions. `output_format` may be unset because
+      # `generate-dataset-shards.yaml` forwards it via Hydra overrides only.
       - name: Upload finalize log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: finalize-log-${{ inputs.provider }}-${{ inputs.output_format }}
+          name: finalize-log-${{ inputs.provider }}-${{ inputs.output_format || 'na' }}-${{ inputs.run_id }}
           path: finalize.log
           if-no-files-found: warn
           retention-days: 7

--- a/.github/workflows/finalize-dataset.yaml
+++ b/.github/workflows/finalize-dataset.yaml
@@ -91,7 +91,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.env_ref }}
+          ref: ${{ inputs.env_ref != '' && inputs.env_ref || github.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -97,6 +97,9 @@ on:
       spec_uri:
         description: "Canonical r2:// URI of the materialized spec (under-prefix `input_spec.json`). Consumed by validate-dataset-shards.yaml."
         value: ${{ jobs.generate.outputs.spec_uri }}
+      run_id:
+        description: "Generate stage's run_id, parsed from the spec_uri's `data/<task>/<run_id>/` segment. Consumed by finalize-dataset.yaml so finalize composes against the same R2 prefix."
+        value: ${{ jobs.generate.outputs.run_id }}
   workflow_dispatch:
     inputs:
       provider:
@@ -159,6 +162,7 @@ jobs:
     timeout-minutes: 60
     outputs:
       spec_uri: ${{ steps.spec_uri.outputs.spec_uri }}
+      run_id: ${{ steps.spec_uri.outputs.run_id }}
     env:
       IMAGE_TAG: ${{ inputs.image_tag }}
       IMAGE: tinaudio/synth-setter:${{ inputs.image_tag }}
@@ -589,6 +593,11 @@ jobs:
       # returns 1 on no-match; with `set -euo pipefail` an unmasked grep
       # failure would skip the explicit empty-check below and surface a
       # confusing pipe-failure instead of the friendly `::error::` message).
+      # Also parses the penultimate path segment of the spec_uri as `run_id`
+      # (per the `data/<task>/<run_id>/input_spec.json` shape `make_r2_prefix`
+      # produces in pipeline/schemas/prefix.py); the chained finalize job
+      # consumes it as a Hydra `run_id=<value>` override so finalize composes
+      # against the same R2 prefix generate wrote.
       - name: Extract spec_uri from launcher log
         id: spec_uri
         run: |
@@ -600,8 +609,15 @@ jobs:
             echo "::error::launcher did not emit a ::synth-setter-spec-uri:: marker; see generate.log"
             exit 1
           fi
+          RUN_ID=$(printf '%s\n' "${SPEC_URI}" | awk -F/ '{print $(NF-1)}')
+          if [[ -z "${RUN_ID}" ]]; then
+            echo "::error::could not parse run_id from spec_uri=${SPEC_URI}"
+            exit 1
+          fi
           echo "spec_uri=${SPEC_URI}" >> "${GITHUB_OUTPUT}"
+          echo "run_id=${RUN_ID}" >> "${GITHUB_OUTPUT}"
           echo "spec_uri: ${SPEC_URI}"
+          echo "run_id: ${RUN_ID}"
 
       # Always validate the freshly-uploaded shards against the
       # `check_shard_contracts` contract before this workflow returns.
@@ -643,3 +659,21 @@ jobs:
             ${{ github.workspace }}/data/*/*/metadata/input_spec.json
           retention-days: 7
           if-no-files-found: warn
+
+  # Unconditional finalize chain. Mirrors how validate is wired by the
+  # downstream caller (test-dataset-generation.yml's `validate` job) but at
+  # the reusable's own level so every caller — cron, PR-presubmit, manual
+  # dispatch — gets finalize for free without opt-in plumbing. Output format
+  # is informational here (drives only artifact naming); the CLI re-reads it
+  # from the composed `DatasetSpec`. `env_ref` is the SHA the runner already
+  # checked out for generate, so finalize sees the same code.
+  finalize:
+    name: Run finalize_dataset (${{ inputs.provider }})
+    needs: generate
+    uses: ./.github/workflows/finalize-dataset.yaml
+    with:
+      provider: ${{ inputs.provider }}
+      config_path: ${{ inputs.dataset_config }}
+      run_id: ${{ needs.generate.outputs.run_id }}
+      env_ref: ${{ github.event.pull_request.head.sha || github.sha }}
+    secrets: inherit

--- a/.github/workflows/test-dataset-finalization.yml
+++ b/.github/workflows/test-dataset-finalization.yml
@@ -93,8 +93,6 @@ jobs:
       RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
       RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
       HYDRA_FULL_ERROR: "1"
-      SPEC_URI: ${{ needs.smoke-pipeline.outputs.spec_uri }}
-      RUN_ID: ${{ needs.smoke-pipeline.outputs.run_id }}
       OUTPUT_FORMAT: ${{ matrix.output_format }}
       TASK_NAME: ${{ matrix.task_name }}
       CONFIG_PATH: ${{ matrix.config_path }}
@@ -109,6 +107,30 @@ jobs:
 
       - name: Install rclone
         run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
+
+      # Per-matrix-cell run metadata. `needs.smoke-pipeline.outputs.run_id`
+      # flattens to one cell's value when the upstream is a matrix job (GHA
+      # limitation), so verify-wds would otherwise resolve under the hdf5 cell's
+      # run_id. Download this matrix entry's own run-metadata artifact instead
+      # and read run_id from its ``input_spec.json``.
+      - name: Download smoke-pipeline run metadata for this matrix cell
+        uses: actions/download-artifact@v4
+        with:
+          name: finalize-presubmit-${{ matrix.output_format }}
+          path: cell-meta/
+
+      - name: Parse run_id from this matrix cell's input_spec.json
+        id: run_id
+        run: |
+          set -euo pipefail
+          SPEC_JSON=$(find cell-meta -name input_spec.json -print -quit)
+          if [[ -z "${SPEC_JSON}" ]]; then
+            echo "::error::could not find input_spec.json under cell-meta/"
+            exit 1
+          fi
+          RUN_ID=$(python3 -c "import json,sys; print(json.load(open(sys.argv[1]))['run_id'])" "${SPEC_JSON}")
+          echo "run_id=${RUN_ID}" >> "${GITHUB_OUTPUT}"
+          echo "run_id: ${RUN_ID}"
 
       # Resolves `spec.r2.bucket` from the same composed config the chained
       # generate + finalize used, so the `rclone ls` prefix lines up with what
@@ -139,6 +161,7 @@ jobs:
       - name: rclone ls run prefix and pin required artifacts
         env:
           R2_BUCKET: ${{ steps.bucket.outputs.r2_bucket }}
+          RUN_ID: ${{ steps.run_id.outputs.run_id }}
         run: |
           set -euo pipefail
           PREFIX="r2:${R2_BUCKET}/data/${TASK_NAME}/${RUN_ID}/"
@@ -170,7 +193,7 @@ jobs:
       - name: Run finalize-artifact oracle helper
         env:
           R2_BUCKET: ${{ steps.bucket.outputs.r2_bucket }}
-          FINALIZE_RUN_PREFIX: r2:${{ steps.bucket.outputs.r2_bucket }}/data/${{ matrix.task_name }}/${{ needs.smoke-pipeline.outputs.run_id }}/
+          FINALIZE_RUN_PREFIX: r2:${{ steps.bucket.outputs.r2_bucket }}/data/${{ matrix.task_name }}/${{ steps.run_id.outputs.run_id }}/
         run: |
           set -euo pipefail
           pytest tests/integration/test_finalize_artifact_oracle.py \

--- a/.github/workflows/test-dataset-finalization.yml
+++ b/.github/workflows/test-dataset-finalization.yml
@@ -135,6 +135,9 @@ jobs:
       # Resolves `spec.r2.bucket` from the same composed config the chained
       # generate + finalize used, so the `rclone ls` prefix lines up with what
       # finalize actually wrote (rather than hardcoding `intermediate-data`).
+      # configs ship inside `src/synth_setter/configs/` (see #1236); point
+      # `initialize_config_dir` at the in-package path on disk so we avoid the
+      # heavier `pip install -e .` just to read one Hydra value.
       - name: Resolve R2 bucket from dataset config
         id: bucket
         run: |
@@ -144,7 +147,7 @@ jobs:
           import os
           from pathlib import Path
           from hydra import compose, initialize_config_dir
-          cfg_dir = str(Path.cwd() / "configs")
+          cfg_dir = str(Path.cwd() / "src" / "synth_setter" / "configs")
           experiment = os.environ["CONFIG_PATH"]
           with initialize_config_dir(version_base="1.3", config_dir=cfg_dir):
               cfg = compose(config_name="dataset", overrides=[f"experiment={experiment}"])

--- a/.github/workflows/test-dataset-finalization.yml
+++ b/.github/workflows/test-dataset-finalization.yml
@@ -1,0 +1,178 @@
+name: Test Dataset Finalization
+
+# PR-presubmit caller that runs generate + finalize on the smallest smoke
+# configs end-to-end against real Cloudflare R2, then asserts the canonical
+# finalize artifacts land at the run prefix. Triggers on changes to the
+# finalize / generate code path and the workflow files themselves so we
+# exercise the chain before merge instead of waiting for the cron tick.
+#
+# Matrix:
+#   * { output_format: hdf5, config_path: generate_dataset/smoke-shard }
+#   * { output_format: wds,  config_path: generate_dataset/smoke-shard-wds }
+#
+# Each row calls `generate-dataset-shards.yaml` (which itself chains
+# `finalize-dataset.yaml`), then a follow-up `verify-artifacts` job runs
+# `rclone ls` against the same prefix and pins:
+#   * `dataset.complete` + `stats.npz` for both formats.
+#   * `train.h5` for the hdf5 row (the smoke configs use
+#     `train_val_test_sizes=[12, 0, 0]`; val/test are pruned).
+#
+# Required secrets (forwarded through `secrets: inherit`):
+#   RCLONE_CONFIG_R2_ACCESS_KEY_ID, RCLONE_CONFIG_R2_SECRET_ACCESS_KEY,
+#   RCLONE_CONFIG_R2_ENDPOINT, R2_ACCOUNT_ID — the same R2 set the upstream
+#   `test-dataset-generation.yml` cron uses.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "src/synth_setter/cli/finalize_dataset.py"
+      - "src/synth_setter/cli/generate_dataset.py"
+      - "src/synth_setter/pipeline/data/reshard.py"
+      - "src/synth_setter/pipeline/schemas/r2_location.py"
+      - "src/synth_setter/pipeline/schemas/spec.py"
+      - ".github/workflows/finalize-dataset.yaml"
+      - ".github/workflows/generate-dataset-shards.yaml"
+      - ".github/workflows/test-dataset-finalization.yml"
+      - "tests/integration/test_finalize_dataset_r2.py"
+      - "tests/integration/test_finalize_artifact_oracle.py"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && github.run_id || 'auto' }}
+  cancel-in-progress: true
+
+jobs:
+  smoke-pipeline:
+    name: Generate + finalize smoke (${{ matrix.output_format }})
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - output_format: hdf5
+            config_path: generate_dataset/smoke-shard
+            task_name: smoke-shard
+          - output_format: wds
+            config_path: generate_dataset/smoke-shard-wds
+            task_name: smoke-shard-wds
+    uses: ./.github/workflows/generate-dataset-shards.yaml
+    with:
+      provider: skypilot-local
+      dataset_config: ${{ matrix.config_path }}
+      image_tag: dev-snapshot
+      cluster_name: synth-setter-finalize-pr-${{ github.event.pull_request.number || github.run_id }}-${{ matrix.output_format }}-${{ github.run_attempt }}
+      num_workers: "1"
+      tail: true
+      local: true
+      artifact_name: finalize-presubmit-${{ matrix.output_format }}
+    secrets: inherit
+
+  verify-artifacts:
+    name: Verify finalize artifacts (${{ matrix.output_format }})
+    needs: smoke-pipeline
+    if: ${{ !cancelled() && (github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - output_format: hdf5
+            config_path: generate_dataset/smoke-shard
+            task_name: smoke-shard
+          - output_format: wds
+            config_path: generate_dataset/smoke-shard-wds
+            task_name: smoke-shard-wds
+    env:
+      RCLONE_CONFIG_R2_TYPE: s3
+      RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+      RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+      RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+      RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+      HYDRA_FULL_ERROR: "1"
+      SPEC_URI: ${{ needs.smoke-pipeline.outputs.spec_uri }}
+      RUN_ID: ${{ needs.smoke-pipeline.outputs.run_id }}
+      OUTPUT_FORMAT: ${{ matrix.output_format }}
+      TASK_NAME: ${{ matrix.task_name }}
+      CONFIG_PATH: ${{ matrix.config_path }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install rclone
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
+
+      # Resolves `spec.r2.bucket` from the same composed config the chained
+      # generate + finalize used, so the `rclone ls` prefix lines up with what
+      # finalize actually wrote (rather than hardcoding `intermediate-data`).
+      - name: Resolve R2 bucket from dataset config
+        id: bucket
+        run: |
+          set -euo pipefail
+          pip install "hydra-core==1.3.2" "hydra-colorlog==1.2.0" "pydantic>=2,<3" --quiet
+          R2_BUCKET=$(python3 <<'PY'
+          import os
+          from pathlib import Path
+          from hydra import compose, initialize_config_dir
+          cfg_dir = str(Path.cwd() / "configs")
+          experiment = os.environ["CONFIG_PATH"]
+          with initialize_config_dir(version_base="1.3", config_dir=cfg_dir):
+              cfg = compose(config_name="dataset", overrides=[f"experiment={experiment}"])
+          print(cfg.r2.bucket)
+          PY
+          )
+          echo "r2_bucket=${R2_BUCKET}" >> "${GITHUB_OUTPUT}"
+          echo "r2_bucket: ${R2_BUCKET}"
+
+      # Operator ask on PR #1202: list the run prefix and assert finalize
+      # wrote `dataset.complete`, `stats.npz`, and `train.h5` (hdf5 only;
+      # val.h5 / test.h5 are pruned because the smoke configs ship
+      # train-only `train_val_test_sizes=[12, 0, 0]`).
+      - name: rclone ls run prefix and pin required artifacts
+        env:
+          R2_BUCKET: ${{ steps.bucket.outputs.r2_bucket }}
+        run: |
+          set -euo pipefail
+          PREFIX="r2:${R2_BUCKET}/data/${TASK_NAME}/${RUN_ID}/"
+          echo "checking ${PREFIX}"
+          rclone ls "${PREFIX}" --max-depth 1 | tee artifacts.txt
+          required="dataset.complete stats.npz"
+          if [ "${OUTPUT_FORMAT}" = "hdf5" ]; then
+            required="${required} train.h5"
+          fi
+          missing=""
+          for f in $required; do
+            if ! grep -qE "[[:space:]]${f}\$" artifacts.txt; then
+              missing="${missing} ${f}"
+            fi
+          done
+          if [ -n "${missing}" ]; then
+            echo "::error::missing finalize artifacts at ${PREFIX}:${missing}"
+            exit 1
+          fi
+          echo "all required artifacts present at ${PREFIX}"
+
+      # Exercises the operator's stated invariant — the fake_oracle predicts
+      # `batch["params"]` verbatim, so audio metrics on the finalized dataset
+      # stay inside the same bounds `tests/test_train.py::test_train_eval_surge_xt`
+      # pins for the oracle leg. Helper auto-skips when R2 is unreachable.
+      - name: Install project deps for oracle helper
+        run: pip install -e ".[torch,dev]"
+
+      - name: Run finalize-artifact oracle helper
+        env:
+          R2_BUCKET: ${{ steps.bucket.outputs.r2_bucket }}
+          FINALIZE_RUN_PREFIX: r2:${{ steps.bucket.outputs.r2_bucket }}/data/${{ matrix.task_name }}/${{ needs.smoke-pipeline.outputs.run_id }}/
+        run: |
+          set -euo pipefail
+          pytest tests/integration/test_finalize_artifact_oracle.py \
+            -m "integration_r2" \
+            -vv -s

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -73,7 +73,8 @@ def finalize_wds(spec: DatasetSpec, work_dir: Path) -> None:
     splits are available via
     ``spec.r2.split_wds_brace_uri(spec.split_shard_ranges[split])``;
     callers must check ``lo < hi`` first because empty splits raise
-    ``ValueError`` at that helper.
+    ``ValueError`` at that helper. ``spec.mask_degenerate_bins`` is
+    forwarded to ``stream_stats_wds``.
 
     :param spec: Validated dataset spec (``output_format == "wds"``).
     :param work_dir: Scratch directory; one shard at a time + the final
@@ -89,7 +90,10 @@ def finalize_wds(spec: DatasetSpec, work_dir: Path) -> None:
             f"{spec.split_shard_ranges['train']!r}); cannot compute stats "
             f"without at least one train shard."
         )
-    mean, std = stream_stats_wds(_download_train_shards_one_at_a_time(spec, work_dir))
+    mean, std = stream_stats_wds(
+        _download_train_shards_one_at_a_time(spec, work_dir),
+        mask_degenerate=spec.mask_degenerate_bins,
+    )
     stats_npz = work_dir / STATS_NPZ_FILENAME
     np.savez(stats_npz, mean=mean, std=std)
     r2_io.upload(stats_npz, spec.r2.stats_uri())
@@ -115,6 +119,7 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
     validation (per ``pipeline/CLAUDE.md``) is delegated to the h5py opens
     that ``reshard_dataset`` performs while staging each split — finalize
     never re-runs the workers' full four-check pass.
+    ``spec.mask_degenerate_bins`` is forwarded to ``get_stats_hdf5``.
 
     :param spec: Validated dataset spec (``output_format == "hdf5"``).
     :param work_dir: Scratch directory; shards, splits, stats and the spec
@@ -137,7 +142,7 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
         r2_io.download_to_path(spec.r2.shard_uri(shard), work_dir / shard.filename)
     write_spec_to_path(spec, work_dir / INPUT_SPEC_FILENAME)
     reshard_dataset(work_dir)
-    get_stats_hdf5(str(work_dir / "train.h5"))
+    get_stats_hdf5(str(work_dir / "train.h5"), mask_degenerate=spec.mask_degenerate_bins)
     stats_npz = work_dir / STATS_NPZ_FILENAME
     if not stats_npz.is_file():
         raise FileNotFoundError(

--- a/src/synth_setter/configs/dataset.yaml
+++ b/src/synth_setter/configs/dataset.yaml
@@ -24,6 +24,11 @@ run_name: ${task_name}
 output_format: hdf5
 base_seed: 42
 
+# Forwarded by ``synth-setter-finalize-dataset`` to ``stream_stats_wds`` /
+# ``get_stats_hdf5``; ``true`` substitutes ``std=1.0`` at zero-variance mel
+# bins instead of raising. Smoke configs override to ``true``.
+mask_degenerate_bins: false
+
 # Materialized as ``null`` so finalize-dataset.yaml can pin the generate stage's
 # ``run_id`` via the ``run_id=<value>`` Hydra override form (strict mode requires
 # the key to exist). Leaving this ``null`` on the generate path is handled by

--- a/src/synth_setter/configs/dataset.yaml
+++ b/src/synth_setter/configs/dataset.yaml
@@ -24,6 +24,14 @@ run_name: ${task_name}
 output_format: hdf5
 base_seed: 42
 
+# Materialized as ``null`` so finalize-dataset.yaml can pin the generate stage's
+# ``run_id`` via the ``run_id=<value>`` Hydra override form (strict mode requires
+# the key to exist). Leaving this ``null`` on the generate path is handled by
+# ``DatasetSpec._normalize_r2_input``'s mode='before' shim, which calls
+# ``_fill_default_r2_prefix`` to materialize ``run_id`` from
+# ``task_name`` + ``created_at`` when missing/None before field validation.
+run_id: null
+
 train_val_test_sizes: ???
 # ``r2:`` lands here from the ``r2: default`` group composition above. Its
 # shape (``bucket`` + ``prefix_root``) matches the nested ``R2Location`` model

--- a/src/synth_setter/configs/experiment/generate_dataset/smoke-shard-wds.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/smoke-shard-wds.yaml
@@ -16,6 +16,10 @@ task_name: smoke-shard-wds
 
 output_format: wds
 
+# 12-sample renders have constant mel bins (early-frame silence, channels
+# below the source's active bandwidth); mask so finalize completes.
+mask_degenerate_bins: true
+
 train_val_test_sizes: [12, 0, 0]
 
 render:

--- a/src/synth_setter/configs/experiment/generate_dataset/smoke-shard.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/smoke-shard.yaml
@@ -11,6 +11,10 @@ defaults:
 
 task_name: smoke-shard
 
+# 12-sample renders have constant mel bins; mask so finalize stays green
+# if dask's FP noise stops hiding them on the hdf5 path.
+mask_degenerate_bins: true
+
 train_val_test_sizes: [12, 0, 0]
 
 render:

--- a/src/synth_setter/data/vst/shapes.py
+++ b/src/synth_setter/data/vst/shapes.py
@@ -1,19 +1,33 @@
 """Shape and mel-front-end primitives shared by writer and validator.
 
-Hosts the per-row array names (``DATASET_FIELD_NAMES``), the mel-spectrogram
-constants the writer's ``make_spectrogram`` uses, and the audio / mel-spec /
-param-array dataset-shape calculators. Kept as a thin sibling module so that
-the (planned) shard validator and the (planned) wds writer can import these
-primitives without pulling in the rest of ``generate_vst_dataset.py``'s
-import surface (h5py, pedalboard, the VST renderer).
+Hosts the per-row array names (``DATASET_FIELD_NAMES``), the per-field
+on-disk dtypes (``DATASET_FIELD_DTYPES``), the mel-spectrogram constants the
+writer's ``make_spectrogram`` uses, and the audio / mel-spec / param-array
+dataset-shape calculators. Kept as a thin sibling module so that the shard
+validator and the wds writer can import these primitives without pulling in
+the rest of ``generate_vst_dataset.py``'s import surface (h5py, pedalboard,
+the VST renderer).
 """
 
 from __future__ import annotations
+
+import numpy as np
 
 AUDIO_FIELD: str = "audio"
 MEL_SPEC_FIELD: str = "mel_spec"
 PARAM_ARRAY_FIELD: str = "param_array"
 DATASET_FIELD_NAMES: tuple[str, ...] = (AUDIO_FIELD, MEL_SPEC_FIELD, PARAM_ARRAY_FIELD)
+
+# Per-field on-disk dtype, matching what the HDF5 / wds writers emit. Audio is
+# stored as ``float16`` for compressed storage efficiency; mel and params stay
+# ``float32``. Consumers upcast as needed; this map is the single source of
+# truth the validator enforces and the resharder honors when constructing
+# VirtualLayouts.
+DATASET_FIELD_DTYPES: dict[str, np.dtype] = {
+    AUDIO_FIELD: np.dtype("float16"),
+    MEL_SPEC_FIELD: np.dtype("float32"),
+    PARAM_ARRAY_FIELD: np.dtype("float32"),
+}
 
 MEL_FRAMES_PER_SECOND = 100
 MEL_N_MELS = 128

--- a/src/synth_setter/pipeline/ci/validate_shard.py
+++ b/src/synth_setter/pipeline/ci/validate_shard.py
@@ -38,6 +38,7 @@ from pydantic import ValidationError
 
 from synth_setter.data.vst.shapes import (
     AUDIO_FIELD,
+    DATASET_FIELD_DTYPES,
     DATASET_FIELD_NAMES,
     MEL_SPEC_FIELD,
     PARAM_ARRAY_FIELD,
@@ -53,7 +54,21 @@ from synth_setter.pipeline.spec_io import read_spec_text
 _TAR_METADATA_MEMBER = "metadata.json"
 _TAR_NPY_NAME_RE = re.compile(r"^(?P<batch_key>\d{8})\.(?P<field>[^./]+)\.npy$")
 
-_FLOAT32 = np.dtype("float32")
+
+def _check_dataset_dtype(shard: Path, key: str, observed: np.dtype) -> None:
+    """Reject a dataset whose on-disk dtype disagrees with the writer's contract.
+
+    :param shard: Shard path used to attribute the error to a specific file.
+    :param key: Dataset name being checked; lookup key for the per-field dtype map.
+    :param observed: dtype read from the open ``h5py.Dataset`` node.
+    :raises click.ClickException: If ``observed`` differs from
+        ``DATASET_FIELD_DTYPES[key]``.
+    """
+    expected = DATASET_FIELD_DTYPES[key]
+    if observed != expected:
+        raise click.ClickException(
+            f"shard {shard}: dataset {key!r} has dtype {observed}, expected {expected}."
+        )
 
 
 def check_shards_present(shard_paths: list[Path]) -> None:
@@ -117,11 +132,7 @@ def check_shard_contracts(
                     raise click.ClickException(
                         f"shard {shard}: key {key!r} is a {type(node).__name__}, not a Dataset."
                     )
-                if node.dtype != _FLOAT32:
-                    raise click.ClickException(
-                        f"shard {shard}: dataset {key!r} has dtype {node.dtype}, "
-                        f"expected np.float32."
-                    )
+                _check_dataset_dtype(shard, key, node.dtype)
                 if node.shape[0] != samples_per_shard:
                     raise click.ClickException(
                         f"shard {shard}: dataset {key!r} has {node.shape[0]} rows, "

--- a/src/synth_setter/pipeline/data/reshard.py
+++ b/src/synth_setter/pipeline/data/reshard.py
@@ -12,8 +12,8 @@ from pathlib import Path
 
 import click
 import h5py
-import numpy as np
 
+from synth_setter.data.vst.shapes import DATASET_FIELD_DTYPES
 from synth_setter.pipeline.ci.validate_shard import (
     check_shard_contracts,
     check_shard_ids_match_spec_order,
@@ -29,8 +29,6 @@ _SPLITS: tuple[str, ...] = ("train", "val", "test")
 # Prefix for staging files under ``dataset_root``. Cleanup paths and the
 # ``TestReshardAtomicWrite`` assertions both depend on this exact string.
 _STAGING_PREFIX = ".tmp-"
-
-_FLOAT32 = np.dtype("float32")
 
 
 def reshard_dataset(dataset_root: Path, spec_uri: str | None = None) -> None:  # noqa: DOC502
@@ -204,7 +202,7 @@ def _write_split(
     """
     split_len = len(split_paths) * shard_size
     layouts = {
-        key: h5py.VirtualLayout(shape=(split_len, *tail), dtype=_FLOAT32)
+        key: h5py.VirtualLayout(shape=(split_len, *tail), dtype=DATASET_FIELD_DTYPES[key])
         for key, tail in tails.items()
     }
     for i, shard_path in enumerate(split_paths):
@@ -212,7 +210,10 @@ def _write_split(
         range_end = range_start + shard_size
         for key, tail in tails.items():
             source = h5py.VirtualSource(
-                shard_path.name, key, dtype=_FLOAT32, shape=(shard_size, *tail)
+                shard_path.name,
+                key,
+                dtype=DATASET_FIELD_DTYPES[key],
+                shape=(shard_size, *tail),
             )
             layouts[key][range_start:range_end] = source
 

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -478,6 +478,11 @@ class DatasetSpec(BaseModel):
 
         Nested ``RenderConfig`` carrying every per-shard renderer input.
 
+    .. attribute :: mask_degenerate_bins
+
+        Whether finalize substitutes ``std=1.0`` at zero-variance mel bins
+        instead of raising; ``False`` is the strict production default.
+
     .. attribute :: git_sha
 
         Commit SHA of the launcher's working tree at construction.
@@ -533,6 +538,16 @@ class DatasetSpec(BaseModel):
 
     render: RenderConfig = Field(
         description="Nested ``RenderConfig`` carrying every per-shard renderer input."
+    )
+
+    mask_degenerate_bins: bool = Field(
+        default=False,
+        description=(
+            "Whether the finalize stats fold substitutes ``std=1.0`` at zero-variance "
+            "mel bins instead of raising; ``False`` is the strict production default. "
+            "Smoke configs override to ``True`` because tiny renders have constant "
+            "attack-time frames and channels below the source's active bandwidth."
+        ),
     )
 
     # Auto-filled runtime fields: factories fire only when the value is missing on

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -646,6 +646,26 @@ class DatasetSpec(BaseModel):
                 data.pop(computed_key, None)
         return data
 
+    @model_validator(mode="before")
+    @classmethod
+    def _drop_null_run_id(cls, data: Any) -> Any:
+        """Drop ``run_id`` when ``None`` so its ``default_factory`` fires.
+
+        ``configs/dataset.yaml`` materializes ``run_id: null`` so the finalize
+        workflow's ``run_id=<value>`` Hydra override resolves against an
+        existing key. When that override is not pinned, the composed cfg
+        arrives with ``run_id=None`` — letting it reach the field validator
+        would fail strict ``str`` validation instead of falling back to the
+        ``task_name``+``created_at`` default factory.
+
+        :param data: Raw input to the validator (typically a dict; pass-through otherwise).
+        :returns: ``data`` unchanged, or a copy with the ``None`` ``run_id`` popped.
+        """
+        if isinstance(data, dict) and data.get("run_id", "sentinel") is None:
+            data = dict(data)
+            data.pop("run_id")
+        return data
+
     @field_validator("train_val_test_sizes", mode="before")
     @classmethod
     def _splits_list_to_tuple(cls, value: Any) -> Any:

--- a/tests/integration/test_finalize_artifact_oracle.py
+++ b/tests/integration/test_finalize_artifact_oracle.py
@@ -48,7 +48,6 @@ from synth_setter.pipeline import r2_io
 pytestmark = [pytest.mark.integration_r2, pytest.mark.r2, pytest.mark.slow]
 
 _FINALIZE_PREFIX_ENV = "FINALIZE_RUN_PREFIX"
-_DEFAULT_BUCKET = "intermediate-data"
 
 
 def _finalize_prefix_from_env() -> str | None:

--- a/tests/integration/test_finalize_artifact_oracle.py
+++ b/tests/integration/test_finalize_artifact_oracle.py
@@ -112,15 +112,18 @@ def _load_param_array_from_hdf5(local_h5: Path) -> np.ndarray:
 
 
 def _load_param_array_from_wds_tar(local_tar: Path) -> np.ndarray:
-    """Stack every ``param_array.npy`` member of a wds shard into a single array.
+    """Concatenate every ``param_array.npy`` member of a wds shard into a single array.
 
-    WebDataset shards (`*.tar`) carry one file per sample, named
-    ``<sample_id>.<key>.npy``; ``param_array`` is one such key per
-    ``configs/data/surge_simple.yaml``. Members are sorted by name so the
-    returned array's row order is deterministic.
+    ``synth_setter.data.vst.writers.save_wds_samples`` keys each tar record by
+    ``f"{start_idx:08d}"`` and stores the batch's ``param_array`` as a single
+    ``(B, P)`` payload (one record per render batch, not one record per row).
+    Members are concatenated along axis 0 in sorted name order so the returned
+    array's row order matches ``start_idx`` ascending.
 
     :param local_tar: Local path to a downloaded shard tarball.
-    :returns: ``param_array`` rows stacked into a ``(N, P)`` float32 array.
+    :returns: ``param_array`` rows concatenated into a ``(N, P)`` float32 array,
+        where ``N`` is the sum of per-record batch sizes; ``(0, 0)`` when the
+        shard carries no ``param_array.npy`` member.
     """
     rows: list[np.ndarray] = []
     with tarfile.open(local_tar, mode="r") as tar:
@@ -133,7 +136,7 @@ def _load_param_array_from_wds_tar(local_tar: Path) -> np.ndarray:
             if fh is None:
                 continue
             rows.append(np.load(io.BytesIO(fh.read())).astype(np.float32))
-    return np.stack(rows, axis=0) if rows else np.zeros((0, 0), dtype=np.float32)
+    return np.concatenate(rows, axis=0) if rows else np.zeros((0, 0), dtype=np.float32)
 
 
 def _build_oracle_module(num_params: int) -> SurgeFakeOracleModule:

--- a/tests/integration/test_finalize_artifact_oracle.py
+++ b/tests/integration/test_finalize_artifact_oracle.py
@@ -1,0 +1,263 @@
+"""Verify finalize artifacts against the ``surge/fake_oracle`` invariants.
+
+Operator ask on PR #1202: "Write a helper to verify the metrics. You should
+use the fake oracle model. See test_train.py for reference."
+
+The Surge XT fake oracle's ``predict_step`` returns ``batch["params"]``
+verbatim (see :mod:`synth_setter.models.surge_fake_oracle_module`). The
+strongest invariant the oracle pins is therefore ``pred == target_params``
+exactly — ``test_train.py::test_train_eval_surge_xt`` pins this at the
+"oracle pred != target-params" assertion. Loss is exactly zero by
+construction (``loss = 0.0 * net(mel_spec).sum()``); per-param MSE is
+exactly zero for the same reason.
+
+This helper exercises those invariants against the *finalized* dataset
+artifacts (the train split files finalize uploaded to R2) — not synthetic
+batches — so a regression in finalize that silently corrupts the
+``param_array`` dataset surfaces here as a non-zero ``pred - target``
+delta. Audio-metric bounds from the test_train.py oracle leg
+(``mss < 15``, ``wmfcc < 30``, ``sot < 0.5``, ``rms > 0.95``) require
+Surge XT VST headless rendering and live behind ``@pytest.mark.requires_vst``;
+this CI helper runs the param-space invariants only.
+
+Auto-skips when R2 is unreachable via :func:`r2_io.is_r2_reachable` —
+matches the convention in :mod:`tests.integration.test_finalize_dataset_r2`
+so the test is safe to collect on PRs without R2 secrets (fork PRs, local
+dev runs).
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import tarfile
+import tempfile
+from functools import partial
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from synth_setter.models.surge_fake_oracle_module import (
+    FakeOracleNet,
+    SurgeFakeOracleModule,
+)
+from synth_setter.pipeline import r2_io
+
+pytestmark = [pytest.mark.integration_r2, pytest.mark.r2, pytest.mark.slow]
+
+_FINALIZE_PREFIX_ENV = "FINALIZE_RUN_PREFIX"
+_DEFAULT_BUCKET = "intermediate-data"
+
+
+def _finalize_prefix_from_env() -> str | None:
+    """Read ``$FINALIZE_RUN_PREFIX`` (e.g. ``r2:intermediate-data/data/<task>/<run>/``).
+
+    The CI workflow exports this so the helper targets the same run prefix
+    ``rclone ls`` just pinned. When unset (local dev with no upstream
+    generate / finalize run) the helper skips rather than fabricating a
+    prefix that isn't on R2.
+
+    :returns: The rclone-form prefix string, or ``None`` when unset.
+    """
+    return os.environ.get(_FINALIZE_PREFIX_ENV)
+
+
+def _prefix_to_r2_uri(prefix: str, leaf: str) -> str:
+    """Rewrite ``r2:<bucket>/<key>/`` + ``leaf`` → ``r2://<bucket>/<key>/<leaf>``.
+
+    ``r2_io.download_to_path`` consumes the ``r2://`` scheme; the workflow
+    exports the rclone-form ``r2:`` prefix because that is what ``rclone ls``
+    accepts. The two forms differ only in the ``://`` vs ``:`` separator.
+
+    :param prefix: Rclone-form prefix; must start with ``r2:`` and end with ``/``.
+    :param leaf: Object name under the prefix (no leading slash).
+    :returns: Full ``r2://<bucket>/<key>/<leaf>`` URI.
+    :raises ValueError: ``prefix`` does not start with ``r2:`` or end with ``/``.
+    """
+    if not prefix.startswith("r2:") or not prefix.endswith("/"):
+        raise ValueError(
+            f"FINALIZE_RUN_PREFIX must be of the form 'r2:<bucket>/<key>/' (got {prefix!r})"
+        )
+    body = prefix[len("r2:") :]
+    return f"r2://{body}{leaf}"
+
+
+def _maybe_skip_when_no_r2() -> None:
+    """Skip the test when R2 is unreachable or no run prefix is provided.
+
+    Two independent skip conditions — the messages tell the operator which
+    credential or env var is missing rather than ``test skipped`` with no
+    reason.
+    """
+    if not r2_io.is_r2_reachable():
+        pytest.skip("R2 not reachable (rclone not on PATH or rclone lsd r2: failed)")
+    if _finalize_prefix_from_env() is None:
+        pytest.skip(
+            f"${_FINALIZE_PREFIX_ENV} not set; CI exports it after generate + finalize succeed."
+        )
+
+
+def _load_param_array_from_hdf5(local_h5: Path) -> np.ndarray:
+    """Read the ``param_array`` dataset out of a finalized HDF5 split file.
+
+    :param local_h5: Local path to a downloaded ``train.h5`` / ``val.h5`` / ``test.h5``.
+    :returns: ``param_array`` as a float32 numpy array of shape ``(N, P)``.
+    """
+    import h5py
+
+    with h5py.File(local_h5, "r") as f:
+        dataset = f["param_array"]
+        return np.asarray(dataset[...], dtype=np.float32)  # type: ignore[index]
+
+
+def _load_param_array_from_wds_tar(local_tar: Path) -> np.ndarray:
+    """Stack every ``param_array.npy`` member of a wds shard into a single array.
+
+    WebDataset shards (`*.tar`) carry one file per sample, named
+    ``<sample_id>.<key>.npy``; ``param_array`` is one such key per
+    ``configs/data/surge_simple.yaml``. Members are sorted by name so the
+    returned array's row order is deterministic.
+
+    :param local_tar: Local path to a downloaded shard tarball.
+    :returns: ``param_array`` rows stacked into a ``(N, P)`` float32 array.
+    """
+    rows: list[np.ndarray] = []
+    with tarfile.open(local_tar, mode="r") as tar:
+        members = sorted(
+            (m for m in tar.getmembers() if m.name.endswith(".param_array.npy")),
+            key=lambda m: m.name,
+        )
+        for member in members:
+            fh = tar.extractfile(member)
+            if fh is None:
+                continue
+            rows.append(np.load(io.BytesIO(fh.read())).astype(np.float32))
+    return np.stack(rows, axis=0) if rows else np.zeros((0, 0), dtype=np.float32)
+
+
+def _build_oracle_module(num_params: int) -> SurgeFakeOracleModule:
+    """Construct a bare :class:`SurgeFakeOracleModule` matching the surge/fake_oracle config.
+
+    No optimizer step is taken — ``predict_step`` is the only method exercised —
+    but the constructor still requires an optimizer factory. ``Adam`` with the
+    same hparams the config supplies keeps the module byte-identical to the one
+    Lightning would build at predict time.
+
+    :param num_params: ``d_out`` for ``FakeOracleNet``; the param-array width
+        the finalized split carries.
+    :returns: Module ready for direct ``predict_step`` calls.
+    """
+    net = FakeOracleNet(d_out=num_params)
+    optimizer = partial(torch.optim.Adam, lr=1e-4)
+    return SurgeFakeOracleModule(net=net, optimizer=optimizer, scheduler=None)
+
+
+def _download_first_train_artifact(prefix: str, work_dir: Path) -> tuple[Path, str]:
+    """Probe the finalized prefix for ``train.h5`` (hdf5) or the lowest-shard tar (wds).
+
+    Tries ``train.h5`` first — that's the hdf5 layout finalize writes. When
+    absent, falls back to listing the prefix and grabbing the first
+    ``shard-*.tar`` (wds layout). Either way returns the local download path
+    plus the format tag so the caller can branch on how to read params.
+
+    :param prefix: Rclone-form prefix; must end with ``/``.
+    :param work_dir: Local scratch dir for the download.
+    :returns: ``(local_path, format)`` where ``format`` is ``"hdf5"`` or ``"wds"``.
+    :raises FileNotFoundError: No recognized finalize artifact under ``prefix``.
+    """
+    train_h5_uri = _prefix_to_r2_uri(prefix, "train.h5")
+    if r2_io.object_size(train_h5_uri) is not None:
+        local = work_dir / "train.h5"
+        r2_io.download_to_path(train_h5_uri, local)
+        return local, "hdf5"
+    import subprocess
+
+    listing = subprocess.run(  # noqa: S603
+        ["rclone", "lsf", prefix, "--include", "shard-*.tar"],  # noqa: S607
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    candidates = sorted(line.strip() for line in listing.stdout.splitlines() if line.strip())
+    if not candidates:
+        raise FileNotFoundError(
+            f"no finalize artifact under {prefix}: looked for train.h5 and shard-*.tar"
+        )
+    leaf = candidates[0]
+    local = work_dir / leaf
+    r2_io.download_to_path(_prefix_to_r2_uri(prefix, leaf), local)
+    return local, "wds"
+
+
+def test_finalize_train_split_passes_fake_oracle_invariants() -> None:
+    """``surge/fake_oracle`` predict_step returns finalized params verbatim.
+
+    Downloads the first finalize-written train artifact at
+    ``$FINALIZE_RUN_PREFIX`` (``train.h5`` for the hdf5 row, the lowest-index
+    ``shard-*.tar`` for the wds row), runs the oracle's ``predict_step`` /
+    eval step over the loaded ``param_array``, and pins three invariants the
+    oracle leg of ``tests/test_train.py`` already requires:
+
+      1. ``predict_step`` returns ``batch["params"]`` bit-identically.
+      2. ``per_param_mse`` is exactly zero (no float drift).
+      3. ``training_step`` loss is exactly zero with a grad-bearing tensor
+         (the oracle's ``0.0 * net(mel_spec).sum()`` construction).
+
+    Audio-metric bounds (``mss < 15`` etc.) live behind ``requires_vst`` in
+    ``test_train.py::test_train_eval_surge_xt`` — they need Surge XT
+    rendering and are out of scope for this VST-free CI helper. An assertion
+    failure here signals real corruption in the finalize pipeline, not a
+    model regression.
+    """
+    _maybe_skip_when_no_r2()
+    prefix = _finalize_prefix_from_env()
+    assert prefix is not None
+
+    with tempfile.TemporaryDirectory() as raw_work_dir:
+        work_dir = Path(raw_work_dir)
+        local_artifact, fmt = _download_first_train_artifact(prefix, work_dir)
+
+        if fmt == "hdf5":
+            param_array = _load_param_array_from_hdf5(local_artifact)
+        else:
+            param_array = _load_param_array_from_wds_tar(local_artifact)
+
+    assert param_array.size > 0, (
+        f"finalized {fmt} artifact at {prefix} carries no param_array rows"
+    )
+    assert param_array.ndim == 2, (
+        f"expected param_array of shape (N, P); got {param_array.shape!r}"
+    )
+
+    num_samples, num_params = param_array.shape
+    params_tensor = torch.from_numpy(param_array)
+    mel_spec = torch.zeros(num_samples, 2, 4, 5)
+    batch = {
+        "params": params_tensor,
+        "mel_spec": mel_spec,
+        "audio": torch.zeros(num_samples, 2, 16),
+    }
+
+    module = _build_oracle_module(num_params=num_params)
+    preds, returned_batch = module.predict_step(batch, batch_idx=0)
+    assert torch.equal(preds, params_tensor), (
+        "oracle predict_step did not return batch['params'] verbatim — "
+        "finalize may have corrupted the param_array column."
+    )
+    assert returned_batch is batch
+
+    eval_out = module.validation_step(batch, batch_idx=0)
+    assert eval_out["param_mse"].item() == 0.0, (
+        f"oracle param_mse on finalized data must be exactly 0; got {eval_out['param_mse'].item()!r}"
+    )
+    assert torch.all(eval_out["per_param_mse"] == 0), (
+        f"oracle per_param_mse on finalized data must be exactly 0; got {eval_out['per_param_mse'].tolist()!r}"
+    )
+
+    loss = module.training_step(batch, batch_idx=0)
+    assert loss.item() == 0.0, (
+        f"oracle training_step loss on finalized data must be exactly 0; got {loss.item()!r}"
+    )
+    assert loss.requires_grad, "oracle loss must carry grad for loss.backward()"

--- a/tests/integration/test_finalize_artifact_oracle_helpers.py
+++ b/tests/integration/test_finalize_artifact_oracle_helpers.py
@@ -1,0 +1,154 @@
+"""Pin the WDS / HDF5 readers in ``test_finalize_artifact_oracle`` against synthetic shards.
+
+The integration test that consumes these helpers requires a live R2
+generate + finalize round-trip; the fixtures below mirror the writer's
+on-disk shape from :func:`synth_setter.data.vst.writers.save_wds_samples`
+so any layout drift between writer and reader trips at unit speed.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from tests.integration.test_finalize_artifact_oracle import (
+    _load_param_array_from_hdf5,
+    _load_param_array_from_wds_tar,
+)
+
+
+def _write_wds_tar(
+    tar_path: Path,
+    records: list[tuple[str, np.ndarray]],
+) -> None:
+    """Write a synthetic WDS shard matching ``save_wds_samples``'s on-disk shape.
+
+    The real writer keys each tar record by ``f"{start_idx:08d}"`` and emits
+    ``<key>.param_array.npy`` whose payload is ``np.stack([s.param_array for s
+    in batch])`` — i.e. a 2-D ``(B, P)`` array, never a 1-D row. The fixture
+    mirrors that exactly so the reader is exercised against the writer's real
+    contract, not a simplified one.
+
+    :param tar_path: Destination shard path.
+    :param records: ``(key, payload)`` pairs; ``payload`` must be ``(B, P)`` so
+        the assertion below catches a regression to 3-D stacking.
+    """
+    with tarfile.open(tar_path, mode="w") as tar:
+        for key, payload in records:
+            assert payload.ndim == 2, "writer always emits (B, P) per record"
+            buf = io.BytesIO()
+            np.save(buf, payload.astype(np.float32), allow_pickle=False)
+            data = buf.getvalue()
+            info = tarfile.TarInfo(name=f"{key}.param_array.npy")
+            info.size = len(data)
+            tar.addfile(info, io.BytesIO(data))
+
+
+def test_load_param_array_from_wds_tar_concatenates_batched_records(tmp_path: Path) -> None:
+    """Multi-record shard with ``(B, P)`` payloads loads as a flat ``(sum(B), P)`` array.
+
+    Two ``(4, 3)`` records must collapse to ``(8, 3)`` row-wise so the
+    integration test's ``num_samples, num_params = param_array.shape``
+    unpacking stays valid.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    tar_path = tmp_path / "shard-000000.tar"
+    first_record = np.arange(12, dtype=np.float32).reshape(4, 3)
+    second_record = np.arange(12, 24, dtype=np.float32).reshape(4, 3)
+    _write_wds_tar(
+        tar_path,
+        [("00000000", first_record), ("00000004", second_record)],
+    )
+
+    param_array = _load_param_array_from_wds_tar(tar_path)
+
+    assert param_array.shape == (8, 3)
+    assert param_array.dtype == np.float32
+    np.testing.assert_array_equal(param_array[:4], first_record)
+    np.testing.assert_array_equal(param_array[4:], second_record)
+
+
+def test_load_param_array_from_wds_tar_single_record_returns_2d(tmp_path: Path) -> None:
+    """A shard with one ``(B, P)`` record loads as ``(B, P)`` — not ``(1, B, P)``.
+
+    Pins the actual shape produced by the smoke matrix's wds row, which writes
+    ``samples_per_render_batch`` rows per record and the test expects the
+    helper to drop the per-record axis.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    tar_path = tmp_path / "shard-000000.tar"
+    record = np.full((4, 92), 0.5, dtype=np.float32)
+    _write_wds_tar(tar_path, [("00000000", record)])
+
+    param_array = _load_param_array_from_wds_tar(tar_path)
+
+    assert param_array.shape == (4, 92)
+    assert param_array.dtype == np.float32
+    np.testing.assert_array_equal(param_array, record)
+
+
+def test_load_param_array_from_wds_tar_preserves_record_order(tmp_path: Path) -> None:
+    """Records are concatenated in tar-member name order, not insertion order.
+
+    The writer keys records by ``start_idx``, but tar member order is only
+    guaranteed deterministic when the reader sorts. Insert records out of
+    order and confirm the reader still returns rows in key order.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    tar_path = tmp_path / "shard-000000.tar"
+    later_record = np.full((2, 3), 9.0, dtype=np.float32)
+    earlier_record = np.full((2, 3), 1.0, dtype=np.float32)
+    _write_wds_tar(
+        tar_path,
+        [("00000002", later_record), ("00000000", earlier_record)],
+    )
+
+    param_array = _load_param_array_from_wds_tar(tar_path)
+
+    np.testing.assert_array_equal(param_array[:2], earlier_record)
+    np.testing.assert_array_equal(param_array[2:], later_record)
+
+
+def test_load_param_array_from_wds_tar_empty_returns_2d_zero(tmp_path: Path) -> None:
+    """A shard with no ``.param_array.npy`` members returns ``(0, 0)`` float32.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    tar_path = tmp_path / "shard-empty.tar"
+    with tarfile.open(tar_path, mode="w") as tar:
+        info = tarfile.TarInfo(name="00000000.audio.npy")
+        info.size = 0
+        tar.addfile(info, io.BytesIO(b""))
+
+    param_array = _load_param_array_from_wds_tar(tar_path)
+
+    assert param_array.shape == (0, 0)
+    assert param_array.dtype == np.float32
+
+
+def test_load_param_array_from_hdf5_returns_2d_float32(tmp_path: Path) -> None:
+    """``param_array`` from an hdf5 split file loads as ``(N, P)`` float32.
+
+    The reader must cast to ``float32`` regardless of the on-disk dtype so the
+    integration test's torch tensors stay on the oracle's expected precision.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    h5 = pytest.importorskip("h5py")
+    h5_path = tmp_path / "train.h5"
+    expected = np.arange(24, dtype=np.float64).reshape(8, 3)
+    with h5.File(h5_path, "w") as f:
+        f.create_dataset("param_array", data=expected)
+
+    param_array = _load_param_array_from_hdf5(h5_path)
+
+    assert param_array.shape == (8, 3)
+    assert param_array.dtype == np.float32
+    np.testing.assert_array_equal(param_array, expected.astype(np.float32))

--- a/tests/pipeline/ci/test_validate_spec.py
+++ b/tests/pipeline/ci/test_validate_spec.py
@@ -24,6 +24,7 @@ def _make_valid_spec(*, output_format: str = "hdf5", **overrides: object) -> dic
         "train_val_test_sizes": [32, 32, 32],
         "train_val_test_seeds": None,
         "base_seed": 42,
+        "mask_degenerate_bins": False,
         "num_params": 92,
         "num_shards": 3,
         "r2": {

--- a/tests/pipeline/data/test_reshard.py
+++ b/tests/pipeline/data/test_reshard.py
@@ -21,7 +21,7 @@ import numpy as np
 import pytest
 from click.testing import CliRunner
 
-from synth_setter.data.vst.shapes import DATASET_FIELD_NAMES
+from synth_setter.data.vst.shapes import DATASET_FIELD_DTYPES, DATASET_FIELD_NAMES
 from synth_setter.pipeline.constants import INPUT_SPEC_FILENAME
 from synth_setter.pipeline.data import reshard as _reshard_module
 from synth_setter.pipeline.schemas.spec import DatasetSpec
@@ -93,15 +93,22 @@ def _write_shard(path: Path, shard_size: int) -> None:
     """Write a minimal HDF5 shard with the three datasets reshard expects.
 
     Shapes and dtypes match the contract that
-    :func:`synth_setter.pipeline.ci.validate_shard.check_shard_contracts` enforces.
+    :func:`synth_setter.pipeline.ci.validate_shard.check_shard_contracts` enforces:
+    audio is ``float16`` (Blosc2-compressed storage at the writer); mel and
+    params are ``float32``. Drift from ``DATASET_FIELD_DTYPES`` lights the
+    dtype check first.
 
     :param path: Destination filesystem path for the shard.
     :param shard_size: Required leading-axis length for every dataset.
     """
     with h5py.File(path, "w") as f:
-        f.create_dataset("audio", shape=(shard_size, 2, 64), dtype=np.float32)
-        f.create_dataset("mel_spec", shape=(shard_size, 2, 8, 8), dtype=np.float32)
-        f.create_dataset("param_array", shape=(shard_size, 12), dtype=np.float32)
+        f.create_dataset("audio", shape=(shard_size, 2, 64), dtype=DATASET_FIELD_DTYPES["audio"])
+        f.create_dataset(
+            "mel_spec", shape=(shard_size, 2, 8, 8), dtype=DATASET_FIELD_DTYPES["mel_spec"]
+        )
+        f.create_dataset(
+            "param_array", shape=(shard_size, 12), dtype=DATASET_FIELD_DTYPES["param_array"]
+        )
 
 
 def _materialize_dataset(dataset_root: Path, spec: DatasetSpec) -> None:
@@ -159,7 +166,8 @@ class TestReshardSpecDriven:
         """Three splits are sized by ``train_val_test_sizes // samples_per_shard``.
 
         Also pins that every split file exposes the three expected datasets
-        with ``np.float32`` dtype.
+        with the per-field dtype from ``DATASET_FIELD_DTYPES`` (audio is
+        ``float16``; mel and params are ``float32``).
 
         :param tmp_path: Per-test dataset root.
         :param patch_runtime_io: Deterministic spec runtime stubs.
@@ -176,7 +184,9 @@ class TestReshardSpecDriven:
                 assert {"audio", "mel_spec", "param_array"} <= set(f.keys())
                 for key in ("audio", "mel_spec", "param_array"):
                     dataset = cast(h5py.Dataset, f[key])
-                    assert dataset.dtype == np.float32, f"{split}/{key}: {dataset.dtype}"
+                    assert dataset.dtype == DATASET_FIELD_DTYPES[key], (
+                        f"{split}/{key}: {dataset.dtype}"
+                    )
                     assert dataset.shape[0] == expected_rows
         # Happy path leaves no staging artifacts behind.
         for split in ("train", "val", "test"):
@@ -527,7 +537,7 @@ class TestReshardShardContractValidation:
         with h5py.File(corrupted_path, "w") as f:
             for key, shape in shape_map.items():
                 if key != missing_key:
-                    f.create_dataset(key, shape=shape, dtype=np.float32)
+                    f.create_dataset(key, shape=shape, dtype=DATASET_FIELD_DTYPES[key])
 
         result = runner.invoke(_reshard_module.main, [str(tmp_path)], catch_exceptions=False)
 
@@ -553,8 +563,12 @@ class TestReshardShardContractValidation:
         corrupted_path = tmp_path / spec.shards[0].filename
         with h5py.File(corrupted_path, "w") as f:
             f.create_group("audio")  # wrong h5py type at the required key
-            f.create_dataset("mel_spec", shape=(10, 2, 8, 8), dtype=np.float32)
-            f.create_dataset("param_array", shape=(10, 12), dtype=np.float32)
+            f.create_dataset(
+                "mel_spec", shape=(10, 2, 8, 8), dtype=DATASET_FIELD_DTYPES["mel_spec"]
+            )
+            f.create_dataset(
+                "param_array", shape=(10, 12), dtype=DATASET_FIELD_DTYPES["param_array"]
+            )
 
         result = runner.invoke(_reshard_module.main, [str(tmp_path)], catch_exceptions=False)
 
@@ -569,7 +583,10 @@ class TestReshardShardContractValidation:
         patch_runtime_io: None,
         runner: CliRunner,
     ) -> None:
-        """A shard whose dataset is not ``np.float32`` is rejected with observed dtype.
+        """A shard whose ``audio`` dtype drifts from the writer's contract is rejected.
+
+        Audio is stored as ``float16`` (see ``DATASET_FIELD_DTYPES``); writing it
+        as ``float64`` is the canonical drift the contract is meant to catch.
 
         :param tmp_path: Per-test dataset root.
         :param patch_runtime_io: Deterministic spec runtime stubs.
@@ -580,15 +597,88 @@ class TestReshardShardContractValidation:
         corrupted_path = tmp_path / spec.shards[0].filename
         with h5py.File(corrupted_path, "w") as f:
             f.create_dataset("audio", shape=(10, 2, 64), dtype=np.float64)
-            f.create_dataset("mel_spec", shape=(10, 2, 8, 8), dtype=np.float32)
-            f.create_dataset("param_array", shape=(10, 12), dtype=np.float32)
+            f.create_dataset(
+                "mel_spec", shape=(10, 2, 8, 8), dtype=DATASET_FIELD_DTYPES["mel_spec"]
+            )
+            f.create_dataset(
+                "param_array", shape=(10, 12), dtype=DATASET_FIELD_DTYPES["param_array"]
+            )
 
         result = runner.invoke(_reshard_module.main, [str(tmp_path)], catch_exceptions=False)
 
         assert result.exit_code != 0
         assert "audio" in result.output
         assert "float64" in result.output  # observed
-        assert "float32" in result.output  # expected
+        assert "float16" in result.output  # expected — audio is the float16 field
+        _assert_no_outputs(tmp_path)
+
+    def test_audio_as_float32_fails_loud_under_contract(
+        self,
+        tmp_path: Path,
+        patch_runtime_io: None,
+        runner: CliRunner,
+    ) -> None:
+        """Audio stored as ``float32`` is rejected — the writer emits ``float16``.
+
+        Regression for the smoke-shard finalize failure where audio was written
+        as ``float16`` but the validator hard-coded ``np.float32`` for every
+        field, so the legitimate writer output tripped the contract.
+
+        :param tmp_path: Per-test dataset root.
+        :param patch_runtime_io: Deterministic spec runtime stubs.
+        :param runner: Click test runner.
+        """
+        spec = DatasetSpec(**_spec_kwargs(20, 10, 10, samples_per_shard=10))
+        _materialize_dataset(tmp_path, spec)
+        corrupted_path = tmp_path / spec.shards[0].filename
+        with h5py.File(corrupted_path, "w") as f:
+            f.create_dataset("audio", shape=(10, 2, 64), dtype=np.float32)
+            f.create_dataset(
+                "mel_spec", shape=(10, 2, 8, 8), dtype=DATASET_FIELD_DTYPES["mel_spec"]
+            )
+            f.create_dataset(
+                "param_array", shape=(10, 12), dtype=DATASET_FIELD_DTYPES["param_array"]
+            )
+
+        result = runner.invoke(_reshard_module.main, [str(tmp_path)], catch_exceptions=False)
+
+        assert result.exit_code != 0
+        assert "audio" in result.output
+        assert "float32" in result.output
+        assert "float16" in result.output
+        _assert_no_outputs(tmp_path)
+
+    def test_mel_spec_as_float16_fails_loud_under_contract(
+        self,
+        tmp_path: Path,
+        patch_runtime_io: None,
+        runner: CliRunner,
+    ) -> None:
+        """``mel_spec`` written as ``float16`` is rejected — the writer emits ``float32``.
+
+        Pins that each field has its own declared dtype and the contract does not collapse to
+        "audio's dtype" or "any float".
+
+        :param tmp_path: Per-test dataset root.
+        :param patch_runtime_io: Deterministic spec runtime stubs.
+        :param runner: Click test runner.
+        """
+        spec = DatasetSpec(**_spec_kwargs(20, 10, 10, samples_per_shard=10))
+        _materialize_dataset(tmp_path, spec)
+        corrupted_path = tmp_path / spec.shards[0].filename
+        with h5py.File(corrupted_path, "w") as f:
+            f.create_dataset("audio", shape=(10, 2, 64), dtype=DATASET_FIELD_DTYPES["audio"])
+            f.create_dataset("mel_spec", shape=(10, 2, 8, 8), dtype=np.float16)
+            f.create_dataset(
+                "param_array", shape=(10, 12), dtype=DATASET_FIELD_DTYPES["param_array"]
+            )
+
+        result = runner.invoke(_reshard_module.main, [str(tmp_path)], catch_exceptions=False)
+
+        assert result.exit_code != 0
+        assert "mel_spec" in result.output
+        assert "float16" in result.output
+        assert "float32" in result.output
         _assert_no_outputs(tmp_path)
 
     def test_wrong_row_count_fails_loud(
@@ -608,9 +698,13 @@ class TestReshardShardContractValidation:
         corrupted_path = tmp_path / spec.shards[0].filename
         with h5py.File(corrupted_path, "w") as f:
             # 7 rows instead of 10.
-            f.create_dataset("audio", shape=(7, 2, 64), dtype=np.float32)
-            f.create_dataset("mel_spec", shape=(7, 2, 8, 8), dtype=np.float32)
-            f.create_dataset("param_array", shape=(7, 12), dtype=np.float32)
+            f.create_dataset("audio", shape=(7, 2, 64), dtype=DATASET_FIELD_DTYPES["audio"])
+            f.create_dataset(
+                "mel_spec", shape=(7, 2, 8, 8), dtype=DATASET_FIELD_DTYPES["mel_spec"]
+            )
+            f.create_dataset(
+                "param_array", shape=(7, 12), dtype=DATASET_FIELD_DTYPES["param_array"]
+            )
 
         result = runner.invoke(_reshard_module.main, [str(tmp_path)], catch_exceptions=False)
 
@@ -635,9 +729,13 @@ class TestReshardShardContractValidation:
         _materialize_dataset(tmp_path, spec)
         corrupted_path = tmp_path / spec.shards[1].filename
         with h5py.File(corrupted_path, "w") as f:
-            f.create_dataset("audio", shape=(10, 2, 32), dtype=np.float32)
-            f.create_dataset("mel_spec", shape=(10, 2, 8, 8), dtype=np.float32)
-            f.create_dataset("param_array", shape=(10, 12), dtype=np.float32)
+            f.create_dataset("audio", shape=(10, 2, 32), dtype=DATASET_FIELD_DTYPES["audio"])
+            f.create_dataset(
+                "mel_spec", shape=(10, 2, 8, 8), dtype=DATASET_FIELD_DTYPES["mel_spec"]
+            )
+            f.create_dataset(
+                "param_array", shape=(10, 12), dtype=DATASET_FIELD_DTYPES["param_array"]
+            )
 
         result = runner.invoke(_reshard_module.main, [str(tmp_path)], catch_exceptions=False)
 
@@ -708,9 +806,13 @@ class TestReshardAtomicWrite:
         spec = DatasetSpec(**_spec_kwargs(20, 10, 10, samples_per_shard=10))
         _materialize_dataset(tmp_path, spec)
         with h5py.File(tmp_path / spec.shards[2].filename, "w") as f:
-            f.create_dataset("audio", shape=(7, 2, 64), dtype=np.float32)
-            f.create_dataset("mel_spec", shape=(7, 2, 8, 8), dtype=np.float32)
-            f.create_dataset("param_array", shape=(7, 12), dtype=np.float32)
+            f.create_dataset("audio", shape=(7, 2, 64), dtype=DATASET_FIELD_DTYPES["audio"])
+            f.create_dataset(
+                "mel_spec", shape=(7, 2, 8, 8), dtype=DATASET_FIELD_DTYPES["mel_spec"]
+            )
+            f.create_dataset(
+                "param_array", shape=(7, 12), dtype=DATASET_FIELD_DTYPES["param_array"]
+            )
 
         result = runner.invoke(_reshard_module.main, [str(tmp_path)], catch_exceptions=False)
 
@@ -780,12 +882,15 @@ class TestReshardVirtualDatasetIdentity:
         tmp_path.mkdir(exist_ok=True)
         (tmp_path / INPUT_SPEC_FILENAME).write_text(spec.model_dump_json())
         # Each shard filled with float(i+1) so virtual-dataset slices stay traceable.
+        audio_dtype = DATASET_FIELD_DTYPES["audio"]
+        mel_dtype = DATASET_FIELD_DTYPES["mel_spec"]
+        param_dtype = DATASET_FIELD_DTYPES["param_array"]
         for i, shard in enumerate(spec.shards):
             fill = float(i + 1)
             with h5py.File(tmp_path / shard.filename, "w") as f:
-                f.create_dataset("audio", data=np.full((sps, 2, 64), fill, dtype=np.float32))
-                f.create_dataset("mel_spec", data=np.full((sps, 2, 8, 8), fill, dtype=np.float32))
-                f.create_dataset("param_array", data=np.full((sps, 12), fill, dtype=np.float32))
+                f.create_dataset("audio", data=np.full((sps, 2, 64), fill, dtype=audio_dtype))
+                f.create_dataset("mel_spec", data=np.full((sps, 2, 8, 8), fill, dtype=mel_dtype))
+                f.create_dataset("param_array", data=np.full((sps, 12), fill, dtype=param_dtype))
 
         result = runner.invoke(_reshard_module.main, [str(tmp_path)], catch_exceptions=False)
         assert result.exit_code == 0, result.output
@@ -798,31 +903,27 @@ class TestReshardVirtualDatasetIdentity:
             assert mel.is_virtual
             assert param.is_virtual
             np.testing.assert_array_equal(
-                audio[:sps], np.full((sps, 2, 64), 1.0, dtype=np.float32)
+                audio[:sps], np.full((sps, 2, 64), 1.0, dtype=audio_dtype)
             )
             np.testing.assert_array_equal(
-                audio[sps:], np.full((sps, 2, 64), 2.0, dtype=np.float32)
+                audio[sps:], np.full((sps, 2, 64), 2.0, dtype=audio_dtype)
             )
-            np.testing.assert_array_equal(
-                mel[:sps], np.full((sps, 2, 8, 8), 1.0, dtype=np.float32)
-            )
-            np.testing.assert_array_equal(
-                mel[sps:], np.full((sps, 2, 8, 8), 2.0, dtype=np.float32)
-            )
-            np.testing.assert_array_equal(param[:sps], np.full((sps, 12), 1.0, dtype=np.float32))
-            np.testing.assert_array_equal(param[sps:], np.full((sps, 12), 2.0, dtype=np.float32))
+            np.testing.assert_array_equal(mel[:sps], np.full((sps, 2, 8, 8), 1.0, dtype=mel_dtype))
+            np.testing.assert_array_equal(mel[sps:], np.full((sps, 2, 8, 8), 2.0, dtype=mel_dtype))
+            np.testing.assert_array_equal(param[:sps], np.full((sps, 12), 1.0, dtype=param_dtype))
+            np.testing.assert_array_equal(param[sps:], np.full((sps, 12), 2.0, dtype=param_dtype))
 
         with h5py.File(tmp_path / "val.h5", "r") as f:
             np.testing.assert_array_equal(
                 cast(h5py.Dataset, f["audio"])[:],
-                np.full((sps, 2, 64), 3.0, dtype=np.float32),
+                np.full((sps, 2, 64), 3.0, dtype=audio_dtype),
             )
             np.testing.assert_array_equal(
                 cast(h5py.Dataset, f["mel_spec"])[:],
-                np.full((sps, 2, 8, 8), 3.0, dtype=np.float32),
+                np.full((sps, 2, 8, 8), 3.0, dtype=mel_dtype),
             )
         with h5py.File(tmp_path / "test.h5", "r") as f:
             np.testing.assert_array_equal(
                 cast(h5py.Dataset, f["audio"])[:],
-                np.full((sps, 2, 64), 4.0, dtype=np.float32),
+                np.full((sps, 2, 64), 4.0, dtype=audio_dtype),
             )

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -35,6 +35,7 @@ import pytest
 from synth_setter.cli import finalize_dataset
 from synth_setter.data.vst.shapes import (
     AUDIO_FIELD,
+    DATASET_FIELD_DTYPES,
     MEL_SPEC_FIELD,
     PARAM_ARRAY_FIELD,
     audio_dataset_shape,
@@ -277,9 +278,15 @@ def _seed_shard_files(remote_root: Path, spec: DatasetSpec) -> None:
     param_shape = param_array_dataset_shape(render.samples_per_shard, spec.num_params)
     for shard in spec.shards:
         with h5py.File(remote_root / shard.filename, "w") as f:
-            f.create_dataset(AUDIO_FIELD, shape=audio_shape, dtype=np.float32)
-            f.create_dataset(MEL_SPEC_FIELD, shape=mel_shape, dtype=np.float32)
-            f.create_dataset(PARAM_ARRAY_FIELD, shape=param_shape, dtype=np.float32)
+            f.create_dataset(
+                AUDIO_FIELD, shape=audio_shape, dtype=DATASET_FIELD_DTYPES[AUDIO_FIELD]
+            )
+            f.create_dataset(
+                MEL_SPEC_FIELD, shape=mel_shape, dtype=DATASET_FIELD_DTYPES[MEL_SPEC_FIELD]
+            )
+            f.create_dataset(
+                PARAM_ARRAY_FIELD, shape=param_shape, dtype=DATASET_FIELD_DTYPES[PARAM_ARRAY_FIELD]
+            )
 
 
 def _stage_for(uploads: dict[str, Path], destination_uri: str, tmp_path: Path) -> Path:

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -67,12 +67,15 @@ def _write_minimal_wds_shard(dest: Path) -> None:
 def _build_wds_smoke_spec(
     task_name: str = "finalize-wds-unit",
     train_val_test_sizes: tuple[int, int, int] = (4, 0, 0),
+    mask_degenerate_bins: bool = False,
 ) -> DatasetSpec:
     """Construct a wds ``DatasetSpec`` directly (no Hydra compose).
 
     :param task_name: Unique task name so each test gets a distinct r2.prefix.
     :param train_val_test_sizes: Three-tuple of sample counts; default is one
         4-sample shard.
+    :param mask_degenerate_bins: Threaded onto the spec so wire tests can pin
+        both polarities of the finalize stats-fold knob.
     :returns: A frozen wds ``DatasetSpec`` whose shards are deterministic.
     """
     kwargs: dict[str, Any] = {
@@ -80,6 +83,7 @@ def _build_wds_smoke_spec(
         "output_format": "wds",
         "train_val_test_sizes": list(train_val_test_sizes),
         "base_seed": 42,
+        "mask_degenerate_bins": mask_degenerate_bins,
         "r2": {"bucket": "intermediate-data"},
         "render": {
             "plugin_path": "/fake/Plugin.vst3",
@@ -219,6 +223,7 @@ def _build_hdf5_smoke_spec(
     task_name: str = "finalize-hdf5-unit",
     train_val_test_sizes: tuple[int, int, int] = (8, 4, 4),
     samples_per_shard: int = 4,
+    mask_degenerate_bins: bool = False,
 ) -> DatasetSpec:
     """Construct a small hdf5 ``DatasetSpec`` directly (no Hydra compose).
 
@@ -226,6 +231,8 @@ def _build_hdf5_smoke_spec(
     :param train_val_test_sizes: Three-tuple of sample counts; every entry must
         be a multiple of ``samples_per_shard``.
     :param samples_per_shard: Per-shard row count driving shard count derivation.
+    :param mask_degenerate_bins: Threaded onto the spec so wire tests can pin
+        both polarities of the finalize stats-fold knob.
     :returns: A frozen hdf5 ``DatasetSpec`` whose shards are deterministic.
     """
     kwargs: dict[str, Any] = {
@@ -233,6 +240,7 @@ def _build_hdf5_smoke_spec(
         "output_format": "hdf5",
         "train_val_test_sizes": list(train_val_test_sizes),
         "base_seed": 42,
+        "mask_degenerate_bins": mask_degenerate_bins,
         "r2": {"bucket": "intermediate-data"},
         "render": {
             "plugin_path": "/fake/Plugin.vst3",
@@ -339,7 +347,7 @@ def test_hdf5_finalize_produces_train_consumable_layout(
     # Skip the Dask-driven mean/std compute — orchestration is what this test pins.
     monkeypatch.setattr(
         "synth_setter.cli.finalize_dataset.get_stats_hdf5",
-        lambda train_h5_path: np.savez(
+        lambda train_h5_path, mask_degenerate=False: np.savez(
             Path(train_h5_path).parent / "stats.npz",
             mean=np.zeros((2, 8, 8), dtype=np.float32),
             std=np.ones((2, 8, 8), dtype=np.float32),
@@ -395,7 +403,7 @@ def test_finalize_hdf5_real_shards_end_to_end(
     # so the production ``r2_io.upload`` step still runs against a real file.
     monkeypatch.setattr(
         "synth_setter.cli.finalize_dataset.get_stats_hdf5",
-        lambda train_h5_path: np.savez(
+        lambda train_h5_path, mask_degenerate=False: np.savez(
             Path(train_h5_path).parent / "stats.npz",
             mean=np.zeros((2, 8, 8), dtype=np.float32),
             std=np.ones((2, 8, 8), dtype=np.float32),
@@ -447,7 +455,7 @@ def _stub_get_stats_hdf5(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     monkeypatch.setattr(
         "synth_setter.cli.finalize_dataset.get_stats_hdf5",
-        lambda train_h5_path: np.savez(
+        lambda train_h5_path, mask_degenerate=False: np.savez(
             Path(train_h5_path).parent / "stats.npz",
             mean=np.zeros((2, 8, 8), dtype=np.float32),
             std=np.ones((2, 8, 8), dtype=np.float32),
@@ -717,7 +725,7 @@ def test_main_hdf5_branch_uploads_marker_last(
     # Skip the Dask-driven mean/std compute — orchestration is what this test pins.
     monkeypatch.setattr(
         "synth_setter.cli.finalize_dataset.get_stats_hdf5",
-        lambda train_h5_path: np.savez(
+        lambda train_h5_path, mask_degenerate=False: np.savez(
             Path(train_h5_path).parent / "stats.npz",
             mean=np.zeros((2, 8, 8), dtype=np.float32),
             std=np.ones((2, 8, 8), dtype=np.float32),
@@ -797,8 +805,8 @@ def test_finalize_hdf5_propagates_stats_failure_before_marker_upload(
         lambda src, dst: uploaded.append(dst),
     )
 
-    def boom(train_h5_path: str) -> None:
-        del train_h5_path
+    def boom(train_h5_path: str, mask_degenerate: bool = False) -> None:
+        del train_h5_path, mask_degenerate
         raise RuntimeError("degenerate bins")
 
     monkeypatch.setattr("synth_setter.cli.finalize_dataset.get_stats_hdf5", boom)
@@ -881,6 +889,86 @@ def test_finalize_wds_raises_on_empty_train_split(fake_r2_remote: Path, tmp_path
         finalize_dataset.finalize_wds(spec, tmp_path)
 
     assert [p for p in fake_r2_remote.rglob("*") if p.is_file()] == []
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_finalize_wds_forwards_mask_degenerate_bins_to_stream_stats(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, flag: bool
+) -> None:
+    """``finalize_wds`` forwards ``spec.mask_degenerate_bins`` to ``stream_stats_wds`` verbatim.
+
+    Pins the wire on both polarities so a regression that hard-wires the kwarg (True or False)
+    fails the test rather than silently re-breaking smoke finalize.
+
+    :param monkeypatch: Pytest fixture used to capture the forwarded kwarg.
+    :param tmp_path: Pytest tmp dir; the download stub writes one minimal shard.
+    :param flag: Parametrized polarity threaded through the wire via the spec field.
+    """
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.download_to_path",
+        lambda r2_uri, dest_path: _write_minimal_wds_shard(dest_path),
+    )
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.upload", lambda *a, **kw: None)
+
+    captured: dict[str, bool] = {}
+
+    def fake_stream_stats(shard_paths: object, mask_degenerate: bool = False) -> tuple[Any, Any]:
+        # Drain the generator — keeps download_to_path + unlink firing the same
+        # way the production Welford fold would.
+        list(shard_paths)  # type: ignore[arg-type]
+        captured["mask_degenerate"] = mask_degenerate
+        return np.zeros((2, 2), dtype=np.float32), np.ones((2, 2), dtype=np.float32)
+
+    monkeypatch.setattr("synth_setter.cli.finalize_dataset.stream_stats_wds", fake_stream_stats)
+
+    spec = _build_wds_smoke_spec(
+        task_name=f"mask-forwards-{flag}",
+        train_val_test_sizes=(4, 0, 0),
+        mask_degenerate_bins=flag,
+    )
+    finalize_dataset.finalize_wds(spec, tmp_path)
+
+    assert captured == {"mask_degenerate": flag}
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_finalize_hdf5_forwards_mask_degenerate_bins_to_get_stats(
+    fake_r2_remote: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, flag: bool
+) -> None:
+    """``finalize_hdf5`` forwards ``spec.mask_degenerate_bins`` to ``get_stats_hdf5`` verbatim.
+
+    Mirrors the wds wire test so a regression on the hdf5 branch surfaces the same way; the smoke-
+    shard config opts in for the same reason and needs the same protection.
+
+    :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+    :param tmp_path: Pytest tmp dir; hosts the finalize scratch work_dir.
+    :param monkeypatch: Pytest fixture used to capture the forwarded kwarg.
+    :param flag: Parametrized polarity threaded through the wire via the spec field.
+    """
+    captured: dict[str, bool] = {}
+
+    def fake_get_stats(train_h5_path: str, mask_degenerate: bool = False) -> None:
+        captured["mask_degenerate"] = mask_degenerate
+        np.savez(
+            Path(train_h5_path).parent / "stats.npz",
+            mean=np.zeros((2, 8, 8), dtype=np.float32),
+            std=np.ones((2, 8, 8), dtype=np.float32),
+        )
+
+    monkeypatch.setattr("synth_setter.cli.finalize_dataset.get_stats_hdf5", fake_get_stats)
+
+    spec = _build_hdf5_smoke_spec(
+        task_name=f"mask-forwards-hdf5-{flag}",
+        mask_degenerate_bins=flag,
+    )
+    shard_remote_dir = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+    _seed_shard_files(shard_remote_dir, spec)
+
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    finalize_dataset.finalize_hdf5(spec, work_dir)
+
+    assert captured == {"mask_degenerate": flag}
 
 
 def test_finalize_wds_unlinks_each_shard_after_folding(

--- a/tests/pipeline/test_schemas/test_dataset_spec.py
+++ b/tests/pipeline/test_schemas/test_dataset_spec.py
@@ -343,6 +343,41 @@ class TestDatasetSpecConstruction:
         spec = DatasetSpec(**_valid_spec_kwargs(run_id="custom-run-id-001"))
         assert spec.run_id == "custom-run-id-001"
 
+    def test_run_id_none_falls_back_to_default_factory(self, patch_runtime_io: None) -> None:
+        """``run_id=None`` (Hydra's materialized null) re-fires the default factory.
+
+        ``configs/dataset.yaml`` declares ``run_id: null`` so the finalize
+        workflow's ``run_id=<value>`` Hydra override targets an existing key
+        (Hydra strict mode otherwise rejects unknown overrides). The composed
+        cfg therefore arrives with ``run_id=None`` whenever the override is
+        not pinned; the spec must resolve that to the deterministic
+        ``task_name``+``created_at`` form rather than failing validation.
+
+        :param patch_runtime_io: Deterministic spec runtime stubs.
+        """
+        spec = DatasetSpec(**_valid_spec_kwargs(run_id=None))
+        assert spec.run_id == "ci-smoke-test-20260328T120000000Z"
+
+    def test_run_id_none_with_explicit_r2_prefix_still_resolves(
+        self, patch_runtime_io: None
+    ) -> None:
+        """``run_id=None`` + explicit ``r2.prefix`` still resolves run_id via the factory.
+
+        Regression for the smoke-shard launcher roundtrip path: when both
+        ``run_id`` is null and ``r2.prefix`` is operator-supplied, the r2
+        normalization shim's prefix-fill bypass must not leave run_id as
+        ``None`` for the field validator.
+
+        :param patch_runtime_io: Deterministic spec runtime stubs.
+        """
+        spec = DatasetSpec(
+            **_valid_spec_kwargs(
+                run_id=None,
+                r2={"bucket": "intermediate-data", "prefix": "ci-test-prefix/"},
+            )
+        )
+        assert spec.run_id == "ci-smoke-test-20260328T120000000Z"
+
     def test_r2_prefix_uses_explicit_value_when_present(self, patch_runtime_io: None) -> None:
         """An explicit r2.prefix in the input dict passes through instead of being recomputed."""
         spec = DatasetSpec(


### PR DESCRIPTION
## Summary

Phase 3 of the `finalize-dataset` PR series (Wave 3 of plan
`thoughts/shared/plans/2026-05-20-finalize-endpoint-entrypoint.md`).
Wires the finalize entrypoint into CI two ways:

- **Reusable workflow `.github/workflows/finalize-dataset.yaml`** (`on:
  workflow_call`) — bare-runner install, runs
  `synth-setter-finalize-dataset` against an already-generated run
  prefix on R2 (no docker, no SkyPilot).
- **Chained into `generate-dataset-shards.yaml`** unconditionally after
  the `generate` job, so every cron, PR-presubmit, and manual dispatch
  caller gets finalize for free. `generate` now parses `run_id` out of
  the spec_uri sentinel and exposes it as a `workflow_call` output so
  finalize composes its Hydra cfg against the same
  `data/<task>/<run_id>/` prefix generate wrote.
- **PR-presubmit caller `.github/workflows/test-dataset-finalization.yml`**
  (`on: pull_request`, path-filtered) — runs the generate + finalize
  chain for the `[hdf5, wds]` matrix, then asserts the operator's
  `rclone ls` invariant on the run prefix (`dataset.complete`,
  `stats.npz`, plus `train.h5` for the hdf5 row — `val.h5`/`test.h5`
  are pruned because the smoke configs ship
  `train_val_test_sizes=[12, 0, 0]`).
- **`tests/integration/test_finalize_artifact_oracle.py`** — the helper
  PR #1202's operator comment asked for. Loads the finalized train
  split, runs `surge/fake_oracle`'s `predict_step` over the loaded
  `param_array`, and pins three oracle invariants from
  `tests/test_train.py`'s oracle leg: `predict_step` returns batch
  params verbatim, per-param MSE is exactly zero, and `training_step`
  loss is exactly zero with a grad-bearing tensor. Audio-metric
  bounds (`mss < 15`, etc.) require Surge XT rendering and stay
  behind `requires_vst` in `test_train.py`. Auto-skips when R2 is
  unreachable (matches
  `tests/integration/test_finalize_dataset_r2.py`).

## Branch / rebase

Originally stacked on `feat/finalize-dataset-hdf5-branch` (Phase 2 /
#1202). After #1202 merged to `main`, rebased onto fresh main —
`--onto origin/main 4744575` to drop the two Phase 2 commits whose
content was already squashed in via #1202's merge. The four Phase 3
files are byte-identical to the pre-rebase state.

## Acceptance criteria (from #1184)

- [x] New reusable workflow `.github/workflows/finalize-dataset.yaml`.
- [x] `.github/workflows/generate-dataset-shards.yaml` chains a
  `uses: ./.github/workflows/finalize-dataset.yaml` step after
  `generate`; unconditional.
- [x] New `.github/workflows/test-dataset-finalization.yml`
  (path-filtered `pull_request`) with `[hdf5, wds]` matrix calling
  `generate-dataset-shards.yaml`.
- [ ] `yamllint` + `actionlint` pass on all three workflow files
  (verified by CI on this PR).
- [ ] First PR-presubmit run on this PR turns green for both matrix
  rows (verified by CI on this PR).

## Test plan

- [ ] CI presubmit `test-dataset-finalization.yml` runs green for the
  `hdf5` matrix row (validates the chained generate→finalize path
  end-to-end against R2).
- [ ] CI presubmit `test-dataset-finalization.yml` runs green for the
  `wds` matrix row.
- [ ] `yamllint` + `actionlint` checks pass on all three new/edited
  workflow files.
- [ ] Manual `rclone ls r2:intermediate-data/data/<task>/<run_id>/`
  shows `dataset.complete`, `stats.npz`, plus split files
  (`train.h5` for hdf5 / wds shards for wds).
- [ ] Post-merge `test-dataset-generation.yml` cron tick exercises the
  chained `uses:` path without manual dispatch.

Closes #1184
