### PR TITLE
feat(cli): finalize_inline flag for synth-setter-generate-dataset

### DIFF
--- a/.github/workflows/generate-and-finalize-dataset.yaml
+++ b/.github/workflows/generate-and-finalize-dataset.yaml
@@ -1,0 +1,93 @@
+name: Generate + Finalize Dataset (inline)
+
+# Runs synth-setter-generate-dataset with finalize_inline=true so the
+# canonical dataset.complete marker is written by the same CLI process
+# that uploaded the shards. Mirrors finalize-dataset.yaml's bare-runner
+# install (no docker, no SkyPilot path); the experiment chosen at
+# dispatch time decides which spec is generated.
+#
+# Required secrets (callers should `secrets: inherit`):
+#   RCLONE_CONFIG_R2_ACCESS_KEY_ID, RCLONE_CONFIG_R2_SECRET_ACCESS_KEY,
+#   RCLONE_CONFIG_R2_ENDPOINT — same R2 credentials the standalone
+#   generate / finalize stages use.
+
+on:
+  workflow_dispatch:
+    inputs:
+      experiment:
+        description: "Experiment YAML stem under configs/experiment/generate_dataset/"
+        required: true
+        type: string
+        default: smoke-shard-with-finalize
+      env_ref:
+        description: "Git ref / SHA to check out"
+        required: false
+        type: string
+        default: ""
+  workflow_call:
+    inputs:
+      experiment:
+        required: true
+        type: string
+      env_ref:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  generate_and_finalize:
+    name: Run generate_dataset (finalize_inline=true)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      RCLONE_CONFIG_R2_TYPE: s3
+      RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+      RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+      RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+      RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+      HYDRA_FULL_ERROR: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.env_ref != '' && inputs.env_ref || github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install rclone
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
+
+      # `pipeline.data.reshard` transitively touches the torch-gated `data/`
+      # package — CPU torch is the minimum that resolves all imports.
+      - name: Install project deps (uv sync --frozen, CPU torch)
+        run: uv sync --frozen --extra cpu --no-default-groups --group dev
+
+      - name: Run synth-setter-generate-dataset (finalize_inline)
+        env:
+          EXPERIMENT: ${{ inputs.experiment }}
+          PROJECT_ROOT: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          uv run synth-setter-generate-dataset \
+            "experiment=generate_dataset/${EXPERIMENT}" \
+            "finalize_inline=true" \
+            2>&1 | tee generate-and-finalize.log
+
+      - name: Upload log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: generate-and-finalize-log-${{ inputs.experiment }}
+          path: generate-and-finalize.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -155,30 +155,26 @@ def finalize_hdf5(spec: DatasetSpec, work_dir: Path) -> None:
     logger.info("uploaded stats to {}", spec.r2.stats_uri())
 
 
-def finalize(cfg: DictConfig) -> None:
-    """Finalize the R2 prefix for ``cfg.dataset_spec_uri``; idempotent on ``dataset.complete``.
+def finalize_from_spec(spec: DatasetSpec, work_dir: Path) -> None:
+    """Finalize a dataset given an in-memory spec; idempotent on ``dataset.complete``.
 
     Returns without work when the marker already exists at the run prefix —
     R2 is the source of truth (per ``pipeline/CLAUDE.md``). The branch on
     ``spec.output_format`` writes the derived artifacts; the marker is
     uploaded strictly last so an interrupted run never advertises artifacts
-    that have not landed.
+    that have not landed. Caller is responsible for ensuring R2 creds are
+    loaded.
 
