### PR TITLE
build(devcontainer): auto-wire wandb MCP server from WANDB_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,7 +58,9 @@ WANDB_S3_ENDPOINT_URL=https://your-account-id.r2.cloudflarestorage.com
 # =============================================================================
 # Weights & Biases (experiment tracking)
 # =============================================================================
-# Used by: training, evaluation, promotion, Docker builds
+# Used by: training, evaluation, promotion, Docker builds, and the Claude
+# Code wandb MCP server wired up by `.mcp.json` (Authorization: Bearer
+# ${WANDB_API_KEY} against https://mcp.withwandb.com/mcp).
 
 # W&B API key (from wandb.ai/settings)
 WANDB_API_KEY=your-wandb-api-key

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "wandb": {
+      "type": "http",
+      "url": "https://mcp.withwandb.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${WANDB_API_KEY}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a project-scoped `.mcp.json` at the repo root so Claude Code wires the W&B MCP server (`https://mcp.withwandb.com/mcp`) automatically using `Authorization: Bearer ${WANDB_API_KEY}`.
- The `${WANDB_API_KEY}` placeholder is expanded from the process env at connect time, and `.devcontainer/{cpu,gpu,root_gpu}/devcontainer.json` already forwards `.env` via `runArgs: ["--env-file", ".env"]`, so the key is already in env inside every devcontainer variant — no per-developer `~/.claude.json` edits, survives rebuilds.
- Notes the new consumer in the `WANDB_API_KEY` block of `.env.example`.

## Why this shape

The W&B MCP server is **not** OAuth — it returns plain-text `Not Found` (HTTP 404) on `/.well-known/oauth-authorization-server`, which causes Claude Code's OAuth-discovery fallback to surface a misleading `Invalid OAuth error response: SyntaxError: JSON Parse error: Unexpected identifier "Not". Raw body: Not Found` after the 401 on `/mcp`. The real auth is an API-key Bearer token. A project-scoped `.mcp.json` with header expansion is the only configuration that:

- works for every devcontainer variant uniformly (cpu / gpu / root_gpu),
- survives container rebuilds (the file is checked into the repo, not `~/.claude.json`),
- keeps the key out of the diff (env expansion at connect time),
- and degrades gracefully for unconfigured users (Claude Code just reports the server as failed in `claude mcp list`).

## Scope note (raised by code-health WARN)

Because `.mcp.json` is project-scoped, it activates on every Claude Code session that opens this repo — host-side too, not only inside the devcontainer. Developers who open the repo on the host without `WANDB_API_KEY` exported in their shell will see the `wandb` server fail to connect (no secret leak, no crash — just an entry in `claude mcp list`). This is intentional: the same wiring is useful for anyone who has a `WANDB_API_KEY` in their host shell.

## Test plan

- [ ] Open the repo in a `.devcontainer/cpu/` session with `WANDB_API_KEY` set in `.env`; confirm `claude mcp list` shows `wandb: … ✓ Connected`.
- [ ] Same as above for `.devcontainer/gpu/` and `.devcontainer/root_gpu/`.
- [ ] Open the repo on the host with `WANDB_API_KEY` unset; confirm `claude mcp list` shows the failure cleanly (no OAuth-shaped error).
- [ ] Open the repo on the host with `WANDB_API_KEY` exported in the shell; confirm `claude mcp list` shows `✓ Connected`.

Closes #1326

# REVIEW_FULL=.agent-reviews/repo-review-full-no-comments.4b4bec348e54b71dde5570b8a99e40d2c973277a.md