### PR TITLE
test(baseline): accept new top-level evaluation key in predict-config diff

### DIFF
--- a/tests/test_compare_baseline_configs.py
+++ b/tests/test_compare_baseline_configs.py
@@ -318,6 +318,7 @@ ACCEPTED_DIFFS: tuple[str, ...] = (
     "data.dataset_root",
     "data.predict_file",
     "data.stats_file",
+    "evaluation",  # eval CLI predict-mode post-processing block; not a model knob
 )
 
 # Leaf-name keys stripped at every nesting depth. Use this list (vs. ACCEPTED_DIFFS)


### PR DESCRIPTION
Fixes #1309.

## Summary
- Nightly run [#26497078329](https://github.com/tinaudio/synth-setter/actions/runs/26497078329/job/78027819804) failed every `test_predict_configs_are_equal[v0.0.0_vs_live__predict_*]` parametrization.
- Root cause: PR #1291 (`refactor(eval): fold VST render + audio metrics into evaluate()`) added a new top-level `evaluation:` block to `src/synth_setter/configs/eval.yaml` gating in-process VST render + audio metrics. The `v0.0.0` baseline doesn't have it, so the resolved-config equality check flags `Right contains 1 more item: {'evaluation': {...}}`.
- The block is equivalent to the pre-#1291 `surge_xt_interactive.py`-driven render+metrics step (just folded into the eval CLI) — not a model knob — so it gets the same `ACCEPTED_DIFFS` treatment as `logger.tensorboard` and the other post-`v0.0.0` additions.

Closes the nightly red status until the `v0.0.0` baseline is itself rebaselined (the existing block comment on lines 305-311 already advises that as the preferred long-term fix).

## Test plan
- [x] `uv run pytest tests/test_compare_baseline_configs.py -k "not slow and not network and not _equal"` — all 14 fast tests pass.
- [x] All 18 previously-failing `test_predict_configs_are_equal[v0.0.0_vs_live__predict_*]` parametrizations pass locally (18/18 in 2:56). Full evidence in the verification comment below.
- [x] All 52 train-side baseline parametrizations still pass (no regression, 52/52 in 7:39).
- [ ] Next nightly turns green on the `test_predict_configs_are_equal[v0.0.0_vs_live__predict_*]` cases.