### PR TITLE
feat(pipeline): default rank/world to (0, 1) when partition env absent

### DIFF
--- a/.github/workflows/nightly-parallel-datagen.yml
+++ b/.github/workflows/nightly-parallel-datagen.yml
@@ -112,8 +112,13 @@ jobs:
       #     keeps it null), so ``main()`` runs ``run(spec)`` inline rather than
       #     dispatching via SkyPilot — exercises ``_dispatch_shards_parallel``
       #     directly on this runner.
-      #   * ``SYNTH_SETTER_WORKER_RANK=0`` / ``SYNTH_SETTER_NUM_WORKERS=1`` so
-      #     the single in-process worker owns every shard.
+      #   * Partition env intentionally unset — exercises the
+      #     ``read_rank_world_from_env`` local default ``(rank=0, world=1)``
+      #     end-to-end. A regression that loses the default fails this
+      #     workflow before a launcher-less developer hits it. The #763
+      #     invariant (partial partition env still raises; only the
+      #     both-absent path defaults) is pinned by the partitioning unit
+      #     tests.
       #   * ``++render.parallel=true`` overrides the default ``parallel=false``
       #     even though the experiment YAML already sets it — the explicit
       #     override keeps the production-path coverage signal in the workflow
@@ -146,8 +151,6 @@ jobs:
             -e EXPERIMENT \
             -e NIGHTLY_TASK_NAME \
             -e HYDRA_FULL_ERROR=1 \
-            -e SYNTH_SETTER_WORKER_RANK=0 \
-            -e SYNTH_SETTER_NUM_WORKERS=1 \
             "$IMAGE" \
             bash -c '
               set -euo pipefail

--- a/src/synth_setter/pipeline/partitioning.py
+++ b/src/synth_setter/pipeline/partitioning.py
@@ -3,7 +3,8 @@
 Each worker owns a contiguous, deterministic slice of shard IDs computed from
 ``(total_shards, rank, world)``. Pure helpers (``get_my_shards``,
 ``validate_rank_world``) and an env-reading shell (``read_rank_world_from_env``)
-that fails loudly on missing partition env — see #763.
+that defaults to single-worker local mode when both partition env vars are
+absent, and rejects any partial / malformed config — see #763.
 
 Env vars are ``SYNTH_SETTER_``-prefixed to dodge SkyPilot's reserved
 ``SKYPILOT_NODE_RANK`` (clobbered to 0 per single-node cluster) and to avoid
@@ -27,8 +28,9 @@ def available_cpus() -> int:
 
     :returns: Number of CPUs usable by this process; always ``>= 1``.
     """
-    if hasattr(os, "sched_getaffinity"):
-        return len(os.sched_getaffinity(0))
+    sched_getaffinity = getattr(os, "sched_getaffinity", None)
+    if sched_getaffinity is not None:
+        return len(sched_getaffinity(0))
     return os.cpu_count() or 1
 
 
@@ -42,20 +44,30 @@ def validate_rank_world(rank: int, world: int) -> None:
 
 
 def read_rank_world_from_env() -> tuple[int, int]:
-    """Read SYNTH_SETTER_WORKER_RANK / SYNTH_SETTER_NUM_WORKERS as ints, no defaults.
+    """Read SYNTH_SETTER_WORKER_RANK / SYNTH_SETTER_NUM_WORKERS as ints.
 
-    Silent defaults are refused so a misconfigured worker can't duplicate every
-    shard across every node — see #763.
+    With both env vars absent, returns ``(0, 1)`` — the local single-worker
+    default that makes ``generate_dataset`` usable without manually exporting
+    partition env. A partial config (only one set) still raises: that pattern
+    almost always means a launcher dropped half its env injection, and silently
+    treating it as single-worker would duplicate every shard across every
+    node — see #763.
 
     :return: ``(rank, world)`` as integers, validated against ``validate_rank_world``.
-    :raises ValueError: If either env var is missing, can't parse as int, or fails the
-        rank/world bounds check.
+    :raises ValueError: If exactly one env var is set, either can't parse as int,
+        or the resulting rank/world fails the bounds check.
     """
