### PR TITLE
fix(ci): force imagePullPolicy=Never in CI to avoid Docker Hub 429

### DIFF
--- a/src/synth_setter/pipeline/skypilot_launch.py
+++ b/src/synth_setter/pipeline/skypilot_launch.py
@@ -171,21 +171,41 @@ _CI_MODE_TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
 
 # SkyPilot's default (cpus: 4+, memory: 4x) doesn't fit in GHA-kind's
 # ~1950m allocatable CPU after kube-system. See PR #876.
+#
+# `kubernetes.pod_config` forces every CI-kind pod (jobs controller + worker)
+# to use the locally-loaded image and never resolve the manifest from Docker
+# Hub. Without this, kind/containerd still contacts registry-1.docker.io and
+# trips its anonymous-pull 429, even though `kind load docker-image` already
+# placed the image on the node. Container `name`-less entry merges into the
+# pod's first container (SkyPilot patch-merge legacy). See #1255.
 _CI_SKY_CONFIG_YAML = """jobs:
   controller:
     resources:
       cpus: 1+
       memory: 1+
+kubernetes:
+  pod_config:
+    spec:
+      containers:
+        - imagePullPolicy: Never
 """
 
 
 def _ensure_ci_sky_config() -> None:
-    """Write ``~/.sky/config.yaml`` with the controller shrink when CI mode is truthy.
+    """Write ``~/.sky/config.yaml`` with CI-only SkyPilot overrides when CI mode is truthy.
+
+    Currently emits two overrides: a managed-jobs controller resource shrink so
+    the controller pod fits a GHA-kind cluster (#876), and a
+    ``kubernetes.pod_config.spec.containers[0].imagePullPolicy: Never`` so
+    every CI-kind pod uses the locally-loaded dev-snapshot image instead of
+    racing Docker Hub's anonymous 429 limit (#1255).
 
     Truthy = ``SYNTH_SETTER_CI_MODE`` ∈ {1, true, yes, on} (case-insensitive).
     Any other value (including ``0``, ``false``, unset) is a no-op, so an
     operator who exports ``SYNTH_SETTER_CI_MODE=0`` doesn't clobber a local
-    config.
+    config, and production runs against real clouds never apply
+    ``imagePullPolicy: Never`` (which would prevent the worker from pulling
+    the image at all).
     """
     if os.environ.get(_CI_MODE_ENV, "").strip().lower() not in _CI_MODE_TRUTHY_VALUES:
         return

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -299,6 +299,29 @@ class TestEnsureCiSkyConfig:
         assert "memory: 1+" in body
         assert "controller:" in body
 
+    def test_writes_image_pull_policy_never_under_kubernetes_pod_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SYNTH_SETTER_CI_MODE=1 → pod_config forces ``imagePullPolicy: Never``.
+
+        Pinning the exact nested location is what makes the override actually
+        reach kubelet — SkyPilot's ``combine_pod_config_fields`` merges this
+        into every kind pod (jobs controller + worker), letting the
+        pre-loaded dev-snapshot image satisfy starts without re-resolving the
+        manifest from Docker Hub (#1255).
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param monkeypatch: Pytest fixture for env/attribute mocking.
+        """
+        import yaml as _yaml
+
+        monkeypatch.setenv("SYNTH_SETTER_CI_MODE", "1")
+        monkeypatch.setenv("HOME", str(tmp_path))
+        _ensure_ci_sky_config()
+        doc = _yaml.safe_load((tmp_path / ".sky" / "config.yaml").read_text(encoding="utf-8"))
+        containers = doc["kubernetes"]["pod_config"]["spec"]["containers"]
+        assert containers == [{"imagePullPolicy": "Never"}]
+
     def test_idempotent_overwrite(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Re-invoking the helper is safe; the file is rewritten, not appended.
 


### PR DESCRIPTION
## Summary

- Inject `kubernetes.pod_config.spec.containers[0].imagePullPolicy: Never` into `~/.sky/config.yaml` from `_ensure_ci_sky_config()`, gated on `SYNTH_SETTER_CI_MODE=1`.
- SkyPilot merges this into every CI-kind pod (jobs controller + worker), so both pods now use the pre-loaded dev-snapshot image and never re-resolve the manifest from Docker Hub.
- Adds a test pinning the exact nested location of the override in the rendered config.

Refs #1255

## Why

The `wds` cell of the `generate-dataset-shards.yaml` matrix [timed out after 40 minutes](https://github.com/tinaudio/synth-setter/actions/runs/26371827439/job/77625225624) on [#1214](https://github.com/tinaudio/synth-setter/pull/1214) because the worker pod was stuck in `ImagePullBackOff` with `429 Too Many Requests` from `registry-1.docker.io`:

```
Failed to pull image "tinaudio/synth-setter:dev-snapshot": ...
  429 Too Many Requests - Server message: toomanyrequests:
  You have reached your unauthenticated pull rate limit.
```

The workflow already loads `dev-snapshot` into the kind node's containerd via `kind load docker-image`, so the image is physically present. Kubelet's `IfNotPresent` default still resolves the manifest from the registry on pod start though, and that resolution is what trips Docker Hub's anonymous limit. Forcing `imagePullPolicy: Never` makes kubelet use the local image without contacting the registry at all. The `hdf5` row earlier in the matrix made it through Docker Hub before the bucket emptied; `wds` was scheduled minutes later and lost the race.

`Never` is safe in CI because the workflow guarantees `kind load docker-image` runs to completion before the launcher starts; in production (no `SYNTH_SETTER_CI_MODE`) this code path is skipped so real-cloud workers continue to pull normally.

A companion follow-up will mirror the image to GHCR to remove the dependency on Docker Hub entirely; this PR is the immediate unblock — hence `Refs` rather than `Fixes`.

## Verification

- [x] `uv run pytest tests/pipeline/test_entrypoints/test_skypilot_launch.py -x -q` — 89 passed (88 existing + 1 new).
- [x] `pre-commit run --files src/synth_setter/pipeline/skypilot_launch.py tests/pipeline/test_entrypoints/test_skypilot_launch.py` — all hooks passed (ruff, ruff-format, pyright, pydoclint, docformatter, interrogate, codespell, …).
- [ ] CI run of `generate-dataset-shards.yaml` (skypilot-local row) reaches the launcher's worker phase without `ImagePullBackOff`.

## Refs

- Tracking issue: [#1255](https://github.com/tinaudio/synth-setter/issues/1255) (Refs #1255)
- Failed run that motivated this: [run 26371827439, job 77625225624](https://github.com/tinaudio/synth-setter/actions/runs/26371827439/job/77625225624) on [#1214](https://github.com/tinaudio/synth-setter/pull/1214)
- Prior art on the CI sky-config seam: [#876](https://github.com/tinaudio/synth-setter/pull/876)
