### PR TITLE
feat(pipeline): add --keep-local for dev runs via rclone alias backend

### DIFF
--- a/src/synth_setter/cli/_keep_local.py
+++ b/src/synth_setter/cli/_keep_local.py
@@ -23,9 +23,12 @@ KEEP_LOCAL_FLAG = "--keep-local"
 def split_keep_local(argv: list[str]) -> tuple[bool, list[str]]:
     """Pop ``--keep-local`` out of ``argv``; return ``(keep_local, remaining)``.
 
-    Boolean-only flag — ``--keep-local=true`` / ``--keep-local true`` and any
-    other suffix-bearing form is rejected so operators can't accidentally
-    pass a value rclone would never see.
+    Boolean-only flag — ``--keep-local=value`` is rejected here so an operator
+    typo doesn't silently pass a value rclone would never see. The
+    space-separated form ``--keep-local true`` is not detected; the trailing
+    token survives in the remaining-overrides list and Hydra rejects it as an
+    unknown override (``Could not override 'true'``), which is the desired
+    failure mode.
 
     :param argv: CLI overrides (``sys.argv[1:]``-shaped).
     :returns: ``(True, [...])`` if ``--keep-local`` was present exactly once;

--- a/src/synth_setter/cli/_keep_local.py
+++ b/src/synth_setter/cli/_keep_local.py
@@ -1,0 +1,71 @@
+"""Shared ``--keep-local`` plumbing for the generate / finalize CLIs.
+
+``--keep-local`` is an operator-side dev-mode switch that redirects rclone's
+``r2:`` remote to a local directory via ``RCLONE_CONFIG_R2_TYPE=alias`` and
+``RCLONE_CONFIG_R2_REMOTE=<path>``. All R2 access in this codebase resolves
+through rclone, so the redirect is invisible to the rest of the pipeline —
+generate's shard uploads, finalize's shard downloads, the spec upload, and
+the ``object_size`` skip probes all transparently land on (and read from)
+the local filesystem. The flag lives outside Hydra so it does not appear
+in the spec snapshot uploaded to "R2".
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from loguru import logger
+
+KEEP_LOCAL_FLAG = "--keep-local"
+
+
+def split_keep_local(argv: list[str]) -> tuple[bool, list[str]]:
+    """Pop ``--keep-local`` out of ``argv``; return ``(keep_local, remaining)``.
+
+    Boolean-only flag — ``--keep-local=true`` / ``--keep-local true`` and any
+    other suffix-bearing form is rejected so operators can't accidentally
+    pass a value rclone would never see.
+
+    :param argv: CLI overrides (``sys.argv[1:]``-shaped).
+    :returns: ``(True, [...])`` if ``--keep-local`` was present exactly once;
+        ``(False, argv)`` otherwise.
+    :raises ValueError: ``--keep-local`` appeared with a ``=value`` suffix,
+        or appeared more than once.
+    """
+    remaining: list[str] = []
+    seen = False
+    for token in argv:
+        if token == KEEP_LOCAL_FLAG:
+            if seen:
+                raise ValueError(f"{KEEP_LOCAL_FLAG} passed more than once")
+            seen = True
+            continue
+        if token.startswith(f"{KEEP_LOCAL_FLAG}="):
+            raise ValueError(
+                f"{KEEP_LOCAL_FLAG} is a boolean flag; got {token!r}. "
+                f"Use {KEEP_LOCAL_FLAG} alone, or drop it."
+            )
+        remaining.append(token)
+    return seen, remaining
+
+
+def redirect_r2_to_local(local_root: Path) -> None:
+    """Point rclone's ``r2:`` remote at ``local_root`` for the rest of the process.
+
+    Materializes ``local_root`` (rclone's ``alias`` backend resolves paths
+    lazily, but the parent dirs must exist when the first upload lands or
+    rclone errors out) and sets ``RCLONE_CONFIG_R2_TYPE=alias`` +
+    ``RCLONE_CONFIG_R2_REMOTE=<local_root>`` in process env. A URI of the
+    form ``r2:<bucket>/<key>`` then materializes at
+    ``<local_root>/<bucket>/<key>``.
+
+    Idempotent — safe to call repeatedly with the same root, or after
+    a previous keep-local session left the env vars set.
+
+    :param local_root: Absolute filesystem path that becomes the fake-R2 root.
+    """
+    local_root.mkdir(parents=True, exist_ok=True)
+    os.environ["RCLONE_CONFIG_R2_TYPE"] = "alias"
+    os.environ["RCLONE_CONFIG_R2_REMOTE"] = str(local_root)
+    logger.info(f"keep-local: R2 redirected to {local_root}")

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -20,6 +20,7 @@ import numpy as np
 from hydra import compose, initialize_config_module
 from loguru import logger
 
