### PR TITLE
fix(ci): run generate-finalize-oracle-eval inside dev-snapshot image

### DIFF
--- a/.github/workflows/generate-finalize-oracle-eval.yaml
+++ b/.github/workflows/generate-finalize-oracle-eval.yaml
@@ -6,13 +6,10 @@ name: Generate + Finalize + Oracle-Eval Dataset (inline)
 # eval against the finalized splits — proving the parameter-array
 # round-trip survived generate + finalize.
 #
-# Generation renders real audio with the Surge XT VST3, so the job runs
-# inside the dev-snapshot image (plugin at /usr/lib/vst3/Surge XT.vst3 plus
-# the headless X11 stack) under the Xvfb wrapper, mirroring
-# nightly-parallel-datagen.yml. WANDB_MODE=offline keeps the run hermetic and
-# lets the inline oracle eval resume the generate-phase run without an API
-# key — the same setup pinned by
-# tests/integration/test_generate_dataset_cli_wandb_e2e.py.
+# Generation renders real audio with the Surge XT VST3, so the job runs the
+# dev-snapshot image under the Xvfb wrapper (mirrors nightly-parallel-datagen.yml).
+# WANDB_MODE=offline keeps the run hermetic so the inline oracle eval can resume
+# the generate-phase run — see tests/integration/test_generate_dataset_cli_wandb_e2e.py.
 #
 # Required secrets (callers should `secrets: inherit`):
 #   RCLONE_CONFIG_R2_ACCESS_KEY_ID, RCLONE_CONFIG_R2_SECRET_ACCESS_KEY,
@@ -66,8 +63,8 @@ jobs:
       RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
       RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
       HYDRA_FULL_ERROR: "1"
-      # offline keeps the inline oracle eval's resume=must hermetic — no API
-      # key, no server-side smoke runs (see the e2e test referenced above).
+      # Keeps the inline oracle eval's resume=must hermetic — no API key, no
+      # server-side smoke runs (see the e2e test referenced in the header).
       WANDB_MODE: offline
     steps:
       - name: Checkout
@@ -93,11 +90,9 @@ jobs:
                 python -X faulthandler -c "from synth_setter.data.vst.core import load_plugin; load_plugin(\"/usr/lib/vst3/Surge XT.vst3\")"
             '
 
-      # Generation renders with the real Surge VST3, so it runs in the image
-      # under the Xvfb wrapper. ensure_plugin_symlinks.sh recreates the
-      # plugins/Surge XT.vst3 symlink the bind-mount shadows; hydra.run.dir is
-      # pinned under the mounted workspace so the host can read the eval's
-      # metrics.json and the tee'd log.
+      # ensure_plugin_symlinks.sh restores the Surge symlink the bind-mount
+      # shadows; hydra.run.dir is pinned under the mounted workspace so the host
+      # can read the eval's metrics.json and the tee'd log.
       - name: Run synth-setter-generate-dataset (oracle_eval_inline)
         env:
           EXPERIMENT: ${{ inputs.experiment }}
@@ -130,8 +125,7 @@ jobs:
 
       # Lightning's trainer.test() prints the final metrics table to stdout
       # (tee'd to the host log above); parse it for test/param_mse and assert
-      # exactly zero — the load-bearing oracle invariant. Runs in the image
-      # because assert_oracle_invariant ships in the synth_setter package.
+      # exactly zero — the load-bearing oracle invariant.
       - name: Assert oracle test/param_mse == 0.0 (log)
         run: |
           set -euo pipefail
@@ -154,7 +148,7 @@ jobs:
         run: |
           set -euo pipefail
           rel=$(cd "${{ github.workspace }}" && find oracle-eval-run -type f -path '*/oracle_eval/*/metrics/metrics.json' -print -quit)
-          if [ -z "${rel}" ]; then
+          if [[ -z "${rel}" ]]; then
             echo "::error::no metrics.json under oracle-eval-run/"; exit 1
           fi
           echo "rel=${rel}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/generate-finalize-oracle-eval.yaml
