### PR TITLE
test(testing): add duck-typed FakeVST3Plugin for VST-free e2e shard renders

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ markers = [
   "pipeline: pipeline integration tests",
   "benchmark: performance benchmarks",
   "requires_vst: requires a VST plugin binary (Surge XT) — skipped unless plugin is present",
+  "fake_vst: end-to-end tests that swap a duck-typed FakeVST3Plugin in place of a real VST",
   "r2: tests requiring R2/rclone access",
   "integration_r2: end-to-end launcher→R2 integration tests (auto-skipped without R2 creds; run in their own GHA workflow)",
   "docker_smoke: smoke tests that run inside the built Docker image",

--- a/tests/data/vst/_fake_plugin.py
+++ b/tests/data/vst/_fake_plugin.py
@@ -2,7 +2,7 @@
 
 import threading
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 
 import numpy as np
@@ -66,7 +66,7 @@ class FakeVST3Plugin:
 
     def process(
         self,
-        midi_events: Iterable[tuple[bytes, float]],
+        midi_events: Iterable[tuple[Sequence[int], float]],
         duration_seconds: float,
         sample_rate: float,
         channels: int,
@@ -75,24 +75,27 @@ class FakeVST3Plugin:
     ) -> np.ndarray:
         """Render deterministic audio matching the real plugin's output contract.
 
-        Empty ``midi_events`` (the production flush calls) yield silence; any
-        ``note_on`` yields a sine at the note's frequency, scaled by velocity.
+        Empty ``midi_events`` (the production flush calls) yield a zero-length
+        buffer because ``core.render_params`` discards the flush return value;
+        any ``note_on`` yields a sine at the note's frequency, scaled by velocity.
 
-        :param midi_events: Iterable of ``(payload_bytes, time_seconds)``; only
-            the first ``note_on`` is honoured.
+        :param midi_events: Iterable of ``(payload, time_seconds)`` where ``payload``
+            matches ``mido.Message.bytes()`` (a ``Sequence[int]``); only the first
+            ``note_on`` is honoured.
         :param duration_seconds: Output length; ``num_samples = duration * sample_rate``.
         :param sample_rate: Output sample rate in Hz.
         :param channels: Channel count of the returned ndarray (axis 0).
         :param block_size: Accepted to match the real plugin's signature; unused.
         :param tail: Accepted to match the real plugin's signature; unused.
-        :returns: ``np.ndarray`` of shape ``(channels, num_samples)``, float32,
-            with peak in ``[0, 1]`` and identical contents across repeated calls
-            for the same inputs.
+        :returns: ``np.ndarray`` of shape ``(channels, num_samples)`` for note-on
+            renders or ``(channels, 0)`` for flush calls, float32, with peak in
+            ``[0, 1]`` and identical contents across repeated calls for the same
+            inputs.
         """
-        num_samples = int(duration_seconds * sample_rate)
         note = _first_note_on(midi_events)
         if note is None:
-            return np.zeros((channels, num_samples), dtype=np.float32)
+            return np.zeros((channels, 0), dtype=np.float32)
+        num_samples = int(duration_seconds * sample_rate)
 
         pitch, velocity = note
         freq = _A4_FREQUENCY_HZ * 2.0 ** ((pitch - _A4_MIDI_NOTE) / _SEMITONES_PER_OCTAVE)
@@ -102,14 +105,16 @@ class FakeVST3Plugin:
         return np.broadcast_to(wave, (channels, num_samples)).copy()
 
 
-def _first_note_on(midi_events: Iterable[tuple[bytes, float]]) -> tuple[int, int] | None:
+def _first_note_on(
+    midi_events: Iterable[tuple[Sequence[int], float]],
+) -> tuple[int, int] | None:
     """Return ``(pitch, velocity)`` of the first ``note_on`` event, or ``None``.
 
     A ``note_on`` with velocity 0 is the MIDI idiom for ``note_off``; it does
     not count as a sounding event here.
 
-    :param midi_events: Iterable of ``(payload_bytes, time_seconds)`` per the
-        ``make_midi_events`` shape used by the production pipeline.
+    :param midi_events: Iterable of ``(payload, time_seconds)`` matching the
+        ``mido.Message.bytes()`` shape used by the production pipeline.
     :returns: ``(pitch, velocity)`` of the first true note-on event, or
         ``None`` if no sounding event is present.
     """

--- a/tests/data/vst/_fake_plugin.py
+++ b/tests/data/vst/_fake_plugin.py
@@ -1,0 +1,120 @@
+"""Duck-typed VST3 plugin test double used in place of a real ``.vst3``."""
+
+import threading
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import numpy as np
+
+_MIDI_STATUS_MASK = 0xF0
+_MIDI_NOTE_ON_STATUS = 0x90
+_MIDI_MAX_VELOCITY = 127.0
+_A4_MIDI_NOTE = 69
+_A4_FREQUENCY_HZ = 440.0
+_SEMITONES_PER_OCTAVE = 12.0
+_DEFAULT_AMPLITUDE_SCALE = 0.5  # peak floor at velocity 127; keeps output within [-1, 1]
+
+
+@dataclass
+class _FakeParameter:
+    raw_value: float = 0.0
+
+
+class FakeVST3Plugin:
+    """Stand-in for ``pedalboard.VST3Plugin`` that needs no ``.vst3`` and no X11.
+
+    Mirrors the surface ``synth_setter.data.vst.core`` calls (``version``,
+    ``parameters[k].raw_value``, ``show_editor``, ``load_preset``, ``reset``,
+    ``process``). ``process`` emits a deterministic sine for any ``note_on``
+    event and silence otherwise — enough to clear the loudness gate so the
+    dataset pipeline writes a complete shard. ``block_size`` and ``tail`` are
+    accepted to match the real plugin's signature but do not affect output.
+
+    .. attribute :: version
+
+       Fixed string the test-double reports for ``pedalboard.VST3Plugin.version``.
+    """
+
+    version = "fake-0.0.0"
+
+    def __init__(self, plugin_path: str) -> None:
+        """Construct the fake; ``plugin_path`` is recorded but never read from disk.
+
+        :param plugin_path: Path string the production code passed; kept as metadata so callers
+            asserting on it can read it back.
+        """
+        self.plugin_path = plugin_path
+        self.parameters: defaultdict[str, _FakeParameter] = defaultdict(_FakeParameter)
+
+    def show_editor(self, close_event: threading.Event) -> None:
+        """Block until ``close_event`` is set, mirroring the real plugin's contract.
+
+        :param close_event: Signalled by ``editor_held_open`` / ``warmup_plugin``
+            to release the editor; ``wait`` returns the moment it is set.
+        """
+        close_event.wait()
+
+    def load_preset(self, preset_path: str) -> None:
+        """Accept the preset path; the fake has no preset state to apply.
+
+        :param preset_path: Filesystem path the production code requested; ignored.
+        """
+
+    def reset(self) -> None:
+        """Mirror the real plugin's reset hook; the fake holds no audio state."""
+
+    def process(
+        self,
+        midi_events: Iterable[tuple[bytes, float]],
+        duration_seconds: float,
+        sample_rate: float,
+        channels: int,
+        block_size: int,
+        tail: bool,
+    ) -> np.ndarray:
+        """Render deterministic audio matching the real plugin's output contract.
+
+        Empty ``midi_events`` (the production flush calls) yield silence; any
+        ``note_on`` yields a sine at the note's frequency, scaled by velocity.
+
+        :param midi_events: Iterable of ``(payload_bytes, time_seconds)``; only
+            the first ``note_on`` is honoured.
+        :param duration_seconds: Output length; ``num_samples = duration * sample_rate``.
+        :param sample_rate: Output sample rate in Hz.
+        :param channels: Channel count of the returned ndarray (axis 0).
+        :param block_size: Accepted to match the real plugin's signature; unused.
+        :param tail: Accepted to match the real plugin's signature; unused.
+        :returns: ``np.ndarray`` of shape ``(channels, num_samples)``, float32,
+            with peak in ``[0, 1]`` and identical contents across repeated calls
+            for the same inputs.
+        """
+        num_samples = int(duration_seconds * sample_rate)
+        note = _first_note_on(midi_events)
+        if note is None:
+            return np.zeros((channels, num_samples), dtype=np.float32)
+
+        pitch, velocity = note
+        freq = _A4_FREQUENCY_HZ * 2.0 ** ((pitch - _A4_MIDI_NOTE) / _SEMITONES_PER_OCTAVE)
+        amplitude = (velocity / _MIDI_MAX_VELOCITY) * _DEFAULT_AMPLITUDE_SCALE
+        t = np.arange(num_samples, dtype=np.float32) / np.float32(sample_rate)
+        wave = (amplitude * np.sin(2.0 * np.pi * freq * t)).astype(np.float32)
+        return np.broadcast_to(wave, (channels, num_samples)).copy()
+
+
+def _first_note_on(midi_events: Iterable[tuple[bytes, float]]) -> tuple[int, int] | None:
+    """Return ``(pitch, velocity)`` of the first ``note_on`` event, or ``None``.
+
+    A ``note_on`` with velocity 0 is the MIDI idiom for ``note_off``; it does
+    not count as a sounding event here.
+
+    :param midi_events: Iterable of ``(payload_bytes, time_seconds)`` per the
+        ``make_midi_events`` shape used by the production pipeline.
+    :returns: ``(pitch, velocity)`` of the first true note-on event, or
+        ``None`` if no sounding event is present.
+    """
+    for payload, _time in midi_events:
+        status, pitch, velocity = payload[0], payload[1], payload[2]
+        if (status & _MIDI_STATUS_MASK) == _MIDI_NOTE_ON_STATUS and velocity > 0:
+            return pitch, velocity
+    return None

--- a/tests/data/vst/conftest.py
+++ b/tests/data/vst/conftest.py
@@ -1,0 +1,40 @@
+"""Shared fixtures for the VST test suite — fake-plugin injection lives here."""
+
+from __future__ import annotations
+
+import pytest
+
+from synth_setter.data.vst import core
+from tests.data.vst._fake_plugin import FakeVST3Plugin
+
+
+@pytest.fixture
+def fake_vst3_plugin() -> FakeVST3Plugin:
+    """Return a fresh ``FakeVST3Plugin`` instance per test (no shared state).
+
+    :returns: Stand-in plugin whose ``plugin_path`` field is set but never
+        read from disk; downstream production code receives this via
+        ``install_fake_plugin``.
+    """
+    return FakeVST3Plugin("plugins/fake.vst3")
+
+
+@pytest.fixture
+def install_fake_plugin(
+    monkeypatch: pytest.MonkeyPatch, fake_vst3_plugin: FakeVST3Plugin
+) -> FakeVST3Plugin:
+    """Patch ``core.load_plugin`` and ``core.VST3Plugin`` to yield the fake.
+
+    Both seams are covered: ``load_plugin`` is the normal pipeline entry
+    point; ``VST3Plugin`` is constructed directly by
+    ``extract_renderer_version``'s fallback path.
+
+    :param monkeypatch: Pytest fixture used to swap the two ``core``
+        callables for the test's duration; teardown restores both.
+    :param fake_vst3_plugin: The instance the patched callables return.
+    :returns: The same ``fake_vst3_plugin`` instance, so tests asserting
+        on it can compare by identity.
+    """
+    monkeypatch.setattr(core, "load_plugin", lambda _path, **_kw: fake_vst3_plugin)
+    monkeypatch.setattr(core, "VST3Plugin", lambda _path: fake_vst3_plugin)
+    return fake_vst3_plugin

--- a/tests/data/vst/test_fake_plugin.py
+++ b/tests/data/vst/test_fake_plugin.py
@@ -1,7 +1,6 @@
 """Contract tests for ``FakeVST3Plugin`` — the duck-typed E2E test double."""
 
 import threading
-import time
 
 import numpy as np
 
@@ -40,13 +39,16 @@ def test_reset_is_a_noop() -> None:
     plugin.reset()
 
 
-def test_process_with_empty_midi_returns_float32_silence() -> None:
-    """Flush calls (``midi_events=[]``) return correctly shaped float32 zeros."""
+def test_process_with_empty_midi_returns_zero_length_float32_buffer() -> None:
+    """Flush calls (``midi_events=[]``) return a zero-length float32 buffer.
+
+    The production pipeline discards the flush return value, so allocating a full-duration zero
+    array would waste ~11MB per call at 44.1 kHz / 32 s.
+    """
     plugin = FakeVST3Plugin("plugins/anything.vst3")
-    out = plugin.process([], 0.5, 44100.0, 2, 2048, True)
-    assert out.shape == (2, 22050)
+    out = plugin.process([], 32.0, 44100.0, 2, 2048, True)
+    assert out.shape == (2, 0)
     assert out.dtype == np.float32
-    assert not out.any()
 
 
 def test_process_with_note_returns_audio_above_loudness_gate() -> None:
@@ -81,7 +83,18 @@ def test_show_editor_blocks_until_close_event_is_set() -> None:
     """``show_editor`` returns only after the host signals ``close_event.set()``."""
     plugin = FakeVST3Plugin("plugins/anything.vst3")
     close_event = threading.Event()
+    entered_wait = threading.Event()
     returned = threading.Event()
+
+    # Wrap ``close_event.wait`` so the test observes the exact moment the
+    # worker enters the blocking call — avoids any timing-based race.
+    original_wait = close_event.wait
+
+    def _instrumented_wait(timeout: float | None = None) -> bool:
+        entered_wait.set()
+        return original_wait(timeout)
+
+    close_event.wait = _instrumented_wait  # type: ignore[method-assign]
 
     def _run() -> None:
         plugin.show_editor(close_event)
@@ -89,7 +102,7 @@ def test_show_editor_blocks_until_close_event_is_set() -> None:
 
     thread = threading.Thread(target=_run, daemon=True)
     thread.start()
-    time.sleep(0.1)  # CI-safe margin for thread-startup + entering close_event.wait()
+    assert entered_wait.wait(timeout=1.0), "worker thread never entered show_editor"
     assert not returned.is_set(), "show_editor returned before close_event was set"
     close_event.set()
     assert returned.wait(timeout=1.0), "show_editor did not return after close_event"

--- a/tests/data/vst/test_fake_plugin.py
+++ b/tests/data/vst/test_fake_plugin.py
@@ -1,0 +1,107 @@
+"""Contract tests for ``FakeVST3Plugin`` — the duck-typed E2E test double."""
+
+import threading
+import time
+
+import numpy as np
+
+from synth_setter.data.vst import core
+from tests.data.vst._fake_plugin import FakeVST3Plugin
+
+
+def test_constructor_and_version_attribute() -> None:
+    """A freshly constructed fake exposes a non-empty ``version`` string."""
+    plugin = FakeVST3Plugin("plugins/anything.vst3")
+    assert isinstance(plugin.version, str) and plugin.version
+
+
+def test_parameters_subscript_assignment_round_trips() -> None:
+    """Writing ``parameters[k].raw_value`` is observable on subsequent reads."""
+    plugin = FakeVST3Plugin("plugins/anything.vst3")
+    plugin.parameters["cutoff"].raw_value = 0.5
+    assert plugin.parameters["cutoff"].raw_value == 0.5
+
+
+def test_parameters_auto_create_on_first_access() -> None:
+    """Unknown parameter keys materialise on first access with raw_value ``0.0``."""
+    plugin = FakeVST3Plugin("plugins/anything.vst3")
+    assert plugin.parameters["never_seen"].raw_value == 0.0
+
+
+def test_load_preset_is_a_noop() -> None:
+    """``load_preset`` accepts any string and does not touch the filesystem."""
+    plugin = FakeVST3Plugin("plugins/anything.vst3")
+    plugin.load_preset("presets/anything.vstpreset")
+
+
+def test_reset_is_a_noop() -> None:
+    """``reset`` is callable on a fresh fake and never raises."""
+    plugin = FakeVST3Plugin("plugins/anything.vst3")
+    plugin.reset()
+
+
+def test_process_with_empty_midi_returns_float32_silence() -> None:
+    """Flush calls (``midi_events=[]``) return correctly shaped float32 zeros."""
+    plugin = FakeVST3Plugin("plugins/anything.vst3")
+    out = plugin.process([], 0.5, 44100.0, 2, 2048, True)
+    assert out.shape == (2, 22050)
+    assert out.dtype == np.float32
+    assert not out.any()
+
+
+def test_process_with_note_returns_audio_above_loudness_gate() -> None:
+    """Rendered audio must clear the dataset pipeline's ``_MIN_LOUDNESS=-55 dB`` gate.
+
+    Otherwise the loudness filter in ``test_generate_vst_dataset.py`` rejects
+    every sample and the E2E shard write fails.
+    """
+    plugin = FakeVST3Plugin("plugins/anything.vst3")
+    note_on = (bytes((0x90, 60, 100)), 0.0)
+    note_off = (bytes((0x80, 60, 0)), 1.0)
+    out = plugin.process((note_on, note_off), 1.0, 44100.0, 2, 2048, True)
+
+    assert out.shape == (2, 44100)
+    assert out.dtype == np.float32
+    rms_db = 20.0 * np.log10(np.sqrt(np.mean(out**2)) + 1e-12)
+    assert rms_db > -55.0, f"rms {rms_db:.2f} dB below loudness gate"
+    assert np.max(np.abs(out)) <= 1.0
+
+
+def test_process_is_deterministic_across_calls() -> None:
+    """Same inputs to ``process`` must produce bit-identical outputs."""
+    plugin = FakeVST3Plugin("plugins/anything.vst3")
+    note_on = (bytes((0x90, 67, 80)), 0.0)
+    args = ((note_on,), 0.25, 44100.0, 2, 2048, True)
+    first = plugin.process(*args)
+    second = plugin.process(*args)
+    assert np.array_equal(first, second)
+
+
+def test_show_editor_blocks_until_close_event_is_set() -> None:
+    """``show_editor`` returns only after the host signals ``close_event.set()``."""
+    plugin = FakeVST3Plugin("plugins/anything.vst3")
+    close_event = threading.Event()
+    returned = threading.Event()
+
+    def _run() -> None:
+        plugin.show_editor(close_event)
+        returned.set()
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    time.sleep(0.1)  # CI-safe margin for thread-startup + entering close_event.wait()
+    assert not returned.is_set(), "show_editor returned before close_event was set"
+    close_event.set()
+    assert returned.wait(timeout=1.0), "show_editor did not return after close_event"
+
+
+def test_install_fake_plugin_redirects_core_load_plugin(
+    install_fake_plugin: FakeVST3Plugin,
+) -> None:
+    """After ``install_fake_plugin``, ``core.load_plugin`` returns the fake instance.
+
+    :param install_fake_plugin: Fixture that monkeypatches the loader and yields the instance it
+        now returns; identity check pins the contract.
+    """
+
+    assert core.load_plugin("plugins/does-not-exist.vst3") is install_fake_plugin

--- a/tests/data/vst/test_fake_plugin_e2e.py
+++ b/tests/data/vst/test_fake_plugin_e2e.py
@@ -20,7 +20,6 @@ import pytest
 
 from synth_setter.data.vst import core
 from synth_setter.data.vst.writers import make_hdf5_dataset
-from synth_setter.pipeline.schemas.spec import RenderConfig
 
 _ = hdf5plugin  # keep type checkers from flagging the side-effect import
 
@@ -28,44 +27,12 @@ from tests.data.vst._fake_plugin import FakeVST3Plugin  # noqa: E402
 from tests.data.vst.test_generate_vst_dataset import (  # noqa: E402  pinned canonical patch
     _HARDCODED_NOTE_PARAMS,
     _HARDCODED_SYNTH_PARAMS,
+    _render_cfg,
 )
 
 _PLUGIN_PATH = "plugins/fake.vst3"  # never touched on disk — load_plugin is patched
 _PRESET_PATH = "presets/fake.vstpreset"
-_SAMPLE_RATE = 44100
-_CHANNELS = 2
-_DURATION = 4.0
-_VELOCITY = 100
-_MIN_LOUDNESS = -55.0
-_SPEC_NAME = "surge_xt"
 _RENDERER_VERSION = "fake-0.0.0"
-
-
-def _render_cfg(num_samples: int, samples_per_render_batch: int) -> RenderConfig:
-    """Build a held-open ``RenderConfig`` pinned to the fake-plugin defaults.
-
-    :param num_samples: Total samples in the shard.
-    :param samples_per_render_batch: Per-batch size; setting smaller than
-        ``num_samples`` forces multiple flush callbacks inside the held-open
-        scope (the cross-flush invariant the test is here to defend).
-    :return: A ``RenderConfig`` pinned to ``always_on`` + ``once``, the only
-        pairing the schema validator allows for held-open editor runs.
-    """
-    return RenderConfig(
-        plugin_path=_PLUGIN_PATH,
-        preset_path=_PRESET_PATH,
-        param_spec_name=_SPEC_NAME,
-        renderer_version=_RENDERER_VERSION,
-        sample_rate=_SAMPLE_RATE,
-        channels=_CHANNELS,
-        velocity=_VELOCITY,
-        signal_duration_seconds=_DURATION,
-        min_loudness=_MIN_LOUDNESS,
-        samples_per_render_batch=samples_per_render_batch,
-        samples_per_shard=num_samples,
-        plugin_reload_cadence="once",
-        gui_toggle_cadence="always_on",
-    )
 
 
 @pytest.mark.fake_vst
@@ -90,7 +57,18 @@ def test_make_hdf5_dataset_writes_valid_shard_under_fake_plugin(
         ``core.VST3Plugin`` for the fake before the writer fires.
     """
     num_samples = 4
-    render_cfg = _render_cfg(num_samples=num_samples, samples_per_render_batch=2)
+    render_cfg = _render_cfg(
+        num_samples=num_samples,
+        samples_per_render_batch=2,
+        plugin_reload_cadence="once",
+        gui_toggle_cadence="always_on",
+    ).model_copy(
+        update={
+            "plugin_path": _PLUGIN_PATH,
+            "preset_path": _PRESET_PATH,
+            "renderer_version": _RENDERER_VERSION,
+        }
+    )
     out = tmp_path / "shard-000000.h5"
     fixed_synth = [_HARDCODED_SYNTH_PARAMS] * num_samples
     fixed_note = [_HARDCODED_NOTE_PARAMS] * num_samples
@@ -115,9 +93,6 @@ def test_make_hdf5_dataset_writes_valid_shard_under_fake_plugin(
     assert np.isfinite(audio).all(), "rendered audio contains NaN/Inf"
     assert (np.abs(audio) <= 1.0).all(), "rendered audio exceeds [-1, 1] bounds"
 
-    crash_log_calls = [
-        call
-        for call in fake_logger.exception.call_args_list
-        if "vst-editor-window crashed" in str(call.args[0])
-    ]
-    assert not crash_log_calls, f"editor-thread crash logged: {crash_log_calls}"
+    assert fake_logger.exception.call_count == 0, (
+        f"unexpected logger.exception calls: {fake_logger.exception.call_args_list}"
+    )

--- a/tests/data/vst/test_fake_plugin_e2e.py
+++ b/tests/data/vst/test_fake_plugin_e2e.py
@@ -1,0 +1,123 @@
+"""End-to-end shard-write proven against a duck-typed ``FakeVST3Plugin``.
+
+No real ``.vst3`` bundle, no X11, no Surge XT — ``install_fake_plugin``
+swaps the loader for the fake, so the whole ``make_hdf5_dataset`` path
+(batch loop, held-open editor, HDF5 writer, mel-spec computation) runs
+on every PR. The real-plugin counterpart at
+``test_always_on_integration.py`` stays as the "does Surge XT still
+work" gate; this is the "does our pipeline still work" gate.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import h5py
+import hdf5plugin  # noqa: F401  side-effect: registers Blosc2 filter for h5py reads
+import numpy as np
+import pytest
+
+from synth_setter.data.vst import core
+from synth_setter.data.vst.writers import make_hdf5_dataset
+from synth_setter.pipeline.schemas.spec import RenderConfig
+
+_ = hdf5plugin  # keep type checkers from flagging the side-effect import
+
+from tests.data.vst._fake_plugin import FakeVST3Plugin  # noqa: E402
+from tests.data.vst.test_generate_vst_dataset import (  # noqa: E402  pinned canonical patch
+    _HARDCODED_NOTE_PARAMS,
+    _HARDCODED_SYNTH_PARAMS,
+)
+
+_PLUGIN_PATH = "plugins/fake.vst3"  # never touched on disk — load_plugin is patched
+_PRESET_PATH = "presets/fake.vstpreset"
+_SAMPLE_RATE = 44100
+_CHANNELS = 2
+_DURATION = 4.0
+_VELOCITY = 100
+_MIN_LOUDNESS = -55.0
+_SPEC_NAME = "surge_xt"
+_RENDERER_VERSION = "fake-0.0.0"
+
+
+def _render_cfg(num_samples: int, samples_per_render_batch: int) -> RenderConfig:
+    """Build a held-open ``RenderConfig`` pinned to the fake-plugin defaults.
+
+    :param num_samples: Total samples in the shard.
+    :param samples_per_render_batch: Per-batch size; setting smaller than
+        ``num_samples`` forces multiple flush callbacks inside the held-open
+        scope (the cross-flush invariant the test is here to defend).
+    :return: A ``RenderConfig`` pinned to ``always_on`` + ``once``, the only
+        pairing the schema validator allows for held-open editor runs.
+    """
+    return RenderConfig(
+        plugin_path=_PLUGIN_PATH,
+        preset_path=_PRESET_PATH,
+        param_spec_name=_SPEC_NAME,
+        renderer_version=_RENDERER_VERSION,
+        sample_rate=_SAMPLE_RATE,
+        channels=_CHANNELS,
+        velocity=_VELOCITY,
+        signal_duration_seconds=_DURATION,
+        min_loudness=_MIN_LOUDNESS,
+        samples_per_render_batch=samples_per_render_batch,
+        samples_per_shard=num_samples,
+        plugin_reload_cadence="once",
+        gui_toggle_cadence="always_on",
+    )
+
+
+@pytest.mark.fake_vst
+def test_make_hdf5_dataset_writes_valid_shard_under_fake_plugin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    install_fake_plugin: FakeVST3Plugin,
+) -> None:
+    """The dataset pipeline produces a valid shard with no real VST3 or X11.
+
+    Four samples in two batches force a mid-shard flush inside the
+    held-open editor scope. Asserts shape/dtype/finiteness and that the
+    editor-thread crash log never fires — the fake's ``show_editor``
+    just blocks on the close event, so there is no realistic failure
+    mode here, but keeping the assertion pins the contract for when
+    the held-open editor surface evolves.
+
+    :param tmp_path: Destination directory for the shard HDF5 file under test.
+    :param monkeypatch: Stubs ``core.logger`` so the crash-gate assertion
+        is observable (loguru does not propagate to ``caplog``).
+    :param install_fake_plugin: Swaps ``core.load_plugin`` /
+        ``core.VST3Plugin`` for the fake before the writer fires.
+    """
+    num_samples = 4
+    render_cfg = _render_cfg(num_samples=num_samples, samples_per_render_batch=2)
+    out = tmp_path / "shard-000000.h5"
+    fixed_synth = [_HARDCODED_SYNTH_PARAMS] * num_samples
+    fixed_note = [_HARDCODED_NOTE_PARAMS] * num_samples
+    fake_logger = MagicMock(wraps=core.logger)
+    monkeypatch.setattr(core, "logger", fake_logger)
+
+    make_hdf5_dataset(
+        hdf5_file=out,
+        render_cfg=render_cfg,
+        fixed_synth_params_list=fixed_synth,
+        fixed_note_params_list=fixed_note,
+    )
+
+    assert out.exists()
+    with h5py.File(out, "r") as f:
+        for key in ("audio", "mel_spec", "param_array"):
+            assert key in f, f"missing expected dataset: {key}"
+        audio_ds = f["audio"]
+        assert isinstance(audio_ds, h5py.Dataset)
+        assert audio_ds.shape[0] == num_samples
+        audio = audio_ds[...]
+    assert np.isfinite(audio).all(), "rendered audio contains NaN/Inf"
+    assert (np.abs(audio) <= 1.0).all(), "rendered audio exceeds [-1, 1] bounds"
+
+    crash_log_calls = [
+        call
+        for call in fake_logger.exception.call_args_list
+        if "vst-editor-window crashed" in str(call.args[0])
+    ]
+    assert not crash_log_calls, f"editor-thread crash logged: {crash_log_calls}"


### PR DESCRIPTION
## Summary

- Adds a duck-typed `FakeVST3Plugin` (`tests/data/vst/_fake_plugin.py`) covering the six attributes/methods `synth_setter.data.vst.core` calls. `process` emits a deterministic sine for any `note_on` event and silence on flush calls, clearing the `_MIN_LOUDNESS=-55 dB` gate so the full pipeline writes a complete shard.
- Adds `fake_vst3_plugin` / `install_fake_plugin` fixtures (`tests/data/vst/conftest.py`) that monkeypatch `core.load_plugin` + `core.VST3Plugin`, plus a `fake_vst` pytest marker.
- Adds `tests/data/vst/test_fake_plugin_e2e.py` mirroring `test_always_on_integration.py`'s HDF5 assertions but running with no real VST and no X11 — exercises the held-open editor path end-to-end in ~1.1 s.

## Why

Today the dataset-pipeline E2E suite (`make_hdf5_dataset`, `make_wds_dataset`, `render_params`) is gated behind `@pytest.mark.requires_vst`. PR-time runners skip these, so only the nightly job (#1197 / #1201) exercises the batch loop, HDF5 writer, mel-spec computation, RenderConfig wiring, and `gui_toggle_cadence` end-to-end. A duck-typed fake lets every CI run cover the pipeline surface, while the nightly real-VST job remains the gate for Steinberg-loader / JUCE-state regressions the fake cannot cover.

## Test plan

- [x] `pytest tests/data/vst/test_fake_plugin.py tests/data/vst/test_fake_plugin_e2e.py` — 11/11 green in ~2.1 s
- [x] `pytest -m fake_vst --collect-only` selects only the new E2E test
- [x] `pytest -m requires_vst --collect-only` still selects the existing real-VST tests; fake fixture does not leak
- [x] `pytest tests/data/vst/test_core.py` — 15/15 still green (sibling tests unaffected by new conftest)
- [x] `ruff check` clean on the four new files
- [x] `pydoclint --style sphinx` clean on the four new files
- [x] Multi-skill dry-run review: 0 BLOCK, 36 WARN across code-health / synth-setter / python-style / tdd-impl / comment-hygiene (see review sentinel for details)

## Follow-up

- Wire a `fake-vst-e2e` CI job that runs the `fake_vst` marker on every PR. Out of scope for this PR; will file a follow-up under Phase #155.
- Review WARNs from the dry-run pass — most actionable: collapse the new local `_render_cfg` into the recently deduped shared helper at `test_generate_vst_dataset.py:49` and replace `time.sleep(0.1)` in `test_show_editor_blocks_until_close_event_is_set` with deterministic event-based sync.

Closes #1233