+from synth_setter.cli._keep_local import redirect_r2_to_local, split_keep_local
 from synth_setter.cli.generate_dataset import spec_from_cfg
 from synth_setter.pipeline import r2_io
 from synth_setter.pipeline.constants import (
@@ -165,9 +166,14 @@ def main() -> None:
     second invocation against a finalized prefix is a no-op rather than a
     full redo.
 
+    ``--keep-local`` redirects rclone's ``r2:`` remote to
+    ``cfg.paths.data_dir`` so downloads, splits, stats, and the marker all
+    read from and write to the local mirror established by a prior keep-local
+    generate run.
+
     :raises ValueError: ``spec.output_format`` is neither ``"hdf5"`` nor ``"wds"``.
     """
-    overrides = list(sys.argv[1:])
+    keep_local, overrides = split_keep_local(sys.argv[1:])
     with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
         cfg = compose(config_name="dataset", overrides=overrides)
 
@@ -178,6 +184,10 @@ def main() -> None:
     cfg.paths.work_dir = str(_OPERATOR_WORKSPACE)
 
     spec = spec_from_cfg(cfg)
+
+    if keep_local:
+        redirect_r2_to_local(Path(cfg.paths.data_dir).resolve())
+
     r2_io.ensure_r2_env_loaded()
 
     marker_uri = spec.r2.dataset_complete_marker_uri()

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -25,6 +25,7 @@ from hydra import compose, initialize_config_module
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
+from synth_setter.cli._keep_local import redirect_r2_to_local, split_keep_local
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.pipeline import r2_io
 from synth_setter.pipeline.partitioning import (
@@ -430,8 +431,17 @@ def main() -> None:
     be picked from ``cfg.skypilot_launch.compute_template`` before Hydra would
     hand the cfg straight to the body. Overrides are replayed verbatim on the
     worker so the launcher/worker composition matches byte-for-byte.
+
+    ``--keep-local`` redirects rclone's ``r2:`` remote to
+    ``cfg.paths.data_dir`` (see :func:`redirect_r2_to_local`); the rest of the
+    pipeline is unchanged, including spec upload and shard uploads. The flag
+    is mutually exclusive with SkyPilot dispatch — worker pods are ephemeral,
+    so a retained-local artifact on the worker would never reach the operator.
+
+    :raises ValueError: ``--keep-local`` was combined with a non-null
+        ``compute_template``.
     """
-    overrides = list(sys.argv[1:])
+    keep_local, overrides = split_keep_local(sys.argv[1:])
 
     with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
         cfg = compose(config_name="dataset", overrides=overrides)
@@ -444,6 +454,16 @@ def main() -> None:
 
     spec = spec_from_cfg(cfg)
     sky_cfg = _sky_cfg_from_dataset_cfg(cfg)
+
+    if keep_local and sky_cfg.compute_template is not None:
+        raise ValueError(
+            "--keep-local is incompatible with SkyPilot dispatch "
+            f"(compute_template={sky_cfg.compute_template!r}); the retained "
+            "artifacts would live on the ephemeral worker pod, not on the "
+            "operator host. Drop --keep-local or unset compute_template."
+        )
+    if keep_local:
+        redirect_r2_to_local(Path(cfg.paths.data_dir).resolve())
 
     # ``_OPERATOR_WORKSPACE`` (not cfg.paths.output_dir) is the anchor: the
     # paths.* pins above are defensive shims for

--- a/src/synth_setter/pipeline/r2_io.py
+++ b/src/synth_setter/pipeline/r2_io.py
@@ -78,6 +78,13 @@ def ensure_r2_env_loaded(env_file: Path | None = None) -> None:
     defaulting + presence+auth checks still run against whatever ``os.environ``
     already has.
 
+    If the caller has pre-set ``RCLONE_CONFIG_R2_TYPE`` to a non-``s3`` value
+    (e.g. ``alias`` for keep-local dev mode), the secret-key check and the
+    rclone auth ping are skipped — s3 credentials are not meaningful when
+    rclone is routing ``r2:`` to a local filesystem (or any other backend).
+    The dotenv step still runs so an operator can still pin overrides via
+    ``env_file`` if they want.
+
     :param env_file: Optional dotenv file to merge into ``os.environ`` first
         (typically ``sky_cfg.env_file``).
     :raises RuntimeError: A required secret key is unset after the load, or
@@ -87,6 +94,10 @@ def ensure_r2_env_loaded(env_file: Path | None = None) -> None:
         for key, value in dotenv_values(env_file).items():
             if key and key.startswith("RCLONE_CONFIG_R2_") and value is not None:
                 os.environ[key] = value
+
+    preset_type = os.environ.get("RCLONE_CONFIG_R2_TYPE")
+    if preset_type and preset_type != "s3":
+        return
 
     for key, default in _R2_STRUCTURAL_DEFAULTS.items():
         os.environ.setdefault(key, default)

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -1118,9 +1118,16 @@ class TestMainKeepLocal:
     ) -> None:
         """``--keep-local`` never reaches Hydra compose (would error as an unknown override).
 
+        Asserts the redirect ran (env vars set), proving the flag was both
+        stripped from the overrides Hydra saw AND recognized by the CLI
+        plumbing — a silent passthrough would either error in Hydra or leave
+        the env vars untouched.
+
         :param monkeypatch: Pytest fixture used to patch argv.
         :param tmp_path: Pytest tmp dir used as the override data_dir.
         """
