### PR TITLE
chore(devcontainer): restore claude/gh tmux panes on rebuild

### DIFF
--- a/.devcontainer/tmux.conf
+++ b/.devcontainer/tmux.conf
@@ -49,6 +49,9 @@ set -g @continuum-save-interval '5'
 # Pin resurrect state to a fixed path so a named volume in devcontainer.json
 # can mount it and survive container rebuilds.
 set -g @resurrect-dir '~/.local/share/tmux/resurrect'
+# Revive claude/gh panes as themselves on rebuild; resurrect drops non-default
+# programs to bare bash otherwise. Relaunches fresh (no in-app state).
+set -g @resurrect-processes '"~claude" "~gh"'
 
 # Must be the last line. Bootstraps TPM and loads the plugins above.
 run '~/.tmux/plugins/tpm/tpm'

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -226,7 +226,7 @@ docs:
       - pattern: ".devcontainer/root_gpu/devcontainer.json"
         covers: "Root-user GPU dev container variant — remoteUser defaults to root, docker-in-docker + act features, --gpus all, VS Code terminal profile defaulting to tmux"
       - pattern: ".devcontainer/tmux.conf"
-        covers: "tmux config installed to ~/.tmux.conf by post-create.sh — mouse mode, true color, 1-indexed windows, larger scrollback, vi copy mode, intuitive split keys, TPM plugin manager + tmux-resurrect + tmux-continuum (auto-restore on, 5-min save interval, resurrect state pinned to ~/.local/share/tmux/resurrect so the named volume can persist it)"
+        covers: "tmux config installed to ~/.tmux.conf by post-create.sh — mouse mode, true color, 1-indexed windows, larger scrollback, vi copy mode, intuitive split keys, TPM plugin manager + tmux-resurrect + tmux-continuum (auto-restore on, 5-min save interval, resurrect state pinned to ~/.local/share/tmux/resurrect so the named volume can persist it, claude/gh panes revived as themselves on restore)"
       - pattern: ".devcontainer/initialize.sh"
         covers: "Host-side initializeCommand — refuses pointer-file `.git` (worktree/submodule/--separate-git-dir), ensures .env exists"
       - pattern: ".devcontainer/post-create.sh"


### PR DESCRIPTION
## Problem

The devcontainer runs tmux with tmux-resurrect + tmux-continuum to auto-save/restore sessions across container rebuilds. After a rebuild, continuum restores sessions and their working directories correctly, but every pane that was running an interactive `claude` (Claude Code CLI) or `gh` process comes back as a bare `bash` shell. We lost 8 running Claude sessions on a recent rebuild and had to relaunch them manually.

Root cause: tmux-resurrect only restores a fixed default program list (`vi vim nvim emacs man less more tail top htop irssi weechat mutt`) unless extra programs are opted in via `@resurrect-processes`. `claude` and `gh` aren't in that list, so they drop to bash on restore.

## Fix

Add one line to `.devcontainer/tmux.conf` (which `post-create.sh` installs verbatim to `~/.tmux.conf`):

    set -g @resurrect-processes '"~claude" "~gh"'

The `~` prefix is resurrect's loose-match — it matches the program regardless of arguments (e.g. `claude --resume <uuid>`). Verified against the installed plugin source (`scripts/process_restore_helpers.sh` `_restore_list`): `@resurrect-processes` **appends** to the default list rather than replacing it, so all the built-in programs stay restored. The edited config was sanity-checked with `tmux -L <throwaway> source-file` (parses clean).

## Limitation (be honest)

This restores the **program** fresh — it relaunches `claude`/`gh` in the correct working directory. It does **NOT** restore Claude's in-app conversation state. After a rebuild the user still has to run `/resume` inside the relaunched `claude` to pick up the prior conversation.

Refs #1328