### PR TITLE
fix(ci): scope imagePullPolicy=Never to the worker task, not ~/.sky/config.yaml

### DIFF
--- a/src/synth_setter/configs/compute/local-template.yaml
+++ b/src/synth_setter/configs/compute/local-template.yaml
@@ -16,12 +16,10 @@
 # cluster via `kind load docker-image` ahead of launch. `image_id` is set
 # per-launch by the launcher from skypilot_launch.worker_image_tag.
 
-# Task-scoped pod_config override: `imagePullPolicy: Never` makes kubelet
-# use the kind-loaded synth-setter image and never resolve its manifest
-# from Docker Hub, avoiding the anonymous-pull 429 that timed out #1255.
-# Scoped to this task (not ~/.sky/config.yaml) so the SkyPilot jobs
-# controller — whose image lives on GAR and is not `kind load`-ed — still
-# pulls normally; a global override blocks the controller from starting.
+# Task-scoped (not ~/.sky/config.yaml): a global override blocks the
+# SkyPilot jobs controller, whose image lives on GAR and is not `kind
+# load`-ed. Name-less container merges into the pod's first container
+# via SkyPilot's patch-merge legacy. See #1255.
 config:
   kubernetes:
     pod_config:

--- a/src/synth_setter/configs/compute/local-template.yaml
+++ b/src/synth_setter/configs/compute/local-template.yaml
@@ -16,6 +16,19 @@
 # cluster via `kind load docker-image` ahead of launch. `image_id` is set
 # per-launch by the launcher from skypilot_launch.worker_image_tag.
 
+# Task-scoped pod_config override: `imagePullPolicy: Never` makes kubelet
+# use the kind-loaded synth-setter image and never resolve its manifest
+# from Docker Hub, avoiding the anonymous-pull 429 that timed out #1255.
+# Scoped to this task (not ~/.sky/config.yaml) so the SkyPilot jobs
+# controller — whose image lives on GAR and is not `kind load`-ed — still
+# pulls normally; a global override blocks the controller from starting.
+config:
+  kubernetes:
+    pod_config:
+      spec:
+        containers:
+          - imagePullPolicy: Never
+
 resources:
   cloud: kubernetes
   # Resource floor: shrunk from `cpus: 2+` to fit kind's allocatable headroom

--- a/src/synth_setter/pipeline/skypilot_launch.py
+++ b/src/synth_setter/pipeline/skypilot_launch.py
@@ -171,41 +171,21 @@ _CI_MODE_TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
 
 # SkyPilot's default (cpus: 4+, memory: 4x) doesn't fit in GHA-kind's
 # ~1950m allocatable CPU after kube-system. See PR #876.
-#
-# `kubernetes.pod_config` forces every CI-kind pod (jobs controller + worker)
-# to use the locally-loaded image and never resolve the manifest from Docker
-# Hub. Without this, kind/containerd still contacts registry-1.docker.io and
-# trips its anonymous-pull 429, even though `kind load docker-image` already
-# placed the image on the node. Container `name`-less entry merges into the
-# pod's first container (SkyPilot patch-merge legacy). See #1255.
 _CI_SKY_CONFIG_YAML = """jobs:
   controller:
     resources:
       cpus: 1+
       memory: 1+
-kubernetes:
-  pod_config:
-    spec:
-      containers:
-        - imagePullPolicy: Never
 """
 
 
 def _ensure_ci_sky_config() -> None:
-    """Write ``~/.sky/config.yaml`` with CI-only SkyPilot overrides when CI mode is truthy.
-
-    Currently emits two overrides: a managed-jobs controller resource shrink so
-    the controller pod fits a GHA-kind cluster (#876), and a
-    ``kubernetes.pod_config.spec.containers[0].imagePullPolicy: Never`` so
-    every CI-kind pod uses the locally-loaded dev-snapshot image instead of
-    racing Docker Hub's anonymous 429 limit (#1255).
+    """Write ``~/.sky/config.yaml`` with the controller shrink when CI mode is truthy.
 
     Truthy = ``SYNTH_SETTER_CI_MODE`` ∈ {1, true, yes, on} (case-insensitive).
     Any other value (including ``0``, ``false``, unset) is a no-op, so an
     operator who exports ``SYNTH_SETTER_CI_MODE=0`` doesn't clobber a local
