### PR TITLE
ci(ci-automation): free runner disk before kind load on skypilot-local row

### DIFF
--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -347,6 +347,21 @@ jobs:
           fi
           echo "docker pull completed for ${IMAGE}"
 
+      # `kind load` shells `docker save` into /var/lib/docker/tmp/; the
+      # ~10 GB tar exhausts ubuntu-latest's root partition without cleanup.
+      - name: Free disk space for kind load (skypilot-local row)
+        if: ${{ inputs.provider == 'skypilot-local' }}
+        run: |
+          set -euo pipefail
+          df -h / | tail -1 | awk '{print "before: " $4 " free on /"}'
+          sudo rm -rf \
+            /usr/share/dotnet \
+            /usr/local/lib/android \
+            /opt/ghc \
+            /usr/local/.ghcup \
+            /opt/hostedtoolcache/CodeQL
+          df -h / | tail -1 | awk '{print "after:  " $4 " free on /"}'
+
       - name: Load dev-snapshot image into kind (skypilot-local row)
         if: ${{ inputs.provider == 'skypilot-local' }}
         run: kind load docker-image "${IMAGE}" --name skypilot


### PR DESCRIPTION
## Summary

- Adds a *Free disk space for kind load (skypilot-local row)* step in `.github/workflows/generate-dataset-shards.yaml` that purges ~25 GB of pre-installed toolchains the workflow never touches (`/usr/share/dotnet`, `/usr/local/lib/android`, `/opt/ghc`, `/usr/local/.ghcup`, `/opt/hostedtoolcache/CodeQL`) before invoking `kind load`.
- Logs `df -h /` before/after so future regressions are debuggable from the run alone.
- Scoped to `inputs.provider == 'skypilot-local'` — the runpod/oci rows use `docker run` directly and don't shell to `docker save`.

## Why

`kind load docker-image` shells out to `docker save -o <tar>` under `/var/lib/docker/tmp/` before piping the archive into the kind node's containerd. The `dev-snapshot` image is ~5.4 GB compressed (~10–15 GB unpacked); combined with the pulled image layers it routinely tips the ubuntu-latest root partition past its ~14 GB post-checkout free budget. Run [26449578660](https://github.com/tinaudio/synth-setter/actions/runs/26449578660/job/77866241299) failed with:

```
ERROR: command "docker save -o /tmp/images-tar.../images.tar tinaudio/synth-setter:dev-snapshot" failed with error: exit status 1
Command Output: Error response from daemon: write /var/lib/docker/tmp/docker-export-.../blobs/sha256/...: no space left on device
```

## Test plan

- [ ] Re-run *Test Dataset Generation* against this branch via `workflow_dispatch` and confirm the *Load dev-snapshot image into kind* step succeeds.
- [ ] Inspect the new step's `before:` / `after:` `df -h /` lines in the run log to confirm headroom (~25 GB reclaimed).
- [ ] Confirm the `runpod` / `oci` rows are unaffected (step skipped via the `if:` guard).

## Review

repo-review-full-no-comments: 0 BLOCK, 4 WARN (all stylistic — `df|tail|awk` pipefail nit, hard-coded paths vs. maintained action, duplicated idiom, citation for `~10 GB`). None block ship; can be addressed in a follow-up.

Refs #1278