### PR TITLE
feat(cli): log e2e generation speed (samples/s) in generate_dataset

### DIFF
--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -15,6 +15,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
+import time
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import ExitStack
 from pathlib import Path
@@ -169,6 +170,7 @@ def generate(spec: DatasetSpec) -> None:
 
     r2_dest_prefix = spec.r2.rclone_prefix()
 
+    start = time.perf_counter()
     with tempfile.TemporaryDirectory() as work_dir_str:
         work_dir = Path(work_dir_str)
 
@@ -176,8 +178,15 @@ def generate(spec: DatasetSpec) -> None:
             rendered, skipped = _dispatch_shards_parallel(spec, my_range, work_dir, r2_dest_prefix)
         else:
             rendered, skipped = _dispatch_shards_serial(spec, my_range, work_dir, r2_dest_prefix)
+        elapsed_s = time.perf_counter() - start
+        samples = rendered * spec.render.samples_per_shard
+        rate = samples / elapsed_s if elapsed_s > 0 else 0.0
         logger.info(
             f"shard summary: rendered={rendered} skipped={skipped} of {len(my_range)} assigned"
+        )
+        logger.info(
+            f"generation speed: {samples} samples in {elapsed_s:.3f}s "
+            f"= {rate:.3f} samples/s (skipped shards excluded)"
         )
 
 

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -170,10 +170,13 @@ def generate(spec: DatasetSpec) -> None:
 
     r2_dest_prefix = spec.r2.rclone_prefix()
 
-    start = time.perf_counter()
     with tempfile.TemporaryDirectory() as work_dir_str:
         work_dir = Path(work_dir_str)
 
+        # ``start`` brackets only the dispatch call so the rate excludes tempdir
+        # setup and any post-dispatch cleanup; it still includes the in-loop R2
+        # skip probes (those are observable cost of the resumability MVP, #750).
+        start = time.perf_counter()
         if spec.render.parallel and len(my_range) > 0:
             rendered, skipped = _dispatch_shards_parallel(spec, my_range, work_dir, r2_dest_prefix)
         else:
@@ -186,7 +189,7 @@ def generate(spec: DatasetSpec) -> None:
         )
         logger.info(
             f"generation speed: {samples} samples in {elapsed_s:.3f}s "
-            f"= {rate:.3f} samples/s (skipped shards excluded)"
+            f"= {rate:.3f} samples/s (wallclock includes R2 skip probes)"
         )
 
 

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -913,6 +913,45 @@ class TestRun:
         assert "rendered=2" in summary_lines[0]
         assert "skipped=1" in summary_lines[0]
 
+    @patch("synth_setter.cli.generate_dataset.logger")
+    def test_run_logs_generation_speed_from_rendered_samples(
+        self,
+        mock_logger: MagicMock,
+        patched_subprocess: MagicMock,  # noqa: ARG002
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """End-of-run summary reports samples/sec computed from ``rendered`` shards only.
+
+        ``samples`` excludes shards that were skipped because they already
+        existed in R2 — the rate measures freshly produced work, not historical
+        output. The wallclock is read with ``time.perf_counter`` so a frozen
+        clock would surface as ``elapsed_s=0`` and a 0.0 rate fallback.
+
+        :param mock_logger: Patched ``generate_dataset.logger`` for capturing
+            the speed log line.
+        :param patched_subprocess: Fixture-activation only (renderer
+            materializes shards so rclone copies have a valid source).
+        :param tmp_path: Pytest tmp dir used by ``_multi_shard_spec``.
+        :param monkeypatch: Used to install the per-shard probe stub so one
+            shard is skipped and two are rendered.
+        """
+        spec = _multi_shard_spec(tmp_path, n=3)
+
+        def _present_only_for_shard_0(uri: str) -> int | None:
+            return 9999 if uri.endswith("shard-000000.h5") else None
+
+        monkeypatch.setattr("synth_setter.pipeline.r2_io.object_size", _present_only_for_shard_0)
+
+        generate(spec)
+
+        info_messages = [str(c.args[0]) for c in mock_logger.info.call_args_list]
+        speed_lines = [m for m in info_messages if "generation speed:" in m]
+        assert len(speed_lines) == 1, f"expected one speed line, got: {info_messages}"
+        expected_samples = 2 * spec.render.samples_per_shard
+        assert f"{expected_samples} samples" in speed_lines[0]
+        assert "samples/s" in speed_lines[0]
+
     def test_run_probe_failure_propagates(
         self,
         patched_subprocess: MagicMock,

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -921,20 +921,12 @@ class TestRun:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """End-of-run summary reports samples/sec computed from ``rendered`` shards only.
+        """Speed log line counts only ``rendered`` shards, not skipped ones.
 
-        ``samples`` excludes shards that were skipped because they already
-        existed in R2 — the rate measures freshly produced work, not historical
-        output. The wallclock is read with ``time.perf_counter`` so a frozen
-        clock would surface as ``elapsed_s=0`` and a 0.0 rate fallback.
-
-        :param mock_logger: Patched ``generate_dataset.logger`` for capturing
-            the speed log line.
-        :param patched_subprocess: Fixture-activation only (renderer
-            materializes shards so rclone copies have a valid source).
-        :param tmp_path: Pytest tmp dir used by ``_multi_shard_spec``.
-        :param monkeypatch: Used to install the per-shard probe stub so one
-            shard is skipped and two are rendered.
+        :param mock_logger: Captures the speed log line's content.
+        :param patched_subprocess: Fixture-activation only.
+        :param tmp_path: Used by ``_multi_shard_spec``.
+        :param monkeypatch: Installs the probe stub that skips shard 0.
         """
         spec = _multi_shard_spec(tmp_path, n=3)
 


### PR DESCRIPTION
Refs #753.

## Summary
- Wrap `generate()`'s shard-dispatch loop in `time.perf_counter` and log a new `generation speed: <N> samples in <S>s = <R> samples/s` line alongside the existing shard summary.
- `samples = rendered * spec.render.samples_per_shard` — shards skipped because they were already in R2 are excluded so the rate reflects freshly produced work, not historical output.
- Guard against `elapsed_s == 0` with a `0.0` fallback (defensive; `time.perf_counter` is monotonic so the branch is effectively unreachable in practice).

This is the per-rank wallclock half of #753 (a smaller, additive step — it does not implement per-shard progress logging, which can land as a follow-up).

## Test plan
- [x] `pytest tests/pipeline/test_entrypoints/test_generate_dataset.py` (53 passed)
- [x] New `TestRun::test_run_logs_generation_speed_from_rendered_samples` pins that samples count = `rendered * samples_per_shard` when one of three shards is already in R2 and is therefore skipped.
- [ ] CI green