### PR TITLE
internal-feat(claude-hooks): edit guard + session-start cwd banner

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,6 +6,18 @@
     }
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "description": "Worktree-status banner: prints cwd, current branch, and whether the agent is sitting in the primary checkout (which AGENTS.md marks read-only). Fires on every session start, resume, /clear, and /compact so post-compaction agents see the same context. Goal: surface the primary-vs-worktree distinction at the moment the agent picks up work, before the first Edit/Write — the AGENTS.md rule lives outside CLAUDE.md so the agent doesn't otherwise see it in the system reminder.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/session-start-cwd-banner.sh"
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Edit|Write",
@@ -14,6 +26,16 @@
           {
             "type": "command",
             "command": "bash agent/hooks/edit-write.sh credential-protect"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "description": "Worktree guard: on Edit/Write inside the primary checkout, prints a WARNING with the exact `git worktree add` command. Default WORKTREE_GUARD_MODE=warn (exit 0, never blocks); =block upgrades to exit 2, =off disables. Edits outside the repo or inside linked worktrees fall through silently. Companion to the SessionStart banner; full rationale lives there.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/worktree-guard.sh"
           }
         ]
       },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,12 @@ Architecture: [docs/architecture.md](docs/architecture.md).
 - **Always work in an isolated git worktree.** Branch switching and stash
   conflicts have caused lost work and accidental commits to wrong branches.
   Use `git worktree add` (or `isolation: "worktree"` when spawning subagents).
-  The main checkout is read-only — `git log`, exploration, `rclone ls`. Never
-  edit files there.
+  The primary checkout is read-only — `git log`, exploration, `rclone ls`.
+  Never edit files there. A `SessionStart` hook
+  (`agent/hooks/session-start-cwd-banner.sh`) prints a primary-vs-worktree
+  banner on startup/resume/clear/compact; a `PreToolUse` hook
+  (`agent/hooks/worktree-guard.sh`) warns on Edit/Write inside the primary
+  checkout (`WORKTREE_GUARD_MODE`: `warn` default / `block` / `off`).
 - **Always verify the branch before push.** Run `git branch --show-current`
   and confirm it matches the target PR branch. A hook prints the branch on
   every `git commit`; don't ignore it.