-    :param cfg: Composed cfg with ``dataset_spec_uri`` (URI accepted by
-        :func:`~synth_setter.pipeline.spec_io.load_spec_from_uri`) and
-        ``paths.output_dir`` (writable scratch dir; created if missing;
-        retained after the call, multi-GB on the hdf5 branch).
+    :param spec: Validated dataset spec.
+    :param work_dir: Writable scratch dir; created if missing; retained
+        after the call (multi-GB on the hdf5 branch).
     :raises ValueError: ``spec.output_format`` is neither ``"hdf5"`` nor ``"wds"``.
     """
-    r2_io.ensure_r2_env_loaded()
-    spec = load_spec_from_uri(cfg.dataset_spec_uri)
-
     marker_uri = spec.r2.dataset_complete_marker_uri()
     if r2_io.object_size(marker_uri) is not None:
         logger.info("skip: {} already exists, run is finalized", marker_uri)
         return
 
-    work_dir = Path(cfg.paths.output_dir)
     work_dir.mkdir(parents=True, exist_ok=True)
     if spec.output_format == "wds":
         finalize_wds(spec, work_dir)
@@ -191,6 +187,23 @@ def finalize(cfg: DictConfig) -> None:
     marker_local.touch()
     r2_io.upload(marker_local, marker_uri)
     logger.info("wrote dataset.complete to {}", marker_uri)
+
+
+def finalize(cfg: DictConfig) -> None:
+    """Finalize the R2 prefix for ``cfg.dataset_spec_uri``; idempotent on ``dataset.complete``.
+
+    Loads R2 creds and the spec from ``cfg.dataset_spec_uri``, then delegates
+    to :func:`finalize_from_spec` for the marker-probe → dispatch → marker-upload
+    body.
+
+    :param cfg: Composed cfg with ``dataset_spec_uri`` (URI accepted by
+        :func:`~synth_setter.pipeline.spec_io.load_spec_from_uri`) and
+        ``paths.output_dir`` (writable scratch dir; created if missing;
+        retained after the call, multi-GB on the hdf5 branch).
+    """
+    r2_io.ensure_r2_env_loaded()
+    spec = load_spec_from_uri(cfg.dataset_spec_uri)
+    finalize_from_spec(spec, Path(cfg.paths.output_dir))
 
 
 @hydra.main(

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -25,6 +25,7 @@ from hydra.core.hydra_config import HydraConfig
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
+from synth_setter.cli.finalize_dataset import finalize_from_spec
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.pipeline import r2_io
 from synth_setter.pipeline.constants import WORKER_SPEC_URI_ENV
@@ -52,6 +53,7 @@ _NON_SPEC_KEYS: tuple[str, ...] = (
     "hydra",
     "run_name",
     "skypilot_launch",
+    "finalize_inline",
 )
 
 # Local spec-mirror anchor; ``operator_workspace()`` also publishes
@@ -504,7 +506,17 @@ def main(cfg: DictConfig) -> None:
 
     if sky_cfg.compute_template is None:
         generate(spec, Path(cfg.paths.output_dir))
+        if cfg.finalize_inline:
+            finalize_from_spec(spec, _OPERATOR_WORKSPACE)
         return
+
+    if cfg.finalize_inline:
+        logger.info(
+            "finalize_inline=true ignored: "
+            f"skypilot_launch.compute_template={sky_cfg.compute_template!r} "
+            "dispatches to a worker; finalize runs out-of-band via the "
+            "finalize-dataset workflow."
+        )
 
     # Deferred import — SkyPilot pulls heavy provider SDKs on import.
     from synth_setter.pipeline.skypilot_launch import dispatch_via_skypilot

--- a/src/synth_setter/configs/dataset.yaml
+++ b/src/synth_setter/configs/dataset.yaml
@@ -29,6 +29,11 @@ base_seed: 42
 # bins instead of raising. Smoke configs override to ``true``.
 mask_degenerate_bins: false
 
+# Run synth-setter-finalize-dataset inline after generate completes.
+# Local-run path only; ignored (with an INFO log) when
+# skypilot_launch.compute_template is set.
+finalize_inline: false
+
 # Null default: ``DatasetSpec._drop_null_run_id`` mode='before' validator pops
 # a ``None`` ``run_id`` so the field's ``default_factory`` (``_default_run_id``)
 # fires from ``task_name`` + ``created_at``. Keeping the key present lets the

--- a/src/synth_setter/configs/experiment/generate_dataset/smoke-shard-with-finalize.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/smoke-shard-with-finalize.yaml
@@ -1,0 +1,9 @@
+# @package _global_
+
+# Used by the generate-and-finalize-dataset workflow; mirrors
+# smoke-shard.yaml but produces dataset.complete in one CLI process.
+defaults:
+  - /experiment/generate_dataset/smoke-shard@_global_
+  - _self_
+
+finalize_inline: true

--- a/src/synth_setter/pipeline/ci/spec_uri.py
+++ b/src/synth_setter/pipeline/ci/spec_uri.py
@@ -80,6 +80,7 @@ _NON_SPEC_CFG_KEYS: tuple[str, ...] = (
     "hydra",
     "run_name",
     "skypilot_launch",
+    "finalize_inline",
 )
 
 

--- a/tests/pipeline/test_entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_finalize_dataset.py
@@ -242,6 +242,53 @@ def test_finalize_uploads_stats_then_marker_at_canonical_uris(
     assert upload_order.index(stats_uri) < upload_order.index(marker_uri)
 
 
+def test_finalize_from_spec_uploads_stats_then_marker_at_canonical_uris(
+    tmp_path: Path,
+    fake_r2_remote: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_finalize_setup: Callable[[int | None], None],  # noqa: ARG001 — installs stubs only
+) -> None:
+    """``finalize_from_spec`` honors the marker-last ordering without re-loading the spec.
+
+    Mirrors ``test_finalize_uploads_stats_then_marker_at_canonical_uris`` but
+    calls the in-memory entry point directly — no ``cfg`` synthesis, no
+    ``load_spec_from_uri`` round-trip — so the inline path
+    (``generate_dataset.main`` will reuse) is pinned independently of the
+    URI-driven entry point.
+
+    :param tmp_path: Hosts the Hydra-style work_dir.
+    :param fake_r2_remote: Local-typed rclone remote; both artifacts land here.
+    :param monkeypatch: Pytest fixture used to wrap ``synth_setter.pipeline.r2_io.upload``
+        with an order-recording spy that still delegates to the real helper.
+    :param stub_finalize_setup: Fixture-activation only — installs the
+        ``ensure_r2_env_loaded`` / ``object_size`` stubs.
+    """
+    spec = _build_wds_smoke_spec(task_name="finalize-from-spec-marker-last")
+    _seed_train_shards(fake_r2_remote, spec)
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+
+    real_upload = r2_io.upload
+    upload_order: list[str] = []
+
+    def spy_upload(src: str | Path, dst: str) -> None:
+        upload_order.append(dst)
+        real_upload(src, dst)
+
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.upload", spy_upload)
+
+    finalize_dataset.finalize_from_spec(spec, work_dir)
+
+    stats_uri = spec.r2.stats_uri()
+    marker_uri = spec.r2.dataset_complete_marker_uri()
+    assert _uri_to_local_path(fake_r2_remote, stats_uri).is_file()
+    assert _uri_to_local_path(fake_r2_remote, marker_uri).is_file()
+    assert upload_order.count(stats_uri) == 1
+    assert upload_order.count(marker_uri) == 1
+    assert upload_order.index(marker_uri) == len(upload_order) - 1
+    assert upload_order.index(stats_uri) < upload_order.index(marker_uri)
+
+
 def test_finalize_is_idempotent_when_marker_already_exists(
     tmp_path: Path,
     fake_r2_remote: Path,

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1518,6 +1518,131 @@ class TestMainDispatchBranches:
         with pytest.raises(ValueError, match="skypilot_launch.cmd is launcher-internal"):
             gd.main()
 
+    def test_main_finalize_inline_true_invokes_finalize_from_spec(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """finalize_inline=true on the local-run branch invokes finalize_from_spec.
+
+        Composes a real ``smoke-shard`` experiment with the new flag set,
+        stubs ``generate`` to a no-op, and replaces ``finalize_from_spec``
+        with a mock so the test pins the wire (call + spec identity)
+        without needing real rclone against a finalize-shaped remote. The
+        end-to-end marker upload is already covered by the Phase 1
+        ``test_finalize_from_spec_uploads_stats_then_marker_at_canonical_uris``
+        sibling test.
+
+        :param monkeypatch: Pytest fixture used to patch argv +
+            ``generate`` + ``finalize_from_spec``.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+            "finalize_inline=true",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+
+        captured: dict[str, object] = {}
+
+        def _capture_spec(spec: object, _work_dir: Path) -> None:
+            captured["spec"] = spec
+
+        monkeypatch.setattr(gd, "generate", _capture_spec)
+        finalize_mock = MagicMock()
+        monkeypatch.setattr(gd, "finalize_from_spec", finalize_mock)
+
+        gd.main()
+
+        finalize_mock.assert_called_once()
+        called_spec, called_work_dir = finalize_mock.call_args[0]
+        assert isinstance(called_spec, DatasetSpec)
+        assert called_spec is captured["spec"]
+        assert isinstance(called_work_dir, Path)
+
+    def test_main_finalize_inline_default_false_skips_finalize(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Default ``finalize_inline=false`` leaves the existing local-run shape unchanged.
+
+        Pins the opt-in invariant — no finalize fires when the operator
+        omits the override.
+
+        :param monkeypatch: Pytest fixture used to patch argv +
+            ``generate`` + ``finalize_from_spec``.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        monkeypatch.setattr(gd, "generate", lambda _spec, _work_dir: None)
+        finalize_mock = MagicMock()
+        monkeypatch.setattr(gd, "finalize_from_spec", finalize_mock)
+
+        gd.main()
+
+        finalize_mock.assert_not_called()
+
+    @patch("synth_setter.cli.generate_dataset.logger")
+    def test_main_finalize_inline_ignored_in_dispatch_branch(
+        self,
+        mock_logger: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """finalize_inline=true is ignored (with INFO log) when dispatching to SkyPilot.
+
+        SkyPilot delegation hands the run to a worker pod; finalize must
+        run out-of-band via the finalize-dataset workflow rather than fire
+        from the launcher process. Pins both halves: ``finalize_from_spec``
+        is not called, and an INFO log line mentions the override was ignored.
+
+        :param mock_logger: Patched ``generate_dataset.logger`` — the
+            established loguru capture pattern in this file.
+        :param monkeypatch: Pytest fixture used to patch argv + dispatch +
+            ``finalize_from_spec`` (asserted unreached).
+        :param tmp_path: Pytest fixture providing a fresh test directory for
+            the minimal compute template.
+        """
+        import synth_setter.cli.generate_dataset as gd
+        import synth_setter.pipeline.skypilot_launch as sl
+
+        template = tmp_path / "template.yaml"
+        template.write_text("resources:\n  cloud: runpod\nenvs:\n  X: ''\n")
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+            f"skypilot_launch.compute_template={template}",
+            "finalize_inline=true",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        monkeypatch.setattr(sl, "dispatch_via_skypilot", lambda *_a, **_k: None)
+        monkeypatch.setattr(
+            gd,
+            "generate",
+            lambda *_a, **_k: pytest.fail("generate must not fire on dispatch branch"),
+        )
+        finalize_mock = MagicMock()
+        monkeypatch.setattr(gd, "finalize_from_spec", finalize_mock)
+
+        gd.main()
+
+        finalize_mock.assert_not_called()
+        info_messages = [str(c.args[0]) for c in mock_logger.info.call_args_list]
+        ignored_lines = [m for m in info_messages if "finalize_inline=true ignored" in m]
+        assert len(ignored_lines) == 1, (
+            f"expected exactly one INFO log mentioning 'finalize_inline=true ignored'; "
+            f"got messages: {info_messages!r}"
+        )
+
 
 class TestMainSpecPersistence:
     """``main()`` writes the local spec, loads R2 env, uploads the canonical spec on every path.


### PR DESCRIPTION
## Summary

Adds an opt-in `finalize_inline` flag to `synth-setter-generate-dataset` so the local-run path produces `dataset.complete` in the same CLI process that rendered the shards — collapsing the two-step generate + finalize handoff into one invocation for the small-volume smoke path. Ships in three phases per the S-doc; all three land here.

- **Phase 1** (`eb519404`) extracts `finalize_from_spec(spec, work_dir)` from `finalize_dataset.finalize(cfg)`; the URI-driven entry point now just loads creds + spec and delegates. New test `test_finalize_from_spec_uploads_stats_then_marker_at_canonical_uris` pins the in-memory wire.
- **Phase 2** (`ad82d926`) wires the flag through `generate_dataset.main()`. Local-run branch calls `finalize_from_spec` after `generate` returns; SkyPilot dispatch branch logs an INFO and ignores it (finalize there continues to run out-of-band via the finalize-dataset workflow). Three new tests cover both polarities and the dispatch-branch ignored path.
- **Phase 3** (`da83b655`) adds the `Generate + Finalize Dataset (inline)` workflow plus the `smoke-shard-with-finalize` experiment. Body shape mirrors `finalize-dataset.yaml` (bare-runner uv install, R2 env from the same secrets).

Default remains `finalize_inline: false` — every existing caller keeps its current shape until it opts in.

## Test plan

- [x] `uv run pytest tests/pipeline/test_entrypoints/test_finalize_dataset.py tests/pipeline/test_entrypoints/test_generate_dataset.py tests/integration/test_finalize_dataset_r2.py` — 79 tests pass locally.
- [x] `uv run pre-commit run --files` on every touched file passes (ruff, pyright, pydoclint, prettier, check-github-workflows).
- [x] `uv run python -c "<compose smoke-shard-with-finalize>"` resolves `cfg.finalize_inline == True`.
- [x] gha-workflow-validator: 8 passed, 0 failures (one informational tag-pinning note matches existing project convention in `finalize-dataset.yaml`).
- [ ] Trigger `Generate + Finalize Dataset (inline)` via "Run workflow" in the GitHub UI on this branch and confirm `rclone ls r2:<bucket>/data/smoke-shard/<run_id>/dataset.complete` returns a non-zero-byte marker. *(Manual verification — pending merge / branch availability in the workflow picker.)*

Fixes #1312