### PR TITLE
ci(package): add wheel build + import smoke workflow

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -132,12 +132,12 @@ jobs:
           assert cfg.data, "data group not composed"
           assert cfg.model, "model group not composed"
           assert cfg.trainer, "trainer group not composed"
-          assert isinstance(cfg.model.out_dim, int), (
-              f"mul resolver did not produce int for cfg.model.out_dim: {cfg.model.out_dim!r}"
+          assert isinstance(cfg.model.net.out_dim, int), (
+              f"mul resolver did not produce int for cfg.model.net.out_dim: {cfg.model.net.out_dim!r}"
           )
 
           print("data._target_:", cfg.data._target_)
           print("model._target_:", cfg.model._target_)
           print("trainer._target_:", cfg.trainer._target_)
-          print("model.out_dim (mul-resolved):", cfg.model.out_dim)
+          print("model.net.out_dim (mul-resolved):", cfg.model.net.out_dim)
           PY

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -46,8 +46,10 @@ jobs:
         with:
           python-version: "3.10"
 
+      # Pin so an upstream tool release can't flip this gate red without a
+      # repo-side change. Bump deliberately as needed.
       - name: Install build tools
-        run: pip install --upgrade build twine
+        run: pip install 'build==1.2.*' 'twine==5.*'
 
       # `python -m build` runs PEP 517 in an isolated env; missing/broken
       # [build-system] fails here instead of falling back to legacy setuptools.
@@ -59,7 +61,7 @@ jobs:
 
       # Cheap diff signal when package-data changes.
       - name: List wheel contents
-        run: python -m zipfile -l dist/*.whl
+        run: python -m zipfile -l dist/synth_setter-*.whl
 
       # `--no-deps` keeps this a packaging check, not a dep-resolution check;
       # the heavy runtime stack (skypilot, torch, h5py) is exercised in Tests.

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -47,9 +47,10 @@ jobs:
           python-version: "3.10"
 
       # Pin so an upstream tool release can't flip this gate red without a
-      # repo-side change. Bump deliberately as needed.
+      # repo-side change. twine 5 rejects Metadata-Version 2.4 emitted by
+      # current setuptools — keep on twine 6.x. Bump deliberately as needed.
       - name: Install build tools
-        run: pip install 'build==1.2.*' 'twine==5.*'
+        run: pip install 'build==1.2.*' 'twine==6.*'
 
       # `python -m build` runs PEP 517 in an isolated env; missing/broken
       # [build-system] fails here instead of falling back to legacy setuptools.

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -99,13 +99,14 @@ jobs:
       # so a broken [tool.setuptools.package-data] glob still passes pytest
       # but breaks for real users. This step installs the built wheel with
       # full deps and runs the canonical Hydra compose path through it.
-      # `--find-links dist` instead of a glob so `[torch]` is parsed by pip
-      # as an extras spec, not by bash as a character class.
+      # Install the explicit wheel path (quoted to keep bash from globbing
+      # the `[torch]`) so pip can't prefer a higher version from PyPI.
       - name: Install wheel with full deps
         run: |
           python -m venv "$RUNNER_TEMP/full"
           "$RUNNER_TEMP/full/bin/pip" install --upgrade pip
-          "$RUNNER_TEMP/full/bin/pip" install --find-links dist 'synth-setter[torch]'
+          WHL=$(ls dist/synth_setter-*.whl)
+          "$RUNNER_TEMP/full/bin/pip" install "${WHL}[torch]"
 
       # Compose train.yaml through the canonical entry pattern — exercises
       # the namespace plugin's auto-registration of `pkg://synth_setter.configs`,

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -1,0 +1,92 @@
+name: Package smoke
+
+# Catches packaging regressions (missing package-data, broken build-backend,
+# src-layout / namespace-package) before a publish attempt surfaces them — see #1235, #542.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "pyproject.toml"
+      - "src/**"
+      - "README.md"
+      - "LICENSE"
+      - ".github/workflows/package-smoke.yml"
+  pull_request:
+    branches: [main, "release/*", "dev"]
+    paths:
+      - "pyproject.toml"
+      - "src/**"
+      - "README.md"
+      - "LICENSE"
+      - ".github/workflows/package-smoke.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: package-smoke-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build-and-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # Pin to requires-python floor so older-interpreter metadata bugs surface here.
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install build tools
+        run: pip install --upgrade build twine
+
+      # `python -m build` runs PEP 517 in an isolated env; missing/broken
+      # [build-system] fails here instead of falling back to legacy setuptools.
+      - name: Build sdist and wheel
+        run: python -m build --outdir dist
+
+      - name: Validate distribution metadata
+        run: twine check --strict dist/*
+
+      # Cheap diff signal when package-data changes.
+      - name: List wheel contents
+        run: python -m zipfile -l dist/*.whl
+
+      # `--no-deps` keeps this a packaging check, not a dep-resolution check;
+      # the heavy runtime stack (skypilot, torch, h5py) is exercised in Tests.
+      - name: Install wheel into clean venv
+        run: |
+          python -m venv "$RUNNER_TEMP/clean"
+          "$RUNNER_TEMP/clean/bin/pip" install --no-deps dist/synth_setter-*.whl
+
+      # cwd outside the repo so Python imports from the wheel, not src/;
+      # find_spec is used for hydra_plugins because its module body needs hydra.
+      - name: Smoke-test installed package
+        working-directory: ${{ runner.temp }}
+        run: |
+          "$RUNNER_TEMP/clean/bin/python" - <<'PY'
+          import importlib.util
+          from importlib.resources import files
+
+          import synth_setter
+
+          spec = importlib.util.find_spec("hydra_plugins.synth_setter_searchpath")
+          assert spec is not None, "hydra_plugins.synth_setter_searchpath not in installed wheel"
+
+          configs = files("synth_setter").joinpath("configs")
+          assert configs.is_dir(), f"configs/ missing from wheel: {configs}"
+          assert configs.joinpath("train.yaml").is_file(), "configs/train.yaml not bundled"
+
+          print("synth_setter:", synth_setter.__file__)
+          print("hydra_plugins.synth_setter_searchpath:", spec.origin)
+          print("configs path:", configs)
+          PY

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -99,11 +99,13 @@ jobs:
       # so a broken [tool.setuptools.package-data] glob still passes pytest
       # but breaks for real users. This step installs the built wheel with
       # full deps and runs the canonical Hydra compose path through it.
+      # `--find-links dist` instead of a glob so `[torch]` is parsed by pip
+      # as an extras spec, not by bash as a character class.
       - name: Install wheel with full deps
         run: |
           python -m venv "$RUNNER_TEMP/full"
           "$RUNNER_TEMP/full/bin/pip" install --upgrade pip
-          "$RUNNER_TEMP/full/bin/pip" install dist/synth_setter-*.whl[torch]
+          "$RUNNER_TEMP/full/bin/pip" install --find-links dist 'synth-setter[torch]'
 
       # Compose train.yaml through the canonical entry pattern — exercises
       # the namespace plugin's auto-registration of `pkg://synth_setter.configs`,

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -32,7 +32,7 @@ concurrency:
 jobs:
   build-and-smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     permissions:
       contents: read
 
@@ -91,4 +91,50 @@ jobs:
           print("synth_setter:", synth_setter.__file__)
           print("hydra_plugins.synth_setter_searchpath:", spec.origin)
           print("configs path:", configs)
+          PY
+
+      # Closes the gap that editable installs mask: tests in test.yml run
+      # against `pip install -e .` where src/.../configs/ is the source dir,
+      # so a broken [tool.setuptools.package-data] glob still passes pytest
+      # but breaks for real users. This step installs the built wheel with
+      # full deps and runs the canonical Hydra compose path through it.
+      - name: Install wheel with full deps
+        run: |
+          python -m venv "$RUNNER_TEMP/full"
+          "$RUNNER_TEMP/full/bin/pip" install --upgrade pip
+          "$RUNNER_TEMP/full/bin/pip" install dist/synth_setter-*.whl[torch]
+
+      # Compose train.yaml through the canonical entry pattern — exercises
+      # the namespace plugin's auto-registration of `pkg://synth_setter.configs`,
+      # the custom `${mul:…}` resolver in model/ffn.yaml, and every YAML in
+      # train's defaults chain (data/ksin, model/ffn, trainer/cpu, callbacks,
+      # logger, paths, extras, hydra). Stops short of `hydra.utils.instantiate`
+      # — that's what tests/test_configs.py covers against the editable tree.
+      - name: Canonical Hydra compose against installed wheel
+        working-directory: ${{ runner.temp }}
+        run: |
+          "$RUNNER_TEMP/full/bin/python" - <<'PY'
+          from hydra import compose, initialize_config_module
+
+          from synth_setter.utils import register_resolvers
+
+          register_resolvers()
+
+          with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
+              cfg = compose(
+                  config_name="train.yaml",
+                  overrides=["data=ksin", "model=ffn", "trainer=cpu"],
+              )
+
+          assert cfg.data, "data group not composed"
+          assert cfg.model, "model group not composed"
+          assert cfg.trainer, "trainer group not composed"
+          assert isinstance(cfg.model.out_dim, int), (
+              f"mul resolver did not produce int for cfg.model.out_dim: {cfg.model.out_dim!r}"
+          )
+
+          print("data._target_:", cfg.data._target_)
+          print("model._target_:", cfg.model._target_)
+          print("trainer._target_:", cfg.trainer._target_)
+          print("model.out_dim (mul-resolved):", cfg.model.out_dim)
           PY


### PR DESCRIPTION
## Summary

Adds `.github/workflows/package-smoke.yml` — a CI gate that exercises the publish path on every PR that touches packaging surface (`pyproject.toml`, `src/**`, `README`, `LICENSE`):

1. `python -m build` — PEP 517 isolated build of sdist + wheel.
2. `twine check --strict dist/*` — catches metadata problems that would fail a PyPI upload.
3. `python -m zipfile -l dist/*.whl` — visible diff signal when package-data changes.
4. `pip install --no-deps dist/synth_setter-*.whl` into a fresh venv outside the repo.
5. Smoke test (`cwd = $RUNNER_TEMP`):
   - `import synth_setter` — package is importable as installed.
   - `find_spec("hydra_plugins.synth_setter_searchpath")` — namespace package was bundled and is discoverable. Uses `find_spec` rather than `import` because the module body needs `hydra`, which `--no-deps` deliberately omits.
   - `importlib.resources.files("synth_setter").joinpath("configs/train.yaml").is_file()` — asserts the package-data contract from `src/synth_setter/resources.py`.

`--no-deps` keeps this scoped to a *packaging* check (does the wheel install and self-resolve?), not a *dep-resolution* check (does the universe still install?) — the heavy runtime stack (skypilot, torch, h5py, …) is exercised by `Tests` (`test.yml`).

## Why now

`pyproject.toml` has no `[build-system]` table today, package-data is shipped via globs, and the project uses both a regular package (`synth_setter`) and a namespace package (`hydra_plugins`) under `src/`. Each of those is a classic packaging trap that only surfaces post-publish unless CI specifically exercises the build → install → import path. Catching it pre-publish — before [#542](https://github.com/tinaudio/synth-setter/issues/542) makes the wheel a published artifact — is cheaper than catching it via a failed PyPI release. Also directly verifies the `importlib.resources` contract that [#1235](https://github.com/tinaudio/synth-setter/issues/1235) is establishing for `configs/` access.

## Local verification

Built the wheel, installed it `--no-deps` into a Python 3.10 venv outside the repo, and ran the smoke step's heredoc body verbatim — exits 0; `find_spec` resolves to `…/site-packages/hydra_plugins/synth_setter_searchpath/__init__.py`; `configs/train.yaml` is bundled. The bug surfaced by hands-on verification (the original heredoc did `import hydra_plugins.synth_setter_searchpath`, which triggers `from hydra.core.config_search_path import ConfigSearchPath` at module body and fails under `--no-deps`) was caught and fixed before push — see commit body.

## Test plan

- [ ] Push triggers the new `Package smoke / build-and-smoke` job.
- [ ] Job exits green: build, `twine check --strict`, install, and the smoke assertions all pass.
- [ ] Editing only `docs/` on a follow-up PR does NOT trigger the job (paths filter sanity check).

## Open WARNs (intentional, see `.agent-reviews/…`)

- `pip install --upgrade build twine` is unpinned (could be `'build==1.2.*' 'twine==5.*'` in a follow-up).
- `python-version: "3.10"` is not patch-pinned (over-engineering for a smoke check).
- `dist/*.whl` glob at L62 vs explicit `dist/synth_setter-*.whl` at L69 (one-line consistency follow-up).
- `actions/*@v6` tag-pinned, matching repo-wide convention (SHA-pinning is an org-level policy choice).

Refs #1235