-    missing = [
-        name for name in (WORKER_RANK_ENV_VAR, NUM_WORKERS_ENV_VAR) if name not in os.environ
-    ]
-    if missing:
-        raise ValueError(f"missing partition env vars: {', '.join(missing)}")
+    rank_present = WORKER_RANK_ENV_VAR in os.environ
+    world_present = NUM_WORKERS_ENV_VAR in os.environ
+    if not rank_present and not world_present:
+        return 0, 1
+    if rank_present != world_present:
+        missing = WORKER_RANK_ENV_VAR if not rank_present else NUM_WORKERS_ENV_VAR
+        present = NUM_WORKERS_ENV_VAR if not rank_present else WORKER_RANK_ENV_VAR
+        raise ValueError(
+            f"partial partition env: {present} set but {missing} missing "
+            "(set both or neither — neither defaults to single-worker local mode)"
+        )
     rank_raw = os.environ[WORKER_RANK_ENV_VAR]
     world_raw = os.environ[NUM_WORKERS_ENV_VAR]
     try:

--- a/tests/integration/test_parallel_shard_dispatch.py
+++ b/tests/integration/test_parallel_shard_dispatch.py
@@ -16,6 +16,7 @@ plugin installed, so the dispatcher path is never coverage-blind.
 
 from __future__ import annotations
 
+import shutil
 import sys
 import textwrap
 from datetime import datetime, timezone
@@ -99,20 +100,50 @@ def _build_spec() -> DatasetSpec:
     return DatasetSpec(**kwargs)  # type: ignore[arg-type]
 
 
