### PR TITLE
fix(testing): unbreak scheduled GPU Tests (predict_vst_audio plugin_path, sweep mandatory overrides)

### DIFF
--- a/tests/test_sweeps.py
+++ b/tests/test_sweeps.py
@@ -8,19 +8,20 @@ from tests.helpers.run_if import RunIf
 from tests.helpers.run_sh_command import run_sh_command
 
 startfile = "src/synth_setter/cli/train.py"
-# `model=`/`data=` are mandatory in `configs/train.yaml` (`???` defaults);
-# `+run_name=` is consumed by the `hydra.run.dir` interpolation in
-# `configs/hydra/default.yaml`. `logger=[]` disables wandb/tensorboard for
-# these throwaway subprocess runs. `~callbacks.lr_monitor` works around #517 —
-# LearningRateMonitor hard-requires a logger and crashes at on_train_start
-# when logger is empty.
-overrides = [
-    "model=ffn",
-    "data=ksin",
-    "+run_name=sweep",
-    "logger=[]",
-    "~callbacks.lr_monitor",
-]
+# Group selections must precede value overrides — later `model=`/`data=`
+# would re-compose the group and silently drop earlier `model.*`/`data.*`
+# tweaks (collapsing sweeps to a single run).
+_SWEEP_OVERRIDES: tuple[str, ...] = (
+    "model=ffn",  # satisfies `model: ???` in configs/train.yaml
+    "data=ksin",  # satisfies `data: ???` in configs/train.yaml
+    "+run_name=sweep",  # consumed by hydra.run.dir interpolation
+    "logger=[]",  # silence wandb/tensorboard for throwaway runs
+    "~callbacks.lr_monitor",  # #517: LearningRateMonitor crashes with empty logger
+)
+# Shrink ksin split + disable worker MP — ksin's default sizes blow out
+# torch.multiprocessing shmem when DDP forks the dataloader.
+_DDP_SIM_SPLIT: tuple[int, int, int] = (100, 100, 100)
+_DDP_SIM_NUM_WORKERS = 0
 
 
 @pytest.mark.gpu
@@ -34,10 +35,11 @@ def test_hydra_sweep(tmp_path: Path) -> None:
     command = [
         startfile,
         "-m",
+        *_SWEEP_OVERRIDES,
         "hydra.sweep.dir=" + str(tmp_path),
         "model.optimizer.lr=0.005,0.01",
         "++trainer.fast_dev_run=true",
-    ] + overrides
+    ]
 
     run_sh_command(command)
 
@@ -53,18 +55,15 @@ def test_hydra_sweep_ddp_sim(tmp_path: Path) -> None:
     command = [
         startfile,
         "-m",
+        *_SWEEP_OVERRIDES,
         "hydra.sweep.dir=" + str(tmp_path),
         "trainer=ddp_sim",
         "+trainer.max_epochs=3",
         "+trainer.limit_train_batches=1",
         "+trainer.limit_val_batches=1",
         "+trainer.limit_test_batches=1",
-        # ksin's default `train_val_test_sizes` (409M train rows) blows out
-        # torch.multiprocessing's shmem when DDP forks the dataloader. Shrink
-        # the split and disable worker MP so this exercises sweep + DDP
-        # plumbing, not dataset throughput.
-        "data.train_val_test_sizes=[100,100,100]",
-        "data.num_workers=0",
+        f"data.train_val_test_sizes={list(_DDP_SIM_SPLIT)}",
+        f"data.num_workers={_DDP_SIM_NUM_WORKERS}",
         "model.optimizer.lr=0.005,0.01,0.02",
-    ] + overrides
+    ]
     run_sh_command(command)

--- a/tests/test_sweeps.py
+++ b/tests/test_sweeps.py
@@ -8,10 +8,19 @@ from tests.helpers.run_if import RunIf
 from tests.helpers.run_sh_command import run_sh_command
 
 startfile = "src/synth_setter/cli/train.py"
-# logger=[] disables wandb/tensorboard for these throwaway sweep subprocess runs.
-# ~callbacks.lr_monitor works around #517 — LearningRateMonitor hard-requires a
-# logger and crashes at on_train_start when logger is empty.
-overrides = ["logger=[]", "~callbacks.lr_monitor"]
+# `model=`/`data=` are mandatory in `configs/train.yaml` (`???` defaults);
+# `+run_name=` is consumed by the `hydra.run.dir` interpolation in
+# `configs/hydra/default.yaml`. `logger=[]` disables wandb/tensorboard for
+# these throwaway subprocess runs. `~callbacks.lr_monitor` works around #517 —
+# LearningRateMonitor hard-requires a logger and crashes at on_train_start
+# when logger is empty.
+overrides = [
+    "model=ffn",
+    "data=ksin",
+    "+run_name=sweep",
+    "logger=[]",
+    "~callbacks.lr_monitor",
+]
 
 
 @pytest.mark.gpu
