### PR TITLE
feat(resources): full install-layout compatibility for packaged resources

### DIFF
--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -250,7 +250,11 @@ docs:
     description: Test layout, fixtures, markers, and the cpu/mps/gpu CI lane split
     sources:
       - pattern: "tests/conftest.py"
-        covers: "Hydra cfg_train/cfg_eval/cfg_surge_xt fixtures, accelerator parametrize, param_spec_name parametrize, experiment_name parametrize, _build_surge_xt_smoke_cfg, surge_xt_smoke_datasets, _validate_surge_dataset, shared constants (NUM_FIXTURE_SAMPLES, VST_HEADLESS_WRAPPER, _VST_SUBPROCESS_TIMEOUT_SECONDS)"
+        covers: "Hydra cfg_train/cfg_eval/cfg_surge_xt fixtures, accelerator parametrize, param_spec_name parametrize, experiment_name parametrize, _build_surge_xt_smoke_cfg, surge_xt_smoke_datasets (materializes wrapper+script via as_file + ExitStack for zip-wheel compat), _validate_surge_dataset, shared constants (NUM_FIXTURE_SAMPLES, _VST_SUBPROCESS_TIMEOUT_SECONDS)"
+      - pattern: "src/synth_setter/resources.py"
+        covers: "Traversable-based package resource discovery (configs_dir, vst_headless_wrapper, generate_vst_dataset_script); as_file re-export for materializing tempfile paths across zipped/unpacked installs"
+      - pattern: "tests/test_zipimport_compat.py"
+        covers: "End-to-end smoke lane that zips src/synth_setter and verifies every resources helper works under zipimport (import, iterdir, read_text, as_file materialization, actual subprocess execution of the renderer)"
       - pattern: "tests/test_train.py"
         covers: "E2E Hydra train / resume / Surge XT smoke + train→eval round-trip"
       - pattern: "tests/test_eval.py"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,7 +36,11 @@ Container-runtime shell helpers (X11 / VST3 bootstrap):
 | `ensure_plugin_symlinks.sh` | `docker/ubuntu22_04/ensure_plugin_symlinks.sh`       |
 
 `run-linux-vst-headless.sh` ships inside the `synth_setter` package and is
-discovered via `synth_setter.resources.vst_headless_wrapper()` — see
+discovered via `synth_setter.resources.vst_headless_wrapper()`; the Python
+worker script `generate_vst_dataset.py` is similarly packaged and located via
+`synth_setter.resources.generate_vst_dataset_script()`. Both return a
+`Traversable` — wrap in `as_file()` when a real on-disk path is required
+(e.g. for `subprocess.run`). See
 [`src/synth_setter/resources.py`](../src/synth_setter/resources.py).
 
 ## See also

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -42,7 +42,11 @@ from synth_setter.pipeline.spec_io import (  # noqa: E402
     upload_spec,
     write_spec_locally,
 )
-from synth_setter.resources import as_file, vst_headless_wrapper  # noqa: E402
+from synth_setter.resources import (  # noqa: E402
+    as_file,
+    generate_vst_dataset_script,
+    vst_headless_wrapper,
+)
 
 # Composed-config keys that aren't DatasetSpec fields (interpolation sources, Hydra
 # runtime, dispatch-mode sub-trees). See dataset.yaml in the shipped configs/
@@ -98,7 +102,12 @@ def _rclone_copy(src: str, dest: str) -> None:
     logger.info(f"rclone returned cleanly: {src} -> {dest}")
 
 
-def build_generate_args(spec: DatasetSpec, shard: ShardSpec, output_dir: Path) -> list[str]:
+def build_generate_args(
+    spec: DatasetSpec,
+    shard: ShardSpec,
+    output_dir: Path,
+    script_path: Path,
+) -> list[str]:
     """Build CLI args for ``generate_vst_dataset.py`` from a spec and shard.
 
     The flag set is derived from ``RenderConfig.model_fields`` so every renderer
@@ -106,11 +115,16 @@ def build_generate_args(spec: DatasetSpec, shard: ShardSpec, output_dir: Path) -
     field on the model auto-extends the CLI invocation. The writer is dispatched
     on ``shard.filename``'s suffix inside the subprocess via
     ``EXTENSION_TO_OUTPUT_FORMAT``.
+
+    :param script_path: Filesystem path to ``generate_vst_dataset.py``. The
+        caller is responsible for keeping this path valid for the subprocess
+        lifetime — under zipped wheels that means an :func:`as_file` /
+        :class:`contextlib.ExitStack` envelope around the subprocess call.
     """
     output_path = output_dir / shard.filename
     args = [
         sys.executable,
-        "src/synth_setter/data/vst/generate_vst_dataset.py",
+        str(script_path),
         str(output_path),
     ]
     for key, value in spec.render.model_dump().items():