+++ b/.github/workflows/generate-finalize-oracle-eval.yaml
@@ -4,9 +4,15 @@ name: Generate + Finalize + Oracle-Eval Dataset (inline)
 # oracle_eval_inline=true so the same CLI process that generated the
 # shards also writes dataset.complete and runs the surge/fake_oracle
 # eval against the finalized splits — proving the parameter-array
-# round-trip survived generate + finalize. Mirrors finalize-dataset.yaml's
-# bare-runner install (no docker, no SkyPilot path); the experiment chosen
-# at dispatch time decides which spec is generated.
+# round-trip survived generate + finalize.
+#
+# Generation renders real audio with the Surge XT VST3, so the job runs
+# inside the dev-snapshot image (plugin at /usr/lib/vst3/Surge XT.vst3 plus
+# the headless X11 stack) under the Xvfb wrapper, mirroring
+# nightly-parallel-datagen.yml. WANDB_MODE=offline keeps the run hermetic and
+# lets the inline oracle eval resume the generate-phase run without an API
+# key — the same setup pinned by
+# tests/integration/test_generate_dataset_cli_wandb_e2e.py.
 #
 # Required secrets (callers should `secrets: inherit`):
 #   RCLONE_CONFIG_R2_ACCESS_KEY_ID, RCLONE_CONFIG_R2_SECRET_ACCESS_KEY,
@@ -22,10 +28,15 @@ on:
         type: string
         default: smoke-shard-with-oracle-eval
       env_ref:
-        description: "Git ref / SHA to check out"
+        description: "Git ref / SHA to check out (mounted over the image's baked checkout)"
         required: false
         type: string
         default: ""
+      image_tag:
+        description: "Docker image tag (e.g. dev-snapshot, dev-snapshot-<sha>)"
+        required: false
+        type: string
+        default: dev-snapshot
   workflow_call:
     inputs:
       experiment:
@@ -34,6 +45,10 @@ on:
       env_ref:
         required: true
         type: string
+      image_tag:
+        required: false
+        type: string
+        default: dev-snapshot
 
 permissions:
   contents: read
@@ -44,79 +59,122 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
+      IMAGE: tinaudio/synth-setter:${{ inputs.image_tag || 'dev-snapshot' }}
       RCLONE_CONFIG_R2_TYPE: s3
       RCLONE_CONFIG_R2_PROVIDER: Cloudflare
       RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
       RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
       RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
       HYDRA_FULL_ERROR: "1"
+      # offline keeps the inline oracle eval's resume=must hermetic — no API
+      # key, no server-side smoke runs (see the e2e test referenced above).
+      WANDB_MODE: offline
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.env_ref != '' && inputs.env_ref || github.sha }}
 
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.10"
+      - name: Pull image
+        run: docker pull "$IMAGE"
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
+      # Fail fast if the plugin / image / mount layout is broken before the
+      # longer generate run — mirrors nightly-parallel-datagen.yml.
+      - name: Smoke-test Surge XT plugin load
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/home/build/synth-setter:ro" \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              git config --global --add safe.directory /home/build/synth-setter
+              src/synth_setter/scripts/run-linux-vst-headless.sh \
+                python -X faulthandler -c "from synth_setter.data.vst.core import load_plugin; load_plugin(\"/usr/lib/vst3/Surge XT.vst3\")"
+            '
 
-      - name: Install rclone
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
-
-      # `pipeline.data.reshard` transitively touches the torch-gated `data/`
-      # package — CPU torch is the minimum that resolves all imports.
-      - name: Install project deps (uv sync --frozen, CPU torch)
-        run: uv sync --frozen --extra cpu --no-default-groups --group dev
-
+      # Generation renders with the real Surge VST3, so it runs in the image
+      # under the Xvfb wrapper. ensure_plugin_symlinks.sh recreates the
+      # plugins/Surge XT.vst3 symlink the bind-mount shadows; hydra.run.dir is
+      # pinned under the mounted workspace so the host can read the eval's
+      # metrics.json and the tee'd log.
       - name: Run synth-setter-generate-dataset (oracle_eval_inline)
         env:
           EXPERIMENT: ${{ inputs.experiment }}
