### PR TITLE
test(testing): add real-wandb grid sweep e2e for generate_dataset cadences

### DIFF
--- a/sweeps/generate_dataset_cadence.yaml
+++ b/sweeps/generate_dataset_cadence.yaml
@@ -10,6 +10,8 @@ command:
   - ${args_no_hyphens}
 name: generate_dataset_cadence_sweep
 method: grid
+# grid ignores `metric` at scheduling time; the field stays for dashboard
+# legibility on runs that do log it.
 metric:
   goal: minimize
   name: render.samples_per_shard

--- a/sweeps/generate_dataset_cadence.yaml
+++ b/sweeps/generate_dataset_cadence.yaml
@@ -1,0 +1,24 @@
+program: src/synth_setter/cli/generate_dataset.py
+# Hardcoded — wandb sweep CLI does not support OmegaConf resolvers.
+# WANDB_ENTITY / WANDB_PROJECT env vars override these at runtime.
+entity: tinaudio
+project: synth-setter
+command:
+  - ${interpreter}
+  - ${program}
+  - experiment=generate_dataset/smoke-shard
+  - ${args_no_hyphens}
+name: generate_dataset_cadence_sweep
+method: grid
+metric:
+  goal: minimize
+  name: render.samples_per_shard
+parameters:
+  render.plugin_reload_cadence:
+    values:
+      - once
+      - render
+  render.gui_toggle_cadence:
+    values:
+      - never
+      - once

