### PR TITLE
chore(claude-md): add unprefixed QRSPI slash-command aliases

### DIFF
--- a/.claude/commands/qrspi-design.md
+++ b/.claude/commands/qrspi-design.md
@@ -1,0 +1,8 @@
+---
+description: QRSPI D — produce a ~200-line design doc; this is where opinions are invited
+argument-hint: <R-doc-path> <ticket-path>
+---
+
+Invoke the `tinaudio-synth-setter-skills:qrspi-design` skill via the Skill
+tool, passing `$ARGUMENTS` through unchanged. That skill carries the canonical
+QRSPI D implementation; this file is a short-name alias.

--- a/.claude/commands/qrspi-implement.md
+++ b/.claude/commands/qrspi-implement.md
@@ -1,6 +1,6 @@
 ---
-description: QRSPI I — implement phases of a P doc autonomously; delegates to implement_plan + tdd-implementation + code-health
-argument-hint: <P-doc-path> <phase-id> [--flag]
+description: QRSPI I — autonomously implement P-doc phases via implement_plan + tdd + code-health
+argument-hint: <P-doc-path> <phase-id> [--pause]
 ---
 
 Invoke the `tinaudio-synth-setter-skills:qrspi-implement` skill via the Skill

--- a/.claude/commands/qrspi-implement.md
+++ b/.claude/commands/qrspi-implement.md
@@ -1,0 +1,8 @@
+---
+description: QRSPI I — implement phases of a P doc autonomously; delegates to implement_plan + tdd-implementation + code-health
+argument-hint: <P-doc-path> <phase-id> [--flag]
+---
+
+Invoke the `tinaudio-synth-setter-skills:qrspi-implement` skill via the Skill
+tool, passing `$ARGUMENTS` through unchanged. That skill carries the canonical
+QRSPI I implementation; this file is a short-name alias.

--- a/.claude/commands/qrspi-plan.md
+++ b/.claude/commands/qrspi-plan.md
@@ -1,0 +1,8 @@
+---
+description: QRSPI P — write the tactical implementation plan; do not re-open design decisions
+argument-hint: <path-to-S-doc>
+---
+
+Invoke the `tinaudio-synth-setter-skills:qrspi-plan` skill via the Skill
+tool, passing `$ARGUMENTS` through unchanged. That skill carries the canonical
+QRSPI P implementation; this file is a short-name alias.

--- a/.claude/commands/qrspi-pr.md
+++ b/.claude/commands/qrspi-pr.md
@@ -1,0 +1,9 @@
+---
+description: QRSPI PR — open the PR, drive CI green, and resolve every inline comment
+argument-hint: [pr-number]
+---
+
+Invoke the `tinaudio-synth-setter-skills:qrspi-pr` skill via the Skill tool,
+passing `$ARGUMENTS` through unchanged (empty is fine — the skill autodetects
+the PR from the current branch). That skill carries the canonical QRSPI PR
+implementation; this file is a short-name alias.

--- a/.claude/commands/qrspi-questions.md
+++ b/.claude/commands/qrspi-questions.md
@@ -1,0 +1,8 @@
+---
+description: QRSPI Q — turn a ticket into factual questions about the existing codebase
+argument-hint: <ticket-path | ticket-url | inline-ticket-text>
+---
+
+Invoke the `tinaudio-synth-setter-skills:qrspi-questions` skill via the Skill
+tool, passing `$ARGUMENTS` through unchanged. That skill carries the canonical
+QRSPI Q implementation; this file is a short-name alias.

--- a/.claude/commands/qrspi-research.md
+++ b/.claude/commands/qrspi-research.md
@@ -1,0 +1,8 @@
+---
+description: QRSPI R — document the codebase ticket-blind, answering only the Q-stage questions
+argument-hint: <path-to-Q-output-file>
+---
+
+Invoke the `tinaudio-synth-setter-skills:qrspi-research` skill via the Skill
+tool, passing `$ARGUMENTS` through unchanged. That skill carries the canonical
+QRSPI R implementation; this file is a short-name alias.

--- a/.claude/commands/qrspi-structure.md
+++ b/.claude/commands/qrspi-structure.md
@@ -1,0 +1,8 @@
+---
+description: QRSPI S — vertical-slice implementation outline (header-file style)
+argument-hint: <path-to-D-doc>
+---
+
+Invoke the `tinaudio-synth-setter-skills:qrspi-structure` skill via the Skill
+tool, passing `$ARGUMENTS` through unchanged. That skill carries the canonical
+QRSPI S implementation; this file is a short-name alias.

--- a/.claude/commands/qrspi-worktree.md
+++ b/.claude/commands/qrspi-worktree.md
@@ -1,0 +1,8 @@
+---
+description: QRSPI W — delegate to wave-orchestration for branch/worktree assignment from a P doc
+argument-hint: <path-to-P-doc>
+---
+
+Invoke the `tinaudio-synth-setter-skills:qrspi-worktree` skill via the Skill
+tool, passing `$ARGUMENTS` through unchanged. That skill carries the canonical
+QRSPI W implementation; this file is a short-name alias.


### PR DESCRIPTION
## Summary

- Add 8 shim files under `.claude/commands/qrspi-*.md` so users can invoke
the QRSPI workflow with short names — `/qrspi-research`, `/qrspi-questions`,
`/qrspi-design`, `/qrspi-structure`, `/qrspi-plan`, `/qrspi-implement`,
`/qrspi-pr`, `/qrspi-worktree` — instead of the plugin-namespaced
`/tinaudio-synth-setter-skills:qrspi-*`.
- Each shim is ~8 lines: frontmatter (`description` + `argument-hint`) plus a
one-sentence delegation to the namespaced skill via the Skill tool. No
SHA-pinned plugin paths, so plugin updates flow through automatically.
Canonical implementation continues to live in the installed
`tinaudio-synth-setter-skills` plugin.
- Mirrors the existing `repo-review` shim pattern from #1085. Files are
force-added because `.claude/` is gitignored — same convention as the
repo-review shims and `.claude/commands/lint-cleanup.md`.

## Test plan

- [ ] In a fresh Claude Code session, confirm all 8 short names appear in
  the skill picker alongside the namespaced versions.
- [ ] Invoke `/qrspi-research <q-file>` and confirm it executes the QRSPI R
  workflow identically to `/tinaudio-synth-setter-skills:qrspi-research`.

## Review

Multi-skill dry-run review (code-health, synth-setter-project-standards)
clean at HEAD \`6419be0\`: 0 BLOCK, 0 WARN. Two WARNs from the initial pass
at \`ed9bef8\` on \`qrspi-implement.md\` (description length, \`[--flag]\`
placeholder) addressed by the fixup commit.

Refs #1221