-          PROJECT_ROOT: ${{ github.workspace }}
         run: |
           set -euo pipefail
-          uv run synth-setter-generate-dataset \
-            "experiment=generate_dataset/${EXPERIMENT}" \
-            "finalize_inline=true" \
-            "oracle_eval_inline=true" \
+          docker run --rm \
+            -v "${{ github.workspace }}:/home/build/synth-setter" \
+            -e RCLONE_CONFIG_R2_TYPE \
+            -e RCLONE_CONFIG_R2_PROVIDER \
+            -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
+            -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
+            -e RCLONE_CONFIG_R2_ENDPOINT \
+            -e EXPERIMENT \
+            -e HYDRA_FULL_ERROR \
+            -e WANDB_MODE \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              git config --global --add safe.directory /home/build/synth-setter
+              bash docker/ubuntu22_04/ensure_plugin_symlinks.sh
+              src/synth_setter/scripts/run-linux-vst-headless.sh \
+                synth-setter-generate-dataset \
+                  "experiment=generate_dataset/${EXPERIMENT}" \
+                  "finalize_inline=true" \
+                  "oracle_eval_inline=true" \
+                  "hydra.run.dir=/home/build/synth-setter/oracle-eval-run"
+            ' \
             2>&1 | tee generate-finalize-oracle-eval.log
 
-      # Lightning's `trainer.test()` prints the final metrics table to stdout;
-      # parse it for `test/param_mse` and assert exactly zero — the load-bearing
-      # oracle invariant. Fails the workflow on any non-zero / missing value.
+      # Lightning's trainer.test() prints the final metrics table to stdout
+      # (tee'd to the host log above); parse it for test/param_mse and assert
+      # exactly zero — the load-bearing oracle invariant. Runs in the image
+      # because assert_oracle_invariant ships in the synth_setter package.
       - name: Assert oracle test/param_mse == 0.0 (log)
         run: |
           set -euo pipefail
-          uv run python -m synth_setter.evaluation.assert_oracle_invariant \
-            generate-finalize-oracle-eval.log
+          docker run --rm \
+            -v "${{ github.workspace }}:/home/build/synth-setter:ro" \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              python3 -m synth_setter.evaluation.assert_oracle_invariant \
+                generate-finalize-oracle-eval.log
+            '
 
-      # Independent structured cross-check: `cli/eval.py` writes the metric_dict
-      # JSON under <eval-dir>/metrics/metrics.json. Globbing under the operator
-      # workspace finds the one inline-eval run's artifact regardless of the
-      # spec's run_id, then asserts the same invariant from a non-stdout source.
+      # Independent structured cross-check: cli/eval.py writes the metric_dict
+      # JSON to <eval-dir>/metrics/metrics.json under the pinned run dir. Emit
+      # a workspace-relative path so the docker assert and the host upload can
+      # both resolve it.
       - name: Locate metrics.json
         id: locate_metrics
         run: |
           set -euo pipefail
-          metrics_path=$(find "${PROJECT_ROOT}/oracle_eval" -type f -name 'metrics.json' | head -n1)
-          if [ -z "${metrics_path}" ]; then
-            echo "::error::no metrics.json under ${PROJECT_ROOT}/oracle_eval"; exit 1
+          rel=$(cd "${{ github.workspace }}" && find oracle-eval-run -type f -path '*/oracle_eval/*/metrics/metrics.json' -print -quit)
+          if [ -z "${rel}" ]; then
+            echo "::error::no metrics.json under oracle-eval-run/"; exit 1
           fi
-          echo "path=${metrics_path}" >> "${GITHUB_OUTPUT}"
-          echo "Located metrics.json at ${metrics_path}"
-        env:
-          PROJECT_ROOT: ${{ github.workspace }}
+          echo "rel=${rel}" >> "${GITHUB_OUTPUT}"
+          echo "Located metrics.json at ${rel}"
 
       - name: Assert oracle test/param_mse == 0.0 (metrics.json)