+def _wire_run_into_fake_renderer(
+    spec: DatasetSpec,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wire ``run(spec)`` to cross the real subprocess boundary into a fake renderer.
+
+    Stubs the renderer-version probe (no real VST3 on disk), the R2 skip-probe
+    (every shard is "absent"), pins ``available_cpus`` to 8 so pool size is
+    deterministic across CI hosts, swaps the renderer args for a
+    ``sys.executable <fake_renderer.py> <output_path>`` invocation, and skips
+    the Linux Xvfb wrapper (fake renderer needs no X11; the wrapper is
+    stress-tested by ``test_parallel_shard_render_linux.py``).
+
+    Partition env (``SYNTH_SETTER_WORKER_RANK`` / ``SYNTH_SETTER_NUM_WORKERS``)
+    is the caller's responsibility — leave both unset for default-mode tests
+    or call ``monkeypatch.setenv`` for explicit-rank tests.
+
+    :param spec: Spec whose ``render.renderer_version`` is mirrored by the stub probe.
+    :param tmp_path: Per-test tmp dir; the fake renderer is dropped here.
+    :param monkeypatch: Pytest fixture used for all the stubs.
+    """
+    monkeypatch.setattr("synth_setter.cli.generate_dataset.available_cpus", lambda: 8)
+    monkeypatch.setattr(
+        "synth_setter.cli.generate_dataset.extract_renderer_version",
+        lambda _path: spec.render.renderer_version,
+    )
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.object_size", lambda *_a, **_k: None)
+    monkeypatch.setattr("synth_setter.cli.generate_dataset.sys.platform", "darwin")
+
+    fake_renderer = _write_fake_renderer(tmp_path)
+
+    def _fake_build_args(_spec: DatasetSpec, shard: ShardSpec, output_dir: Path) -> list[str]:
+        return [sys.executable, str(fake_renderer), str(output_dir / shard.filename)]
+
+    monkeypatch.setattr("synth_setter.cli.generate_dataset.build_generate_args", _fake_build_args)
+
+
 def test_parallel_dispatch_crosses_real_subprocess_boundary(
     fake_r2_remote: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``parallel=True`` + 4 shards uploads every shard via real subprocess + real rclone.
-
-    Stubs the renderer-version probe (no real VST3 on disk) and the R2
-    skip-probe (every shard is "absent"), pins ``available_cpus`` to 8 so
-    pool size is deterministic across CI hosts, and swaps the renderer args
-    for a ``sys.executable <fake_renderer.py> <output_path>`` invocation.
-    The dispatch path then runs end-to-end: ``ThreadPoolExecutor`` →
-    ``subprocess.check_call`` → fresh Python → empty file written → real
-    ``rclone copy`` → ``fake_r2_remote``.
 
     State-based assertion: every shard's filename exists under the fake R2
     remote when ``run(spec)`` returns.
@@ -126,24 +157,7 @@ def test_parallel_dispatch_crosses_real_subprocess_boundary(
 
     monkeypatch.setenv("SYNTH_SETTER_WORKER_RANK", "0")
     monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "1")
-    monkeypatch.setattr("synth_setter.cli.generate_dataset.available_cpus", lambda: 8)
-    monkeypatch.setattr(
-        "synth_setter.cli.generate_dataset.extract_renderer_version",
-        lambda _path: spec.render.renderer_version,
-    )
-    monkeypatch.setattr("synth_setter.pipeline.r2_io.object_size", lambda *_a, **_k: None)
-    # Skip the Linux Xvfb-wrapper prefix in ``_render_and_upload_shard`` — the
-    # fake renderer needs no X11, and the wrapper isn't on PATH from the test
-    # CWD (``fake_r2_remote`` chdirs into tmp_path). The wrapper itself is
-    # stress-tested by ``test_parallel_shard_render_linux.py``.
-    monkeypatch.setattr("synth_setter.cli.generate_dataset.sys.platform", "darwin")
-
-    fake_renderer = _write_fake_renderer(tmp_path)
-
-    def _fake_build_args(_spec: DatasetSpec, shard: ShardSpec, output_dir: Path) -> list[str]:
-        return [sys.executable, str(fake_renderer), str(output_dir / shard.filename)]
-
-    monkeypatch.setattr("synth_setter.cli.generate_dataset.build_generate_args", _fake_build_args)
+    _wire_run_into_fake_renderer(spec, tmp_path, monkeypatch)
 
     run(spec)
 
@@ -152,3 +166,59 @@ def test_parallel_dispatch_crosses_real_subprocess_boundary(
         assert (bucket_prefix / shard.filename).is_file(), (
             f"shard {shard.shard_id} did not land in fake R2: {shard.filename}"
         )
+
+
+def test_two_ranks_render_disjoint_complete_shard_partition(
+    fake_r2_remote: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two ranks (0/2 + 1/2) over the same spec produce a disjoint, complete shard set.
+
+    Cross-checks the launcher/worker env-var contract end-to-end: rank-0 and
+    rank-1 each render their slice through the real subprocess boundary; the
+    union must cover every shard and the intersection must be empty. Catches
+    drift between ``WORKER_RANK_ENV_VAR`` / ``NUM_WORKERS_ENV_VAR`` (the
+    launcher-side injection) and the names ``read_rank_world_from_env`` reads.
+    If anyone renames one side without the other, both ranks fall back to the
+    single-worker default and render every shard, breaking the disjointness
+    assertion.
+
+    :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+    :param tmp_path: Per-test tmp dir for the fake renderer script.
+    :param monkeypatch: Used by the shared setup helper plus per-rank env injection.
+    """
+    spec = _build_spec()
+    assert len(spec.shards) == _NUM_SHARDS
+
+    _wire_run_into_fake_renderer(spec, tmp_path, monkeypatch)
+    bucket_prefix = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+
+    def _landed_filenames() -> set[str]:
+        return {
+            shard.filename for shard in spec.shards if (bucket_prefix / shard.filename).is_file()
+        }
+
+    monkeypatch.setenv("SYNTH_SETTER_WORKER_RANK", "0")
+    monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "2")
+    run(spec)
+    rank_0_landed = _landed_filenames()
+
+    # Wipe the bucket between ranks so rank-1's landed set is observed
+    # independently — otherwise the intersection check would be vacuously
+    # empty by set-difference construction and couldn't catch a regression
+    # where rank-1 silently re-renders rank-0's shards.
+    if bucket_prefix.exists():
+        shutil.rmtree(bucket_prefix)
+
+    monkeypatch.setenv("SYNTH_SETTER_WORKER_RANK", "1")
+    monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "2")
+    run(spec)
+    rank_1_landed = _landed_filenames()
+
+    every_shard = {shard.filename for shard in spec.shards}
+    assert rank_0_landed | rank_1_landed == every_shard, "ranks left a shard unrendered"
+    assert not (rank_0_landed & rank_1_landed), (
+        f"ranks rendered overlapping shards: {rank_0_landed & rank_1_landed}"
+    )
+    assert rank_0_landed and rank_1_landed, "one rank rendered nothing — env-var injection broke"

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -213,13 +213,14 @@ class TestRun:
 
     @pytest.fixture(autouse=True)
     def _set_default_skypilot_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Default to a single-worker rank/world for tests that don't care about partitioning.
