### PR TITLE
fix(deps): pin kubernetes==35.0.0 — unblock SkyPilot pod_config validation

### DIFF
--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -295,9 +295,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ github.workspace }}/.venv-launcher
-          key: launcher-uv-${{ runner.os }}-py310-skypilot0.12.0-${{ hashFiles('uv.lock', 'pyproject.toml') }}
+          key: launcher-uv-${{ runner.os }}-py310-skypilot0.12.0-k8s35-${{ hashFiles('uv.lock', 'pyproject.toml') }}
           restore-keys: |
-            launcher-uv-${{ runner.os }}-py310-skypilot0.12.0-
+            launcher-uv-${{ runner.os }}-py310-skypilot0.12.0-k8s35-
 
       # Idempotent: `uv venv` creates the venv if missing; `uv pip install` is
       # a no-op on a cache hit (resolver sees the requested versions already
@@ -311,7 +311,7 @@ jobs:
           if [[ ! -x "${VENV}/bin/python" ]]; then
             uv venv "${VENV}" --python 3.10
           fi
-          uv pip install --python "${VENV}/bin/python" -e . "skypilot[kubernetes]==0.12.0"
+          uv pip install --python "${VENV}/bin/python" -e . "skypilot[kubernetes]==0.12.0" "kubernetes==35.0.0"
           echo "${VENV}/bin" >> "${GITHUB_PATH}"
           sudo apt-get install -y -qq rclone
 

--- a/.github/workflows/test-skypilot-local.yml
+++ b/.github/workflows/test-skypilot-local.yml
@@ -86,7 +86,7 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y -qq socat
 
       - name: Install SkyPilot (kubernetes extra)
-        run: pip install "skypilot[kubernetes]==0.12.0"
+        run: pip install "skypilot[kubernetes]==0.12.0" "kubernetes==35.0.0"
 
       # Provision the local kind cluster. `--no-gpus` keeps the cluster CPU-
       # only so the runner image's missing nvidia-container-toolkit doesn't

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,8 @@ dependencies = [
   "wandb",
   # --------- pipeline --------- #
   "click<8.2",
+  # Pin: kubernetes>=36 breaks SkyPilot pod_config validation — see #1239.
+  "kubernetes==35.0.0",
   "numpy",
   "oci",
   "pydantic>=2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = [
   # --------- pipeline --------- #
   "click<8.2",
   # Pin: kubernetes>=36 breaks SkyPilot pod_config validation — see #1239.
+  # Co-pin echoed in .github/workflows/test-skypilot-local.yml and
+  # .github/workflows/generate-dataset-shards.yaml.
   "kubernetes==35.0.0",
   "numpy",
   "oci",


### PR DESCRIPTION
## Summary

Permanently pins `kubernetes==35.0.0` across the repo so neither the cron-driven launcher venv nor the skypilot-local smoke runner can resolve `kubernetes` 36.x, which breaks SkyPilot 0.12.0's `pod_config` validation.

## Root cause

`kubernetes` 36.0.0 was uploaded to PyPI at 2026-05-20T20:44:20Z. The hourly `Test Dataset Generation` cron (`generate-dataset-shards.yaml`, job `dispatch / Run generate_dataset (skypilot-local)`) installs `skypilot[kubernetes]==0.12.0` without pinning the underlying `kubernetes` package, so the next time the GHA cache was rebuilt the launcher venv began resolving 36.0.0. SkyPilot 0.12.0's `pod_config` validator can't parse the 36.x type annotations and raises:

```
sky.exceptions.InvalidCloudConfigs: Invalid pod_config.
Details: Validation error in metadata.labels:
No module named 'kubernetes.client.models.dict[str, str]'
```

Diagnostic PR #1241 (`diag/1239-pin-kubernetes-35`) confirmed the hypothesis by pinning `kubernetes==35.0.0` on just the launcher install line and re-dispatching the workflow.

## Edits (3 files)

- **`pyproject.toml`** — added `"kubernetes==35.0.0"` to `[project].dependencies` (pipeline group) with a one-line `# Pin: … see #1239` comment. This is the canonical pin so anyone installing the package gets the safe version.
- **`.github/workflows/generate-dataset-shards.yaml`** — appended `"kubernetes==35.0.0"` to the launcher `uv pip install` line, and bumped the launcher venv cache key by inserting `k8s35-` into both `key:` and `restore-keys:` so warm caches from before the pin cannot mask the fix. Same change as #1241.
- **`.github/workflows/test-skypilot-local.yml`** — appended `"kubernetes==35.0.0"` to the `pip install "skypilot[kubernetes]==0.12.0"` line. This workflow has no cache, so no key bump.

`skypilot[runpod,oci]==0.12.0` is untouched.

## `uv lock`

Ran `uv lock` locally; the existing tracked `uv.lock` is an 8-line stub (`source = { virtual = "." }`, no resolved packages) — running `uv lock` would expand it to ~7600 lines of fully-resolved deps, which is an unrelated repo-wide change far outside this fix's scope. Reverted the regenerated lockfile and kept the stub as-is. If the project ever decides to start tracking a real `uv.lock`, that's its own PR.

## Test plan

- [ ] CI presubmit (PR workflows) goes green on this branch.
- [ ] Manual dispatch of `Test Dataset Generation` on this branch reaches `Run generate_dataset (skypilot-local)` completion without the `InvalidCloudConfigs` / `metadata.labels` error.
- [ ] `test-skypilot-local.yml` workflow run on this branch passes.
- [ ] After merge, the next hourly `Test Dataset Generation` cron tick on `main` is green.

Closes #1239