### PR TITLE
ci(ci-automation): reclaim disk via jlumbroso/free-disk-space before kind load

### DIFF
--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -224,10 +224,8 @@ jobs:
           echo "name=${CLUSTER_NAME}" >> "${GITHUB_OUTPUT}"
           echo "cluster_name: ${CLUSTER_NAME}"
 
-      # `kind load` rehydrates the image into a second containerd snapshotter
-      # inside the kind node; `/` (~25 GB) is too small for the CUDA stack,
-      # `/mnt` (~70 GB ephemeral) is not. Must precede `Pull image (background)`
-      # so there is no docker cache to migrate.
+      # `kind load` doubles the CUDA image into the kind node's snapshotter;
+      # `/` (~25 GB) overflows, `/mnt` (~70 GB) doesn't. Must run pre-pull.
       - name: Move docker storage to /mnt (skypilot-local row)
         if: ${{ inputs.provider == 'skypilot-local' }}
         run: |
@@ -236,7 +234,7 @@ jobs:
           sudo mkdir -p /mnt/docker
           echo '{"data-root":"/mnt/docker"}' | sudo tee /etc/docker/daemon.json >/dev/null
           sudo systemctl start docker
-          docker info --format 'data-root: {{.DockerRootDir}}'
+          docker info --format '{{.DockerRootDir}}' | grep -qx /mnt/docker
 
       # A2 (#1164): pull the worker image in the background so the kind binary
       # install + Python / uv setup can run in parallel. The pull only fills

--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -224,6 +224,20 @@ jobs:
           echo "name=${CLUSTER_NAME}" >> "${GITHUB_OUTPUT}"
           echo "cluster_name: ${CLUSTER_NAME}"
 
+      # `kind load` rehydrates the image into a second containerd snapshotter
+      # inside the kind node; `/` (~25 GB) is too small for the CUDA stack,
+      # `/mnt` (~70 GB ephemeral) is not. Must precede `Pull image (background)`
+      # so there is no docker cache to migrate.
+      - name: Move docker storage to /mnt (skypilot-local row)
+        if: ${{ inputs.provider == 'skypilot-local' }}
+        run: |
+          set -euo pipefail
+          sudo systemctl stop docker.socket docker
+          sudo mkdir -p /mnt/docker
+          echo '{"data-root":"/mnt/docker"}' | sudo tee /etc/docker/daemon.json >/dev/null
+          sudo systemctl start docker
+          docker info --format 'data-root: {{.DockerRootDir}}'
+
       # A2 (#1164): pull the worker image in the background so the kind binary
       # install + Python / uv setup can run in parallel. The pull only fills
       # the host Docker cache; nothing downstream of this step reads from it
@@ -346,21 +360,6 @@ jobs:
             exit "${ec}"
           fi
           echo "docker pull completed for ${IMAGE}"
-
-      # `kind load` shells `docker save` into /var/lib/docker/tmp/; the
-      # ~10 GB tar exhausts ubuntu-latest's root partition without cleanup.
-      - name: Free disk space for kind load (skypilot-local row)
-        if: ${{ inputs.provider == 'skypilot-local' }}
-        run: |
-          set -euo pipefail
-          df -h / | tail -1 | awk '{print "before: " $4 " free on /"}'
-          sudo rm -rf \
-            /usr/share/dotnet \
-            /usr/local/lib/android \
-            /opt/ghc \
-            /usr/local/.ghcup \
-            /opt/hostedtoolcache/CodeQL
-          df -h / | tail -1 | awk '{print "after:  " $4 " free on /"}'
 
       - name: Load dev-snapshot image into kind (skypilot-local row)
         if: ${{ inputs.provider == 'skypilot-local' }}

--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -225,14 +225,15 @@ jobs:
           echo "cluster_name: ${CLUSTER_NAME}"
 
       # `kind load` doubles the CUDA image into the kind node's snapshotter;
-      # peak host footprint is ~30 GB. Reclaim ~30 GB on `/` pre-pull.
-      # `tool-cache: true` deletes /opt/hostedtoolcache — setup-python below
-      # re-fetches Python (~20 s).
+      # peak host footprint is ~30 GB. Reclaim ~25 GB on `/` pre-pull.
+      # tool-cache stays off — deleting /opt/hostedtoolcache breaks the
+      # downstream `helm/kind-action` step (its tool-cache library expects
+      # the directory to exist, not just be empty).
       - name: Free disk space for kind load (skypilot-local row)
         if: ${{ inputs.provider == 'skypilot-local' }}
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
-          tool-cache: true
+          tool-cache: false
           android: true
           dotnet: true
           haskell: true

--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -225,13 +225,14 @@ jobs:
           echo "cluster_name: ${CLUSTER_NAME}"
 
       # `kind load` doubles the CUDA image into the kind node's snapshotter;
-      # the 25 GB default free on `/` overflows. /mnt is too small (14 GB) to
-      # rehost docker, so reclaim ~40 GB on `/` instead, before the pull.
+      # peak host footprint is ~30 GB. Reclaim ~30 GB on `/` pre-pull.
+      # `tool-cache: true` deletes /opt/hostedtoolcache — setup-python below
+      # re-fetches Python (~20 s).
       - name: Free disk space for kind load (skypilot-local row)
         if: ${{ inputs.provider == 'skypilot-local' }}
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
-          tool-cache: false
+          tool-cache: true
           android: true
           dotnet: true
           haskell: true

