### PR TITLE
feat(pipeline): keep rendered shards locally via DatasetSpec.output_dir

### DIFF
--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -231,8 +231,11 @@ def _dispatch_shards_parallel(
 
     :param spec: Validated dataset spec.
     :param my_range: Non-empty contiguous range of shard IDs owned by this rank.
-    :param work_dir: Per-run tempdir owned by ``run()``; peak local disk
-        scales with the pool size (one in-flight shard per worker thread).
+    :param work_dir: Per-run staging dir owned by ``run()`` (tempdir, or
+        ``spec.output_dir`` when set); with a tempdir peak local disk scales
+        with the pool size (one in-flight shard per worker thread), with
+        ``spec.output_dir`` the unlink is skipped so peak disk scales with
+        ``my_range``.
     :param r2_dest_prefix: ``spec.r2.rclone_prefix()``.
     :returns: ``(rendered, skipped)`` summary counts over ``my_range``.
     """

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -16,7 +16,7 @@ import subprocess
 import sys
 import tempfile
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
-from contextlib import ExitStack
+from contextlib import AbstractContextManager, ExitStack, nullcontext
 from pathlib import Path
 from typing import Any
 
@@ -121,8 +121,11 @@ def run(spec: DatasetSpec) -> None:
     copy once on the launcher host before either calling ``run(spec)`` inline
     (local-run) or dispatching to a SkyPilot worker pod that re-enters via
     ``from_hydra`` → ``run(spec)``. Each shard is rendered, uploaded, and
-    unlinked before moving on — bounding local disk to one shard at a time.
-    Subprocesses fail-fast: later shards are not attempted on subprocess error.
+    (when ``spec.output_dir`` is ``None``) unlinked before moving on, bounding
+    local disk to one shard at a time. With ``spec.output_dir`` set, shards
+    are staged there and kept on disk after upload; peak local disk grows
+    with the rank's owned-shard count. Subprocesses fail-fast: later shards
+    are not attempted on subprocess error.
 
     Before each render, R2 is probed for the shard's destination object: if it already exists with
     non-zero size, the shard is skipped (resumability MVP — see #750). The probe uses
@@ -159,9 +162,17 @@ def run(spec: DatasetSpec) -> None:
 
     r2_dest_prefix = spec.r2.rclone_prefix()
 
-    with tempfile.TemporaryDirectory() as work_dir_str:
-        work_dir = Path(work_dir_str)
+    work_dir_cm: AbstractContextManager[str]
+    if spec.output_dir is None:
+        work_dir_cm = tempfile.TemporaryDirectory()
+    else:
+        work_dir = Path(spec.output_dir)
+        work_dir.mkdir(parents=True, exist_ok=True)
+        logger.info(f"staging shards at operator-supplied output_dir: {work_dir}")
+        work_dir_cm = nullcontext(str(work_dir))
 
+    with work_dir_cm as work_dir_str:
+        work_dir = Path(work_dir_str)
         if spec.render.parallel and len(my_range) > 0:
             rendered, skipped = _dispatch_shards_parallel(spec, my_range, work_dir, r2_dest_prefix)
         else:
@@ -293,14 +304,18 @@ def _render_and_upload_shard(
     work_dir: Path,
     r2_dest_prefix: str,
 ) -> None:
-    """Render a single shard, upload it to R2, then unlink the local file.
+    """Render a single shard, upload it to R2, then unlink (unless ``spec.output_dir`` is set).
 
-    Unlinking after upload bounds local disk to one in-flight shard per caller — necessary on
-    disk-constrained workers running multi-shard partitions. Under ``render.parallel=True`` this
-    bound applies per worker thread, so peak local disk scales with the dispatcher's pool size
-    (see ``_dispatch_shards_parallel`` and ``RenderConfig.parallel``). The renderer subprocess is
-    wrapped in a retry loop bounded by ``spec.render.max_retries`` (default 0 = strict
-    fail-fast); rclone is outside the loop because it already retries via ``--retries=3``.
+    With ``spec.output_dir is None``, unlinking after upload bounds local disk to one
+    in-flight shard per caller — necessary on disk-constrained workers running multi-shard
+    partitions. Under ``render.parallel=True`` this bound applies per worker thread, so peak
+    local disk scales with the dispatcher's pool size (see ``_dispatch_shards_parallel`` and
+    ``RenderConfig.parallel``). When ``spec.output_dir`` is set the unlink is skipped so the
+    operator can inspect/reuse the shards; the disk bound then no longer holds and peak local
+    disk scales with the rank's full assigned range (or the entire dataset for a single-worker
+    run). The renderer subprocess is wrapped in a retry loop bounded by ``spec.render.max_retries``
+    (default 0 = strict fail-fast); rclone is outside the loop because it already retries via
+    ``--retries=3``.
 
     :raises subprocess.CalledProcessError: Renderer (or rclone) subprocess exited non-zero after
         exhausting the retry budget.
@@ -339,8 +354,11 @@ def _render_and_upload_shard(
     logger.info(f"shard rendered: {shard_path} ({shard_path.stat().st_size} bytes)")
     _rclone_copy(str(shard_path), r2_dest_prefix)
     logger.info(f"shard uploaded: {shard.filename} -> {r2_dest_prefix}")
-    shard_path.unlink()
-    logger.info(f"shard removed locally: {shard_path}")
+    if spec.output_dir is None:
+        shard_path.unlink()
+        logger.info(f"shard removed locally: {shard_path}")
+    else:
+        logger.info(f"shard kept locally (output_dir set): {shard_path}")
 
 
 def spec_from_cfg(cfg: DictConfig) -> DatasetSpec:

--- a/src/synth_setter/configs/dataset.yaml
+++ b/src/synth_setter/configs/dataset.yaml
@@ -29,6 +29,12 @@ base_seed: 42
 # bins instead of raising. Smoke configs override to ``true``.
 mask_degenerate_bins: false
 
+# Optional local directory for staged shards; when set, ``run()`` writes shards
+# here instead of a ``TemporaryDirectory`` and skips the post-upload unlink so
+# the operator can inspect or reuse them locally. ``null`` keeps the default
+# ephemeral-tempdir + unlink behaviour.
+output_dir: null
+
 # Materialized as ``null`` so finalize-dataset.yaml can pin the generate stage's
 # ``run_id`` via the ``run_id=<value>`` Hydra override form (strict mode requires
 # the key to exist). Leaving this ``null`` on the generate path is handled by

--- a/src/synth_setter/configs/dataset.yaml
+++ b/src/synth_setter/configs/dataset.yaml
@@ -29,10 +29,8 @@ base_seed: 42
 # bins instead of raising. Smoke configs override to ``true``.
 mask_degenerate_bins: false
 
-# Optional local directory for staged shards; when set, ``run()`` writes shards
-# here instead of a ``TemporaryDirectory`` and skips the post-upload unlink so
-# the operator can inspect or reuse them locally. ``null`` keeps the default
-# ephemeral-tempdir + unlink behaviour.
+# Local staging dir for rendered shards; ``null`` uses a ``TemporaryDirectory``
+# and unlinks each shard after R2 upload. Set a path to keep shards on disk.
 output_dir: null
 
 # Materialized as ``null`` so finalize-dataset.yaml can pin the generate stage's

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -483,6 +483,11 @@ class DatasetSpec(BaseModel):
         Whether finalize substitutes ``std=1.0`` at zero-variance mel bins
         instead of raising; ``False`` is the strict production default.
 
+    .. attribute :: output_dir
+
+        Optional local directory where ``run()`` stages and keeps each shard;
+        ``None`` keeps the default tempdir + post-upload unlink.
+
     .. attribute :: git_sha
 
         Commit SHA of the launcher's working tree at construction.
@@ -547,6 +552,19 @@ class DatasetSpec(BaseModel):
             "mel bins instead of raising; ``False`` is the strict production default. "
             "Smoke configs override to ``True`` because tiny renders have constant "
             "attack-time frames and channels below the source's active bandwidth."
+        ),
+    )
+
+    output_dir: str | None = Field(
+        default=None,
+        description=(
+            "Optional local directory where ``run()`` stages and keeps each rendered shard. "
+            "When ``None``, shards go to a ``TemporaryDirectory`` and are unlinked after upload, "
+            "bounding local disk to one in-flight shard per worker thread. When set, the "
+            "directory is created (``parents=True``) and the per-shard unlink is skipped so the "
+            "operator can inspect or reuse the shards; R2 upload still happens so finalize is "
+            "unaffected. The path is honoured per-rank — on a SkyPilot dispatch the value is a "
+            "path on the worker pod, not the launcher's filesystem."
         ),
     )
 

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1115,6 +1115,95 @@ class TestRun:
         assert renderer_calls == 3
         assert not (fake_r2_remote / spec.r2.bucket / spec.r2.prefix).exists()
 
+    def test_output_dir_keeps_shard_after_upload(
+        self,
+        patched_subprocess: MagicMock,  # noqa: ARG002
+        fake_r2_remote: Path,
+        tmp_path: Path,
+    ) -> None:
+        """``spec.output_dir`` set → shards stay under that dir; upload still lands in R2.
+
+        :param patched_subprocess: Fixture-activation only.
+        :param fake_r2_remote: Asserted to contain the uploaded shard.
+        :param tmp_path: Both ``output_dir`` and plugin-path resolution.
+        """
+        out_dir = tmp_path / "local-shards"
+        kwargs = _base_spec_kwargs(tmp_path, output_dir=str(out_dir))
+        spec = DatasetSpec(**kwargs)  # type: ignore[arg-type]
+
+        run(spec)
+
+        assert (out_dir / spec.shards[0].filename).is_file()
+        assert (
+            fake_r2_remote / spec.r2.bucket / spec.r2.prefix / spec.shards[0].filename
+        ).is_file()
+
+    def test_output_dir_is_created_when_missing(
+        self,
+        patched_subprocess: MagicMock,  # noqa: ARG002
+        fake_r2_remote: Path,  # noqa: ARG002
+        tmp_path: Path,
+    ) -> None:
+        """A non-existent ``output_dir`` (and its parents) is created before rendering.
+
+        :param patched_subprocess: Fixture-activation only.
+        :param fake_r2_remote: Fixture-activation only.
+        :param tmp_path: Multi-segment path that doesn't exist yet.
+        """
+        out_dir = tmp_path / "does-not-exist" / "yet"
+        assert not out_dir.exists()
+        kwargs = _base_spec_kwargs(tmp_path, output_dir=str(out_dir))
+        spec = DatasetSpec(**kwargs)  # type: ignore[arg-type]
+
+        run(spec)
+
+        assert out_dir.is_dir()
+        assert out_dir.parent.is_dir()
+        assert (out_dir / spec.shards[0].filename).is_file()
+
+    def test_output_dir_unset_still_unlinks_local_shard(
+        self,
+        fake_r2_remote: Path,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``output_dir=None`` preserves the unlink-after-upload contract.
+
+        Regression guard against the keep-local branch leaking into the default path — pins the
+        disk-bounding invariant for tempdir-mode runs.
+
+        :param fake_r2_remote: Asserted to contain the uploaded shard.
+        :param tmp_path: Used by ``_base_spec_kwargs``.
+        :param monkeypatch: Spies on ``Path.unlink``.
+        """
+        spec = DatasetSpec(**_base_spec_kwargs(tmp_path))  # type: ignore[arg-type]
+        assert spec.output_dir is None
+        unlinked: list[Path] = []
+        real_unlink = Path.unlink
+
+        def _spy_unlink(self: Path, missing_ok: bool = False) -> None:
+            unlinked.append(self)
+            real_unlink(self, missing_ok=missing_ok)
+
+        monkeypatch.setattr(Path, "unlink", _spy_unlink)
+
+        def _dispatcher(args: list[str]) -> int:
+            if args and args[0] == "rclone":
+                return _REAL_CHECK_CALL(args)
+            return _materialize_shard(args)
+
+        with patch(
+            "synth_setter.cli.generate_dataset.subprocess.check_call",
+            side_effect=_dispatcher,
+        ):
+            run(spec)
+
+        shard_names = {p.name for p in unlinked}
+        assert spec.shards[0].filename in shard_names
+        assert (
+            fake_r2_remote / spec.r2.bucket / spec.r2.prefix / spec.shards[0].filename
+        ).is_file()
+
 
 # ---------------------------------------------------------------------------
 # build_generate_args — arg construction from spec + shard


### PR DESCRIPTION
## Summary

Closes #1285.

- Add optional `output_dir: str | None` to `DatasetSpec` (and `output_dir: null` to `configs/dataset.yaml`).
- When set, `run()` stages shards in that directory (`mkdir(parents=True, exist_ok=True)`) instead of a `TemporaryDirectory`, and the post-upload `shard_path.unlink()` is skipped so the operator can inspect / reuse the shards locally. R2 upload still happens, so finalize and downstream stages are unchanged.
- `None` (default) preserves the historical tempdir + unlink behaviour. Both branches go through a single `with` block via `contextlib.nullcontext`.

## Use case

```
synth-setter-generate-dataset \
  experiment=generate_dataset/custom-test \
  output_dir=/tmp/custom-test-shards
```

After the run, `/tmp/custom-test-shards/shard-000000.h5`, `shard-000001.h5`, ... are available on disk.

## Test plan

- [x] `pytest tests/pipeline/test_entrypoints/test_generate_dataset.py` — 52 passed
  - 3 new `TestRun` cases: shard kept after upload when `output_dir` set, directory (+ parents) created when missing, default `None` path still unlinks (regression guard)
- [x] `pre-commit run --files <touched>` — ruff, ruff format, pyright, pydoclint, docformatter, interrogate, prettier all pass
- [x] Multi-skill dry-run review (`repo-review-full-no-comments`) — 0 BLOCK, 23 WARN; high-signal findings (docstring drift in `run()` / `_render_and_upload_shard` / `_dispatch_shards_parallel`, over-long YAML comment) addressed before opening
- [ ] CI green