@@ -50,6 +59,12 @@ def test_hydra_sweep_ddp_sim(tmp_path: Path) -> None:
         "+trainer.limit_train_batches=1",
         "+trainer.limit_val_batches=1",
         "+trainer.limit_test_batches=1",
+        # ksin's default `train_val_test_sizes` (409M train rows) blows out
+        # torch.multiprocessing's shmem when DDP forks the dataloader. Shrink
+        # the split and disable worker MP so this exercises sweep + DDP
+        # plumbing, not dataset throughput.
+        "data.train_val_test_sizes=[100,100,100]",
+        "data.num_workers=0",
         "model.optimizer.lr=0.005,0.01,0.02",
     ] + overrides
     run_sh_command(command)

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -16,6 +16,7 @@ from synth_setter.cli.eval import evaluate
 from synth_setter.cli.train import train
 from synth_setter.data.vst import param_specs, preset_paths
 from tests.conftest import (
+    _SURGE_FIXTURE_PLUGIN_PATH,
     _VST_SUBPROCESS_TIMEOUT_SECONDS,
     NUM_FIXTURE_SAMPLES,
     VST_HEADLESS_WRAPPER,
@@ -329,6 +330,7 @@ def test_train_eval_surge_xt(
         "synth_setter.evaluation.predict_vst_audio",
         str(predictions_dir),
         str(audio_dir),
+        f"--plugin_path={_SURGE_FIXTURE_PLUGIN_PATH}",
         f"--param_spec={param_spec_name}",
         f"--preset_path={preset_paths[param_spec_name]}",
         "-t",


### PR DESCRIPTION
## Summary

Closes #1276. The scheduled `GPU Tests` workflow has been red on every nightly. Latest red run: [26389202009](https://github.com/tinaudio/synth-setter/actions/runs/26389202009) — `4 failed, 9 passed, 2 skipped`. Two distinct breaks in `pytest -m gpu`, both fixed in `tests/`:

### 1. `tests/test_train.py::test_train_eval_surge_xt[gpu-surge/{fake_oracle,ffn_full}]`

```
ImportError: Unable to load plugin plugins/Surge XT.vst3: plugin file not found.
```

`test_train_eval_surge_xt` invokes the `predict_vst_audio` CLI subprocess without `--plugin_path`, falling back to the click default `plugins/Surge XT.vst3`. The dev-snapshot Docker image installs the plugin at `/usr/lib/vst3/Surge XT.vst3`; `.github/workflows/test-gpu.yml:81` already exports `SYNTH_SETTER_PLUGIN_PATH=/usr/lib/vst3/Surge XT.vst3` and `tests/conftest.py:36` reads that into `_SURGE_FIXTURE_PLUGIN_PATH`. Forward it to the subprocess argv so the child inherits the same path the rest of the fixture uses.

### 2. `tests/test_sweeps.py::test_hydra_sweep{,_ddp_sim}`

```
hydra.errors.ConfigCompositionException: You must specify 'model', e.g, model=<OPTION>
```

`src/synth_setter/configs/train.yaml` has `data: ???` and `model: ???` since #687. `tests/test_sweeps.py:overrides` never supplied them — these tests have been silently broken on `main` since that migration. `+run_name=` (consumed by `hydra.run.dir`'s interpolation) was also missing. Add `model=ffn`, `data=ksin`, `+run_name=sweep` to the shared `overrides`.

`test_hydra_sweep_ddp_sim` additionally hits `torch.multiprocessing` shmem failures on the ksin default `train_val_test_sizes` (409M train rows) when DDP-sim forks the dataloader; pin `data.train_val_test_sizes=[100,100,100]` and `data.num_workers=0` so the test exercises sweep + DDP plumbing, not dataset throughput.

## Changes

- **`tests/test_train.py`** — import `_SURGE_FIXTURE_PLUGIN_PATH` from `conftest`; pass `--plugin_path={_SURGE_FIXTURE_PLUGIN_PATH}` to the `predict_vst_audio` subprocess.
- **`tests/test_sweeps.py`** — add `model=ffn`, `data=ksin`, `+run_name=sweep` to the shared `overrides`; in `test_hydra_sweep_ddp_sim`, pin `data.train_val_test_sizes=[100,100,100]` and `data.num_workers=0`.

No source changes; tests-only.

## Test plan

- [ ] CI: `GPU Tests` workflow goes green on the next scheduled run / manual dispatch
- [x] `python -m py_compile tests/test_sweeps.py tests/test_train.py` clean
- [x] `ruff check tests/test_sweeps.py tests/test_train.py` clean