### PR TITLE
automation(devcontainer): scrub core.hooksPath across all scopes before pre-commit install

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -59,7 +59,17 @@ fi
 # --local, pre-commit install → .git/hooks/*) don't land root-owned in the
 # bind-mounted workspace. Both opt-in DEVCONTAINER_USER=root sessions and
 # Codespaces (which runs postCreateCommand as root) hit this path.
+#
+# Before dropping, scrub core.hooksPath from the scopes only root can reach:
+# /etc/gitconfig (--system) and /root/.gitconfig (--global). --global is
+# per-user, so a stray entry there shadows .git/hooks/pre-commit for any
+# later root shell or root-running agent and makes `pre-commit install`
+# refuse with "Cowardly refusing…". These writes land outside the workspace,
+# so they don't violate the no-root-owned-files invariant above.
 if [ "$(id -u)" -eq 0 ]; then
+  for scope in --system --global; do
+    git config "$scope" --unset-all core.hooksPath 2>/dev/null || true
+  done
   exec runuser -u dev -- bash "$(readlink -f "${BASH_SOURCE[0]}")"
 fi
 
@@ -101,10 +111,17 @@ else
   echo "RESTRICTED_AGENT_GIT_PAT not set, skipping git credential config"
 fi
 
-# Pre-commit hooks (pre-commit itself is in the image's deps). Strip any
-# absolute host-path core.hooksPath that may leak from the host .git/config
-# (harmless in Codespaces; bites local devcontainer users).
-git config --local --unset-all core.hooksPath 2>/dev/null || true
+# Pre-commit hooks (pre-commit itself is in the image's deps). Strip
+# core.hooksPath from every scope dev can write — --local catches the
+# host-bind-mounted .git/config leak, --global catches a stray entry in
+# /home/dev/.gitconfig, --worktree catches per-worktree overrides. Without
+# this, `pre-commit install` aborts with "Cowardly refusing…" and any
+# value set here would silently shadow .git/hooks/pre-commit at commit
+# time. --system is handled in the root pre-exec above; dev cannot write
+# /etc/gitconfig.
+for scope in --global --local --worktree; do
+  git config "$scope" --unset-all core.hooksPath 2>/dev/null || true
+done
 pre-commit install
 
 echo "Dev container ready. Run 'make test-fast' to verify."


### PR DESCRIPTION
## Summary

`post-create.sh` only unset `core.hooksPath` at `--local` scope, so a stray entry in `--system` (`/etc/gitconfig`), `--global` (`/root/.gitconfig` or `/home/dev/.gitconfig`), or `--worktree` made `pre-commit install` abort with `Cowardly refusing to install hooks with core.hooksPath set` and could silently shadow `.git/hooks/pre-commit` for commits that did succeed.

This PR scrubs all four scopes, split across the root pre-exec and the dev pass:

- **Root pre-exec** (before `runuser`): scrubs `--system` and `--global` (root's `/root/.gitconfig`). These writes land outside the bind-mounted workspace, so the existing no-root-owned-workspace-files invariant still holds.
- **Dev pass**: scrubs `--global` (dev's `/home/dev/.gitconfig`), `--local`, and `--worktree`.

`--global` has to be done per-user because each user's git global config is its own file. `--system` has to be done as root because dev cannot write `/etc/gitconfig`.

## Effect on spawned agents

The hook itself is already shared across worktrees (`.git/hooks/pre-commit` lives in the main repo's `.git/`, which every worktree under `.claude/worktrees/*` resolves back to via its `.git` pointer file). What this fix actually buys is preventing a stray `core.hooksPath` from shadowing that shared hook for agents — particularly any agent that runs as root, whose `--global` config was previously never touched by `post-create.sh`.

## Pre-PR review

`/repo-review-full-no-comments` returned 0 BLOCK / 4 WARN across code-health, synth-setter-project-standards, and shell-style. The WARNs (comment length above the 2-line cap; borderline-DRY scrub loop; broad `|| true` swallow matching the file's existing idiom) are advisory and can be addressed inline if reviewers prefer.

## Test plan

- [ ] Rebuild a devcontainer with a pre-existing `core.hooksPath` in `/root/.gitconfig` and confirm `pre-commit install` no longer aborts.
- [ ] Repeat with `core.hooksPath` set in `/home/dev/.gitconfig`.
- [ ] Verify `.git/hooks/pre-commit` is owned by `dev` (not root) after `post-create.sh` runs from a root-invoked Codespaces start.
- [ ] Confirm a normal devcontainer with no stray `core.hooksPath` is unaffected (cleanup is a no-op via `2>/dev/null || true`).

Fixes #1299