### PR TITLE
feat(cli): oracle_eval_inline flag for synth-setter-generate-dataset

### DIFF
--- a/.github/workflows/generate-finalize-oracle-eval.yaml
+++ b/.github/workflows/generate-finalize-oracle-eval.yaml
@@ -89,11 +89,34 @@ jobs:
       # Lightning's `trainer.test()` prints the final metrics table to stdout;
       # parse it for `test/param_mse` and assert exactly zero — the load-bearing
       # oracle invariant. Fails the workflow on any non-zero / missing value.
-      - name: Assert oracle test/param_mse == 0.0
+      - name: Assert oracle test/param_mse == 0.0 (log)
         run: |
           set -euo pipefail
           uv run python -m synth_setter.evaluation.assert_oracle_invariant \
             generate-finalize-oracle-eval.log
+
+      # Independent structured cross-check: `cli/eval.py` writes the metric_dict
+      # JSON under <eval-dir>/metrics/metrics.json. Globbing under the operator
+      # workspace finds the one inline-eval run's artifact regardless of the
+      # spec's run_id, then asserts the same invariant from a non-stdout source.
+      - name: Locate metrics.json
+        id: locate_metrics
+        run: |
+          set -euo pipefail
+          metrics_path=$(find "${PROJECT_ROOT}/oracle_eval" -type f -name 'metrics.json' | head -n1)
+          if [ -z "${metrics_path}" ]; then
+            echo "::error::no metrics.json under ${PROJECT_ROOT}/oracle_eval"; exit 1
+          fi
+          echo "path=${metrics_path}" >> "${GITHUB_OUTPUT}"
+          echo "Located metrics.json at ${metrics_path}"
+        env:
+          PROJECT_ROOT: ${{ github.workspace }}
+
+      - name: Assert oracle test/param_mse == 0.0 (metrics.json)
+        run: |
+          set -euo pipefail
+          uv run python -m synth_setter.evaluation.assert_oracle_invariant \
+            --metrics-json "${{ steps.locate_metrics.outputs.path }}"
 
       - name: Upload log
         if: always()
@@ -101,5 +124,14 @@ jobs:
         with:
           name: generate-finalize-oracle-eval-log-${{ inputs.experiment }}
           path: generate-finalize-oracle-eval.log
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload metrics.json
+        if: always() && steps.locate_metrics.outputs.path != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: generate-finalize-oracle-eval-metrics-${{ inputs.experiment }}
+          path: ${{ steps.locate_metrics.outputs.path }}
           if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/generate-finalize-oracle-eval.yaml
+++ b/.github/workflows/generate-finalize-oracle-eval.yaml
@@ -86,11 +86,20 @@ jobs:
             "oracle_eval_inline=true" \
             2>&1 | tee generate-finalize-oracle-eval.log
 
+      # Lightning's `trainer.test()` prints the final metrics table to stdout;
+      # parse it for `test/param_mse` and assert exactly zero — the load-bearing
+      # oracle invariant. Fails the workflow on any non-zero / missing value.
+      - name: Assert oracle test/param_mse == 0.0
+        run: |
+          set -euo pipefail
+          uv run python -m synth_setter.evaluation.assert_oracle_invariant \
+            generate-finalize-oracle-eval.log
+
       - name: Upload log
         if: always()
         uses: actions/upload-artifact@v4
         with:
           name: generate-finalize-oracle-eval-log-${{ inputs.experiment }}
           path: generate-finalize-oracle-eval.log
-          if-no-files-found: warn
+          if-no-files-found: error
           retention-days: 7

