### PR TITLE
chore(generate_dataset): address generate_dataset review WARNs from PR #1311

### DIFF
--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -1,12 +1,13 @@
 """Spec-driven generate_dataset runner.
 
-Two console-script surfaces:
+Two ``@hydra.main`` console-script surfaces share the dataset config:
 
 - ``synth-setter-generate-dataset`` → :func:`main` — operator entry; runs the
   spec in-process or dispatches it to SkyPilot based on
   ``cfg.skypilot_launch.compute_template``.
 - ``synth-setter-generate-dataset-from-hydra`` → :func:`from_hydra` — worker
-  entry; pure ``@hydra.main`` re-compose so launcher/worker share argv.
+  entry; SkyPilot re-invokes it with the launcher's overrides replayed so
+  composition matches byte-for-byte.
 """
 
 from __future__ import annotations
@@ -116,30 +117,24 @@ def build_generate_args(spec: DatasetSpec, shard: ShardSpec, output_dir: Path) -
 
 
 def generate(spec: DatasetSpec, work_dir: Path) -> None:
-    """Render+upload each owned shard; writes shards under ``work_dir``.
+    """Render+upload each owned shard; fail-fast on subprocess error.
 
-    ``work_dir`` is the Hydra per-run output dir supplied by the caller.
-    Spec upload no longer happens here — ``main()`` writes the canonical R2
-    copy once on the launcher host before either calling
-    ``generate(spec, work_dir)`` inline (local-run) or dispatching to a
-    SkyPilot worker pod that re-enters via
-    ``from_hydra`` → ``generate(spec, work_dir)``. Subprocesses fail-fast:
-    later shards are not attempted on subprocess error.
+    Before each render, R2 is probed for the shard's destination object: if it
+    already exists with non-zero size, the shard is skipped (resumability MVP
+    — see #750). The probe uses ``check=True``, so a non-zero rclone exit
+    (auth, network) propagates as a hard failure rather than degrading
+    silently into a re-render.
 
-    Before each render, R2 is probed for the shard's destination object: if it already exists with
-    non-zero size, the shard is skipped (resumability MVP — see #750). The probe uses
-    ``check=True``, so a non-zero rclone exit (auth, network) propagates as a hard failure rather
-    than degrading silently into a re-render.
+    The launcher builds the spec interpreter-only (no pedalboard / X11)
+    trusting ``configs/render/<spec>.yaml``; the worker — which has pedalboard
+    — verifies the plugin and the pinned ``renderer_version`` agree.
 
-    The launcher builds the spec interpreter-only (no pedalboard / X11) trusting
-    ``configs/render/<spec>.yaml``; this is where the worker — which has pedalboard
-    — verifies the plugin and pinned ``renderer_version`` agree.
-
-    :param spec: Validated dataset spec; rank/world env partitions ``spec.shards``
-        across worker pods, and ``spec.render.renderer_version`` is cross-checked
-        against the loaded plugin.
-    :param work_dir: Caller-supplied output dir (the Hydra per-run output dir);
-        created if missing. Shards are written here before the rclone upload.
+    :param spec: Validated dataset spec; rank/world env partitions
+        ``spec.shards`` across worker pods, and
+        ``spec.render.renderer_version`` is cross-checked against the loaded
+        plugin.
+    :param work_dir: Created if missing; peak local disk per rank scales with
+        ``len(my_range) * shard_size`` (shards persist after upload).
     :raises RuntimeError: If the worker's plugin version disagrees with
         ``spec.render.renderer_version``.
     """
@@ -167,8 +162,8 @@ def generate(spec: DatasetSpec, work_dir: Path) -> None:
     r2_dest_prefix = spec.r2.rclone_prefix()
     work_dir.mkdir(parents=True, exist_ok=True)
 
-    # ``start`` brackets only the dispatch call so the rate still includes the
-    # in-loop R2 skip probes (observable cost of the resumability MVP, #750).
+    # ``start`` brackets only the dispatch call; the rate includes in-loop R2
+    # skip probes (observable cost of the resumability MVP, #750).
     start = time.perf_counter()
     if spec.render.parallel and len(my_range) > 0:
         rendered, skipped = _dispatch_shards_parallel(spec, my_range, work_dir, r2_dest_prefix)
@@ -235,7 +230,8 @@ def _dispatch_shards_parallel(
 
     :param spec: Validated dataset spec.
     :param my_range: Non-empty contiguous range of shard IDs owned by this rank.
-    :param work_dir: Hydra per-run output dir; every owned shard lands here.
+    :param work_dir: Hydra per-run output dir; up to ``workers`` shards are
+        actively being written here at once on top of the retained set.
     :param r2_dest_prefix: ``spec.r2.rclone_prefix()``.
     :returns: ``(rendered, skipped)`` summary counts over ``my_range``.
     """
@@ -445,6 +441,10 @@ def _build_worker_cmd(overrides: list[str], spec: DatasetSpec) -> str:
     :param spec: Launcher's ``DatasetSpec``; runtime fields are pinned into
         the worker overrides for compose determinism.
     :return: Bash one-liner suitable for use as a ``sky.Task`` ``run:`` block.
+        The worker's ``${hydra:runtime.output_dir}`` will not match the
+        launcher's — each side resolves its own timestamp via
+        ``configs/hydra/default.yaml``; that's intentional (each pod owns
+        its run dir).
     """
     pinned_overrides = [f"+created_at={spec.created_at.isoformat()}"]
     all_overrides = list(overrides) + pinned_overrides
@@ -469,21 +469,20 @@ def from_hydra(cfg: DictConfig) -> None:
 
 @hydra.main(version_base="1.3", config_path="pkg://synth_setter.configs", config_name="dataset")
 def main(cfg: DictConfig) -> None:
-    """Operator CLI: run the composed dataset spec locally or dispatch to SkyPilot.
+    """Persist the canonical spec to R2, then run locally or dispatch to SkyPilot.
 
-    Worker-side overrides are replayed verbatim under ``_build_worker_cmd`` so
-    the launcher/worker composition matches byte-for-byte; ``HydraConfig`` is
-    the authoritative source for the operator's task overrides.
+    Dispatches via SkyPilot when ``cfg.skypilot_launch.compute_template`` is
+    set; otherwise calls ``generate()`` inline.
 
-    :param cfg: Hydra-composed dataset cfg.
+    :param cfg: Hydra-composed dataset cfg; ``cfg.paths.output_dir`` is the
+        per-run dir supplied by ``@hydra.main``.
     """
     overrides = list(HydraConfig.get().overrides.task)
     spec = spec_from_cfg(cfg)
     sky_cfg = _sky_cfg_from_dataset_cfg(cfg)
 
-    # ``_OPERATOR_WORKSPACE`` is the launcher-side spec-mirror anchor; the
-    # Hydra per-run dir (``cfg.paths.output_dir``) is shard-scoped, not the
-    # operator-side artifact root.
+    # ``_OPERATOR_WORKSPACE`` (not ``cfg.paths.output_dir``) — the spec mirror
+    # is operator-side and outlives the Hydra per-run dir.
     spec_path = write_spec_locally(spec, _OPERATOR_WORKSPACE)
     logger.info(f"wrote local spec to {spec_path}")
 

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -63,6 +63,25 @@ _OPERATOR_WORKSPACE = operator_workspace()
 # launcher's workspace (which may not exist on the worker filesystem).
 _WORKER_REPO_ROOT = "/home/build/synth-setter"
 
+# Shared decorator so both surfaces stay locked to the same compose triple
+# (drift between them silently picks up the wrong config).
+_dataset_hydra_main = hydra.main(
+    version_base="1.3",
+    config_path="pkg://synth_setter.configs",
+    config_name="dataset",
+)
+
+
+def _hydra_work_dir(cfg: DictConfig) -> Path:
+    """Return the per-run Hydra output dir as a ``Path``.
+
+    :param cfg: Composed dataset cfg whose ``paths.output_dir`` interpolates
+        from ``${hydra:runtime.output_dir}``.
+    :returns: ``Path(cfg.paths.output_dir)`` — the work_dir both entrypoints
+        feed into ``generate``.
+    """
+    return Path(cfg.paths.output_dir)
+
 
 def _rclone_copy(src: str, dest: str) -> None:
     """Upload a file to R2 via rclone with checksum verification.
@@ -457,17 +476,17 @@ def _build_worker_cmd(overrides: list[str], spec: DatasetSpec) -> str:
     return " && ".join(parts)
 
 
-@hydra.main(version_base="1.3", config_path="pkg://synth_setter.configs", config_name="dataset")
+@_dataset_hydra_main
 def from_hydra(cfg: DictConfig) -> None:
     """Worker-side @hydra.main entry: build the spec and render it in-process.
 
     :param cfg: Composed Hydra dataset cfg supplied by ``@hydra.main`` from
         the worker's argv overrides.
     """
-    generate(spec_from_cfg(cfg), Path(cfg.paths.output_dir))
+    generate(spec_from_cfg(cfg), _hydra_work_dir(cfg))
 
 
-@hydra.main(version_base="1.3", config_path="pkg://synth_setter.configs", config_name="dataset")
+@_dataset_hydra_main
 def main(cfg: DictConfig) -> None:
     """Persist the canonical spec to R2, then run locally or dispatch to SkyPilot.
 
@@ -477,7 +496,7 @@ def main(cfg: DictConfig) -> None:
     :param cfg: Hydra-composed dataset cfg; ``cfg.paths.output_dir`` is the
         per-run dir supplied by ``@hydra.main``.
     """
-    overrides = list(HydraConfig.get().overrides.task)
+    overrides = [str(o) for o in HydraConfig.get().overrides.task]
     spec = spec_from_cfg(cfg)
     sky_cfg = _sky_cfg_from_dataset_cfg(cfg)
 
@@ -502,7 +521,7 @@ def main(cfg: DictConfig) -> None:
     spec_uri = spec.r2.input_spec_uri()
 
     if sky_cfg.compute_template is None:
-        generate(spec, Path(cfg.paths.output_dir))
+        generate(spec, _hydra_work_dir(cfg))
         return
 
     # Deferred import — SkyPilot pulls heavy provider SDKs on import.

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -114,6 +114,28 @@ def _renderer_argv_lists(mock: MagicMock) -> list[list[str]]:
     ]
 
 
+def _pin_hydra_isolation(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Pin rank/world and redirect ``PROJECT_ROOT`` so ``@hydra.main`` per-run dirs land in tmp.
+
+    The three ``main()``-exercising test classes share this isolation pattern;
+    centralising it here prevents drift across the autouse fixtures.
+
+    :param monkeypatch: Pytest fixture used to set env vars.
+    :param tmp_path: Per-test tmp dir hosting ``PROJECT_ROOT``.
+    """
+    monkeypatch.setenv("SYNTH_SETTER_WORKER_RANK", "0")
+    monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "1")
+    monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+
+
+def _noop_generate(_spec: object, _work_dir: object) -> None:
+    """No-op stand-in for ``generate(spec, work_dir)`` in launcher-only tests.
+
+    :param _spec: Ignored; underscore-prefixed to signal disuse.
+    :param _work_dir: Ignored; underscore-prefixed to signal disuse.
+    """
+
+
 def _base_spec_kwargs(tmp_path: Path, **overrides: object) -> dict[str, object]:
     """Return valid DatasetSpec kwargs for direct construction."""
     kwargs: dict[str, object] = {
@@ -264,7 +286,7 @@ class TestRun:
         :param patched_subprocess: Subprocess dispatcher used to introspect the
             single renderer call's argv.
         :param spec: Fixture-provided ``DatasetSpec``.
-        :param tmp_path: Caller-supplied work_dir for ``generate()``.
+        :param tmp_path: Doubles as the ``work_dir`` passed to ``generate``.
         """
         generate(spec, tmp_path)
 
@@ -290,7 +312,7 @@ class TestRun:
         :param patched_subprocess: Subprocess dispatcher used to introspect the
             renderer argv (looking for the headless-wrapper prefix on Linux).
         :param spec: Fixture-provided ``DatasetSpec``.
-        :param tmp_path: Caller-supplied work_dir for ``generate()``.
+        :param tmp_path: Doubles as the ``work_dir`` passed to ``generate``.
         """
         generate(spec, tmp_path)
 
@@ -324,7 +346,7 @@ class TestRun:
         :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
         :param patched_subprocess: Fixture-activation only (handles the
             ``subprocess.check_call`` patch).
-        :param tmp_path: Caller-supplied work_dir for ``generate()``.
+        :param tmp_path: Doubles as the ``work_dir`` passed to ``generate``.
         """
         generate(spec, tmp_path)
 
@@ -345,7 +367,7 @@ class TestRun:
         :param spec: Fixture-provided ``DatasetSpec``.
         :param fake_r2_remote: Local-typed rclone remote — asserted empty since
             no shard should land when the renderer fails.
-        :param tmp_path: Caller-supplied work_dir for ``generate()``.
+        :param tmp_path: Doubles as the ``work_dir`` passed to ``generate``.
         """
         patched_subprocess.side_effect = subprocess.CalledProcessError(
             1, "generate_vst_dataset.py"
@@ -377,7 +399,7 @@ class TestRun:
         :param spec: Fixture-provided ``DatasetSpec``.
         :param monkeypatch: Used to invalidate the ``r2:`` remote type so the
             real rclone subprocess exits non-zero on the copy.
-        :param tmp_path: Caller-supplied work_dir for ``generate()``.
+        :param tmp_path: Doubles as the ``work_dir`` passed to ``generate``.
         """
         monkeypatch.setenv("RCLONE_CONFIG_R2_TYPE", "this-backend-does-not-exist")
 
@@ -460,7 +482,7 @@ class TestRun:
 
         :param fake_r2_remote: Local-typed R2 remote — asserted to contain every
             shard alongside the on-disk copies.
-        :param tmp_path: Caller-supplied work_dir for ``generate()``.
+        :param tmp_path: Doubles as the ``work_dir`` passed to ``generate``.
         """
         spec = _multi_shard_spec(tmp_path, n=3)
 
@@ -527,7 +549,7 @@ class TestRun:
         :param fake_r2_remote: Local-typed R2 remote — must remain empty since
             no shard file is written and rclone is therefore never invoked.
         :param spec: Fixture-provided ``DatasetSpec``.
-        :param tmp_path: Caller-supplied work_dir for ``generate()``.
+        :param tmp_path: Doubles as the ``work_dir`` passed to ``generate``.
         """
         # Renderer-only side effect: return 0 without writing the shard file,
         # so the ``shard_path.is_file()`` guard raises before any rclone call.
@@ -733,7 +755,7 @@ class TestRun:
         :param spec: Fixture-provided ``DatasetSpec``.
         :param monkeypatch: Used to override the probe to claim the shard is
             already in R2.
-        :param tmp_path: Caller-supplied work_dir for ``generate()``.
+        :param tmp_path: Doubles as the ``work_dir`` passed to ``generate``.
         """
         monkeypatch.setattr("synth_setter.pipeline.r2_io.object_size", lambda *_a, **_k: 12345)
 
@@ -757,7 +779,7 @@ class TestRun:
             to fire exactly once.
         :param fake_r2_remote: Local-typed R2 remote — shard should land here.
         :param spec: Fixture-provided ``DatasetSpec``.
-        :param tmp_path: Caller-supplied work_dir for ``generate()``.
+        :param tmp_path: Doubles as the ``work_dir`` passed to ``generate``.
         """
         generate(spec, tmp_path)
 
@@ -782,7 +804,7 @@ class TestRun:
         :param fake_r2_remote: Local-typed R2 remote — shard should land here.
         :param spec: Fixture-provided ``DatasetSpec``.
         :param monkeypatch: Used to override the probe to report 0 bytes.
-        :param tmp_path: Caller-supplied work_dir for ``generate()``.
+        :param tmp_path: Doubles as the ``work_dir`` passed to ``generate``.
         """
         monkeypatch.setattr("synth_setter.pipeline.r2_io.object_size", lambda *_a, **_k: 0)
 
@@ -933,7 +955,7 @@ class TestRun:
             invoked (the probe failure raises before any render/upload).
         :param spec: Fixture-provided ``DatasetSpec``.
         :param monkeypatch: Used to install the raising probe stub.
-        :param tmp_path: Caller-supplied work_dir for ``generate()``.
+        :param tmp_path: Doubles as the ``work_dir`` passed to ``generate``.
         """
 
         def _raise(*_a: object, **_k: object) -> None:
@@ -1362,18 +1384,13 @@ class TestMainDispatchBranches:
     """``main()`` composes the dataset cfg from argv, then dispatches local or via SkyPilot."""
 
     @pytest.fixture(autouse=True)
-    def _set_default_skypilot_env(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        """Pin single-worker rank/world + isolate Hydra's per-run dir to ``tmp_path``.
+    def _isolate_hydra(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Pin rank/world + ``PROJECT_ROOT`` so ``main()``'s Hydra dir lands under tmp.
 
-        ``@hydra.main`` resolves ``${paths.log_dir}`` from ``${oc.env:PROJECT_ROOT}``;
-        redirecting PROJECT_ROOT keeps the per-run dir under the test tree.
-
-        :param monkeypatch: Pytest fixture used to set env vars.
-        :param tmp_path: Per-test tmp dir hosting PROJECT_ROOT.
+        :param monkeypatch: Pytest fixture forwarded to ``_pin_hydra_isolation``.
+        :param tmp_path: Per-test tmp dir forwarded to ``_pin_hydra_isolation``.
         """
-        monkeypatch.setenv("SYNTH_SETTER_WORKER_RANK", "0")
-        monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "1")
-        monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+        _pin_hydra_isolation(monkeypatch, tmp_path)
 
     @pytest.fixture(autouse=True)
     def _stub_spec_io_in_main(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1530,18 +1547,13 @@ class TestMainSpecPersistence:
     """
 
     @pytest.fixture(autouse=True)
-    def _set_default_skypilot_env(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        """Pin single-worker rank/world + isolate Hydra's per-run dir to ``tmp_path``.
+    def _isolate_hydra(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Pin rank/world + ``PROJECT_ROOT`` so ``main()``'s Hydra dir lands under tmp.
 
-        ``@hydra.main`` resolves ``${paths.log_dir}`` from ``${oc.env:PROJECT_ROOT}``;
-        redirecting PROJECT_ROOT keeps the per-run dir under the test tree.
-
-        :param monkeypatch: Pytest fixture used to set env vars.
-        :param tmp_path: Per-test tmp dir hosting PROJECT_ROOT.
+        :param monkeypatch: Pytest fixture forwarded to ``_pin_hydra_isolation``.
+        :param tmp_path: Per-test tmp dir forwarded to ``_pin_hydra_isolation``.
         """
-        monkeypatch.setenv("SYNTH_SETTER_WORKER_RANK", "0")
-        monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "1")
-        monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+        _pin_hydra_isolation(monkeypatch, tmp_path)
 
     @pytest.fixture(autouse=True)
     def _stub_run_and_spec_io(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1555,7 +1567,7 @@ class TestMainSpecPersistence:
         """
         import synth_setter.cli.generate_dataset as gd
 
-        monkeypatch.setattr(gd, "generate", lambda _spec, _work_dir: None)
+        monkeypatch.setattr(gd, "generate", _noop_generate)
         monkeypatch.setattr(
             gd,
             "write_spec_locally",
@@ -1779,15 +1791,13 @@ class TestMainHydraOutputDir:
     """
 
     @pytest.fixture(autouse=True)
-    def _isolate_hydra_output_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        """Redirect PROJECT_ROOT to tmp so Hydra writes the per-run dir under the test tree.
+    def _isolate_hydra(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Pin rank/world + ``PROJECT_ROOT`` so ``main()``'s Hydra dir lands under tmp.
 
-        :param monkeypatch: Pytest fixture used to override env vars.
-        :param tmp_path: Per-test tmp dir hosting the synthetic checkout root.
+        :param monkeypatch: Pytest fixture forwarded to ``_pin_hydra_isolation``.
+        :param tmp_path: Per-test tmp dir forwarded to ``_pin_hydra_isolation``.
         """
-        monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
-        monkeypatch.setenv("SYNTH_SETTER_WORKER_RANK", "0")
-        monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "1")
+        _pin_hydra_isolation(monkeypatch, tmp_path)
 
     @pytest.fixture(autouse=True)
     def _stub_run_and_spec_io(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1797,7 +1807,7 @@ class TestMainHydraOutputDir:
         """
         import synth_setter.cli.generate_dataset as gd
 
-        monkeypatch.setattr(gd, "generate", lambda _spec, _work_dir: None)
+        monkeypatch.setattr(gd, "generate", _noop_generate)
         monkeypatch.setattr(
             gd,
             "write_spec_locally",

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1142,39 +1142,38 @@ class TestRun:
         assert renderer_calls == 3
         assert not (fake_r2_remote / spec.r2.bucket / spec.r2.prefix).exists()
 
-    def test_shard_lands_in_work_dir_before_upload(
+    def test_each_shard_lands_in_work_dir_before_its_upload(
         self,
         patched_subprocess: MagicMock,  # noqa: ARG002
-        spec: DatasetSpec,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Caller-supplied ``work_dir`` hosts the rendered shard at the upload boundary.
+        """Every owned shard exists at ``work_dir / shard.filename`` when its upload fires.
 
-        Stubs ``_rclone_copy`` to snapshot the source path and its on-disk
-        existence at the upload moment — proving the shard landed at
-        ``work_dir / shard.filename`` before the upload runs.
+        Stubs ``_rclone_copy`` to snapshot the source path + existence at
+        each upload moment. Asserts the invariant across a 3-shard spec —
+        catches a regression where only the first shard lands before
+        upload (single-shard coverage misses that class of bug).
 
         :param patched_subprocess: Fixture-activation only; renderer side of the
-            dispatcher materializes the shard file into ``work_dir``.
-        :param spec: Fixture-provided single-shard ``DatasetSpec``.
-        :param tmp_path: Caller-supplied work_dir for this run.
+            dispatcher materializes each shard file into ``work_dir``.
+        :param tmp_path: Doubles as the ``work_dir`` passed to ``generate``.
         :param monkeypatch: Used to install the rclone-stub that captures the
-            shard path + existence at the upload moment.
+            shard path + existence at every upload moment.
         """
-        captured: dict[str, object] = {}
+        spec = _multi_shard_spec(tmp_path, n=3)
+        captured: list[tuple[Path, bool]] = []
 
         def _capture_src(src: str, _dest: str) -> None:
             src_path = Path(src)
-            captured["src"] = src_path
-            captured["existed_at_upload"] = src_path.is_file()
+            captured.append((src_path, src_path.is_file()))
 
         monkeypatch.setattr("synth_setter.cli.generate_dataset._rclone_copy", _capture_src)
 
         generate(spec, tmp_path)
 
-        assert captured["src"] == tmp_path / spec.shards[0].filename
-        assert captured["existed_at_upload"] is True
+        assert [src for src, _ in captured] == [tmp_path / s.filename for s in spec.shards]
+        assert all(existed for _, existed in captured)
 
 
 # ---------------------------------------------------------------------------
@@ -1820,18 +1819,24 @@ class TestMainHydraOutputDir:
         )
         monkeypatch.setattr(gd.r2_io, "ensure_r2_env_loaded", MagicMock(return_value=None))
 
-    def test_main_resolves_output_dir_under_hydra_main(
-        self, monkeypatch: pytest.MonkeyPatch
+    def test_main_forwards_hydra_per_run_dir_into_generate(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """Inside main(), cfg.paths.output_dir equals HydraConfig.get().runtime.output_dir.
+        """``main()`` feeds the Hydra per-run output dir into ``generate(spec, work_dir)``.
 
-        Pins the @hydra.main decoration contract: the per-run dir is supplied by
-        Hydra runtime rather than pinned by the launcher to a hand-picked anchor.
+        Behavioral assertions: the work_dir handed to ``generate`` is (a) under
+        the test's ``PROJECT_ROOT`` (so PROJECT_ROOT actually drives Hydra's
+        path resolution) and (b) a real dir on disk by the time ``generate``
+        sees it. Avoids the prior tautology of asserting
+        ``cfg.paths.output_dir == HydraConfig.get().runtime.output_dir`` —
+        that's true by construction under ``@hydra.main`` and would survive a
+        regression where the value drifted away from the per-run dir entirely.
 
-        :param monkeypatch: Pytest fixture used to patch ``sys.argv`` + capture cfg.
+        :param monkeypatch: Pytest fixture used to patch ``sys.argv`` + capture
+            ``generate``'s ``work_dir`` argument.
+        :param tmp_path: Doubles as ``PROJECT_ROOT`` (via the autouse fixture);
+            the Hydra per-run dir must land beneath it.
         """
-        from hydra.core.hydra_config import HydraConfig
-
         import synth_setter.cli.generate_dataset as gd
 
         argv = [
@@ -1841,19 +1846,20 @@ class TestMainHydraOutputDir:
         ]
         monkeypatch.setattr("sys.argv", argv)
 
-        observed: dict[str, str] = {}
-        real_spec_from_cfg = gd.spec_from_cfg
+        captured: dict[str, Path] = {}
 
-        def _capture_then_build(cfg: object) -> DatasetSpec:
-            observed["output_dir"] = cfg.paths.output_dir  # type: ignore[attr-defined]
-            observed["runtime_output_dir"] = HydraConfig.get().runtime.output_dir
-            return real_spec_from_cfg(cfg)  # type: ignore[arg-type]
+        def _capture_work_dir(_spec: object, work_dir: Path) -> None:
+            captured["work_dir"] = work_dir
 
-        monkeypatch.setattr(gd, "spec_from_cfg", _capture_then_build)
+        monkeypatch.setattr(gd, "generate", _capture_work_dir)
 
         gd.main()
 
-        assert observed["output_dir"] == observed["runtime_output_dir"]
+        work_dir = captured["work_dir"]
+        assert work_dir.is_relative_to(tmp_path), (
+            f"Hydra per-run dir {work_dir} is not under PROJECT_ROOT {tmp_path}"
+        )
+        assert work_dir.is_dir()
 
 
 def test_smoke_job_name_rejects_unsafe_task_name() -> None:


### PR DESCRIPTION
Closes #1314. Follow-up to merged PR #1311.

Applies the highest-value review WARNs surfaced by the 7-skill
`repo-review-full-no-comments` pass against PR #1311 (full sentinel
posted as [#1311 inline comment](https://github.com/tinaudio/synth-setter/pull/1311#issuecomment-4555620873)).

Four focused commits, two files (`src/synth_setter/cli/generate_dataset.py`
and `tests/pipeline/test_entrypoints/test_generate_dataset.py`):

## Commits

1. **`docs(cli): tighten generate_dataset docstrings`** — module-header
   asymmetry, `generate()` migration narrative, missing peak-disk note,
   `_dispatch_shards_parallel` lost asymmetry, `main()` contract leakage,
   `_build_worker_cmd` launcher/worker divergence note, in-loop "still
   includes" delta phrasing, `_OPERATOR_WORKSPACE` write-site comment.
2. **`refactor(cli): dedup @hydra.main triple + coerce overrides to str`** —
   lift `hydra.main(...)` triple to module-level `_dataset_hydra_main`,
   extract `_hydra_work_dir(cfg)`, coerce
   `HydraConfig.get().overrides.task` per element so `list[str]` survives
   the shell-quote boundary.
3. **`test(generate_dataset): dedup hydra-isolation fixtures + noop generate
   stub`** — three near-identical autouse fixtures collapsed to
   `_pin_hydra_isolation`; three `lambda _spec, _work_dir: None` stubs
   collapsed to `_noop_generate`; 11 most-repeated `:param tmp_path:`
   filler lines tightened.
4. **`test(generate_dataset): strengthen Hydra-output and per-shard upload
   coverage`** — `test_main_resolves_output_dir_under_hydra_main` (asserted
   a Hydra-by-construction tautology) → `test_main_forwards_hydra_per_run_dir_into_generate`
   (asserts the captured `work_dir` is under `PROJECT_ROOT` and exists on
   disk by the time `generate` sees it). `test_shard_lands_in_work_dir_before_upload`
   extended to `test_each_shard_lands_in_work_dir_before_its_upload`
   covering a 3-shard spec.

## Deferred (not in this PR)

- `logger.info(f"...")` → pattern-parameter migration — pre-existing
  convention across the whole file; project-wide change.
- `work_dir.mkdir(parents=True, exist_ok=True)` staleness guard — corner
  case is non-trivial to guard cleanly under the Hydra per-run dir
  contract.
- Schema/content invariants on `test_shards_persist_after_upload` —
  would require synthesising valid HDF5 content in the test fixture.

## Test plan

- [x] `uv run pytest tests/pipeline/test_entrypoints/test_generate_dataset.py` — 55 pass
- [x] `pre-commit run --files <changed>` — ruff / pyright / docformatter / pydoclint / interrogate / codespell green
- [ ] CI on this branch (runs on push)