### PR TITLE
ci: fix by hoist r2 fields out of f-string in nightly-parallel-datagen

### DIFF
--- a/.github/workflows/nightly-parallel-datagen.yml
+++ b/.github/workflows/nightly-parallel-datagen.yml
@@ -169,6 +169,8 @@ jobs:
       # URI isn't reproducible from ``(experiment, run_id)`` alone. Read it from
       # the locally-written spec under
       # ``<workspace>/data/<task_name>/<run_id>/metadata/input_spec.json``.
+      # Hoist ``r2["bucket"]`` / ``r2["prefix"]`` to locals: Python <3.12 rejects
+      # ``\"`` inside f-string parts, and the single-quoted heredoc forbids ``'``.
       - name: Resolve spec_uri from local materialized spec
         id: spec_uri
         env:
@@ -185,9 +187,9 @@ jobs:
           SPEC_PATH="${specs[0]}"
           SPEC_URI=$(python3 -c '
           import json, sys
-          spec = json.load(open(sys.argv[1]))
-          r2 = spec["r2"]
-          print(f"r2://{r2[\"bucket\"]}/{r2[\"prefix\"]}input_spec.json")
+          r2 = json.load(open(sys.argv[1]))["r2"]
+          bucket, prefix = r2["bucket"], r2["prefix"]
+          print(f"r2://{bucket}/{prefix}input_spec.json")
           ' "${SPEC_PATH}")
           R2_PREFIX=$(python3 -c '
           import json, sys


### PR DESCRIPTION
## Summary

- The nightly cron's `Resolve spec_uri from local materialized spec` step has been failing every night (latest: [run 26494852896, job 78020533537](https://github.com/tinaudio/synth-setter/actions/runs/26494852896/job/78020533537), tracked in #1237) with:

  ```
  File "<string>", line 5
      print(f"r2://{r2[\"bucket\"]}/{r2[\"prefix\"]}input_spec.json")
  SyntaxError: f-string expression part cannot include a backslash
  ```

- The runner is `ubuntu-22.04` (Python 3.10); the `\"` inside the f-string expression part is rejected before 3.12. The script is wrapped in a single-quoted shell heredoc, so inner `'` isn't an option either.

- Read `bucket` / `prefix` into locals before the f-string so the expression parts only reference bare names. No behavior change. Regression came from #1303 (the step was introduced there to replace the old stdout-sentinel routing).

## Test plan

- [x] Reproduce the failure locally on Python 3.10 with the original snippet — `SyntaxError` as observed in CI.
- [x] Run the fixed snippet locally on Python 3.10 — prints the expected `r2://<bucket>/<prefix>input_spec.json` URI.
- [ ] Next scheduled nightly run (or manual `workflow_dispatch`) succeeds end-to-end through the validate step.

Fixes #1237.