### PR TITLE
experiment(ci): pin kubernetes==35.0.0 — test skypilot-local cron regression hypothesis B

### DIFF
--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -295,9 +295,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.venv-launcher
-          key: launcher-uv-${{ runner.os }}-py310-skypilot0.12.0-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+          key: launcher-uv-${{ runner.os }}-py310-skypilot0.12.0-k8s35-${{ hashFiles('uv.lock', 'pyproject.toml') }}
           restore-keys: |
-            launcher-uv-${{ runner.os }}-py310-skypilot0.12.0-
+            launcher-uv-${{ runner.os }}-py310-skypilot0.12.0-k8s35-
 
       # Idempotent: `uv venv` creates the venv if missing; `uv pip install` is
       # a no-op on a cache hit (resolver sees the requested versions already
@@ -311,7 +311,7 @@ jobs:
           if [[ ! -x "${VENV}/bin/python" ]]; then
             uv venv "${VENV}" --python 3.10
           fi
-          uv pip install --python "${VENV}/bin/python" -e . "skypilot[kubernetes]==0.12.0"
+          uv pip install --python "${VENV}/bin/python" -e . "skypilot[kubernetes]==0.12.0" "kubernetes==35.0.0"
           echo "${VENV}/bin" >> "${GITHUB_PATH}"
           sudo apt-get install -y -qq rclone
 


### PR DESCRIPTION
## Summary

Diagnostic PR for [#1239](https://github.com/tinaudio/synth-setter/issues/1239). Pins `kubernetes==35.0.0` on the launcher venv install line in `.github/workflows/generate-dataset-shards.yaml` to test the hypothesis that the cron regression on `skypilot-local` is caused by the `kubernetes` 36.0.0 PyPI release (uploaded 2026-05-20T20:44:20Z, ~2 h before our last green cron tick).

Also bumps the launcher venv cache key (`k8s35-` suffix) so a warm cache built before the pin cannot ship `kubernetes==36.0.0` and mask the experiment.

## Companion PR

Pairs with [#1239](https://github.com/tinaudio/synth-setter/issues/1239)'s hypothesis A at [#1240](https://github.com/tinaudio/synth-setter/pull/1240) — reverts [#1220](https://github.com/tinaudio/synth-setter/pull/1220). Whichever PR's `test-dataset-generation` dispatch goes green points to the cause.

## Dispatched run

[Actions run 26253338754](https://github.com/tinaudio/synth-setter/actions/runs/26253338754)

## Verification

- [ ] [Run 26253338754](https://github.com/tinaudio/synth-setter/actions/runs/26253338754) reaches a terminal state.
- [ ] Outcome captured on [#1239](https://github.com/tinaudio/synth-setter/issues/1239).

## Do not merge

This branch is for diagnostic dispatch only.

Refs #1239