### PR TITLE
fix(deps): re-add rootutils as dev dep for v0.0.0 baseline scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,10 @@ dev = [
   "pytest-randomly",
   "pytest-repeat",
   "pytest-xdist",
+  # Required only by the v0.0.0 baseline `src/{train,eval}.py` that
+  # tests/test_compare_baseline_configs.py runs through the live Python.
+  # Not used by `synth_setter/` itself — see #1268.
+  "rootutils",
   "ruff",
 ]
 docs = [
@@ -196,6 +200,10 @@ dev = [
   "pytest-randomly",
   "pytest-repeat",
   "pytest-xdist",
+  # Required only by the v0.0.0 baseline `src/{train,eval}.py` that
+  # tests/test_compare_baseline_configs.py runs through the live Python.
+  # Not used by `synth_setter/` itself — see #1268.
+  "rootutils",
   "ruff",
   { include-group = "docs" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -5277,6 +5277,18 @@ wheels = [
 ]
 
 [[package]]
+name = "rootutils"
+version = "1.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/9e/62489bd92acc537ed902fc3ebc0e055e8a96c6ca3071dfdecd9c513176ec/rootutils-1.0.7.tar.gz", hash = "sha256:7e2444cdbf4a73a907875fb109d55a38b4ee21313cef305bf59fadbf540440bc", size = 5730, upload-time = "2023-05-19T13:05:21.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/17/1e8ba0be5b52aa7a18f0df7bd6ab31345a3a4f515d6beac6a765fcacaaa3/rootutils-1.0.7-py3-none-any.whl", hash = "sha256:89f1994e6d0f499db7aca7f90edc146801cb33c8565a15c7cee4a4e4fc8c6eef", size = 6403, upload-time = "2023-05-19T13:05:19.416Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5996,7 +6008,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.7.0"
+version = "8.7.2"
 source = { virtual = "." }
 dependencies = [
     { name = "click" },
@@ -6064,6 +6076,7 @@ all = [
     { name = "pytest-randomly" },
     { name = "pytest-repeat" },
     { name = "pytest-xdist" },
+    { name = "rootutils" },
     { name = "ruff" },
     { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
@@ -6103,6 +6116,7 @@ dev = [
     { name = "pytest-randomly" },
     { name = "pytest-repeat" },
     { name = "pytest-xdist" },
+    { name = "rootutils" },
     { name = "ruff" },
 ]
 docs = [
@@ -6141,6 +6155,7 @@ dev = [
     { name = "pytest-randomly" },
     { name = "pytest-repeat" },
     { name = "pytest-xdist" },
+    { name = "rootutils" },
     { name = "ruff" },
 ]
 docs = [
@@ -6195,6 +6210,7 @@ requires-dist = [
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "rootutils", marker = "extra == 'dev'" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "runpod", specifier = "==1.8.1" },
     { name = "scipy", specifier = ">=1.14,<1.15" },
@@ -6247,6 +6263,7 @@ dev = [
     { name = "pytest-randomly" },
     { name = "pytest-repeat" },
     { name = "pytest-xdist" },
+    { name = "rootutils" },
     { name = "ruff" },
 ]
 docs = [


### PR DESCRIPTION
## Summary
- The slow-tests baseline pinned at tag `v0.0.0` ships `src/train.py` and `src/eval.py` that `import rootutils` at module top. PR #1268 dropped rootutils from runtime deps; the cpu-slow workflow's `test_compare_baseline_configs.py` forwards those baseline scripts to the live Python via a PATH shim, so every parametrized case post-merge failed with `ModuleNotFoundError: No module named 'rootutils'` (run [26377334189](https://github.com/tinaudio/synth-setter/actions/runs/26377334189)).
- Re-add `rootutils` to both `[project.optional-dependencies].dev` (used by `uv pip install -e .[torch,dev]` in `.github/workflows/cpu-slow.yml`) and the PEP 735 `[dependency-groups].dev`, with an inline comment scoping the dependency to baseline reproduction. No production code path imports rootutils — `uv.lock` confirms the entry is gated by `marker = "extra == 'dev'"`.

## Test plan
- [x] `pytest tests/test_compare_baseline_configs.py -k "task1] or task5] or task8] or predict_flow-nsynth or predict_vae-full" -m "slow and not gpu and not mps and not requires_vst"` — 8 cases sampled from each failing family (kosc_train, surge_train, predict) all pass locally.
- [ ] cpu-slow workflow goes green on this branch.

Closes #1272