### PR TITLE
internal-feat(pipeline): add Hydra-compose mode to synth-setter-spec-uri

### DIFF
--- a/src/synth_setter/pipeline/ci/spec_uri.py
+++ b/src/synth_setter/pipeline/ci/spec_uri.py
@@ -41,10 +41,35 @@ _EXIT_USAGE = 1
 _EXIT_MISSING_FILE = 2
 _EXIT_INVALID_SPEC = 3
 
-_USAGE = (
-    "Usage: synth-setter-spec-uri <input_spec.json>\n"
-    "   or: synth-setter-spec-uri --from-experiment EXP --run-id-override RUNID\n"
-)
+
+def _usage_text() -> str:
+    """Return the dual-mode usage banner with the live program name interpolated.
+
+    Reads ``sys.argv[0]`` so a ``python -m synth_setter.pipeline.ci.spec_uri``
+    invocation (or any non-default entrypoint) displays the actual command
+    the operator just ran rather than a stale ``synth-setter-spec-uri`` literal.
+
+    :returns: Two-line usage string ending in a trailing newline.
+    """
+    prog = Path(sys.argv[0]).name if sys.argv and sys.argv[0] else "synth-setter-spec-uri"
+    return (
+        f"Usage: {prog} <input_spec.json>\n"
+        f"   or: {prog} --from-experiment EXP --run-id-override RUNID\n"
+    )
+
+
+class _UsageErrorMarker:
+    """Singleton sentinel returned by ``_parse_hydra_argv`` to signal a usage error.
+
+    A class-based sentinel cannot collide with any user-supplied string (unlike
+    the prior ``"__usage__"`` magic value), so a real experiment named
+    ``__usage__`` is no longer special-cased into a usage error.
+    """
+
+    __slots__ = ()
+
+
+_USAGE_ERROR: _UsageErrorMarker = _UsageErrorMarker()
 
 # Composed-config keys that aren't ``DatasetSpec`` fields. Mirrors
 # ``cli.generate_dataset._NON_SPEC_KEYS`` — keep in sync if either side adds
@@ -109,17 +134,17 @@ def compute_spec_uri_from_hydra(experiment: str, run_id_override: str) -> str:
     return DatasetSpec(**spec_kwargs).r2.input_spec_uri()
 
 
-def _parse_hydra_argv(argv: list[str]) -> tuple[str, str] | None:
+def _parse_hydra_argv(argv: list[str]) -> tuple[str, str] | _UsageErrorMarker | None:
     """Extract ``(experiment, run_id_override)`` from argv when both flags are set.
 
     Accepts both ``--flag VALUE`` and ``--flag=VALUE`` forms. Returns ``None``
     when *neither* flag is present (caller falls through to file mode).
-    Returns ``("__usage__", "")`` sentinel when *some* flag is present but the
-    pair is incomplete or has stray args, signalling a usage error.
+    Returns ``_USAGE_ERROR`` (a sentinel object) when *some* flag is present
+    but the pair is incomplete or has stray args, signalling a usage error.
 
     :param argv: ``sys.argv[1:]`` slice.
     :returns: ``(experiment, run_id_override)`` on a complete pair;
-        ``("__usage__", "")`` on a malformed invocation;
+        ``_USAGE_ERROR`` on a malformed invocation;
         ``None`` when neither flag is present.
     """
     # Exact-name match (plus the ``=value`` form) so future flags like
@@ -147,9 +172,9 @@ def _parse_hydra_argv(argv: list[str]) -> tuple[str, str] | None:
             run_id_override = arg.split("=", 1)[1]
             i += 1
         else:
-            return ("__usage__", "")
+            return _USAGE_ERROR
     if not experiment or not run_id_override:
-        return ("__usage__", "")
+        return _USAGE_ERROR
     return (experiment, run_id_override)
 
 
@@ -159,24 +184,28 @@ def main() -> None:
 
     hydra_args = _parse_hydra_argv(argv)
     if hydra_args is not None:
-        experiment, run_id_override = hydra_args
-        if experiment == "__usage__":
-            sys.stderr.write(_USAGE)
+        if isinstance(hydra_args, _UsageErrorMarker):
+            sys.stderr.write(_usage_text())
             sys.exit(_EXIT_USAGE)
