### PR TITLE
test(data-pipeline): add cfg_dataset fixtures + repo-root generate_dataset parity test

### DIFF
--- a/.pydoclint-baseline.txt
+++ b/.pydoclint-baseline.txt
@@ -674,27 +674,16 @@ tests/_baseline_worktree.py
 tests/conftest.py
     DOC101: Function `_validate_surge_dataset`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `_validate_surge_dataset`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [num_samples: int, path: Path].
-    DOC203: Function `cfg_train_global` return type(s) in docstring not consistent with the return annotation. Return annotation types: ['DictConfig']; docstring return section types: ['']
-    DOC203: Function `cfg_eval_global` return type(s) in docstring not consistent with the return annotation. Return annotation types: ['DictConfig']; docstring return section types: ['']
-    DOC203: Function `cfg_train` return type(s) in docstring not consistent with the return annotation. Return annotation types: ['DictConfig']; docstring return section types: ['']
     DOC402: Function `cfg_train` has "yield" statements, but the docstring does not have a "Yields" section
     DOC404: Function `cfg_train` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC203: Function `cfg_eval` return type(s) in docstring not consistent with the return annotation. Return annotation types: ['DictConfig']; docstring return section types: ['']
     DOC402: Function `cfg_eval` has "yield" statements, but the docstring does not have a "Yields" section
     DOC404: Function `cfg_eval` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
-    DOC203: Function `accelerator` return type(s) in docstring not consistent with the return annotation. Return annotation types: ['str']; docstring return section types: ['']
-    DOC203: Function `param_spec_name` return type(s) in docstring not consistent with the return annotation. Return annotation types: ['str']; docstring return section types: ['']
-    DOC203: Function `_build_surge_xt_smoke_cfg` return type(s) in docstring not consistent with the return annotation. Return annotation types: ['DictConfig']; docstring return section types: ['']
-    DOC203: Function `cfg_surge_xt_global` return type(s) in docstring not consistent with the return annotation. Return annotation types: ['DictConfig']; docstring return section types: ['']
-    DOC203: Function `surge_xt_smoke_datasets` return type(s) in docstring not consistent with the return annotation. Return annotation types: ['Path']; docstring return section types: ['']
     DOC101: Function `cfg_surge_xt`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `cfg_surge_xt`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [surge_xt_smoke_datasets: Path].
-    DOC203: Function `cfg_surge_xt` return type(s) in docstring not consistent with the return annotation. Return annotation types: ['DictConfig']; docstring return section types: ['']
     DOC402: Function `cfg_surge_xt` has "yield" statements, but the docstring does not have a "Yields" section
     DOC404: Function `cfg_surge_xt` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
     DOC101: Function `cfg_surge_xt_eval`: Docstring contains fewer arguments than in function signature.
     DOC103: Function `cfg_surge_xt_eval`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [surge_xt_smoke_datasets: Path].
-    DOC203: Function `cfg_surge_xt_eval` return type(s) in docstring not consistent with the return annotation. Return annotation types: ['DictConfig']; docstring return section types: ['']
     DOC402: Function `cfg_surge_xt_eval` has "yield" statements, but the docstring does not have a "Yields" section
     DOC404: Function `cfg_surge_xt_eval` yield type(s) in docstring not consistent with the return annotation. Return annotation exists, but docstring "yields" section does not exist or has 0 type(s).
     DOC101: Function `pytest_addoption`: Docstring contains fewer arguments than in function signature.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 import sys
+from collections.abc import Iterator
 from pathlib import Path
 
 import h5py
@@ -234,6 +235,49 @@ def cfg_eval(cfg_eval_global: DictConfig, tmp_path: Path) -> DictConfig:
 
     with open_dict(cfg):
         cfg.paths.output_dir = str(tmp_path)
