### PR TITLE
test(testing): parametrized subprocess smoke for synth-setter-generate-dataset CLI

### DIFF
--- a/tests/test_generate_dataset_cli_overrides.py
+++ b/tests/test_generate_dataset_cli_overrides.py
@@ -1,0 +1,44 @@
+"""Parametrized subprocess smoke for the ``synth-setter-generate-dataset`` CLI.
+
+Each parametrize case is a single string of Hydra-style overrides; the test
+body shells out to the installed entrypoint and lets ``check=True`` raise on
+any non-zero exit. The list is intentionally tiny — extend ``OVERRIDE_ARGS``
+with whatever override combinations you want to pin.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+
+import pytest
+
+_ENTRYPOINT = "synth-setter-generate-dataset"
+
+# ``render/surge_xt.yaml`` hardcodes ``plugin_path``, so the env var only
+# reaches the CLI when baked into the override string below. Matches the
+# convention in ``tests/data/vst/test_preset_params.py`` and friends.
+_PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
+
+OVERRIDE_ARGS: list[str] = [
+    # ``--help`` still walks the defaults list, so an ``experiment=`` override
+    # is required even for the cheapest invocation.
+    "experiment=generate_dataset/smoke-shard --help",
+    f"experiment=generate_dataset/smoke-shard render.plugin_path={shlex.quote(_PLUGIN_PATH)}",
+]
+
+
+@pytest.mark.slow
+@pytest.mark.network
+@pytest.mark.r2
+@pytest.mark.requires_vst
+@pytest.mark.parametrize("override_args", OVERRIDE_ARGS, ids=lambda s: s or "<empty>")
+def test_generate_dataset_cli_accepts_overrides(override_args: str) -> None:
+    """Invoke the CLI with ``override_args`` and assert it exits 0.
+
+    :param override_args: Whitespace-separated override string passed straight
+        through to the CLI after ``shlex.split``.
+    """
+    argv = [_ENTRYPOINT, *shlex.split(override_args)]
+    subprocess.run(argv, check=True)  # noqa: S603 — argv built from in-test literals

--- a/tests/test_generate_dataset_cli_overrides.py
+++ b/tests/test_generate_dataset_cli_overrides.py
@@ -29,16 +29,22 @@ OVERRIDE_ARGS: list[str] = [
 ]
 
 
+# Bounded so a hung VST init or stalled R2 upload can't block CI indefinitely.
+_CLI_TIMEOUT_S = 600
+
+
 @pytest.mark.slow
 @pytest.mark.network
 @pytest.mark.r2
 @pytest.mark.requires_vst
-@pytest.mark.parametrize("override_args", OVERRIDE_ARGS, ids=lambda s: s or "<empty>")
+@pytest.mark.parametrize("override_args", OVERRIDE_ARGS)
 def test_generate_dataset_cli_accepts_overrides(override_args: str) -> None:
-    """Invoke the CLI with ``override_args`` and assert it exits 0.
+    """Assert the CLI exits 0 for each override string (shlex-split into argv tail).
 
-    :param override_args: Whitespace-separated override string passed straight
-        through to the CLI after ``shlex.split``.
+    :param override_args: argv tail after ``shlex.split``; may mix Hydra overrides and flags.
     """
     argv = [_ENTRYPOINT, *shlex.split(override_args)]
-    subprocess.run(argv, check=True)  # noqa: S603 — argv built from in-test literals
+    # capture_output so CalledProcessError surfaces the actual error on CI.
+    subprocess.run(  # noqa: S603 — argv built from in-test literals
+        argv, check=True, capture_output=True, text=True, timeout=_CLI_TIMEOUT_S
+    )


### PR DESCRIPTION
## Summary

- Adds `tests/test_generate_dataset_cli_overrides.py`: one parametrized pytest where each entry is a single Hydra-override string passed to the installed `synth-setter-generate-dataset` entrypoint. Body splits with `shlex` and shells out under `check=True`.
- Seed list has two entries: the cheapest `--help` smoke and a real `experiment=generate_dataset/smoke-shard` render. Extend `OVERRIDE_ARGS` with whatever override combinations you want to pin as smoke checks.
- Markers: `slow`, `network`, `r2`, `requires_vst` — keeps it deselected by the default CI filter (`pyproject.toml:507`).
- Plugin path honors `SYNTH_SETTER_PLUGIN_PATH` (with `plugins/Surge XT.vst3` default), matching the convention used in `tests/data/vst/test_preset_params.py`, `tests/integration/test_parallel_shard_render_linux.py`, `tests/docker/test_smoke.py`, etc.

Sibling to the in-process W&B sweep test on the `test/wandb-sweep-cadence-e2e` branch (issue #1305) — that exercises the agent path in-process; this exercises the operator-facing CLI subprocess path.

Closes #1316

## Test plan

- [x] `pre-commit run --files tests/test_generate_dataset_cli_overrides.py` → all hooks pass locally
- [x] `SYNTH_SETTER_PLUGIN_PATH="/usr/lib/vst3/Surge XT.vst3" pytest tests/test_generate_dataset_cli_overrides.py -v` → 2 passed in 1:54 (the real smoke-shard case rendered audio + uploaded to R2)
- [ ] CI passes