+        experiment, run_id_override = hydra_args
         try:
             uri = compute_spec_uri_from_hydra(experiment, run_id_override)
-        # Hydra's compose can raise a wide set of types (MissingConfigException,
-        # OmegaConfBaseException, OverridesParser errors, etc.). Catch broadly
-        # and collapse to one stderr line — distinguishing them in the CLI buys
-        # nothing the exit code doesn't already encode.
+        # Hydra's compose plus the downstream ``DatasetSpec(**spec_kwargs)``
+        # construction can both raise (MissingConfigException, OmegaConfBaseException,
+        # OverridesParser errors, ValidationError, TypeError); collapse them all to
+        # one stderr line — distinguishing them in the CLI buys nothing the exit
+        # code doesn't already encode.
         except Exception as exc:  # noqa: BLE001
-            sys.stderr.write(f"error: compose failed for experiment {experiment!r}: {exc}\n")
+            sys.stderr.write(
+                f"error: failed to derive spec URI for experiment {experiment!r} "
+                f"({type(exc).__name__}): {exc}\n"
+            )
             sys.exit(_EXIT_INVALID_SPEC)
         sys.stdout.write(uri + "\n")
         return
 
     if len(argv) != 1:
-        sys.stderr.write(_USAGE)
+        sys.stderr.write(_usage_text())
         sys.exit(_EXIT_USAGE)
     spec_path = Path(argv[0])
     if not spec_path.is_file():

