### PR TITLE
fix(ci-automation): mask degenerate mel bins on the smoke finalize cells

### DIFF
--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -65,7 +65,7 @@ def _download_train_shards_one_at_a_time(spec: DatasetSpec, work_dir: Path) -> I
             local.unlink(missing_ok=True)
 
 
-def finalize_wds(spec: DatasetSpec, work_dir: Path, mask_degenerate_bins: bool = False) -> None:
+def finalize_wds(spec: DatasetSpec, work_dir: Path) -> None:
     """Stream stats over the train shards and upload ``stats.npz``.
 
     Per-shard tar files stay in their original R2 location; only the
@@ -73,13 +73,12 @@ def finalize_wds(spec: DatasetSpec, work_dir: Path, mask_degenerate_bins: bool =
     splits are available via
     ``spec.r2.split_wds_brace_uri(spec.split_shard_ranges[split])``;
     callers must check ``lo < hi`` first because empty splits raise
-    ``ValueError`` at that helper.
+    ``ValueError`` at that helper. ``spec.mask_degenerate_bins`` is
+    forwarded to ``stream_stats_wds``.
 
     :param spec: Validated dataset spec (``output_format == "wds"``).
     :param work_dir: Scratch directory; one shard at a time + the final
         ``stats.npz`` live here transiently.
-    :param mask_degenerate_bins: Forwarded to ``stream_stats_wds``; ``True``
-        substitutes ``std=1.0`` at zero-variance mel bins instead of raising.
     :raises ValueError: The train split is empty
         (``spec.split_shard_ranges["train"]`` has ``lo >= hi``); stats
         cannot be computed without at least one train shard.
@@ -93,7 +92,7 @@ def finalize_wds(spec: DatasetSpec, work_dir: Path, mask_degenerate_bins: bool =
         )
     mean, std = stream_stats_wds(
         _download_train_shards_one_at_a_time(spec, work_dir),
-        mask_degenerate=mask_degenerate_bins,
+        mask_degenerate=spec.mask_degenerate_bins,
     )
     stats_npz = work_dir / STATS_NPZ_FILENAME
     np.savez(stats_npz, mean=mean, std=std)
@@ -101,7 +100,7 @@ def finalize_wds(spec: DatasetSpec, work_dir: Path, mask_degenerate_bins: bool =
     logger.info("uploaded stats to {}", spec.r2.stats_uri())
 
 
-def finalize_hdf5(spec: DatasetSpec, work_dir: Path, mask_degenerate_bins: bool = False) -> None:
+def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
     """Download every shard, reshard into split files, compute stats, upload all artifacts.
 
     Writes ``work_dir/input_spec.json`` flat (via
@@ -120,12 +119,11 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path, mask_degenerate_bins: bool 
     validation (per ``pipeline/CLAUDE.md``) is delegated to the h5py opens
     that ``reshard_dataset`` performs while staging each split — finalize
     never re-runs the workers' full four-check pass.
+    ``spec.mask_degenerate_bins`` is forwarded to ``get_stats_hdf5``.
 
     :param spec: Validated dataset spec (``output_format == "hdf5"``).
     :param work_dir: Scratch directory; shards, splits, stats and the spec
         copy live here transiently for the duration of the call.
-    :param mask_degenerate_bins: Forwarded to ``get_stats_hdf5``; ``True``
-        substitutes ``std=1.0`` at zero-variance mel bins instead of raising.
     :raises ValueError: The train split is empty
         (``spec.split_shard_ranges["train"]`` has ``lo >= hi``); reshard
         would prune ``train.h5`` and stats compute would fail with a
@@ -144,7 +142,7 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path, mask_degenerate_bins: bool 
         r2_io.download_to_path(spec.r2.shard_uri(shard), work_dir / shard.filename)
     write_spec_to_path(spec, work_dir / INPUT_SPEC_FILENAME)
     reshard_dataset(work_dir)
-    get_stats_hdf5(str(work_dir / "train.h5"), mask_degenerate=mask_degenerate_bins)
+    get_stats_hdf5(str(work_dir / "train.h5"), mask_degenerate=spec.mask_degenerate_bins)
     stats_npz = work_dir / STATS_NPZ_FILENAME
     if not stats_npz.is_file():
         raise FileNotFoundError(
@@ -184,9 +182,6 @@ def main() -> None:
     cfg.paths.output_dir = str(_REPO_ROOT)
     cfg.paths.work_dir = str(_REPO_ROOT)
 
-    # Read before spec_from_cfg; ``_NON_SPEC_KEYS`` drops it from spec construction.
-    mask_degenerate_bins = bool(cfg.get("mask_degenerate_bins", False))
-
     spec = spec_from_cfg(cfg)
     r2_io.ensure_r2_env_loaded()
 
@@ -198,9 +193,9 @@ def main() -> None:
     with tempfile.TemporaryDirectory() as raw_work_dir:
         work_dir = Path(raw_work_dir)
         if spec.output_format == "wds":
-            finalize_wds(spec, work_dir, mask_degenerate_bins=mask_degenerate_bins)
+            finalize_wds(spec, work_dir)
         elif spec.output_format == "hdf5":
-            finalize_hdf5(spec, work_dir, mask_degenerate_bins=mask_degenerate_bins)
+            finalize_hdf5(spec, work_dir)
         else:
             raise ValueError(f"unsupported output_format: {spec.output_format!r}")
         marker_local = work_dir / DATASET_COMPLETE_FILENAME

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -79,9 +79,7 @@ def finalize_wds(spec: DatasetSpec, work_dir: Path, mask_degenerate_bins: bool =
     :param work_dir: Scratch directory; one shard at a time + the final
         ``stats.npz`` live here transiently.
     :param mask_degenerate_bins: Forwarded to ``stream_stats_wds``; ``True``
-        substitutes ``std=1.0`` at any zero-variance mel position instead of
-        raising. Small CI smoke datasets (12 samples) have deterministically
-        constant positions and need this flag to finalize.
+        substitutes ``std=1.0`` at zero-variance mel bins instead of raising.
     :raises ValueError: The train split is empty
         (``spec.split_shard_ranges["train"]`` has ``lo >= hi``); stats
         cannot be computed without at least one train shard.
@@ -127,10 +125,7 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path, mask_degenerate_bins: bool 
     :param work_dir: Scratch directory; shards, splits, stats and the spec
         copy live here transiently for the duration of the call.
     :param mask_degenerate_bins: Forwarded to ``get_stats_hdf5``; ``True``
-        substitutes ``std=1.0`` at any zero-variance mel position instead of
-        raising. Wds is the typical canary because Welford reports exact zero
-        variance, but the hdf5 dask path can flip to zero too once FP noise
-        no longer hides constant bins.
+        substitutes ``std=1.0`` at zero-variance mel bins instead of raising.
     :raises ValueError: The train split is empty
         (``spec.split_shard_ranges["train"]`` has ``lo >= hi``); reshard
         would prune ``train.h5`` and stats compute would fail with a
@@ -189,9 +184,7 @@ def main() -> None:
     cfg.paths.output_dir = str(_REPO_ROOT)
     cfg.paths.work_dir = str(_REPO_ROOT)
 
-    # Pop the finalize-only knob before ``spec_from_cfg`` — it is listed in
-    # ``_NON_SPEC_KEYS`` so DatasetSpec construction would ignore it, but the
-    # explicit read keeps the wiring discoverable from this function.
+    # Read before spec_from_cfg; ``_NON_SPEC_KEYS`` drops it from spec construction.
     mask_degenerate_bins = bool(cfg.get("mask_degenerate_bins", False))
 
     spec = spec_from_cfg(cfg)

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -65,7 +65,7 @@ def _download_train_shards_one_at_a_time(spec: DatasetSpec, work_dir: Path) -> I
             local.unlink(missing_ok=True)
 
 
-def finalize_wds(spec: DatasetSpec, work_dir: Path) -> None:
+def finalize_wds(spec: DatasetSpec, work_dir: Path, mask_degenerate_bins: bool = False) -> None:
     """Stream stats over the train shards and upload ``stats.npz``.
 
     Per-shard tar files stay in their original R2 location; only the
@@ -78,6 +78,10 @@ def finalize_wds(spec: DatasetSpec, work_dir: Path) -> None:
     :param spec: Validated dataset spec (``output_format == "wds"``).
     :param work_dir: Scratch directory; one shard at a time + the final
         ``stats.npz`` live here transiently.
+    :param mask_degenerate_bins: Forwarded to ``stream_stats_wds``; ``True``
+        substitutes ``std=1.0`` at any zero-variance mel position instead of
+        raising. Small CI smoke datasets (12 samples) have deterministically
+        constant positions and need this flag to finalize.
     :raises ValueError: The train split is empty
         (``spec.split_shard_ranges["train"]`` has ``lo >= hi``); stats
         cannot be computed without at least one train shard.
@@ -89,14 +93,17 @@ def finalize_wds(spec: DatasetSpec, work_dir: Path) -> None:
             f"{spec.split_shard_ranges['train']!r}); cannot compute stats "
             f"without at least one train shard."
         )
-    mean, std = stream_stats_wds(_download_train_shards_one_at_a_time(spec, work_dir))
+    mean, std = stream_stats_wds(
+        _download_train_shards_one_at_a_time(spec, work_dir),
+        mask_degenerate=mask_degenerate_bins,
+    )
     stats_npz = work_dir / STATS_NPZ_FILENAME
     np.savez(stats_npz, mean=mean, std=std)
     r2_io.upload(stats_npz, spec.r2.stats_uri())
     logger.info("uploaded stats to {}", spec.r2.stats_uri())
 
 
-def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
+def finalize_hdf5(spec: DatasetSpec, work_dir: Path, mask_degenerate_bins: bool = False) -> None:
     """Download every shard, reshard into split files, compute stats, upload all artifacts.
 
     Writes ``work_dir/input_spec.json`` flat (via
@@ -119,6 +126,11 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
     :param spec: Validated dataset spec (``output_format == "hdf5"``).
     :param work_dir: Scratch directory; shards, splits, stats and the spec
         copy live here transiently for the duration of the call.
+    :param mask_degenerate_bins: Forwarded to ``get_stats_hdf5``; ``True``
+        substitutes ``std=1.0`` at any zero-variance mel position instead of
+        raising. Wds is the typical canary because Welford reports exact zero
+        variance, but the hdf5 dask path can flip to zero too once FP noise
+        no longer hides constant bins.
     :raises ValueError: The train split is empty
         (``spec.split_shard_ranges["train"]`` has ``lo >= hi``); reshard
         would prune ``train.h5`` and stats compute would fail with a
@@ -137,7 +149,7 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
         r2_io.download_to_path(spec.r2.shard_uri(shard), work_dir / shard.filename)
     write_spec_to_path(spec, work_dir / INPUT_SPEC_FILENAME)
     reshard_dataset(work_dir)
-    get_stats_hdf5(str(work_dir / "train.h5"))
+    get_stats_hdf5(str(work_dir / "train.h5"), mask_degenerate=mask_degenerate_bins)
     stats_npz = work_dir / STATS_NPZ_FILENAME
     if not stats_npz.is_file():
         raise FileNotFoundError(
@@ -177,6 +189,11 @@ def main() -> None:
     cfg.paths.output_dir = str(_REPO_ROOT)
     cfg.paths.work_dir = str(_REPO_ROOT)
 
+    # Pop the finalize-only knob before ``spec_from_cfg`` — it is listed in
+    # ``_NON_SPEC_KEYS`` so DatasetSpec construction would ignore it, but the
+    # explicit read keeps the wiring discoverable from this function.
+    mask_degenerate_bins = bool(cfg.get("mask_degenerate_bins", False))
+
     spec = spec_from_cfg(cfg)
     r2_io.ensure_r2_env_loaded()
 
@@ -188,9 +205,9 @@ def main() -> None:
     with tempfile.TemporaryDirectory() as raw_work_dir:
         work_dir = Path(raw_work_dir)
         if spec.output_format == "wds":
-            finalize_wds(spec, work_dir)
+            finalize_wds(spec, work_dir, mask_degenerate_bins=mask_degenerate_bins)
         elif spec.output_format == "hdf5":
-            finalize_hdf5(spec, work_dir)
+            finalize_hdf5(spec, work_dir, mask_degenerate_bins=mask_degenerate_bins)
         else:
             raise ValueError(f"unsupported output_format: {spec.output_format!r}")
         marker_local = work_dir / DATASET_COMPLETE_FILENAME

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -54,7 +54,6 @@ _NON_SPEC_KEYS: tuple[str, ...] = (
     "hydra",
     "run_name",
     "skypilot_launch",
-    "mask_degenerate_bins",  # finalize-only knob; read directly by finalize_dataset.main()
 )
 
 # Operator-side artifact anchor — local checkout where the spec is written

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -54,6 +54,9 @@ _NON_SPEC_KEYS: tuple[str, ...] = (
     "hydra",
     "run_name",
     "skypilot_launch",
+    # Finalize-only knob (forwarded to ``stream_stats_wds`` / ``get_stats_hdf5``);
+    # not a DatasetSpec field.
+    "mask_degenerate_bins",
 )
 
 # Operator-side artifact anchor — local checkout where the spec is written

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -54,9 +54,7 @@ _NON_SPEC_KEYS: tuple[str, ...] = (
     "hydra",
     "run_name",
     "skypilot_launch",
-    # Finalize-only knob (forwarded to ``stream_stats_wds`` / ``get_stats_hdf5``);
-    # not a DatasetSpec field.
-    "mask_degenerate_bins",
+    "mask_degenerate_bins",  # finalize-only knob; read directly by finalize_dataset.main()
 )
 
 # Operator-side artifact anchor — local checkout where the spec is written

--- a/src/synth_setter/configs/dataset.yaml
+++ b/src/synth_setter/configs/dataset.yaml
@@ -24,6 +24,17 @@ run_name: ${task_name}
 output_format: hdf5
 base_seed: 42
 
+# Forwarded by ``synth-setter-finalize-dataset`` to the wds / hdf5 stats path
+# (``stream_stats_wds`` / ``get_stats_hdf5``). Strict (``false``) is the
+# production default — degenerate mel bins surface as a hard failure with the
+# operator-actionable ``ValueError`` from
+# ``synth_setter.pipeline.data.stats._check_degenerate_bins``. Smoke configs
+# (``smoke-shard``, ``smoke-shard-wds``) flip it to ``true`` because at 12
+# samples some mel positions (early-frame silence, channels below the source's
+# active bandwidth) are deterministically constant and Welford's exact
+# variance reports them.
+mask_degenerate_bins: false
+
 # Materialized as ``null`` so finalize-dataset.yaml can pin the generate stage's
 # ``run_id`` via the ``run_id=<value>`` Hydra override form (strict mode requires
 # the key to exist). Leaving this ``null`` on the generate path is handled by

--- a/src/synth_setter/configs/dataset.yaml
+++ b/src/synth_setter/configs/dataset.yaml
@@ -24,15 +24,9 @@ run_name: ${task_name}
 output_format: hdf5
 base_seed: 42
 
-# Forwarded by ``synth-setter-finalize-dataset`` to the wds / hdf5 stats path
-# (``stream_stats_wds`` / ``get_stats_hdf5``). Strict (``false``) is the
-# production default — degenerate mel bins surface as a hard failure with the
-# operator-actionable ``ValueError`` from
-# ``synth_setter.pipeline.data.stats._check_degenerate_bins``. Smoke configs
-# (``smoke-shard``, ``smoke-shard-wds``) flip it to ``true`` because at 12
-# samples some mel positions (early-frame silence, channels below the source's
-# active bandwidth) are deterministically constant and Welford's exact
-# variance reports them.
+# Forwarded by ``synth-setter-finalize-dataset`` to ``stream_stats_wds`` /
+# ``get_stats_hdf5``; ``true`` substitutes ``std=1.0`` at zero-variance mel
+# bins instead of raising. Smoke configs override to ``true``.
 mask_degenerate_bins: false
 
 # Materialized as ``null`` so finalize-dataset.yaml can pin the generate stage's

--- a/src/synth_setter/configs/experiment/generate_dataset/smoke-shard-wds.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/smoke-shard-wds.yaml
@@ -16,10 +16,8 @@ task_name: smoke-shard-wds
 
 output_format: wds
 
-# 12-sample renders have deterministically constant mel positions (early-frame
-# silence, channels below the source's active bandwidth) that Welford reports
-# as zero variance. Mask them so finalize completes instead of raising;
-# production datasets keep the strict default in ``configs/dataset.yaml``.
+# 12-sample renders have constant mel bins (early-frame silence, channels
+# below the source's active bandwidth); mask so finalize completes.
 mask_degenerate_bins: true
 
 train_val_test_sizes: [12, 0, 0]

--- a/src/synth_setter/configs/experiment/generate_dataset/smoke-shard-wds.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/smoke-shard-wds.yaml
@@ -16,6 +16,12 @@ task_name: smoke-shard-wds
 
 output_format: wds
 
+# 12-sample renders have deterministically constant mel positions (early-frame
+# silence, channels below the source's active bandwidth) that Welford reports
+# as zero variance. Mask them so finalize completes instead of raising;
+# production datasets keep the strict default in ``configs/dataset.yaml``.
+mask_degenerate_bins: true
+
 train_val_test_sizes: [12, 0, 0]
 
 render:

--- a/src/synth_setter/configs/experiment/generate_dataset/smoke-shard.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/smoke-shard.yaml
@@ -11,6 +11,12 @@ defaults:
 
 task_name: smoke-shard
 
+# 12-sample renders have deterministically constant mel positions Welford
+# reports as zero variance; the hdf5 path masks the same bins so its dask
+# compute does not regress the CI cell if FP noise stops hiding them.
+# Production datasets keep the strict default in ``configs/dataset.yaml``.
+mask_degenerate_bins: true
+
 train_val_test_sizes: [12, 0, 0]
 
 render:

--- a/src/synth_setter/configs/experiment/generate_dataset/smoke-shard.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/smoke-shard.yaml
@@ -11,10 +11,8 @@ defaults:
 
 task_name: smoke-shard
 
-# 12-sample renders have deterministically constant mel positions Welford
-# reports as zero variance; the hdf5 path masks the same bins so its dask
-# compute does not regress the CI cell if FP noise stops hiding them.
-# Production datasets keep the strict default in ``configs/dataset.yaml``.
+# 12-sample renders have constant mel bins; mask so finalize stays green
+# if dask's FP noise stops hiding them on the hdf5 path.
 mask_degenerate_bins: true
 
 train_val_test_sizes: [12, 0, 0]

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -478,6 +478,11 @@ class DatasetSpec(BaseModel):
 
         Nested ``RenderConfig`` carrying every per-shard renderer input.
 
+    .. attribute :: mask_degenerate_bins
+
+        Whether finalize substitutes ``std=1.0`` at zero-variance mel bins
+        instead of raising; ``False`` is the strict production default.
+
     .. attribute :: git_sha
 
         Commit SHA of the launcher's working tree at construction.
@@ -533,6 +538,16 @@ class DatasetSpec(BaseModel):
 
     render: RenderConfig = Field(
         description="Nested ``RenderConfig`` carrying every per-shard renderer input."
+    )
+
+    mask_degenerate_bins: bool = Field(
+        default=False,
+        description=(
+            "Whether the finalize stats fold substitutes ``std=1.0`` at zero-variance "
+            "mel bins instead of raising; ``False`` is the strict production default. "
+            "Smoke configs override to ``True`` because tiny renders have constant "
+            "attack-time frames and channels below the source's active bandwidth."
+        ),
     )
 
     # Auto-filled runtime fields: factories fire only when the value is missing on

--- a/tests/pipeline/ci/test_validate_spec.py
+++ b/tests/pipeline/ci/test_validate_spec.py
@@ -24,6 +24,7 @@ def _make_valid_spec(*, output_format: str = "hdf5", **overrides: object) -> dic
         "train_val_test_sizes": [32, 32, 32],
         "train_val_test_seeds": None,
         "base_seed": 42,
+        "mask_degenerate_bins": False,
         "num_params": 92,
         "num_shards": 3,
         "r2": {

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -339,7 +339,7 @@ def test_hdf5_finalize_produces_train_consumable_layout(
     # Skip the Dask-driven mean/std compute — orchestration is what this test pins.
     monkeypatch.setattr(
         "synth_setter.cli.finalize_dataset.get_stats_hdf5",
-        lambda train_h5_path: np.savez(
+        lambda train_h5_path, mask_degenerate=False: np.savez(
             Path(train_h5_path).parent / "stats.npz",
             mean=np.zeros((2, 8, 8), dtype=np.float32),
             std=np.ones((2, 8, 8), dtype=np.float32),
@@ -395,7 +395,7 @@ def test_finalize_hdf5_real_shards_end_to_end(
     # so the production ``r2_io.upload`` step still runs against a real file.
     monkeypatch.setattr(
         "synth_setter.cli.finalize_dataset.get_stats_hdf5",
-        lambda train_h5_path: np.savez(
+        lambda train_h5_path, mask_degenerate=False: np.savez(
             Path(train_h5_path).parent / "stats.npz",
             mean=np.zeros((2, 8, 8), dtype=np.float32),
             std=np.ones((2, 8, 8), dtype=np.float32),
@@ -447,7 +447,7 @@ def _stub_get_stats_hdf5(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     monkeypatch.setattr(
         "synth_setter.cli.finalize_dataset.get_stats_hdf5",
-        lambda train_h5_path: np.savez(
+        lambda train_h5_path, mask_degenerate=False: np.savez(
             Path(train_h5_path).parent / "stats.npz",
             mean=np.zeros((2, 8, 8), dtype=np.float32),
             std=np.ones((2, 8, 8), dtype=np.float32),
@@ -624,8 +624,10 @@ def test_finalize_hdf5_temp_work_dir_is_torn_down_on_failure(
     captured_work_dir: dict[str, Path] = {}
     r2_stand_in = tmp_path / "r2"
 
-    def boom_finalize_hdf5(spec: object, work_dir: Path) -> None:
-        del spec
+    def boom_finalize_hdf5(
+        spec: object, work_dir: Path, mask_degenerate_bins: bool = False
+    ) -> None:
+        del spec, mask_degenerate_bins
         # Capture the live tempdir path before the raise so the post-call
         # assertion can prove ``TemporaryDirectory`` cleanup ran.
         captured_work_dir["path"] = Path(work_dir)
@@ -717,7 +719,7 @@ def test_main_hdf5_branch_uploads_marker_last(
     # Skip the Dask-driven mean/std compute — orchestration is what this test pins.
     monkeypatch.setattr(
         "synth_setter.cli.finalize_dataset.get_stats_hdf5",
-        lambda train_h5_path: np.savez(
+        lambda train_h5_path, mask_degenerate=False: np.savez(
             Path(train_h5_path).parent / "stats.npz",
             mean=np.zeros((2, 8, 8), dtype=np.float32),
             std=np.ones((2, 8, 8), dtype=np.float32),
@@ -797,8 +799,8 @@ def test_finalize_hdf5_propagates_stats_failure_before_marker_upload(
         lambda src, dst: uploaded.append(dst),
     )
 
-    def boom(train_h5_path: str) -> None:
-        del train_h5_path
+    def boom(train_h5_path: str, mask_degenerate: bool = False) -> None:
+        del train_h5_path, mask_degenerate
         raise RuntimeError("degenerate bins")
 
     monkeypatch.setattr("synth_setter.cli.finalize_dataset.get_stats_hdf5", boom)
@@ -881,6 +883,42 @@ def test_finalize_wds_raises_on_empty_train_split(fake_r2_remote: Path, tmp_path
         finalize_dataset.finalize_wds(spec, tmp_path)
 
     assert [p for p in fake_r2_remote.rglob("*") if p.is_file()] == []
+
+
+def test_finalize_wds_forwards_mask_degenerate_bins_to_stream_stats(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``finalize_wds(..., mask_degenerate_bins=True)`` calls ``stream_stats_wds`` with the flag.
+
+    Pins the wire so smoke configs that set ``mask_degenerate_bins: true`` at
+    the dataset cfg level survive into the stats step — a regression that
+    dropped the kwarg from this call site would resurrect the CI failure
+    even though both endpoints still accept the flag in isolation.
+
+    :param monkeypatch: Pytest fixture used to capture the forwarded kwarg.
+    :param tmp_path: Pytest tmp dir; the download stub never fires.
+    """
+    monkeypatch.setattr(
+        "synth_setter.pipeline.r2_io.download_to_path",
+        lambda r2_uri, dest_path: _write_minimal_wds_shard(dest_path),
+    )
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.upload", lambda *a, **kw: None)
+
+    captured: dict[str, bool] = {}
+
+    def fake_stream_stats(shard_paths: object, mask_degenerate: bool = False) -> tuple[Any, Any]:
+        # Drain the generator so its download-and-unlink contract runs even
+        # though the real Welford fold is short-circuited.
+        list(shard_paths)  # type: ignore[arg-type]
+        captured["mask_degenerate"] = mask_degenerate
+        return np.zeros((2, 2), dtype=np.float32), np.ones((2, 2), dtype=np.float32)
+
+    monkeypatch.setattr("synth_setter.cli.finalize_dataset.stream_stats_wds", fake_stream_stats)
+
+    spec = _build_wds_smoke_spec(task_name="mask-forwards", train_val_test_sizes=(4, 0, 0))
+    finalize_dataset.finalize_wds(spec, tmp_path, mask_degenerate_bins=True)
+
+    assert captured == {"mask_degenerate": True}
 
 
 def test_finalize_wds_unlinks_each_shard_after_folding(

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -885,18 +885,18 @@ def test_finalize_wds_raises_on_empty_train_split(fake_r2_remote: Path, tmp_path
     assert [p for p in fake_r2_remote.rglob("*") if p.is_file()] == []
 
 
+@pytest.mark.parametrize("flag", [True, False])
 def test_finalize_wds_forwards_mask_degenerate_bins_to_stream_stats(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, flag: bool
 ) -> None:
-    """``finalize_wds(..., mask_degenerate_bins=True)`` calls ``stream_stats_wds`` with the flag.
+    """``finalize_wds`` forwards ``mask_degenerate_bins`` to ``stream_stats_wds`` verbatim.
 
-    Pins the wire so smoke configs that set ``mask_degenerate_bins: true`` at
-    the dataset cfg level survive into the stats step — a regression that
-    dropped the kwarg from this call site would resurrect the CI failure
-    even though both endpoints still accept the flag in isolation.
+    Pins the wire on both polarities so a regression that hard-wires the kwarg (True or False)
+    fails the test rather than silently re-breaking smoke finalize.
 
     :param monkeypatch: Pytest fixture used to capture the forwarded kwarg.
-    :param tmp_path: Pytest tmp dir; the download stub never fires.
+    :param tmp_path: Pytest tmp dir; the download stub writes one minimal shard.
+    :param flag: Parametrized polarity threaded through the wire.
     """
     monkeypatch.setattr(
         "synth_setter.pipeline.r2_io.download_to_path",
@@ -907,18 +907,55 @@ def test_finalize_wds_forwards_mask_degenerate_bins_to_stream_stats(
     captured: dict[str, bool] = {}
 
     def fake_stream_stats(shard_paths: object, mask_degenerate: bool = False) -> tuple[Any, Any]:
-        # Drain the generator so its download-and-unlink contract runs even
-        # though the real Welford fold is short-circuited.
+        # Drain the generator — keeps download_to_path + unlink firing the same
+        # way the production Welford fold would.
         list(shard_paths)  # type: ignore[arg-type]
         captured["mask_degenerate"] = mask_degenerate
         return np.zeros((2, 2), dtype=np.float32), np.ones((2, 2), dtype=np.float32)
 
     monkeypatch.setattr("synth_setter.cli.finalize_dataset.stream_stats_wds", fake_stream_stats)
 
-    spec = _build_wds_smoke_spec(task_name="mask-forwards", train_val_test_sizes=(4, 0, 0))
-    finalize_dataset.finalize_wds(spec, tmp_path, mask_degenerate_bins=True)
+    spec = _build_wds_smoke_spec(task_name=f"mask-forwards-{flag}", train_val_test_sizes=(4, 0, 0))
+    finalize_dataset.finalize_wds(spec, tmp_path, mask_degenerate_bins=flag)
 
-    assert captured == {"mask_degenerate": True}
+    assert captured == {"mask_degenerate": flag}
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_finalize_hdf5_forwards_mask_degenerate_bins_to_get_stats(
+    fake_r2_remote: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, flag: bool
+) -> None:
+    """``finalize_hdf5`` forwards ``mask_degenerate_bins`` to ``get_stats_hdf5`` verbatim.
+
+    Mirrors the wds wire test so a regression on the hdf5 branch surfaces the same way; the smoke-
+    shard config opts in for the same reason and needs the same protection.
+
+    :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+    :param tmp_path: Pytest tmp dir; hosts the finalize scratch work_dir.
+    :param monkeypatch: Pytest fixture used to capture the forwarded kwarg.
+    :param flag: Parametrized polarity threaded through the wire.
+    """
+    captured: dict[str, bool] = {}
+
+    def fake_get_stats(train_h5_path: str, mask_degenerate: bool = False) -> None:
+        captured["mask_degenerate"] = mask_degenerate
+        np.savez(
+            Path(train_h5_path).parent / "stats.npz",
+            mean=np.zeros((2, 8, 8), dtype=np.float32),
+            std=np.ones((2, 8, 8), dtype=np.float32),
+        )
+
+    monkeypatch.setattr("synth_setter.cli.finalize_dataset.get_stats_hdf5", fake_get_stats)
+
+    spec = _build_hdf5_smoke_spec(task_name=f"mask-forwards-hdf5-{flag}")
+    shard_remote_dir = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+    _seed_shard_files(shard_remote_dir, spec)
+
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    finalize_dataset.finalize_hdf5(spec, work_dir, mask_degenerate_bins=flag)
+
+    assert captured == {"mask_degenerate": flag}
 
 
 def test_finalize_wds_unlinks_each_shard_after_folding(

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -67,12 +67,15 @@ def _write_minimal_wds_shard(dest: Path) -> None:
 def _build_wds_smoke_spec(
     task_name: str = "finalize-wds-unit",
     train_val_test_sizes: tuple[int, int, int] = (4, 0, 0),
+    mask_degenerate_bins: bool = False,
 ) -> DatasetSpec:
     """Construct a wds ``DatasetSpec`` directly (no Hydra compose).
 
     :param task_name: Unique task name so each test gets a distinct r2.prefix.
     :param train_val_test_sizes: Three-tuple of sample counts; default is one
         4-sample shard.
+    :param mask_degenerate_bins: Threaded onto the spec so wire tests can pin
+        both polarities of the finalize stats-fold knob.
     :returns: A frozen wds ``DatasetSpec`` whose shards are deterministic.
     """
     kwargs: dict[str, Any] = {
@@ -80,6 +83,7 @@ def _build_wds_smoke_spec(
         "output_format": "wds",
         "train_val_test_sizes": list(train_val_test_sizes),
         "base_seed": 42,
+        "mask_degenerate_bins": mask_degenerate_bins,
         "r2": {"bucket": "intermediate-data"},
         "render": {
             "plugin_path": "/fake/Plugin.vst3",
@@ -219,6 +223,7 @@ def _build_hdf5_smoke_spec(
     task_name: str = "finalize-hdf5-unit",
     train_val_test_sizes: tuple[int, int, int] = (8, 4, 4),
     samples_per_shard: int = 4,
+    mask_degenerate_bins: bool = False,
 ) -> DatasetSpec:
     """Construct a small hdf5 ``DatasetSpec`` directly (no Hydra compose).
 
@@ -226,6 +231,8 @@ def _build_hdf5_smoke_spec(
     :param train_val_test_sizes: Three-tuple of sample counts; every entry must
         be a multiple of ``samples_per_shard``.
     :param samples_per_shard: Per-shard row count driving shard count derivation.
+    :param mask_degenerate_bins: Threaded onto the spec so wire tests can pin
+        both polarities of the finalize stats-fold knob.
     :returns: A frozen hdf5 ``DatasetSpec`` whose shards are deterministic.
     """
     kwargs: dict[str, Any] = {
@@ -233,6 +240,7 @@ def _build_hdf5_smoke_spec(
         "output_format": "hdf5",
         "train_val_test_sizes": list(train_val_test_sizes),
         "base_seed": 42,
+        "mask_degenerate_bins": mask_degenerate_bins,
         "r2": {"bucket": "intermediate-data"},
         "render": {
             "plugin_path": "/fake/Plugin.vst3",
@@ -624,10 +632,8 @@ def test_finalize_hdf5_temp_work_dir_is_torn_down_on_failure(
     captured_work_dir: dict[str, Path] = {}
     r2_stand_in = tmp_path / "r2"
 
-    def boom_finalize_hdf5(
-        spec: object, work_dir: Path, mask_degenerate_bins: bool = False
-    ) -> None:
-        del spec, mask_degenerate_bins
+    def boom_finalize_hdf5(spec: object, work_dir: Path) -> None:
+        del spec
         # Capture the live tempdir path before the raise so the post-call
         # assertion can prove ``TemporaryDirectory`` cleanup ran.
         captured_work_dir["path"] = Path(work_dir)
@@ -889,14 +895,14 @@ def test_finalize_wds_raises_on_empty_train_split(fake_r2_remote: Path, tmp_path
 def test_finalize_wds_forwards_mask_degenerate_bins_to_stream_stats(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, flag: bool
 ) -> None:
-    """``finalize_wds`` forwards ``mask_degenerate_bins`` to ``stream_stats_wds`` verbatim.
+    """``finalize_wds`` forwards ``spec.mask_degenerate_bins`` to ``stream_stats_wds`` verbatim.
 
     Pins the wire on both polarities so a regression that hard-wires the kwarg (True or False)
     fails the test rather than silently re-breaking smoke finalize.
 
     :param monkeypatch: Pytest fixture used to capture the forwarded kwarg.
     :param tmp_path: Pytest tmp dir; the download stub writes one minimal shard.
-    :param flag: Parametrized polarity threaded through the wire.
+    :param flag: Parametrized polarity threaded through the wire via the spec field.
     """
     monkeypatch.setattr(
         "synth_setter.pipeline.r2_io.download_to_path",
@@ -915,8 +921,12 @@ def test_finalize_wds_forwards_mask_degenerate_bins_to_stream_stats(
 
     monkeypatch.setattr("synth_setter.cli.finalize_dataset.stream_stats_wds", fake_stream_stats)
 
-    spec = _build_wds_smoke_spec(task_name=f"mask-forwards-{flag}", train_val_test_sizes=(4, 0, 0))
-    finalize_dataset.finalize_wds(spec, tmp_path, mask_degenerate_bins=flag)
+    spec = _build_wds_smoke_spec(
+        task_name=f"mask-forwards-{flag}",
+        train_val_test_sizes=(4, 0, 0),
+        mask_degenerate_bins=flag,
+    )
+    finalize_dataset.finalize_wds(spec, tmp_path)
 
     assert captured == {"mask_degenerate": flag}
 
@@ -925,7 +935,7 @@ def test_finalize_wds_forwards_mask_degenerate_bins_to_stream_stats(
 def test_finalize_hdf5_forwards_mask_degenerate_bins_to_get_stats(
     fake_r2_remote: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, flag: bool
 ) -> None:
-    """``finalize_hdf5`` forwards ``mask_degenerate_bins`` to ``get_stats_hdf5`` verbatim.
+    """``finalize_hdf5`` forwards ``spec.mask_degenerate_bins`` to ``get_stats_hdf5`` verbatim.
 
     Mirrors the wds wire test so a regression on the hdf5 branch surfaces the same way; the smoke-
     shard config opts in for the same reason and needs the same protection.
@@ -933,7 +943,7 @@ def test_finalize_hdf5_forwards_mask_degenerate_bins_to_get_stats(
     :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
     :param tmp_path: Pytest tmp dir; hosts the finalize scratch work_dir.
     :param monkeypatch: Pytest fixture used to capture the forwarded kwarg.
-    :param flag: Parametrized polarity threaded through the wire.
+    :param flag: Parametrized polarity threaded through the wire via the spec field.
     """
     captured: dict[str, bool] = {}
 
@@ -947,13 +957,16 @@ def test_finalize_hdf5_forwards_mask_degenerate_bins_to_get_stats(
 
     monkeypatch.setattr("synth_setter.cli.finalize_dataset.get_stats_hdf5", fake_get_stats)
 
-    spec = _build_hdf5_smoke_spec(task_name=f"mask-forwards-hdf5-{flag}")
+    spec = _build_hdf5_smoke_spec(
+        task_name=f"mask-forwards-hdf5-{flag}",
+        mask_degenerate_bins=flag,
+    )
     shard_remote_dir = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
     _seed_shard_files(shard_remote_dir, spec)
 
     work_dir = tmp_path / "work"
     work_dir.mkdir()
-    finalize_dataset.finalize_hdf5(spec, work_dir, mask_degenerate_bins=flag)
+    finalize_dataset.finalize_hdf5(spec, work_dir)
 
     assert captured == {"mask_degenerate": flag}
 


### PR DESCRIPTION
## Summary

Unblocks the `test-dataset-finalization.yml` wds matrix cell on PR #1214 (and pre-empts the same flake on the hdf5 cell). The smoke matrix's wds row was failing in the `Run synth-setter-finalize-dataset` step with:

```
ValueError: Found 2002 mel bin(s) with zero variance across the dataset
(std shape (2, 128, 401); ...). Rerun with --mask-degenerate-bins to mask
these bins instead of failing.
```
([failing run](https://github.com/tinaudio/synth-setter/actions/runs/26189589640))

### Root cause

- Both smoke configs render 12 samples of `surge_simple` audio.
- The rendered audio is deterministically constant at certain mel positions — early frames (attack-time silence) and channels below the source's active bandwidth.
- `stream_stats_wds`'s Welford reports the exact zero variance and raises by default.
- The hdf5 cell happened to pass only because dask's two-pass `std(axis=0)` introduces float noise that lands those same positions just above zero. Same input data, different rounding.

`get_stats_hdf5` / `stream_stats_wds` already accept `mask_degenerate=True` to substitute `std=1.0` at degenerate positions (which yields `(spec - mean) / std == 0` on the constant-bin training distribution — no datamodule changes). The finalize CLI was not surfacing the knob.

### Changes

- `configs/dataset.yaml` — add top-level `mask_degenerate_bins: false`. Strict default holds for production datasets so a real upstream regression still surfaces loudly.
- `configs/experiment/generate_dataset/smoke-shard.yaml` and `smoke-shard-wds.yaml` — override to `true`. Both rows get the same setting so the hdf5 row does not regress when FP noise stops hiding constant bins.
- `src/synth_setter/cli/finalize_dataset.py` — thread `mask_degenerate_bins` through `finalize_wds`, `finalize_hdf5`, and `main()`. `main()` reads it from the composed cfg via `cfg.get("mask_degenerate_bins", False)` and forwards to the dispatched branch.
- `src/synth_setter/cli/generate_dataset.py` — register `"mask_degenerate_bins"` in `_NON_SPEC_KEYS` so `spec_from_cfg` pops the finalize-only key before constructing the `DatasetSpec`.
- `tests/pipeline/test_entrypoints/test_finalize_dataset.py` — extend existing stub signatures for the new kwarg; add `test_finalize_wds_forwards_mask_degenerate_bins_to_stream_stats` and the symmetric `test_finalize_hdf5_forwards_mask_degenerate_bins_to_get_stats`, both parametrized over `[True, False]` to pin both polarities of the wire.

### Why not just bump `train_val_test_sizes`?

12 samples is intentionally tiny so the smoke matrix fits inside the `generate-dataset-shards.yaml` 20-min step timeout. A larger train size would push the smoke render past that budget without buying coverage the existing matrix doesn't already exercise.

## Test plan

- [ ] `test-dataset-finalization.yml` wds matrix row turns green on this PR.
- [ ] `test-dataset-finalization.yml` hdf5 matrix row stays green.
- [x] `pytest tests/pipeline tests/integration/test_finalize_dataset_r2.py` — 658 passed, 2 skipped locally.
- [x] Hydra compose of both smoke experiments resolves `mask_degenerate_bins == True`.
- [x] Pre-commit (ruff, pyright, pydoclint, yamllint, mdformat, etc.) green on the staged files.
- [x] Multi-skill review (`repo-review-full-no-comments`) — 0 BLOCK, 11 WARN; 8 addressed in follow-up commit, 3 accepted as documented trade-offs.

Refs #1184