### PR TITLE
docs: dequote .env.example values + warn about --env-file semantics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,11 +7,9 @@
 # To export all vars into your current shell:
 #   set -a && source .env; set +a
 #
-# Write values BARE — KEY=value, never KEY="value". Docker `--env-file`
-# (devcontainers + SkyPilot launcher) passes quotes through literally, so
-# RCLONE_CONFIG_R2_TYPE="s3" arrives in the container as `"s3"` and rclone
-# rejects it. Shell `source` and python-dotenv strip quotes, which masks the
-# bug outside the container.
+# Write values BARE — KEY=value, never KEY="value". The devcontainers
+# (.devcontainer/{cpu,gpu,root_gpu}/devcontainer.json) load this file via
+# Docker `--env-file`, which passes quotes through literally — see #1282.
 
 # =============================================================================
 # Cloudflare R2 (S3-compatible object storage)

--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,10 @@
 # To export all vars into your current shell:
 #   set -a && source .env; set +a
 #
-# Write values BARE — KEY=value, never KEY="value". The devcontainers
-# (.devcontainer/{cpu,gpu,root_gpu}/devcontainer.json) load this file via
-# Docker `--env-file`, which passes quotes through literally — see #1282.
+# Write values BARE — KEY=value, never KEY="value". Docker `--env-file`
+# (devcontainers + `docker run --env-file .env` per docs/reference/docker.md)
+# passes quotes through literally; shell `source` and python-dotenv strip
+# them, which masks the bug — see #1282.
 
 # =============================================================================
 # Cloudflare R2 (S3-compatible object storage)

--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,12 @@
 #
 # To export all vars into your current shell:
 #   set -a && source .env; set +a
+#
+# Write values BARE — KEY=value, never KEY="value". Docker `--env-file`
+# (devcontainers + SkyPilot launcher) passes quotes through literally, so
+# RCLONE_CONFIG_R2_TYPE="s3" arrives in the container as `"s3"` and rclone
+# rejects it. Shell `source` and python-dotenv strip quotes, which masks the
+# bug outside the container.
 
 # =============================================================================
 # Cloudflare R2 (S3-compatible object storage)
@@ -36,7 +42,7 @@ R2_BUCKET=intermediate-data
 # Optional env var to use a remote SkyPilot API server.
 # See docs/operations/skypilot-remote-server-playbook.md for how to set up
 # a remote server.
-SKYPILOT_API_SERVER_ENDPOINT="https://skypilot:YOUR_PASSWORD@YOUR_SKYPILOT_HOSTNAME"
+SKYPILOT_API_SERVER_ENDPOINT=https://skypilot:YOUR_PASSWORD@YOUR_SKYPILOT_HOSTNAME
 
 # Required for W&B to resolve R2 artifact references via S3 protocol
 # (without this, W&B attempts to resolve against AWS S3)


### PR DESCRIPTION
## Summary

- Dequote `SKYPILOT_API_SERVER_ENDPOINT` in `.env.example` (was the only quoted value in the file).
- Add a header note telling users to write values bare, naming the devcontainers as the Docker `--env-file` consumer and pointing to #1282 for the bug mechanism.

## Why

The devcontainers (`.devcontainer/{cpu,gpu,root_gpu}/devcontainer.json`) load `.env` via Docker `--env-file`, which passes everything after `=` through literally — `KEY="value"` arrives in the container as the 7-character string `"value"`. Shell `source` and python-dotenv strip quotes, so the file "works" outside the container and silently breaks inside it.

A user copying the example pattern wrote `RCLONE_CONFIG_R2_TYPE="s3"` and hit:

```
rclone failed to authenticate to R2 with the resolved credentials (exit 1):
Failed to create file system for "r2:": didn't find backend called "\"s3\""
```

The `.setdefault()` guards in `src/synth_setter/pipeline/r2_io.py:53-92` don't catch this — Docker injected the quoted value first, so the key was already present and `setdefault` was a no-op. `.devcontainer/post-create.sh:89` already hand-rolls a quote-stripper for `RESTRICTED_AGENT_GIT_PAT` to dodge the same footgun, which is evidence the issue recurs.

Note: the SkyPilot launcher consumes `.env` via `dotenv_values()` (`src/synth_setter/pipeline/skypilot_launch.py:87,242-282`), which strips quotes — it is not affected. Only the devcontainers' Docker `--env-file` path is, so only they are named in the header.

## Changes

`.env.example`:
- Header: new 3-line note after the `set -a && source .env` tip telling users to write values bare; names `.devcontainer/{cpu,gpu,root_gpu}/devcontainer.json` as the affected consumer; points to #1282 for the rclone repro.
- Line 39 → drop the `"..."` around `SKYPILOT_API_SERVER_ENDPOINT`.

## Test plan

- [ ] CI `pr-metadata-gate.yaml` passes (linked issue #1282 has type Bug, domain `documentation`, milestone `documentation v1.0.0`).
- [ ] CI lint passes (gitlint, prettier, mdformat).
- [ ] Manual: `grep -nE '="' .env.example` shows only the explanatory comment, no data lines.
- [ ] Manual: a fresh `cp .env.example .env`, fill in real R2 creds bare, devcontainer rebuild → `rclone lsd r2:` succeeds.

Fixes #1282