--- a/src/synth_setter/pipeline/ci/spec_uri.py
+++ b/src/synth_setter/pipeline/ci/spec_uri.py
@@ -1,18 +1,26 @@
 #!/usr/bin/env python3
 """Print the canonical R2 URI of a materialized ``input_spec.json``.
 
-Reads the local spec file, parses it as a ``DatasetSpec``, and emits
-``spec.r2.input_spec_uri()`` — the under-prefix URI where the spec itself
-lives (``r2://<bucket>/<prefix>input_spec.json``).
+Two modes:
 
-Keeping this in Python rather than bash lets the URI be parsed by the real
-``DatasetSpec`` model (so any schema drift fails loud at the validator
-rather than silently in jq/sed) and lets argv / fs / parse failures map
-to distinct exit codes for log scanners.
+- **File mode** (default): ``synth-setter-spec-uri <input_spec.json>`` reads
+  the local spec file, parses it as a ``DatasetSpec``, and emits
+  ``spec.r2.input_spec_uri()``.
+- **Hydra-compose mode**: ``synth-setter-spec-uri --from-experiment EXP
+  --run-id-override RUNID`` composes the dataset cfg via the same Hydra
+  pipeline ``synth-setter-generate-dataset`` uses, with ``run_id`` pinned to
+  ``RUNID``. Useful for CI cells that need to derive the URI a launcher *will*
+  write, before it has written it — e.g. for per-matrix-cell validator
+  pairing without the stdout-sentinel grep contract.
+
+Both modes go through the real ``DatasetSpec`` model (so any schema drift
+fails loud at this seam rather than silently in jq/sed) and emit the URI on
+stdout; argv / fs / parse failures map to distinct exit codes for log scanners.
 
 Usage::
 
     synth-setter-spec-uri <input_spec.json>
+    synth-setter-spec-uri --from-experiment EXP --run-id-override RUNID
 
 Prints the resulting URI to stdout; exits non-zero on wrong arity, missing
 or unreadable spec, or invalid spec content.
@@ -22,7 +30,10 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
+from typing import Any
 
+from hydra import compose, initialize_config_module
+from omegaconf import OmegaConf
 from pydantic import ValidationError
 
 from synth_setter.pipeline.schemas.spec import DatasetSpec
@@ -33,6 +44,22 @@ from synth_setter.pipeline.schemas.spec import DatasetSpec
 _EXIT_USAGE = 1
 _EXIT_MISSING_FILE = 2
 _EXIT_INVALID_SPEC = 3
+
+_USAGE = (
+    "Usage: synth-setter-spec-uri <input_spec.json>\n"
+    "   or: synth-setter-spec-uri --from-experiment EXP --run-id-override RUNID\n"
+)
+
+# Composed-config keys that aren't ``DatasetSpec`` fields. Mirrors
+# ``cli.generate_dataset._NON_SPEC_KEYS`` — keep in sync if either side adds
+# a new top-level cfg sub-tree (interpolation source, dispatch group, etc.).
+_NON_SPEC_CFG_KEYS: tuple[str, ...] = (
+    "data",
+    "paths",
+    "hydra",
+    "run_name",
+    "skypilot_launch",
+)
 
 
 def compute_spec_uri(spec_path: Path) -> str:
@@ -46,12 +73,113 @@ def compute_spec_uri(spec_path: Path) -> str:
     return spec.r2.input_spec_uri()
 
 
+def compute_spec_uri_from_hydra(experiment: str, run_id_override: str) -> str:
+    """Hydra-compose the dataset cfg with ``run_id`` pinned, return the canonical URI.
+
+    Uses ``initialize_config_module("synth_setter.configs")`` + the same
+    ``compose(config_name="dataset", ...)`` call ``synth-setter-generate-dataset``
+    uses, plus a ``+run_id=<value>`` override. Pinning ``run_id`` suppresses the
+    ``_default_run_id`` factory (which would otherwise sample ``created_at`` and
+    produce a non-deterministic URI), and ``r2.prefix`` derivation is a pure
+    function of ``(prefix_root, task_name, run_id)`` — so the resulting URI is
+    fully determined by ``(experiment, run_id_override)``.
+
+    Exceptions from Hydra ``compose`` (unknown experiment, malformed override)
+    and from ``DatasetSpec`` construction propagate to the caller; the CLI
+    layer collapses both onto ``_EXIT_INVALID_SPEC`` for log scanners.
+
+    :param experiment: Hydra experiment name (e.g. ``generate_dataset/smoke-shard``).
+    :param run_id_override: Cell-specific run_id; surfaces in the URI as the
+        ``<run_id>`` path segment.
+    :returns: ``r2://<bucket>/<prefix>input_spec.json`` URI string.
+    :raises TypeError: composed cfg's top level is not a mapping.
+    """
+    overrides = [f"experiment={experiment}", f"+run_id={run_id_override}"]
+    with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
+        cfg = compose(config_name="dataset", overrides=overrides)
+    # Programmatic compose leaves ${hydra:runtime.output_dir} unset; pin
+    # paths.* with placeholders so resolve() doesn't trip — values are
+    # irrelevant to URI derivation, which depends only on task_name + run_id
+    # + r2.bucket.
+    cfg.paths.root_dir = "."
+    cfg.paths.output_dir = "."
+    cfg.paths.work_dir = "."
+    raw: Any = OmegaConf.to_container(cfg, resolve=True)
+    if not isinstance(raw, dict):
+        raise TypeError(f"composed config is not a mapping: {type(raw).__name__}")
+    spec_kwargs = {
+        k: v for k, v in raw.items() if isinstance(k, str) and k not in _NON_SPEC_CFG_KEYS
+    }
+    return DatasetSpec(**spec_kwargs).r2.input_spec_uri()
+
+
+def _parse_hydra_argv(argv: list[str]) -> tuple[str, str] | None:
+    """Extract ``(experiment, run_id_override)`` from argv when both flags are set.
+
+    Accepts both ``--flag VALUE`` and ``--flag=VALUE`` forms. Returns ``None``
+    when *neither* flag is present (caller falls through to file mode).
+    Returns ``("__usage__", "")`` sentinel when *some* flag is present but the
+    pair is incomplete or has stray args, signalling a usage error.
+
+    :param argv: ``sys.argv[1:]`` slice.
+    :returns: ``(experiment, run_id_override)`` on a complete pair;
+        ``("__usage__", "")`` on a malformed invocation;
+        ``None`` when neither flag is present.
+    """
+    flag_prefixes = ("--from-experiment", "--run-id-override")
+    if not any(a.startswith(flag_prefixes) for a in argv):
+        return None
+
+    experiment: str | None = None
+    run_id_override: str | None = None
+    i = 0
+    while i < len(argv):
+        a = argv[i]
+        if a == "--from-experiment" and i + 1 < len(argv):
+            experiment = argv[i + 1]
+            i += 2
+        elif a.startswith("--from-experiment="):
+            experiment = a.split("=", 1)[1]
+            i += 1
+        elif a == "--run-id-override" and i + 1 < len(argv):
+            run_id_override = argv[i + 1]
+            i += 2
+        elif a.startswith("--run-id-override="):
+            run_id_override = a.split("=", 1)[1]
+            i += 1
+        else:
+            return ("__usage__", "")
+    if experiment is None or run_id_override is None:
+        return ("__usage__", "")
+    return (experiment, run_id_override)
+
+
 def main() -> None:
-    """CLI entry: ``synth-setter-spec-uri <spec.json>``."""
-    if len(sys.argv) != 2:
-        sys.stderr.write(f"Usage: {sys.argv[0]} <input_spec.json>\n")
+    """CLI entry: file mode or Hydra-compose mode (see module docstring)."""
+    argv = sys.argv[1:]
+
+    hydra_args = _parse_hydra_argv(argv)
+    if hydra_args is not None:
+        experiment, run_id_override = hydra_args
+        if experiment == "__usage__":
+            sys.stderr.write(_USAGE)
+            sys.exit(_EXIT_USAGE)
+        try:
+            uri = compute_spec_uri_from_hydra(experiment, run_id_override)
+        # Hydra's compose can raise a wide set of types (MissingConfigException,
+        # OmegaConfBaseException, OverridesParser errors, etc.). Catch broadly
+        # and collapse to one stderr line — distinguishing them in the CLI buys
+        # nothing the exit code doesn't already encode.
+        except Exception as exc:  # noqa: BLE001
+            sys.stderr.write(f"error: compose failed for experiment {experiment!r}: {exc}\n")
+            sys.exit(_EXIT_INVALID_SPEC)
+        sys.stdout.write(uri + "\n")
+        return
+
+    if len(argv) != 1:
+        sys.stderr.write(_USAGE)
         sys.exit(_EXIT_USAGE)
-    spec_path = Path(sys.argv[1])
+    spec_path = Path(argv[0])
     if not spec_path.is_file():
         sys.stderr.write(f"error: spec file not found: {spec_path}\n")
         sys.exit(_EXIT_MISSING_FILE)

--- a/src/synth_setter/pipeline/ci/spec_uri.py
+++ b/src/synth_setter/pipeline/ci/spec_uri.py
@@ -21,16 +21,12 @@ Usage::
 
     synth-setter-spec-uri <input_spec.json>
     synth-setter-spec-uri --from-experiment EXP --run-id-override RUNID
-
-Prints the resulting URI to stdout; exits non-zero on wrong arity, missing
-or unreadable spec, or invalid spec content.
 """
 
 from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import Any
 
 from hydra import compose, initialize_config_module
 from omegaconf import OmegaConf