+        """Pin rank=0/world=1 explicitly so partition-agnostic tests are insulated from host env.
 
-        ``run()`` now requires ``SYNTH_SETTER_WORKER_RANK`` / ``SYNTH_SETTER_NUM_WORKERS`` to be set
-        (silent default removed — see ``read_rank_world_from_env``). Most tests in this class
-        exercise behaviors orthogonal to partitioning, so set rank=0/world=1 by default; tests
-        that probe multi-worker partitioning override via ``monkeypatch.setenv`` and tests for
-        the missing-env contract override via ``monkeypatch.delenv``.
+        ``read_rank_world_from_env`` defaults to ``(0, 1)`` when both vars are
+        absent, but this fixture also overwrites any value the developer's shell
+        may have exported (e.g. an in-flight multi-worker debugging session) so
+        the partition-agnostic tests in this class stay deterministic. Tests
+        that probe multi-worker partitioning override via ``monkeypatch.setenv``;
+        the default-fallback test overrides via ``monkeypatch.delenv``.
         """
         monkeypatch.setenv("SYNTH_SETTER_WORKER_RANK", "0")
         monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "1")
@@ -596,25 +597,58 @@ class TestRun:
         patched_subprocess.assert_not_called()
         assert not (fake_r2_remote / spec.r2.bucket / spec.r2.prefix).exists()
 