--- a/tests/test_wandb_sweep_generate_dataset.py
+++ b/tests/test_wandb_sweep_generate_dataset.py
@@ -62,20 +62,25 @@ def _compose_dataset_cfg(
     :returns: Composed DictConfig ready for ``spec_from_cfg``.
     """
     GlobalHydra.instance().clear()
-    with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
-        cfg = compose(
-            config_name="dataset",
-            overrides=[
-                "experiment=generate_dataset/smoke-shard",
-                f"render.plugin_reload_cadence={plugin_reload_cadence}",
-                f"render.gui_toggle_cadence={gui_toggle_cadence}",
-            ],
-        )
-    with open_dict(cfg):
-        cfg.paths.root_dir = str(paths_root)
-        cfg.paths.output_dir = str(paths_root)
-        cfg.paths.work_dir = str(paths_root)
-    return cfg
+    try:
+        with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
+            cfg = compose(
+                config_name="dataset",
+                overrides=[
+                    "experiment=generate_dataset/smoke-shard",
+                    f"render.plugin_reload_cadence={plugin_reload_cadence}",
+                    f"render.gui_toggle_cadence={gui_toggle_cadence}",
+                ],
+            )
+        with open_dict(cfg):
+            cfg.paths.root_dir = str(paths_root)
+            cfg.paths.output_dir = str(paths_root)
+            cfg.paths.work_dir = str(paths_root)
+        return cfg
+    finally:
+        # Leave GlobalHydra clean so later tests that call initialize_*
+        # without their own pre-clear do not hit "already initialized".
+        GlobalHydra.instance().clear()
 
 
 @pytest.mark.slow
@@ -106,14 +111,19 @@ def test_wandb_grid_sweep_threads_cadence_overrides(
     """
     # Local import: wandb is optional at install time, gated by RunIf(wandb=True).
     import wandb
-
     from synth_setter.cli.generate_dataset import spec_from_cfg
 
     monkeypatch.delenv("WANDB_MODE", raising=False)
+    # Pin W&B's per-run output dir under tmp_path so wandb.init() does not
+    # drop a `./wandb/` directory into the repo checkout for local runs.
+    monkeypatch.setenv("WANDB_DIR", str(tmp_path))
 
     sweep_cfg = yaml.safe_load(_SWEEP_YAML.read_text())
-    entity = os.environ.get("WANDB_ENTITY", sweep_cfg.get("entity"))
-    project = os.environ.get("WANDB_PROJECT", sweep_cfg.get("project", "synth-setter"))
+    # `or` (not the dict default) — CI templating sometimes exports an
+    # empty WANDB_ENTITY / WANDB_PROJECT, and "" would silently shadow the
+    # YAML's hardcoded values and crash inside wandb.sweep().
+    entity = os.environ.get("WANDB_ENTITY") or sweep_cfg.get("entity")
+    project = os.environ.get("WANDB_PROJECT") or sweep_cfg.get("project", "synth-setter")
 
     observed: set[tuple[str, str]] = set()
 

--- a/tests/test_wandb_sweep_generate_dataset.py
+++ b/tests/test_wandb_sweep_generate_dataset.py
@@ -1,0 +1,138 @@
+"""End-to-end test for the ``generate_dataset`` W&B grid sweep over render cadences.
+
+Exercises the ``sweeps/generate_dataset_cadence.yaml`` plumbing on the live
+W&B backend: registers the sweep, then drives an in-process agent that
+threads each swept ``render.plugin_reload_cadence`` / ``render.gui_toggle_cadence``
+cell through the same Hydra compose path the CLI uses, and confirms the
+constructed ``DatasetSpec`` carries the swept values.
+
+The trial body deliberately stops at ``spec_from_cfg`` — the cadence
+validator (``RenderConfig._always_on_requires_plugin_reload_once``) fires
+inside compose, before any rendering side effect, so this test costs nothing
+on R2 / SkyPilot / VST3 while still catching regressions in the
+``${args_no_hyphens}`` → Hydra → ``RenderConfig`` round-trip.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+from hydra import compose, initialize_config_module
+from hydra.core.global_hydra import GlobalHydra
+from omegaconf import open_dict
+
+from tests.helpers.run_if import RunIf
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
+
+_SWEEP_YAML = Path(__file__).resolve().parent.parent / "sweeps" / "generate_dataset_cadence.yaml"
+
+# 2x2 grid — every cell satisfies the RenderConfig cross-field validator on
+# Linux (where CI runs); the "always_on + render" rejection cell is covered
+# by the render-matrix workflow's contract job, not by this test.
+_EXPECTED_CELLS: frozenset[tuple[str, str]] = frozenset(
+    {
+        ("once", "never"),
+        ("once", "once"),
+        ("render", "never"),
+        ("render", "once"),
+    }
+)
+
+
+def _compose_dataset_cfg(
+    plugin_reload_cadence: str, gui_toggle_cadence: str, paths_root: Path
+) -> DictConfig:
+    """Compose the smoke-shard dataset cfg with the swept cadence overrides.
+
+    :param plugin_reload_cadence: Value the sweep agent selected for
+        ``render.plugin_reload_cadence``.
+    :param gui_toggle_cadence: Value the sweep agent selected for
+        ``render.gui_toggle_cadence``.
+    :param paths_root: Per-test scratch dir; pinned into ``cfg.paths.*`` so
+        ``spec_from_cfg``'s ``resolve=True`` does not trip on the unresolved
+        ``${hydra:runtime.output_dir}`` interpolation.
+
+    :returns: Composed DictConfig ready for ``spec_from_cfg``.
+    """
+    GlobalHydra.instance().clear()
+    with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
+        cfg = compose(
+            config_name="dataset",
+            overrides=[
+                "experiment=generate_dataset/smoke-shard",
+                f"render.plugin_reload_cadence={plugin_reload_cadence}",
+                f"render.gui_toggle_cadence={gui_toggle_cadence}",
+            ],
+        )
+    with open_dict(cfg):
+        cfg.paths.root_dir = str(paths_root)
+        cfg.paths.output_dir = str(paths_root)
+        cfg.paths.work_dir = str(paths_root)
+    return cfg
+
+
+@pytest.mark.slow
+@pytest.mark.network
+@RunIf(wandb=True)
+@pytest.mark.skipif(
+    not os.environ.get("WANDB_API_KEY"),
+    reason="WANDB_API_KEY not set — wandb sweep requires the live backend (offline mode is unsupported for sweeps).",
+)
+def test_wandb_grid_sweep_threads_cadence_overrides(tmp_path: Path) -> None:
+    """Live W&B grid sweep over the two render cadence params on smoke-shard.
+
+    Registers a grid sweep on the configured entity/project (overridable via
+    ``WANDB_ENTITY`` / ``WANDB_PROJECT``), runs the agent in-process via
+    ``function=trial`` so each cell stays within this interpreter, and
+    asserts every (plugin_reload_cadence, gui_toggle_cadence) cell threads
+    cleanly through Hydra into the constructed ``DatasetSpec``.
+
+    :param tmp_path: Per-test scratch dir handed to ``_compose_dataset_cfg``
+        so ``cfg.paths.*`` resolves without leaking into the operator
+        workspace.
+    """
+    import wandb
+
+    from synth_setter.cli.generate_dataset import spec_from_cfg
+
+    sweep_cfg = yaml.safe_load(_SWEEP_YAML.read_text())
+    entity = os.environ.get("WANDB_ENTITY", sweep_cfg.get("entity"))
+    project = os.environ.get("WANDB_PROJECT", sweep_cfg.get("project", "synth-setter"))
+
+    observed: set[tuple[str, str]] = set()
+
+    def trial() -> None:
+        # Force online mode — sweeps require the live backend, so silently
+        # honoring a leaked WANDB_MODE=offline from another test would mask
+        # a real failure as a green run.
+        with wandb.init(mode="online") as run:
+            plugin_reload_cadence = run.config["render.plugin_reload_cadence"]
+            gui_toggle_cadence = run.config["render.gui_toggle_cadence"]
+            cfg = _compose_dataset_cfg(plugin_reload_cadence, gui_toggle_cadence, tmp_path)
+            spec = spec_from_cfg(cfg)
+            assert spec.render.plugin_reload_cadence == plugin_reload_cadence
+            assert spec.render.gui_toggle_cadence == gui_toggle_cadence
+            run.log(
+                {
+                    "plugin_reload_cadence_observed": spec.render.plugin_reload_cadence,
+                    "gui_toggle_cadence_observed": spec.render.gui_toggle_cadence,
+                    "render.samples_per_shard": spec.render.samples_per_shard,
+                }
+            )
+            observed.add((spec.render.plugin_reload_cadence, spec.render.gui_toggle_cadence))
+
+    sweep_id = wandb.sweep(sweep_cfg, entity=entity, project=project)
+    wandb.agent(
+        sweep_id, function=trial, entity=entity, project=project, count=len(_EXPECTED_CELLS)
+    )
+
+    assert observed == _EXPECTED_CELLS, (
+        f"Sweep agent did not observe the full grid: missing "
+        f"{_EXPECTED_CELLS - observed}, extra {observed - _EXPECTED_CELLS}"
+    )

--- a/tests/test_wandb_sweep_generate_dataset.py
+++ b/tests/test_wandb_sweep_generate_dataset.py
@@ -1,21 +1,16 @@
 """End-to-end test for the ``generate_dataset`` W&B grid sweep over render cadences.
 
-Exercises the ``sweeps/generate_dataset_cadence.yaml`` plumbing on the live
-W&B backend: registers the sweep, then drives an in-process agent that
-threads each swept ``render.plugin_reload_cadence`` / ``render.gui_toggle_cadence``
-cell through the same Hydra compose path the CLI uses, and confirms the
-constructed ``DatasetSpec`` carries the swept values.
-
-The trial body deliberately stops at ``spec_from_cfg`` — the cadence
-validator (``RenderConfig._always_on_requires_plugin_reload_once``) fires
-inside compose, before any rendering side effect, so this test costs nothing
-on R2 / SkyPilot / VST3 while still catching regressions in the
-``${args_no_hyphens}`` → Hydra → ``RenderConfig`` round-trip.
+Stops at ``spec_from_cfg`` so the cross-field validator
+(``RenderConfig._always_on_requires_plugin_reload_once``) fires inside Hydra
+compose — no R2 / SkyPilot / VST3 cost — while still catching regressions
+in the ``${args_no_hyphens}`` → Hydra → ``RenderConfig`` round-trip.
 """
 
 from __future__ import annotations
 
+import itertools
 import os
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -32,17 +27,23 @@ if TYPE_CHECKING:
 
 _SWEEP_YAML = Path(__file__).resolve().parent.parent / "sweeps" / "generate_dataset_cadence.yaml"
 
-# 2x2 grid — every cell satisfies the RenderConfig cross-field validator on
-# Linux (where CI runs); the "always_on + render" rejection cell is covered
-# by the render-matrix workflow's contract job, not by this test.
-_EXPECTED_CELLS: frozenset[tuple[str, str]] = frozenset(
-    {
-        ("once", "never"),
-        ("once", "once"),
-        ("render", "never"),
-        ("render", "once"),
-    }
-)
+
+def _expected_cells_from_yaml() -> frozenset[tuple[str, str]]:
+    """Cartesian product of the cadence param values declared in the sweep YAML.
+
+    Reading the grid out of the YAML rather than hardcoding it keeps this test from drifting
+    silently when an operator edits the sweep config.
+
+    :returns: Every (plugin_reload_cadence, gui_toggle_cadence) cell the sweep advertises to W&B.
+    """
+    cfg = yaml.safe_load(_SWEEP_YAML.read_text())
+    params = cfg["parameters"]
+    plug = params["render.plugin_reload_cadence"]["values"]
+    gui = params["render.gui_toggle_cadence"]["values"]
+    return frozenset(itertools.product(plug, gui))
+
+
+_EXPECTED_CELLS = _expected_cells_from_yaml()
 
 
 def _compose_dataset_cfg(
@@ -50,13 +51,13 @@ def _compose_dataset_cfg(
 ) -> DictConfig:
     """Compose the smoke-shard dataset cfg with the swept cadence overrides.
 
-    :param plugin_reload_cadence: Value the sweep agent selected for
-        ``render.plugin_reload_cadence``.
-    :param gui_toggle_cadence: Value the sweep agent selected for
-        ``render.gui_toggle_cadence``.
-    :param paths_root: Per-test scratch dir; pinned into ``cfg.paths.*`` so
-        ``spec_from_cfg``'s ``resolve=True`` does not trip on the unresolved
-        ``${hydra:runtime.output_dir}`` interpolation.
+    :param plugin_reload_cadence: One of ``{"once", "render"}`` (matches
+        ``_PluginReloadCadence`` in ``pipeline/schemas/spec.py``).
+    :param gui_toggle_cadence: One of ``{"never", "once", "render", "always_on"}``;
+        ``"always_on"`` requires ``plugin_reload_cadence == "once"`` per the
+        ``RenderConfig`` cross-field validator.
+    :param paths_root: Pinned into ``cfg.paths.*`` so ``spec_from_cfg``'s
+        ``resolve=True`` does not trip on ``${hydra:runtime.output_dir}``.
 
     :returns: Composed DictConfig ready for ``spec_from_cfg``.
     """
@@ -82,24 +83,33 @@ def _compose_dataset_cfg(
 @RunIf(wandb=True)
 @pytest.mark.skipif(
     not os.environ.get("WANDB_API_KEY"),
-    reason="WANDB_API_KEY not set — wandb sweep requires the live backend (offline mode is unsupported for sweeps).",
+    reason="WANDB_API_KEY not set — sweeps need the live W&B backend.",
 )
-def test_wandb_grid_sweep_threads_cadence_overrides(tmp_path: Path) -> None:
+def test_wandb_grid_sweep_threads_cadence_overrides(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Live W&B grid sweep over the two render cadence params on smoke-shard.
 
     Registers a grid sweep on the configured entity/project (overridable via
     ``WANDB_ENTITY`` / ``WANDB_PROJECT``), runs the agent in-process via
     ``function=trial`` so each cell stays within this interpreter, and
-    asserts every (plugin_reload_cadence, gui_toggle_cadence) cell threads
-    cleanly through Hydra into the constructed ``DatasetSpec``.
+    asserts every (plugin_reload_cadence, gui_toggle_cadence) cell declared
+    in the sweep YAML threads cleanly through Hydra into the constructed
+    ``DatasetSpec``.
 
     :param tmp_path: Per-test scratch dir handed to ``_compose_dataset_cfg``
         so ``cfg.paths.*`` resolves without leaking into the operator
         workspace.
+    :param monkeypatch: Used to scrub ``WANDB_MODE`` from the environment so
+        a leaked ``offline`` value cannot silently neuter ``wandb.sweep`` /
+        ``wandb.agent`` (sweeps require the live backend).
     """
+    # Local import: wandb is optional at install time, gated by RunIf(wandb=True).
     import wandb
 
     from synth_setter.cli.generate_dataset import spec_from_cfg
+
+    monkeypatch.delenv("WANDB_MODE", raising=False)
 
     sweep_cfg = yaml.safe_load(_SWEEP_YAML.read_text())
     entity = os.environ.get("WANDB_ENTITY", sweep_cfg.get("entity"))
@@ -108,31 +118,36 @@ def test_wandb_grid_sweep_threads_cadence_overrides(tmp_path: Path) -> None:
     observed: set[tuple[str, str]] = set()
 
     def trial() -> None:
-        # Force online mode — sweeps require the live backend, so silently
-        # honoring a leaked WANDB_MODE=offline from another test would mask
-        # a real failure as a green run.
         with wandb.init(mode="online") as run:
-            plugin_reload_cadence = run.config["render.plugin_reload_cadence"]
-            gui_toggle_cadence = run.config["render.gui_toggle_cadence"]
-            cfg = _compose_dataset_cfg(plugin_reload_cadence, gui_toggle_cadence, tmp_path)
+            plug = run.config["render.plugin_reload_cadence"]
+            gui = run.config["render.gui_toggle_cadence"]
+            cfg = _compose_dataset_cfg(plug, gui, tmp_path)
             spec = spec_from_cfg(cfg)
-            assert spec.render.plugin_reload_cadence == plugin_reload_cadence
-            assert spec.render.gui_toggle_cadence == gui_toggle_cadence
+            cell = (spec.render.plugin_reload_cadence, spec.render.gui_toggle_cadence)
+            assert cell in _EXPECTED_CELLS, f"unexpected sweep cell {cell!r}"
             run.log(
                 {
-                    "plugin_reload_cadence_observed": spec.render.plugin_reload_cadence,
-                    "gui_toggle_cadence_observed": spec.render.gui_toggle_cadence,
-                    "render.samples_per_shard": spec.render.samples_per_shard,
+                    "plugin_reload_cadence_observed": cell[0],
+                    "gui_toggle_cadence_observed": cell[1],
                 }
             )
-            observed.add((spec.render.plugin_reload_cadence, spec.render.gui_toggle_cadence))
+            observed.add(cell)
 
     sweep_id = wandb.sweep(sweep_cfg, entity=entity, project=project)
-    wandb.agent(
-        sweep_id, function=trial, entity=entity, project=project, count=len(_EXPECTED_CELLS)
-    )
+    try:
+        wandb.agent(
+            sweep_id, function=trial, entity=entity, project=project, count=len(_EXPECTED_CELLS)
+        )
+    finally:
+        # Stop the sweep on the server so repeated CI runs do not leak
+        # half-grids into the W&B project history.
+        try:
+            wandb.Api().sweep(f"{entity}/{project}/{sweep_id}").stop()
+        except Exception as cleanup_exc:  # noqa: BLE001 — best-effort cleanup
+            warnings.warn(f"wandb sweep cleanup failed: {cleanup_exc!r}", stacklevel=1)
 
+    missing = sorted(_EXPECTED_CELLS - observed)
+    extra = sorted(observed - _EXPECTED_CELLS)
     assert observed == _EXPECTED_CELLS, (
-        f"Sweep agent did not observe the full grid: missing "
-        f"{_EXPECTED_CELLS - observed}, extra {observed - _EXPECTED_CELLS}"
+        f"Sweep agent did not observe the full grid: missing={missing}, extra={extra}"
     )

--- a/tests/test_wandb_sweep_generate_dataset.py
+++ b/tests/test_wandb_sweep_generate_dataset.py
@@ -111,6 +111,7 @@ def test_wandb_grid_sweep_threads_cadence_overrides(
     """
     # Local import: wandb is optional at install time, gated by RunIf(wandb=True).
     import wandb
+
     from synth_setter.cli.generate_dataset import spec_from_cfg
 
     monkeypatch.delenv("WANDB_MODE", raising=False)

--- a/tests/test_wandb_sweep_generate_dataset.py
+++ b/tests/test_wandb_sweep_generate_dataset.py
@@ -1,9 +1,14 @@
 """End-to-end test for the ``generate_dataset`` W&B grid sweep over render cadences.
 
-Stops at ``spec_from_cfg`` so the cross-field validator
-(``RenderConfig._always_on_requires_plugin_reload_once``) fires inside Hydra
-compose — no R2 / SkyPilot / VST3 cost — while still catching regressions
-in the ``${args_no_hyphens}`` → Hydra → ``RenderConfig`` round-trip.
+Drives the sweep in-process via ``wandb.agent(function=trial)``; each
+trial pulls swept values off ``run.config`` and threads them through
+``compose(... overrides=[...])`` into ``spec_from_cfg``. Stops at
+``spec_from_cfg`` so the cross-field validator
+(``RenderConfig._always_on_requires_plugin_reload_once``) fires without
+any R2 / SkyPilot / VST3 cost. The sweep YAML's ``command:`` /
+``${args_no_hyphens}`` templating is **not** exercised by the in-process
+agent path; a separate static assertion pins that contract so the
+subprocess-launched (operator-facing) form stays well-formed.
 """
 
 from __future__ import annotations
@@ -162,3 +167,20 @@ def test_wandb_grid_sweep_threads_cadence_overrides(
     assert observed == _EXPECTED_CELLS, (
         f"Sweep agent did not observe the full grid: missing={missing}, extra={extra}"
     )
+
+
+def test_sweep_yaml_command_includes_args_no_hyphens() -> None:
+    """Pin the operator-facing ``command:`` shape so subprocess agents stay wired.
+
+    The in-process agent path consumes ``run.config`` directly and bypasses
+    the YAML's ``command:`` list, so the live-backend test above never
+    notices if ``${args_no_hyphens}`` (or the ``program`` / ``interpreter``
+    placeholders) drop out. A subprocess-launched ``wandb agent`` would,
+    though — and silently degrade to single-cell runs.
+    """
+    cfg = yaml.safe_load(_SWEEP_YAML.read_text())
+    command = cfg["command"]
+    assert command[0] == "${interpreter}", command
+    assert command[1] == "${program}", command
+    assert "${args_no_hyphens}" in command, command
+    assert any(tok.startswith("experiment=") for tok in command), command


### PR DESCRIPTION
## Summary

- Adds `sweeps/generate_dataset_cadence.yaml` — a 2x2 W&B grid sweep over
  `render.plugin_reload_cadence` x `render.gui_toggle_cadence`, modelled on
  `sweeps/ksin.yaml`.
- Adds `tests/test_wandb_sweep_generate_dataset.py` — registers the sweep
  on the live W&B backend and drives an in-process agent via
  `function=trial`, asserting every grid cell declared in the sweep YAML
  threads cleanly through Hydra into the constructed `DatasetSpec`.

The trial body stops at `spec_from_cfg`, so this exercises the
`${args_no_hyphens}` -> Hydra -> `RenderConfig` plumbing (including the
cross-field validator) without incurring VST3 / R2 / SkyPilot cost. The
test is marked `slow` + `network` and skips without `WANDB_API_KEY`
(sweeps require the live backend — offline mode is unsupported).

Pre-PR multi-skill review (code-health, synth-setter-project-standards,
python-style, tdd-implementation, comment-hygiene) was run; findings
addressed in the second commit (YAML-driven grid, `WANDB_MODE` scrub,
best-effort sweep cleanup, tightened comments).

Closes #1305.

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `pytest tests/test_wandb_sweep_generate_dataset.py` skips cleanly
      without `WANDB_API_KEY`
- [x] Smoke-check of `_compose_dataset_cfg` confirms all four grid cells
      thread through `spec_from_cfg` with the expected cadence values
- [ ] CI green
- [ ] Live wandb run (manual, with `WANDB_API_KEY`) — verify agent
      enumerates every YAML-declared grid cell