-    config, and production runs against real clouds never apply
-    ``imagePullPolicy: Never`` (which would prevent the worker from pulling
-    the image at all).
+    config.
     """
     if os.environ.get(_CI_MODE_ENV, "").strip().lower() not in _CI_MODE_TRUTHY_VALUES:
         return

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -299,16 +299,16 @@ class TestEnsureCiSkyConfig:
         assert "memory: 1+" in body
         assert "controller:" in body
 
-    def test_writes_image_pull_policy_never_under_kubernetes_pod_config(
+    def test_global_config_does_not_carry_pod_config(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """SYNTH_SETTER_CI_MODE=1 → pod_config forces ``imagePullPolicy: Never``.
+        """``~/.sky/config.yaml`` must not set ``kubernetes.pod_config`` globally.
 
-        Pinning the exact nested location is what makes the override actually
-        reach kubelet — SkyPilot's ``combine_pod_config_fields`` merges this
-        into every kind pod (jobs controller + worker), letting the
-        pre-loaded dev-snapshot image satisfy starts without re-resolving the
-        manifest from Docker Hub (#1255).
+        A global ``imagePullPolicy: Never`` blocks the SkyPilot jobs
+        controller — whose image lives on GAR and is not ``kind load``-ed —
+        from starting (#1255 → run 26374103900). The pod-config override
+        belongs in the per-task ``local-template.yaml`` instead, where it
+        scopes to the user worker pod only.
 
         :param tmp_path: Pytest fixture providing a fresh test directory.
         :param monkeypatch: Pytest fixture for env/attribute mocking.
@@ -319,8 +319,7 @@ class TestEnsureCiSkyConfig:
         monkeypatch.setenv("HOME", str(tmp_path))
         _ensure_ci_sky_config()
         doc = _yaml.safe_load((tmp_path / ".sky" / "config.yaml").read_text(encoding="utf-8"))
-        containers = doc["kubernetes"]["pod_config"]["spec"]["containers"]
-        assert containers == [{"imagePullPolicy": "Never"}]
+        assert "kubernetes" not in doc
 
     def test_idempotent_overwrite(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Re-invoking the helper is safe; the file is rewritten, not appended.
@@ -371,6 +370,38 @@ class TestEnsureCiSkyConfig:
         monkeypatch.setenv("HOME", str(tmp_path))
         _ensure_ci_sky_config()
         assert (tmp_path / ".sky" / "config.yaml").is_file()
+
+
+class TestLocalTemplatePodConfig:
+    """``configs/compute/local-template.yaml`` carries the task-scoped pod_config override.
+
+    ``imagePullPolicy: Never`` must be scoped to the user worker task — a
+    global override blocks the SkyPilot jobs controller from pulling its
+    own (non-``kind load``-ed) image (#1255 → run 26374103900).
+    """
+
+    def test_image_pull_policy_never_is_scoped_to_task(self) -> None:
+        """Top-level ``config.kubernetes.pod_config`` lands on ``Resources._cluster_config_overrides``.
+
+        SkyPilot reads the top-level ``config:`` field as the task's
+        override config, so the merge applies only when provisioning this
+        task — the controller's resources are unaffected.
+        """
+        from pathlib import Path as _Path
+
+        import yaml as _yaml
+
+        template_path = (
+            _Path(__file__).resolve().parents[3]
+            / "src"
+            / "synth_setter"
+            / "configs"
+            / "compute"
+            / "local-template.yaml"
+        )
+        doc = _yaml.safe_load(template_path.read_text(encoding="utf-8"))
+        containers = doc["config"]["kubernetes"]["pod_config"]["spec"]["containers"]
+        assert containers == [{"imagePullPolicy": "Never"}]
 
 
 class TestEmitSpecUri:

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -371,8 +371,8 @@ class TestEnsureCiSkyConfig:
 class TestLocalTemplatePodConfig:
     """``configs/compute/local-template.yaml`` carries the task-scoped pod_config override.
 
-    The override must live on the user worker task — a global write would
-    block the SkyPilot jobs controller from pulling its own image (#1255).
+    The override must live on the user worker task — a global write would block the SkyPilot jobs
+    controller from pulling its own image (#1255).
     """
 
     def test_image_pull_policy_never_is_scoped_to_task(self) -> None:

--- a/tests/pipeline/test_entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/test_entrypoints/test_skypilot_launch.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock
 
 import click
 import pytest
+import yaml
 from click.testing import CliRunner
 
 from synth_setter.pipeline.constants import WORKER_SPEC_URI_ENV
@@ -305,21 +306,16 @@ class TestEnsureCiSkyConfig:
         """``~/.sky/config.yaml`` must not set ``kubernetes.pod_config`` globally.
 
         A global ``imagePullPolicy: Never`` blocks the SkyPilot jobs
-        controller — whose image lives on GAR and is not ``kind load``-ed —
-        from starting (#1255 → run 26374103900). The pod-config override
-        belongs in the per-task ``local-template.yaml`` instead, where it
-        scopes to the user worker pod only.
+        controller (its GAR image is not ``kind load``-ed) — see #1255.
 
         :param tmp_path: Pytest fixture providing a fresh test directory.
         :param monkeypatch: Pytest fixture for env/attribute mocking.
         """
-        import yaml as _yaml
-
         monkeypatch.setenv("SYNTH_SETTER_CI_MODE", "1")
         monkeypatch.setenv("HOME", str(tmp_path))
         _ensure_ci_sky_config()
-        doc = _yaml.safe_load((tmp_path / ".sky" / "config.yaml").read_text(encoding="utf-8"))
-        assert "kubernetes" not in doc
+        doc = yaml.safe_load((tmp_path / ".sky" / "config.yaml").read_text(encoding="utf-8"))
+        assert "pod_config" not in doc.get("kubernetes", {})
 
     def test_idempotent_overwrite(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Re-invoking the helper is safe; the file is rewritten, not appended.
@@ -375,31 +371,14 @@ class TestEnsureCiSkyConfig:
 class TestLocalTemplatePodConfig:
     """``configs/compute/local-template.yaml`` carries the task-scoped pod_config override.
 
-    ``imagePullPolicy: Never`` must be scoped to the user worker task — a
-    global override blocks the SkyPilot jobs controller from pulling its
-    own (non-``kind load``-ed) image (#1255 → run 26374103900).
+    The override must live on the user worker task — a global write would
+    block the SkyPilot jobs controller from pulling its own image (#1255).
     """
 
     def test_image_pull_policy_never_is_scoped_to_task(self) -> None:
-        """Top-level ``config.kubernetes.pod_config`` lands on ``Resources._cluster_config_overrides``.
-
-        SkyPilot reads the top-level ``config:`` field as the task's
-        override config, so the merge applies only when provisioning this
-        task — the controller's resources are unaffected.
-        """
-        from pathlib import Path as _Path
-
-        import yaml as _yaml
-
-        template_path = (
-            _Path(__file__).resolve().parents[3]
-            / "src"
-            / "synth_setter"
-            / "configs"
-            / "compute"
-            / "local-template.yaml"
-        )
-        doc = _yaml.safe_load(template_path.read_text(encoding="utf-8"))
+        """Top-level ``config:`` is task-scoped — SkyPilot merges it into the worker pod only."""
+        template_path = Path(str(configs_dir() / "compute" / "local-template.yaml"))
+        doc = yaml.safe_load(template_path.read_text(encoding="utf-8"))
         containers = doc["config"]["kubernetes"]["pod_config"]["spec"]["containers"]
         assert containers == [{"imagePullPolicy": "Never"}]
 


### PR DESCRIPTION
## Summary

- Moves the `imagePullPolicy: Never` override out of `_ensure_ci_sky_config`'s global `~/.sky/config.yaml` write and into the top-level `config:` block of `src/synth_setter/configs/compute/local-template.yaml`. SkyPilot reads that field as the task's `Resources._cluster_config_overrides`, so the merge fires only when provisioning the user worker — never the jobs controller.
- Removes the now-redundant `kubernetes.pod_config` block from `_CI_SKY_CONFIG_YAML`; the controller-resource shrink (`jobs.controller.resources`) stays.
- Updates `tests/pipeline/test_entrypoints/test_skypilot_launch.py` to assert the new shape: `~/.sky/config.yaml` carries no `kubernetes.pod_config` key (the inverse of the old assertion), and `local-template.yaml` does carry the per-task override.

## Why

Run [26374103900](https://github.com/tinaudio/synth-setter/actions/runs/26374103900/job/77631256867) — the `Test Dataset Finalization` workflow on main, exercising the fix that landed in #1257 — timed out at 40 min in the launcher step for **both** matrix rows. The launcher tee showed kubelet rejecting the SkyPilot jobs controller pod 35+ times:

```
sky.provision.kubernetes.config.KubernetesError: Failed to create container while launching the node.
Error details: Container image "us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:20250909"
               is not present with pull policy of Never.
```

The image referenced is the **SkyPilot jobs-controller** image (resolved from SkyPilot's remote catalog: `skypilot:custom-cpu-ubuntu-2004` → `us-docker.pkg.dev/sky-dev-465/skypilotk8s/skypilot:20250909`). It lives on Google Artifact Registry (no anonymous rate limit) and is **not** loaded into kind by `kind load docker-image` — only `tinaudio/synth-setter:dev-snapshot` is. PR #1257's global `kubernetes.pod_config.spec.containers[0].imagePullPolicy: Never` merged into every kind pod SkyPilot provisions, including the controller, so kubelet refused to pull the controller image and the cluster never came up.

The original #1255 symptom — anonymous Docker Hub 429 on the worker's `tinaudio/synth-setter:dev-snapshot` pull — still gets `Never` because the per-task scope reaches the worker pod (where `kind load` already placed the image). Kubelet uses the loaded copy without re-resolving the manifest from Docker Hub, so the 429 path stays closed. The controller pulls normally from GAR.

I verified SkyPilot's task loader accepts the new YAML and that the override lands on `Resources._cluster_config_overrides` (task-scoped):

```python
>>> sky.Task.from_yaml_config(yaml.safe_load(open('local-template.yaml'))).resources[0].cluster_config_overrides
{'kubernetes': {'pod_config': {'spec': {'containers': [{'imagePullPolicy': 'Never'}]}}}}
```

## Test plan

- [ ] Local: `pytest tests/pipeline/test_entrypoints/test_skypilot_launch.py` — 91 passed in 2.14s on `4e0593a2`.
- [ ] CI: rerun `Test Dataset Finalization` (workflow_dispatch on main with this branch cherry-picked) and confirm both matrix rows finish the launcher step in <10 min and the verify-artifacts job passes. The previous run on main timed out the 40-min step cap.
- [ ] Operator local-dev: a kind cluster with the synth-setter image pre-loaded (per the local-template.yaml comment) still works; without the pre-load, the worker now fails fast with `not present with pull policy of Never` (intentional — matches the documented invariant on the YAML).

Fixes #1255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)