@@ -311,16 +325,17 @@ def _render_and_upload_shard(
         exhausting the retry budget.
     :raises RuntimeError: Renderer exited 0 without writing the expected shard file.
     """
-    # Zipped wheels extract the wrapper to a temp file that only lives while
-    # ``as_file()`` is open; ``ExitStack`` keeps it on disk across the retry
-    # loop, and skips materialization on non-Linux.
+    # Zipped wheels extract the script + Linux wrapper to temp files that only
+    # live while ``as_file()`` is open; ``ExitStack`` keeps them on disk across
+    # the retry loop, and skips the wrapper on non-Linux.
     with ExitStack() as stack:
+        script_path = Path(stack.enter_context(as_file(generate_vst_dataset_script())))
         if sys.platform == "linux":
             wrapper_path = stack.enter_context(as_file(vst_headless_wrapper()))
             args = [str(wrapper_path)]
         else:
             args = []
-        args += build_generate_args(spec, shard, work_dir)
+        args += build_generate_args(spec, shard, work_dir, script_path)
         logger.info(f"rendering shard {shard.shard_id} -> {shard.filename}")
         max_attempts = spec.render.max_retries + 1
         for attempt in range(max_attempts):

--- a/src/synth_setter/data/vst/generate_vst_dataset.py
+++ b/src/synth_setter/data/vst/generate_vst_dataset.py
@@ -12,7 +12,17 @@ from pedalboard import VST3Plugin
 from pyloudnorm import Meter
 from pydantic_settings import BaseSettings, CliApp, CliPositionalArg, SettingsConfigDict
 
-rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
+try:
+    # Operator-checkout path: bootstraps PROJECT_ROOT + adds the source tree to
+    # sys.path so the script can `import synth_setter` even when run directly.
+    rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)
+except FileNotFoundError:
+    # Packaged-resource path: ``as_file()`` extracts this script to a tempfile
+    # under zipped wheels, so the ``.project-root`` indicator isn't reachable
+    # from ``__file__``. The launcher already has ``synth_setter`` importable
+    # via site-packages / zipimport — fall through to the imports below.
+    pass
+
 from synth_setter.pipeline.schemas.spec import (  # noqa: E402
     EXTENSION_TO_OUTPUT_FORMAT,
     RenderConfig,

--- a/src/synth_setter/resources.py
+++ b/src/synth_setter/resources.py
@@ -1,21 +1,42 @@
 """Locate data files shipped inside the ``synth_setter`` package.
 
-All callsites must use these helpers — never ``Path(__file__).parents[N]``
-or repo-relative strings. ``importlib.resources`` keeps the lookup correct
-under editable installs, wheels, and zip imports.
+All callsites must use these helpers — never ``Path(__file__).parents[N]``,
+``str(traversable)`` cast to ``Path``, or repo-relative strings.
+``importlib.resources`` keeps the lookup correct under every install layout
+Python's import machinery accepts: editable installs, unpacked wheels, zipped
+wheels / zipapps, and namespace-package multi-sources.
 
-:func:`configs_dir` and :func:`vst_headless_wrapper` return ``Traversable``
-objects, not real ``Path``\\ s. Callers that hand the result to Hydra,
-``subprocess``, or any other API that needs a concrete filesystem path must
-wrap the result in :func:`as_file` (re-exported here) so it stays valid
-under zipped wheels. ``str(traversable)`` happens to resolve to a real
-on-disk path under unpacked-wheel and editable installs, but the
-``as_file`` context is the only install-layout-safe way to materialize.
+The helpers return ``Traversable`` objects, not real ``Path``\\ s. The
+``Traversable`` protocol promises ``iterdir``, ``is_file``, ``is_dir``,
+``joinpath``, ``/``, ``name``, ``open``, ``read_bytes``, ``read_text`` — and
+nothing else. In particular it does NOT promise ``__fspath__``, ``glob``,
+``stem``, or ``suffix`` — those exist only on the concrete ``Path`` subclass
+that backs unpacked installs.
+
+Two patterns survive every layout:
+
+1. **Stay on the Traversable API.** For directory iteration use
+   ``iterdir()`` + a filter on ``name``; for reading a packaged YAML use
+   ``read_text()`` straight into the parser
+   (``OmegaConf.create(traversable.read_text())``).
+
+2. **Materialize via** :func:`as_file` **(re-exported here).** When a third
+   party API only accepts a filesystem path — ``subprocess``, anything that
+   does its own ``open(path)`` — wrap the Traversable in ``as_file`` and hold
+   the resulting context open across the API call::
+
+       with as_file(vst_headless_wrapper()) as wrapper_path:
+           subprocess.check_call([str(wrapper_path), ...])
+
+   Under zipped installs ``as_file`` extracts to a tempfile and cleans up on
+   exit; under unpacked installs it's a no-op that returns the on-disk path.
+   :class:`contextlib.ExitStack` is the right tool when multiple resources
+   need to outlive a single ``with`` block.
 
 Hydra entrypoints use the ``pkg://`` URI scheme directly
 (``@hydra.main(config_path="pkg://synth_setter.configs", ...)``,
 ``initialize_config_module(config_module="synth_setter.configs")``), so
-``configs_dir`` itself is only needed for the small set of helpers that
+:func:`configs_dir` itself is only needed for the small set of helpers that
 want a ``Traversable`` handle on the tree.
 """
 
@@ -24,16 +45,21 @@ from __future__ import annotations
 from importlib.abc import Traversable
 from importlib.resources import as_file, files
 
-__all__ = ["as_file", "configs_dir", "vst_headless_wrapper"]
+__all__ = [
+    "as_file",
+    "configs_dir",
+    "generate_vst_dataset_script",
+    "vst_headless_wrapper",
+]
 
 
 def configs_dir() -> Traversable:
     """Return the ``synth_setter/configs`` directory as a Traversable.
 
     Hydra itself uses the ``pkg://synth_setter.configs`` URI scheme — this
-    helper is for callers that want a ``Traversable`` handle on the tree
-    for iteration or YAML loading. Wrap in :func:`as_file` when a real
-    filesystem path is required.
+    helper is for callers that want a ``Traversable`` handle on the tree for
+    iteration (``iterdir()``) or text loading (``read_text()``). Wrap in
+    :func:`as_file` when a real filesystem path is required.
 
     :returns: Traversable pointing at the shipped Hydra config tree.
     """
@@ -43,12 +69,24 @@ def configs_dir() -> Traversable:
 def vst_headless_wrapper() -> Traversable:
     """Return the Xvfb + xsettingsd + dbus wrapper for headless VST init.
 
-    Linux callers materialize this via :func:`as_file` and prepend the
-    yielded ``Path`` to the renderer ``argv`` so the VST3 plugin gets a
-    display before pedalboard imports it. ``str(vst_headless_wrapper())``
-    only works under unpacked-wheel installs — use :func:`as_file` to
-    survive a zipped wheel.
+    Linux callers materialize this via :func:`as_file` and prepend the yielded
+    ``Path`` to the renderer ``argv`` so the VST3 plugin gets a display before
+    pedalboard imports it.
 
     :returns: Traversable pointing at ``run-linux-vst-headless.sh``.
     """
     return files("synth_setter") / "scripts" / "run-linux-vst-headless.sh"
+
+
+def generate_vst_dataset_script() -> Traversable:
+    """Return the ``generate_vst_dataset.py`` worker script.
+
+    Invoked as a subprocess by :func:`synth_setter.cli.generate_dataset.run`
+    once per shard; callers materialize via :func:`as_file` and pass the
+    yielded ``Path`` as the ``python <script>`` argument. The previous
+    cwd-relative invocation (``"src/synth_setter/data/vst/..."``) only worked
+    when the launcher ran from a repo checkout.
+
+    :returns: Traversable pointing at ``data/vst/generate_vst_dataset.py``.
+    """
+    return files("synth_setter") / "data" / "vst" / "generate_vst_dataset.py"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import sys
 from collections.abc import Iterator
+from contextlib import ExitStack
 from pathlib import Path
 
 import h5py
@@ -18,7 +19,7 @@ from hydra.core.global_hydra import GlobalHydra
 from omegaconf import DictConfig, open_dict
 
 from synth_setter.data.vst import param_specs, preset_paths
-from synth_setter.resources import vst_headless_wrapper
+from synth_setter.resources import as_file, generate_vst_dataset_script, vst_headless_wrapper
 from synth_setter.utils.utils import register_resolvers
 from tests._baseline_worktree import worktree_for_ref  # noqa: F401 — pytest fixture re-export
 
@@ -56,7 +57,12 @@ NUM_FIXTURE_SAMPLES = 5
 # wrapping lives at the audio-rendering boundary (the subprocess call),
 # not at the container entrypoint — the click CLI stays X11-agnostic so
 # idle and passthrough don't pay the Xvfb startup cost.
-VST_HEADLESS_WRAPPER = str(vst_headless_wrapper())
+#
+# Eager ``str(vst_headless_wrapper())`` doesn't survive zipped-wheel
+# installs — the underlying Traversable has no on-disk path until
+# :func:`as_file` extracts it. Callers materialize on demand inside an
+# :class:`contextlib.ExitStack` envelope around the subprocess call (see
+# :func:`surge_xt_smoke_datasets` below and ``tests/test_train.py``).
 
 
 def _validate_surge_dataset(path: Path, num_samples: int) -> None:
@@ -482,54 +488,60 @@ def surge_xt_smoke_datasets(tmp_path: Path, param_spec_name: str) -> Path:
 
     Path(smoke_dataset_dir).mkdir(parents=True, exist_ok=True)
 
-    generate_dataset_args = []
-    if sys.platform == "linux":
-        generate_dataset_args.append(VST_HEADLESS_WRAPPER)
+    # Materialize packaged resources via ``as_file`` so the fixture survives a
+    # zipped-wheel install — the extracted tempfiles must outlive the
+    # subprocess, hence the surrounding ``ExitStack``.
+    with ExitStack() as stack:
+        script_path = stack.enter_context(as_file(generate_vst_dataset_script()))
+        generate_dataset_args: list[str] = []
+        if sys.platform == "linux":
+            wrapper_path = stack.enter_context(as_file(vst_headless_wrapper()))
+            generate_dataset_args.append(str(wrapper_path))
 
-    generate_dataset_args += [
-        sys.executable,
-        "src/synth_setter/data/vst/generate_vst_dataset.py",
-        str(smoke_dataset_dir / "train.h5"),
-        f"--plugin_path={_SURGE_FIXTURE_PLUGIN_PATH}",
-        f"--preset_path={preset_paths[param_spec_name]}",
-        f"--param_spec_name={param_spec_name}",
-        f"--renderer_version={_SURGE_FIXTURE_RENDERER_VERSION}",
-        f"--sample_rate={_SURGE_FIXTURE_SAMPLE_RATE}",
-        f"--channels={_SURGE_FIXTURE_CHANNELS}",
-        f"--velocity={_SURGE_FIXTURE_VELOCITY}",
-        f"--signal_duration_seconds={_SURGE_FIXTURE_DURATION_SECONDS}",
-        f"--min_loudness={_SURGE_FIXTURE_MIN_LOUDNESS}",
-        f"--samples_per_render_batch={NUM_FIXTURE_SAMPLES}",
-        f"--samples_per_shard={NUM_FIXTURE_SAMPLES}",
-    ]
+        generate_dataset_args += [
+            sys.executable,
+            str(script_path),
+            str(smoke_dataset_dir / "train.h5"),
+            f"--plugin_path={_SURGE_FIXTURE_PLUGIN_PATH}",
+            f"--preset_path={preset_paths[param_spec_name]}",
+            f"--param_spec_name={param_spec_name}",
+            f"--renderer_version={_SURGE_FIXTURE_RENDERER_VERSION}",
+            f"--sample_rate={_SURGE_FIXTURE_SAMPLE_RATE}",
+            f"--channels={_SURGE_FIXTURE_CHANNELS}",
+            f"--velocity={_SURGE_FIXTURE_VELOCITY}",
+            f"--signal_duration_seconds={_SURGE_FIXTURE_DURATION_SECONDS}",
+            f"--min_loudness={_SURGE_FIXTURE_MIN_LOUDNESS}",
+            f"--samples_per_render_batch={NUM_FIXTURE_SAMPLES}",
+            f"--samples_per_shard={NUM_FIXTURE_SAMPLES}",
+        ]
 
-    # capture_output=False (default): child inherits parent's stdout/stderr, no pipe is
-    # created. Avoids the `capture_output=True` deadlock where fork-inherited fds in
-    # pytest/DataLoader workers keep the pipe's read end open and block `communicate()`
-    # forever. Output flows to pytest's normal capture (visible with `-s` or on failure);
-    # we lose `result.stdout/stderr` on the failure branch but keep the exit code, which
-    # is what the failure branch needs to fail loud. See #695.
-    try:
-        result = subprocess.run(  # noqa: S603
-            generate_dataset_args,
-            text=True,
-            check=False,
-            timeout=_VST_SUBPROCESS_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired:
-        pytest.fail(
-            f"generate_vst_dataset timed out after {_VST_SUBPROCESS_TIMEOUT_SECONDS}s\n"
-            f"command: {generate_dataset_args}\n"
-            f"(child stdout/stderr printed above; rerun with `pytest -s` if captured)",
-            pytrace=False,
-        )
-    if result.returncode != 0:
-        pytest.fail(
-            f"generate_vst_dataset failed (exit {result.returncode})\n"
-            f"command: {generate_dataset_args}\n"
-            f"(child stdout/stderr printed above; rerun with `pytest -s` if captured)",
-            pytrace=False,
-        )
+        # capture_output=False (default): child inherits parent's stdout/stderr, no pipe is
+        # created. Avoids the `capture_output=True` deadlock where fork-inherited fds in
+        # pytest/DataLoader workers keep the pipe's read end open and block `communicate()`
+        # forever. Output flows to pytest's normal capture (visible with `-s` or on failure);
+        # we lose `result.stdout/stderr` on the failure branch but keep the exit code, which
+        # is what the failure branch needs to fail loud. See #695.
+        try:
+            result = subprocess.run(  # noqa: S603
+                generate_dataset_args,
+                text=True,
+                check=False,
+                timeout=_VST_SUBPROCESS_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            pytest.fail(
+                f"generate_vst_dataset timed out after {_VST_SUBPROCESS_TIMEOUT_SECONDS}s\n"
+                f"command: {generate_dataset_args}\n"
+                f"(child stdout/stderr printed above; rerun with `pytest -s` if captured)",
+                pytrace=False,
+            )
+        if result.returncode != 0:
+            pytest.fail(
+                f"generate_vst_dataset failed (exit {result.returncode})\n"
+                f"command: {generate_dataset_args}\n"
+                f"(child stdout/stderr printed above; rerun with `pytest -s` if captured)",
+                pytrace=False,
+            )
     assert (smoke_dataset_dir / "train.h5").exists(), (
         "Dataset generation failed to produce train.h5 fixture"
     )

--- a/tests/data/vst/test_generate_vst_dataset_cli.py
+++ b/tests/data/vst/test_generate_vst_dataset_cli.py
@@ -76,7 +76,9 @@ def test_build_generate_args_roundtrips_through_cli_parser() -> None:
     break this round-trip even when the field-set parity tests still pass.
     """
     spec = _smoke_spec()
-    args = build_generate_args(spec, spec.shards[0], Path("/tmp"))
+    args = build_generate_args(
+        spec, spec.shards[0], Path("/tmp"), Path("/fake/generate_vst_dataset.py")
+    )
 
     parsed = CliApp.run(_GenerateCliArgs, cli_args=args[2:])
     reconstructed = RenderConfig(**parsed.model_dump(exclude={"data_file"}))

--- a/tests/integration/test_parallel_shard_dispatch.py
+++ b/tests/integration/test_parallel_shard_dispatch.py
@@ -132,7 +132,12 @@ def _wire_run_into_fake_renderer(
 
     fake_renderer = _write_fake_renderer(tmp_path)
 
-    def _fake_build_args(_spec: DatasetSpec, shard: ShardSpec, output_dir: Path) -> list[str]:
+    def _fake_build_args(
+        _spec: DatasetSpec,
+        shard: ShardSpec,
+        output_dir: Path,
+        _script_path: Path,
+    ) -> list[str]:
         return [sys.executable, str(fake_renderer), str(output_dir / shard.filename)]
 
     monkeypatch.setattr("synth_setter.cli.generate_dataset.build_generate_args", _fake_build_args)

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -42,10 +42,10 @@ from synth_setter.cli.generate_dataset import (
     run,
 )
 from synth_setter.pipeline.schemas.spec import DatasetSpec, RenderConfig
-from synth_setter.resources import vst_headless_wrapper
 from tests.helpers.subprocess_args import find_script_index
 
-VST_HEADLESS_WRAPPER = str(vst_headless_wrapper())
+_WRAPPER_NAME = "run-linux-vst-headless.sh"
+_SCRIPT_NAME = "generate_vst_dataset.py"
 
 # Reusable VST3 bundle with a real Contents/moduleinfo.json so
 # extract_renderer_version (called by run) returns a deterministic version
@@ -272,7 +272,7 @@ class TestRun:
         renderer_calls = _renderer_argv_lists(patched_subprocess)
         assert len(renderer_calls) == 1
         args = renderer_calls[0]
-        # args = [VST_HEADLESS_WRAPPER (linux only), python, generate_vst_dataset.py, ...]
+        # args = [wrapper-path (linux only), python, generate_vst_dataset.py, ...]
         assert any("generate_vst_dataset.py" in a for a in args)
         assert str(spec.render.samples_per_shard) in args
 
@@ -297,11 +297,11 @@ class TestRun:
         assert len(renderer_calls) == 1
         args = renderer_calls[0]
         if sys.platform == "linux":
-            assert args[0] == VST_HEADLESS_WRAPPER
-            assert args[2] == "src/synth_setter/data/vst/generate_vst_dataset.py"
+            assert args[0].endswith(_WRAPPER_NAME), args[0]
+            assert args[2].endswith(_SCRIPT_NAME), args[2]
         else:
-            assert VST_HEADLESS_WRAPPER not in args
-            assert args[1] == "src/synth_setter/data/vst/generate_vst_dataset.py"
+            assert not any(a.endswith(_WRAPPER_NAME) for a in args)
+            assert args[1].endswith(_SCRIPT_NAME), args[1]
 
     def test_uploads_shard_to_r2_after_generation(
         self,
@@ -1121,6 +1121,9 @@ class TestRun:
 # ---------------------------------------------------------------------------
 
 
+_FAKE_SCRIPT = Path("/fake/generate_vst_dataset.py")
+
+
 class TestBuildGenerateArgs:
     """build_generate_args() produces correct CLI arg lists from spec + shard."""
 
@@ -1128,7 +1131,7 @@ class TestBuildGenerateArgs:
         """Output file path is {output_dir}/{shard.filename}."""
         shard = spec.shards[0]
 
-        args = build_generate_args(spec, shard, tmp_path)
+        args = build_generate_args(spec, shard, tmp_path, _FAKE_SCRIPT)
 
         assert args[2] == str(tmp_path / "shard-000000.h5")
 
@@ -1140,7 +1143,7 @@ class TestBuildGenerateArgs:
         """
         shard = spec.shards[0]
 
-        args = build_generate_args(spec, shard, Path("out"))
+        args = build_generate_args(spec, shard, Path("out"), _FAKE_SCRIPT)
 
         flag_idx = args.index("--samples_per_shard")
         assert args[flag_idx + 1] == str(spec.render.samples_per_shard)
@@ -1149,19 +1152,19 @@ class TestBuildGenerateArgs:
         """The flag set equals ``RenderConfig.model_fields`` — auto-derived parity guard."""
         shard = spec.shards[0]
 
-        args = build_generate_args(spec, shard, Path("out"))
+        args = build_generate_args(spec, shard, Path("out"), _FAKE_SCRIPT)
 
         option_keys: set[str] = {arg.lstrip("-") for arg in args if arg.startswith("--")}
 
         assert option_keys == set(RenderConfig.model_fields.keys())
 
     def test_args_start_with_python_and_script(self, spec: DatasetSpec) -> None:
-        """First arg is the Python executable, second is the generation script."""
+        """First arg is the Python executable, second is the materialized script path."""
         shard = spec.shards[0]
 
-        args = build_generate_args(spec, shard, Path("out"))
+        args = build_generate_args(spec, shard, Path("out"), _FAKE_SCRIPT)
 
-        assert args[1] == "src/synth_setter/data/vst/generate_vst_dataset.py"
+        assert args[1] == str(_FAKE_SCRIPT)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -14,6 +14,7 @@ supplied inner command (typically ``synth-setter-generate-dataset``) that writes
 from __future__ import annotations
 
 import os
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
@@ -42,7 +43,7 @@ from synth_setter.pipeline.skypilot_launch import (
 from synth_setter.pipeline.skypilot_launch import (
     _run_cred_bootstrap as _real_run_cred_bootstrap,
 )
-from synth_setter.resources import configs_dir
+from synth_setter.resources import as_file, configs_dir
 
 
 @pytest.fixture()
@@ -73,9 +74,16 @@ def env_file(tmp_path: Path) -> Path:
 
 
 @pytest.fixture()
-def template_yaml() -> Path:
-    """Resolve the in-repo SkyPilot RunPod template path."""
-    return Path(str(configs_dir() / "compute" / "runpod-template.yaml"))
+def template_yaml() -> Iterator[Path]:
+    """Materialize the shipped RunPod template as a real on-disk Path.
+
+    :func:`as_file` keeps the extracted tempfile (under a zipped wheel) alive
+    for the SkyPilot click invocation in the test body.
+
+    :yields Path: Filesystem path to the materialized template YAML.
+    """
+    with as_file(configs_dir() / "compute" / "runpod-template.yaml") as path:
+        yield path
 
 
 @pytest.fixture(autouse=True)

--- a/tests/pipeline/test_schemas/test_image_config.py
+++ b/tests/pipeline/test_schemas/test_image_config.py
@@ -13,7 +13,7 @@ import pytest
 from pydantic import ValidationError
 
 from synth_setter.pipeline.schemas.image_config import load_image_config
-from synth_setter.resources import configs_dir
+from synth_setter.resources import as_file, configs_dir
 
 VALID_SHA = "a" * 40
 VALID_ISSUE = 266
@@ -244,9 +244,8 @@ class TestStaticFieldsAndYamlMerge:
 
     def test_static_field_values_match_dev_snapshot_yaml(self) -> None:
         """Real dev-snapshot.yaml fields match expected defaults (catches drift)."""
-        config_path = Path(str(configs_dir() / "image" / "dev-snapshot.yaml"))
-
-        result = load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
+        with as_file(configs_dir() / "image" / "dev-snapshot.yaml") as config_path:
+            result = load_image_config(config_path, github_sha=VALID_SHA, issue_number=VALID_ISSUE)
 
         assert result.dockerfile == "docker/ubuntu22_04/Dockerfile"
         assert result.image == "tinaudio/synth-setter"

--- a/tests/schemas/test_callbacks_config.py
+++ b/tests/schemas/test_callbacks_config.py
@@ -7,8 +7,6 @@ schema (``instantiate_callbacks`` short-circuits on falsy).
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 from pydantic import ValidationError
 
@@ -16,7 +14,7 @@ from synth_setter.resources import configs_dir
 from synth_setter.schemas.callbacks_config import CallbackInstance, CallbacksConfig
 from tests.schemas.conftest import compose_train_cfg
 
-_CALLBACKS_CONFIG_DIR = Path(str(configs_dir() / "callbacks"))
+_CALLBACKS_CONFIG_DIR = configs_dir() / "callbacks"
 
 
 def _all_callback_config_names() -> list[str]:
@@ -24,7 +22,11 @@ def _all_callback_config_names() -> list[str]:
 
     :return: Sorted list of YAML stems found in ``configs/callbacks/``.
     """
-    names = sorted(p.stem for p in _CALLBACKS_CONFIG_DIR.glob("*.yaml"))
+    names = sorted(
+        p.name.removesuffix(".yaml")
+        for p in _CALLBACKS_CONFIG_DIR.iterdir()
+        if p.is_file() and p.name.endswith(".yaml")
+    )
     assert names, (
         f"no callback YAMLs found under {_CALLBACKS_CONFIG_DIR} — "
         "has the callbacks composition layout changed?"

--- a/tests/schemas/test_data_config.py
+++ b/tests/schemas/test_data_config.py
@@ -7,7 +7,6 @@ and accepts them, deferring the failure to ``hydra.utils.instantiate``.
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, cast
 
 import pytest
@@ -21,7 +20,7 @@ from synth_setter.schemas.data_config import DataConfig
 from synth_setter.schemas.paths_config import PathsConfig
 from tests.schemas.conftest import compose_subtree
 
-_DATA_CONFIG_DIR = Path(str(configs_dir() / "data"))
+_DATA_CONFIG_DIR = configs_dir() / "data"
 
 
 def _all_data_config_names() -> list[str]:
@@ -29,7 +28,11 @@ def _all_data_config_names() -> list[str]:
 
     :return: Sorted list of YAML stems found in ``configs/data/``.
     """
-    names = sorted(p.stem for p in _DATA_CONFIG_DIR.glob("*.yaml"))
+    names = sorted(
+        p.name.removesuffix(".yaml")
+        for p in _DATA_CONFIG_DIR.iterdir()
+        if p.is_file() and p.name.endswith(".yaml")
+    )
     assert names, f"no data YAMLs found under {_DATA_CONFIG_DIR} — has the layout changed?"
     return names
 

--- a/tests/schemas/test_logger_config.py
+++ b/tests/schemas/test_logger_config.py
@@ -6,8 +6,6 @@ Every ``configs/logger/`` YAML must validate; logger kwargs ride
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 from pydantic import ValidationError
 
@@ -15,7 +13,7 @@ from synth_setter.resources import configs_dir
 from synth_setter.schemas.logger_config import LoggerConfig, LoggerInstance
 from tests.schemas.conftest import compose_subtree
 
-_LOGGER_CONFIG_DIR = Path(str(configs_dir() / "logger"))
+_LOGGER_CONFIG_DIR = configs_dir() / "logger"
 
 
 def _all_logger_config_names() -> list[str]:
@@ -23,7 +21,11 @@ def _all_logger_config_names() -> list[str]:
 
     :return: Sorted list of YAML stems found in ``configs/logger/``.
     """
-    names = sorted(p.stem for p in _LOGGER_CONFIG_DIR.glob("*.yaml"))
+    names = sorted(
+        p.name.removesuffix(".yaml")
+        for p in _LOGGER_CONFIG_DIR.iterdir()
+        if p.is_file() and p.name.endswith(".yaml")
+    )
     assert names, f"no logger YAMLs found under {_LOGGER_CONFIG_DIR} — has the layout changed?"
     return names
 

--- a/tests/schemas/test_model_config.py
+++ b/tests/schemas/test_model_config.py
@@ -6,8 +6,6 @@ Every YAML under ``configs/model/`` must validate; variant kwargs ride
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 from pydantic import ValidationError
 
@@ -15,7 +13,7 @@ from synth_setter.resources import configs_dir
 from synth_setter.schemas.model_config import ModelConfig, OptimizerConfig
 from tests.schemas.conftest import compose_subtree
 
-_MODEL_CONFIG_DIR = Path(str(configs_dir() / "model"))
+_MODEL_CONFIG_DIR = configs_dir() / "model"
 
 _VALID_TARGET = "synth_setter.models.X"
 
@@ -31,7 +29,11 @@ def _all_model_config_names() -> list[str]:
 
     :return: Sorted list of YAML stems found in ``configs/model/``.
     """
-    names = sorted(p.stem for p in _MODEL_CONFIG_DIR.glob("*.yaml"))
+    names = sorted(
+        p.name.removesuffix(".yaml")
+        for p in _MODEL_CONFIG_DIR.iterdir()
+        if p.is_file() and p.name.endswith(".yaml")
+    )
     assert names, f"no model YAMLs found under {_MODEL_CONFIG_DIR} — has the layout changed?"
     return names
 

--- a/tests/schemas/test_trainer_config.py
+++ b/tests/schemas/test_trainer_config.py
@@ -6,8 +6,6 @@ kwargs ride ``extra="allow"``.
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 from pydantic import ValidationError
 
@@ -15,7 +13,7 @@ from synth_setter.resources import configs_dir
 from synth_setter.schemas.trainer_config import TrainerConfig
 from tests.schemas.conftest import compose_subtree
 
-_TRAINER_CONFIG_DIR = Path(str(configs_dir() / "trainer"))
+_TRAINER_CONFIG_DIR = configs_dir() / "trainer"
 
 
 def _all_trainer_config_names() -> list[str]:
@@ -23,7 +21,11 @@ def _all_trainer_config_names() -> list[str]:
 
     :return: Sorted list of YAML stems found in ``configs/trainer/``.
     """
-    names = sorted(p.stem for p in _TRAINER_CONFIG_DIR.glob("*.yaml"))
+    names = sorted(
+        p.name.removesuffix(".yaml")
+        for p in _TRAINER_CONFIG_DIR.iterdir()
+        if p.is_file() and p.name.endswith(".yaml")
+    )
     assert names, f"no trainer YAMLs found under {_TRAINER_CONFIG_DIR} — has the layout changed?"
     return names
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -73,25 +73,25 @@ class TestWandbConfigResolvesFromEnv:
     def test_wandb_entity_resolves_from_env(self, monkeypatch):
         """OmegaConf resolves WANDB_ENTITY from environment."""
         monkeypatch.setenv("WANDB_ENTITY", "test-entity")
-        cfg = OmegaConf.load(str(configs_dir() / "logger" / "wandb.yaml"))
+        cfg = OmegaConf.create((configs_dir() / "logger" / "wandb.yaml").read_text())
         assert OmegaConf.select(cfg, "wandb.entity") == "test-entity"
 
     def test_wandb_project_resolves_from_env(self, monkeypatch):
         """OmegaConf resolves WANDB_PROJECT from environment."""
         monkeypatch.setenv("WANDB_PROJECT", "test-project")
-        cfg = OmegaConf.load(str(configs_dir() / "logger" / "wandb.yaml"))
+        cfg = OmegaConf.create((configs_dir() / "logger" / "wandb.yaml").read_text())
         assert OmegaConf.select(cfg, "wandb.project") == "test-project"
 
     def test_wandb_entity_defaults_to_none_when_env_unset(self, monkeypatch):
         """Entity falls back to None (user's default W&B entity) when env var unset."""
         monkeypatch.delenv("WANDB_ENTITY", raising=False)
-        cfg = OmegaConf.load(str(configs_dir() / "logger" / "wandb.yaml"))
+        cfg = OmegaConf.create((configs_dir() / "logger" / "wandb.yaml").read_text())
         assert OmegaConf.select(cfg, "wandb.entity") is None
 
     def test_wandb_project_defaults_to_synth_setter_when_env_unset(self, monkeypatch):
         """Project falls back to synth-setter when env var unset."""
         monkeypatch.delenv("WANDB_PROJECT", raising=False)
-        cfg = OmegaConf.load(str(configs_dir() / "logger" / "wandb.yaml"))
+        cfg = OmegaConf.create((configs_dir() / "logger" / "wandb.yaml").read_text())
         assert OmegaConf.select(cfg, "wandb.project") == "synth-setter"
 
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -3,6 +3,7 @@
 import os
 import subprocess
 import sys
+from contextlib import ExitStack
 from pathlib import Path
 
 import numpy as np
@@ -15,10 +16,10 @@ from omegaconf import DictConfig, open_dict
 from synth_setter.cli.eval import evaluate
 from synth_setter.cli.train import train
 from synth_setter.data.vst import param_specs, preset_paths
+from synth_setter.resources import as_file, vst_headless_wrapper
 from tests.conftest import (
     _VST_SUBPROCESS_TIMEOUT_SECONDS,
     NUM_FIXTURE_SAMPLES,
-    VST_HEADLESS_WRAPPER,
     _build_surge_xt_smoke_cfg,
 )
 from tests.helpers.run_if import RunIf
@@ -47,7 +48,7 @@ def test_train_fast_dev_run_tiny_model_tiny_data(cfg_train: DictConfig) -> None:
 
 
 @pytest.mark.gpu
-@RunIf(min_gpus=1)
+@RunIf(min_gpus=1)  # pyright: ignore[reportCallIssue]  # RunIf.__new__ returns MarkDecorator
 def test_train_fast_dev_run_gpu(cfg_train: DictConfig) -> None:
     """Run for 1 train, val and test step on GPU.
 
@@ -61,7 +62,7 @@ def test_train_fast_dev_run_gpu(cfg_train: DictConfig) -> None:
 
 
 @pytest.mark.gpu
-@RunIf(min_gpus=1)
+@RunIf(min_gpus=1)  # pyright: ignore[reportCallIssue]  # RunIf.__new__ returns MarkDecorator
 @pytest.mark.slow
 def test_train_fast_dev_run_gpu_compile(cfg_train: DictConfig) -> None:
     """Run for 1 train, val and test step on GPU with torch.compile enabled.
@@ -77,7 +78,7 @@ def test_train_fast_dev_run_gpu_compile(cfg_train: DictConfig) -> None:
 
 
 @pytest.mark.gpu
-@RunIf(min_gpus=1)
+@RunIf(min_gpus=1)  # pyright: ignore[reportCallIssue]  # RunIf.__new__ returns MarkDecorator
 @pytest.mark.slow
 def test_train_epoch_gpu_amp(cfg_train: DictConfig) -> None:
     """Train 1 epoch on GPU with mixed-precision.
@@ -93,7 +94,7 @@ def test_train_epoch_gpu_amp(cfg_train: DictConfig) -> None:
 
 
 @pytest.mark.gpu
-@RunIf(min_gpus=1)
+@RunIf(min_gpus=1)  # pyright: ignore[reportCallIssue]  # RunIf.__new__ returns MarkDecorator
 @pytest.mark.slow
 def test_train_epoch_double_val_loop(cfg_train: DictConfig) -> None:
     """Train 1 epoch with validation loop twice per epoch.
@@ -135,7 +136,7 @@ def test_train_ddp_sim(cfg_train: DictConfig) -> None:
 
 
 @pytest.mark.gpu
-@RunIf(min_gpus=1)
+@RunIf(min_gpus=1)  # pyright: ignore[reportCallIssue]  # RunIf.__new__ returns MarkDecorator
 @pytest.mark.slow
 def test_train_resume(tmp_path: Path, cfg_train: DictConfig) -> None:
     """Run 1 epoch, finish, and resume for another epoch.
@@ -319,41 +320,45 @@ def test_train_eval_surge_xt(
     audio_dir = tmp_path / "audio"
     runner = CliRunner()
 
-    args = []
-    if sys.platform == "linux":
-        args.append(VST_HEADLESS_WRAPPER)
+    # Materialize the Xvfb wrapper inside an ``ExitStack`` so the extracted
+    # tempfile outlives the subprocess on zipped-wheel installs.
+    with ExitStack() as stack:
+        args: list[str] = []
+        if sys.platform == "linux":
+            wrapper_path = stack.enter_context(as_file(vst_headless_wrapper()))
+            args.append(str(wrapper_path))
 
-    args += [
-        sys.executable,
-        "-m",
-        "synth_setter.evaluation.predict_vst_audio",
-        str(predictions_dir),
-        str(audio_dir),
-        f"--param_spec={param_spec_name}",
-        f"--preset_path={preset_paths[param_spec_name]}",
-        "-t",
-    ]
-    try:
-        result = subprocess.run(  # noqa: S603, S607
-            args,
-            text=True,
-            check=False,
-            timeout=_VST_SUBPROCESS_TIMEOUT_SECONDS,
-        )
-    except subprocess.TimeoutExpired:
-        pytest.fail(
-            f"predict_vst_audio timed out after {_VST_SUBPROCESS_TIMEOUT_SECONDS}s\n"
-            f"command: {args}\n"
-            f"(child stdout/stderr printed above; rerun with `pytest -s` if captured)",
-            pytrace=False,
-        )
-    if result.returncode != 0:
-        pytest.fail(
-            f"predict_vst_audio failed (exit {result.returncode})\n"
-            f"command: {args}\n"
-            f"(child stdout/stderr printed above; rerun with `pytest -s` if captured)",
-            pytrace=False,
-        )
+        args += [
+            sys.executable,
+            "-m",
+            "synth_setter.evaluation.predict_vst_audio",
+            str(predictions_dir),
+            str(audio_dir),
+            f"--param_spec={param_spec_name}",
+            f"--preset_path={preset_paths[param_spec_name]}",
+            "-t",
+        ]
+        try:
+            result = subprocess.run(  # noqa: S603, S607
+                args,
+                text=True,
+                check=False,
+                timeout=_VST_SUBPROCESS_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired:
+            pytest.fail(
+                f"predict_vst_audio timed out after {_VST_SUBPROCESS_TIMEOUT_SECONDS}s\n"
+                f"command: {args}\n"
+                f"(child stdout/stderr printed above; rerun with `pytest -s` if captured)",
+                pytrace=False,
+            )
+        if result.returncode != 0:
+            pytest.fail(
+                f"predict_vst_audio failed (exit {result.returncode})\n"
+                f"command: {args}\n"
+                f"(child stdout/stderr printed above; rerun with `pytest -s` if captured)",
+                pytrace=False,
+            )
 
     sample_dirs = sorted(d for d in audio_dir.iterdir() if d.is_dir())
     assert [d.name for d in sample_dirs] == [f"sample_{i}" for i in range(NUM_FIXTURE_SAMPLES)]

--- a/tests/test_zipimport_compat.py
+++ b/tests/test_zipimport_compat.py
@@ -196,3 +196,36 @@ def test_as_file_materializes_generate_script_under_zipimport(
     result = _run_in_zipped_python(synth_setter_zip, code)
     assert result.returncode == 0, f"as_file(generate_vst_dataset_script) failed: {result.stderr}"
     assert "OK" in result.stdout
+
+
+def test_generate_script_actually_executes_under_zipimport(synth_setter_zip: Path) -> None:
+    """Spawn the materialized renderer as ``python <script> --help`` and assert exit 0.
+
+    Stronger than the materialization check above: the script's own module-top
+    imports (``rootutils.setup_root``, then ``from synth_setter…``) have to
+    survive being invoked from a tempfile location. Catches the failure mode
+    where ``rootutils`` can't walk up from a temp path to find ``.project-root``
+    and crashes the renderer before the launcher's argv even reaches the CLI.
+
+    :param synth_setter_zip: Session-scoped fixture path to the in-tree zip.
+    """
+    code = textwrap.dedent("""
+        import subprocess, sys
+        from synth_setter.resources import as_file, generate_vst_dataset_script
+
+        with as_file(generate_vst_dataset_script()) as script_path:
+            result = subprocess.run(
+                [sys.executable, str(script_path), "--help"],
+                capture_output=True,
+                text=True,
+                timeout=20,
+            )
+        assert result.returncode == 0, (
+            f"renderer --help exited {result.returncode}: {result.stderr[:600]}"
+        )
+        assert "--plugin_path" in result.stdout, "expected CLI flag missing from --help"
+        print("OK")
+    """)
+    result = _run_in_zipped_python(synth_setter_zip, code)
+    assert result.returncode == 0, f"renderer execution under zip failed: {result.stderr}"
+    assert "OK" in result.stdout

--- a/tests/test_zipimport_compat.py
+++ b/tests/test_zipimport_compat.py
@@ -1,0 +1,198 @@
+"""Verify package resources work under zipimport.
+
+Without this lane, every refactor toward the ``Traversable`` API is unverified
+— the unpacked test suite cannot tell the difference between code that
+correctly stays on the protocol and code that has accidentally drifted back
+to ``__fspath__`` / ``.glob()`` / ``str(traversable)``-as-real-path. Both
+shapes pass when the install layout happens to be a ``PosixPath``.
+
+The fixture zips the ``synth_setter`` source tree once per session and spawns
+a fresh Python with ``PYTHONPATH=<zip>`` and a wiped ``sys.path`` so the
+subprocess can only find the package via ``zipimport``. Each test injects a
+small Python program over ``-c`` and asserts on its stdout — failure modes
+(missing ``__fspath__``, broken ``open``, ``glob`` returning ``[]``) surface
+as a non-zero exit with a readable traceback.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def synth_setter_zip(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Zip the in-tree ``src/synth_setter`` for zipimport.
+
+    Uses :func:`shutil.make_archive` with ``base_dir="synth_setter"`` so the
+    archive root contains ``synth_setter/__init__.py`` — the exact layout
+    Python's zipimporter expects on ``sys.path``. Built once per pytest
+    session; the resulting path is reused across the smoke tests below.
+
+    :param tmp_path_factory: pytest-provided factory for session-scoped temp
+        directories; the zip lives under one of its mktemp dirs.
+    :returns: Absolute path to the built ``.zip``.
+    """
+    here = Path(__file__).resolve()
+    src_root = here.parent.parent / "src"
+    assert (src_root / "synth_setter" / "__init__.py").is_file(), (
+        f"synth_setter package not found under {src_root}; the smoke test expects a src/ layout"
+    )
+    target_dir = tmp_path_factory.mktemp("zipimport")
+    archive_stem = target_dir / "synth_setter"
+    archive_path = Path(
+        shutil.make_archive(
+            base_name=str(archive_stem),
+            format="zip",
+            root_dir=str(src_root),
+            base_dir="synth_setter",
+        )
+    )
+    return archive_path
+
+
+def _run_in_zipped_python(zip_path: Path, code: str) -> subprocess.CompletedProcess[str]:
+    """Spawn a subprocess that can only ``import synth_setter`` via the zip.
+
+    ``PYTHONNOUSERSITE`` disables ``~/.local/lib/...`` injection; ``PYTHONPATH``
+    is set to the zip alone; ``PYTHONDONTWRITEBYTECODE`` keeps the test from
+    littering ``__pycache__`` next to the source tree.
+
+    :param zip_path: Archive built by :func:`synth_setter_zip`.
+    :param code: Python source to execute under ``python -c``.
+    :returns: The completed process; caller asserts on ``returncode`` /
+        ``stdout`` / ``stderr``.
+    """
+    return subprocess.run(  # noqa: S603 — controlled argv for the layout smoke test
+        [sys.executable, "-s", "-c", code],
+        env={
+            "PYTHONPATH": str(zip_path),
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PYTHONNOUSERSITE": "1",
+            "PATH": "/usr/bin:/bin",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
+
+
+def test_synth_setter_resources_importable_from_zip(synth_setter_zip: Path) -> None:
+    """``synth_setter.resources`` resolves under zipimport with no on-disk install.
+
+    :param synth_setter_zip: Session-scoped fixture path to the in-tree zip.
+    """
+    result = _run_in_zipped_python(
+        synth_setter_zip,
+        "import synth_setter.resources; print(type(synth_setter.resources).__name__)",
+    )
+    assert result.returncode == 0, f"zipimport of synth_setter.resources failed: {result.stderr}"
+    assert "module" in result.stdout
+
+
+def test_configs_dir_iteration_works_under_zipimport(synth_setter_zip: Path) -> None:
+    """``configs_dir().iterdir()`` returns Traversables that work without ``__fspath__``.
+
+    Exercises the schema-test pattern: list YAML names under a configs
+    subdirectory without ever materializing a real ``Path``. Catches regressions
+    that swap ``iterdir()``/``name`` for ``.glob()``/``.stem``.
+
+    :param synth_setter_zip: Session-scoped fixture path to the in-tree zip.
+    """
+    code = textwrap.dedent("""
+        from synth_setter.resources import configs_dir
+
+        trainer_dir = configs_dir() / "trainer"
+        assert trainer_dir.is_dir(), f"trainer/ not found in zipped configs"
+
+        yaml_names = sorted(
+            p.name
+            for p in trainer_dir.iterdir()
+            if p.is_file() and p.name.endswith(".yaml")
+        )
+        assert yaml_names, "no YAMLs under configs/trainer/ via zipimport"
+        print("\\n".join(yaml_names))
+    """)
+    result = _run_in_zipped_python(synth_setter_zip, code)
+    assert result.returncode == 0, f"iterdir failed: {result.stderr}"
+    assert "default.yaml" in result.stdout
+
+
+def test_configs_dir_read_text_works_under_zipimport(synth_setter_zip: Path) -> None:
+    """``(configs_dir() / "X.yaml").read_text()`` returns expected file content.
+
+    Exercises the ``OmegaConf.create(traversable.read_text())`` pattern used in
+    place of ``OmegaConf.load(str(traversable))`` — the latter calls ``open()``
+    on a synthetic path that doesn't exist under zip.
+
+    :param synth_setter_zip: Session-scoped fixture path to the in-tree zip.
+    """
+    code = textwrap.dedent("""
+        from synth_setter.resources import configs_dir
+
+        text = (configs_dir() / "train.yaml").read_text()
+        assert text, "train.yaml read_text() returned empty"
+        assert "defaults" in text, "train.yaml missing Hydra defaults key"
+        print("OK")
+    """)
+    result = _run_in_zipped_python(synth_setter_zip, code)
+    assert result.returncode == 0, f"read_text failed: {result.stderr}"
+    assert "OK" in result.stdout
+
+
+def test_as_file_materializes_wrapper_under_zipimport(synth_setter_zip: Path) -> None:
+    """``as_file(vst_headless_wrapper())`` yields a real ``Path`` even under zip.
+
+    Production subprocess sites depend on this — ``as_file`` must extract the
+    zip entry to a tempfile and yield its filesystem path, and the path must
+    survive long enough for ``subprocess.check_call`` to ``exec()`` it.
+
+    :param synth_setter_zip: Session-scoped fixture path to the in-tree zip.
+    """
+    code = textwrap.dedent("""
+        from pathlib import Path
+        from synth_setter.resources import as_file, vst_headless_wrapper
+
+        with as_file(vst_headless_wrapper()) as wrapper_path:
+            assert isinstance(wrapper_path, Path), type(wrapper_path).__name__
+            assert wrapper_path.is_file(), f"{wrapper_path} not on disk inside as_file"
+            assert wrapper_path.name.endswith("run-linux-vst-headless.sh"), wrapper_path.name
+            assert "Xvfb" in wrapper_path.read_text(), "wrapper missing Xvfb invocation"
+        print("OK")
+    """)
+    result = _run_in_zipped_python(synth_setter_zip, code)
+    assert result.returncode == 0, f"as_file(vst_headless_wrapper) failed: {result.stderr}"
+    assert "OK" in result.stdout
+
+
+def test_as_file_materializes_generate_script_under_zipimport(
+    synth_setter_zip: Path,
+) -> None:
+    """``as_file(generate_vst_dataset_script())`` yields a runnable ``Path``.
+
+    The subprocess launcher passes this path to ``python <script>`` once per
+    shard; if ``as_file`` doesn't extract the ``.py`` under zip, every shard
+    render is a ``FileNotFoundError``.
+
+    :param synth_setter_zip: Session-scoped fixture path to the in-tree zip.
+    """
+    code = textwrap.dedent("""
+        from pathlib import Path
+        from synth_setter.resources import as_file, generate_vst_dataset_script
+
+        with as_file(generate_vst_dataset_script()) as script_path:
+            assert isinstance(script_path, Path), type(script_path).__name__
+            assert script_path.is_file(), f"{script_path} not on disk inside as_file"
+            assert script_path.name.endswith("generate_vst_dataset.py"), script_path.name
+            assert "__main__" in script_path.read_text(), "script missing __main__ guard"
+        print("OK")
+    """)
+    result = _run_in_zipped_python(synth_setter_zip, code)
+    assert result.returncode == 0, f"as_file(generate_vst_dataset_script) failed: {result.stderr}"
+    assert "OK" in result.stdout

--- a/tests/test_zipimport_compat.py
+++ b/tests/test_zipimport_compat.py
@@ -7,9 +7,14 @@ to ``__fspath__`` / ``.glob()`` / ``str(traversable)``-as-real-path. Both
 shapes pass when the install layout happens to be a ``PosixPath``.
 
 The fixture zips the ``synth_setter`` source tree once per session and spawns
-a fresh Python with ``PYTHONPATH=<zip>`` and a wiped ``sys.path`` so the
-subprocess can only find the package via ``zipimport``. Each test injects a
-small Python program over ``-c`` and asserts on its stdout — failure modes
+a fresh Python with ``PYTHONPATH=<zip>`` prepended to ``sys.path``, ``-s``
+plus ``PYTHONNOUSERSITE=1`` to skip the user site, and a minimal ``env`` that
+omits ``VIRTUAL_ENV``. The parent venv's ``site-packages`` is still imported
+by ``site`` (deliberately: transitive deps like ``rootutils`` and
+``omegaconf`` must remain importable for the ``generate_vst_dataset.py
+--help`` smoke), but ``synth_setter`` itself resolves out of the zip because
+``PYTHONPATH`` precedes ``site-packages`` on ``sys.path``. Each test injects
+a small Python program over ``-c`` and asserts on its stdout — failure modes
 (missing ``__fspath__``, broken ``open``, ``glob`` returning ``[]``) surface
 as a non-zero exit with a readable traceback.
 """


### PR DESCRIPTION
## Summary

Make every callsite of the `synth_setter.resources` helpers — `configs_dir()`, `vst_headless_wrapper()`, and the new `generate_vst_dataset_script()` — work correctly across all four install layouts Python supports: editable, unpacked wheel, zipped wheel / zipapp, and namespace-package multi-source. Until this PR the project paid the syntactic cost of typing those helpers as `Traversable` but the actual test and production code drifted back to `__fspath__`/`.glob()`/`str(traversable)` patterns that only happen to work under `PosixPath` returns. Adds `tests/test_zipimport_compat.py` as the load-bearing regression guard — without it, every refactor toward `Traversable` is unverified.

## What's in here (5 commits)

### 1. `feat(resources)` — `bb1d8f92`

- Adds `generate_vst_dataset_script() -> Traversable` next to the two existing helpers; the launcher subprocesses the result once per shard.
- Rewrites the module docstring to lead with the install-layout-safe patterns (`Traversable` API plus `as_file` / `ExitStack` for paths that must outlive a subprocess) and revokes the previous "`str(traversable)` happens to resolve to a real path under unpacked-wheel and editable installs" affordance. That escape hatch is exactly what let zipimport-incompatible code silently pass the unpacked-only test suite.

### 2. `test` — `b404f25b`

`tests/test_zipimport_compat.py`. Zips `src/synth_setter` once per session via `shutil.make_archive`, spawns Python with `PYTHONPATH=<zip>`, `PYTHONNOUSERSITE=1`, `-s`, and the parent venv stripped. Six tests cover the import surface end-to-end: module import, `configs_dir().iterdir()`, `(traversable).read_text()`, `as_file(vst_headless_wrapper())` materialization, `as_file(generate_vst_dataset_script())` materialization, **and** actual subprocess execution of the materialized renderer with `--help`. The last one catches the failure mode where the script's own module-top init (e.g. `rootutils.setup_root`) crashes when invoked from a tempfile location.

### 3. `fix(generate_dataset)` — `a5346779`

`build_generate_args(spec, shard, output_dir)` hard-coded the renderer script as `"src/synth_setter/data/vst/generate_vst_dataset.py"` — a cwd-relative string that breaks the moment the launcher runs from anywhere other than a repo checkout. Threads a `script_path: Path` parameter through and materializes it in `_render_and_upload_shard` inside the existing `ExitStack` that already covers the Linux `vst_headless_wrapper`. Test assertions previously pinning the literal cwd-relative string at three sites now match by `.endswith("generate_vst_dataset.py")`, consistent with `tests/helpers/subprocess_args.find_script_index`.

### 4. `refactor(tests)` — `908cf2b7`

Migrates the test code to the install-layout-safe shape it should have used all along:

- **5 schema tests** — `Path(str(configs_dir())) / "X"` followed by `.glob("*.yaml")` + `.stem` → `configs_dir() / "X"` followed by `.iterdir()` + `name.endswith(".yaml")`. The `Traversable` protocol promises the latter, not the former.
- **`tests/test_configs.py`** — `OmegaConf.load(str(configs_dir() / "X.yaml"))` → `OmegaConf.create((traversable).read_text())`. `OmegaConf.load` calls `open()` on a synthetic path under zip; `read_text()` doesn't touch the filesystem.
- **`test_image_config.py`** and **`test_skypilot_launch.py`** fixture — wrap single-file consumers in `with as_file(...) as path:` so zip extraction outlives `load_image_config` / SkyPilot click invocation.
- **`tests/conftest.py`** + **`tests/test_train.py`** — drop the eager module-level `VST_HEADLESS_WRAPPER = str(vst_headless_wrapper())` (it doesn't survive zipimport) in favor of `ExitStack(as_file(vst_headless_wrapper()))` envelopes around the actual `subprocess.run` calls.
- Silences 5 pre-existing pyright false positives on `RunIf(...)` decorations in `test_train.py` (came into pre-commit's pyright hook scope when the file was touched; `RunIf.__new__` returns a `MarkDecorator`, not a `RunIf`, and pyright doesn't follow that flow).

### 5. `fix(generate_dataset)` — `4da0a3c6` — addresses the pre-PR review

`rootutils.setup_root(__file__, indicator=".project-root", pythonpath=True)` at the top of `generate_vst_dataset.py` raised `FileNotFoundError` when `as_file()` extracted the script to a tempfile — the walk-up for `.project-root` failed and crashed the renderer before any `from synth_setter…` import even ran, before any CLI flag was parsed. Wrap in `try / except FileNotFoundError`: the operator-checkout path still gets the source tree added to `sys.path` for direct invocation; the packaged path falls through, relying on `synth_setter` already being importable via the launcher's site-packages / zipimport. The smoke test in commit 2 was strengthened to actually execute the script with `--help` so this exact failure mode can't recur silently.

## Test plan

- [x] `pytest tests/test_zipimport_compat.py -v` — 6 passed against an actually-zipped install (including the end-to-end execution test)
- [x] `pytest tests/schemas/ tests/test_configs.py tests/pipeline/test_entrypoints/test_skypilot_launch.py tests/pipeline/test_entrypoints/test_generate_dataset.py tests/data/vst/test_generate_vst_dataset_cli.py tests/pipeline/test_schemas/test_image_config.py` — 270 passed across all touched areas
- [x] `uvx ruff check` and `uvx ruff format --check` clean for every changed file (no new errors vs main)
- [x] `pre-commit run --files <changed>` passes (`ruff`, `ruff-format`, `pyright`, `pydoclint`, `interrogate`, `docformatter`, `codespell` all green)
- [x] End-to-end subprocess execution: spawned Python with `PYTHONPATH=<zip>`, invoked `as_file(generate_vst_dataset_script())` → `subprocess.run([sys.executable, str(p), "--help"])` → exit 0, `--plugin_path` in stdout
- [ ] CI: dataset generation, MPS, GPU, local launcher roundtrip, docker validation — let CI confirm nothing else regressed

## Deferred follow-ups

- `tests/test_zipimport_compat.py` doesn't construct `SYSTEMROOT` / `PATHEXT` / `TEMP` env vars in its wiped subprocess env, which Windows needs to start Python. Worth handling if CI ever expands to Windows runners.
- `cli/generate_dataset.py:30,67` still use `rootutils.setup_root(__file__, ...)` and `Path(__file__).parents[3]` at module top for operator-side anchors. They're documented as checkout-only and out of scope here, but technically they keep the *module* un-importable under zipimport. Worth a separate hardening pass if the launcher itself ever needs to run from a packaged install.

Refs #1236
Part of #223