### PR TITLE
ci(testing): add deflake-mps workflow + pytest-repeat/randomly plugins

### DIFF
--- a/.github/workflows/deflake-mps.yml
+++ b/.github/workflows/deflake-mps.yml
@@ -78,7 +78,7 @@ jobs:
           COUNT: ${{ inputs.count || 3 }}
         run: |
           set -euo pipefail
-          [[ "$COUNT" =~ ^[0-9]+$ ]] || { echo "ERROR: count must be a positive integer, got: $COUNT" >&2; exit 2; }
+          [[ "$COUNT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: count must be a positive integer (>= 1), got: $COUNT" >&2; exit 2; }
           mkdir -p deflake-artifacts
           pytest \
             --count="$COUNT" \

--- a/.github/workflows/deflake-mps.yml
+++ b/.github/workflows/deflake-mps.yml
@@ -15,6 +15,12 @@ on:
         required: true
         type: number
         default: 50
+  # PR-self-test: runs the harness against a fast non-MPS test (count=3) so
+  # a change to this file is exercised end-to-end before merge — at-rest
+  # workflow_dispatch can't fire until the file is on the default branch.
+  pull_request:
+    paths:
+      - ".github/workflows/deflake-mps.yml"
 
 permissions:
   contents: read
@@ -68,8 +74,8 @@ jobs:
         continue-on-error: true
         env:
           HYDRA_FULL_ERROR: "1"
-          NODE_ID: ${{ inputs.test_node_id }}
-          COUNT: ${{ inputs.count }}
+          NODE_ID: ${{ inputs.test_node_id || 'tests/pipeline/test_file_uri.py::TestFileUriScheme::test_scheme_constant_is_canonical_file_prefix' }}
+          COUNT: ${{ inputs.count || 3 }}
         run: |
           set -euo pipefail
           [[ "$COUNT" =~ ^[0-9]+$ ]] || { echo "ERROR: count must be a positive integer, got: $COUNT" >&2; exit 2; }
@@ -86,8 +92,8 @@ jobs:
       - name: Summarize results
         if: always()
         env:
-          NODE_ID: ${{ inputs.test_node_id }}
-          COUNT: ${{ inputs.count }}
+          NODE_ID: ${{ inputs.test_node_id || 'tests/pipeline/test_file_uri.py::TestFileUriScheme::test_scheme_constant_is_canonical_file_prefix' }}
+          COUNT: ${{ inputs.count || 3 }}
         run: |
           python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
           import os

--- a/.github/workflows/deflake-mps.yml
+++ b/.github/workflows/deflake-mps.yml
@@ -6,7 +6,7 @@ name: Deflake (MPS)
 on:
   workflow_dispatch:
     inputs:
-      test_node_id:
+      pytest_node_id:
         description: "Pytest node id (e.g. tests/test_train.py::test_train_eval_surge_xt[mps-surge_4-loss_l2_mel])"
         required: true
         type: string
@@ -15,12 +15,16 @@ on:
         required: true
         type: number
         default: 50
-  # PR-self-test: runs the harness against a fast non-MPS test (count=3) so
-  # a change to this file is exercised end-to-end before merge — at-rest
-  # workflow_dispatch can't fire until the file is on the default branch.
+  # PR-self-test: runs the harness against `tests/_meta/test_deflake_self_test.py`
+  # (count=3, intentionally failing) so the failure paths — tmp_path retention,
+  # junit failure parsing, summarizer arithmetic — are exercised end-to-end
+  # before merge. At-rest `workflow_dispatch` can't fire until the file is on
+  # the default branch, so changes to either the workflow or the sentinel test
+  # must trigger this self-test.
   pull_request:
     paths:
       - ".github/workflows/deflake-mps.yml"
+      - "tests/_meta/test_deflake_self_test.py"
 
 permissions:
   contents: read
@@ -68,14 +72,17 @@ jobs:
         run: uv pip list --system
 
       # COUNT validated as a positive int — `type: number` admits floats; pytest-repeat needs int.
-      # NODE_ID + COUNT routed through env (never inlined into `run: |`) so an adversarial
+      # PYTEST_NODE_ID + COUNT routed through env (never inlined into `run: |`) so an adversarial
       # dispatch input can't break out of the bash/Python context.
+      # DEFLAKE_SELF_TEST opts the sentinel in (see its module-level `pytestmark.skipif`);
+      # harmless for dispatched runs targeting other tests, which don't read the env var.
       - name: Run deflake loop
         continue-on-error: true
         env:
           HYDRA_FULL_ERROR: "1"
-          NODE_ID: ${{ inputs.test_node_id || 'tests/pipeline/test_file_uri.py::TestFileUriScheme::test_scheme_constant_is_canonical_file_prefix' }}
+          PYTEST_NODE_ID: ${{ inputs.pytest_node_id || 'tests/_meta/test_deflake_self_test.py::test_always_fails' }}
           COUNT: ${{ inputs.count || 3 }}
+          DEFLAKE_SELF_TEST: "1"
         run: |
           set -euo pipefail
           [[ "$COUNT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: count must be a positive integer (>= 1), got: $COUNT" >&2; exit 2; }
@@ -86,13 +93,37 @@ jobs:
             -o tmp_path_retention_policy=failed \
             --basetemp "$PWD/deflake-artifacts/pytest" \
             --junitxml deflake-artifacts/junit.xml \
-            -- "$NODE_ID" \
+            -- "$PYTEST_NODE_ID" \
             2>&1 | tee deflake-artifacts/pytest.log
+
+      # PR-self-test only: assert the deflake-artifacts bundle contains what
+      # the sentinel run is supposed to produce, so a regression in tmp_path
+      # retention, junit failure aggregation, or the upload glob fails CI
+      # before merge. Dispatched runs target user-chosen tests, so we can't
+      # assert anything about their outputs — skip there.
+      - name: Verify artifact contents (PR self-test)
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          set -euo pipefail
+          test -s deflake-artifacts/pytest.log || { echo "::error::pytest.log missing or empty"; exit 1; }
+          test -s deflake-artifacts/junit.xml || { echo "::error::junit.xml missing or empty"; exit 1; }
+          grep -q 'failures="3"' deflake-artifacts/junit.xml || {
+            echo "::error::expected failures=\"3\" in junit.xml — summarizer fail-rate path won't be exercised"
+            cat deflake-artifacts/junit.xml
+            exit 1
+          }
+          markers=$(find deflake-artifacts/pytest -name 'deflake-self-test-marker' | wc -l | tr -d ' ')
+          [[ "$markers" -eq 3 ]] || {
+            echo "::error::expected 3 retained tmp_paths with sentinel marker, found $markers"
+            find deflake-artifacts/pytest -type f
+            exit 1
+          }
+          echo "✅ artifacts verified: junit failures=3, 3 tmp_paths retained with sentinel marker"
 
       - name: Summarize results
         if: always()
         env:
-          NODE_ID: ${{ inputs.test_node_id || 'tests/pipeline/test_file_uri.py::TestFileUriScheme::test_scheme_constant_is_canonical_file_prefix' }}
+          PYTEST_NODE_ID: ${{ inputs.pytest_node_id || 'tests/_meta/test_deflake_self_test.py::test_always_fails' }}
           COUNT: ${{ inputs.count || 3 }}
         run: |
           python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
@@ -100,11 +131,11 @@ jobs:
           import xml.etree.ElementTree as ET
           from pathlib import Path
 
-          node_id = os.environ["NODE_ID"]
+          pytest_node_id = os.environ["PYTEST_NODE_ID"]
           count = os.environ["COUNT"]
           junit = Path("deflake-artifacts/junit.xml")
           print("## Deflake results\n")
-          print(f"- node id: `{node_id}`")
+          print(f"- node id: `{pytest_node_id}`")
           print(f"- iterations requested: **{count}**")
           if not junit.exists():
               print("\n_junit.xml missing — pytest collection likely failed; see logs._")

--- a/.github/workflows/deflake-mps.yml
+++ b/.github/workflows/deflake-mps.yml
@@ -74,6 +74,10 @@ jobs:
       # COUNT validated as a positive int — `type: number` admits floats; pytest-repeat needs int.
       # PYTEST_NODE_ID + COUNT routed through env (never inlined into `run: |`) so an adversarial
       # dispatch input can't break out of the bash/Python context.
+      # Defaults are event-scoped rather than `inputs.* || <fallback>`: GHA expressions treat `0`
+      # as falsy, so `inputs.count || 3` would silently rewrite a dispatched `count=0` to 3 and
+      # bypass the positive-integer validator. The event check preserves the raw input so the
+      # validator can reject it.
       # DEFLAKE_SELF_TEST opts the sentinel in only on PR self-test; dispatched runs leave it
       # unset so a broad selector like `tests/` can't accidentally pull the failing sentinel in.
       # `continue-on-error` is also PR-scoped: the sentinel is *supposed* to fail (that's how the
@@ -83,8 +87,8 @@ jobs:
         continue-on-error: ${{ github.event_name == 'pull_request' }}
         env:
           HYDRA_FULL_ERROR: "1"
-          PYTEST_NODE_ID: ${{ inputs.pytest_node_id || 'tests/_meta/test_deflake_self_test.py::test_always_fails' }}
-          COUNT: ${{ inputs.count || 3 }}
+          PYTEST_NODE_ID: ${{ github.event_name == 'pull_request' && 'tests/_meta/test_deflake_self_test.py::test_always_fails' || inputs.pytest_node_id }}
+          COUNT: ${{ github.event_name == 'pull_request' && '3' || inputs.count }}
           DEFLAKE_SELF_TEST: ${{ github.event_name == 'pull_request' && '1' || '' }}
         run: |
           set -euo pipefail
@@ -126,8 +130,8 @@ jobs:
       - name: Summarize results
         if: always()
         env:
-          PYTEST_NODE_ID: ${{ inputs.pytest_node_id || 'tests/_meta/test_deflake_self_test.py::test_always_fails' }}
-          COUNT: ${{ inputs.count || 3 }}
+          PYTEST_NODE_ID: ${{ github.event_name == 'pull_request' && 'tests/_meta/test_deflake_self_test.py::test_always_fails' || inputs.pytest_node_id }}
+          COUNT: ${{ github.event_name == 'pull_request' && '3' || inputs.count }}
         run: |
           python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
           import os

--- a/.github/workflows/deflake-mps.yml
+++ b/.github/workflows/deflake-mps.yml
@@ -1,0 +1,129 @@
+name: Deflake (MPS)
+
+# Rerun a single pytest node N times on macOS Apple Silicon and upload every
+# failed iteration's tmp_path as an artifact — diagnostic harness for the
+# MPS-non-determinism flakes tracked in #1260.
+on:
+  workflow_dispatch:
+    inputs:
+      test_node_id:
+        description: "Pytest node id (e.g. tests/test_train.py::test_train_eval_surge_xt[mps-surge_4-loss_l2_mel])"
+        required: true
+        type: string
+      count:
+        description: "Number of iterations"
+        required: true
+        type: number
+        default: 50
+
+permissions:
+  contents: read
+
+jobs:
+  deflake:
+    runs-on: macos-latest
+
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv pip install --system -e ".[torch,dev]"
+
+      # Mirror `test-mps.yml`'s Surge XT provisioning — same cask + symlink path
+      # the configs and `--plugin_path` defaults expect.
+      - name: Install Surge XT VST3
+        run: |
+          brew install --cask surge-xt
+          mkdir -p plugins
+          ln -sfn '/Library/Audio/Plug-Ins/VST3/Surge XT.vst3' 'plugins/Surge XT.vst3'
+
+      - name: Smoke-test Surge XT plugin load
+        run: |
+          python -X faulthandler -c "from synth_setter.data.vst.core import load_plugin; load_plugin('plugins/Surge XT.vst3')"
+
+      - name: Probe MPS availability
+        run: |
+          python -c "import torch; assert torch.backends.mps.is_available(), 'MPS not available on this runner'"
+
+      - name: List dependencies
+        run: uv pip list --system
+
+      # COUNT validated as a positive int — `type: number` admits floats; pytest-repeat needs int.
+      # NODE_ID + COUNT routed through env (never inlined into `run: |`) so an adversarial
+      # dispatch input can't break out of the bash/Python context.
+      - name: Run deflake loop
+        continue-on-error: true
+        env:
+          HYDRA_FULL_ERROR: "1"
+          NODE_ID: ${{ inputs.test_node_id }}
+          COUNT: ${{ inputs.count }}
+        run: |
+          set -euo pipefail
+          [[ "$COUNT" =~ ^[0-9]+$ ]] || { echo "ERROR: count must be a positive integer, got: $COUNT" >&2; exit 2; }
+          mkdir -p deflake-artifacts
+          pytest \
+            --count="$COUNT" \
+            -vv -s \
+            -o tmp_path_retention_policy=failed \
+            --basetemp "$PWD/deflake-artifacts/pytest" \
+            --junitxml deflake-artifacts/junit.xml \
+            -- "$NODE_ID" \
+            2>&1 | tee deflake-artifacts/pytest.log
+
+      - name: Summarize results
+        if: always()
+        env:
+          NODE_ID: ${{ inputs.test_node_id }}
+          COUNT: ${{ inputs.count }}
+        run: |
+          python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import os
+          import xml.etree.ElementTree as ET
+          from pathlib import Path
+
+          node_id = os.environ["NODE_ID"]
+          count = os.environ["COUNT"]
+          junit = Path("deflake-artifacts/junit.xml")
+          print("## Deflake results\n")
+          print(f"- node id: `{node_id}`")
+          print(f"- iterations requested: **{count}**")
+          if not junit.exists():
+              print("\n_junit.xml missing — pytest collection likely failed; see logs._")
+              raise SystemExit(0)
+          root = ET.parse(junit).getroot()
+          ts = root if root.tag == "testsuite" else root.find("testsuite")
+          if ts is None:
+              print("\n_junit.xml had no testsuite element — see logs._")
+              raise SystemExit(0)
+          total = int(ts.get("tests", 0))
+          fails = int(ts.get("failures", 0)) + int(ts.get("errors", 0))
+          rate = (fails / total * 100) if total else 0.0
+          print(f"- iterations run: **{total}**")
+          print(f"- failures: **{fails}**")
+          print(f"- fail rate: **{rate:.1f}%**")
+          PY
+
+      # `run_attempt` in the artifact name so a re-run of the same dispatch
+      # doesn't collide. `warn` (not `error`) so zero-failure runs still
+      # upload the junit + log bundle.
+      - name: Upload deflake artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deflake-mps-${{ github.run_id }}-${{ github.run_attempt }}
+          path: deflake-artifacts/
+          retention-days: 14
+          if-no-files-found: warn

--- a/.github/workflows/deflake-mps.yml
+++ b/.github/workflows/deflake-mps.yml
@@ -74,15 +74,18 @@ jobs:
       # COUNT validated as a positive int — `type: number` admits floats; pytest-repeat needs int.
       # PYTEST_NODE_ID + COUNT routed through env (never inlined into `run: |`) so an adversarial
       # dispatch input can't break out of the bash/Python context.
-      # DEFLAKE_SELF_TEST opts the sentinel in (see its module-level `pytestmark.skipif`);
-      # harmless for dispatched runs targeting other tests, which don't read the env var.
+      # DEFLAKE_SELF_TEST opts the sentinel in only on PR self-test; dispatched runs leave it
+      # unset so a broad selector like `tests/` can't accidentally pull the failing sentinel in.
+      # `continue-on-error` is also PR-scoped: the sentinel is *supposed* to fail (that's how the
+      # Verify step gets a junit with failures to assert on), so a green PR check is correct;
+      # for dispatched runs the operator wants the job conclusion to reflect pytest's real exit.
       - name: Run deflake loop
-        continue-on-error: true
+        continue-on-error: ${{ github.event_name == 'pull_request' }}
         env:
           HYDRA_FULL_ERROR: "1"
           PYTEST_NODE_ID: ${{ inputs.pytest_node_id || 'tests/_meta/test_deflake_self_test.py::test_always_fails' }}
           COUNT: ${{ inputs.count || 3 }}
-          DEFLAKE_SELF_TEST: "1"
+          DEFLAKE_SELF_TEST: ${{ github.event_name == 'pull_request' && '1' || '' }}
         run: |
           set -euo pipefail
           [[ "$COUNT" =~ ^[1-9][0-9]*$ ]] || { echo "ERROR: count must be a positive integer (>= 1), got: $COUNT" >&2; exit 2; }

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ coverage.xml
 .pytest_cache/
 mutants/
 .mutmut-cache/
+deflake-artifacts/
 
 # Translations
 *.mo

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,12 @@ test-bats: ## Run BATS shell tests
 	bats --recursive tests/
 
 # Local mirror of .github/workflows/deflake-mps.yml — see that workflow for the rationale on each flag.
+# `pipefail` (target-scoped via bash) ensures pytest's non-zero exit propagates through `tee`.
+deflake: SHELL := /bin/bash
 deflake: ## Rerun TEST COUNT times; retain failed tmp_paths under deflake-artifacts/
 	@test -n "$(TEST)" || (echo "usage: make deflake TEST=<node-id> [COUNT=50]" >&2; exit 1)
-	mkdir -p deflake-artifacts
+	@set -o pipefail; \
+	mkdir -p deflake-artifacts && \
 	pytest \
 	  --count=$(or $(COUNT),50) \
 	  -vv -s \

--- a/Makefile
+++ b/Makefile
@@ -73,10 +73,10 @@ deflake: ## Rerun TEST COUNT times; retain failed tmp_paths under deflake-artifa
 	@set -o pipefail; \
 	mkdir -p deflake-artifacts && \
 	pytest \
-	  --count=$(or $(COUNT),50) \
+	  --count="$(or $(COUNT),50)" \
 	  -vv -s \
 	  -o tmp_path_retention_policy=failed \
-	  --basetemp $(CURDIR)/deflake-artifacts/pytest \
+	  --basetemp "$(CURDIR)/deflake-artifacts/pytest" \
 	  --junitxml deflake-artifacts/junit.xml \
 	  -- "$(TEST)" 2>&1 | tee deflake-artifacts/pytest.log
 

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,18 @@ test-infra: ## Devcontainer + GHA invariant tests — stdlib-only, no torch/Hydr
 test-bats: ## Run BATS shell tests
 	bats --recursive tests/
 
+# Local mirror of .github/workflows/deflake-mps.yml — see that workflow for the rationale on each flag.
+deflake: ## Rerun TEST COUNT times; retain failed tmp_paths under deflake-artifacts/
+	@test -n "$(TEST)" || (echo "usage: make deflake TEST=<node-id> [COUNT=50]" >&2; exit 1)
+	mkdir -p deflake-artifacts
+	pytest \
+	  --count=$(or $(COUNT),50) \
+	  -vv -s \
+	  -o tmp_path_retention_policy=failed \
+	  --basetemp $(CURDIR)/deflake-artifacts/pytest \
+	  --junitxml deflake-artifacts/junit.xml \
+	  -- "$(TEST)" 2>&1 | tee deflake-artifacts/pytest.log
+
 install: ## End-to-end: install uv, create .venv (Python 3.10), install deps, set up pre-commit
 	@command -v uv >/dev/null 2>&1 || [ -x "$$HOME/.local/bin/uv" ] || \
 		{ echo "Installing uv..."; curl -LsSf https://astral.sh/uv/install.sh | sh; }

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -265,6 +265,8 @@ docs:
         covers: "Pre-submit MPS lane on macos-latest (-m mps), triggered on src/synth_setter/configs/ PRs"
       - pattern: ".github/workflows/test-gpu.yml"
         covers: "Twice-weekly GPU lane on gpu-x64 (-m gpu)"
+      - pattern: ".github/workflows/deflake-mps.yml"
+        covers: "Manual-dispatch diagnostic loop on macos-latest — reruns a single pytest node N times via pytest-repeat (#1260 flake harness); uploads failed tmp_paths per iteration."
       - pattern: "pyproject.toml"
         covers: "Marker registration ([tool.pytest.ini_options].markers) and default selector"
         scope: "pytest-config"

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -58,6 +58,8 @@ CI and `make` selectors are **not identical** — CI may use different marker co
 
 **Markers** are registered in [`pyproject.toml`](../../pyproject.toml) under `[tool.pytest.ini_options].markers`. The file lists each marker's purpose. Strict markers are on — unknown marker names fail collection, so new markers must be added to `pyproject.toml` first.
 
+**Test order and seeding are randomized.** `pytest-randomly` is on by default; each run shuffles test order and reseeds `random` / `numpy.random` / `torch`. To reproduce a flake, copy the `Using --randomly-seed=NNN` line printed at session start and pass it back via `-p randomly --randomly-seed=NNN`; disable shuffling with `-p no:randomly`. The on-demand deflake harness ([`deflake-mps.yml`](../../.github/workflows/deflake-mps.yml) / `make deflake TEST=<node-id> [COUNT=50]`) reruns a single node N times and uploads failed iterations' `tmp_path` as artifacts — see [#1260](https://github.com/tinaudio/synth-setter/issues/1260).
+
 ______________________________________________________________________
 
 ## 3. Which shape fits your test?

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,8 @@ dev = [
   "pytest",
   "pytest-benchmark",
   "pytest-cov",
+  "pytest-randomly",
+  "pytest-repeat",
   "pytest-xdist",
   "ruff",
 ]
@@ -152,6 +154,8 @@ dev = [
   "pytest",
   "pytest-benchmark",
   "pytest-cov",
+  "pytest-randomly",
+  "pytest-repeat",
   "pytest-xdist",
   "ruff",
   { include-group = "docs" },

--- a/tests/_meta/test_deflake_self_test.py
+++ b/tests/_meta/test_deflake_self_test.py
@@ -8,6 +8,7 @@ touches ``.github/workflows/deflake-mps.yml``. Gated by
 """
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -17,12 +18,12 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-def test_always_fails(tmp_path):
-    """Write a sentinel marker into ``tmp_path``, then fail.
+def test_always_fails(tmp_path: Path) -> None:
+    """Fail unconditionally, leaving a sentinel file in ``tmp_path``.
 
-    The marker filename is asserted by the workflow's
-    ``Verify artifact contents`` step to prove
-    ``tmp_path_retention_policy=failed`` actually retained the dir.
+    :param tmp_path: Per-iteration pytest tmpdir; retained by
+        ``tmp_path_retention_policy=failed`` so the workflow's
+        ``Verify artifact contents`` step can grep for the marker.
     """
     (tmp_path / "deflake-self-test-marker").write_text("sentinel")
     pytest.fail("intentional sentinel failure for the deflake self-test")

--- a/tests/_meta/test_deflake_self_test.py
+++ b/tests/_meta/test_deflake_self_test.py
@@ -1,0 +1,28 @@
+"""Sentinel test for the deflake-mps PR self-test.
+
+Always fails when run, so the deflake harness's failure paths
+(``tmp_path_retention_policy=failed`` retention, junit failure aggregation,
+summarizer fail-rate arithmetic) are exercised end-to-end on every PR that
+touches ``.github/workflows/deflake-mps.yml``. Gated by
+``DEFLAKE_SELF_TEST=1`` so default ``pytest tests/`` runs stay green.
+"""
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("DEFLAKE_SELF_TEST") != "1",
+    reason="deflake sentinel — set DEFLAKE_SELF_TEST=1 to opt in (deflake-mps.yml does)",
+)
+
+
+def test_always_fails(tmp_path):
+    """Write a sentinel marker into ``tmp_path``, then fail.
+
+    The marker filename is asserted by the workflow's
+    ``Verify artifact contents`` step to prove
+    ``tmp_path_retention_policy=failed`` actually retained the dir.
+    """
+    (tmp_path / "deflake-self-test-marker").write_text("sentinel")
+    pytest.fail("intentional sentinel failure for the deflake self-test")

--- a/uv.lock
+++ b/uv.lock
@@ -2311,7 +2311,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp" },
+    { name = "zipp", marker = "python_full_version < '3.13' or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -2645,9 +2645,8 @@ dependencies = [
     { name = "packaging" },
     { name = "pytorch-lightning" },
     { name = "pyyaml" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchmetrics" },
     { name = "tqdm" },
@@ -4101,14 +4100,12 @@ dependencies = [
     { name = "numpy" },
     { name = "omegaconf" },
     { name = "scipy" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchaudio", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchaudio", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torchaudio", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchaudio", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchaudio", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
+    { name = "torchaudio", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/65/bc/b79b34944bff2e9868c7f162b61f186cc006e51bd1452013d971aee74e31/pesto_pitch-2.0.1.tar.gz", hash = "sha256:9ea0690be863e929af73de3653f09567c9d6583951fd75281bf16a6fa85f427e", size = 631175, upload-time = "2025-02-18T16:24:22.304Z" }
@@ -4916,6 +4913,30 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-randomly"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/b3/36192dacc0f470ac2cc516f73e01739c9a48a8224f76beada4f85e1c8a89/pytest_randomly-4.1.0.tar.gz", hash = "sha256:47f1d9746c3bc3efabd53ae1ebfb8bb385cf3d4df4b505b6d58d9c97a3dfe70f", size = 14302, upload-time = "2026-04-20T13:01:51.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/db/2df9a1fca597a273f957a559c20c2d95d629928384507b2afa43ba6909d1/pytest_randomly-4.1.0-py3-none-any.whl", hash = "sha256:f55e89e53367b090c0c053697d7f9d77595543d0e0516c93978b50c0f6b252f9", size = 8353, upload-time = "2026-04-20T13:01:50.382Z" },
+]
+
+[[package]]
+name = "pytest-repeat"
+version = "0.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/80/d4/69e9dbb9b8266df0b157c72be32083403c412990af15c7c15f7a3fd1b142/pytest_repeat-0.9.4.tar.gz", hash = "sha256:d92ac14dfaa6ffcfe6917e5d16f0c9bc82380c135b03c2a5f412d2637f224485", size = 6488, upload-time = "2025-04-07T14:59:53.077Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/d4/8b706b81b07b43081bd68a2c0359fe895b74bf664b20aca8005d2bb3be71/pytest_repeat-0.9.4-py3-none-any.whl", hash = "sha256:c1738b4e412a6f3b3b9e0b8b29fcd7a423e50f87381ad9307ef6f5a8601139f3", size = 4180, upload-time = "2025-04-07T14:59:51.492Z" },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4980,9 +5001,8 @@ dependencies = [
     { name = "lightning-utilities" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchmetrics" },
     { name = "tqdm" },
@@ -5988,7 +6008,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.5.2"
+version = "8.6.0"
 source = { virtual = "." }
 dependencies = [
     { name = "click" },
@@ -6030,18 +6050,15 @@ dependencies = [
     { name = "tensorboard" },
     { name = "threadpoolctl" },
     { name = "tomli", marker = "python_full_version < '3.11' or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchaudio", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchaudio", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torchaudio", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchaudio", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchaudio", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
+    { name = "torchaudio", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchmetrics" },
-    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "wandb" },
     { name = "webdataset" },
@@ -6057,34 +6074,36 @@ all = [
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
+    { name = "pytest-repeat" },
     { name = "pytest-xdist" },
     { name = "ruff" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchaudio", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchaudio", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torchaudio", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchaudio", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchaudio", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
+    { name = "torchaudio", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchmetrics" },
-    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
 ]
 cpu = [
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchaudio", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torchaudio", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchaudio", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
 ]
 cu128 = [
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
-    { name = "torchaudio", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
-    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torchaudio", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torchaudio", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
 ]
 dev = [
     { name = "hypothesis" },
@@ -6094,6 +6113,8 @@ dev = [
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
+    { name = "pytest-repeat" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -6105,18 +6126,15 @@ docs = [
 ]
 torch = [
     { name = "lightning" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchaudio", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchaudio", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torchaudio", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchaudio", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchaudio", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
+    { name = "torchaudio", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchmetrics" },
-    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
 ]
 
@@ -6133,6 +6151,8 @@ dev = [
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
+    { name = "pytest-repeat" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -6182,6 +6202,8 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-benchmark", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
+    { name = "pytest-randomly", marker = "extra == 'dev'" },
+    { name = "pytest-repeat", marker = "extra == 'dev'" },
     { name = "pytest-xdist", marker = "extra == 'dev'" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -6236,6 +6258,8 @@ dev = [
     { name = "pytest" },
     { name = "pytest-benchmark" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
+    { name = "pytest-repeat" },
     { name = "pytest-xdist" },
     { name = "ruff" },
 ]
@@ -6400,26 +6424,23 @@ resolution-markers = [
     "(python_full_version >= '3.13' and sys_platform == 'linux') or (python_full_version >= '3.13' and sys_platform == 'win32')",
     "(python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32')",
     "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')",
-    "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "cuda-bindings", version = "12.9.6", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "cuda-toolkit", version = "12.8.1", source = { registry = "https://pypi.org/simple" }, extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "filelock", marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "fsspec", marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "jinja2", marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "filelock", marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "fsspec", marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "jinja2", marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (python_full_version < '3.11' and sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (python_full_version >= '3.11' and sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "nvidia-cudnn-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "nvidia-cusparselt-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "nvidia-nccl-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "nvidia-nvshmem-cu12", marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "setuptools", marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "sympy", marker = "extra == 'extra-12-synth-setter-cu128'" },
+    { name = "setuptools", marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "sympy", marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "triton", version = "3.6.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "typing-extensions", marker = "extra == 'extra-12-synth-setter-cu128'" },
+    { name = "typing-extensions", marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:5ac6e34681d5a0e527edb741b38254899cd03087a7dd7e841791a4ee0a5e7011", upload-time = "2026-04-27T17:32:32Z" },
@@ -6442,60 +6463,39 @@ wheels = [
 [[package]]
 name = "torch"
 version = "2.12.0"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
-resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
-]
-dependencies = [
-    { name = "filelock", marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "fsspec", marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "jinja2", marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (python_full_version >= '3.11' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (python_full_version < '3.11' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "setuptools", marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "sympy", marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "typing-extensions", marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-]
-wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:1834bd984f8a2f4f16bdfbeecca9146184b220aa46276bf5756735b5dae12812", upload-time = "2026-05-12T16:20:02Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:10802fd383bbfed646212e765a72c37d2185205d4f26eb197a254e8ac7ddcb25", upload-time = "2026-05-12T16:20:07Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:b41339df93d491435e790ff8bcbae1c0ce777175889bfd1281d119862793e6a2", upload-time = "2026-05-12T16:20:12Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:90dd587a5f61bfe1307148b581e2084fc5bc4a06e2b90a20e9a36b81087ff16b", upload-time = "2026-05-12T16:20:17Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:10ee1448a9f304d3b987eb4656f664ba6e4d7b410ca7a5a7c642199777a2cf88", upload-time = "2026-05-12T16:20:21Z" },
-]
-
-[[package]]
-name = "torch"
-version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.11'",
+    "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version < '3.11' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
 ]
 dependencies = [
     { name = "cuda-bindings", version = "13.2.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "cuda-toolkit", version = "13.0.2", source = { registry = "https://pypi.org/simple" }, extra = ["cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "filelock", marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
-    { name = "fsspec", marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
-    { name = "jinja2", marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "filelock", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "fsspec", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "jinja2", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32') or (python_full_version < '3.11' and sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (python_full_version < '3.11' and sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (python_full_version >= '3.11' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform != 'linux' and sys_platform != 'win32') or (python_full_version >= '3.11' and sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (python_full_version >= '3.11' and sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (python_full_version < '3.11' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "nvidia-cublas", marker = "(sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "nvidia-cudnn-cu13", marker = "(sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "nvidia-cusparselt-cu13", marker = "(sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "nvidia-nccl-cu13", marker = "(sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "nvidia-nvshmem-cu13", marker = "(sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "setuptools", marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
-    { name = "sympy", marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "setuptools", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "sympy", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "triton", version = "3.7.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "typing-extensions", marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "typing-extensions", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/b7/53fe0436586716ab7aecff41e26b9302d57c85ded481fd83a2cd741e6b4e/torch-2.12.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:1834bd984f8a2f4f16bdfbeecca9146184b220aa46276bf5756735b5dae12812", size = 87981887, upload-time = "2026-05-13T14:55:53.234Z" },
@@ -6568,32 +6568,21 @@ wheels = [
 [[package]]
 name = "torchaudio"
 version = "2.11.0"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
-resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
-]
-wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6ebb59c694909eccb5d61b7cc199d297692012c43286e36d92983aa7bad7586d", upload-time = "2026-03-23T15:50:10Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:492dd64645e9d0bb843e94f1d9a4d1e31426262ffc594fafecc1697df9df5eb9", upload-time = "2026-03-23T15:50:10Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a1cf1acc883bee9cb906a933572fed6a8a933f86ef34e9ea7d803f72317e8c1b", upload-time = "2026-03-23T15:50:10Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:e3f9696a9ef1d49acc452159b052370c636406d072e9d8f10895fda87b591ea9", upload-time = "2026-03-23T15:50:10Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:bda09ea630ae7207384fb0f28c35e4f8c0d82dd6eba020b6b335ad0caa9fed49", upload-time = "2026-03-23T15:50:10Z" },
-]
-
-[[package]]
-name = "torchaudio"
-version = "2.11.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.11'",
+    "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version < '3.11' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/d9/357eb5fe4e19a861e6fa1af4d9f535e8fa8692336e6cf436e8a21262e054/torchaudio-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6ebb59c694909eccb5d61b7cc199d297692012c43286e36d92983aa7bad7586d", size = 684145, upload-time = "2026-03-23T18:13:46.671Z" },
@@ -6653,9 +6642,6 @@ resolution-markers = [
     "(python_full_version >= '3.13' and sys_platform == 'linux') or (python_full_version >= '3.13' and sys_platform == 'win32')",
     "(python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32')",
     "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')",
-    "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.11.0%2Bcu128-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:4d9549e8197105b52a1530c4cc3a27f94a50c60266555876902d7a0ef09e9039", upload-time = "2026-03-23T15:50:23Z" },
@@ -6683,9 +6669,8 @@ dependencies = [
     { name = "lightning-utilities" },
     { name = "numpy" },
     { name = "packaging" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/81/34/39b8b749333db56c0585d7a11fa62a283c087bb1dfc897d69fb8cedbefb1/torchmetrics-1.9.0.tar.gz", hash = "sha256:a488609948600df52d3db4fcdab02e62aab2a85ef34da67037dc3e65b8512faa", size = 581765, upload-time = "2026-03-09T17:41:22.443Z" }
@@ -6701,14 +6686,11 @@ resolution-markers = [
     "(python_full_version >= '3.13' and sys_platform == 'linux') or (python_full_version >= '3.13' and sys_platform == 'win32')",
     "(python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32')",
     "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')",
-    "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "pillow", marker = "extra == 'extra-12-synth-setter-cu128'" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-12-synth-setter-cu128'" },
+    { name = "numpy", marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "pillow", marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:2a04bf491eb22e6487defe6cead6ffaabbce13fb5981b8eb3540050f96cb0599", upload-time = "2026-04-09T23:21:33Z" },
@@ -6731,42 +6713,26 @@ wheels = [
 [[package]]
 name = "torchvision"
 version = "0.27.0"
-source = { registry = "https://download.pytorch.org/whl/cpu" }
-resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32'",
-]
-dependencies = [
-    { name = "numpy", marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "pillow", marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
-]
-wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:0822b58d2c5d325cd0c7152b744acbd15f898c07572e2cfb70b075a865a4f6f9", upload-time = "2026-05-12T16:20:37Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:df0c166b6bdf7c47f88e81e8b43bc085451d5c50d0c5d1691bc474c1227d6fed", upload-time = "2026-05-12T16:20:37Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:1a6dd742a150645126df9e0b2e449874c1d635897c773b322c2e067e98382dfe", upload-time = "2026-05-12T16:20:37Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:41d6dae73e1af09fa82ded597ae57f2a2314285acde54b25890a8f8e51b999d7", upload-time = "2026-05-12T16:20:37Z" },
-    { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:c5121f1b9ab09a7f73e837871deb8321551f7eaeb19d87aa00de9191968eae44", upload-time = "2026-05-12T16:20:37Z" },
-]
-
-[[package]]
-name = "torchvision"
-version = "0.27.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.11'",
+    "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version < '3.11' and sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.13' and sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.13' and sys_platform == 'emscripten' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform == 'emscripten' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version >= '3.11' and python_full_version < '3.13' and sys_platform != 'emscripten' and sys_platform != 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
+    "python_full_version < '3.11' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128'",
 ]
 dependencies = [
-    { name = "numpy", marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
-    { name = "pillow", marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "numpy", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "pillow", marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/13/15/2df874db140bbfe42f377e05e2dd38f2b9dc88414a6607eecc42073b2baa/torchvision-0.27.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:0822b58d2c5d325cd0c7152b744acbd15f898c07572e2cfb70b075a865a4f6f9", size = 1758817, upload-time = "2026-05-13T14:57:20.113Z" },


### PR DESCRIPTION
Refs #1260, #1256, #898

## Summary

Adds an on-demand harness for investigating MPS test flakes. Tracking issue: [#1260](https://github.com/tinaudio/synth-setter/issues/1260). The motivating open bug is [#1256](https://github.com/tinaudio/synth-setter/issues/1256) (`test_train_eval_surge_xt[mps-surge/fake_oracle]` rms drop below threshold); the historical silent-render variant is [#898](https://github.com/tinaudio/synth-setter/issues/898).

- `pytest-repeat` + `pytest-randomly` added to dev extras (and the matching `[dependency-groups].dev`). `--count=N` reruns a node N times in one process; randomly prints its seed each run so any RNG-driven flake is repro'd with `--randomly-seed=<n>`.
- New workflow [`deflake-mps.yml`](.github/workflows/deflake-mps.yml) — `workflow_dispatch` with `pytest_node_id` and `count` inputs (default 50). Setup mirrors `test-mps.yml` (Surge XT cask, MPS probe). The pytest step uses `-o tmp_path_retention_policy=failed` + a workspace-rooted `--basetemp` so only failed iterations' tmp dirs survive, writes `junit.xml`, emits a step summary with the failure rate, and uploads `deflake-artifacts/` with 14-day retention. `continue-on-error: true` on the pytest step so summary + upload always run.
- Inputs are routed through step-level `env:` bindings (`PYTEST_NODE_ID`, `COUNT`) and referenced as `"$PYTEST_NODE_ID"` / `os.environ["COUNT"]` rather than `${{ inputs.* }}` inside `run:` blocks — closes the shell- and Python-injection vectors flagged in the multi-skill review. `set -euo pipefail` + `[[ "$COUNT" =~ ^[0-9]+$ ]]` guard a non-integer dispatch input.
- `make deflake TEST=… COUNT=…` Makefile target mirrors the CI invocation for local repro.
- `.gitignore`: `deflake-artifacts/`.

No conftest changes; everything per-run is set via pytest `-o` overrides inline. Default suite behavior unchanged *except* `pytest-randomly` now shuffles test order by default — by design (it surfaces order-dependency flakes); any newly-failing test is a real bug to file separately. Disable per-invocation with `-p no:randomly` if needed.

## Out of scope (follow-ups under [#1260](https://github.com/tinaudio/synth-setter/issues/1260))

- CPU / GPU / VST runner profiles (`deflake-cpu.yml` etc.) — copy-paste once MPS is shaken out.
- A `quarantine` marker / nightly flake-tracking job — separate concern.
- Auto-dispatch on test failure via `workflow_run` — wire up once the manual variant is proven.

## Verification

- [x] **Plugins register their flags after install.**

  ```bash
  $ .venv/bin/pytest --help 2>&1 | grep -E "count=|randomly" | head -10
  pytest-randomly:
    --randomly-seed=RANDOMLY_SEED
                          Set the seed that pytest-randomly uses (int), or pass
    --randomly-dont-reset-seed
                          Stop pytest-randomly from resetting random.seed() at the
    --randomly-dont-reorganize
                          Stop pytest-randomly from randomly reorganizing the test
    --count=COUNT         Number of times to repeat each test
  ```

- [x] **Env-routed inputs work end-to-end on a synthetic 50% flake.** Created a throwaway test (`test_smoke.py`) with one always-passing test and one `assert random.random() < 0.5` test, ran the exact env-bound invocation from `deflake-mps.yml`:

  ```bash
  $ PYTEST_NODE_ID="test_smoke.py" COUNT="6" bash -c '
    set -euo pipefail
    [[ "$COUNT" =~ ^[0-9]+$ ]] || { echo "ERROR: ..." >&2; exit 2; }
    mkdir -p deflake-artifacts
    pytest --count="$COUNT" -vv -s \
      -o tmp_path_retention_policy=failed \
      --basetemp "$PWD/deflake-artifacts/pytest" \
      --junitxml deflake-artifacts/junit.xml \
      --rootdir . -- "$PYTEST_NODE_ID" 2>&1 | tee deflake-artifacts/pytest.log
  ' | tail -3
  ========================= 3 failed, 9 passed in 0.03s ==========================
  ```

- [x] **COUNT validator rejects non-integer dispatch inputs.**

  ```bash
  $ COUNT="2.5" bash -c '[[ "$COUNT" =~ ^[0-9]+$ ]] || { echo "OK: rejected non-integer COUNT: $COUNT"; exit 2; }'
  OK: rejected non-integer COUNT: 2.5
  $ COUNT="" bash -c '[[ "$COUNT" =~ ^[0-9]+$ ]] || { echo "OK: rejected empty COUNT"; exit 2; }'
  OK: rejected empty COUNT
  ```

- [x] **`tmp_path_retention_policy=failed` keeps only failed iterations.** 12 total iterations, 9 passes, 3 failures:

  ```bash
  $ find deflake-artifacts -maxdepth 3 -type d | sort
  deflake-artifacts
  deflake-artifacts/pytest
  deflake-artifacts/pytest/test_flake_50pct_<N>_6_0
  deflake-artifacts/pytest/test_flake_50pct_<M>_6_0
  deflake-artifacts/pytest/test_flake_50pct_<K>_6_0
  ```

  Only the 3 failed iterations' tmp dirs survived — all 9 passed iterations were discarded.

- [x] **JUnit summary script parses correctly with env-routed inputs.** Same logic as the workflow's `Summarize results` step:

  ```bash
  $ PYTEST_NODE_ID="test_smoke.py" COUNT="6" python3 -c '
  import os, xml.etree.ElementTree as ET
  from pathlib import Path
  pytest_node_id = os.environ["PYTEST_NODE_ID"]; count = os.environ["COUNT"]
  ts = ET.parse(Path("deflake-artifacts/junit.xml")).getroot()
  ts = ts if ts.tag == "testsuite" else ts.find("testsuite")
  if ts is None: raise SystemExit(0)
  total = int(ts.get("tests", 0))
  fails = int(ts.get("failures", 0)) + int(ts.get("errors", 0))
  print(f"node={pytest_node_id} req={count} run={total} fail={fails} rate={fails/total*100:.1f}%")'
  node=test_smoke.py req=6 run=12 fail=3 rate=25.0%
  ```

- [x] **Pre-commit hooks pass** on every changed file:

  ```bash
  $ pre-commit run --files .github/workflows/deflake-mps.yml Makefile | grep -E "Passed|Failed"
  trim trailing whitespace.................................................Passed
  fix end of files.........................................................Passed
  check yaml...............................................................Passed
  detect private key.......................................................Passed
  don't commit to branch...................................................Passed
  check for case conflicts.................................................Passed
  check for added large files..............................................Passed
  Validate GitHub Workflows................................................Passed
  prettier.................................................................Passed
  codespell................................................................Passed
  ```

- [x] **Multi-skill self-review.** Ran `repo-review-full-no-comments` (4 parallel passes: code-health, synth-setter-project-standards, gha-workflow-validator, comment-hygiene). All 4 BLOCKs (2× injection, 2× comment-cap) plus 4 in-scope WARNs (junit guard, unused id, artifact-name collision, COUNT validator) resolved in commit `e72c57bd`. See `.agent-reviews/repo-review-full-no-comments.e72c57bd1643acfc0da11b257941da59722a8ba8.md`.

- [ ] **Real CI dispatch against [#1256](https://github.com/tinaudio/synth-setter/issues/1256).** Pending merge — once on `main`, dispatch `Deflake (MPS)` with `pytest_node_id = tests/test_train.py::test_train_eval_surge_xt[mps-surge/fake_oracle]` and `count = 20`, confirm step summary reports fail rate and `deflake-mps-<run_id>-<run_attempt>.zip` artifact contains retained tmp dirs from any failed iterations.

Refs [#1260](https://github.com/tinaudio/synth-setter/issues/1260), [#1256](https://github.com/tinaudio/synth-setter/issues/1256), [#898](https://github.com/tinaudio/synth-setter/issues/898)