--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -225,16 +225,19 @@ jobs:
           echo "cluster_name: ${CLUSTER_NAME}"
 
       # `kind load` doubles the CUDA image into the kind node's snapshotter;
-      # `/` (~25 GB) overflows, `/mnt` (~70 GB) doesn't. Must run pre-pull.
-      - name: Move docker storage to /mnt (skypilot-local row)
+      # the 25 GB default free on `/` overflows. /mnt is too small (14 GB) to
+      # rehost docker, so reclaim ~40 GB on `/` instead, before the pull.
+      - name: Free disk space for kind load (skypilot-local row)
         if: ${{ inputs.provider == 'skypilot-local' }}
-        run: |
-          set -euo pipefail
-          sudo systemctl stop docker.socket docker
-          sudo mkdir -p /mnt/docker
-          echo '{"data-root":"/mnt/docker"}' | sudo tee /etc/docker/daemon.json >/dev/null
-          sudo systemctl start docker
-          docker info --format '{{.DockerRootDir}}' | grep -qx /mnt/docker
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
 
       # A2 (#1164): pull the worker image in the background so the kind binary
       # install + Python / uv setup can run in parallel. The pull only fills


### PR DESCRIPTION
Refs #1278.

## Summary

- Replaces the limited `sudo rm -rf` cleanup (#1280) with
  `jlumbroso/free-disk-space@v1.3.1` (SHA-pinned). Enables `android`,
  `dotnet`, `haskell`, `large-packages`, `docker-images`, and
  `swap-storage` — typical reclaim is ~25 GB on `/`.
- Moves the cleanup to **before** `Pull image (background)` so the budget
  covers both the docker pull and the `kind load` re-extraction.

## Why

`kind load docker-image` rehydrates the image into a second containerd
snapshotter inside the kind node. The `dev-snapshot` image is 5.5 GB
compressed (one CUDA-venv layer is 4.4 GB of that), and the rehydration
roughly doubles on-disk footprint, so peak `/var/lib/...` usage is ~30 GB.
`ubuntu-latest` ships with ~14 GB free on `/`; the prior `rm -rf` step
freed ~22 GB, leaving ~25 GB — not enough. A recent run died at
`failed to extract layer ... write
/var/lib/containerd/.../nvidia/cudnn/lib/libcudnn_engines_precompiled.so.9:
no space left on device` (see run 26478037384, job 77968570041).

`jlumbroso/free-disk-space` is the de facto solution for this class of
failure (used by k8s-sigs, helm, and many CI-heavy repos). With the flags
above it typically reclaims ~25 GB — enough headroom for the pull + kind
load extract.

### Why `tool-cache: false`

`tool-cache: true` deletes `/opt/hostedtoolcache` entirely (not just its
contents). The downstream `helm/kind-action@v1.14.0` step uses
`@actions/tool-cache` under the hood, which bails with
`Cache directory '/opt/hostedtoolcache' does not exist` when the dir is
missing — run 26482149837 had all six generate cells fail at `Install
kind` for this reason. Keeping `tool-cache: false` is required; the other
six categories already provide enough headroom.

## Out of scope (the real fix)

The 4.4 GB CUDA-venv layer is dead weight on the skypilot-local row, which
runs `sky local up --no-gpus` and never executes a CUDA kernel. A
`TORCH_BACKEND=cpu` image variant would drop that layer to ~250 MB (CPU
torch wheel) and remove this class of disk pressure entirely. Tracked
separately — this PR is the band-aid until that lands.

## Iteration history

- `4e064f9` / `8044b0d` — initial attempt: move docker `data-root` to
  `/mnt/docker`. Reverted: GHA's `/mnt` is the ~14 GB Azure resource disk,
  not the ~70 GB I assumed. The next CI run died at `docker pull` with
  ENOSPC at the torch layer.
- `a63c602` — switched to `jlumbroso/free-disk-space` with default flags
  (no tool-cache). 5 of 6 generate cells passed; one cell still hit ENOSPC
  at `kind load` extracting `libtriton.so`.
- `cdcbf6a` — added `tool-cache: true` for ~5 GB more headroom.
- `07eb6ff` — reverted `tool-cache: true`; `helm/kind-action` needs the
  `/opt/hostedtoolcache` directory to exist. Side observation from run
  26482149837: the current `ubuntu-24.04` runner image reports 145G total
  / 121G free on `/` after the default jlumbroso flags, so the original
  disk-pressure failures may be specific to the older runner image — this
  PR is now cheap insurance more than a hard requirement.

## Test plan

- [ ] CI matrix on this PR exercises the new step on every skypilot-local
      row of `generate-dataset-shards.yaml` — passing matrix proves the
      pull + `kind load` extraction both fit within the freed budget.
- [ ] `Free disk space for kind load (skypilot-local row)` step logs a
      reclaim of ≥20 GiB on `/`.
- [ ] `Install kind` (`helm/kind-action`) step still succeeds, confirming
      `/opt/hostedtoolcache` survives the cleanup.

(Live verification checklist + adversarial checks in the verification-results
comment — the comment's earlier wording references the abandoned `/mnt`
approach; the underlying checks still apply to the current free-disk-space
approach modulo step name.)