+        env:
+          METRICS_REL: ${{ steps.locate_metrics.outputs.rel }}
         run: |
           set -euo pipefail
-          uv run python -m synth_setter.evaluation.assert_oracle_invariant \
-            --metrics-json "${{ steps.locate_metrics.outputs.path }}"
+          docker run --rm \
+            -v "${{ github.workspace }}:/home/build/synth-setter:ro" \
+            -e METRICS_REL \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              python3 -m synth_setter.evaluation.assert_oracle_invariant \
+                --metrics-json "${METRICS_REL}"
+            '
 
       - name: Upload log
         if: always()
@@ -128,10 +186,10 @@ jobs:
           retention-days: 7
 
       - name: Upload metrics.json
-        if: always() && steps.locate_metrics.outputs.path != ''
+        if: always() && steps.locate_metrics.outputs.rel != ''
         uses: actions/upload-artifact@v4
         with:
           name: generate-finalize-oracle-eval-metrics-${{ inputs.experiment }}
-          path: ${{ steps.locate_metrics.outputs.path }}
+          path: ${{ steps.locate_metrics.outputs.rel }}
           if-no-files-found: error
           retention-days: 7


### PR DESCRIPTION
## Summary

The `Generate + Finalize + Oracle-Eval Dataset (inline)` workflow (added in #1325) has failed on every run. It ran on a bare `ubuntu-latest` runner with **no Surge XT VST3 plugin**, so `generate()`'s `extract_renderer_version(plugins/Surge XT.vst3)` raised `FileNotFoundError` before any render:

```
File "src/synth_setter/cli/generate_dataset.py", line 224, in generate
    actual_renderer_version = extract_renderer_version(Path(render.plugin_path))
File "src/synth_setter/data/vst/core.py", line 55, in extract_renderer_version
    raise FileNotFoundError(f"Plugin path does not exist: {plugin_path}")
FileNotFoundError: Plugin path does not exist: plugins/Surge XT.vst3
```

Unlike finalize (which the header claimed to mirror), **generation renders real audio with the plugin** and needs the headless X11 stack only the `dev-snapshot` image bakes. PR #1325's last test-plan item — actually triggering the workflow — was left unchecked, so the break shipped unverified.

## Fix

Run the job inside the `dev-snapshot` image, mirroring `nightly-parallel-datagen.yml`:

- `docker run` the CLI under `run-linux-vst-headless.sh` (Xvfb) after `ensure_plugin_symlinks.sh` recreates the `plugins/Surge XT.vst3` symlink the bind-mount shadows.
- `WANDB_MODE=offline` so the inline oracle eval's `resume=must` is hermetic (no API key, no server-side smoke runs) — the exact setup pinned by `tests/integration/test_generate_dataset_cli_wandb_e2e.py::test_oracle_eval_inline_resumes_generate_wandb_run`.
- Pin `hydra.run.dir` under the mounted workspace so the host can read the eval's `metrics.json` and the tee'd log; the two oracle-invariant asserts run in the image (the module ships in the package). This also fixes a latent second bug — the old `Locate metrics.json` step searched `$PROJECT_ROOT/oracle_eval`, but the artifact lands under the hydra run dir.
- New `image_tag` input (default `dev-snapshot`) for pinning a specific image.

## Test plan

- [x] `gha-workflow-validator`: 10/10 checks, 0 warnings, 0 failures.
- [x] `repo-review-full-no-comments`: 0 BLOCK across 5 skills; comment-hygiene + shell-style WARNs applied.
- [x] Pre-commit (prettier, codespell) passes on the workflow.
- [ ] Trigger `Generate + Finalize + Oracle-Eval Dataset (inline)` via "Run workflow" on this branch and confirm the uploaded log shows `test/param_mse: 0.0` and both assert steps pass. *(Manual — requires dispatch on the branch.)*

Fixes #1336