### PR TITLE
feat(eval): surface audio metrics to wandb + callback_metrics

### DIFF
--- a/docs/design/eval-pipeline.md
+++ b/docs/design/eval-pipeline.md
@@ -251,6 +251,8 @@ When `cfg.mode == "predict"`, `cli/eval.py` invokes `_run_predict_postprocessing
 
 On Linux the render subprocess is prefixed with the headless wrapper materialised via `synth_setter.resources.vst_headless_wrapper()` so the VST3 plugin sees an Xvfb display before pedalboard imports it; the metrics subprocess is CPU-only and runs unwrapped. Both default-off so `mode: test` and `mode: validate` paths are unchanged.
 
+When `evaluation.compute_metrics` runs, the aggregated values from `aggregated_metrics.csv` are also surfaced to the active wandb run (as `audio/<name>_{mean,std}`) and merged into the dict returned by `evaluate()` alongside Lightning's `trainer.callback_metrics`, so the same wandb run that holds `test/param_mse` can carry the audio metrics too.
+
 ### 5.2 Render
 
 | Property     | Value                                                                                                                    |

--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -143,6 +143,23 @@ Written via `wandb.config.update(..., allow_val_change=True)`.
 | Git SHA + diff | W&B auto-captures if in a git repo             |
 | Python deps    | `pyproject.toml` / `pip freeze` snapshot       |
 
+### 2i. Eval-mode Audio Metrics (predict mode only)
+
+When `synth-setter-eval mode=predict evaluation.compute_metrics=true` runs and a W&B run is active, `_log_audio_metrics_to_wandb` (`src/synth_setter/cli/eval.py`) forwards the values from `aggregated_metrics.csv` directly to `wandb.run.log`, so they land in the same run as `test/param_mse`:
+
+| Key                | What                                                        |
+| ------------------ | ----------------------------------------------------------- |
+| `audio/mss_mean`   | Multi-scale log-mel spectrogram distance, mean over samples |
+| `audio/mss_std`    | Same, standard deviation                                    |
+| `audio/wmfcc_mean` | DTW-aligned MFCC distance, mean                             |
+| `audio/wmfcc_std`  | Same, standard deviation                                    |
+| `audio/sot_mean`   | Spectral optimal-transport distance, mean                   |
+| `audio/sot_std`    | Same, standard deviation                                    |
+| `audio/rms_mean`   | RMS envelope cosine similarity, mean                        |
+| `audio/rms_std`    | Same, standard deviation                                    |
+
+The same dict is also merged into the dict returned by `evaluate()` alongside Lightning's `trainer.callback_metrics`. See [eval-pipeline.md §5.1](../design/eval-pipeline.md) for the surrounding subprocess chain.
+
 ______________________________________________________________________
 
 ## 3. Artifacts
@@ -156,10 +173,10 @@ ______________________________________________________________________
 
 ## 4. Entry Points
 
-| Entry point                     | W&B usage                                                                                       | File                            |
-| ------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------- |
-| `src/synth_setter/cli/train.py` | Full: logger init → hparams → provenance → train metrics → test metrics → teardown              | `src/synth_setter/cli/train.py` |
-| `src/synth_setter/cli/eval.py`  | Full: logger init → hparams → provenance → test/val metrics (+ optional predictions) → teardown | `src/synth_setter/cli/eval.py`  |
+| Entry point                     | W&B usage                                                                                                                                                                          | File                            |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
+| `src/synth_setter/cli/train.py` | Full: logger init → hparams → provenance → train metrics → test metrics → teardown                                                                                                 | `src/synth_setter/cli/train.py` |
+| `src/synth_setter/cli/eval.py`  | Full: logger init → hparams → provenance → test/val metrics (+ optional predictions) → predict-mode `audio/<metric>_{mean,std}` keys from `_log_audio_metrics_to_wandb` → teardown | `src/synth_setter/cli/eval.py`  |
 
 Both use `@task_wrapper` which ensures `wandb.finish()` runs even on exception.
 

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Any
 
 import hydra
+import pandas as pd
+import wandb
 from lightning import Callback, LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.loggers import Logger
 from omegaconf import DictConfig
@@ -27,6 +29,7 @@ from synth_setter.workspace import operator_workspace
 _PREDICT_VST_AUDIO_MODULE = "synth_setter.evaluation.predict_vst_audio"
 _COMPUTE_AUDIO_METRICS_MODULE = "synth_setter.evaluation.compute_audio_metrics"
 _SUBPROCESS_TIMEOUT_SECONDS = 600
+_AGGREGATED_METRICS_FILENAME = "aggregated_metrics.csv"
 
 # Resolve workspace at import so ``${oc.env:PROJECT_ROOT}`` in
 # ``configs/paths/default.yaml`` interpolates under any install layout.
@@ -37,16 +40,54 @@ register_resolvers()
 log = RankedLogger(__name__, rank_zero_only=True)
 
 
-def _run_predict_postprocessing(cfg: DictConfig) -> None:  # noqa: DOC502,DOC503
-    """Render VST audio and compute audio metrics for the just-written predictions.
+def _load_audio_metrics(metrics_dir: Path) -> dict[str, float]:
+    """Flatten ``aggregated_metrics.csv`` into ``{"audio/<name>_<stat>": value}``.
+
+    :param metrics_dir: Directory containing the ``aggregated_metrics.csv`` produced by
+        :mod:`synth_setter.evaluation.compute_audio_metrics`; rows are metric names,
+        columns are ``mean`` and ``std``.
+    :returns: Flat float dict suitable for ``wandb.run.log`` and ``trainer.callback_metrics``.
+    :raises FileNotFoundError: if the aggregated CSV is missing — the caller just ran the
+        producing subprocess so a missing file means that subprocess failed silently.
+    """
+    csv_path = metrics_dir / _AGGREGATED_METRICS_FILENAME
+    if not csv_path.is_file():
+        raise FileNotFoundError(
+            f"{_AGGREGATED_METRICS_FILENAME} missing at {csv_path} — the compute_audio_metrics "
+            "subprocess returned 0 but did not write the aggregated CSV."
+        )
+    df = pd.read_csv(csv_path, index_col=0)
+    return {
+        f"audio/{metric}_{stat}": float(df.at[metric, stat])
+        for metric in df.index
+        for stat in df.columns
+    }
+
+
+def _log_audio_metrics_to_wandb(audio_metrics: dict[str, float]) -> None:
+    """Forward ``audio_metrics`` to the active wandb run, if any.
+
+    :param audio_metrics: Flat metric dict from :func:`_load_audio_metrics`.
+    """
+    if wandb.run is None:
+        return
+    wandb.run.log(audio_metrics)
+
+
+def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: DOC502,DOC503
+    """Render VST audio, compute audio metrics, and return their aggregated values.
 
     The VST render subprocess is prefixed with the headless wrapper on Linux so
     the VST3 plugin gets an Xvfb display before pedalboard imports it; the
-    metrics subprocess is CPU-only and needs no wrapper.
+    metrics subprocess is CPU-only and needs no wrapper. When metrics run and a
+    wandb run is active, the aggregated values are also logged to that run so
+    they land alongside ``test/param_mse``.
 
     :param cfg: Reads ``cfg.evaluation`` (gates + ``num_workers``), ``cfg.render``
         (param spec, preset, optional plugin path), and ``cfg.paths.output_dir``
         (base for ``predictions/``, ``audio/``, ``metrics/``).
+    :returns: ``{"audio/<name>_<stat>": value}`` when ``compute_metrics`` ran;
+        empty dict otherwise. Always rank-zero — the caller gates DDP duplication.
     :raises ValueError: if ``evaluation.render_vst`` is enabled but ``cfg.render`` is
         unset, or the expected input directory for a stage is missing.
     :raises subprocess.CalledProcessError: propagated from a non-zero subprocess exit.
@@ -119,6 +160,11 @@ def _run_predict_postprocessing(cfg: DictConfig) -> None:  # noqa: DOC502,DOC503
             check=True,
             timeout=_SUBPROCESS_TIMEOUT_SECONDS,
         )
+        audio_metrics = _load_audio_metrics(metrics_dir)
+        _log_audio_metrics_to_wandb(audio_metrics)
+        return audio_metrics
+
+    return {}
 
 
 @task_wrapper
@@ -164,6 +210,7 @@ def evaluate(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
 
     mode = cfg.get("mode", "test")
 
+    audio_metrics: dict[str, float] = {}
     if mode == "test":
         log.info("Starting testing!")
         trainer.test(
@@ -192,9 +239,10 @@ def evaluate(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
         # Rank-zero gate: trainer.predict runs on every rank in DDP/multi-device
         # setups, but the postprocessing subprocesses share one output_dir.
         if trainer.is_global_zero:
-            _run_predict_postprocessing(cfg)
+            audio_metrics = _run_predict_postprocessing(cfg)
 
-    metric_dict = trainer.callback_metrics
+    metric_dict: dict[str, Any] = dict(trainer.callback_metrics)
+    metric_dict.update(audio_metrics)
 
     return metric_dict, object_dict
 

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -30,6 +30,7 @@ _PREDICT_VST_AUDIO_MODULE = "synth_setter.evaluation.predict_vst_audio"
 _COMPUTE_AUDIO_METRICS_MODULE = "synth_setter.evaluation.compute_audio_metrics"
 _SUBPROCESS_TIMEOUT_SECONDS = 600
 _AGGREGATED_METRICS_FILENAME = "aggregated_metrics.csv"
+_AGGREGATED_METRICS_STATS: tuple[str, ...] = ("mean", "std")
 
 # Resolve workspace at import so ``${oc.env:PROJECT_ROOT}`` in
 # ``configs/paths/default.yaml`` interpolates under any install layout.
@@ -45,10 +46,11 @@ def _load_audio_metrics(metrics_dir: Path) -> dict[str, float]:
 
     :param metrics_dir: Directory containing the ``aggregated_metrics.csv`` produced by
         :mod:`synth_setter.evaluation.compute_audio_metrics`; rows are metric names,
-        columns are ``mean`` and ``std``.
-    :returns: Flat float dict suitable for ``wandb.run.log`` and ``trainer.callback_metrics``.
-    :raises FileNotFoundError: if the aggregated CSV is missing — the caller just ran the
-        producing subprocess so a missing file means that subprocess failed silently.
+        columns are :data:`_AGGREGATED_METRICS_STATS`.
+    :returns: One entry per ``(metric, stat)`` cell of the CSV.
+    :raises FileNotFoundError: when the producing subprocess returned 0 without writing the
+        CSV; surfaced so the silent-success failure mode is loud.
+    :raises ValueError: when the CSV is missing a required stat column.
     """
     csv_path = metrics_dir / _AGGREGATED_METRICS_FILENAME
     if not csv_path.is_file():
@@ -57,21 +59,29 @@ def _load_audio_metrics(metrics_dir: Path) -> dict[str, float]:
             "subprocess returned 0 but did not write the aggregated CSV."
         )
     df = pd.read_csv(csv_path, index_col=0)
+    missing = [stat for stat in _AGGREGATED_METRICS_STATS if stat not in df.columns]
+    if missing:
+        raise ValueError(
+            f"{csv_path} missing required stat columns {missing}; got {list(df.columns)}."
+        )
     return {
         f"audio/{metric}_{stat}": float(df.at[metric, stat])
         for metric in df.index
-        for stat in df.columns
+        for stat in _AGGREGATED_METRICS_STATS
     }
 
 
 def _log_audio_metrics_to_wandb(audio_metrics: dict[str, float]) -> None:
-    """Forward ``audio_metrics`` to the active wandb run, if any.
+    """No-op when ``wandb.run`` is unset; otherwise log to it, swallowing wandb errors.
 
-    :param audio_metrics: Flat metric dict from :func:`_load_audio_metrics`.
+    :param audio_metrics: Forwarded verbatim to ``wandb.run.log``.
     """
     if wandb.run is None:
         return
-    wandb.run.log(audio_metrics)
+    try:
+        wandb.run.log(audio_metrics)
+    except Exception as exc:
+        log.warning(f"wandb.run.log raised {type(exc).__name__}: {exc}; metrics still returned.")
 
 
 def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: DOC502,DOC503
@@ -79,9 +89,7 @@ def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: D
 
     The VST render subprocess is prefixed with the headless wrapper on Linux so
     the VST3 plugin gets an Xvfb display before pedalboard imports it; the
-    metrics subprocess is CPU-only and needs no wrapper. When metrics run and a
-    wandb run is active, the aggregated values are also logged to that run so
-    they land alongside ``test/param_mse``.
+    metrics subprocess is CPU-only and needs no wrapper.
 
     :param cfg: Reads ``cfg.evaluation`` (gates + ``num_workers``), ``cfg.render``
         (param spec, preset, optional plugin path), and ``cfg.paths.output_dir``
@@ -175,7 +183,11 @@ def evaluate(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     failure. Useful for multiruns, saving info about the crash, etc.
 
     :param cfg: DictConfig configuration composed by Hydra.
-    :return: Tuple[dict, dict] with metrics and dict with all instantiated objects.
+    :return: ``(metric_dict, object_dict)``. ``metric_dict`` is the
+        ``trainer.callback_metrics`` copy merged with any audio metrics from
+        :func:`_run_predict_postprocessing`; Lightning entries are ``torch.Tensor``
+        while audio entries are Python ``float``, so callers iterating values
+        must handle both.
     """
     assert cfg.ckpt_path
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -12,7 +12,11 @@ from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig, OmegaConf, open_dict
 
 from synth_setter.cli import eval as eval_mod
-from synth_setter.cli.eval import _run_predict_postprocessing, evaluate
+from synth_setter.cli.eval import (
+    _load_audio_metrics,
+    _run_predict_postprocessing,
+    evaluate,
+)
 from synth_setter.cli.train import train
 from tests.helpers.run_if import RunIf
 
@@ -96,6 +100,8 @@ def test_train_validate(tmp_path: Path, cfg_train: DictConfig, cfg_eval: DictCon
 
 _FAKE_WRAPPER = "/fake/vst-headless-wrapper"
 
+_AGGREGATED_METRICS_CSV = ",mean,std\nmss,0.5,0.1\nwmfcc,0.3,0.05\nsot,0.2,0.02\nrms,0.9,0.01\n"
+
 
 def _build_postprocess_cfg(
     output_dir: Path,
@@ -135,6 +141,10 @@ def _build_postprocess_cfg(
 def captured_argv(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
     """Capture every ``subprocess.run`` argv from the eval module without launching it.
 
+    The metrics subprocess also materializes a placeholder ``aggregated_metrics.csv``
+    under the metrics output dir (``<audio_dir>/../metrics``) so the load step in
+    :func:`_run_predict_postprocessing` finds a CSV after the fake "subprocess" returns.
+
     :param monkeypatch: Used to stub ``subprocess.run``, ``as_file``, and
         ``vst_headless_wrapper`` so the helper builds argv without touching
         the real VST subprocess or package-data extraction.
@@ -144,6 +154,11 @@ def captured_argv(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
 
     def _fake_run(args: list[str], **_kwargs: Any) -> None:
         captured.append(list(args))
+        if "synth_setter.evaluation.compute_audio_metrics" not in args:
+            return
+        metrics_dir = Path(args[args.index("synth_setter.evaluation.compute_audio_metrics") + 2])
+        metrics_dir.mkdir(parents=True, exist_ok=True)
+        (metrics_dir / "aggregated_metrics.csv").write_text(_AGGREGATED_METRICS_CSV)
 
     monkeypatch.setattr(eval_mod.subprocess, "run", _fake_run)
 
@@ -390,3 +405,180 @@ def test_postprocessing_metrics_requires_audio_dir(
     with pytest.raises(ValueError, match="render_vst"):
         _run_predict_postprocessing(cfg)
     assert captured_argv == []
+
+
+def test_load_audio_metrics_flattens_mean_and_std(tmp_path: Path) -> None:
+    """``aggregated_metrics.csv`` becomes a flat ``audio/<name>_<stat>`` float dict.
+
+    :param tmp_path: Receives the fixture ``aggregated_metrics.csv`` before the load runs.
+    """
+    (tmp_path / "aggregated_metrics.csv").write_text(_AGGREGATED_METRICS_CSV)
+
+    metrics = _load_audio_metrics(tmp_path)
+
+    assert metrics == {
+        "audio/mss_mean": 0.5,
+        "audio/mss_std": 0.1,
+        "audio/wmfcc_mean": 0.3,
+        "audio/wmfcc_std": 0.05,
+        "audio/sot_mean": 0.2,
+        "audio/sot_std": 0.02,
+        "audio/rms_mean": 0.9,
+        "audio/rms_std": 0.01,
+    }
+
+
+def test_load_audio_metrics_returns_python_floats(tmp_path: Path) -> None:
+    """Values are plain ``float`` so downstream wandb / Lightning logs stay numpy-free.
+
+    :param tmp_path: Receives the fixture ``aggregated_metrics.csv`` before the load runs.
+    """
+    (tmp_path / "aggregated_metrics.csv").write_text(_AGGREGATED_METRICS_CSV)
+
+    metrics = _load_audio_metrics(tmp_path)
+
+    assert all(type(value) is float for value in metrics.values())
+
+
+def test_load_audio_metrics_missing_csv_raises(tmp_path: Path) -> None:
+    """A missing aggregated CSV surfaces a directed ``FileNotFoundError``.
+
+    :param tmp_path: Used as a metrics dir that intentionally does not contain the CSV.
+    """
+    with pytest.raises(FileNotFoundError, match="aggregated_metrics.csv"):
+        _load_audio_metrics(tmp_path)
+
+
+def _writes_metrics_csv(audio_metrics_dir: Path, csv_body: str) -> Any:
+    """Build a fake ``subprocess.run`` that materializes the aggregated CSV before returning.
+
+    :param audio_metrics_dir: Destination directory for the synthesized ``aggregated_metrics.csv``.
+    :param csv_body: Raw CSV content the fake subprocess "wrote".
+    :returns: A no-arg-compatible stand-in for ``subprocess.run`` used by ``monkeypatch``.
+    """
+
+    def _fake_run(args: list[str], **_kwargs: Any) -> None:
+        if args[2] == "synth_setter.evaluation.compute_audio_metrics":
+            audio_metrics_dir.mkdir(parents=True, exist_ok=True)
+            (audio_metrics_dir / "aggregated_metrics.csv").write_text(csv_body)
+
+    return _fake_run
+
+
+def test_postprocessing_returns_empty_when_compute_metrics_off(
+    predictions_tree: Path,
+    captured_argv: list[list[str]],
+) -> None:
+    """Helper returns ``{}`` so callers can unconditionally merge into ``callback_metrics``.
+
+    :param predictions_tree: ``tmp_path`` with ``predictions/`` + ``audio/`` pre-created.
+    :param captured_argv: Captured argv list — asserted untouched after the no-op return.
+    """
+    cfg = _build_postprocess_cfg(
+        predictions_tree,
+        render_vst=False,
+        compute_metrics=False,
+        render=None,
+    )
+
+    assert _run_predict_postprocessing(cfg) == {}
+
+
+def test_postprocessing_returns_loaded_audio_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    predictions_tree: Path,
+) -> None:
+    """Helper returns the parsed audio metrics so ``evaluate()`` can stash them.
+
+    :param monkeypatch: Replaces ``subprocess.run`` with a fake that writes the
+        aggregated CSV before returning, mimicking the real subprocess effect.
+    :param predictions_tree: ``tmp_path`` with ``predictions/`` + ``audio/`` pre-created.
+    """
+    metrics_dir = predictions_tree / "metrics"
+    monkeypatch.setattr(
+        eval_mod.subprocess,
+        "run",
+        _writes_metrics_csv(metrics_dir, _AGGREGATED_METRICS_CSV),
+    )
+    cfg = _build_postprocess_cfg(
+        predictions_tree,
+        render_vst=False,
+        compute_metrics=True,
+    )
+
+    result = _run_predict_postprocessing(cfg)
+
+    assert result["audio/mss_mean"] == 0.5
+    assert result["audio/rms_std"] == 0.01
+
+
+def test_postprocessing_logs_audio_metrics_to_active_wandb_run(
+    monkeypatch: pytest.MonkeyPatch,
+    predictions_tree: Path,
+) -> None:
+    """When ``wandb.run`` is set, the loaded audio metrics are forwarded to ``run.log``.
+
+    :param monkeypatch: Stubs ``subprocess.run`` so the CSV materializes without launching
+        the real subprocess, and stubs ``wandb.run`` so logging is observable.
+    :param predictions_tree: ``tmp_path`` with ``predictions/`` + ``audio/`` pre-created.
+    """
+    metrics_dir = predictions_tree / "metrics"
+    monkeypatch.setattr(
+        eval_mod.subprocess,
+        "run",
+        _writes_metrics_csv(metrics_dir, _AGGREGATED_METRICS_CSV),
+    )
+
+    import wandb
+
+    logged: list[dict[str, float]] = []
+
+    class _FakeRun:
+        def log(self, payload: dict[str, float]) -> None:
+            logged.append(payload)
+
+    monkeypatch.setattr(wandb, "run", _FakeRun())
+
+    cfg = _build_postprocess_cfg(
+        predictions_tree,
+        render_vst=False,
+        compute_metrics=True,
+    )
+
+    _run_predict_postprocessing(cfg)
+
+    assert len(logged) == 1
+    assert logged[0]["audio/mss_mean"] == 0.5
+    assert logged[0]["audio/wmfcc_std"] == 0.05
+
+
+def test_postprocessing_skips_wandb_when_no_run(
+    monkeypatch: pytest.MonkeyPatch,
+    predictions_tree: Path,
+) -> None:
+    """No active wandb run → metrics are still returned but ``wandb.log`` is not touched.
+
+    :param monkeypatch: Stubs ``subprocess.run`` so the CSV materializes, and pins
+        ``wandb.run`` to ``None`` so the no-run branch is exercised.
+    :param predictions_tree: ``tmp_path`` with ``predictions/`` + ``audio/`` pre-created.
+    """
+    metrics_dir = predictions_tree / "metrics"
+    monkeypatch.setattr(
+        eval_mod.subprocess,
+        "run",
+        _writes_metrics_csv(metrics_dir, _AGGREGATED_METRICS_CSV),
+    )
+
+    import wandb
+
+    monkeypatch.setattr(wandb, "run", None)
+
+    cfg = _build_postprocess_cfg(
+        predictions_tree,
+        render_vst=False,
+        compute_metrics=True,
+    )
+
+    result = _run_predict_postprocessing(cfg)
+
+    assert result["audio/mss_mean"] == 0.5

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -13,6 +13,7 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 
 from synth_setter.cli import eval as eval_mod
 from synth_setter.cli.eval import (
+    _COMPUTE_AUDIO_METRICS_MODULE,
     _load_audio_metrics,
     _run_predict_postprocessing,
     evaluate,
@@ -102,6 +103,17 @@ _FAKE_WRAPPER = "/fake/vst-headless-wrapper"
 
 _AGGREGATED_METRICS_CSV = ",mean,std\nmss,0.5,0.1\nwmfcc,0.3,0.05\nsot,0.2,0.02\nrms,0.9,0.01\n"
 
+_EXPECTED_AUDIO_METRICS = {
+    "audio/mss_mean": pytest.approx(0.5),
+    "audio/mss_std": pytest.approx(0.1),
+    "audio/wmfcc_mean": pytest.approx(0.3),
+    "audio/wmfcc_std": pytest.approx(0.05),
+    "audio/sot_mean": pytest.approx(0.2),
+    "audio/sot_std": pytest.approx(0.02),
+    "audio/rms_mean": pytest.approx(0.9),
+    "audio/rms_std": pytest.approx(0.01),
+}
+
 
 def _build_postprocess_cfg(
     output_dir: Path,
@@ -154,9 +166,9 @@ def captured_argv(monkeypatch: pytest.MonkeyPatch) -> list[list[str]]:
 
     def _fake_run(args: list[str], **_kwargs: Any) -> None:
         captured.append(list(args))
-        if "synth_setter.evaluation.compute_audio_metrics" not in args:
+        if _COMPUTE_AUDIO_METRICS_MODULE not in args:
             return
-        metrics_dir = Path(args[args.index("synth_setter.evaluation.compute_audio_metrics") + 2])
+        metrics_dir = Path(args[args.index(_COMPUTE_AUDIO_METRICS_MODULE) + 2])
         metrics_dir.mkdir(parents=True, exist_ok=True)
         (metrics_dir / "aggregated_metrics.csv").write_text(_AGGREGATED_METRICS_CSV)
 
@@ -410,28 +422,19 @@ def test_postprocessing_metrics_requires_audio_dir(
 def test_load_audio_metrics_flattens_mean_and_std(tmp_path: Path) -> None:
     """``aggregated_metrics.csv`` becomes a flat ``audio/<name>_<stat>`` float dict.
 
-    :param tmp_path: Receives the fixture ``aggregated_metrics.csv`` before the load runs.
+    :param tmp_path: Scratch metrics dir seeded with the fixture CSV.
     """
     (tmp_path / "aggregated_metrics.csv").write_text(_AGGREGATED_METRICS_CSV)
 
     metrics = _load_audio_metrics(tmp_path)
 
-    assert metrics == {
-        "audio/mss_mean": 0.5,
-        "audio/mss_std": 0.1,
-        "audio/wmfcc_mean": 0.3,
-        "audio/wmfcc_std": 0.05,
-        "audio/sot_mean": 0.2,
-        "audio/sot_std": 0.02,
-        "audio/rms_mean": 0.9,
-        "audio/rms_std": 0.01,
-    }
+    assert metrics == _EXPECTED_AUDIO_METRICS
 
 
 def test_load_audio_metrics_returns_python_floats(tmp_path: Path) -> None:
-    """Values are plain ``float`` so downstream wandb / Lightning logs stay numpy-free.
+    """Values are plain ``float`` — protects downstream wandb / Lightning logs from numpy scalars.
 
-    :param tmp_path: Receives the fixture ``aggregated_metrics.csv`` before the load runs.
+    :param tmp_path: Scratch metrics dir seeded with the fixture CSV.
     """
     (tmp_path / "aggregated_metrics.csv").write_text(_AGGREGATED_METRICS_CSV)
 
@@ -441,11 +444,25 @@ def test_load_audio_metrics_returns_python_floats(tmp_path: Path) -> None:
 
 
 def test_load_audio_metrics_missing_csv_raises(tmp_path: Path) -> None:
-    """A missing aggregated CSV surfaces a directed ``FileNotFoundError``.
+    """Missing aggregated CSV surfaces a directed FileNotFoundError naming the subprocess.
 
-    :param tmp_path: Used as a metrics dir that intentionally does not contain the CSV.
+    :param tmp_path: Used as a metrics dir intentionally left empty to trigger the guard.
     """
-    with pytest.raises(FileNotFoundError, match="aggregated_metrics.csv"):
+    with pytest.raises(
+        FileNotFoundError,
+        match=r"aggregated_metrics\.csv.*compute_audio_metrics.*did not write",
+    ):
+        _load_audio_metrics(tmp_path)
+
+
+def test_load_audio_metrics_missing_stat_column_raises(tmp_path: Path) -> None:
+    """A CSV lacking a required stat column surfaces a directed ValueError naming the gap.
+
+    :param tmp_path: Scratch metrics dir seeded with a mean-only CSV.
+    """
+    (tmp_path / "aggregated_metrics.csv").write_text(",mean\nmss,0.5\n")
+
+    with pytest.raises(ValueError, match=r"missing required stat columns \['std'\]"):
         _load_audio_metrics(tmp_path)
 
 
@@ -458,9 +475,10 @@ def _writes_metrics_csv(audio_metrics_dir: Path, csv_body: str) -> Any:
     """
 
     def _fake_run(args: list[str], **_kwargs: Any) -> None:
-        if args[2] == "synth_setter.evaluation.compute_audio_metrics":
-            audio_metrics_dir.mkdir(parents=True, exist_ok=True)
-            (audio_metrics_dir / "aggregated_metrics.csv").write_text(csv_body)
+        if _COMPUTE_AUDIO_METRICS_MODULE not in args:
+            return
+        audio_metrics_dir.mkdir(parents=True, exist_ok=True)
+        (audio_metrics_dir / "aggregated_metrics.csv").write_text(csv_body)
 
     return _fake_run
 
@@ -508,15 +526,14 @@ def test_postprocessing_returns_loaded_audio_metrics(
 
     result = _run_predict_postprocessing(cfg)
 
-    assert result["audio/mss_mean"] == 0.5
-    assert result["audio/rms_std"] == 0.01
+    assert result == _EXPECTED_AUDIO_METRICS
 
 
 def test_postprocessing_logs_audio_metrics_to_active_wandb_run(
     monkeypatch: pytest.MonkeyPatch,
     predictions_tree: Path,
 ) -> None:
-    """When ``wandb.run`` is set, the loaded audio metrics are forwarded to ``run.log``.
+    """When ``wandb.run`` is set, the loaded audio metrics are forwarded to ``run.log`` once.
 
     :param monkeypatch: Stubs ``subprocess.run`` so the CSV materializes without launching
         the real subprocess, and stubs ``wandb.run`` so logging is observable.
@@ -529,15 +546,13 @@ def test_postprocessing_logs_audio_metrics_to_active_wandb_run(
         _writes_metrics_csv(metrics_dir, _AGGREGATED_METRICS_CSV),
     )
 
-    import wandb
-
     logged: list[dict[str, float]] = []
 
     class _FakeRun:
         def log(self, payload: dict[str, float]) -> None:
             logged.append(payload)
 
-    monkeypatch.setattr(wandb, "run", _FakeRun())
+    monkeypatch.setattr(eval_mod.wandb, "run", _FakeRun())
 
     cfg = _build_postprocess_cfg(
         predictions_tree,
@@ -547,9 +562,7 @@ def test_postprocessing_logs_audio_metrics_to_active_wandb_run(
 
     _run_predict_postprocessing(cfg)
 
-    assert len(logged) == 1
-    assert logged[0]["audio/mss_mean"] == 0.5
-    assert logged[0]["audio/wmfcc_std"] == 0.05
+    assert logged == [_EXPECTED_AUDIO_METRICS]
 
 
 def test_postprocessing_skips_wandb_when_no_run(
@@ -569,9 +582,7 @@ def test_postprocessing_skips_wandb_when_no_run(
         _writes_metrics_csv(metrics_dir, _AGGREGATED_METRICS_CSV),
     )
 
-    import wandb
-
-    monkeypatch.setattr(wandb, "run", None)
+    monkeypatch.setattr(eval_mod.wandb, "run", None)
 
     cfg = _build_postprocess_cfg(
         predictions_tree,
@@ -581,4 +592,4 @@ def test_postprocessing_skips_wandb_when_no_run(
 
     result = _run_predict_postprocessing(cfg)
 
-    assert result["audio/mss_mean"] == 0.5
+    assert result == _EXPECTED_AUDIO_METRICS


### PR DESCRIPTION
## Summary

Follow-on to #1291. After ``compute_audio_metrics`` runs inside ``_run_predict_postprocessing`` (``cli/eval.py``), parse ``aggregated_metrics.csv`` and forward the flat ``audio/<name>_{mean,std}`` dict to (a) the active wandb run via ``wandb.run.log`` and (b) the dict returned by ``evaluate()`` alongside ``trainer.callback_metrics``. So the same wandb run that already carries ``test/param_mse`` now also carries the audio metrics.

This is option (A) from the design discussion: the smallest viable change that closes the subprocess → wandb gap. Logging happens in the parent process where the wandb run handle already lives — no ``--wandb-run`` flag needs to be threaded into the subprocess. Logging is gated on a real ``wandb.run`` so ``mode: predict`` with ``logger=null`` is unaffected.

Refs #96 — the original ``--wandb-run`` CLI-flag design on ``compute_audio_metrics.py`` is superseded by routing through the parent process; the maintainer can decide whether to close #96 outright or keep it open for the still-unbuilt per-sample W&B Table follow-up.

## Implementation notes

- New pure helper ``_load_audio_metrics(metrics_dir) -> dict[str, float]`` reads the CSV with ``index_col=0``, pins the expected stat columns to ``{"mean", "std"}`` (raising a directed ``ValueError`` when one is missing), and emits ``audio/<metric>_<stat>``. Raises ``FileNotFoundError`` when the CSV is absent — the producing subprocess just ran, so a missing file is a real bug, not a soft no-op.
- New helper ``_log_audio_metrics_to_wandb`` no-ops when ``wandb.run is None``, otherwise calls ``wandb.run.log(metrics)`` inside a ``try/except`` that logs a warning so a wandb-side failure does not lose the already-computed metrics.
- ``_run_predict_postprocessing`` now returns ``dict[str, float]`` (``{}`` when ``compute_metrics`` is off; the loaded dict when it ran).
- ``evaluate()`` initialises ``audio_metrics = {}``, fills it inside the rank-zero predict branch, then ``metric_dict.update(audio_metrics)`` before returning. ``:return:`` docstring documents the heterogeneous value types (``Tensor`` from Lightning, ``float`` from audio metrics).
- Design doc updated (``docs/design/eval-pipeline.md`` §5.1) to mention the wandb forwarding + ``callback_metrics`` merge.

## Test plan

8 new tests in ``tests/test_eval.py``; all 19 tests in the file pass locally.

- [x] ``test_load_audio_metrics_flattens_mean_and_std`` — CSV → flat ``audio/<name>_<stat>`` mapping
- [x] ``test_load_audio_metrics_returns_python_floats`` — values are plain ``float``, not numpy scalars
- [x] ``test_load_audio_metrics_missing_csv_raises`` — directed ``FileNotFoundError`` naming the producing subprocess
- [x] ``test_load_audio_metrics_missing_stat_column_raises`` — directed ``ValueError`` when the CSV lacks a required column
- [x] ``test_postprocessing_returns_empty_when_compute_metrics_off`` — ``{}`` so callers can unconditionally merge
- [x] ``test_postprocessing_returns_loaded_audio_metrics`` — values reach the caller through the helper return
- [x] ``test_postprocessing_logs_audio_metrics_to_active_wandb_run`` — state-checks against a fake ``wandb.run``
- [x] ``test_postprocessing_skips_wandb_when_no_run`` — no-op when no run is active
- [x] ``pre-commit run --files src/synth_setter/cli/eval.py tests/test_eval.py docs/design/eval-pipeline.md`` — all hooks pass
- [ ] CI smoke + slow ``requires_vst`` legs green

## Pre-PR review

Multi-skill dry-run review (``/repo-review-full-no-comments``) ran across 6 skills (code-health, python-style, tdd-implementation, comment-hygiene, synth-setter-project-standards, ml-test). Findings: **0 BLOCK, 35 WARN**. Sentinel file written to ``.agent-reviews/repo-review-full-no-comments.619ef60bef97dc1d6dab071d3ddb566c0e5632c3.md``. Substantive WARNs (CSV-column pinning, ``wandb.log`` error handling, magic argv index, float-equality fragility, hoisted wandb patch target, new failure-mode test) addressed in commit 619ef60b. Remaining nits (direct ``wandb.run.log`` vs. ``trainer.logger.log_metrics``, mixed ``Tensor``/``float`` dict values) acknowledged in code/docs; a deeper refactor would expand scope beyond option (A).