### PR TITLE
fix(cli): inline oracle eval resumes the generate wandb run

### DIFF
--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -56,7 +56,7 @@ docs:
       - pattern: "src/synth_setter/cli/eval.py"
         covers: "Checkpoint resolution from W&B, evaluation logging"
       - pattern: "src/synth_setter/cli/generate_dataset.py"
-        covers: "WandbLogger lifecycle for dataset generation: spec → hyperparams + dataset-spec artifact, per-shard + summary history rows, run id pinned to spec.run_id"
+        covers: "WandbLogger lifecycle for dataset generation: spec → hyperparams + dataset-spec artifact, per-shard + summary history rows, run id pinned to spec.run_id, inline oracle eval resuming the run to append test/* rows"
       - pattern: "src/synth_setter/configs/dataset.yaml"
         covers: "Default `logger: wandb` for dataset generation; entity/project sourced from logger/wandb.yaml"
       - pattern: "sweeps/**"

--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -255,6 +255,17 @@ wandb agent <entity>/<project>/<sweep_id>          # runs trials
 Each trial subprocess opens its own wandb run with `id = spec.run_id`; the
 `WANDB_SWEEP_ID` env (set by the agent) attaches the run to the sweep grid.
 
+### 5f. Inline oracle eval (`oracle_eval_inline=true`)
+
+When `oracle_eval_inline=true`, the local-run path shells out to
+`synth_setter.cli.eval` after `generate(...)` has closed its run.
+`_run_oracle_eval_subprocess` (`src/synth_setter/cli/generate_dataset.py`)
+re-opens the same run via `+logger.wandb.id=<spec.run_id> +logger.wandb.resume=must`, so Lightning's `trainer.test` deposits `test/*`
+metrics (e.g. `test/param_mse` from the surge fake-oracle) onto the generate
+run — a `wandb sync` then merges both phases under one run id. The eval
+subprocess inherits `WANDB_MODE` from the launcher, so its offline/online
+posture follows the parent's.
+
 ______________________________________________________________________
 
 ## 6. Known Gaps

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -110,7 +110,9 @@ def _run_oracle_eval_subprocess(dataset_root: Path, run_id: str) -> None:
         f"hydra.run.dir={dataset_root}",
         "ckpt_path=null",
         "logger=wandb",