@@ -104,7 +100,7 @@ def compute_spec_uri_from_hydra(experiment: str, run_id_override: str) -> str:
     cfg.paths.root_dir = "."
     cfg.paths.output_dir = "."
     cfg.paths.work_dir = "."
-    raw: Any = OmegaConf.to_container(cfg, resolve=True)
+    raw: object = OmegaConf.to_container(cfg, resolve=True)
     if not isinstance(raw, dict):
         raise TypeError(f"composed config is not a mapping: {type(raw).__name__}")
     spec_kwargs = {
@@ -126,30 +122,33 @@ def _parse_hydra_argv(argv: list[str]) -> tuple[str, str] | None:
         ``("__usage__", "")`` on a malformed invocation;
         ``None`` when neither flag is present.
     """
-    flag_prefixes = ("--from-experiment", "--run-id-override")
-    if not any(a.startswith(flag_prefixes) for a in argv):
+    # Exact-name match (plus the ``=value`` form) so future flags like
+    # ``--from-experiment-source`` can't accidentally route through this parser.
+    hydra_flags = {"--from-experiment", "--run-id-override"}
+    eq_prefixes = ("--from-experiment=", "--run-id-override=")
+    if not any(a in hydra_flags or a.startswith(eq_prefixes) for a in argv):
         return None
 
     experiment: str | None = None
     run_id_override: str | None = None
     i = 0
     while i < len(argv):
-        a = argv[i]
-        if a == "--from-experiment" and i + 1 < len(argv):
+        arg = argv[i]
+        if arg == "--from-experiment" and i + 1 < len(argv):
             experiment = argv[i + 1]
             i += 2
-        elif a.startswith("--from-experiment="):
-            experiment = a.split("=", 1)[1]
+        elif arg.startswith("--from-experiment="):
+            experiment = arg.split("=", 1)[1]
             i += 1
-        elif a == "--run-id-override" and i + 1 < len(argv):
+        elif arg == "--run-id-override" and i + 1 < len(argv):
             run_id_override = argv[i + 1]
             i += 2
-        elif a.startswith("--run-id-override="):
-            run_id_override = a.split("=", 1)[1]
+        elif arg.startswith("--run-id-override="):
+            run_id_override = arg.split("=", 1)[1]
             i += 1
         else:
             return ("__usage__", "")
-    if experiment is None or run_id_override is None:
+    if not experiment or not run_id_override:
         return ("__usage__", "")
     return (experiment, run_id_override)
 

--- a/tests/pipeline/test_ci/test_spec_uri.py
+++ b/tests/pipeline/test_ci/test_spec_uri.py
@@ -215,6 +215,43 @@ _HYDRA_EXPERIMENT = "generate_dataset/smoke-shard"
 class TestComputeSpecUriFromHydra:
     """``compute_spec_uri_from_hydra`` derives the URI by Hydra-composing the dataset cfg."""
 
+    def test_matches_launcher_side_computation(self) -> None:
+        """URI equals what ``synth-setter-generate-dataset`` would compute via ``spec_from_cfg``.
+
+        Pins the load-bearing claim of this whole feature: the helper and the
+        launcher exercise the same derivation, so a CI cell consuming this URI
+        will hit the same R2 object the launcher writes. Catches drift between
+        ``_NON_SPEC_CFG_KEYS`` and ``cli.generate_dataset._NON_SPEC_KEYS`` and
+        any future divergence in cfg-to-spec construction.
+        """
+        from hydra import compose, initialize_config_module
+
+        from synth_setter.cli.generate_dataset import spec_from_cfg
+
+        overrides = [f"experiment={_HYDRA_EXPERIMENT}", "+run_id=parity-test"]
+        with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
+            cfg = compose(config_name="dataset", overrides=overrides)
+        cfg.paths.root_dir = "."
+        cfg.paths.output_dir = "."
+        cfg.paths.work_dir = "."
+
+        launcher_uri = spec_from_cfg(cfg).r2.input_spec_uri()
+        helper_uri = compute_spec_uri_from_hydra(_HYDRA_EXPERIMENT, "parity-test")
+        assert helper_uri == launcher_uri
+
+    def test_non_spec_cfg_keys_mirror_cli_canonical(self) -> None:
+        """``_NON_SPEC_CFG_KEYS`` equals ``cli.generate_dataset._NON_SPEC_KEYS``.
+
+        Converts the comment-guarded "keep in sync" invariant into a tested
+        one. If either side gains a new top-level cfg sub-tree, this test
+        fails immediately rather than the helper silently feeding a non-spec
+        key into ``DatasetSpec(**spec_kwargs)``.
+        """
+        from synth_setter.cli.generate_dataset import _NON_SPEC_KEYS
+        from synth_setter.pipeline.ci.spec_uri import _NON_SPEC_CFG_KEYS
+
+        assert _NON_SPEC_CFG_KEYS == _NON_SPEC_KEYS
+
     def test_run_id_override_lands_in_uri(self) -> None:
         """The ``run_id_override`` argument appears verbatim in the under-prefix URI."""
         uri = compute_spec_uri_from_hydra(_HYDRA_EXPERIMENT, "cell-runpod-hdf5")
@@ -371,19 +408,24 @@ class TestCliFromExperimentMode:
     ) -> None:
         """Hydra failures (missing experiment, bad override) collapse to exit 3.
 
-        Reuses the existing ``_EXIT_INVALID_SPEC`` code so log scanners that
-        already grep exit 3 for "spec didn't validate" pick up compose failures
-        too — both signal "the caller couldn't get a usable spec from the input".
+        Reuses ``_EXIT_INVALID_SPEC`` so log scanners that already grep exit 3
+        for "spec didn't validate" pick up compose failures too — both signal
+        "the caller couldn't get a usable spec from the input".
 
         :param monkeypatch: Pytest fixture used to set ``sys.argv``.
         :param capsys: Pytest fixture capturing stdout/stderr.
         """
+        import uuid
+
+        # Randomized name so a future contributor naming a real experiment can't
+        # silently flip this test from negative-case to positive-case.
+        bogus = f"generate_dataset/does-not-exist-{uuid.uuid4().hex}"
         monkeypatch.setattr(
             "sys.argv",
             [
                 "synth-setter-spec-uri",
                 "--from-experiment",
-                "generate_dataset/does-not-exist-anywhere",
+                bogus,
                 "--run-id-override",
                 "x",
             ],

--- a/tests/pipeline/test_ci/test_spec_uri.py
+++ b/tests/pipeline/test_ci/test_spec_uri.py
@@ -435,3 +435,58 @@ class TestCliFromExperimentMode:
         assert exc.value.code == 3
         err = capsys.readouterr().err
         assert "Traceback" not in err
+
+    def test_experiment_named_usage_does_not_trip_sentinel(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``--from-experiment __usage__`` reaches Hydra, not the sentinel branch.
+
+        Defends the upgrade from the prior ``"__usage__"`` magic string to a
+        class-based sentinel: a user passing ``--from-experiment __usage__``
+        now hits Hydra compose (which fails because no such experiment file
+        exists, exit 3) rather than being misrouted into the usage-error
+        branch (exit 1).
+
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        :param capsys: Pytest fixture capturing stdout/stderr.
+        """
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "synth-setter-spec-uri",
+                "--from-experiment",
+                "__usage__",
+                "--run-id-override",
+                "x",
+            ],
+        )
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 3, "should reach compose, not the usage branch"
+        err = capsys.readouterr().err
+        assert "Traceback" not in err
+        assert "__usage__" in err
+
+    def test_usage_text_uses_live_argv_program_name(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Usage banner uses ``Path(sys.argv[0]).name`` rather than hard-coding the script name.
+
+        A ``python -m synth_setter.pipeline.ci.spec_uri`` invocation (or any
+        non-default entrypoint) should display the actual command the operator
+        just ran.
+
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        :param capsys: Pytest fixture capturing stdout/stderr.
+        """
+        monkeypatch.setattr("sys.argv", ["/usr/local/bin/aliased-spec-uri"])
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "aliased-spec-uri" in err
+        assert "synth-setter-spec-uri" not in err

--- a/tests/pipeline/test_ci/test_spec_uri.py
+++ b/tests/pipeline/test_ci/test_spec_uri.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 import pytest
 
-from synth_setter.pipeline.ci.spec_uri import compute_spec_uri, main
+from synth_setter.pipeline.ci.spec_uri import (
+    compute_spec_uri,
+    compute_spec_uri_from_hydra,
+    main,
+)
 from synth_setter.pipeline.schemas.spec import DatasetSpec
 
 
@@ -202,4 +206,190 @@ class TestMainCli:
         assert exc.value.code == 3
         err = capsys.readouterr().err
         assert str(bad) in err
+        assert "Traceback" not in err
+
+
+_HYDRA_EXPERIMENT = "generate_dataset/smoke-shard"
+
+
+class TestComputeSpecUriFromHydra:
+    """``compute_spec_uri_from_hydra`` derives the URI by Hydra-composing the dataset cfg."""
+
+    def test_run_id_override_lands_in_uri(self) -> None:
+        """The ``run_id_override`` argument appears verbatim in the under-prefix URI."""
+        uri = compute_spec_uri_from_hydra(_HYDRA_EXPERIMENT, "cell-runpod-hdf5")
+        assert "/cell-runpod-hdf5/input_spec.json" in uri
+        assert uri.endswith("/input_spec.json")
+        assert uri.startswith("r2://")
+
+    def test_uri_invariant_to_created_at_when_run_id_pinned(self) -> None:
+        """Two calls with the same ``run_id_override`` produce identical URIs.
+
+        The default ``created_at`` factory fires fresh on each compose, so the
+        only way both calls produce equal URIs is if ``run_id`` (pinned)
+        suppresses the ``created_at``-derived run_id factory and the prefix
+        derivation ignores ``created_at``. This pins the invariant the
+        downstream "validator computes URI from matrix coords" flow relies on.
+        """
+        uri_a = compute_spec_uri_from_hydra(_HYDRA_EXPERIMENT, "pinned")
+        uri_b = compute_spec_uri_from_hydra(_HYDRA_EXPERIMENT, "pinned")
+        assert uri_a == uri_b
+
+    def test_distinct_run_ids_produce_distinct_uris(self) -> None:
+        """Different ``run_id_override`` values produce different URIs."""
+        uri_a = compute_spec_uri_from_hydra(_HYDRA_EXPERIMENT, "cell-a")
+        uri_b = compute_spec_uri_from_hydra(_HYDRA_EXPERIMENT, "cell-b")
+        assert uri_a != uri_b
+        assert "/cell-a/" in uri_a and "/cell-b/" in uri_b
+
+    def test_uri_format_matches_canonical_prefix_template(self) -> None:
+        """URI follows ``r2://<bucket>/data/<task>/<run>/input_spec.json`` exactly."""
+        uri = compute_spec_uri_from_hydra(_HYDRA_EXPERIMENT, "abc12345")
+        assert uri.endswith("/data/smoke-shard/abc12345/input_spec.json")
+
+
+class TestCliFromExperimentMode:
+    """``--from-experiment EXP --run-id-override RUNID`` CLI mode."""
+
+    def test_prints_uri_to_stdout(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Happy path: both flags set → exactly one URI line on stdout.
+
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        :param capsys: Pytest fixture capturing stdout/stderr.
+        """
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "synth-setter-spec-uri",
+                "--from-experiment",
+                _HYDRA_EXPERIMENT,
+                "--run-id-override",
+                "cli-cell-42",
+            ],
+        )
+        main()
+        out = capsys.readouterr().out.strip()
+        assert out == compute_spec_uri_from_hydra(_HYDRA_EXPERIMENT, "cli-cell-42")
+
+    def test_equals_form_accepted(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``--flag=value`` form is honored alongside the space-separated form.
+
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        :param capsys: Pytest fixture capturing stdout/stderr.
+        """
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "synth-setter-spec-uri",
+                f"--from-experiment={_HYDRA_EXPERIMENT}",
+                "--run-id-override=eq-form-cell",
+            ],
+        )
+        main()
+        out = capsys.readouterr().out.strip()
+        assert "/eq-form-cell/" in out
+
+    def test_from_experiment_requires_run_id_override(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``--from-experiment`` alone surfaces a usage error + exit 1.
+
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        :param capsys: Pytest fixture capturing stdout/stderr.
+        """
+        monkeypatch.setattr(
+            "sys.argv",
+            ["synth-setter-spec-uri", "--from-experiment", _HYDRA_EXPERIMENT],
+        )
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 1
+        assert "Usage:" in capsys.readouterr().err
+
+    def test_run_id_override_requires_from_experiment(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """``--run-id-override`` alone surfaces a usage error + exit 1.
+
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        :param capsys: Pytest fixture capturing stdout/stderr.
+        """
+        monkeypatch.setattr(
+            "sys.argv",
+            ["synth-setter-spec-uri", "--run-id-override", "orphaned"],
+        )
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 1
+        assert "Usage:" in capsys.readouterr().err
+
+    def test_positional_and_flag_modes_are_mutually_exclusive(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Mixing positional ``spec.json`` with ``--from-experiment`` exits 1.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        :param capsys: Pytest fixture capturing stdout/stderr.
+        """
+        spec_path = _write_spec(tmp_path)
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "synth-setter-spec-uri",
+                str(spec_path),
+                "--from-experiment",
+                _HYDRA_EXPERIMENT,
+                "--run-id-override",
+                "mixed",
+            ],
+        )
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 1
+        assert "Usage:" in capsys.readouterr().err
+
+    def test_unknown_experiment_exits_three_without_traceback(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Hydra failures (missing experiment, bad override) collapse to exit 3.
+
+        Reuses the existing ``_EXIT_INVALID_SPEC`` code so log scanners that
+        already grep exit 3 for "spec didn't validate" pick up compose failures
+        too — both signal "the caller couldn't get a usable spec from the input".
+
+        :param monkeypatch: Pytest fixture used to set ``sys.argv``.
+        :param capsys: Pytest fixture capturing stdout/stderr.
+        """
+        monkeypatch.setattr(
+            "sys.argv",
+            [
+                "synth-setter-spec-uri",
+                "--from-experiment",
+                "generate_dataset/does-not-exist-anywhere",
+                "--run-id-override",
+                "x",
+            ],
+        )
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 3
+        err = capsys.readouterr().err
         assert "Traceback" not in err


### PR DESCRIPTION
## Summary

Preflight + helper PR for the spec-uri / sentinel-removal effort tracked in #1297. Adds a Hydra-compose mode to `synth-setter-spec-uri` so a CI cell can derive the canonical `input_spec.json` URI a launcher *will* write, **before** it has written it — paving the way to delete the `::synth-setter-spec-uri::` stdout-sentinel grep contract.

PR B (followup) will flip `.github/workflows/generate-dataset-shards.yaml` to call this new mode and delete the sentinel + the launcher-side regression guards. **No workflow changes here**; this PR is purely additive so the migration is reversible.

## What this PR adds

- `compute_spec_uri_from_hydra(experiment, run_id_override) -> str` — uses the same `initialize_config_module("synth_setter.configs")` + `compose(config_name="dataset", overrides=[...])` path that `synth-setter-generate-dataset` uses, plus a `+run_id=<value>` override. Since `r2.prefix` is a pure function of `(prefix_root, task_name, run_id)` and pinning `run_id` suppresses the `_default_run_id` factory's `created_at` dependency, the resulting URI is fully determined by `(experiment, run_id_override)`.
- CLI flags `--from-experiment EXP --run-id-override RUNID`. Backwards compatible with the existing positional `<spec.json>` mode; the two modes are mutually exclusive at the CLI layer.
- 12 new tests covering: launcher-parity (URI equals what `cli.generate_dataset.spec_from_cfg(cfg).r2.input_spec_uri()` would produce), `_NON_SPEC_KEYS` drift defense, `run_id` override invariance under `created_at` change, distinct-run_id → distinct-URI, canonical prefix template, and all six CLI shapes (happy path, equals form, each-flag-required, mutual exclusion with positional mode, unknown-experiment exit-3-without-traceback).

## What this PR does NOT change

- The `::synth-setter-spec-uri::` stdout sentinel emitted by `cli/generate_dataset.py:481` — still there.
- The workflow's grep block in `generate-dataset-shards.yaml:605` — still there.
- The launcher's regression guards (`test_launcher_does_not_print_spec_uri_sentinel` etc.) — still there.

All of those go away in PR B.

## Why the launcher and this helper can't drift

Both call `compose(config_name="dataset", overrides=[f"experiment={...}", f"+run_id={...}"])` and then `DatasetSpec(**spec_kwargs).r2.input_spec_uri()`. The new `test_matches_launcher_side_computation` pins that equivalence by invoking both paths and asserting equality. A future change that touches `_NON_SPEC_KEYS` / `_NON_SPEC_CFG_KEYS` on one side without the other fails `test_non_spec_cfg_keys_mirror_cli_canonical` immediately.

## Test plan

- [x] `pytest tests/pipeline/test_ci/test_spec_uri.py` — 21 passed (8 pre-existing, 13 new)
- [x] `make format && pre-commit run --all-files` clean (ruff, ruff-format, pyright, pydoclint, prettier, mdformat, shellcheck, codespell)
- [x] Pre-PR multi-skill review (7 checklists; 2 BLOCKs + cross-cutting WARNs addressed in `a898c6f1`; report at `.agent-reviews/`)
- [x] Smoke probe: `synth-setter-spec-uri --from-experiment generate_dataset/smoke-shard --run-id-override test-pinned-12345` returns `r2://intermediate-data/data/smoke-shard/test-pinned-12345/input_spec.json` deterministically
- [ ] CI green on this PR's head SHA
- [ ] Manual: not required — pure additive helper, no behavior change for existing callers

Refs #1297