--- a/.github/workflows/generate-finalize-oracle-eval.yaml
+++ b/.github/workflows/generate-finalize-oracle-eval.yaml
@@ -1,0 +1,96 @@
+name: Generate + Finalize + Oracle-Eval Dataset (inline)
+
+# Runs synth-setter-generate-dataset with finalize_inline=true and
+# oracle_eval_inline=true so the same CLI process that generated the
+# shards also writes dataset.complete and runs the surge/fake_oracle
+# eval against the finalized splits — proving the parameter-array
+# round-trip survived generate + finalize. Mirrors finalize-dataset.yaml's
+# bare-runner install (no docker, no SkyPilot path); the experiment chosen
+# at dispatch time decides which spec is generated.
+#
+# Required secrets (callers should `secrets: inherit`):
+#   RCLONE_CONFIG_R2_ACCESS_KEY_ID, RCLONE_CONFIG_R2_SECRET_ACCESS_KEY,
+#   RCLONE_CONFIG_R2_ENDPOINT — same R2 credentials the standalone
+#   generate / finalize stages use.
+
+on:
+  workflow_dispatch:
+    inputs:
+      experiment:
+        description: "Experiment YAML stem under configs/experiment/generate_dataset/"
+        required: true
+        type: string
+        default: smoke-shard-with-oracle-eval
+      env_ref:
+        description: "Git ref / SHA to check out"
+        required: false
+        type: string
+        default: ""
+  workflow_call:
+    inputs:
+      experiment:
+        required: true
+        type: string
+      env_ref:
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  generate_and_finalize_and_oracle_eval:
+    name: Run generate_dataset (finalize_inline=true, oracle_eval_inline=true)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      RCLONE_CONFIG_R2_TYPE: s3
+      RCLONE_CONFIG_R2_PROVIDER: Cloudflare
+      RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+      RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+      RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+      HYDRA_FULL_ERROR: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.env_ref != '' && inputs.env_ref || github.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install rclone
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
+
+      # `pipeline.data.reshard` transitively touches the torch-gated `data/`
+      # package — CPU torch is the minimum that resolves all imports.
+      - name: Install project deps (uv sync --frozen, CPU torch)
+        run: uv sync --frozen --extra cpu --no-default-groups --group dev
+
+      - name: Run synth-setter-generate-dataset (oracle_eval_inline)
+        env:
+          EXPERIMENT: ${{ inputs.experiment }}
+          PROJECT_ROOT: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          uv run synth-setter-generate-dataset \
+            "experiment=generate_dataset/${EXPERIMENT}" \
+            "finalize_inline=true" \
+            "oracle_eval_inline=true" \
+            2>&1 | tee generate-finalize-oracle-eval.log
+
+      - name: Upload log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: generate-finalize-oracle-eval-log-${{ inputs.experiment }}
+          path: generate-finalize-oracle-eval.log
+          if-no-files-found: warn
+          retention-days: 7

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -179,19 +179,14 @@ def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: D
 def evaluate(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     """Evaluate the given checkpoint on a datamodule testset.
 
-    This method is wrapped in optional @task_wrapper decorator, that controls the behavior during
-    failure. Useful for multiruns, saving info about the crash, etc.
+    Wrapped in ``@task_wrapper`` so crashes still flush the run dir.
 
-    :param cfg: DictConfig configuration composed by Hydra. ``cfg.ckpt_path``
-        may be ``None`` — Lightning's ``trainer.test`` / ``validate`` /
-        ``predict`` accept that and evaluate the in-memory model, which the
-        ``surge/fake_oracle`` baseline relies on for inline oracle-eval after
-        ``generate_dataset`` finalize.
-    :return: ``(metric_dict, object_dict)``. ``metric_dict`` is the
-        ``trainer.callback_metrics`` copy merged with any audio metrics from
-        :func:`_run_predict_postprocessing`; Lightning entries are ``torch.Tensor``
-        while audio entries are Python ``float``, so callers iterating values
-        must handle both.
+    :param cfg: Hydra-composed cfg; ``cfg.ckpt_path=None`` is allowed and
+        evaluates the in-memory model (Lightning's documented no-op).
+    :return: ``(metric_dict, object_dict)``. ``metric_dict`` merges
+        ``trainer.callback_metrics`` (``torch.Tensor`` values) with audio
+        metrics from :func:`_run_predict_postprocessing` (Python ``float``),
+        so callers iterating values must handle both.
     """
     log.info(f"Instantiating datamodule <{cfg.data._target_}>")
     datamodule: LightningDataModule = hydra.utils.instantiate(cfg.data)

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -182,15 +182,17 @@ def evaluate(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     This method is wrapped in optional @task_wrapper decorator, that controls the behavior during
     failure. Useful for multiruns, saving info about the crash, etc.
 
-    :param cfg: DictConfig configuration composed by Hydra.
+    :param cfg: DictConfig configuration composed by Hydra. ``cfg.ckpt_path``
+        may be ``None`` — Lightning's ``trainer.test`` / ``validate`` /
+        ``predict`` accept that and evaluate the in-memory model, which the
+        ``surge/fake_oracle`` baseline relies on for inline oracle-eval after
+        ``generate_dataset`` finalize.
     :return: ``(metric_dict, object_dict)``. ``metric_dict`` is the
         ``trainer.callback_metrics`` copy merged with any audio metrics from
         :func:`_run_predict_postprocessing`; Lightning entries are ``torch.Tensor``
         while audio entries are Python ``float``, so callers iterating values
         must handle both.
     """
-    assert cfg.ckpt_path
-
     log.info(f"Instantiating datamodule <{cfg.data._target_}>")
     datamodule: LightningDataModule = hydra.utils.instantiate(cfg.data)
 

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -1,5 +1,6 @@
 """Hydra entrypoint for evaluating a trained model on a datamodule's test split."""
 
+import json
 import subprocess
 import sys
 from contextlib import ExitStack
@@ -256,6 +257,34 @@ def evaluate(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     return metric_dict, object_dict
 
 
+def _dump_metric_dict(metric_dict: dict[str, Any], output_dir: Path) -> Path:
+    """Serialize ``metric_dict`` to ``<output_dir>/metrics/metrics.json``; return the path.
+
+    Lightning tensors and numpy arrays are coerced to native floats / lists
+    so downstream gates (workflow asserters, CSV joiners) can parse without
+    importing torch. Callers that want the structured artifact for a
+    pass/fail gate read from the returned path.
+
+    :param metric_dict: Return value of :func:`evaluate`'s first tuple element.
+    :param output_dir: Hydra per-run output dir; the ``metrics/`` subdir is
+        created if missing.
+    :returns: Absolute path to the written ``metrics.json``.
+    """
+    metrics_dir = output_dir / "metrics"
+    metrics_dir.mkdir(parents=True, exist_ok=True)
+    serializable: dict[str, Any] = {}
+    for key, value in metric_dict.items():
+        if hasattr(value, "item") and not hasattr(value, "__len__"):
+            serializable[key] = value.item()
+        elif hasattr(value, "tolist"):
+            serializable[key] = value.tolist()
+        else:
+            serializable[key] = value
+    out_path = metrics_dir / "metrics.json"
+    out_path.write_text(json.dumps(serializable, indent=2, sort_keys=True))
+    return out_path
+
+
 @hydra.main(version_base="1.3", config_path="pkg://synth_setter.configs", config_name="eval.yaml")
 def main(cfg: DictConfig) -> None:
     """Run the evaluation entrypoint.
@@ -266,7 +295,8 @@ def main(cfg: DictConfig) -> None:
     # (e.g. ask for tags if none are provided in cfg, print cfg tree, etc.)
     extras(cfg)
 
-    evaluate(cfg)
+    metric_dict, _ = evaluate(cfg)
+    _dump_metric_dict(metric_dict, Path(cfg.paths.output_dir))
 
 
 if __name__ == "__main__":

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -528,6 +528,19 @@ def main(cfg: DictConfig) -> None:
     spec = spec_from_cfg(cfg)
     sky_cfg = _sky_cfg_from_dataset_cfg(cfg)
 
+    if sky_cfg.compute_template is None and cfg.oracle_eval_inline:
+        if not cfg.finalize_inline:
+            raise ValueError(
+                "oracle_eval_inline=true requires finalize_inline=true; "
+                "the inline oracle eval reads the {train,val,test}.h5 files "
+                "finalize uploads to R2."
+            )
+        if cfg.output_format != "hdf5":
+            raise ValueError(
+                "oracle_eval_inline=true only supports output_format=hdf5; "
+                f"got {cfg.output_format!r}."
+            )
+
     # ``_OPERATOR_WORKSPACE`` is the launcher-side spec-mirror anchor; the
     # Hydra per-run dir (``cfg.paths.output_dir``) is shard-scoped, not the
     # operator-side artifact root.
@@ -554,17 +567,6 @@ def main(cfg: DictConfig) -> None:
         if cfg.finalize_inline:
             finalize_from_spec(spec, _OPERATOR_WORKSPACE)
         if cfg.oracle_eval_inline:
-            if not cfg.finalize_inline:
-                raise ValueError(
-                    "oracle_eval_inline=true requires finalize_inline=true; "
-                    "the inline oracle eval reads the {train,val,test}.h5 files "
-                    "finalize uploads to R2."
-                )
-            if cfg.output_format != "hdf5":
-                raise ValueError(
-                    "oracle_eval_inline=true only supports output_format=hdf5; "
-                    f"got {cfg.output_format!r}."
-                )
             eval_dir = _OPERATOR_WORKSPACE / "oracle_eval" / spec.run_id
             _download_finalized_splits(spec, eval_dir)
             _run_oracle_eval_subprocess(eval_dir)

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -54,6 +54,7 @@ _NON_SPEC_KEYS: tuple[str, ...] = (
     "run_name",
     "skypilot_launch",
     "finalize_inline",
+    "oracle_eval_inline",
 )
 
 # Local spec-mirror anchor; ``operator_workspace()`` also publishes
@@ -63,6 +64,48 @@ _OPERATOR_WORKSPACE = operator_workspace()
 # Worker-side checkout path — baked WORKDIR of the dev-snapshot image, not the
 # launcher's workspace (which may not exist on the worker filesystem).
 _WORKER_REPO_ROOT = "/home/build/synth-setter"
+
+# Wall-clock bound on the inline oracle-eval subprocess (seconds). Sized for
+# the smoke-shard datasets the inline path is used with — multi-minute eval
+# runs belong on the dispatch path, not inline.
+_ORACLE_EVAL_TIMEOUT_SECONDS = 600
+
+
+def _download_finalized_splits(spec: DatasetSpec, dest: Path) -> None:
+    """Download the finalized ``{train,val,test}.h5`` splits from R2 into ``dest``.
+
+    :param spec: Validated dataset spec; ``spec.r2.split_h5_uri(split)`` builds
+        the canonical R2 URI for each split.
+    :param dest: Local directory to receive the three split files; created if
+        missing.
+    """
+    dest.mkdir(parents=True, exist_ok=True)
+    for split in ("train", "val", "test"):
+        r2_io.download_to_path(spec.r2.split_h5_uri(split), dest / f"{split}.h5")
+
+
+def _run_oracle_eval_subprocess(dataset_root: Path) -> None:
+    """Subprocess ``synth-setter-eval`` against ``experiment=surge/fake_oracle``.
+
+    Runs the fake-oracle on ``dataset_root``'s {train,val,test}.h5 to confirm
+    the parameter-array round-trip survived generate + finalize. ``check=True``
+    so a non-zero eval exit (or wall-clock timeout) propagates to the caller.
+
+    :param dataset_root: Directory holding the finalized HDF5 split files;
+        passed verbatim to the eval datamodule's ``dataset_root`` override.
+    """
+    argv = [
+        sys.executable,
+        "-m",
+        "synth_setter.cli.eval",
+        "experiment=surge/fake_oracle",
+        f"data.dataset_root={dataset_root}",
+        "ckpt_path=null",
+        "logger=null",
+        "mode=test",
+    ]
+    logger.info(f"oracle_eval_inline subprocess: {argv}")
+    subprocess.run(argv, check=True, timeout=_ORACLE_EVAL_TIMEOUT_SECONDS)  # noqa: S603
 
 
 def _rclone_copy(src: str, dest: str) -> None:
@@ -478,6 +521,8 @@ def main(cfg: DictConfig) -> None:
     the authoritative source for the operator's task overrides.
 
     :param cfg: Hydra-composed dataset cfg.
+    :raises ValueError: ``oracle_eval_inline=true`` without
+        ``finalize_inline=true``, or with ``output_format!=hdf5``.
     """
     overrides = list(HydraConfig.get().overrides.task)
     spec = spec_from_cfg(cfg)
@@ -508,11 +553,27 @@ def main(cfg: DictConfig) -> None:
         generate(spec, Path(cfg.paths.output_dir))
         if cfg.finalize_inline:
             finalize_from_spec(spec, _OPERATOR_WORKSPACE)
+        if cfg.oracle_eval_inline:
+            if not cfg.finalize_inline:
+                raise ValueError(
+                    "oracle_eval_inline=true requires finalize_inline=true; "
+                    "the inline oracle eval reads the {train,val,test}.h5 files "
+                    "finalize uploads to R2."
+                )
+            if cfg.output_format != "hdf5":
+                raise ValueError(
+                    "oracle_eval_inline=true only supports output_format=hdf5; "
+                    f"got {cfg.output_format!r}."
+                )
+            eval_dir = _OPERATOR_WORKSPACE / "oracle_eval" / spec.run_id
+            _download_finalized_splits(spec, eval_dir)
+            _run_oracle_eval_subprocess(eval_dir)
         return
 
-    if cfg.finalize_inline:
+    if cfg.finalize_inline or cfg.oracle_eval_inline:
         logger.info(
-            "finalize_inline=true ignored: "
+            f"finalize_inline={cfg.finalize_inline}, "
+            f"oracle_eval_inline={cfg.oracle_eval_inline} ignored: "
             f"skypilot_launch.compute_template={sky_cfg.compute_template!r} "
             "dispatches to a worker; finalize runs out-of-band via the "
             "finalize-dataset workflow."

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -517,7 +517,9 @@ def main(cfg: DictConfig) -> None:
 
     :param cfg: Hydra-composed dataset cfg.
     :raises ValueError: ``oracle_eval_inline=true`` without
-        ``finalize_inline=true``, or with ``output_format!=hdf5``.
+        ``finalize_inline=true``, with ``output_format!=hdf5``, or with
+        a zero-size train / val / test split (the eval datamodule opens
+        all three split files unconditionally).
     """
     overrides = list(HydraConfig.get().overrides.task)
     spec = spec_from_cfg(cfg)
@@ -534,6 +536,12 @@ def main(cfg: DictConfig) -> None:
             raise ValueError(
                 "oracle_eval_inline=true only supports output_format=hdf5; "
                 f"got {cfg.output_format!r}."
+            )
+        if any(size == 0 for size in spec.train_val_test_sizes):
+            raise ValueError(
+                "oracle_eval_inline=true requires all of "
+                f"train_val_test_sizes > 0; got {tuple(spec.train_val_test_sizes)}. "
+                "SurgeDataModule opens train.h5 / val.h5 / test.h5 unconditionally."
             )
 
     # ``_OPERATOR_WORKSPACE`` is the launcher-side spec-mirror anchor; the

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -94,6 +94,7 @@ def _run_oracle_eval_subprocess(dataset_root: Path) -> None:
         "synth_setter.cli.eval",
         "experiment=surge/fake_oracle",
         f"data.dataset_root={dataset_root}",
+        f"hydra.run.dir={dataset_root}",
         "ckpt_path=null",
         "logger=null",
         "mode=test",

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -65,19 +65,15 @@ _OPERATOR_WORKSPACE = operator_workspace()
 # launcher's workspace (which may not exist on the worker filesystem).
 _WORKER_REPO_ROOT = "/home/build/synth-setter"
 
-# Wall-clock bound on the inline oracle-eval subprocess (seconds). Sized for
-# the smoke-shard datasets the inline path is used with — multi-minute eval
-# runs belong on the dispatch path, not inline.
+# Smoke-shard-sized; longer eval runs belong on the dispatch path, not inline.
 _ORACLE_EVAL_TIMEOUT_SECONDS = 600
 
 
 def _download_finalized_splits(spec: DatasetSpec, dest: Path) -> None:
-    """Download the finalized ``{train,val,test}.h5`` splits from R2 into ``dest``.
+    """Download finalized ``{train,val,test}.h5`` from R2 into ``dest`` (created if missing).
 
-    :param spec: Validated dataset spec; ``spec.r2.split_h5_uri(split)`` builds
-        the canonical R2 URI for each split.
-    :param dest: Local directory to receive the three split files; created if
-        missing.
+    :param spec: Resolves the per-split R2 URI via ``spec.r2.split_h5_uri``.
+    :param dest: Local directory to receive the three split files.
     """
     dest.mkdir(parents=True, exist_ok=True)
     for split in ("train", "val", "test"):
@@ -85,14 +81,12 @@ def _download_finalized_splits(spec: DatasetSpec, dest: Path) -> None:
 
 
 def _run_oracle_eval_subprocess(dataset_root: Path) -> None:
-    """Subprocess ``synth-setter-eval`` against ``experiment=surge/fake_oracle``.
+    """Run the fake-oracle eval on ``dataset_root`` to verify the param-array round-trip.
 
-    Runs the fake-oracle on ``dataset_root``'s {train,val,test}.h5 to confirm
-    the parameter-array round-trip survived generate + finalize. ``check=True``
-    so a non-zero eval exit (or wall-clock timeout) propagates to the caller.
+    ``check=True`` so a non-zero eval exit (or wall-clock timeout) propagates
+    to the caller.
 
-    :param dataset_root: Directory holding the finalized HDF5 split files;
-        passed verbatim to the eval datamodule's ``dataset_root`` override.
+    :param dataset_root: Holds the finalized HDF5 splits the eval datamodule reads.
     """
     argv = [
         sys.executable,

--- a/src/synth_setter/configs/dataset.yaml
+++ b/src/synth_setter/configs/dataset.yaml
@@ -34,10 +34,8 @@ mask_degenerate_bins: false
 # skypilot_launch.compute_template is set.
 finalize_inline: false
 
-# Run synth-setter-eval inline (subprocess) against experiment=surge/fake_oracle
-# after finalize completes. Requires finalize_inline=true and output_format=hdf5;
-# raises ValueError otherwise. Ignored with INFO when skypilot_launch.compute_template
-# is set.
+# Run surge/fake_oracle inline (subprocess) after finalize. Requires
+# finalize_inline=true + output_format=hdf5. Local-run only.
 oracle_eval_inline: false
 
 # Null default: ``DatasetSpec._drop_null_run_id`` mode='before' validator pops

--- a/src/synth_setter/configs/dataset.yaml
+++ b/src/synth_setter/configs/dataset.yaml
@@ -34,6 +34,12 @@ mask_degenerate_bins: false
 # skypilot_launch.compute_template is set.
 finalize_inline: false
 
+# Run synth-setter-eval inline (subprocess) against experiment=surge/fake_oracle
+# after finalize completes. Requires finalize_inline=true and output_format=hdf5;
+# raises ValueError otherwise. Ignored with INFO when skypilot_launch.compute_template
+# is set.
+oracle_eval_inline: false
+
 # Null default: ``DatasetSpec._drop_null_run_id`` mode='before' validator pops
 # a ``None`` ``run_id`` so the field's ``default_factory`` (``_default_run_id``)
 # fires from ``task_name`` + ``created_at``. Keeping the key present lets the

--- a/src/synth_setter/configs/experiment/generate_dataset/smoke-shard-with-oracle-eval.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/smoke-shard-with-oracle-eval.yaml
@@ -8,4 +8,11 @@ defaults:
   - /experiment/generate_dataset/smoke-shard-with-finalize@_global_
   - _self_
 
+# Override train_val_test_sizes — SurgeDataModule.setup() opens
+# {train,val,test}.h5 unconditionally, so the inline oracle eval needs
+# non-zero val/test splits to load (the upstream smoke-shard.yaml ships
+# [12, 0, 0] which fails the datamodule at FileNotFoundError on val.h5).
+# Sizes must be multiples of render.samples_per_shard=4.
+train_val_test_sizes: [12, 4, 4]
+
 oracle_eval_inline: true

--- a/src/synth_setter/configs/experiment/generate_dataset/smoke-shard-with-oracle-eval.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/smoke-shard-with-oracle-eval.yaml
@@ -1,0 +1,11 @@
+# @package _global_
+
+# Used by the generate-finalize-oracle-eval workflow; mirrors
+# smoke-shard-with-finalize.yaml but additionally runs the
+# surge/fake_oracle eval inline so the same CLI process verifies the
+# parameter-array round-trip survived generate + finalize.
+defaults:
+  - /experiment/generate_dataset/smoke-shard-with-finalize@_global_
+  - _self_
+
+oracle_eval_inline: true

--- a/src/synth_setter/evaluation/assert_oracle_invariant.py
+++ b/src/synth_setter/evaluation/assert_oracle_invariant.py
@@ -1,0 +1,73 @@
+"""Parse a `synth-setter-eval` log for `test/param_mse` and assert it is exactly zero.
+
+Used by the `Generate + Finalize + Oracle-Eval Dataset (inline)` workflow to turn Lightning's
+printed metrics table into a hard pass/fail gate — the oracle's load-bearing invariant is `pred ==
+target` (and therefore `param_mse == 0.0`), so any other value means generate or finalize corrupted
+the parameter-array round-trip.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+_METRIC_KEY = "test/param_mse"
+_FLOAT_RE = re.compile(r"[-+]?\d+(?:\.\d+)?(?:[eE][-+]?\d+)?")
+
+
+def parse_metric_from_log(log_text: str, metric_key: str = _METRIC_KEY) -> float:
+    """Return the float that Lightning printed next to ``metric_key`` in its final table.
+
+    Lightning's `trainer.test()` writes a final metrics table whose rows look
+    like ``| test/param_mse | 0.0 |`` (the exact box-drawing characters vary by
+    version). The last occurrence of ``metric_key`` is the test-epoch value;
+    earlier matches may be per-batch progress lines that don't carry the
+    final aggregate.
+
+    :param log_text: Captured stdout/stderr from the eval subprocess.
+    :param metric_key: Lightning log key to look up; defaults to
+        ``"test/param_mse"`` — the only key the oracle test mode emits.
+    :returns: Parsed float value from the last matching line.
+    :raises ValueError: ``metric_key`` not found, or no float follows it.
+    """
+    matches = [line for line in log_text.splitlines() if metric_key in line]
+    if not matches:
+        raise ValueError(f"{metric_key!r} not found in log")
+    last_line = matches[-1]
+    floats = _FLOAT_RE.findall(last_line)
+    if not floats:
+        raise ValueError(f"no float found on metric line: {last_line!r}")
+    return float(floats[-1])
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI: read the log path from argv, parse, and exit non-zero on failure.
+
+    :param argv: Argument list excluding the program name; defaults to
+        ``sys.argv[1:]``.
+    :returns: 0 when ``test/param_mse == 0.0`` exactly; 1 otherwise (also when
+        the metric is missing, non-numeric, or NaN).
+    """
+    args = sys.argv[1:] if argv is None else argv
+    if len(args) != 1:
+        print("usage: assert_oracle_invariant <log-path>", file=sys.stderr)  # noqa: T201
+        return 1
+    log_path = Path(args[0])
+    try:
+        value = parse_metric_from_log(log_path.read_text())
+    except (FileNotFoundError, ValueError) as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)  # noqa: T201
+        return 1
+    if value != 0.0:
+        print(  # noqa: T201
+            f"FAIL: test/param_mse={value!r}; oracle requires exact 0.0",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"PASS: test/param_mse={value}")  # noqa: T201
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/synth_setter/evaluation/assert_oracle_invariant.py
+++ b/src/synth_setter/evaluation/assert_oracle_invariant.py
@@ -1,13 +1,17 @@
-"""Parse a `synth-setter-eval` log for `test/param_mse` and assert it is exactly zero.
+"""Assert ``test/param_mse == 0.0`` against the eval log or the metrics.json artifact.
 
-Used by the `Generate + Finalize + Oracle-Eval Dataset (inline)` workflow to turn Lightning's
-printed metrics table into a hard pass/fail gate — the oracle's load-bearing invariant is `pred ==
-target` (and therefore `param_mse == 0.0`), so any other value means generate or finalize corrupted
-the parameter-array round-trip.
+Used by the `Generate + Finalize + Oracle-Eval Dataset (inline)` workflow as a
+two-pronged gate on the oracle's load-bearing invariant (``pred == target`` →
+``param_mse == 0.0``). The log assertion catches anything that lands in
+Lightning's stdout table; the JSON assertion reads the structured artifact
+`cli/eval.py` writes to the per-run output dir. Either failing means generate
+or finalize corrupted the parameter-array round-trip.
 """
 
 from __future__ import annotations
 
+import argparse
+import json
 import re
 import sys
 from pathlib import Path
@@ -41,31 +45,63 @@ def parse_metric_from_log(log_text: str, metric_key: str = _METRIC_KEY) -> float
     return float(floats[-1])
 
 
+def parse_metric_from_json(json_text: str, metric_key: str = _METRIC_KEY) -> float:
+    """Return the float at ``metric_key`` from the metrics.json artifact.
+
+    :param json_text: Contents of the per-run ``metrics/metrics.json`` file.
+    :param metric_key: Key to look up; defaults to ``"test/param_mse"``.
+    :returns: Coerced ``float(payload[metric_key])``.
+    :raises ValueError: Payload not a dict, key missing, or value not numeric.
+    """
+    payload = json.loads(json_text)
+    if not isinstance(payload, dict):
+        raise ValueError(f"metrics.json must be a JSON object; got {type(payload).__name__}")
+    if metric_key not in payload:
+        raise ValueError(f"{metric_key!r} not found in metrics.json (keys: {sorted(payload)})")
+    value = payload[metric_key]
+    if not isinstance(value, (int, float)):
+        raise ValueError(f"{metric_key!r} is non-numeric in metrics.json: {value!r}")
+    return float(value)
+
+
 def main(argv: list[str] | None = None) -> int:
-    """CLI: read the log path from argv, parse, and exit non-zero on failure.
+    """CLI: assert ``test/param_mse == 0.0`` against a log file or a metrics.json artifact.
+
+    Pass either the eval subprocess's captured log (default) or the JSON
+    artifact via ``--metrics-json``. Running both back-to-back from a
+    workflow asserts the invariant twice — once on the unstructured stdout
+    table, once on the structured artifact — so a regression in either
+    surface fails the gate.
 
     :param argv: Argument list excluding the program name; defaults to
         ``sys.argv[1:]``.
-    :returns: 0 when ``test/param_mse == 0.0`` exactly; 1 otherwise (also when
-        the metric is missing, non-numeric, or NaN).
+    :returns: 0 when ``test/param_mse == 0.0`` exactly; 1 otherwise.
     """
-    args = sys.argv[1:] if argv is None else argv
-    if len(args) != 1:
-        print("usage: assert_oracle_invariant <log-path>", file=sys.stderr)  # noqa: T201
-        return 1
-    log_path = Path(args[0])
+    parser = argparse.ArgumentParser(description=__doc__)
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("log_path", nargs="?", type=Path, help="Path to the eval subprocess log.")
+    source.add_argument(
+        "--metrics-json",
+        type=Path,
+        help="Path to ``metrics/metrics.json`` written by ``cli/eval.py:_dump_metric_dict``.",
+    )
+    ns = parser.parse_args(argv)
+    source_path = ns.metrics_json if ns.metrics_json is not None else ns.log_path
+    source_label = "metrics.json" if ns.metrics_json is not None else "log"
+    parse = parse_metric_from_json if ns.metrics_json is not None else parse_metric_from_log
+
     try:
-        value = parse_metric_from_log(log_path.read_text())
+        value = parse(source_path.read_text())
     except (FileNotFoundError, ValueError) as exc:
-        print(f"FAIL: {exc}", file=sys.stderr)  # noqa: T201
+        print(f"FAIL ({source_label}): {exc}", file=sys.stderr)  # noqa: T201
         return 1
     if value != 0.0:
         print(  # noqa: T201
-            f"FAIL: test/param_mse={value!r}; oracle requires exact 0.0",
+            f"FAIL ({source_label}): test/param_mse={value!r}; oracle requires exact 0.0",
             file=sys.stderr,
         )
         return 1
-    print(f"PASS: test/param_mse={value}")  # noqa: T201
+    print(f"PASS ({source_label}): test/param_mse={value}")  # noqa: T201
     return 0
 
 

--- a/src/synth_setter/pipeline/ci/spec_uri.py
+++ b/src/synth_setter/pipeline/ci/spec_uri.py
@@ -81,6 +81,7 @@ _NON_SPEC_CFG_KEYS: tuple[str, ...] = (
     "run_name",
     "skypilot_launch",
     "finalize_inline",
+    "oracle_eval_inline",
 )
 
 

--- a/tests/evaluation/test_assert_oracle_invariant.py
+++ b/tests/evaluation/test_assert_oracle_invariant.py
@@ -1,13 +1,15 @@
-"""Pin the log-parser used by the generate-finalize-oracle-eval workflow's gate."""
+"""Pin the log and metrics.json parsers used by the workflow gate."""
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
 from synth_setter.evaluation.assert_oracle_invariant import (
     main,
+    parse_metric_from_json,
     parse_metric_from_log,
 )
 
@@ -90,7 +92,64 @@ def test_main_exits_one_on_missing_log(tmp_path: Path) -> None:
     assert main([str(tmp_path / "missing.log")]) == 1
 
 
-def test_main_exits_one_on_wrong_argc() -> None:
-    """CLI returns 1 on missing or extra positional arguments rather than tracebacking."""
-    assert main([]) == 1
-    assert main(["a", "b"]) == 1
+def test_main_exits_nonzero_on_no_args() -> None:
+    """Argparse rejects the call with no source argument; CLI exits non-zero."""
+    with pytest.raises(SystemExit) as exc:
+        main([])
+    assert exc.value.code != 0
+
+
+def test_json_parser_extracts_metric() -> None:
+    """metrics.json key lookup returns the stored float without tensor / numpy coercion."""
+    payload = {"test/param_mse": 0.0, "test/per_param_mse": [0.0, 0.0, 0.0, 0.0]}
+    assert parse_metric_from_json(json.dumps(payload)) == 0.0
+
+
+def test_json_parser_raises_when_payload_is_not_dict() -> None:
+    """A JSON list at the top level isn't a metric dict and must fail the gate, not coerce."""
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        parse_metric_from_json(json.dumps([1, 2, 3]))
+
+
+def test_json_parser_raises_when_key_missing() -> None:
+    """Missing ``test/param_mse`` key means eval never ran the test phase — surface the gap."""
+    with pytest.raises(ValueError, match="not found in metrics.json"):
+        parse_metric_from_json(json.dumps({"val/param_mse": 0.0}))
+
+
+def test_json_parser_raises_when_value_non_numeric() -> None:
+    """A non-numeric metric (e.g. NaN serialized as the string ``"NaN"``) is a parse failure."""
+    with pytest.raises(ValueError, match="non-numeric"):
+        parse_metric_from_json(json.dumps({"test/param_mse": "NaN"}))
+
+
+def test_main_metrics_json_mode_exits_zero_on_zero_metric(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--metrics-json`` happy path: CLI returns 0 and reports the source label.
+
+    :param tmp_path: Holds the JSON fixture.
+    :param capsys: Captures the PASS line for source-label assertion.
+    """
+    metrics = tmp_path / "metrics.json"
+    metrics.write_text(json.dumps({"test/param_mse": 0.0}))
+    assert main(["--metrics-json", str(metrics)]) == 0
+    out = capsys.readouterr().out
+    assert "PASS" in out
+    assert "metrics.json" in out
+
+
+def test_main_metrics_json_mode_exits_one_on_nonzero_metric(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--metrics-json`` failure path: CLI returns 1 and FAIL is tagged with the source.
+
+    :param tmp_path: Holds the JSON fixture.
+    :param capsys: Captures the FAIL line for source-label assertion.
+    """
+    metrics = tmp_path / "metrics.json"
+    metrics.write_text(json.dumps({"test/param_mse": 0.0001}))
+    assert main(["--metrics-json", str(metrics)]) == 1
+    err = capsys.readouterr().err
+    assert "FAIL" in err
+    assert "metrics.json" in err

--- a/tests/evaluation/test_assert_oracle_invariant.py
+++ b/tests/evaluation/test_assert_oracle_invariant.py
@@ -1,0 +1,96 @@
+"""Pin the log-parser used by the generate-finalize-oracle-eval workflow's gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from synth_setter.evaluation.assert_oracle_invariant import (
+    main,
+    parse_metric_from_log,
+)
+
+_LIGHTNING_TABLE_ZERO = """\
+Testing DataLoader 0: 100%|██████████| 1/1 [00:00<00:00,  6.30it/s]
+────────────────────────────────────────────────────────────────────────────
+      Test metric             DataLoader 0
+────────────────────────────────────────────────────────────────────────────
+     test/param_mse                  0.0
+────────────────────────────────────────────────────────────────────────────
+"""
+
+
+_LIGHTNING_TABLE_NONZERO = """\
+     test/param_mse                  0.0001234
+"""
+
+
+def test_parser_extracts_zero_from_lightning_table() -> None:
+    """Real Lightning table layout parses to 0.0 — pins the workflow gate's happy path."""
+    assert parse_metric_from_log(_LIGHTNING_TABLE_ZERO) == 0.0
+
+
+def test_parser_extracts_nonzero_decimal() -> None:
+    """Decimal metric values parse correctly so a non-zero MSE surfaces in the gate."""
+    assert parse_metric_from_log(_LIGHTNING_TABLE_NONZERO) == pytest.approx(0.0001234)
+
+
+def test_parser_uses_last_match_when_metric_appears_multiple_times() -> None:
+    """Last match wins so the final-epoch aggregate beats per-batch progress lines."""
+    text = "progress test/param_mse = 0.42\nfinal test/param_mse 0.0\n"
+    assert parse_metric_from_log(text) == 0.0
+
+
+def test_parser_raises_when_metric_missing() -> None:
+    """Subprocess that exited before logging the metric must fail the gate, not pass silently."""
+    with pytest.raises(ValueError, match="not found"):
+        parse_metric_from_log("no metric here\n")
+
+
+def test_parser_raises_when_metric_line_has_no_float() -> None:
+    """A metric line without a numeric value is a parse failure, not a zero match."""
+    with pytest.raises(ValueError, match="no float"):
+        parse_metric_from_log("test/param_mse pending\n")
+
+
+def test_main_exits_zero_on_zero_metric(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CLI returns 0 when the log carries the exact-zero oracle invariant.
+
+    :param tmp_path: Holds the fixture log file.
+    :param capsys: Captures the PASS line for assertion.
+    """
+    log = tmp_path / "eval.log"
+    log.write_text(_LIGHTNING_TABLE_ZERO)
+    assert main([str(log)]) == 0
+    assert "PASS" in capsys.readouterr().out
+
+
+def test_main_exits_one_on_nonzero_metric(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CLI returns 1 when the metric is finite-but-nonzero — the round-trip drifted.
+
+    :param tmp_path: Holds the fixture log file.
+    :param capsys: Captures the FAIL line for assertion.
+    """
+    log = tmp_path / "eval.log"
+    log.write_text(_LIGHTNING_TABLE_NONZERO)
+    assert main([str(log)]) == 1
+    assert "FAIL" in capsys.readouterr().err
+
+
+def test_main_exits_one_on_missing_log(tmp_path: Path) -> None:
+    """CLI returns 1 (not crash) when the log file is absent.
+
+    :param tmp_path: Used to construct an absent path.
+    """
+    assert main([str(tmp_path / "missing.log")]) == 1
+
+
+def test_main_exits_one_on_wrong_argc() -> None:
+    """CLI returns 1 on missing or extra positional arguments rather than tracebacking."""
+    assert main([]) == 1
+    assert main(["a", "b"]) == 1

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1637,9 +1637,244 @@ class TestMainDispatchBranches:
 
         finalize_mock.assert_not_called()
         info_messages = [str(c.args[0]) for c in mock_logger.info.call_args_list]
-        ignored_lines = [m for m in info_messages if "finalize_inline=true ignored" in m]
+        ignored_lines = [
+            m for m in info_messages if "finalize_inline=True" in m and "ignored" in m
+        ]
         assert len(ignored_lines) == 1, (
-            f"expected exactly one INFO log mentioning 'finalize_inline=true ignored'; "
+            f"expected exactly one INFO log mentioning 'finalize_inline=True' + 'ignored'; "
+            f"got messages: {info_messages!r}"
+        )
+
+    def test_main_oracle_eval_inline_true_invokes_subprocess(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """oracle_eval_inline=true on the local-run branch shells out to synth-setter-eval.
+
+        Stubs ``generate`` + ``finalize_from_spec`` + ``_download_finalized_splits``
+        and patches ``_run_oracle_eval_subprocess`` to capture its
+        ``dataset_root`` argument. Asserts the eval helper fires exactly
+        once with a path under ``_OPERATOR_WORKSPACE/oracle_eval/<run_id>/``.
+        The argv shape itself is pinned by
+        ``test_run_oracle_eval_subprocess_builds_expected_argv``.
+
+        :param monkeypatch: Pytest fixture used to patch argv + the four
+            module-level seams.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+            "finalize_inline=true",
+            "oracle_eval_inline=true",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        monkeypatch.setattr(gd, "generate", lambda _spec, _work_dir: None)
+        monkeypatch.setattr(gd, "finalize_from_spec", MagicMock())
+        download_mock = MagicMock()
+        monkeypatch.setattr(gd, "_download_finalized_splits", download_mock)
+        oracle_mock = MagicMock()
+        monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
+
+        gd.main()
+
+        oracle_mock.assert_called_once()
+        dataset_root = oracle_mock.call_args[0][0]
+        assert isinstance(dataset_root, Path)
+        # ``_OPERATOR_WORKSPACE/oracle_eval/<run_id>/`` is the contracted layout —
+        # the parent directory of the eval dir must be the ``oracle_eval`` folder.
+        assert dataset_root.parent.name == "oracle_eval", (
+            f"dataset_root should land under <workspace>/oracle_eval/<run_id>/; got {dataset_root!r}"
+        )
+        # ``_download_finalized_splits`` is the seam between finalize and eval —
+        # it must run first, into the same directory the eval subprocess reads.
+        download_mock.assert_called_once()
+        _, downloaded_dest = download_mock.call_args[0]
+        assert downloaded_dest == dataset_root
+
+    def test_run_oracle_eval_subprocess_builds_expected_argv(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Helper subprocesses ``synth_setter.cli.eval`` with the contract argv.
+
+        Pins the exact argv shape the inline oracle eval depends on:
+        ``-m synth_setter.cli.eval``, ``experiment=surge/fake_oracle``,
+        ``ckpt_path=null``, ``mode=test``, and a ``data.dataset_root=``
+        argument carrying the caller-supplied path. Runs the helper
+        directly (no Hydra compose) so the test is insulated from
+        cfg-resolution noise.
+
+        :param monkeypatch: Used to patch the module's ``subprocess.run``.
+        :param tmp_path: Standin for the finalize download directory.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        run_mock = MagicMock()
+        monkeypatch.setattr(gd.subprocess, "run", run_mock)
+
+        gd._run_oracle_eval_subprocess(tmp_path)
+
+        run_mock.assert_called_once()
+        called_argv = run_mock.call_args[0][0]
+        assert "-m" in called_argv
+        assert "synth_setter.cli.eval" in called_argv
+        assert "experiment=surge/fake_oracle" in called_argv
+        assert f"data.dataset_root={tmp_path}" in called_argv
+        assert "ckpt_path=null" in called_argv
+        assert "mode=test" in called_argv
+
+    def test_main_oracle_eval_inline_default_false_skips(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Default ``oracle_eval_inline=false`` leaves the eval subprocess unfired.
+
+        Pins the opt-in invariant: omitting the override never triggers a
+        synth-setter-eval subprocess, even when ``finalize_inline=true``.
+
+        :param monkeypatch: Pytest fixture used to patch argv + the
+            ``generate`` / ``finalize_from_spec`` / oracle-eval seams.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+            "finalize_inline=true",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        monkeypatch.setattr(gd, "generate", lambda _spec, _work_dir: None)
+        monkeypatch.setattr(gd, "finalize_from_spec", MagicMock())
+        oracle_mock = MagicMock()
+        monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
+
+        gd.main()
+
+        oracle_mock.assert_not_called()
+
+    def test_main_oracle_eval_inline_requires_finalize_inline(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``oracle_eval_inline=true`` without ``finalize_inline=true`` raises.
+
+        Inline oracle eval consumes the finalized {train,val,test}.h5 files
+        finalize uploads to R2; running it without finalize would always
+        miss the splits. Surface that misconfiguration loudly.
+
+        :param monkeypatch: Pytest fixture used to patch argv + the
+            ``generate`` / oracle-eval seams (asserted unreached).
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+            "oracle_eval_inline=true",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        monkeypatch.setenv("HYDRA_FULL_ERROR", "1")
+        monkeypatch.setattr(gd, "generate", lambda _spec, _work_dir: None)
+        oracle_mock = MagicMock()
+        monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
+
+        with pytest.raises(ValueError, match="requires finalize_inline=true"):
+            gd.main()
+        oracle_mock.assert_not_called()
+
+    def test_main_oracle_eval_inline_rejects_wds(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``oracle_eval_inline=true`` with ``output_format=wds`` raises.
+
+        The oracle eval pipeline reads HDF5 split files; WDS shards aren't
+        consumed by the same datamodule. Reject at the launcher seam so
+        the failure surfaces before the (lengthy) eval subprocess fires.
+
+        :param monkeypatch: Pytest fixture used to patch argv + the
+            ``generate`` / ``finalize_from_spec`` / oracle-eval seams
+            (asserted unreached).
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+            "finalize_inline=true",
+            "oracle_eval_inline=true",
+            "output_format=wds",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        monkeypatch.setenv("HYDRA_FULL_ERROR", "1")
+        monkeypatch.setattr(gd, "generate", lambda _spec, _work_dir: None)
+        monkeypatch.setattr(gd, "finalize_from_spec", MagicMock())
+        oracle_mock = MagicMock()
+        monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
+
+        with pytest.raises(ValueError, match="only supports output_format=hdf5"):
+            gd.main()
+        oracle_mock.assert_not_called()
+
+    @patch("synth_setter.cli.generate_dataset.logger")
+    def test_main_oracle_eval_inline_ignored_in_dispatch_branch(
+        self,
+        mock_logger: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """``oracle_eval_inline=true`` is ignored (with INFO log) on the dispatch branch.
+
+        SkyPilot delegation hands the run to a worker pod; the oracle eval
+        runs out-of-band via its own workflow rather than fire from the
+        launcher process. Pins both halves: the eval subprocess is not
+        called, and an INFO log line mentions the override was ignored.
+
+        :param mock_logger: Patched ``generate_dataset.logger`` — the
+            established loguru capture pattern in this file.
+        :param monkeypatch: Pytest fixture used to patch argv + dispatch +
+            the oracle-eval seam (asserted unreached).
+        :param tmp_path: Pytest fixture providing a fresh test directory for
+            the minimal compute template.
+        """
+        import synth_setter.cli.generate_dataset as gd
+        import synth_setter.pipeline.skypilot_launch as sl
+
+        template = tmp_path / "template.yaml"
+        template.write_text("resources:\n  cloud: runpod\nenvs:\n  X: ''\n")
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+            f"skypilot_launch.compute_template={template}",
+            "oracle_eval_inline=true",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        monkeypatch.setattr(sl, "dispatch_via_skypilot", lambda *_a, **_k: None)
+        monkeypatch.setattr(
+            gd,
+            "generate",
+            lambda *_a, **_k: pytest.fail("generate must not fire on dispatch branch"),
+        )
+        oracle_mock = MagicMock()
+        monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
+
+        gd.main()
+
+        oracle_mock.assert_not_called()
+        info_messages = [str(c.args[0]) for c in mock_logger.info.call_args_list]
+        ignored_lines = [
+            m for m in info_messages if "oracle_eval_inline=True" in m and "ignored" in m
+        ]
+        assert len(ignored_lines) == 1, (
+            f"expected exactly one INFO log mentioning 'oracle_eval_inline=True' + 'ignored'; "
             f"got messages: {info_messages!r}"
         )
 

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1651,15 +1651,11 @@ class TestMainDispatchBranches:
     ) -> None:
         """oracle_eval_inline=true on the local-run branch shells out to synth-setter-eval.
 
-        Stubs ``generate`` + ``finalize_from_spec`` + ``_download_finalized_splits``
-        and patches ``_run_oracle_eval_subprocess`` to capture its
-        ``dataset_root`` argument. Asserts the eval helper fires exactly
-        once with a path under ``_OPERATOR_WORKSPACE/oracle_eval/<run_id>/``.
-        The argv shape itself is pinned by
-        ``test_run_oracle_eval_subprocess_builds_expected_argv``.
+        Asserts the eval helper fires once with ``dataset_root`` under
+        ``_OPERATOR_WORKSPACE/oracle_eval/<run_id>/`` and that
+        ``_download_finalized_splits`` populates the same path first.
 
-        :param monkeypatch: Pytest fixture used to patch argv + the four
-            module-level seams.
+        :param monkeypatch: Patches argv + the four module-level seams.
         """
         import synth_setter.cli.generate_dataset as gd
 
@@ -1701,15 +1697,12 @@ class TestMainDispatchBranches:
     ) -> None:
         """Helper subprocesses ``synth_setter.cli.eval`` with the contract argv.
 
-        Pins the exact argv shape the inline oracle eval depends on:
-        ``-m synth_setter.cli.eval``, ``experiment=surge/fake_oracle``,
-        ``ckpt_path=null``, ``mode=test``, and a ``data.dataset_root=``
-        argument carrying the caller-supplied path. Runs the helper
-        directly (no Hydra compose) so the test is insulated from
-        cfg-resolution noise.
+        Pins the load-bearing overrides (``experiment=surge/fake_oracle``,
+        ``data.dataset_root``, ``ckpt_path=null``, ``mode=test``). Runs the
+        helper directly so cfg-resolution noise can't mask an argv drift.
 
-        :param monkeypatch: Used to patch the module's ``subprocess.run``.
-        :param tmp_path: Standin for the finalize download directory.
+        :param monkeypatch: Patches the module's ``subprocess.run``.
+        :param tmp_path: Stands in for the finalize download directory.
         """
         import synth_setter.cli.generate_dataset as gd
 
@@ -1731,13 +1724,9 @@ class TestMainDispatchBranches:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Default ``oracle_eval_inline=false`` leaves the eval subprocess unfired.
+        """Opt-in invariant: default false ⇒ neither download nor eval subprocess fires.
 
-        Pins the opt-in invariant: omitting the override never triggers a
-        synth-setter-eval subprocess, even when ``finalize_inline=true``.
-
-        :param monkeypatch: Pytest fixture used to patch argv + the
-            ``generate`` / ``finalize_from_spec`` / oracle-eval seams.
+        :param monkeypatch: Patches argv + the four module-level seams.
         """
         import synth_setter.cli.generate_dataset as gd
 
@@ -1750,11 +1739,14 @@ class TestMainDispatchBranches:
         monkeypatch.setattr("sys.argv", argv)
         monkeypatch.setattr(gd, "generate", lambda _spec, _work_dir: None)
         monkeypatch.setattr(gd, "finalize_from_spec", MagicMock())
+        download_mock = MagicMock()
         oracle_mock = MagicMock()
+        monkeypatch.setattr(gd, "_download_finalized_splits", download_mock)
         monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
 
         gd.main()
 
+        download_mock.assert_not_called()
         oracle_mock.assert_not_called()
 
     def test_main_oracle_eval_inline_requires_finalize_inline(
@@ -1839,19 +1831,17 @@ class TestMainDispatchBranches:
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
     ) -> None:
-        """``oracle_eval_inline=true`` is ignored (with INFO log) on the dispatch branch.
+        """Dispatch branch: ``oracle_eval_inline=true`` is logged-and-ignored, not raised.
 
-        SkyPilot delegation hands the run to a worker pod; the oracle eval
-        runs out-of-band via its own workflow rather than fire from the
-        launcher process. Pins both halves: the eval subprocess is not
-        called, and an INFO log line mentions the override was ignored.
+        SkyPilot hands the run to a worker pod; oracle eval runs out-of-band
+        via its own workflow. Asserts no eval subprocess fires and the INFO
+        log mentions the override was ignored.
 
         :param mock_logger: Patched ``generate_dataset.logger`` — the
             established loguru capture pattern in this file.
-        :param monkeypatch: Pytest fixture used to patch argv + dispatch +
-            the oracle-eval seam (asserted unreached).
-        :param tmp_path: Pytest fixture providing a fresh test directory for
-            the minimal compute template.
+        :param monkeypatch: Patches argv + dispatch + the oracle-eval seam.
+        :param tmp_path: Holds the minimal compute template the dispatch
+            branch reads from disk.
         """
         import synth_setter.cli.generate_dataset as gd
         import synth_setter.pipeline.skypilot_launch as sl

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1713,6 +1713,9 @@ class TestMainDispatchBranches:
         assert "synth_setter.cli.eval" in called_argv
         assert "experiment=surge/fake_oracle" in called_argv
         assert f"data.dataset_root={tmp_path}" in called_argv
+        # Pins the Hydra per-run dir to the same path as data.dataset_root so
+        # the workflow's metrics.json glob lands at <tmp_path>/metrics/metrics.json.
+        assert f"hydra.run.dir={tmp_path}" in called_argv
         assert "ckpt_path=null" in called_argv
         assert "mode=test" in called_argv
 

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1761,14 +1761,15 @@ class TestMainDispatchBranches:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """``oracle_eval_inline=true`` without ``finalize_inline=true`` raises.
+        """Fail-fast guard: ``oracle_eval_inline=true`` without ``finalize_inline=true``.
 
-        Inline oracle eval consumes the finalized {train,val,test}.h5 files
-        finalize uploads to R2; running it without finalize would always
-        miss the splits. Surface that misconfiguration loudly.
+        Inline oracle eval reads the finalized ``{train,val,test}.h5`` files
+        finalize uploads; running without finalize would always miss them.
+        The guard fires up front so the operator doesn't pay generate's
+        render cost before the misconfig surfaces.
 
-        :param monkeypatch: Pytest fixture used to patch argv + the
-            ``generate`` / oracle-eval seams (asserted unreached).
+        :param monkeypatch: Patches argv and the ``generate`` / ``finalize_from_spec``
+            / oracle-eval seams; the test asserts none of them is reached.
         """
         import synth_setter.cli.generate_dataset as gd
 
@@ -1780,27 +1781,31 @@ class TestMainDispatchBranches:
         ]
         monkeypatch.setattr("sys.argv", argv)
         monkeypatch.setenv("HYDRA_FULL_ERROR", "1")
-        monkeypatch.setattr(gd, "generate", lambda _spec, _work_dir: None)
+        generate_mock = MagicMock()
+        finalize_mock = MagicMock()
         oracle_mock = MagicMock()
+        monkeypatch.setattr(gd, "generate", generate_mock)
+        monkeypatch.setattr(gd, "finalize_from_spec", finalize_mock)
         monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
 
         with pytest.raises(ValueError, match="requires finalize_inline=true"):
             gd.main()
+        generate_mock.assert_not_called()
+        finalize_mock.assert_not_called()
         oracle_mock.assert_not_called()
 
     def test_main_oracle_eval_inline_rejects_wds(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """``oracle_eval_inline=true`` with ``output_format=wds`` raises.
+        """``oracle_eval_inline=true`` + ``output_format=wds`` raises before ``generate()``.
 
-        The oracle eval pipeline reads HDF5 split files; WDS shards aren't
-        consumed by the same datamodule. Reject at the launcher seam so
-        the failure surfaces before the (lengthy) eval subprocess fires.
+        The oracle eval datamodule reads HDF5 split files; WDS shards aren't
+        consumed by the same loader. The guard fires up front so neither
+        generate nor finalize run before the misconfig surfaces.
 
-        :param monkeypatch: Pytest fixture used to patch argv + the
-            ``generate`` / ``finalize_from_spec`` / oracle-eval seams
-            (asserted unreached).
+        :param monkeypatch: Patches argv and the ``generate`` / ``finalize_from_spec``
+            / oracle-eval seams; the test asserts none of them is reached.
         """
         import synth_setter.cli.generate_dataset as gd
 
@@ -1814,13 +1819,17 @@ class TestMainDispatchBranches:
         ]
         monkeypatch.setattr("sys.argv", argv)
         monkeypatch.setenv("HYDRA_FULL_ERROR", "1")
-        monkeypatch.setattr(gd, "generate", lambda _spec, _work_dir: None)
-        monkeypatch.setattr(gd, "finalize_from_spec", MagicMock())
+        generate_mock = MagicMock()
+        finalize_mock = MagicMock()
         oracle_mock = MagicMock()
+        monkeypatch.setattr(gd, "generate", generate_mock)
+        monkeypatch.setattr(gd, "finalize_from_spec", finalize_mock)
         monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
 
         with pytest.raises(ValueError, match="only supports output_format=hdf5"):
             gd.main()
+        generate_mock.assert_not_called()
+        finalize_mock.assert_not_called()
         oracle_mock.assert_not_called()
 
     @patch("synth_setter.cli.generate_dataset.logger")

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1665,6 +1665,9 @@ class TestMainDispatchBranches:
             f"render.plugin_path={TEST_PLUGIN_VST3}",
             "finalize_inline=true",
             "oracle_eval_inline=true",
+            # Override smoke-shard's [12, 0, 0] — the zero-size guard rejects
+            # train_val_test_sizes with any zero split for oracle_eval_inline.
+            "train_val_test_sizes=[12, 4, 4]",
         ]
         monkeypatch.setattr("sys.argv", argv)
         monkeypatch.setattr(gd, "generate", lambda _spec, _work_dir: None)
@@ -1809,6 +1812,43 @@ class TestMainDispatchBranches:
         monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
 
         with pytest.raises(ValueError, match="only supports output_format=hdf5"):
+            gd.main()
+        generate_mock.assert_not_called()
+        finalize_mock.assert_not_called()
+        oracle_mock.assert_not_called()
+
+    def test_main_oracle_eval_inline_rejects_zero_size_split(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Fail-fast guard: ``oracle_eval_inline=true`` rejects ``[N, 0, 0]``-style sizes.
+
+        ``SurgeDataModule.setup()`` opens train/val/test ``.h5`` unconditionally
+        regardless of stage, so any zero-size split would FileNotFoundError
+        deep inside Lightning. The launcher catches the misconfig up front.
+
+        :param monkeypatch: Patches argv and the ``generate`` / ``finalize_from_spec``
+            / oracle-eval seams; the test asserts none of them is reached.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+            "finalize_inline=true",
+            "oracle_eval_inline=true",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        monkeypatch.setenv("HYDRA_FULL_ERROR", "1")
+        generate_mock = MagicMock()
+        finalize_mock = MagicMock()
+        oracle_mock = MagicMock()
+        monkeypatch.setattr(gd, "generate", generate_mock)
+        monkeypatch.setattr(gd, "finalize_from_spec", finalize_mock)
+        monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
+
+        with pytest.raises(ValueError, match="train_val_test_sizes > 0"):
             gd.main()
         generate_mock.assert_not_called()
         finalize_mock.assert_not_called()

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1679,13 +1679,9 @@ class TestMainDispatchBranches:
         oracle_mock.assert_called_once()
         dataset_root = oracle_mock.call_args[0][0]
         assert isinstance(dataset_root, Path)
-        # ``_OPERATOR_WORKSPACE/oracle_eval/<run_id>/`` is the contracted layout —
-        # the parent directory of the eval dir must be the ``oracle_eval`` folder.
         assert dataset_root.parent.name == "oracle_eval", (
             f"dataset_root should land under <workspace>/oracle_eval/<run_id>/; got {dataset_root!r}"
         )
-        # ``_download_finalized_splits`` is the seam between finalize and eval —
-        # it must run first, into the same directory the eval subprocess reads.
         download_mock.assert_called_once()
         _, downloaded_dest = download_mock.call_args[0]
         assert downloaded_dest == dataset_root
@@ -1753,15 +1749,9 @@ class TestMainDispatchBranches:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Fail-fast guard: ``oracle_eval_inline=true`` without ``finalize_inline=true``.
+        """``oracle_eval_inline=true`` without ``finalize_inline=true`` raises pre-``generate()``.
 
-        Inline oracle eval reads the finalized ``{train,val,test}.h5`` files
-        finalize uploads; running without finalize would always miss them.
-        The guard fires up front so the operator doesn't pay generate's
-        render cost before the misconfig surfaces.
-
-        :param monkeypatch: Patches argv and the ``generate`` / ``finalize_from_spec``
-            / oracle-eval seams; the test asserts none of them is reached.
+        :param monkeypatch: Patches argv + the three seams the test asserts are unreached.
         """
         import synth_setter.cli.generate_dataset as gd
 
@@ -1792,12 +1782,9 @@ class TestMainDispatchBranches:
     ) -> None:
         """``oracle_eval_inline=true`` + ``output_format=wds`` raises before ``generate()``.
 
-        The oracle eval datamodule reads HDF5 split files; WDS shards aren't
-        consumed by the same loader. The guard fires up front so neither
-        generate nor finalize run before the misconfig surfaces.
+        Eval reads HDF5 splits; WDS shards aren't consumed by the same loader.
 
-        :param monkeypatch: Patches argv and the ``generate`` / ``finalize_from_spec``
-            / oracle-eval seams; the test asserts none of them is reached.
+        :param monkeypatch: Patches argv + the three seams the test asserts are unreached.
         """
         import synth_setter.cli.generate_dataset as gd
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -17,6 +17,7 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 from synth_setter.cli import eval as eval_mod
 from synth_setter.cli.eval import (
     _COMPUTE_AUDIO_METRICS_MODULE,
+    _dump_metric_dict,
     _load_audio_metrics,
     _run_predict_postprocessing,
     evaluate,
@@ -76,6 +77,35 @@ def test_evaluate_runs_oracle_with_null_ckpt_path(
     assert param_mse.dtype.is_floating_point
     assert torch.isfinite(param_mse), f"oracle test/param_mse must be finite; got {param_mse!r}"
     assert param_mse.item() == 0.0
+
+
+def test_dump_metric_dict_writes_json_with_coerced_scalars(tmp_path: Path) -> None:
+    """Lightning tensors and numpy arrays are coerced to native floats / lists in ``metrics.json``.
+
+    Pins the artifact downstream gates (workflow asserter, CSV joiners) read from —
+    a torch / numpy dependency in those gates would force imports just to deserialize.
+
+    :param tmp_path: Hydra-style output dir; the ``metrics/`` subdir lands under it.
+    """
+    import json
+
+    import numpy as np
+
+    metric_dict = {
+        "test/param_mse": torch.tensor(0.0),
+        "test/per_param_mse": torch.tensor([0.0, 0.0, 0.0, 0.0]),
+        "audio/mss_mean": np.float32(0.5),
+        "raw/string": "v1",
+    }
+    out_path = _dump_metric_dict(metric_dict, tmp_path)
+
+    assert out_path == tmp_path / "metrics" / "metrics.json"
+    assert out_path.is_file()
+    payload = json.loads(out_path.read_text())
+    assert payload["test/param_mse"] == 0.0
+    assert payload["test/per_param_mse"] == [0.0, 0.0, 0.0, 0.0]
+    assert payload["audio/mss_mean"] == pytest.approx(0.5)
+    assert payload["raw/string"] == "v1"
 
 
 @pytest.mark.gpu

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from hydra import compose, initialize_config_module
+from hydra.core.global_hydra import GlobalHydra
 from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig, OmegaConf, open_dict
 
@@ -19,7 +21,59 @@ from synth_setter.cli.eval import (
     evaluate,
 )
 from synth_setter.cli.train import train
+from synth_setter.data.vst import param_specs
+from synth_setter.workspace import operator_workspace
 from tests.helpers.run_if import RunIf
+
+
+@pytest.mark.requires_vst
+@pytest.mark.slow
+def test_evaluate_runs_oracle_with_null_ckpt_path(
+    tmp_path: Path,
+    surge_xt_smoke_datasets: Path,
+) -> None:
+    """``evaluate()`` runs the fake oracle on its untrained state when ``ckpt_path`` is ``None``.
+
+    ``ckpt_path=null`` must survive Hydra composition into ``evaluate()`` so the
+    inline oracle-eval path (generate-dataset finalize → ``synth-setter-eval``)
+    can probe a fresh model. The fake oracle returns ``batch["params"]``
+    verbatim, so ``test/param_mse`` collapses to exactly zero independent of
+    training state — that exact-zero is the load-bearing oracle invariant.
+
+    :param tmp_path: Per-test temp dir used as Hydra ``paths.output_dir`` /
+        ``paths.log_dir`` so the run writes nowhere durable.
+    :param surge_xt_smoke_datasets: Smoke-fixture directory holding
+        ``{train,val,test}.h5`` + ``stats.npz`` for ``data=surge``.
+    """
+    with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
+        cfg = compose(
+            config_name="eval.yaml",
+            return_hydra_config=True,
+            overrides=[
+                "experiment=surge/test-mps-fake-oracle",
+                "trainer=cpu",
+                f"model.net.d_out={len(param_specs['surge_4'])}",
+                "callbacks.log_per_param_mse.param_spec=surge_4",
+            ],
+        )
+
+    with open_dict(cfg):
+        cfg.paths.root_dir = str(operator_workspace())
+        cfg.paths.output_dir = str(tmp_path)
+        cfg.paths.log_dir = str(tmp_path)
+        cfg.data.dataset_root = str(surge_xt_smoke_datasets)
+        cfg.data.predict_file = str(surge_xt_smoke_datasets / "test.h5")
+        cfg.data.batch_size = 1
+        cfg.data.num_workers = 0
+        cfg.ckpt_path = None
+
+    HydraConfig().set_config(cfg)
+    try:
+        metric_dict, _ = evaluate(cfg)
+    finally:
+        GlobalHydra.instance().clear()
+
+    assert metric_dict["test/param_mse"].item() == 0.0
 
 
 @pytest.mark.gpu

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+import torch
 from hydra import compose, initialize_config_module
 from hydra.core.global_hydra import GlobalHydra
 from hydra.core.hydra_config import HydraConfig
@@ -73,7 +74,12 @@ def test_evaluate_runs_oracle_with_null_ckpt_path(
     finally:
         GlobalHydra.instance().clear()
 
-    assert metric_dict["test/param_mse"].item() == 0.0
+    param_mse = metric_dict["test/param_mse"]
+    assert isinstance(param_mse, torch.Tensor)
+    assert param_mse.numel() == 1
+    assert param_mse.dtype.is_floating_point
+    assert torch.isfinite(param_mse), f"oracle test/param_mse must be finite; got {param_mse!r}"
+    assert param_mse.item() == 0.0
 
 
 @pytest.mark.gpu

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -33,18 +33,14 @@ def test_evaluate_runs_oracle_with_null_ckpt_path(
     tmp_path: Path,
     surge_xt_smoke_datasets: Path,
 ) -> None:
-    """``evaluate()`` runs the fake oracle on its untrained state when ``ckpt_path`` is ``None``.
+    """Fake oracle returns ``batch["params"]`` verbatim, so ``test/param_mse`` is exactly zero.
 
-    ``ckpt_path=null`` must survive Hydra composition into ``evaluate()`` so the
-    inline oracle-eval path (generate-dataset finalize → ``synth-setter-eval``)
-    can probe a fresh model. The fake oracle returns ``batch["params"]``
-    verbatim, so ``test/param_mse`` collapses to exactly zero independent of
-    training state — that exact-zero is the load-bearing oracle invariant.
+    The load-bearing invariant is that ``ckpt_path=null`` survives Hydra
+    composition into ``evaluate()`` and the oracle's exact-zero MSE reaches
+    the metric dict.
 
-    :param tmp_path: Per-test temp dir used as Hydra ``paths.output_dir`` /
-        ``paths.log_dir`` so the run writes nowhere durable.
-    :param surge_xt_smoke_datasets: Smoke-fixture directory holding
-        ``{train,val,test}.h5`` + ``stats.npz`` for ``data=surge``.
+    :param tmp_path: Pinned as Hydra ``paths.output_dir`` / ``paths.log_dir``.
+    :param surge_xt_smoke_datasets: Holds ``{train,val,test}.h5`` + ``stats.npz``.
     """
     with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
         cfg = compose(


### PR DESCRIPTION
## Summary

Adds an opt-in `oracle_eval_inline` flag to `synth-setter-generate-dataset` so the launcher runs `synth-setter-eval` against `experiment=surge/fake_oracle` (subprocess) inline after `finalize_inline` lands `dataset.complete` — the same CLI process that uploaded the shards now also verifies the parameter-array round-trip survived generate + finalize. Hdf5-only for v1; finalize_inline required. Ships in three phases per the S-doc; all three land here.

- **Phase 1** (`1270a77e`) drops the unconditional `assert cfg.ckpt_path` in `cli/eval.py` so `ckpt_path=null` CLI overrides survive composition. Lightning already accepts `None` at the three `trainer.test` / `trainer.validate` / `trainer.predict` call sites; the `eval.yaml:29` default stays `???` for everyone else. One new test (`test_evaluate_runs_oracle_with_null_ckpt_path`) pins the no-checkpoint oracle path.
- **Phase 2** (`26c1d272`) wires the flag through `generate_dataset.main()`. Adds `oracle_eval_inline: false` to `configs/dataset.yaml`, mirrors the addition into `_NON_SPEC_KEYS` / `_PROTECTED_KEYS`, and adds two private helpers (`_download_finalized_splits`, `_run_oracle_eval_subprocess`). Local-run branch calls them after `finalize_from_spec` returns; `ValueError` guards reject `oracle_eval_inline=true` without `finalize_inline=true` and `output_format != "hdf5"`. SkyPilot dispatch branch extends the existing INFO log to mention both flags. Six new tests cover the five enumerated scenarios plus an argv-shape contract test for `_run_oracle_eval_subprocess` itself.
- **Phase 3** (`70fffba3`) adds the `Generate + Finalize + Oracle-Eval Dataset (inline)` workflow plus the `smoke-shard-with-oracle-eval` experiment that sets both flags. Body shape mirrors `generate-and-finalize-dataset.yaml`.

Default remains `oracle_eval_inline: false` — every existing caller keeps its current shape until it opts in.

## Test plan

- [x] `uv run pytest tests/test_eval.py tests/pipeline/test_entrypoints/test_generate_dataset.py tests/pipeline/test_ci/` — 120 tests pass locally on the focused suite.
- [x] `uv run pre-commit run --files` on every touched file passes (ruff, pyright, pydoclint, prettier, check-github-workflows).
- [x] `gha-workflow-validator` on `.github/workflows/generate-finalize-oracle-eval.yaml`: 0 failures.
- [x] Hydra compose check resolves both flags to true for `experiment=generate_dataset/smoke-shard-with-oracle-eval`.
- [ ] `uv run synth-setter-eval experiment=surge/test-mps-fake-oracle ckpt_path=null data.dataset_root=<smoke-dir> +model.net.d_out=4 +callbacks.log_per_param_mse.param_spec=surge_4` exits 0 and the stdout shows `test/param_mse: 0.0`. *(Manual leg — requires a local smoke dataset_root.)*
- [ ] Hydra compose smoke prints `True False` for `experiment=generate_dataset/smoke-shard` + `oracle_eval_inline=true`. *(Manual leg — confirms the cfg key is wired without composing the with-oracle-eval experiment.)*
- [ ] Trigger `Generate + Finalize + Oracle-Eval Dataset (inline)` via "Run workflow" and confirm the uploaded `generate-finalize-oracle-eval.log` shows `test/param_mse: 0.0`. *(Manual — pending merge / branch availability in the workflow picker.)*

Fixes #1319