-        f"+logger.wandb.id={run_id}",
+        # id already exists in logger/wandb.yaml (id: null) so a plain
+        # override suffices; resume is absent there and needs +append.
+        f"logger.wandb.id={run_id}",
         "+logger.wandb.resume=must",
         # configs/data/surge*.yaml marks predict_file a mandatory `???` value;
         # mode=test never reads it, so null satisfies the resolver instead of

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -32,7 +32,7 @@ from omegaconf import DictConfig, OmegaConf
 from synth_setter.cli.finalize_dataset import finalize_from_spec
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.pipeline import r2_io
-from synth_setter.pipeline.constants import WORKER_SPEC_URI_ENV
+from synth_setter.pipeline.constants import STATS_NPZ_FILENAME, WORKER_SPEC_URI_ENV
 from synth_setter.pipeline.partitioning import (
     available_cpus,
     get_my_shards,
@@ -76,23 +76,30 @@ _ORACLE_EVAL_TIMEOUT_SECONDS = 600
 
 
 def _download_finalized_splits(spec: DatasetSpec, dest: Path) -> None:
-    """Download finalized ``{train,val,test}.h5`` from R2 into ``dest`` (created if missing).
+    """Download finalized ``{train,val,test}.h5`` + ``stats.npz`` into ``dest`` (created if missing).
 
-    :param spec: Resolves the per-split R2 URI via ``spec.r2.split_h5_uri``.
-    :param dest: Local directory to receive the three split files.
+    The eval datamodule loads normalization stats from ``dest/stats.npz``
+    (``use_saved_mean_and_variance=true``), so it must land beside the splits.
+
+    :param spec: Resolves the R2 URIs via ``spec.r2.split_h5_uri`` /
+        ``spec.r2.stats_uri``.
+    :param dest: Local directory to receive the splits and stats file.
     """
     dest.mkdir(parents=True, exist_ok=True)
     for split in ("train", "val", "test"):
         r2_io.download_to_path(spec.r2.split_h5_uri(split), dest / f"{split}.h5")
+    r2_io.download_to_path(spec.r2.stats_uri(), dest / STATS_NPZ_FILENAME)
 
 
-def _run_oracle_eval_subprocess(dataset_root: Path) -> None:
+def _run_oracle_eval_subprocess(dataset_root: Path, run_id: str) -> None:
     """Run the fake-oracle eval on ``dataset_root`` to verify the param-array round-trip.
 
     ``check=True`` so a non-zero eval exit (or wall-clock timeout) propagates
     to the caller.
 
     :param dataset_root: Holds the finalized HDF5 splits the eval datamodule reads.
+    :param run_id: Canonical ``spec.run_id``; the eval resumes this wandb run
+        so its ``test/*`` metrics land on the generate phase's run.
     """
     argv = [
         sys.executable,
@@ -102,7 +109,16 @@ def _run_oracle_eval_subprocess(dataset_root: Path) -> None:
         f"data.dataset_root={dataset_root}",
         f"hydra.run.dir={dataset_root}",
         "ckpt_path=null",
-        "logger=null",
+        "logger=wandb",
+        f"+logger.wandb.id={run_id}",
+        "+logger.wandb.resume=must",
+        # surge data config marks predict_file mandatory (???); mode=test
+        # never reads it, so null keeps datamodule instantiation from raising.
+        "data.predict_file=null",
+        # SurgeXTDataset floors len to samples // batch_size; the 128 default
+        # would yield zero batches on the smoke-sized test split (4 samples),
+        # so test_step never runs and no test/* metric is logged — see #1331.
+        "data.batch_size=1",
         "mode=test",
     ]
     logger.info(f"oracle_eval_inline subprocess: {argv}")
@@ -769,7 +785,7 @@ def main(cfg: DictConfig) -> None:
         if cfg.oracle_eval_inline:
             eval_dir = _OPERATOR_WORKSPACE / "oracle_eval" / spec.run_id
             _download_finalized_splits(spec, eval_dir)
-            _run_oracle_eval_subprocess(eval_dir)
+            _run_oracle_eval_subprocess(eval_dir, spec.run_id)
         return
 
     if cfg.finalize_inline or cfg.oracle_eval_inline:

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -76,7 +76,7 @@ _ORACLE_EVAL_TIMEOUT_SECONDS = 600
 
 
 def _download_finalized_splits(spec: DatasetSpec, dest: Path) -> None:
-    """Download finalized ``{train,val,test}.h5`` + ``stats.npz`` into ``dest`` (created if missing).
+    """Download ``{train,val,test}.h5`` + ``stats.npz`` into ``dest``.
 
     The eval datamodule loads normalization stats from ``dest/stats.npz``
     (``use_saved_mean_and_variance=true``), so it must land beside the splits.

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -112,8 +112,9 @@ def _run_oracle_eval_subprocess(dataset_root: Path, run_id: str) -> None:
         "logger=wandb",
         f"+logger.wandb.id={run_id}",
         "+logger.wandb.resume=must",
-        # surge data config marks predict_file mandatory (???); mode=test
-        # never reads it, so null keeps datamodule instantiation from raising.
+        # configs/data/surge*.yaml marks predict_file a mandatory `???` value;
+        # mode=test never reads it, so null satisfies the resolver instead of
+        # raising MissingMandatoryValue at datamodule instantiation — see #1331.
         "data.predict_file=null",
         # SurgeXTDataset floors len to samples // batch_size; the 128 default
         # would yield zero batches on the smoke-sized test split (4 samples),

--- a/tests/integration/test_generate_dataset_cli_wandb_e2e.py
+++ b/tests/integration/test_generate_dataset_cli_wandb_e2e.py
@@ -349,7 +349,12 @@ def test_phase_3_sweep_cadence_cell_runs_end_to_end(
 
 
 def _single_wandb_binary(run_dir: Path) -> Path:
-    """Return the sole ``run-*.wandb`` binary under one offline-run dir."""
+    """Return the sole ``run-*.wandb`` binary under one offline-run dir.
+
+    :param run_dir: a single ``offline-run-*`` dir; must hold exactly one
+        ``run-*.wandb`` binary.
+    :returns: the lone matching binary path.
+    """
     binaries = list(run_dir.glob("run-*.wandb"))
     assert len(binaries) == 1, (
         f"expected exactly one .wandb binary under {run_dir}; got {binaries}"

--- a/tests/integration/test_generate_dataset_cli_wandb_e2e.py
+++ b/tests/integration/test_generate_dataset_cli_wandb_e2e.py
@@ -129,6 +129,8 @@ def _run_cli(
     hydra_run_dir: Path,
     r2_prefix: str,
     extra_overrides: list[str] | None = None,
+    extra_env: dict[str, str] | None = None,
+    timeout: int = 300,
 ) -> subprocess.CompletedProcess[str]:
     """Subprocess-invoke ``synth-setter-generate-dataset`` with offline wandb.
 
@@ -144,6 +146,12 @@ def _run_cli(
         purges it on teardown.
     :param extra_overrides: Additional Hydra overrides appended after the
         baseline pins (e.g. cadence overrides for Phase 3).
+    :param extra_env: Merged on top of the base env (``WANDB_MODE=offline``
+        + ``PYTHONPATH``); use to pin ``SYNTH_SETTER_WORKSPACE`` when the
+        test cares where ``operator_workspace()`` lands on disk.
+    :param timeout: Wall-clock seconds for the whole CLI; lift above the
+        300s default when the invocation also runs inline finalize / oracle
+        eval phases.
     :returns: The completed subprocess; the caller asserts on
         ``returncode`` + reads the wandb dir under ``hydra_run_dir``.
     """
@@ -163,13 +171,15 @@ def _run_cli(
     worktree_src = Path(__file__).resolve().parents[2] / "src"
     pythonpath = f"{worktree_src}:{os.environ.get('PYTHONPATH', '')}"
     env = {**os.environ, "WANDB_MODE": "offline", "PYTHONPATH": pythonpath}
+    if extra_env:
+        env.update(extra_env)
     return subprocess.run(  # noqa: S603 — args built from validated config + test-controlled paths
         [sys.executable, "-m", "synth_setter.cli.generate_dataset", *overrides],
         env=env,
         capture_output=True,
         text=True,
         check=False,
-        timeout=300,
+        timeout=timeout,
     )
 
 
@@ -336,3 +346,81 @@ def test_phase_3_sweep_cadence_cell_runs_end_to_end(
             f"cadence override {key}={value!r} not found in wandb binary at "
             f"{wandb_binaries[0]} (cell reload={reload_cadence} gui={gui_cadence})"
         )
+
+
+def _single_wandb_binary(run_dir: Path) -> Path:
+    """Return the sole ``run-*.wandb`` binary under one offline-run dir."""
+    binaries = list(run_dir.glob("run-*.wandb"))
+    assert len(binaries) == 1, (
+        f"expected exactly one .wandb binary under {run_dir}; got {binaries}"
+    )
+    return binaries[0]
+
+
+def test_oracle_eval_inline_resumes_generate_wandb_run(
+    cli_env: tuple[Path, str],
+) -> None:
+    """Inline oracle eval resumes the generate-phase wandb run id.
+
+    One CLI invocation with ``oracle_eval_inline=true`` +
+    ``finalize_inline=true`` under ``WANDB_MODE=offline``. After the CLI
+    exits, the launcher's hydra dir and the operator workspace's
+    ``oracle_eval/<run_id>/`` dir each hold one ``offline-run-*-<run_id>``
+    directory; the two ``<run_id>`` slugs must match (the eval child
+    resumed the same wandb run). Generate's dir must carry shard +
+    summary history rows; eval's dir must carry at least one ``test/*``
+    row from Lightning's ``trainer.test``.
+
+    :param cli_env: ``(hydra_run_dir, r2_prefix)`` from the fixture — gates
+        skip conditions and owns R2 cleanup.
+    """
+    hydra_run_dir, prefix = cli_env
+    # ``operator_workspace()`` honors ``$SYNTH_SETTER_WORKSPACE`` and
+    # decides where ``main()`` writes ``oracle_eval/<run_id>/``; pin it to
+    # the fixture's tmp_path so the eval's wandb dir is reachable from the
+    # test without depending on the checkout-root walk.
+    workspace = hydra_run_dir.parent
+    result = _run_cli(
+        hydra_run_dir=hydra_run_dir,
+        r2_prefix=prefix,
+        extra_overrides=[
+            "experiment=generate_dataset/smoke-shard-with-oracle-eval",
+            "finalize_inline=true",
+            "oracle_eval_inline=true",
+        ],
+        extra_env={"SYNTH_SETTER_WORKSPACE": str(workspace)},
+        timeout=600,
+    )
+    _assert_cli_succeeded(result, context="oracle_eval_inline shared-wandb-run")
+
+    generate_run_dir = _find_offline_run_dir(hydra_run_dir)
+    generate_run_id = generate_run_dir.name.split("-", 3)[-1]
+
+    eval_workspace_dir = workspace / "oracle_eval" / generate_run_id
+    assert eval_workspace_dir.is_dir(), (
+        f"expected eval workspace dir at {eval_workspace_dir}; "
+        f"main()'s oracle_eval_inline branch did not run with the launcher's run_id"
+    )
+    eval_run_dir = _find_offline_run_dir(eval_workspace_dir)
+    eval_run_id = eval_run_dir.name.split("-", 3)[-1]
+    assert eval_run_id == generate_run_id, (
+        f"eval wandb run id {eval_run_id!r} does not match generate's "
+        f"{generate_run_id!r} — the eval subprocess opened a fresh run "
+        f"instead of resuming"
+    )
+
+    generate_binary = _single_wandb_binary(generate_run_dir)
+    generate_rows = read_history_rows(generate_binary)
+    assert any("shard/bytes" in r for r in generate_rows), (
+        f"generate dir missing per-shard history rows in {generate_binary}"
+    )
+    assert any("shards/rendered" in r for r in generate_rows), (
+        f"generate dir missing summary history row in {generate_binary}"
+    )
+
+    eval_binary = _single_wandb_binary(eval_run_dir)
+    eval_rows = read_history_rows(eval_binary)
+    assert any(any(k.startswith("test/") for k in r) for r in eval_rows), (
+        f"eval dir has no test/* history rows in {eval_binary}; "
+        f"oracle eval did not log Lightning test_step metrics to the resumed run"
+    )

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1758,7 +1758,8 @@ class TestMainDispatchBranches:
         # The eval resumes the generate run rather than opening a fresh one, so
         # its test/* metrics share the run id (logger=null crashed Hydra — see #1331).
         assert "logger=wandb" in called_argv
-        assert "+logger.wandb.id=some-run-id" in called_argv
+        # id exists in logger/wandb.yaml (plain override); resume is absent (+append).
+        assert "logger.wandb.id=some-run-id" in called_argv
         assert "+logger.wandb.resume=must" in called_argv
         # surge data config marks predict_file mandatory; mode=test never reads it.
         assert "data.predict_file=null" in called_argv

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1691,6 +1691,37 @@ class TestMainDispatchBranches:
         _, downloaded_dest = download_mock.call_args[0]
         assert downloaded_dest == dataset_root
 
+    def test_download_finalized_splits_fetches_stats_npz_beside_splits(
+        self,
+        spec: DatasetSpec,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Finalize download lands ``stats.npz`` in the same dir as the splits.
+
+        The eval datamodule loads normalization stats from
+        ``<dataset_root>/stats.npz`` (``use_saved_mean_and_variance=true``);
+        without it the inline oracle eval crashes — see #1331.
+
+        :param spec: Fixture-provided ``DatasetSpec``; resolves the R2 URIs.
+        :param monkeypatch: Patches the module's ``r2_io.download_to_path``.
+        :param tmp_path: Destination dir for the downloaded artifacts.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        downloads: dict[Path, str] = {}
+        monkeypatch.setattr(
+            gd.r2_io,
+            "download_to_path",
+            lambda uri, dest: downloads.__setitem__(Path(dest), uri),
+        )
+
+        gd._download_finalized_splits(spec, tmp_path)
+
+        assert downloads[tmp_path / "stats.npz"] == spec.r2.stats_uri()
+        for split in ("train", "val", "test"):
+            assert downloads[tmp_path / f"{split}.h5"] == spec.r2.split_h5_uri(split)
+
     def test_run_oracle_eval_subprocess_builds_expected_argv(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -1699,8 +1730,10 @@ class TestMainDispatchBranches:
         """Helper subprocesses ``synth_setter.cli.eval`` with the contract argv.
 
         Pins the load-bearing overrides (``experiment=surge/fake_oracle``,
-        ``data.dataset_root``, ``ckpt_path=null``, ``mode=test``). Runs the
-        helper directly so cfg-resolution noise can't mask an argv drift.
+        ``data.dataset_root``, ``ckpt_path=null``, ``mode=test``) plus the
+        wandb-resume trio that routes the eval's ``test/*`` metrics onto the
+        generate run. Runs the helper directly so cfg-resolution noise can't
+        mask an argv drift.
 
         :param monkeypatch: Patches the module's ``subprocess.run``.
         :param tmp_path: Stands in for the finalize download directory.
@@ -1710,7 +1743,7 @@ class TestMainDispatchBranches:
         run_mock = MagicMock()
         monkeypatch.setattr(gd.subprocess, "run", run_mock)
 
-        gd._run_oracle_eval_subprocess(tmp_path)
+        gd._run_oracle_eval_subprocess(tmp_path, "some-run-id")
 
         run_mock.assert_called_once()
         called_argv = run_mock.call_args[0][0]
@@ -1722,6 +1755,16 @@ class TestMainDispatchBranches:
         # the workflow's metrics.json glob lands at <tmp_path>/metrics/metrics.json.
         assert f"hydra.run.dir={tmp_path}" in called_argv
         assert "ckpt_path=null" in called_argv
+        # The eval resumes the generate run rather than opening a fresh one, so
+        # its test/* metrics share the run id (logger=null crashed Hydra — see #1331).
+        assert "logger=wandb" in called_argv
+        assert "+logger.wandb.id=some-run-id" in called_argv
+        assert "+logger.wandb.resume=must" in called_argv
+        # surge data config marks predict_file mandatory; mode=test never reads it.
+        assert "data.predict_file=null" in called_argv
+        # batch_size=1 keeps the smoke-sized test split (4 samples) from
+        # flooring to zero batches under the 128 default — see #1331.
+        assert "data.batch_size=1" in called_argv
         assert "mode=test" in called_argv
 
     def test_main_oracle_eval_inline_default_false_skips(


### PR DESCRIPTION
## Summary

- `oracle_eval_inline` was broken end-to-end: the eval subprocess was invoked with `logger=null`, which crashes Hydra composition (`Config group override must be a string or a list. Got NoneType`). The feature's only prior test mocked `subprocess.run`, so the crash never surfaced.
- Swap `logger=null` for `logger=wandb +logger.wandb.id=<spec.run_id> +logger.wandb.resume=must` so the inline oracle eval **resumes the generate phase's wandb run** and its `test/*` metrics land on the same run (the original motivation — sweep rows now show generation + eval together). `_run_oracle_eval_subprocess` gains a `run_id` arg; the `main()` call site passes `spec.run_id`.
- Making the eval actually run unmasked two latent blockers, both fixed within the eval-invocation surface so the round-trip works: download `stats.npz` beside the splits (`use_saved_mean_and_variance=true` loads it from `dataset_root`), and pin `data.predict_file=null` (mandatory-but-unused under `mode=test`) + `data.batch_size=1` (so the 4-sample smoke test split doesn't floor to zero batches and skip `test_step`).

## Tests

- **New real-workflow integration test** (`test_oracle_eval_inline_resumes_generate_wandb_run`) — drives the CLI with `oracle_eval_inline=true` under `WANDB_MODE=offline` against real Surge VST + real R2, then asserts on-disk wandb state: two `offline-run-*-<run_id>` dirs share one run_id slug, generate's `.wandb` carries shard+summary rows, eval's `.wandb` carries `test/*` rows. **No mocks.**
- New focused unit test pinning the `stats.npz` download; legacy argv unit test updated for the new signature + overrides.

## Test plan

- [x] `pytest tests/integration/test_generate_dataset_cli_wandb_e2e.py::test_oracle_eval_inline_resumes_generate_wandb_run` — 1 passed in 202s (ran, not skipped; real VST + R2)
- [x] `pytest tests/pipeline/test_entrypoints/test_generate_dataset.py` — 66 passed
- [x] `ruff check` + `pyright` clean on touched files

Closes #1331