+        cfg.paths.log_dir = str(tmp_path)
+
+    yield cfg
+
+    GlobalHydra.instance().clear()
+
+
+@pytest.fixture(scope="package")
+def cfg_dataset_global() -> DictConfig:
+    """Build a default Hydra DictConfig for ``generate_dataset``.
+
+    Omits ``return_hydra_config=True`` so the ``hydra.*`` sub-tree (whose
+    ``sweep.subdir`` interpolates the runtime-only ``${hydra.job.num}``) does
+    not leak in and break ``spec_from_cfg``'s ``resolve=True`` round-trip.
+
+    :return: A DictConfig composed from ``configs/dataset.yaml`` with
+        ``experiment=generate_dataset/smoke-shard`` so every required (``???``)
+        field is populated.
+    """
+    with initialize(version_base="1.3", config_path="../configs"):
+        cfg = compose(
+            config_name="dataset",
+            overrides=["experiment=generate_dataset/smoke-shard"],
+        )
+        with open_dict(cfg):
+            cfg.paths.root_dir = str(rootutils.find_root(indicator=".project-root"))
+    return cfg
+
+
+@pytest.fixture(scope="function")
+def cfg_dataset(cfg_dataset_global: DictConfig, tmp_path: Path) -> Iterator[DictConfig]:
+    """Build on top of ``cfg_dataset_global()`` and redirect paths into ``tmp_path``.
+
+    :param cfg_dataset_global: The package-scoped dataset DictConfig to copy.
+    :param tmp_path: The per-test temporary path used as output/work/log root.
+
+    :yields DictConfig: ``paths.{output_dir,work_dir,log_dir}`` pinned to
+        ``tmp_path``; teardown clears Hydra's global singleton.
+    """
+    cfg = cfg_dataset_global.copy()
+    with open_dict(cfg):
+        cfg.paths.output_dir = str(tmp_path)
+        cfg.paths.work_dir = str(tmp_path)
         cfg.paths.log_dir = str(tmp_path)
 
     yield cfg

--- a/tests/test_generate_dataset_shards.py
+++ b/tests/test_generate_dataset_shards.py
@@ -1,0 +1,27 @@
+"""Repo-root entrypoint tests for ``synth_setter.cli.generate_dataset``.
+
+Mirrors the shape of ``tests/test_train.py`` and ``tests/test_eval.py``: package-
+scoped Hydra fixture + function-scoped wrapper + direct call into the
+``@hydra.main``-decorated entry.
+"""
+
+from __future__ import annotations
+
+from omegaconf import DictConfig
+
+from synth_setter.cli.generate_dataset import spec_from_cfg
+from synth_setter.pipeline.schemas.spec import DatasetSpec
+
+
+def test_cfg_dataset_composes_and_validates_as_dataset_spec(
+    cfg_dataset: DictConfig,
+) -> None:
+    """The new fixture composes ``dataset.yaml`` and round-trips through ``DatasetSpec``.
+
+    :param cfg_dataset: Function-scoped fixture composing ``dataset.yaml`` with the
+        ``generate_dataset/smoke-shard`` experiment and ``tmp_path``-pinned paths.
+    """
+    spec = spec_from_cfg(cfg_dataset)
+    assert isinstance(spec, DatasetSpec)
+    assert spec.num_shards >= 1
+    assert spec.render.samples_per_shard >= 1

--- a/tests/test_generate_dataset_shards.py
+++ b/tests/test_generate_dataset_shards.py
@@ -1,9 +1,4 @@
-"""Repo-root entrypoint tests for ``synth_setter.cli.generate_dataset``.
-
-Mirrors the shape of ``tests/test_train.py`` and ``tests/test_eval.py``: package-
-scoped Hydra fixture + function-scoped wrapper + direct call into the
-``@hydra.main``-decorated entry.
-"""
+"""Tests for the ``synth-setter-generate-dataset`` CLI entrypoint."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

- Adds `cfg_dataset_global` (package scope) + `cfg_dataset` (function scope) fixtures to `tests/conftest.py`, mirroring the `cfg_train_global`/`cfg_train` pair.
- New `tests/test_generate_dataset_shards.py` with a single CPU parity test that composes `configs/dataset.yaml` via the `generate_dataset/smoke-shard` experiment and asserts round-trip through `DatasetSpec`.
- Phase 1 of the QRSPI plan at `thoughts/shared/plans/2026-05-20-test-generate-dataset-conftest-parity.md`; Phase 2 will add a VST-gated e2e test to the same file.

## Test plan

- [ ] `pytest tests/test_generate_dataset_shards.py::test_cfg_dataset_composes_and_validates_as_dataset_spec -x`
- [ ] `pytest tests/ -x -k "not slow and not requires_vst" --co -q | grep test_generate_dataset_shards`
- [ ] `pre-commit run --files tests/conftest.py tests/test_generate_dataset_shards.py`

Closes #1228