+        import os
+
         argv = [
             "finalize",
             "experiment=generate_dataset/smoke-shard-wds",
@@ -1130,3 +1137,5 @@ class TestMainKeepLocal:
         monkeypatch.setattr(sys, "argv", argv)
 
         finalize_dataset.main()
+
+        assert os.environ.get("RCLONE_CONFIG_R2_TYPE") == "alias"

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -1028,3 +1028,105 @@ def _compose_smoke_wds_spec() -> DatasetSpec:
     cfg.paths.output_dir = str(finalize_dataset._OPERATOR_WORKSPACE)  # noqa: SLF001
     cfg.paths.work_dir = str(finalize_dataset._OPERATOR_WORKSPACE)  # noqa: SLF001
     return finalize_dataset.spec_from_cfg(cfg)
+
+
+class TestMainKeepLocal:
+    """``--keep-local`` redirects rclone's ``r2:`` remote to ``cfg.paths.data_dir``."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_r2_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Drop ``RCLONE_CONFIG_R2_*`` so each test observes a clean redirect state.
+
+        :param monkeypatch: Pytest fixture used to remove env vars.
+        """
+        import os
+
+        for key in list(os.environ):
+            if key.startswith("RCLONE_CONFIG_R2_"):
+                monkeypatch.delenv(key, raising=False)
+
+    @pytest.fixture(autouse=True)
+    def _stub_main_internals(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Short-circuit ``main()`` past the keep-local wiring without doing rclone I/O.
+
+        Pins the marker probe to ``0`` (object exists) so ``main()`` returns
+        immediately after the redirect runs, without entering ``finalize_wds``
+        / ``finalize_hdf5``. ``ensure_r2_env_loaded`` is also a no-op because
+        we want to assert what the redirect set, not what loader resolution
+        layered on top.
+
+        :param monkeypatch: Pytest fixture used to install stubs.
+        """
+        monkeypatch.setattr(
+            "synth_setter.pipeline.r2_io.ensure_r2_env_loaded",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr("synth_setter.pipeline.schemas.spec._get_git_sha", lambda: "a" * 40)
+        monkeypatch.setattr("synth_setter.pipeline.schemas.spec._is_repo_dirty", lambda: False)
+        monkeypatch.setattr("synth_setter.pipeline.schemas.spec._utc_now", lambda: _FIXED_NOW)
+        monkeypatch.setattr("synth_setter.pipeline.r2_io.object_size", lambda _uri: 0)
+
+    def test_keep_local_sets_alias_env_to_resolved_paths_data_dir(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """``--keep-local`` resolves ``cfg.paths.data_dir`` into the rclone env vars.
+
+        :param monkeypatch: Pytest fixture used to patch argv.
+        :param tmp_path: Pytest tmp dir used as the override data_dir.
+        """
+        import os
+
+        local_root = tmp_path / "finalize-local"
+        argv = [
+            "finalize",
+            "experiment=generate_dataset/smoke-shard-wds",
+            f"paths.data_dir={local_root}",
+            "--keep-local",
+        ]
+        monkeypatch.setattr(sys, "argv", argv)
+
+        finalize_dataset.main()
+
+        assert os.environ["RCLONE_CONFIG_R2_TYPE"] == "alias"
+        assert os.environ["RCLONE_CONFIG_R2_REMOTE"] == str(local_root.resolve())
+        assert local_root.is_dir()
+
+    def test_without_keep_local_does_not_touch_rclone_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No ``--keep-local`` → ``main()`` leaves ``RCLONE_CONFIG_R2_*`` alone.
+
+        :param monkeypatch: Pytest fixture used to patch argv.
+        """
+        import os
+
+        argv = ["finalize", "experiment=generate_dataset/smoke-shard-wds"]
+        monkeypatch.setattr(sys, "argv", argv)
+
+        finalize_dataset.main()
+
+        assert "RCLONE_CONFIG_R2_TYPE" not in os.environ
+        assert "RCLONE_CONFIG_R2_REMOTE" not in os.environ
+
+    def test_keep_local_flag_stripped_from_hydra_overrides(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """``--keep-local`` never reaches Hydra compose (would error as an unknown override).
+
+        :param monkeypatch: Pytest fixture used to patch argv.
+        :param tmp_path: Pytest tmp dir used as the override data_dir.
+        """
+        argv = [
+            "finalize",
+            "experiment=generate_dataset/smoke-shard-wds",
+            f"paths.data_dir={tmp_path}",
+            "--keep-local",
+        ]
+        monkeypatch.setattr(sys, "argv", argv)
+
+        finalize_dataset.main()

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1805,12 +1805,16 @@ class TestMainKeepLocal:
     ) -> None:
         """``--keep-local`` never reaches Hydra compose — it would error as an unknown override.
 
-        The split happens before ``initialize_config_module``; if it leaked
-        through, Hydra would raise on the dangling token.
+        Asserts ``main()`` completes AND the redirect ran (env vars set), proving
+        the flag was both stripped from the overrides Hydra saw AND recognized
+        by the CLI plumbing. A silent passthrough would either error in Hydra
+        or leave the env vars untouched.
 
         :param monkeypatch: Pytest fixture used to patch argv.
         :param tmp_path: Pytest tmp dir used as the override data_dir.
         """
+        import os
+
         import synth_setter.cli.generate_dataset as gd
 
         argv = [
@@ -1823,3 +1827,5 @@ class TestMainKeepLocal:
         monkeypatch.setattr("sys.argv", argv)
 
         gd.main()
+
+        assert os.environ.get("RCLONE_CONFIG_R2_TYPE") == "alias"

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1663,3 +1663,163 @@ class TestMainSpecPersistence:
         kwargs = recorded["kwargs"]
         assert isinstance(kwargs, dict)
         assert kwargs["spec_uri"] == spec.r2.input_spec_uri()
+
+
+class TestMainKeepLocal:
+    """``--keep-local`` redirects rclone's ``r2:`` remote to ``cfg.paths.data_dir``."""
+
+    @pytest.fixture(autouse=True)
+    def _set_default_skypilot_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Single-worker rank/world so ``run()`` would succeed if it ran.
+
+        :param monkeypatch: Pytest fixture used to set env vars.
+        """
+        monkeypatch.setenv("SYNTH_SETTER_WORKER_RANK", "0")
+        monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "1")
+
+    @pytest.fixture(autouse=True)
+    def _clear_r2_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Drop ``RCLONE_CONFIG_R2_*`` so each test observes a clean redirect state.
+
+        :param monkeypatch: Pytest fixture used to remove env vars.
+        """
+        import os
+
+        for key in list(os.environ):
+            if key.startswith("RCLONE_CONFIG_R2_"):
+                monkeypatch.delenv(key, raising=False)
+
+    @pytest.fixture(autouse=True)
+    def _stub_run_and_spec_io(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Stub side-effects so the test reaches the keep-local branch.
+
+        :param monkeypatch: Pytest fixture used to patch the helpers.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        monkeypatch.setattr(gd, "run", lambda *_a, **_kw: None)
+        monkeypatch.setattr(
+            "synth_setter.cli.generate_dataset.write_spec_locally",
+            MagicMock(side_effect=lambda spec, out: Path(out) / "input_spec.json"),
+        )
+        monkeypatch.setattr(
+            "synth_setter.cli.generate_dataset.upload_spec",
+            MagicMock(return_value="r2://stub-bucket/stub-key/input_spec.json"),
+        )
+        monkeypatch.setattr(gd.r2_io, "ensure_r2_env_loaded", MagicMock(return_value=None))
+
+    def test_keep_local_rejected_with_compute_template(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """``--keep-local`` + non-null ``compute_template`` raises ValueError.
+
+        Worker pods are ephemeral, so a retained artifact there is useless;
+        rejecting at the launcher avoids dispatching a confusing run.
+
+        :param monkeypatch: Pytest fixture used to patch argv.
+        :param tmp_path: Pytest tmp dir for a stub compute template.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        template = tmp_path / "template.yaml"
+        template.write_text("resources:\n  cloud: runpod\nenvs:\n  X: ''\n")
+
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+            f"skypilot_launch.compute_template={template}",
+            "--keep-local",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+
+        with pytest.raises(ValueError, match="--keep-local is incompatible with SkyPilot"):
+            gd.main()
+
+    def test_keep_local_sets_alias_env_to_resolved_paths_data_dir(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """``--keep-local`` resolves ``cfg.paths.data_dir`` into the rclone env vars.
+
+        Operators can override the destination with ``paths.data_dir=<...>``;
+        the redirect picks up that override (not a hard-coded path).
+
+        :param monkeypatch: Pytest fixture used to patch argv.
+        :param tmp_path: Pytest tmp dir used as the override data_dir.
+        """
+        import os
+
+        import synth_setter.cli.generate_dataset as gd
+
+        local_root = tmp_path / "my-data"
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+            f"paths.data_dir={local_root}",
+            "--keep-local",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+
+        gd.main()
+
+        assert os.environ["RCLONE_CONFIG_R2_TYPE"] == "alias"
+        assert os.environ["RCLONE_CONFIG_R2_REMOTE"] == str(local_root.resolve())
+        assert local_root.is_dir()
+
+    def test_without_keep_local_does_not_touch_rclone_env(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """No ``--keep-local`` → ``main()`` leaves ``RCLONE_CONFIG_R2_*`` alone.
+
+        The default path must not change rclone resolution; production runs continue to talk to
+        real R2.
+
+        :param monkeypatch: Pytest fixture used to patch argv.
+        """
+        import os
+
+        import synth_setter.cli.generate_dataset as gd
+
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+
+        gd.main()
+
+        assert "RCLONE_CONFIG_R2_TYPE" not in os.environ
+        assert "RCLONE_CONFIG_R2_REMOTE" not in os.environ
+
+    def test_keep_local_stripped_from_hydra_overrides(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """``--keep-local`` never reaches Hydra compose — it would error as an unknown override.
+
+        The split happens before ``initialize_config_module``; if it leaked
+        through, Hydra would raise on the dangling token.
+
+        :param monkeypatch: Pytest fixture used to patch argv.
+        :param tmp_path: Pytest tmp dir used as the override data_dir.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+            f"paths.data_dir={tmp_path}",
+            "--keep-local",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+
+        gd.main()

--- a/tests/pipeline/test_entrypoints/test_keep_local.py
+++ b/tests/pipeline/test_entrypoints/test_keep_local.py
@@ -1,0 +1,97 @@
+"""Tests for ``synth_setter.cli._keep_local`` — shared --keep-local plumbing."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from synth_setter.cli._keep_local import (
+    KEEP_LOCAL_FLAG,
+    redirect_r2_to_local,
+    split_keep_local,
+)
+
+
+class TestSplitKeepLocal:
+    """``split_keep_local`` strips the flag from argv; boolean-only surface."""
+
+    def test_absent_returns_false_and_original_argv(self) -> None:
+        """No ``--keep-local`` → ``(False, argv)`` with argv unchanged."""
+        argv = ["experiment=foo", "render.parallel=true"]
+        keep_local, remaining = split_keep_local(argv)
+        assert keep_local is False
+        assert remaining == argv
+
+    def test_present_returns_true_and_strips_flag(self) -> None:
+        """``--keep-local`` is removed; other overrides survive in order."""
+        argv = ["experiment=foo", KEEP_LOCAL_FLAG, "render.parallel=true"]
+        keep_local, remaining = split_keep_local(argv)
+        assert keep_local is True
+        assert remaining == ["experiment=foo", "render.parallel=true"]
+
+    def test_present_at_start_strips_correctly(self) -> None:
+        """Flag at index 0 still strips cleanly."""
+        argv = [KEEP_LOCAL_FLAG, "experiment=foo"]
+        keep_local, remaining = split_keep_local(argv)
+        assert keep_local is True
+        assert remaining == ["experiment=foo"]
+
+    def test_equals_form_rejected(self) -> None:
+        """``--keep-local=true`` form raises — flag is boolean-only."""
+        argv = ["experiment=foo", f"{KEEP_LOCAL_FLAG}=true"]
+        with pytest.raises(ValueError, match="boolean flag"):
+            split_keep_local(argv)
+
+    def test_duplicate_rejected(self) -> None:
+        """Passing the flag twice raises so silent dedup never masks a typo."""
+        argv = [KEEP_LOCAL_FLAG, "experiment=foo", KEEP_LOCAL_FLAG]
+        with pytest.raises(ValueError, match="more than once"):
+            split_keep_local(argv)
+
+    def test_empty_argv_returns_false_and_empty(self) -> None:
+        """``[]`` is a no-op."""
+        assert split_keep_local([]) == (False, [])
+
+
+class TestRedirectR2ToLocal:
+    """``redirect_r2_to_local`` sets the two env vars rclone reads for ``r2:``."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_r2_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Drop any ``RCLONE_CONFIG_R2_*`` keys so each test starts clean.
+
+        :param monkeypatch: Pytest fixture used to remove env vars.
+        """
+        for key in list(os.environ):
+            if key.startswith("RCLONE_CONFIG_R2_"):
+                monkeypatch.delenv(key, raising=False)
+
+    def test_sets_alias_type_and_remote_path(self, tmp_path: Path) -> None:
+        """``r2:`` is reconfigured to an ``alias`` rooted at ``local_root``.
+
+        :param tmp_path: Pytest tmp dir used as the local-R2 root.
+        """
+        redirect_r2_to_local(tmp_path)
+        assert os.environ["RCLONE_CONFIG_R2_TYPE"] == "alias"
+        assert os.environ["RCLONE_CONFIG_R2_REMOTE"] == str(tmp_path)
+
+    def test_creates_root_directory_if_missing(self, tmp_path: Path) -> None:
+        """A non-existent ``local_root`` is created so the first rclone copy lands.
+
+        :param tmp_path: Pytest tmp dir under which the missing path lives.
+        """
+        local_root = tmp_path / "data" / "missing"
+        assert not local_root.exists()
+        redirect_r2_to_local(local_root)
+        assert local_root.is_dir()
+
+    def test_idempotent_with_same_root(self, tmp_path: Path) -> None:
+        """Calling twice with the same root is a no-op on the second call.
+
+        :param tmp_path: Pytest tmp dir used as the local-R2 root.
+        """
+        redirect_r2_to_local(tmp_path)
+        redirect_r2_to_local(tmp_path)
+        assert os.environ["RCLONE_CONFIG_R2_REMOTE"] == str(tmp_path)

--- a/tests/pipeline/test_entrypoints/test_keep_local.py
+++ b/tests/pipeline/test_entrypoints/test_keep_local.py
@@ -54,6 +54,29 @@ class TestSplitKeepLocal:
         """``[]`` is a no-op."""
         assert split_keep_local([]) == (False, [])
 
+    def test_prefix_match_passes_through(self) -> None:
+        """``--keep-localx`` (prefix without ``=``) is not the flag; survives in remaining.
+
+        Pins the boundary of the ``startswith("--keep-local=")`` gate so a
+        rename or loosening to ``startswith("--keep-local")`` would surface here.
+        """
+        argv = ["--keep-localx", "experiment=foo"]
+        keep_local, remaining = split_keep_local(argv)
+        assert keep_local is False
+        assert remaining == argv
+
+    def test_space_separated_value_falls_through_to_hydra(self) -> None:
+        """``--keep-local true`` strips the flag but leaves ``true`` in remaining.
+
+        Documented contract — Hydra then rejects the dangling token. Pins the
+        behavior so a future "peek-ahead" implementation announces itself by
+        breaking this test.
+        """
+        argv = [KEEP_LOCAL_FLAG, "true", "experiment=foo"]
+        keep_local, remaining = split_keep_local(argv)
+        assert keep_local is True
+        assert remaining == ["true", "experiment=foo"]
+
 
 class TestRedirectR2ToLocal:
     """``redirect_r2_to_local`` sets the two env vars rclone reads for ``r2:``."""

--- a/tests/pipeline/test_r2_io.py
+++ b/tests/pipeline/test_r2_io.py
@@ -708,22 +708,22 @@ class TestEnsureR2EnvLoaded:
         assert captured["RCLONE_CONFIG_R2_TYPE"] == "s3"
         assert captured["RCLONE_CONFIG_R2_PROVIDER"] == "Cloudflare"
 
-    def test_does_not_overwrite_caller_provided_type_and_provider(
+    def test_caller_provided_s3_type_with_other_provider_still_validates(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A caller's ``TYPE`` / ``PROVIDER`` win — the defaults only fill the unset case.
+        """``TYPE=s3`` with a non-default provider keeps the secret + auth-ping checks.
 
-        Preserves the rclone env-override design: callers (e.g. a future non-Cloudflare
-        S3-compatible backend) can override the structural keys without having to opt out
-        of ``ensure_r2_env_loaded``.
+        A non-Cloudflare S3-compatible backend (AWS, B2, etc.) is reached via
+        ``TYPE=s3`` + a different ``PROVIDER``; credentials are still needed,
+        so the function preserves the full validation path. Only the unset
+        defaults are filled — the caller's provider survives.
 
         :param monkeypatch: Pytest fixture used to populate env vars.
         """
         import os
 
         _set_all_r2_secrets(monkeypatch)
-        monkeypatch.setenv("RCLONE_CONFIG_R2_TYPE", "caller-type")
-        monkeypatch.setenv("RCLONE_CONFIG_R2_PROVIDER", "caller-provider")
+        monkeypatch.setenv("RCLONE_CONFIG_R2_PROVIDER", "AWS")
         captured: dict[str, str] = {}
 
         def _capture(*_a: object, **_kw: object) -> subprocess.CompletedProcess[str]:
@@ -733,5 +733,46 @@ class TestEnsureR2EnvLoaded:
         with patch.object(r2_io.subprocess, "run", side_effect=_capture):
             r2_io.ensure_r2_env_loaded(env_file=None)
 
-        assert captured["RCLONE_CONFIG_R2_TYPE"] == "caller-type"
-        assert captured["RCLONE_CONFIG_R2_PROVIDER"] == "caller-provider"
+        assert captured["RCLONE_CONFIG_R2_TYPE"] == "s3"
+        assert captured["RCLONE_CONFIG_R2_PROVIDER"] == "AWS"
+
+    def test_caller_provided_non_s3_type_bypasses_validation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``TYPE=alias`` (or any non-s3 type) skips the cred check and the auth ping.
+
+        rclone's ``alias`` / ``local`` / etc. backends do not consume S3 credentials,
+        so requiring them is wrong. ``--keep-local`` dev mode pre-sets ``TYPE=alias``
+        before this function runs; the early-return keeps that path no-error even
+        with no R2 creds in the environment.
+
+        :param monkeypatch: Pytest fixture used to populate env vars.
+        """
+        import os
+
+        monkeypatch.setenv("RCLONE_CONFIG_R2_TYPE", "alias")
+        monkeypatch.setenv("RCLONE_CONFIG_R2_REMOTE", "/var/tmp/local-r2")  # noqa: S108
+
+        with patch.object(r2_io.subprocess, "run") as mock_run:
+            r2_io.ensure_r2_env_loaded(env_file=None)
+
+        mock_run.assert_not_called()
+        assert os.environ["RCLONE_CONFIG_R2_TYPE"] == "alias"
+        assert "RCLONE_CONFIG_R2_PROVIDER" not in os.environ
+
+    def test_caller_provided_local_type_also_bypasses_validation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``TYPE=local`` (the test-fixture form) takes the same early-return path.
+
+        The fake-R2 fixture in ``tests/pipeline/conftest.py`` uses ``TYPE=local``;
+        production keep-local uses ``TYPE=alias``. Both must bypass cred validation.
+
+        :param monkeypatch: Pytest fixture used to set TYPE.
+        """
+        monkeypatch.setenv("RCLONE_CONFIG_R2_TYPE", "local")
+
+        with patch.object(r2_io.subprocess, "run") as mock_run:
+            r2_io.ensure_r2_env_loaded(env_file=None)
+
+        mock_run.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `--keep-local` to `synth-setter-generate-dataset` and `synth-setter-finalize-dataset`. When set, both CLIs redirect rclone's `r2:` remote to `cfg.paths.data_dir` (defaults to `<workspace>/data/`) so generate shards, finalize splits, stats, the `dataset.complete` marker, and the spec upload all land on the local filesystem instead of R2.
- Reuses the rclone env-var override (`RCLONE_CONFIG_R2_TYPE=alias` + `_REMOTE=<path>`) that `tests/pipeline/conftest.py:34` already uses via the `fake_r2_remote` fixture. Single chokepoint — no code branching in `_rclone_copy`, `run()`, `_render_and_upload_shard`, or finalize internals.
- Generate→finalize chains naturally through the same local root; resumability (`r2_io.object_size` skip probes) becomes a local stat call with no semantic change.

## Implementation notes

- New `src/synth_setter/cli/_keep_local.py` houses `split_keep_local(argv)` (rejects `--keep-local=...` and duplicates; the space-separated `--keep-local true` form intentionally falls through to Hydra) and `redirect_r2_to_local(local_root)`.
- `--keep-local` is stripped from argv before Hydra compose so it doesn't appear in the spec snapshot uploaded to "R2".
- `r2_io.ensure_r2_env_loaded` early-returns when `RCLONE_CONFIG_R2_TYPE` is pre-set to a non-`s3` value, so the keep-local path needs no S3 credentials. `TYPE=s3` (with any provider) still runs full validation.
- Generate raises `ValueError` for `--keep-local` + non-null `compute_template` — worker pods are ephemeral, so a retained-local artifact there would never reach the operator.

## Difference from #1283's proposal

#1283 proposed adding `DatasetSpec.output_dir` as a spec field and branching in `run()`. This PR achieves the same operator-facing outcome (shards survive on disk for inspection) via the rclone redirect, which avoids spec-schema churn, keeps the dev-mode toggle out of the canonical spec snapshot, and works for finalize artifacts (splits, stats, marker) without any extra plumbing.

## Open review findings (deferred to discussion)

`/repo-review-full-no-comments` flagged a few BLOCK-level concerns worth a look — none are blockers for me, but reviewer judgment is welcome:

- **R2-as-source-of-truth tension** (ml-pipeline). If someone runs generate without `--keep-local` and then finalize with it (or vice versa) against the same `r2.prefix`, the marker probe / shard download sees an empty store and hard-fails at first download — not silent divergence, but still a confusing UX. A `keep_local` sentinel file at the local mirror root could refuse mismatched runs.
- **Provenance of the on-disk spec** (ml-pipeline). The spec records `r2://` URIs even though objects live on local disk; cross-host consumption of a keep-local spec would dangle. Acceptable for a single-host dev-mode flag IMO, but worth confirming.
- **`RCLONE_CONFIG_R2_TYPE` bypass breadth** (synth-setter + ml-pipeline). The early-return in `ensure_r2_env_loaded` skips cred validation for *any* non-`s3` type. A lingering shell env from a prior experiment could silently bypass. Easy tightening: narrow to `{"alias", "local"}` or also require `RCLONE_CONFIG_R2_REMOTE`.

Other findings (comment-hygiene `:param:` boilerplate, structured-log f-string nits, fixture duplication across test files) are tracked in the sentinel report and addressable as polish.

## Test plan

- [x] `uv run pytest tests/pipeline/test_entrypoints/ tests/pipeline/test_r2_io.py` — 230 passed, 0 failed
- [x] `uv run pre-commit run --files <all touched>` — ruff, ruff-format, pyright, docformatter, interrogate, pydoclint, codespell all green
- [x] Smoke-tested `RCLONE_CONFIG_R2_TYPE=alias` + `_REMOTE=<path>` against real `rclone copyto` — bytes land at `<path>/<bucket>/<prefix>/<filename>`
- [ ] Manual dev-loop verification: `synth-setter-generate-dataset experiment=generate_dataset/smoke-shard --keep-local` followed by `ls <workspace>/data/intermediate-data/smoke-shard/<run>/`

## Notes for the reviewer

- The existing `paths.output_dir = _OPERATOR_WORKSPACE` compose-shim (generate_dataset.py:441-443, finalize_dataset.py:176-178) is left alone — orthogonal to this PR.
- Issue #1283 is `Closes`'d. It's currently not parented under any Phase; the metadata gate doesn't require Phase-parenting but flagging for future taxonomy cleanup.

Closes #1283