--- a/agent/hooks/session-start-cwd-banner.sh
+++ b/agent/hooks/session-start-cwd-banner.sh
@@ -47,8 +47,9 @@ main() {
     # `--detach` always works regardless of where the branch is checked out,
     # matching the primary-edit guard's remediation and `_lib.sh` convention.
     printf 'Spawn a worktree before editing:\n'
-    printf '  git worktree add --detach .claude/worktrees/%s && cd .claude/worktrees/%s\n' \
-      "$slug" "$slug"
+    # Anchor to $primary_root so the command works even when the session started in a subdir.
+    printf '  git worktree add --detach %s/.claude/worktrees/%s && cd %s/.claude/worktrees/%s\n' \
+      "$primary_root" "$slug" "$primary_root" "$slug"
   else
     printf '  status   : isolated worktree (OK)\n'
     printf '  primary  : %s\n' "$primary_root"

--- a/agent/hooks/session-start-cwd-banner.sh
+++ b/agent/hooks/session-start-cwd-banner.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# session-start-cwd-banner.sh — SessionStart hook (matchers: startup, resume,
+# clear, compact). Prints a short banner to stdout so the agent sees its cwd
+# and whether it's in the primary checkout before issuing the first tool call.
+# Exits 0 outside a git repo (no banner; silent).
+set -euo pipefail
+
+main() {
+  # Drain stdin to avoid SIGPIPE when the harness pipes event JSON.
+  cat >/dev/null 2>&1 || true
+
+  local git_dir common_dir
+  git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
+  common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || exit 0
+
+  local abs_git_dir abs_common_dir primary_root branch
+  abs_git_dir=$(cd "$git_dir" 2>/dev/null && pwd) || exit 0
+  abs_common_dir=$(cd "$common_dir" 2>/dev/null && pwd) || exit 0
+  primary_root=$(dirname "$abs_common_dir")
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "<detached>")
+
+  local in_primary=0
+  [[ "$abs_git_dir" == "$abs_common_dir" ]] && in_primary=1
+
+  local worktree_count
+  worktree_count=$(git worktree list --porcelain 2>/dev/null | awk '/^worktree /' | wc -l | tr -d ' ')
+
+  printf '[worktree status]\n'
+  printf '  cwd      : %s\n' "$PWD"
+  printf '  branch   : %s\n' "$branch"
+  if (( in_primary == 1 )); then
+    local slug=${branch//\//-}
+    [[ -z "$slug" || "$slug" == "<detached>" ]] && slug="scratch"
+    printf '  status   : PRIMARY CHECKOUT — read-only per AGENTS.md\n'
+    # shellcheck disable=SC2016  # backticks are literal markdown-style hint to the agent, not command substitution
+    printf '  worktrees: %s active (run `git worktree list` for paths)\n' "$worktree_count"
+    printf '\n'
+    printf 'Spawn a worktree before editing:\n'
+    printf '  git worktree add .claude/worktrees/%s %s && cd .claude/worktrees/%s\n' \
+      "$slug" "$branch" "$slug"
+  else
+    printf '  status   : isolated worktree (OK)\n'
+    printf '  primary  : %s\n' "$primary_root"
+    # shellcheck disable=SC2016  # backticks are literal markdown-style hint to the agent, not command substitution
+    printf '  worktrees: %s active (run `git worktree list` for paths)\n' "$worktree_count"
+  fi
+}
+
+main "$@"

--- a/agent/hooks/session-start-cwd-banner.sh
+++ b/agent/hooks/session-start-cwd-banner.sh
@@ -13,11 +13,22 @@ main() {
   git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
   common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || exit 0
 
-  local abs_git_dir abs_common_dir primary_root branch
+  local abs_git_dir abs_common_dir primary_root branch_label short_sha
   abs_git_dir=$(cd "$git_dir" 2>/dev/null && pwd) || exit 0
   abs_common_dir=$(cd "$common_dir" 2>/dev/null && pwd) || exit 0
   primary_root=$(dirname "$abs_common_dir")
-  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "<detached>")
+  # `git branch --show-current` is the only reliable detached-HEAD probe:
+  # --abbrev-ref returns the literal "HEAD" instead of erroring out, so a
+  # `|| <fallback>` chain on it never fires.
+  branch_label=$(git branch --show-current 2>/dev/null || true)
+  local slug
+  if [[ -n "$branch_label" ]]; then
+    slug=${branch_label//\//-}
+  else
+    short_sha=$(git rev-parse --short HEAD 2>/dev/null || true)
+    branch_label="(detached HEAD${short_sha:+ ${short_sha}})"
+    slug="detached-${short_sha:-scratch}"
+  fi
 
   local in_primary=0
   [[ "$abs_git_dir" == "$abs_common_dir" ]] && in_primary=1
@@ -27,17 +38,17 @@ main() {
 
   printf '[worktree status]\n'
   printf '  cwd      : %s\n' "$PWD"
-  printf '  branch   : %s\n' "$branch"
+  printf '  branch   : %s\n' "$branch_label"
   if (( in_primary == 1 )); then
-    local slug=${branch//\//-}
-    [[ -z "$slug" || "$slug" == "<detached>" ]] && slug="scratch"
     printf '  status   : PRIMARY CHECKOUT — read-only per AGENTS.md\n'
     # shellcheck disable=SC2016  # backticks are literal markdown-style hint to the agent, not command substitution
     printf '  worktrees: %s active (run `git worktree list` for paths)\n' "$worktree_count"
     printf '\n'
+    # `--detach` always works regardless of where the branch is checked out,
+    # matching the primary-edit guard's remediation and `_lib.sh` convention.
     printf 'Spawn a worktree before editing:\n'
-    printf '  git worktree add .claude/worktrees/%s %s && cd .claude/worktrees/%s\n' \
-      "$slug" "$branch" "$slug"
+    printf '  git worktree add --detach .claude/worktrees/%s && cd .claude/worktrees/%s\n' \
+      "$slug" "$slug"
   else
     printf '  status   : isolated worktree (OK)\n'
     printf '  primary  : %s\n' "$primary_root"

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -29,6 +29,8 @@ cp agent/hooks/_lib.sh \
    agent/hooks/pre-pr-review-gate.sh \
    agent/hooks/edit-write.sh \
    agent/hooks/verify-gh-taxonomy.sh \
+   agent/hooks/worktree-guard.sh \
+   agent/hooks/session-start-cwd-banner.sh \
    "$SANDBOX/agent/hooks/"
 cp agent/_shared/review_sentinel.py "$SANDBOX/agent/_shared/"
 cd "$SANDBOX"
@@ -1039,6 +1041,113 @@ T_taxonomy_check_ci_minimum_joins_with_comma_space() {
   [[ "$result" == "domain-label" ]] || { echo "expected 'domain-label', got: '$result'"; return 1; }
 }
 it "verify-gh-taxonomy: check_ci_minimum joins missing fields with ', ' (comma+space)" T_taxonomy_check_ci_minimum_joins_with_comma_space
+
+# ===========================================================================
+# worktree-guard.sh — primary-checkout detection + mode dispatch
+# ===========================================================================
+#
+# Sandbox is its own primary checkout at $SANDBOX; tests that need a linked
+# worktree do `git worktree add` inside the sandbox (reset_sandbox tears them
+# down between cases). Empty stdin is intentional — the guard ignores
+# tool_input.file_path, so the test harness need not synthesize realistic JSON.
+
+T_worktree_guard_warns_in_primary() {
+  local out stderr_file
+  stderr_file="$TEST_DIR/wg_stderr.txt"
+  out=$(echo '' | bash agent/hooks/worktree-guard.sh 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  grep -q "WARNING" "$stderr_file" || { echo "stderr should contain WARNING; got: $(cat "$stderr_file")"; return 1; }
+  grep -q "git worktree add" "$stderr_file" || { echo "stderr should suggest 'git worktree add'"; return 1; }
+}
+it "worktree-guard: edit in primary (warn mode default) → exit 0 with WARNING + remediation on stderr" T_worktree_guard_warns_in_primary
+
+T_worktree_guard_blocks_in_primary_when_mode_block() {
+  local out stderr_file
+  stderr_file="$TEST_DIR/wg_stderr.txt"
+  out=$(WORKTREE_GUARD_MODE=block bash -c 'echo "" | bash agent/hooks/worktree-guard.sh' 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:2" ]] || { echo "expected EXIT:2, got: $out"; return 1; }
+  grep -q "BLOCKED" "$stderr_file" || { echo "stderr should contain BLOCKED; got: $(cat "$stderr_file")"; return 1; }
+}
+it "worktree-guard: WORKTREE_GUARD_MODE=block in primary → exit 2 with BLOCKED on stderr" T_worktree_guard_blocks_in_primary_when_mode_block
+
+T_worktree_guard_off_mode_silent_in_primary() {
+  local out stderr_file
+  stderr_file="$TEST_DIR/wg_stderr.txt"
+  out=$(WORKTREE_GUARD_MODE=off bash -c 'echo "" | bash agent/hooks/worktree-guard.sh' 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ -z "$(cat "$stderr_file")" ]] || { echo "stderr should be empty in off mode; got: $(cat "$stderr_file")"; return 1; }
+}
+it "worktree-guard: WORKTREE_GUARD_MODE=off → exit 0 with no output (escape hatch)" T_worktree_guard_off_mode_silent_in_primary
+
+T_worktree_guard_silent_in_linked_worktree() {
+  local out stderr_file wt
+  stderr_file="$TEST_DIR/wg_stderr.txt"
+  wt="$TEST_DIR/linked-wt"
+  git worktree add -q -b wg-test-branch "$wt" >/dev/null 2>&1
+  out=$(cd "$wt" && echo '' | bash "$SANDBOX/agent/hooks/worktree-guard.sh" 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ -z "$(cat "$stderr_file")" ]] || { echo "stderr should be empty in linked worktree; got: $(cat "$stderr_file")"; return 1; }
+}
+it "worktree-guard: edit inside a linked worktree → exit 0, no warning" T_worktree_guard_silent_in_linked_worktree
+
+T_worktree_guard_silent_outside_repo() {
+  local out stderr_file scratch
+  stderr_file="$TEST_DIR/wg_stderr.txt"
+  scratch=$(mktemp -d "$TEST_DIR/no-git-XXXX")
+  out=$(cd "$scratch" && echo '' | bash "$SANDBOX/agent/hooks/worktree-guard.sh" 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ -z "$(cat "$stderr_file")" ]] || { echo "stderr should be empty outside any git repo; got: $(cat "$stderr_file")"; return 1; }
+}
+it "worktree-guard: edit outside any git repo → exit 0, no warning" T_worktree_guard_silent_outside_repo
+
+T_worktree_guard_unknown_mode_falls_back_to_warn() {
+  local out stderr_file
+  stderr_file="$TEST_DIR/wg_stderr.txt"
+  out=$(WORKTREE_GUARD_MODE=bogus bash -c 'echo "" | bash agent/hooks/worktree-guard.sh' 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0 even on unknown mode, got: $out"; return 1; }
+  grep -q "ignoring unknown WORKTREE_GUARD_MODE=bogus" "$stderr_file" || {
+    echo "stderr should log the unknown-mode fallback; got: $(cat "$stderr_file")"
+    return 1
+  }
+}
+it "worktree-guard: unknown WORKTREE_GUARD_MODE value logs + exits 0 (never blocks via typo)" T_worktree_guard_unknown_mode_falls_back_to_warn
+
+# ===========================================================================
+# session-start-cwd-banner.sh — banner content per cwd
+# ===========================================================================
+
+T_session_start_banner_in_primary() {
+  local out
+  out=$(bash agent/hooks/session-start-cwd-banner.sh </dev/null 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ "$out" == *"PRIMARY CHECKOUT"* ]] || { echo "banner should flag PRIMARY CHECKOUT; got: $out"; return 1; }
+  [[ "$out" == *"git worktree add"* ]] || { echo "banner should suggest 'git worktree add'; got: $out"; return 1; }
+}
+it "session-start-banner: in primary → stdout flags PRIMARY CHECKOUT and shows remediation" T_session_start_banner_in_primary
+
+T_session_start_banner_in_linked_worktree() {
+  local out wt
+  wt="$TEST_DIR/banner-wt"
+  git worktree add -q -b banner-test-branch "$wt" >/dev/null 2>&1
+  out=$(cd "$wt" && bash "$SANDBOX/agent/hooks/session-start-cwd-banner.sh" </dev/null 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ "$out" == *"isolated worktree"* ]] || { echo "banner should say 'isolated worktree'; got: $out"; return 1; }
+  [[ "$out" != *"PRIMARY CHECKOUT"* ]] || { echo "banner should NOT flag PRIMARY in a linked worktree; got: $out"; return 1; }
+}
+it "session-start-banner: in linked worktree → stdout reports 'isolated worktree (OK)'" T_session_start_banner_in_linked_worktree
+
+T_session_start_banner_silent_outside_repo() {
+  local out scratch
+  scratch=$(mktemp -d "$TEST_DIR/banner-no-git-XXXX")
+  out=$(cd "$scratch" && bash "$SANDBOX/agent/hooks/session-start-cwd-banner.sh" </dev/null 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  local without_exit="${out%EXIT:*}"
+  [[ -z "${without_exit//[[:space:]]/}" ]] || {
+    echo "banner should be silent outside any git repo; got: $without_exit"
+    return 1
+  }
+}
+it "session-start-banner: outside any git repo → silent, exit 0" T_session_start_banner_silent_outside_repo
 
 # ===========================================================================
 # Run

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -1112,6 +1112,57 @@ T_worktree_guard_unknown_mode_falls_back_to_warn() {
 }
 it "worktree-guard: unknown WORKTREE_GUARD_MODE value logs + exits 0 (never blocks via typo)" T_worktree_guard_unknown_mode_falls_back_to_warn
 
+T_worktree_guard_off_and_unknown_drain_large_stdin() {
+  # Regression: before draining-before-dispatch, `off` and unknown-mode
+  # exited without reading stdin, leaving a >64KB-pipe-buffer write blocked
+  # in the harness writer; the read-end close then surfaced as SIGPIPE
+  # (exit 141 with pipefail). Both early-exit paths must drain.
+  #
+  # `head -c N /dev/zero` is a *finite* source: it emits exactly N bytes
+  # then exits 0, so the pipeline only flags SIGPIPE if the *hook* (not an
+  # infinite generator like `yes`) failed to read.
+  local exit_code
+  set +e
+  head -c 131072 /dev/zero | WORKTREE_GUARD_MODE=off bash agent/hooks/worktree-guard.sh >/dev/null 2>&1
+  exit_code=$?
+  set -e
+  [[ "$exit_code" == "0" ]] || { echo "off-mode pipeline exit was $exit_code (likely SIGPIPE in writer)"; return 1; }
+  set +e
+  head -c 131072 /dev/zero | WORKTREE_GUARD_MODE=bogus bash agent/hooks/worktree-guard.sh >/dev/null 2>&1
+  exit_code=$?
+  set -e
+  [[ "$exit_code" == "0" ]] || { echo "unknown-mode pipeline exit was $exit_code (likely SIGPIPE in writer)"; return 1; }
+}
+it "worktree-guard: off + unknown modes drain stdin before exiting (no SIGPIPE risk)" T_worktree_guard_off_and_unknown_drain_large_stdin
+
+T_worktree_guard_detached_head_in_primary() {
+  # Regression: --abbrev-ref HEAD returns the literal "HEAD" when detached,
+  # so the warning + remediation must not show 'HEAD' as a branch name, and
+  # `git worktree add --detach` must not be passed a positional commit-ish
+  # of "HEAD" derived from the bad detection.
+  local out stderr_file
+  stderr_file="$TEST_DIR/wg_stderr.txt"
+  git checkout -q --detach HEAD
+  out=$(echo '' | bash agent/hooks/worktree-guard.sh 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  grep -q "WARNING" "$stderr_file" || { echo "stderr should still WARN in detached primary; got: $(cat "$stderr_file")"; return 1; }
+  grep -q "detached HEAD" "$stderr_file" || {
+    echo "stderr should report detached HEAD, not literal branch name; got: $(cat "$stderr_file")"
+    return 1
+  }
+  # Remediation must use --detach (always works); no branch arg leaked from the bad probe.
+  grep -q "git worktree add --detach" "$stderr_file" || {
+    echo "stderr should recommend 'git worktree add --detach'; got: $(cat "$stderr_file")"
+    return 1
+  }
+  grep -qE "git worktree add .* HEAD$" "$stderr_file" && {
+    echo "stderr should NOT pass 'HEAD' as a branch arg; got: $(cat "$stderr_file")"
+    return 1
+  }
+  return 0
+}
+it "worktree-guard: detached HEAD in primary → 'detached HEAD' in message, '--detach' remediation, no 'HEAD' branch arg" T_worktree_guard_detached_head_in_primary
+
 # ===========================================================================
 # session-start-cwd-banner.sh — banner content per cwd
 # ===========================================================================
@@ -1148,6 +1199,31 @@ T_session_start_banner_silent_outside_repo() {
   }
 }
 it "session-start-banner: outside any git repo → silent, exit 0" T_session_start_banner_silent_outside_repo
+
+T_session_start_banner_detached_head_in_primary() {
+  # Regression: --abbrev-ref HEAD returns literal "HEAD" when detached, so the
+  # banner used to render `branch: HEAD` (misleading) and bake `HEAD` into the
+  # remediation. Switch to --show-current + a labeled fallback.
+  local out
+  git checkout -q --detach HEAD
+  out=$(bash agent/hooks/session-start-cwd-banner.sh </dev/null 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ "$out" == *"PRIMARY CHECKOUT"* ]] || { echo "detached primary should still flag PRIMARY CHECKOUT; got: $out"; return 1; }
+  [[ "$out" == *"detached HEAD"* ]] || {
+    echo "banner should label detached HEAD instead of printing 'branch: HEAD'; got: $out"
+    return 1
+  }
+  [[ "$out" != *"branch   : HEAD"* ]] || {
+    echo "banner should NOT show 'branch: HEAD' for detached HEAD; got: $out"
+    return 1
+  }
+  # Remediation must use --detach and must not pass HEAD as a branch arg.
+  [[ "$out" == *"git worktree add --detach"* ]] || {
+    echo "banner should recommend 'git worktree add --detach'; got: $out"
+    return 1
+  }
+}
+it "session-start-banner: detached HEAD in primary → 'detached HEAD' label, '--detach' remediation, no 'branch: HEAD'" T_session_start_banner_detached_head_in_primary
 
 # ===========================================================================
 # Run

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -1163,6 +1163,30 @@ T_worktree_guard_detached_head_in_primary() {
 }
 it "worktree-guard: detached HEAD in primary → 'detached HEAD' in message, '--detach' remediation, no 'HEAD' branch arg" T_worktree_guard_detached_head_in_primary
 
+T_worktree_guard_remediation_path_is_absolute_from_subdir() {
+  # Regression: original remediation used relative `.claude/worktrees/<slug>`, so
+  # running from `<primary>/src/foo/` produced `git worktree add --detach
+  # .claude/worktrees/<slug>` — which `cd`'d the agent into a path that didn't
+  # exist (subdir-relative). Remediation must anchor at $primary_root.
+  local out stderr_file subdir
+  stderr_file="$TEST_DIR/wg_stderr.txt"
+  subdir="$SANDBOX/src/nested"
+  mkdir -p "$subdir"
+  out=$(cd "$subdir" && echo '' | bash "$SANDBOX/agent/hooks/worktree-guard.sh" 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  grep -q "WARNING" "$stderr_file" || { echo "subdir cwd should still WARN; got: $(cat "$stderr_file")"; return 1; }
+  grep -qE "git worktree add --detach ${SANDBOX}/\\.claude/worktrees/" "$stderr_file" || {
+    echo "remediation must anchor at \$primary_root (${SANDBOX}); got: $(cat "$stderr_file")"
+    return 1
+  }
+  grep -qE "git worktree add --detach \\.claude/worktrees/" "$stderr_file" && {
+    echo "remediation must NOT use a bare relative path; got: $(cat "$stderr_file")"
+    return 1
+  }
+  return 0
+}
+it "worktree-guard: remediation path anchored to primary_root (works from any subdir)" T_worktree_guard_remediation_path_is_absolute_from_subdir
+
 # ===========================================================================
 # session-start-cwd-banner.sh — banner content per cwd
 # ===========================================================================
@@ -1224,6 +1248,25 @@ T_session_start_banner_detached_head_in_primary() {
   }
 }
 it "session-start-banner: detached HEAD in primary → 'detached HEAD' label, '--detach' remediation, no 'branch: HEAD'" T_session_start_banner_detached_head_in_primary
+
+T_session_start_banner_remediation_path_is_absolute_from_subdir() {
+  # Same regression as worktree-guard's subdir-anchored-path test:
+  # the SessionStart hook's PWD is whatever the operator launched `claude`
+  # from. If it's a subdir of primary, a bare relative `.claude/worktrees/...`
+  # in the remediation `cd`'s into a path that doesn't exist.
+  local out subdir
+  subdir="$SANDBOX/src/nested-banner"
+  mkdir -p "$subdir"
+  out=$(cd "$subdir" && bash "$SANDBOX/agent/hooks/session-start-cwd-banner.sh" </dev/null 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ "$out" == *"PRIMARY CHECKOUT"* ]] || { echo "subdir cwd should still flag PRIMARY; got: $out"; return 1; }
+  echo "$out" | grep -qE "git worktree add --detach ${SANDBOX}/\\.claude/worktrees/" || {
+    echo "remediation must anchor at \$primary_root (${SANDBOX}); got: $out"
+    return 1
+  }
+  return 0
+}
+it "session-start-banner: remediation path anchored to primary_root (works from any subdir)" T_session_start_banner_remediation_path_is_absolute_from_subdir
 
 # ===========================================================================
 # Run

--- a/agent/hooks/worktree-guard.sh
+++ b/agent/hooks/worktree-guard.sh
@@ -61,7 +61,9 @@ main() {
     slug="detached-${short_sha:-scratch}"
   fi
 
-  command -v log >/dev/null 2>&1 && log "primary-checkout edit detected (mode=${mode}, branch=${branch_label})"
+  # `declare -F`, not `command -v`: `/usr/bin/log` exists on macOS, so `command -v log`
+  # would succeed and invoke that external command under set -e instead of the shell function.
+  declare -F log >/dev/null 2>&1 && log "primary-checkout edit detected (mode=${mode}, branch=${branch_label})"
 
   local prefix override_hint
   if [[ "$mode" == "block" ]]; then
@@ -82,8 +84,8 @@ AGENTS.md "Always" rule: the primary checkout is read-only; switch to an
 isolated worktree before editing.
 
 Recommended (current HEAD: ${branch_label}):
-  git worktree add --detach .claude/worktrees/${slug}
-  cd .claude/worktrees/${slug}
+  git worktree add --detach ${primary_root}/.claude/worktrees/${slug}
+  cd ${primary_root}/.claude/worktrees/${slug}
 
 ${override_hint}
 EOF

--- a/agent/hooks/worktree-guard.sh
+++ b/agent/hooks/worktree-guard.sh
@@ -21,6 +21,10 @@ readonly SCRIPT_DIR
 }
 
 main() {
+  # Drain stdin so the calling tool harness doesn't see SIGPIPE if it pipes
+  # JSON. Done before mode dispatch so off/unknown-mode early exits drain too.
+  cat >/dev/null 2>&1 || true
+
   local mode="${WORKTREE_GUARD_MODE:-warn}"
   case "$mode" in
     off) exit 0 ;;
@@ -30,9 +34,6 @@ main() {
       exit 0
       ;;
   esac
-
-  # Drain stdin so the calling tool harness doesn't see SIGPIPE if it pipes JSON.
-  cat >/dev/null 2>&1 || true
 
   local git_dir common_dir
   git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
@@ -45,13 +46,22 @@ main() {
 
   [[ "$abs_git_dir" == "$abs_common_dir" ]] || exit 0
 
-  local primary_root branch slug
+  # `git branch --show-current` returns empty for detached HEAD (Git 2.22+);
+  # --abbrev-ref returns the literal string "HEAD", which made the original
+  # `|| echo "<detached>"` fallback unreachable and leaked "HEAD" into both
+  # the message and the remediation command.
+  local primary_root branch_label slug short_sha
   primary_root=$(dirname "$abs_common_dir")
-  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "<detached>")
-  slug=${branch//\//-}
-  [[ -z "$slug" || "$slug" == "<detached>" ]] && slug="scratch"
+  branch_label=$(git branch --show-current 2>/dev/null || true)
+  if [[ -n "$branch_label" ]]; then
+    slug=${branch_label//\//-}
+  else
+    short_sha=$(git rev-parse --short HEAD 2>/dev/null || true)
+    branch_label="(detached HEAD${short_sha:+ ${short_sha}})"
+    slug="detached-${short_sha:-scratch}"
+  fi
 
-  command -v log >/dev/null 2>&1 && log "primary-checkout edit detected (mode=${mode}, branch=${branch})"
+  command -v log >/dev/null 2>&1 && log "primary-checkout edit detected (mode=${mode}, branch=${branch_label})"
 
   local prefix override_hint
   if [[ "$mode" == "block" ]]; then
@@ -62,13 +72,17 @@ main() {
     override_hint="Override: WORKTREE_GUARD_MODE=off (one-off edits) or =block (fail-fast)."
   fi
 
+  # `--detach` keeps the branch checkout intact here and creates a worktree
+  # pinned to the current HEAD commit; agent commits there and later pushes
+  # via `git push origin HEAD:<branch>`. Plain `git worktree add path branch`
+  # would fail since the branch is already checked out in this primary.
   cat >&2 <<EOF
 ${prefix}: editing inside the primary checkout (${primary_root}).
 AGENTS.md "Always" rule: the primary checkout is read-only; switch to an
 isolated worktree before editing.
 
-Recommended for branch '${branch}':
-  git worktree add .claude/worktrees/${slug} ${branch}
+Recommended (current HEAD: ${branch_label}):
+  git worktree add --detach .claude/worktrees/${slug}
   cd .claude/worktrees/${slug}
 
 ${override_hint}

--- a/agent/hooks/worktree-guard.sh
+++ b/agent/hooks/worktree-guard.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# worktree-guard.sh — PreToolUse advisory for AGENTS.md's "Always work in an
+# isolated git worktree" rule. Compares git's per-worktree git dir against the
+# common git dir; equality means the current cwd is the primary checkout.
+#
+# Modes (WORKTREE_GUARD_MODE):
+#   warn   default — loud stderr, exit 0 (never blocks)
+#   block  exit 2 with the same message
+#   off    no-op
+set -euo pipefail
+
+# shellcheck disable=SC2034  # read by log() in _lib.sh via ${HOOK_NAME:-unknown}
+readonly HOOK_NAME="worktree-guard"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+readonly SCRIPT_DIR
+
+[[ -f "${SCRIPT_DIR}/_lib.sh" ]] && {
+  # shellcheck source=agent/hooks/_lib.sh
+  # shellcheck disable=SC1091
+  source "${SCRIPT_DIR}/_lib.sh"
+}
+
+main() {
+  local mode="${WORKTREE_GUARD_MODE:-warn}"
+  case "$mode" in
+    off) exit 0 ;;
+    warn|block) ;;
+    *)
+      printf 'worktree-guard: ignoring unknown WORKTREE_GUARD_MODE=%s (use warn|block|off)\n' "$mode" >&2
+      exit 0
+      ;;
+  esac
+
+  # Drain stdin so the calling tool harness doesn't see SIGPIPE if it pipes JSON.
+  cat >/dev/null 2>&1 || true
+
+  local git_dir common_dir
+  git_dir=$(git rev-parse --git-dir 2>/dev/null) || exit 0
+  common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || exit 0
+
+  # Primary's --git-dir is relative (`.git`); linked worktrees' is absolute. Normalize before comparing.
+  local abs_git_dir abs_common_dir
+  abs_git_dir=$(cd "$git_dir" 2>/dev/null && pwd) || exit 0
+  abs_common_dir=$(cd "$common_dir" 2>/dev/null && pwd) || exit 0
+
+  [[ "$abs_git_dir" == "$abs_common_dir" ]] || exit 0
+
+  local primary_root branch slug
+  primary_root=$(dirname "$abs_common_dir")
+  branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "<detached>")
+  slug=${branch//\//-}
+  [[ -z "$slug" || "$slug" == "<detached>" ]] && slug="scratch"
+
+  command -v log >/dev/null 2>&1 && log "primary-checkout edit detected (mode=${mode}, branch=${branch})"
+
+  local prefix override_hint
+  if [[ "$mode" == "block" ]]; then
+    prefix="BLOCKED"
+    override_hint="Override: WORKTREE_GUARD_MODE=off (one-off edits) or =warn (advisory only)."
+  else
+    prefix="WARNING"
+    override_hint="Override: WORKTREE_GUARD_MODE=off (one-off edits) or =block (fail-fast)."
+  fi
+
+  cat >&2 <<EOF
+${prefix}: editing inside the primary checkout (${primary_root}).
+AGENTS.md "Always" rule: the primary checkout is read-only; switch to an
+isolated worktree before editing.
+
+Recommended for branch '${branch}':
+  git worktree add .claude/worktrees/${slug} ${branch}
+  cd .claude/worktrees/${slug}
+
+${override_hint}
+EOF
+
+  [[ "$mode" == "block" ]] && exit 2
+  exit 0
+}
+
+main "$@"

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -164,6 +164,8 @@ _EXPECTED_SHARED_HOOK_COMMANDS: tuple[tuple[str, str], ...] = (
     ("No-yaml-run-comments", "bash agent/hooks/no-yaml-run-comments.sh"),
     ("PR review resolver", "bash agent/hooks/pr-review-resolver.sh"),
     ("Taxonomy verification", "bash agent/hooks/verify-gh-taxonomy.sh"),
+    ("Worktree guard", "bash agent/hooks/worktree-guard.sh"),
+    ("Worktree-status banner", "bash agent/hooks/session-start-cwd-banner.sh"),
 )
 
 

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -26,7 +26,11 @@ def _load_settings() -> dict[str, Any]:
 
 
 def _matcher_entries() -> list[dict[str, Any]]:
-    """Return every PreToolUse/PostToolUse matcher-entry in source order.
+    """Return every matcher-entry across all hook events in source order.
+
+    Iterates every value of the top-level ``hooks`` map — currently
+    ``SessionStart``, ``PreToolUse``, and ``PostToolUse`` — so any new hook
+    event added under ``hooks`` is picked up automatically.
 
     :returns: Flat list of matcher-entry objects.
     """


### PR DESCRIPTION
## Summary

- Adds `agent/hooks/worktree-guard.sh` — `PreToolUse Edit|Write` hook that warns (`WORKTREE_GUARD_MODE=warn` default), blocks (`=block`), or no-ops (`=off`) when the agent edits inside the primary checkout. Detects primary via `git rev-parse --git-dir` vs `--git-common-dir`.
- Adds `agent/hooks/session-start-cwd-banner.sh` — `SessionStart` hook (matchers `startup|resume|clear|compact`) that prints cwd, branch, primary-vs-worktree verdict, worktree count, and the exact `git worktree add` command when in primary.
- Wires both into `.claude/settings.json` alongside the existing PreToolUse gates. 9 new tests in `agent/hooks/test.sh` (62 PASS / 0 FAIL).

Closes #1222

## Why this is needed

The "always work in an isolated git worktree" rule lives in `AGENTS.md`, not `CLAUDE.md`. `CLAUDE.md` is auto-loaded into the system reminder on every turn; `AGENTS.md` is only referenced. Agents that don't proactively read `AGENTS.md` never see the rule and default to editing wherever cwd points — which is the primary checkout. This change surfaces the rule at the two moments it matters: when a session resumes (banner) and before each `Edit|Write` (guard).

## Pre-PR review

`/repo-review-full-no-comments` fan-out (`code-health`, `synth-setter-project-standards`, `shell-style`, `comment-hygiene`) returned **0 BLOCK, 28 WARN**. 7 high-leverage WARNs were fixed by amending the commit before push (dead `HOOK_NAME` in banner, slug inconsistency between the two hooks, mode-suggestion asymmetry in the heredoc, comment trimming, duplicate rationale in `.claude/settings.json` description). The remaining 11 WARNs are documented as intentional defers in the sentinel review file at `.agent-reviews/repo-review-full-no-comments.cb85d1a*.md` — they are mostly cosmetic (`awk` → `grep`, `[[ -z $(cat) ]]` → `[[ ! -s ]]`, mktemp X-padding) or rule-of-three deferrals (extract duplicated probe into `_lib.sh` when the third caller lands).

## Test plan

- [x] `bash agent/hooks/test.sh` → 62 PASS / 0 FAIL
- [x] `pre-commit run --files <changed>` → all checks pass (shellcheck, codespell, prettier, mdformat)
- [x] `python3 -m pytest tests/claude_hooks/` → 112 PASS (Python-side settings.json schema validation)
- [x] Live-fired `worktree-guard.sh` in primary (warn + block + off + linked-worktree-silent)
- [x] Live-fired `session-start-cwd-banner.sh` in primary (shows `PRIMARY CHECKOUT` + remediation) and in a linked worktree (`isolated worktree (OK)`)
- [ ] Settings.json hook entries take effect — verified by next session start (post-merge, the next `claude` session in this repo will fire the banner and the guard).

## Out of scope (deferred follow-ups)

- Stale-worktree sweep for `agent-a*` paths (>40 in `git worktree list`) — left as manual operation; needs more analysis around in-flight sub-agent races.
- Moving the AGENTS.md "Always" rule into `CLAUDE.md` so it lands in the system reminder — separate decision; the hooks make this less urgent.
- Extract the primary-detection probe into `_lib.sh::describe_worktree` — wait for the third caller.