### PR TITLE
docs(deps): document uv sync command surface + relock cadence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,12 +31,10 @@ Install the project in editable mode with development dependencies:
 make install        # runs: pip install uv && uv pip install -e ".[torch,dev]"
 ```
 
-`make install` uses `uv pip install -e ".[torch,dev]"` under the hood,
-which is convenient but does **not** consume the committed lockfile. For
-reproducible installs (the same wheel pins CI uses), prefer `uv sync` —
-see [docs/reference/dependency-management.md](docs/reference/dependency-management.md)
-for the full command surface, including the Linux CPU/CUDA split and the
-"resync flip" footgun to avoid on Linux.
+`make install` does not consume the committed lockfile. For the same wheel
+pins CI uses, run `uv sync --frozen` — see
+[docs/reference/dependency-management.md](docs/reference/dependency-management.md)
+for per-platform commands.
 
 Install pre-commit hooks:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,13 @@ Install the project in editable mode with development dependencies:
 make install        # runs: pip install uv && uv pip install -e ".[torch,dev]"
 ```
 
+`make install` uses `uv pip install -e ".[torch,dev]"` under the hood,
+which is convenient but does **not** consume the committed lockfile. For
+reproducible installs (the same wheel pins CI uses), prefer `uv sync` —
+see [docs/reference/dependency-management.md](docs/reference/dependency-management.md)
+for the full command surface, including the Linux CPU/CUDA split and the
+"resync flip" footgun to avoid on Linux.
+
 Install pre-commit hooks:
 
 ```bash
@@ -150,16 +157,17 @@ make benchmark      # performance benchmarks
 
 Tests use `pytest` with strict markers. The registered markers are:
 
-| Marker                      | Meaning                             |
-| --------------------------- | ----------------------------------- |
-| `@pytest.mark.slow`         | Long-running tests                  |
-| `@pytest.mark.gpu`          | Requires a GPU                      |
-| `@pytest.mark.requires_vst` | Requires Surge XT VST plugin binary |
-| `@pytest.mark.r2`           | Requires R2/rclone access           |
-| `@pytest.mark.hypothesis`   | Property-based tests (Hypothesis)   |
-| `@pytest.mark.pipeline`     | Pipeline integration tests          |
-| `@pytest.mark.benchmark`    | Performance benchmarks              |
-| `@pytest.mark.docker_smoke` | Smoke tests inside Docker image     |
+| Marker                      | Meaning                                                                            |
+| --------------------------- | ---------------------------------------------------------------------------------- |
+| `@pytest.mark.slow`         | Long-running tests                                                                 |
+| `@pytest.mark.gpu`          | Requires a GPU                                                                     |
+| `@pytest.mark.mps`          | Requires Apple MPS (Metal); use for any test that exercises an MPS-incompatible op |
+| `@pytest.mark.requires_vst` | Requires Surge XT VST plugin binary                                                |
+| `@pytest.mark.r2`           | Requires R2/rclone access                                                          |
+| `@pytest.mark.hypothesis`   | Property-based tests (Hypothesis)                                                  |
+| `@pytest.mark.pipeline`     | Pipeline integration tests                                                         |
+| `@pytest.mark.benchmark`    | Performance benchmarks                                                             |
+| `@pytest.mark.docker_smoke` | Smoke tests inside Docker image                                                    |
 
 Tests with missing dependencies (GPU, VST plugin, R2 credentials) are skipped
 automatically. This is expected and reported by pytest.

--- a/README.md
+++ b/README.md
@@ -106,19 +106,13 @@ the install command for your hardware:
 | Linux CPU-only (CI / laptop) | `uv sync --frozen --extra cpu --no-default-groups --group dev` |
 | Lint / type-check only       | `uv sync --frozen --only-group dev`                            |
 
-**Mac users: never pass `--extra cpu` or `--extra cu128`.** The marker in
-`[tool.uv.sources]` excludes both on Apple Silicon, so the flag is a silent
-no-op that confuses readers. A bare `uv sync --frozen` resolves torch from
-PyPI's MPS-capable wheel.
+Two table caveats:
 
-**CUDA is the source of truth for reported numbers.** MPS results need not
-match CPU/CUDA bit-for-bit (and some ops fall back to CPU under MPS). When a
-Mac collaborator sees a small numerical divergence from a Linux-CUDA run,
-that is expected — not a reproducibility bug.
+- Mac must use bare `uv sync --frozen` — backend extras are a silent no-op there.
+- CUDA is the source of truth for reported numbers; MPS may diverge slightly.
 
-Dependency-management details (relock cadence, the resync flip on Linux,
-lockfile-diff review) live in
-[docs/reference/dependency-management.md](docs/reference/dependency-management.md).
+Full rationale plus the relock cadence and the Linux-only resync flip live
+in [docs/reference/dependency-management.md](docs/reference/dependency-management.md).
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ set -a && source .env && set +a
 > **Already have Surge XT installed system-wide?** Skip `make install-surge-xt`
 > and symlink it manually:
 > `ln -s "/path/to/Surge XT.vst3" "plugins/Surge XT.vst3"`.
-> See [docs/getting-started.md &sect;2d](docs/getting-started.md#2d-install-the-surge-xt-vst3).
+> See [docs/getting-started.md §2d](docs/getting-started.md#2d-install-the-surge-xt-vst3).
 
 > **Prefer pip or conda?** If you'd rather manage the Python interpreter and
 > venv yourself, see
@@ -96,11 +96,29 @@ set -a && source .env && set +a
 
 ### GPU vs CPU
 
-This project depends on PyTorch (`torch>=2.0.0`), but the install does not fix
-whether you use a CPU-only build or a CUDA-enabled build. Choose and install the
-appropriate PyTorch package for your system (CPU-only or a specific CUDA version)
-using the [PyTorch install matrix](https://pytorch.org/get-started/locally/), then
-install the remaining dependencies as described above.
+The PyTorch backend is routed per platform from the committed `uv.lock`. Pick
+the install command for your hardware:
+
+| Target                       | Command                                                        |
+| ---------------------------- | -------------------------------------------------------------- |
+| macOS (Apple Silicon, MPS)   | `uv sync --frozen`                                             |
+| Linux GPU box (CUDA 12.8)    | `uv sync --frozen --extra cu128`                               |
+| Linux CPU-only (CI / laptop) | `uv sync --frozen --extra cpu --no-default-groups --group dev` |
+| Lint / type-check only       | `uv sync --frozen --only-group dev`                            |
+
+**Mac users: never pass `--extra cpu` or `--extra cu128`.** The marker in
+`[tool.uv.sources]` excludes both on Apple Silicon, so the flag is a silent
+no-op that confuses readers. A bare `uv sync --frozen` resolves torch from
+PyPI's MPS-capable wheel.
+
+**CUDA is the source of truth for reported numbers.** MPS results need not
+match CPU/CUDA bit-for-bit (and some ops fall back to CPU under MPS). When a
+Mac collaborator sees a small numerical divergence from a Linux-CUDA run,
+that is expected — not a reproducibility bug.
+
+Dependency-management details (relock cadence, the resync flip on Linux,
+lockfile-diff review) live in
+[docs/reference/dependency-management.md](docs/reference/dependency-management.md).
 
 ## Quick Start
 

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -12,6 +12,18 @@ version: 1
 
 docs:
   # ── Docker reference ────────────────────────────────────────────
+  - doc: docs/reference/dependency-management.md
+    description: uv sync command surface, relock cadence, Linux resync flip
+    sources:
+      - pattern: "pyproject.toml"
+        covers: "[project.dependencies], [project.optional-dependencies] backend extras (cpu, cu128) and legacy shims (torch, dev, docs, all), [dependency-groups] dev+docs, [tool.uv].conflicts, [[tool.uv.index]], [tool.uv.sources]"
+      - pattern: "uv.lock"
+        covers: "Committed universal lockfile (macOS + Linux + Windows resolution); regenerate with `uv lock` after pyproject edits and review the diff in PRs"
+      - pattern: ".github/workflows/uv-lock-check.yml"
+        covers: "macOS + Linux matrix running `uv lock --check` on every PR that touches pyproject.toml or uv.lock; catches stale-lock drift"
+      - pattern: "docker/ubuntu22_04/Dockerfile"
+        covers: "Container install via `uv sync --frozen --extra ${TORCH_BACKEND} --no-install-project` against the committed lock; dev-base stage installs the package editable on top"
+
   - doc: docs/reference/docker.md
     description: Docker build, run, debug reference
     sources:

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -114,7 +114,7 @@ docs:
       - pattern: "scripts/skypilot/capture-state.sh"
         covers: "Best-effort kube-apiserver + controller on-pod sky_logs snapshot called from generate-dataset-shards.yaml (skypilot-local row) before `sky local down` reaps the kind cluster. Captures pod describes, events, controller logs, and the controller's provision.log so scheduling-side hangs are diagnosable post-mortem (#876). Bash-3.2 portable so the same script runs on macOS CI."
       - pattern: "pyproject.toml"
-        covers: "skypilot[runpod,oci]==0.12.0 listed under [project.dependencies] — required, not optional (decision: see §8.2)"
+        covers: "skypilot[runpod,oci,kubernetes]==0.12.0 listed under [project.dependencies] — required, not optional"
         scope: "skypilot"
 
   # ── Storage provenance spec ─────────────────────────────────────

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -568,6 +568,22 @@ This is expected. VST tests require Surge XT to be installed (see
 [section 4a](#4a-surge-xt-vst-plugin)). They are excluded from `make test-fast`
 by default.
 
+### CI fails with `uv lock --check`
+
+If you added or changed a dependency in `pyproject.toml`, the committed
+`uv.lock` is now stale and the `uv-lock-check` workflow rejects the PR.
+Re-lock and commit the diff:
+
+```bash
+uv lock
+git add uv.lock
+git commit -m "chore(deps): relock for <reason>"
+```
+
+Run `uv lock` on a Mac or GPU box, **never** under a `--extra cpu`
+environment (see the resync-flip note in
+[docs/reference/dependency-management.md](reference/dependency-management.md)).
+
 ______________________________________________________________________
 
 ## 9. What to Try Next

--- a/docs/reference/dependency-management.md
+++ b/docs/reference/dependency-management.md
@@ -15,10 +15,12 @@ command differs by hardware, and how to keep the committed `uv.lock` honest.
 | Regenerate the lock after a dep edit | `uv lock` (then commit the diff)                               |
 
 `--frozen` errors instead of silently re-resolving when the lock and
-`pyproject.toml` disagree. CI uses it everywhere.
+`pyproject.toml` disagree. CI uses it for the main project install everywhere
+it can.
 
-A separate per-PR matrix runs `uv lock --check` on macOS + Linux
-(`.github/workflows/uv-lock-check.yml`); a stale lock is what it catches.
+`.github/workflows/uv-lock-check.yml` runs `uv lock --check` on macOS + Linux
+for every PR that touches `pyproject.toml` or `uv.lock`; a stale lock is
+what it catches.
 
 ## Mac: no backend flag
 
@@ -90,12 +92,13 @@ are the ones you wanted.
 
 `pyproject.toml` retains `[project.optional-dependencies]` entries for
 `torch`, `dev`, `docs`, and `all`. These exist so `pip install -e ".[torch,dev]"`
-keeps working for callsites that cannot honor `[tool.uv.sources]`:
+keeps working for callsites that cannot honor `[tool.uv.sources]`, including:
 
 - `Makefile`'s `make install` target.
 - `environment.yaml` (Conda envs).
 - `scripts/sync_worker_checkout.sh` (SkyPilot worker setup).
 - `.github/workflows/docs.yml` (mkdocs build).
+- `.github/workflows/test-dataset-finalization.yml` (`pip install -e ".[torch,dev]"` smoke).
 
 The shims do not produce a lockfile-validated install; they re-resolve every
 time. Prefer `uv sync --frozen` for any new install path. Removal of the

--- a/docs/reference/dependency-management.md
+++ b/docs/reference/dependency-management.md
@@ -14,12 +14,11 @@ command differs by hardware, and how to keep the committed `uv.lock` honest.
 | Verify the lock is in sync           | `uv lock --check`                                              |
 | Regenerate the lock after a dep edit | `uv lock` (then commit the diff)                               |
 
-`--frozen` errors instead of silently re-resolving if the lock and
-`pyproject.toml` disagree. CI uses it everywhere; you should too.
+`--frozen` errors instead of silently re-resolving when the lock and
+`pyproject.toml` disagree. CI uses it everywhere.
 
-A separate matrix runs `uv lock --check` on macOS + Linux on every PR — see
-`.github/workflows/uv-lock-check.yml`. A stale lock there is the failure mode
-the matrix exists to catch.
+A separate per-PR matrix runs `uv lock --check` on macOS + Linux
+(`.github/workflows/uv-lock-check.yml`); a stale lock is what it catches.
 
 ## Mac: no backend flag
 
@@ -29,8 +28,7 @@ Mac** — the marker in `[tool.uv.sources]` excludes both on macOS, so the
 flag is a silent no-op that confuses readers. The `cpu`/`cu128` extras
 are Linux/Windows backend selectors.
 
-Intel Macs silently get a CPU-only torch from the same PyPI wheel
-(no MPS). Expected, not a bug.
+Intel Macs resolve to a CPU-only torch from the same wheel (no MPS hardware).
 
 ## CUDA is the source of truth for reported numbers
 
@@ -45,16 +43,17 @@ marker so CI can route it to the macOS runner.
 
 ## The resync flip (Linux footgun)
 
-`uv sync` does **exact** syncing by default — it removes/replaces anything
-not matching the current command's resolution. Backend selection is **not
-sticky** — `--extra cpu` applies only to the command it's passed to; the
-next `uv` invocation has no memory of it.
+Two `uv sync` behaviours combine into a Linux footgun:
 
-On Linux that combines into a trap: **any `uv` command without `--extra cpu`
-re-resolves torch to CUDA and exact-syncs the CPU wheel out**, pulling
-multi-GB CUDA wheels onto a GPU-less box. The CUDA torch often still imports
-on a CPU-only box (it just finds no GPU), so the wrong, bloated environment
-can pass tests silently.
+1. **Exact sync**: every invocation removes/replaces packages not matching
+   the current resolution.
+2. **Non-sticky extras**: `--extra cpu` applies only to the command it's
+   passed to; the next `uv` invocation has no memory of it.
+
+So any later `uv` command without `--extra cpu` re-resolves torch to CUDA
+and exact-syncs the CPU wheel out, pulling multi-GB CUDA wheels onto a
+GPU-less box. The wrong env often still imports (no GPU is not an import
+error), so tests can pass silently on the bloated install.
 
 The trap is **Linux-only**. macOS is immune (markers exclude both extras).
 
@@ -112,9 +111,8 @@ package's metadata.
 If the closure is publicly-installable (e.g. `synth-setter[cloud]` for a
 hypothetical cloud-only optional dep set), use `[project.optional-dependencies]`.
 
-After either edit: run `uv lock`, review the diff, commit `pyproject.toml`
-
-- `uv.lock` in the same commit.
+After either edit: run `uv lock`, review the diff, and commit `pyproject.toml`
+and `uv.lock` in the same commit.
 
 ## Open questions
 

--- a/docs/reference/dependency-management.md
+++ b/docs/reference/dependency-management.md
@@ -1,0 +1,136 @@
+# Dependency management
+
+Single source of truth for how dependencies install in this project, why the
+command differs by hardware, and how to keep the committed `uv.lock` honest.
+
+## Command surface
+
+| Target                               | Command                                                        |
+| ------------------------------------ | -------------------------------------------------------------- |
+| macOS (Apple Silicon, MPS)           | `uv sync --frozen`                                             |
+| Linux GPU box (CUDA 12.8)            | `uv sync --frozen --extra cu128`                               |
+| Linux CPU-only — laptop / CI runner  | `uv sync --frozen --extra cpu --no-default-groups --group dev` |
+| Lint / type-check only (no torch)    | `uv sync --frozen --only-group dev`                            |
+| Verify the lock is in sync           | `uv lock --check`                                              |
+| Regenerate the lock after a dep edit | `uv lock` (then commit the diff)                               |
+
+`--frozen` errors instead of silently re-resolving if the lock and
+`pyproject.toml` disagree. CI uses it everywhere; you should too.
+
+A separate matrix runs `uv lock --check` on macOS + Linux on every PR — see
+`.github/workflows/uv-lock-check.yml`. A stale lock there is the failure mode
+the matrix exists to catch.
+
+## Mac: no backend flag
+
+A bare `uv sync --frozen` on Apple Silicon resolves torch from PyPI's
+MPS-capable wheel. **Do not pass `--extra cpu` or `--extra cu128` on a
+Mac** — the marker in `[tool.uv.sources]` excludes both on macOS, so the
+flag is a silent no-op that confuses readers. The `cpu`/`cu128` extras
+are Linux/Windows backend selectors.
+
+Intel Macs silently get a CPU-only torch from the same PyPI wheel
+(no MPS). Expected, not a bug.
+
+## CUDA is the source of truth for reported numbers
+
+MPS results need not match CPU/CUDA bit-for-bit. Some ops fall back to CPU
+under MPS; others raise "operator not currently implemented for the MPS
+device" unless `PYTORCH_ENABLE_MPS_FALLBACK=1` is set. When a Mac
+collaborator sees a small numerical divergence from a Linux-CUDA run on the
+same input, that's MPS divergence — not a reproducibility bug to chase.
+
+Gate any test that hits an MPS-incompatible op behind the `mps` pytest
+marker so CI can route it to the macOS runner.
+
+## The resync flip (Linux footgun)
+
+`uv sync` does **exact** syncing by default — it removes/replaces anything
+not matching the current command's resolution. Backend selection is **not
+sticky** — `--extra cpu` applies only to the command it's passed to; the
+next `uv` invocation has no memory of it.
+
+On Linux that combines into a trap: **any `uv` command without `--extra cpu`
+re-resolves torch to CUDA and exact-syncs the CPU wheel out**, pulling
+multi-GB CUDA wheels onto a GPU-less box. The CUDA torch often still imports
+on a CPU-only box (it just finds no GPU), so the wrong, bloated environment
+can pass tests silently.
+
+The trap is **Linux-only**. macOS is immune (markers exclude both extras).
+
+How to avoid it on Linux:
+
+- CI runners are ephemeral per-run — they survive the flip because there is
+  no "later command" to flip them. This is why CI doesn't set `UV_EXTRA`.
+- **Never run `uv add` or `uv lock` inside a `--extra cpu` environment.** Do
+  all dependency edits and relocks on a Mac or GPU box where the default
+  resolution is the one we want.
+- If you are running interactively on a GPU-less Linux box, export
+  `UV_EXTRA=cpu` in the shell so every `uv` invocation inherits the flag.
+
+## Relock cadence
+
+`uv.lock` is committed and reviewed like code. Run `uv lock` (or
+`uv lock --upgrade`) when you:
+
+- Add, remove, or rebound a dependency in `pyproject.toml`.
+- Want to pick up a security fix or bug fix from upstream.
+- See `uv lock --check` fail in CI on a PR you didn't expect to bump deps.
+
+**Regenerate on a Mac or GPU box, not on a `--extra cpu` Linux env.** A lock
+made under `--extra cpu` will pin the CPU torch as the default-resolution
+branch and the next bare `uv sync` from a GPU box will fight it.
+
+**Review the lockfile diff in PRs** — especially torch, CUDA, and native
+wheels (`pedalboard`, `librosa`/`soundfile`, `h5py`/`hdf5plugin`). A
+lockfile change can move a result. The `uv-lock-check.yml` matrix can only
+prove the lock is consistent with `pyproject.toml`, not that the new pins
+are the ones you wanted.
+
+## Backward-compat shims
+
+`pyproject.toml` retains `[project.optional-dependencies]` entries for
+`torch`, `dev`, `docs`, and `all`. These exist so `pip install -e ".[torch,dev]"`
+keeps working for callsites that cannot honor `[tool.uv.sources]`:
+
+- `Makefile`'s `make install` target.
+- `environment.yaml` (Conda envs).
+- `scripts/sync_worker_checkout.sh` (SkyPilot worker setup).
+- `.github/workflows/docs.yml` (mkdocs build).
+
+The shims do not produce a lockfile-validated install; they re-resolve every
+time. Prefer `uv sync --frozen` for any new install path. Removal of the
+shims tracks alongside migration of the callsites above.
+
+## Adding a new extra or dependency group
+
+If a workflow needs a slim install closure (e.g. lint-only, validator-only),
+add a `[dependency-groups]` group rather than a `[project.optional-dependencies]`
+extra. Groups are PEP 735 — private to `uv sync`, not published in the
+package's metadata.
+
+If the closure is publicly-installable (e.g. `synth-setter[cloud]` for a
+hypothetical cloud-only optional dep set), use `[project.optional-dependencies]`.
+
+After either edit: run `uv lock`, review the diff, commit `pyproject.toml`
+
+- `uv.lock` in the same commit.
+
+## Open questions
+
+- **GPU fleet CUDA generations.** The lock pins `cu128` wheels via
+  `pytorch-cu128`. CUDA wheels are forward-compatible with newer drivers;
+  the failure mode is a box whose driver is *older* than cu128. If the
+  fleet ever spans multiple toolkit generations, the fix is a second routed
+  extra (e.g. `cu118`), not a revert to `uv pip install --torch-backend`.
+  Tracked under #1243's open questions.
+
+## Related
+
+- [`pyproject.toml`](../../pyproject.toml) — the canonical `[tool.uv.sources]`,
+  `[tool.uv].conflicts`, and `[dependency-groups]` definitions.
+- [`uv.lock`](../../uv.lock) — the universal lockfile (macOS + Linux + Windows).
+- [`.github/workflows/uv-lock-check.yml`](../../.github/workflows/uv-lock-check.yml) —
+  the per-OS lock-sync gate.
+- [`docs/getting-started.md`](../getting-started.md) — first-install
+  walkthrough.

--- a/docs/reference/github-actions.md
+++ b/docs/reference/github-actions.md
@@ -21,6 +21,7 @@ For GitHub Actions concepts, see [GitHub's docs](https://docs.github.com/en/acti
 | `pr-metadata-gate`        | Enforces that every PR links a taxonomy-compliant issue (type, label, milestone, Epic lineage).                                                                                 | Walks issue parent chain up to 4 levels; falls back to Epic check if GraphQL parent field unavailable.                                                                                                                                                                        |
 | `bats-tests`              | Runs BATS tests against shell scripts under `scripts/` and `tests/`.                                                                                                            |                                                                                                                                                                                                                                                                               |
 | `docker-build-validation` | Builds the dev-snapshot Docker image; pushes to Docker Hub + GHCR and runs smoke tests on push-to-main/workflow_dispatch; PRs are build-only.                                   | Image is public and ships no credentials; R2/W&B creds flow in at runtime. See [Public image, runtime secrets](#public-image-runtime-secrets).                                                                                                                                |
+| `uv-lock-check`           | Verifies `uv.lock` stays in sync with `pyproject.toml` via `uv lock --check` on `ubuntu-latest` + `macos-latest`. Gates every PR that touches either file.                      | Matrix runs both OSes because `uv.lock` is universal — a lock generated on one platform can encode an unvalidated branch for the other. See [Universal lockfile validation](#universal-lockfile-validation).                                                                  |
 
 ### Pipeline
 
@@ -166,6 +167,10 @@ Or use the Actions tab UI.
 ### PR metadata gate epic traversal
 
 `pr-metadata-gate` walks the issue parent chain (sub-issue hierarchy) up to 4 levels looking for an Epic. If GitHub's GraphQL `parent` field is unavailable for the auth token, it falls back to checking whether the issue itself is an Epic. Orphan issues — those not under any Epic — fail the gate.
+
+### Universal lockfile validation
+
+`uv.lock` is a single file that encodes the resolution for every platform we support (macOS, Linux, Windows). A lock generated on one OS can encode a branch for another OS that was never actually validated — fine for static-metadata wheels, risky for varies-by-platform native deps. `uv-lock-check` runs `uv lock --check` on both `ubuntu-latest` and `macos-latest` so each platform's branch of the universal resolution is exercised on every PR that touches `pyproject.toml` or `uv.lock`. A failure means the lock is stale relative to `pyproject.toml`; the fix is `uv lock` + commit the diff. See [docs/reference/dependency-management.md](dependency-management.md) for the relock cadence and the Linux-only resync flip.
 
 ## Keeping this doc in sync
 


### PR DESCRIPTION
## Summary

Phase 3 of #1243's uv-lock migration — stacked on #1267 (Phase 2). Documents the `uv sync --frozen` command surface that #1267 wired into CI, the Linux-only resync flip, the relock cadence, and the MPS divergence guidance Mac collaborators need.

> **Stacked on #1267.** Base branch is `chore/1245-uv-frozen-ci-matrix`. Merge order: #1267 → rebase this onto main → merge this.

Closes #1246
Refs #1243

## What's in

### New canonical reference

- `docs/reference/dependency-management.md` — ~150 lines covering:
  - Command surface table (macOS / Linux GPU / Linux CPU / lint-only / lock-maintenance)
  - "Mac: no backend flag" + Intel-Mac caveat
  - "CUDA is the source of truth for reported numbers" + the `mps` marker policy
  - The Linux-only resync flip (the 2-behaviour combination, the consequence, and how CI + interactive shells avoid it)
  - Relock cadence — when to run `uv lock`, "regenerate on a Mac or GPU box never under `--extra cpu`", lockfile-diff review in PRs
  - Backward-compat shim inventory (the CI/dev callsites still consuming `[torch,dev]` / `[dev]` / `[torch]` / `[all]`)
  - How to add a new extra or dependency group

### Existing doc updates

- `README.md` "GPU vs CPU" — replaces the generic "choose your PyTorch package" prose with the four-row install command table, two table caveats (Mac no-backend-flag, CUDA-as-source-of-truth), and a pointer to the reference doc.
- `CONTRIBUTING.md` — adds a `uv sync` reproducibility pointer in "Clone and install"; adds `@pytest.mark.mps` to the marker table (was registered in `pyproject.toml` but undocumented).
- `docs/getting-started.md` — new Troubleshooting entry for `uv lock --check` CI failures with the relock+commit recipe.
- `docs/reference/github-actions.md` — catalogs the new `uv-lock-check` workflow and adds a "Universal lockfile validation" gotcha explaining the Linux+macOS matrix.
- `docs/doc-map.yaml` — Phase 2's skypilot extras update reflected (`runpod,oci` → `runpod,oci,kubernetes`); the new `dependency-management.md` reference doc is registered alongside the other `docs/reference/` entries.

## Pre-PR review gate

Three-skill parallel pass (code-health + synth-setter-project-standards + comment-hygiene): 1 BLOCK addressed (orphan-bullet from mdformat mangling a `+` continuation), 5 WARN addressed (sibling duplication between README and reference doc; CI claim overstatement; lock-check matrix path-filter description; resync-flip prose restructure; shim-consumer list missing `test-dataset-finalization.yml`). Full report in the REVIEW_FULL sentinel referenced below.

## Test plan

- [ ] Render preview of `README.md` and `docs/reference/dependency-management.md` confirms the install command tables read correctly.
- [ ] `mkdocs build` (run by `docs.yml` on PR) succeeds — verifies the new reference doc's markdown is well-formed and the cross-doc links resolve.
- [ ] doc-drift skill rerun against this branch finds no new drift (the three findings from #1267's doc-drift sweep are all addressed: doc-map skypilot extras, github-actions catalog, getting-started relock note).
- [ ] Reviewer: confirm the resync-flip explanation matches the project's working understanding of Linux CPU/CUDA interaction.