-    def test_run_raises_when_skypilot_env_missing(
+    def test_run_defaults_to_single_worker_when_skypilot_env_absent(
         self,
         patched_subprocess: MagicMock,
         fake_r2_remote: Path,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Missing partition env → ValueError before any rclone or subprocess work.
+        """No partition env → rank=0/world=1, the lone worker renders every shard.
 
-        Removes the silent-default smell where a worker invoked without partition env would
-        otherwise duplicate every shard across every node.
+        Underwrites the dev-experience contract that ``synth-setter-generate-dataset`` works
+        out of the box without exporting ``SYNTH_SETTER_WORKER_RANK`` / ``SYNTH_SETTER_NUM_WORKERS``.
 
-        :param patched_subprocess: Subprocess dispatcher; asserted never invoked.
-        :param fake_r2_remote: Local-typed R2 remote — asserted empty.
+        :param patched_subprocess: Subprocess dispatcher used to introspect renderer argv per shard.
+        :param fake_r2_remote: Local-typed R2 remote — asserted to contain every shard.
         :param tmp_path: Pytest tmp dir used by ``_multi_shard_spec``.
         :param monkeypatch: Used to unset the rank/world env vars.
         """
         monkeypatch.delenv("SYNTH_SETTER_WORKER_RANK", raising=False)
         monkeypatch.delenv("SYNTH_SETTER_NUM_WORKERS", raising=False)
+        spec = _multi_shard_spec(tmp_path, n=3)
+
+        run(spec)
+
+        rendered_filenames = {
+            Path(args[find_script_index(args) + 1]).name
+            for args in _renderer_argv_lists(patched_subprocess)
+        }
+        assert rendered_filenames == {shard.filename for shard in spec.shards}
+        bucket_prefix = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+        for shard in spec.shards:
+            assert (bucket_prefix / shard.filename).is_file()
+
+    def test_run_raises_on_partial_partition_env(
+        self,
+        patched_subprocess: MagicMock,
+        fake_r2_remote: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Only world set (rank dropped) → ValueError before any rclone or subprocess work.
+
+        Partial partition env almost always means a launcher dropped half its env injection;
+        silently coercing it to single-worker would duplicate every shard across every node
+        (#763). The default-to-(0, 1) fallback is gated on BOTH vars being absent.
+
+        :param patched_subprocess: Subprocess dispatcher; asserted never invoked.
+        :param fake_r2_remote: Local-typed R2 remote — asserted empty.
+        :param tmp_path: Pytest tmp dir used by ``_multi_shard_spec``.
+        :param monkeypatch: Used to set world but unset rank.
+        """
+        monkeypatch.delenv("SYNTH_SETTER_WORKER_RANK", raising=False)
+        monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "2")
         spec = _multi_shard_spec(tmp_path, n=3)
 
         with pytest.raises(ValueError) as excinfo:

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -1554,6 +1554,43 @@ class TestDispatchViaSkypilot:
         for call in mock_sky.Task.from_yaml_config.return_value.update_envs.call_args_list:
             assert call.args[0][NUM_WORKERS_ENV_VAR] == "3"
 
+    def test_single_worker_dispatch_still_injects_rank_world_env(
+        self,
+        tmp_path: Path,
+        fake_plugin: Path,
+        env_file: Path,
+        mock_sky: MagicMock,
+    ) -> None:
+        """Single-worker dispatch still injects explicit rank=0 / world=1 partition env.
+
+        The worker-side fallback in ``read_rank_world_from_env`` is a local-mode
+        convenience; the launcher must keep injecting the explicit partition env
+        on every dispatch — otherwise a future ``num_workers=N`` regression that
+        drops the injection would silently fall back to single-worker and
+        duplicate every shard across every node (#763).
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param fake_plugin: Fixture-provided fake VST3 plugin path.
+        :param env_file: Fixture-provided worker env file path.
+        :param mock_sky: Mocked ``sky`` module from fixture.
+        """
+        template = _write_runpod_yaml(tmp_path)
+        spec = _build_spec(fake_plugin)
+        sky_cfg = SkypilotLaunchConfig(
+            compute_template=str(template),
+            cmd="echo",
+            env_file=str(env_file),
+            job_name="single-worker-env",
+        )
+
+        dispatch_via_skypilot(spec, sky_cfg, spec_uri=_DISPATCH_SPEC_URI)
+
+        update_envs_calls = mock_sky.Task.from_yaml_config.return_value.update_envs.call_args_list
+        assert len(update_envs_calls) == 1
+        injected = update_envs_calls[0].args[0]
+        assert injected[WORKER_RANK_ENV_VAR] == "0"
+        assert injected[NUM_WORKERS_ENV_VAR] == "1"
+
     @pytest.mark.parametrize(
         "field, value, match",
         [

--- a/tests/pipeline/test_partitioning.py
+++ b/tests/pipeline/test_partitioning.py
@@ -175,12 +175,13 @@ class TestValidation:
 
 
 class TestReadRankWorldFromEnv:
-    """Read SYNTH_SETTER_WORKER_RANK / SYNTH_SETTER_NUM_WORKERS with no defaults.
+    """Read SYNTH_SETTER_WORKER_RANK / SYNTH_SETTER_NUM_WORKERS with a local-only default.
 
-    The silent-default behavior is intentionally refused: a worker invoked
-    with a multi-shard spec but no partition env would otherwise duplicate
-    every shard across every node. Any missing/malformed/out-of-bounds env
-    must raise — generate_dataset.run propagates the ValueError to the worker exit path.
+    Both env vars absent → ``(0, 1)`` so a one-off ``generate_dataset`` run
+    doesn't require exporting partition env. Partial config (only one set) and
+    any malformed / out-of-bounds value still raise — partial almost always
+    means a launcher dropped half its env injection, and silently coercing it
+    to single-worker would duplicate every shard across every node (#763).
     """
 
     @pytest.fixture(autouse=True)
@@ -197,25 +198,37 @@ class TestReadRankWorldFromEnv:
         monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "4")
         assert read_rank_world_from_env() == (2, 4)
 
-    def test_both_missing_raises_with_both_names_in_message(self) -> None:
-        """Both vars missing → ValueError naming both."""
+    def test_both_missing_defaults_to_local_single_worker(self) -> None:
+        """Both vars absent → ``(0, 1)`` so local runs need no env setup."""
+        assert read_rank_world_from_env() == (0, 1)
+
+    def test_only_rank_missing_raises_naming_both_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only world set → ValueError naming both vars; partial config never silently defaults.
+
+        :param monkeypatch: Used to set world without rank.
+        """
+        monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "2")
         with pytest.raises(ValueError) as excinfo:
             read_rank_world_from_env()
         message = str(excinfo.value)
         assert "SYNTH_SETTER_WORKER_RANK" in message
         assert "SYNTH_SETTER_NUM_WORKERS" in message
 
-    def test_only_rank_missing_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Only rank var missing → ValueError naming rank."""
-        monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "1")
-        with pytest.raises(ValueError, match="SYNTH_SETTER_WORKER_RANK"):
-            read_rank_world_from_env()
+    def test_only_world_missing_raises_naming_both_vars(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only rank set → ValueError naming both vars; partial config never silently defaults.
 
-    def test_only_world_missing_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Only world var missing → ValueError naming world."""
+        :param monkeypatch: Used to set rank without world.
+        """
         monkeypatch.setenv("SYNTH_SETTER_WORKER_RANK", "0")
-        with pytest.raises(ValueError, match="SYNTH_SETTER_NUM_WORKERS"):
+        with pytest.raises(ValueError) as excinfo:
             read_rank_world_from_env()
+        message = str(excinfo.value)
+        assert "SYNTH_SETTER_WORKER_RANK" in message
+        assert "SYNTH_SETTER_NUM_WORKERS" in message
 
     def test_non_integer_rank_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Non-integer rank ('abc') → ValueError naming SYNTH_SETTER_WORKER_RANK."""


### PR DESCRIPTION
## Summary

- [`read_rank_world_from_env`](https://github.com/tinaudio/synth-setter/blob/chore/local-default-rank-world/src/synth_setter/pipeline/partitioning.py) now defaults to `(0, 1)` when both `SYNTH_SETTER_WORKER_RANK` and `SYNTH_SETTER_NUM_WORKERS` are unset, so `synth-setter-generate-dataset` runs locally without exporting partition env. Partial config (only one set) still raises — that pattern almost always means a launcher dropped half its env injection, and silently coercing it would duplicate every shard across every node ([#763](https://github.com/tinaudio/synth-setter/issues/763) invariant preserved).
- Defense-in-depth tests pin the launcher/worker env-var contract so the relaxed worker default can't hide a launcher regression:
  - new launcher-side test asserts single-worker dispatch still injects explicit `WORKER_RANK=0` / `NUM_WORKERS=1`
  - new cross-platform integration test drives two ranks across the real subprocess boundary, wipes R2 state between runs, and asserts a disjoint + complete shard partition
- [`nightly-parallel-datagen.yml`](https://github.com/tinaudio/synth-setter/blob/chore/local-default-rank-world/.github/workflows/nightly-parallel-datagen.yml) drops the redundant hardcoded partition env so it exercises the new default end-to-end in CI — a regression that loses the fallback fails the workflow before a launcher-less developer hits it.
- Drive-by: rebound `os.sched_getaffinity` via `getattr` in `available_cpus` so pyright's narrowing works on macOS as well as Linux (the prior `hasattr` guard ran fine but didn't satisfy pyright on macOS).

> Note: PR base is `chore/1247-uv-lock-foundation` (the in-flight uv-lock branch this was cut from), not `main`. Retarget to `main` after #1247 lands, or rebase if #1247 stalls.

Fixes [#1250](https://github.com/tinaudio/synth-setter/issues/1250)

## Test plan

- [x] `uv run pytest tests/pipeline/test_partitioning.py tests/pipeline/test_entrypoints/test_generate_dataset.py tests/pipeline/test_entrypoints/test_skypilot_launch.py tests/integration/test_parallel_shard_dispatch.py` → 173 passed
- [x] `uv run pre-commit run --files <touched files>` → all hooks pass (ruff, pyright, docformatter, pydoclint, GHA validator)
- [x] Pre-PR multi-skill review (`/repo-review-full-no-comments`) — 0 BLOCK, ~14 WARN across 9 skills; 2 fixed in-PR (vacuous disjointness assertion, exact-order coupling), 12 deferred with documented rationale (sentinel: `.agent-reviews/repo-review-full-no-comments.6a09002df339c35e68eff0b1a625143c906cdfaa.md`)
- [ ] Nightly `nightly-parallel-datagen` succeeds on its next 05:00 UTC run — workflow-level proof the default works end-to-end (post-merge verification)