### PR TITLE
fix(ci): repoint test-dataset-generation Hydra compose at src/synth_setter/configs

### DIFF
--- a/.github/workflows/test-dataset-generation.yml
+++ b/.github/workflows/test-dataset-generation.yml
@@ -224,7 +224,7 @@ jobs:
           import sys
           from pathlib import Path
           from hydra import compose, initialize_config_dir
-          cfg_dir = str(Path.cwd() / 'configs')
+          cfg_dir = str(Path.cwd() / 'src' / 'synth_setter' / 'configs')
           experiment = os.environ['DISPATCH_DATASET_CONFIG']
           with initialize_config_dir(version_base='1.3', config_dir=cfg_dir):
               cfg = compose(config_name='dataset', overrides=[f'experiment={experiment}'])
@@ -262,7 +262,7 @@ jobs:
           import os
           from pathlib import Path
           from hydra import compose, initialize_config_dir
-          cfg_dir = str(Path.cwd() / 'configs')
+          cfg_dir = str(Path.cwd() / 'src' / 'synth_setter' / 'configs')
           experiment = os.environ['DATASET_CONFIG']
           with initialize_config_dir(version_base='1.3', config_dir=cfg_dir):
               cfg = compose(config_name='dataset', overrides=[f'experiment={experiment}'])


### PR DESCRIPTION
## Summary

`test-dataset-generation.yml` has been broken on every scheduled run since #1236 — both `python3 -c` Hydra-compose blocks (`setup.matrix` for the dispatch path and `setup.bucket` for every run) still hand `initialize_config_dir` a `cfg_dir` of `Path.cwd() / 'configs'`, the directory that #1236 moved into the package at `src/synth_setter/configs/`.

The hourly cron failure cascades: the `bucket` step exits with `MissingConfigException: Primary config directory not found.`, `generate-launcher` is skipped, and all four `validate` cells (hdf5/wds × spec/shards) then fail with empty `needs.generate-launcher.outputs.spec_uri`. Example run: https://github.com/tinaudio/synth-setter/actions/runs/26402274119

#1249 swept several other stale `configs/` refs and `test-dataset-finalization.yml:151` was repointed at the new location, but `test-dataset-generation.yml` was missed in that pass.

This PR points both compose blocks at `Path.cwd() / 'src' / 'synth_setter' / 'configs'`, matching the path expression already used by `test-dataset-finalization.yml`.

## Test plan

- [x] Local `compose(config_name='dataset', overrides=['experiment=generate_dataset/smoke-shard'])` from repo root with the new `cfg_dir` resolves `output_format=hdf5` and `r2.bucket=intermediate-data`.
- [ ] Next scheduled hourly run (or a `workflow_dispatch`) on this branch completes the `setup` job and proceeds into `generate-launcher` / `validate`.

Fixes #1273