### PR TITLE
ci: trigger PR-smoke on skypilot_launch.py changes

### DIFF
--- a/.github/workflows/test-dataset-finalization.yml
+++ b/.github/workflows/test-dataset-finalization.yml
@@ -31,6 +31,7 @@ on:
       - "src/synth_setter/pipeline/data/reshard.py"
       - "src/synth_setter/pipeline/schemas/r2_location.py"
       - "src/synth_setter/pipeline/schemas/spec.py"
+      - "src/synth_setter/pipeline/skypilot_launch.py"
       - ".github/workflows/finalize-dataset.yaml"
       - ".github/workflows/generate-dataset-shards.yaml"
       - ".github/workflows/test-dataset-finalization.yml"

--- a/.github/workflows/test-local-launcher-roundtrip.yml
+++ b/.github/workflows/test-local-launcher-roundtrip.yml
@@ -33,6 +33,7 @@ on:
       - "src/synth_setter/pipeline/schemas/shard_metadata.py"
       - "src/synth_setter/pipeline/partitioning.py"
       - "src/synth_setter/pipeline/r2_io.py"
+      - "src/synth_setter/pipeline/skypilot_launch.py"
       - "src/synth_setter/pipeline/spec_io.py"
       - "src/synth_setter/pipeline/ci/**"
       - "src/synth_setter/cli/generate_dataset.py"


### PR DESCRIPTION
## Summary

- Add `src/synth_setter/pipeline/skypilot_launch.py` to the `on.pull_request.paths` allow-lists in [`test-dataset-finalization.yml`](https://github.com/tinaudio/synth-setter/blob/main/.github/workflows/test-dataset-finalization.yml) and [`test-local-launcher-roundtrip.yml`](https://github.com/tinaudio/synth-setter/blob/main/.github/workflows/test-local-launcher-roundtrip.yml).
- No source edits, no test changes — two YAML insertions only.

## Why

[PR #1257](https://github.com/tinaudio/synth-setter/pull/1257) fixed a Docker Hub rate-limit timeout ([failing run](https://github.com/tinaudio/synth-setter/actions/runs/26371827439/job/77625225624)) by editing `src/synth_setter/pipeline/skypilot_launch.py`. Neither PR-presubmit smoke workflow (`Generate + finalize smoke (hdf5/wds)` matrix, `Launcher -> real-R2 roundtrip`) auto-fired on the PR because their `paths:` allow-lists did not include the launcher file. The fix had to be validated by manual `workflow_dispatch`. Adding the launcher to both allow-lists closes that coverage gap so future edits get presubmit smoke coverage.

## Refs

- [#1263](https://github.com/tinaudio/synth-setter/issues/1263) — coverage-gap tracking issue
- [#1257](https://github.com/tinaudio/synth-setter/pull/1257) — Docker Hub rate-limit fix that exposed the gap

Refs #1263
