### PR TITLE
feat(eval): R2 dataset download in the datamodule + inline oracle-eval for the generate sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ thoughts/
 
 # Surge-XT mini-example local artifacts (e.g. learned-model presets)
 presets/*.fxp
+
+# wandb local run/sweep artifacts
+wandb/

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -56,7 +56,7 @@ docs:
       - pattern: "src/synth_setter/cli/eval.py"
         covers: "Checkpoint resolution from W&B, evaluation logging"
       - pattern: "src/synth_setter/cli/generate_dataset.py"
-        covers: "WandbLogger lifecycle for dataset generation: spec → hyperparams + dataset-spec artifact, per-shard + summary history rows, run id pinned to spec.run_id, inline oracle eval resuming the run to append test/* rows"
+        covers: "WandbLogger lifecycle for dataset generation: spec → hyperparams + dataset-spec artifact, per-shard + summary history rows, run id pinned to spec.run_id, inline oracle eval resuming the run to append audio/* rows"
       - pattern: "src/synth_setter/configs/dataset.yaml"
         covers: "Default `logger: wandb` for dataset generation; entity/project sourced from logger/wandb.yaml"
       - pattern: "sweeps/**"

--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -260,11 +260,11 @@ Each trial subprocess opens its own wandb run with `id = spec.run_id`; the
 When `oracle_eval_inline=true`, the local-run path shells out to
 `synth_setter.cli.eval` after `generate(...)` has closed its run.
 `_run_oracle_eval_subprocess` (`src/synth_setter/cli/generate_dataset.py`)
-re-opens the same run via `+logger.wandb.id=<spec.run_id> +logger.wandb.resume=must`, so Lightning's `trainer.test` deposits `test/*`
-metrics (e.g. `test/param_mse` from the surge fake-oracle) onto the generate
-run — a `wandb sync` then merges both phases under one run id. The eval
-subprocess inherits `WANDB_MODE` from the launcher, so its offline/online
-posture follows the parent's.
+re-opens the same run via `logger.wandb.id=<spec.run_id> +logger.wandb.resume=must`, runs `mode=predict` with `render=surge_simple` to
+re-render the predicted params, and deposits `audio/*` audio-similarity
+metrics onto the generate run — a `wandb sync` then merges both phases under
+one run id. The eval subprocess inherits `WANDB_MODE` from the launcher, so
+its offline/online posture follows the parent's.
 
 ______________________________________________________________________
 

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -9,11 +9,11 @@ from typing import Any
 
 import hydra
 import pandas as pd
+import wandb
 from lightning import Callback, LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.loggers import Logger
 from omegaconf import DictConfig
 
-import wandb
 from synth_setter.resources import as_file, vst_headless_wrapper
 from synth_setter.utils import (
     RankedLogger,

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -9,12 +9,11 @@ from typing import Any
 
 import hydra
 import pandas as pd
-import wandb
 from lightning import Callback, LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.loggers import Logger
 from omegaconf import DictConfig
 
-from synth_setter.pipeline import r2_io
+import wandb
 from synth_setter.resources import as_file, vst_headless_wrapper
 from synth_setter.utils import (
     RankedLogger,
@@ -113,7 +112,7 @@ def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: D
         if cfg.get("render") is None:
             raise ValueError(
                 "evaluation.render_vst=true requires a render config group "
-                "(e.g. `+render=surge_xt`); cfg.render is unset."
+                "(e.g. `render=surge_xt`); cfg.render is unset."
             )
         if not predictions_dir.is_dir():
             raise ValueError(
@@ -286,24 +285,6 @@ def _dump_metric_dict(metric_dict: dict[str, Any], output_dir: Path) -> Path:
     return out_path
 
 
-def _download_eval_dataset(cfg: DictConfig) -> None:
-    """Hydrate ``data.dataset_root`` from R2 when a download URI is configured.
-
-    Opt-in (``evaluation.download_dataset_root_uri`` defaults to ``null``): with a
-    URI set, load R2 creds then copy the prefix into ``data.dataset_root`` without
-    clobbering existing files, so eval can run against an R2-resident dataset on a
-    fresh worker. A ``null`` URI is a no-op — the local ``dataset_root`` is used as-is.
-
-    :param cfg: Composed eval config; reads ``evaluation.download_dataset_root_uri``
-        and ``data.dataset_root``.
-    """
-    dataset_uri = cfg.evaluation.download_dataset_root_uri
-    if not dataset_uri:
-        return
-    r2_io.ensure_r2_env_loaded()
-    r2_io.download_dir_no_overwrite(dataset_uri, cfg.data.dataset_root)
-
-
 @hydra.main(version_base="1.3", config_path="pkg://synth_setter.configs", config_name="eval.yaml")
 def main(cfg: DictConfig) -> None:
     """Run the evaluation entrypoint.
@@ -313,7 +294,6 @@ def main(cfg: DictConfig) -> None:
     # apply extra utilities
     # (e.g. ask for tags if none are provided in cfg, print cfg tree, etc.)
     extras(cfg)
-    _download_eval_dataset(cfg)
 
     metric_dict, _ = evaluate(cfg)
     _dump_metric_dict(metric_dict, Path(cfg.paths.output_dir))

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -286,6 +286,24 @@ def _dump_metric_dict(metric_dict: dict[str, Any], output_dir: Path) -> Path:
     return out_path
 
 
+def _download_eval_dataset(cfg: DictConfig) -> None:
+    """Hydrate ``data.dataset_root`` from R2 when a download URI is configured.
+
+    Opt-in (``evaluation.download_dataset_root_uri`` defaults to ``null``): with a
+    URI set, load R2 creds then copy the prefix into ``data.dataset_root`` without
+    clobbering existing files, so eval can run against an R2-resident dataset on a
+    fresh worker. A ``null`` URI is a no-op — the local ``dataset_root`` is used as-is.
+
+    :param cfg: Composed eval config; reads ``evaluation.download_dataset_root_uri``
+        and ``data.dataset_root``.
+    """
+    dataset_uri = cfg.evaluation.download_dataset_root_uri
+    if not dataset_uri:
+        return
+    r2_io.ensure_r2_env_loaded()
+    r2_io.download_dir_no_overwrite(dataset_uri, cfg.data.dataset_root)
+
+
 @hydra.main(version_base="1.3", config_path="pkg://synth_setter.configs", config_name="eval.yaml")
 def main(cfg: DictConfig) -> None:
     """Run the evaluation entrypoint.
@@ -295,10 +313,7 @@ def main(cfg: DictConfig) -> None:
     # apply extra utilities
     # (e.g. ask for tags if none are provided in cfg, print cfg tree, etc.)
     extras(cfg)
-    dataset_uri = cfg.evaluation.download_dataset_root_uri
-    if dataset_uri:
-        r2_io.ensure_r2_env_loaded()
-        r2_io.download_dir_no_overwrite(dataset_uri, cfg.data.dataset_root)
+    _download_eval_dataset(cfg)
 
     metric_dict, _ = evaluate(cfg)
     _dump_metric_dict(metric_dict, Path(cfg.paths.output_dir))

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -9,11 +9,12 @@ from typing import Any
 
 import hydra
 import pandas as pd
-import wandb
 from lightning import Callback, LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.loggers import Logger
 from omegaconf import DictConfig
 
+import wandb
+from synth_setter.pipeline import r2_io
 from synth_setter.resources import as_file, vst_headless_wrapper
 from synth_setter.utils import (
     RankedLogger,
@@ -294,6 +295,10 @@ def main(cfg: DictConfig) -> None:
     # apply extra utilities
     # (e.g. ask for tags if none are provided in cfg, print cfg tree, etc.)
     extras(cfg)
+    dataset_uri = cfg.evaluation.download_dataset_root_uri
+    if dataset_uri:
+        r2_io.ensure_r2_env_loaded()
+        r2_io.download_dir_no_overwrite(dataset_uri, cfg.data.dataset_root)
 
     metric_dict, _ = evaluate(cfg)
     _dump_metric_dict(metric_dict, Path(cfg.paths.output_dir))

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -9,11 +9,11 @@ from typing import Any
 
 import hydra
 import pandas as pd
+import wandb
 from lightning import Callback, LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.loggers import Logger
 from omegaconf import DictConfig
 
-import wandb
 from synth_setter.pipeline import r2_io
 from synth_setter.resources import as_file, vst_headless_wrapper
 from synth_setter.utils import (

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -22,13 +22,13 @@ from pathlib import Path
 from typing import Any
 
 import hydra
-import wandb
 from hydra.core.hydra_config import HydraConfig
 from lightning.pytorch.loggers import Logger
 from lightning.pytorch.loggers.wandb import WandbLogger
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
+import wandb
 from synth_setter.cli.finalize_dataset import finalize_from_spec
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.pipeline import r2_io
@@ -110,19 +110,19 @@ def _run_oracle_eval_subprocess(dataset_root: Path, run_id: str) -> None:
         f"hydra.run.dir={dataset_root}",
         "ckpt_path=null",
         "logger=wandb",
+        # eval.yaml defaults render to null; render_vst=true re-renders the
+        # predicted params, so select the surge_simple group the smoke shard
+        # was generated with (param spec + preset must match the dataset).
+        "render=surge_simple",
         # id already exists in logger/wandb.yaml (id: null) so a plain
         # override suffices; resume is absent there and needs +append.
         f"logger.wandb.id={run_id}",
         "+logger.wandb.resume=must",
-        # configs/data/surge*.yaml marks predict_file a mandatory `???` value;
-        # mode=test never reads it, so null satisfies the resolver instead of
-        # raising MissingMandatoryValue at datamodule instantiation — see #1331.
-        "data.predict_file=null",
         # SurgeXTDataset floors len to samples // batch_size; the 128 default
         # would yield zero batches on the smoke-sized test split (4 samples),
         # so test_step never runs and no test/* metric is logged — see #1331.
         "data.batch_size=1",
-        "mode=test",
+        "mode=predict",
     ]
     logger.info(f"oracle_eval_inline subprocess: {argv}")
     subprocess.run(argv, check=True, timeout=_ORACLE_EVAL_TIMEOUT_SECONDS)  # noqa: S603
@@ -603,15 +603,17 @@ def _render_and_upload_shard(
 def spec_from_cfg(cfg: DictConfig) -> DatasetSpec:
     """Build a DatasetSpec from a Hydra-composed cfg.
 
-    Resolves all interpolations, drops the non-DatasetSpec sub-trees, and constructs the model.
-    Raises if the composed config is not a mapping.
+    Drops the non-DatasetSpec sub-trees *before* resolving so their
+    interpolations are never evaluated: the spec never reads them, and they may
+    reference resolvers only available under ``@hydra.main`` (e.g. ``data``'s
+    ``dataset_root: ${hydra:runtime.output_dir}/data``). Raises if the composed
+    config is not a mapping.
     """
-    raw: object = OmegaConf.to_container(cfg, resolve=True)
+    spec_keys = [k for k in cfg if isinstance(k, str) and k not in _NON_SPEC_KEYS]
+    raw: object = OmegaConf.to_container(OmegaConf.masked_copy(cfg, spec_keys), resolve=True)
     if not isinstance(raw, dict):
         raise TypeError(f"composed config is not a mapping: {type(raw).__name__}")
-    spec_kwargs: dict[str, Any] = {
-        k: v for k, v in raw.items() if isinstance(k, str) and k not in _NON_SPEC_KEYS
-    }
+    spec_kwargs: dict[str, Any] = {k: v for k, v in raw.items() if isinstance(k, str)}
     return DatasetSpec(**spec_kwargs)
 
 

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -22,13 +22,13 @@ from pathlib import Path
 from typing import Any
 
 import hydra
+import wandb
 from hydra.core.hydra_config import HydraConfig
 from lightning.pytorch.loggers import Logger
 from lightning.pytorch.loggers.wandb import WandbLogger
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
-import wandb
 from synth_setter.cli.finalize_dataset import finalize_from_spec
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.pipeline import r2_io
@@ -99,7 +99,7 @@ def _run_oracle_eval_subprocess(dataset_root: Path, run_id: str) -> None:
 
     :param dataset_root: Holds the finalized HDF5 splits the eval datamodule reads.
     :param run_id: Canonical ``spec.run_id``; the eval resumes this wandb run
-        so its ``test/*`` metrics land on the generate phase's run.
+        so its ``audio/*`` metrics land on the generate phase's run.
     """
     argv = [
         sys.executable,
@@ -120,7 +120,7 @@ def _run_oracle_eval_subprocess(dataset_root: Path, run_id: str) -> None:
         "+logger.wandb.resume=must",
         # SurgeXTDataset floors len to samples // batch_size; the 128 default
         # would yield zero batches on the smoke-sized test split (4 samples),
-        # so test_step never runs and no test/* metric is logged — see #1331.
+        # so predict_step never runs and no audio/* metric is logged — see #1331.
         "data.batch_size=1",
         "mode=predict",
     ]

--- a/src/synth_setter/configs/data/surge.yaml
+++ b/src/synth_setter/configs/data/surge.yaml
@@ -1,7 +1,8 @@
 _target_: synth_setter.data.surge_datamodule.SurgeDataModule
-dataset_root: ???
+dataset_root: ${hydra:runtime.output_dir}/data
+download_dataset_root_uri: null
 use_saved_mean_and_variance: true
 batch_size: 128
 ot: true
 num_workers: 11
-predict_file: ???
+predict_file: null

--- a/src/synth_setter/configs/data/surge.yaml
+++ b/src/synth_setter/configs/data/surge.yaml
@@ -1,5 +1,5 @@
 _target_: synth_setter.data.surge_datamodule.SurgeDataModule
-dataset_root: ${hydra:runtime.output_dir}/data
+dataset_root: ${paths.output_dir}/data
 download_dataset_root_uri: null
 use_saved_mean_and_variance: true
 batch_size: 128

--- a/src/synth_setter/configs/data/surge_debug.yaml
+++ b/src/synth_setter/configs/data/surge_debug.yaml
@@ -1,5 +1,5 @@
 _target_: synth_setter.data.surge_datamodule.SurgeDataModule
-dataset_root: ${hydra:runtime.output_dir}/data
+dataset_root: ${paths.output_dir}/data
 download_dataset_root_uri: null
 use_saved_mean_and_variance: true
 batch_size: 128

--- a/src/synth_setter/configs/data/surge_debug.yaml
+++ b/src/synth_setter/configs/data/surge_debug.yaml
@@ -1,8 +1,9 @@
 _target_: synth_setter.data.surge_datamodule.SurgeDataModule
-dataset_root: ???
+dataset_root: ${hydra:runtime.output_dir}/data
+download_dataset_root_uri: null
 use_saved_mean_and_variance: true
 batch_size: 128
 ot: true
 num_workers: 11
-predict_file: ???
+predict_file: null
 repeat_first_batch: true

--- a/src/synth_setter/configs/data/surge_mini.yaml
+++ b/src/synth_setter/configs/data/surge_mini.yaml
@@ -1,7 +1,8 @@
 _target_: synth_setter.data.surge_datamodule.SurgeDataModule
-dataset_root: ???
+dataset_root: ${hydra:runtime.output_dir}/data
+download_dataset_root_uri: null
 use_saved_mean_and_variance: true
 batch_size: 128
 ot: true
 num_workers: 11
-predict_file: ???
+predict_file: null

--- a/src/synth_setter/configs/data/surge_mini.yaml
+++ b/src/synth_setter/configs/data/surge_mini.yaml
@@ -1,5 +1,5 @@
 _target_: synth_setter.data.surge_datamodule.SurgeDataModule
-dataset_root: ${hydra:runtime.output_dir}/data
+dataset_root: ${paths.output_dir}/data
 download_dataset_root_uri: null
 use_saved_mean_and_variance: true
 batch_size: 128

--- a/src/synth_setter/configs/data/surge_simple.yaml
+++ b/src/synth_setter/configs/data/surge_simple.yaml
@@ -1,7 +1,8 @@
 _target_: synth_setter.data.surge_datamodule.SurgeDataModule
-dataset_root: ???
+dataset_root: ${hydra:runtime.output_dir}/data
+download_dataset_root_uri: null
 use_saved_mean_and_variance: true
 batch_size: 128
 ot: true
 num_workers: 11
-predict_file: ???
+predict_file: null

--- a/src/synth_setter/configs/data/surge_simple.yaml
+++ b/src/synth_setter/configs/data/surge_simple.yaml
@@ -1,5 +1,5 @@
 _target_: synth_setter.data.surge_datamodule.SurgeDataModule
-dataset_root: ${hydra:runtime.output_dir}/data
+dataset_root: ${paths.output_dir}/data
 download_dataset_root_uri: null
 use_saved_mean_and_variance: true
 batch_size: 128

--- a/src/synth_setter/configs/eval.yaml
+++ b/src/synth_setter/configs/eval.yaml
@@ -20,6 +20,7 @@ mode: test
 
 # Predict-mode post-processing; gated off so `mode: test`/`validate` stay unchanged.
 evaluation:
+  download_dataset_root_uri: null
   render_vst: false
   compute_metrics: false
   rerender_target: true

--- a/src/synth_setter/configs/eval.yaml
+++ b/src/synth_setter/configs/eval.yaml
@@ -20,7 +20,6 @@ mode: test
 
 # Predict-mode post-processing; gated off so `mode: test`/`validate` stay unchanged.
 evaluation:
-  download_dataset_root_uri: null
   render_vst: false
   compute_metrics: false
   rerender_target: true

--- a/src/synth_setter/configs/experiment/generate_dataset/smoke-shard-with-oracle-eval.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/smoke-shard-with-oracle-eval.yaml
@@ -8,11 +8,10 @@ defaults:
   - /experiment/generate_dataset/smoke-shard-with-finalize@_global_
   - _self_
 
-# Override train_val_test_sizes — SurgeDataModule.setup() opens
-# {train,val,test}.h5 unconditionally, so the inline oracle eval needs
-# non-zero val/test splits to load (the upstream smoke-shard.yaml ships
-# [12, 0, 0] which fails the datamodule at FileNotFoundError on val.h5).
+# Pin non-zero val/test splits: SurgeDataModule.setup() opens
+# {train,val,test}.h5 (and the predict split) unconditionally, so a zero-sized
+# val or test split would raise FileNotFoundError during the inline oracle eval.
 # Sizes must be multiples of render.samples_per_shard=4.
-train_val_test_sizes: [12, 4, 4]
+train_val_test_sizes: [4, 4, 4]
 
 oracle_eval_inline: true

--- a/src/synth_setter/configs/experiment/generate_dataset/smoke-shard.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/smoke-shard.yaml
@@ -22,11 +22,5 @@ render:
   min_loudness: -55.0
   samples_per_render_batch: 4
   samples_per_shard: 4
-  # Materialized so the render-matrix workflow can resolve
-  # `render.gui_toggle_cadence=<cell>` / `render.plugin_reload_cadence=<cell>`
-  # overrides against this experiment without flipping the platform-aware
-  # default in `configs/render/surge_xt.yaml`. The base values match the
-  # Pydantic schema defaults — overrides flow through the cross-field
-  # validator (`RenderConfig._always_on_requires_plugin_reload_once`).
-  gui_toggle_cadence: never
+  gui_toggle_cadence: once
   plugin_reload_cadence: render

--- a/src/synth_setter/configs/experiment/generate_dataset/smoke-shard.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/smoke-shard.yaml
@@ -15,7 +15,7 @@ task_name: smoke-shard
 # if dask's FP noise stops hiding them on the hdf5 path.
 mask_degenerate_bins: true
 
-train_val_test_sizes: [12, 0, 0]
+train_val_test_sizes: [4, 4, 4]
 
 render:
   sample_rate: 44100

--- a/src/synth_setter/configs/experiment/surge/fake_oracle.yaml
+++ b/src/synth_setter/configs/experiment/surge/fake_oracle.yaml
@@ -4,6 +4,8 @@ defaults:
   - surge/base
   - override /model: surge_fake_oracle
   - override /data: surge
+  - override /callbacks: eval_surge
+  - override /trainer: cpu
   - _self_
 
 run_name: fake_oracle
@@ -12,6 +14,8 @@ experiment_name: surge-fake-oracle
 model:
   net:
     d_out: 300
+
+mode: predict
 
 tags:
   - surge
@@ -22,3 +26,17 @@ callbacks:
     _target_: synth_setter.utils.callbacks.LogPerParamMSE
     param_spec: surge_xt
   plot_proj_ii: null
+
+data:
+  batch_size: 1
+  predict_file: ???
+
+render: ???
+
+ckpt_path: null
+
+evaluation:
+  render_vst: true
+  compute_metrics: true
+  rerender_target: false
+  num_workers: 1

--- a/src/synth_setter/configs/experiment/surge/fake_oracle.yaml
+++ b/src/synth_setter/configs/experiment/surge/fake_oracle.yaml
@@ -13,6 +13,7 @@ experiment_name: surge-fake-oracle
 
 model:
   net:
+    # TODO: update d_out -> to -1 or 0 to show that it is not used.
     d_out: 300
 
 mode: predict
@@ -24,14 +25,12 @@ tags:
 callbacks:
   log_per_param_mse:
     _target_: synth_setter.utils.callbacks.LogPerParamMSE
+    # TODO: update  param_spec: surge_xt -> ???
     param_spec: surge_xt
   plot_proj_ii: null
 
 data:
   batch_size: 1
-  predict_file: ???
-
-render: ???
 
 ckpt_path: null
 

--- a/src/synth_setter/configs/experiment/surge/test-mps-fake-oracle.yaml
+++ b/src/synth_setter/configs/experiment/surge/test-mps-fake-oracle.yaml
@@ -26,6 +26,16 @@ tags:
 logger: null
 test: false
 
+# Predict-mode eval knobs — kept in lockstep with surge/fake_oracle.yaml (see header).
+mode: predict
+render: ???
+
+evaluation:
+  render_vst: true
+  compute_metrics: true
+  rerender_target: false
+  num_workers: 1
+
 model:
   compile: false
   scheduler: null

--- a/src/synth_setter/configs/experiment/surge/test-mps-fake-oracle.yaml
+++ b/src/synth_setter/configs/experiment/surge/test-mps-fake-oracle.yaml
@@ -27,8 +27,10 @@ logger: null
 test: false
 
 # Predict-mode eval knobs — kept in lockstep with surge/fake_oracle.yaml (see header).
+# render defaults to null; predict-mode callers select a group (e.g. render=surge_simple)
+# and eval raises if render_vst runs without one.
 mode: predict
-render: ???
+render: null
 
 evaluation:
   render_vst: true

--- a/src/synth_setter/data/surge_datamodule.py
+++ b/src/synth_setter/data/surge_datamodule.py
@@ -1,23 +1,25 @@
 import random
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Literal, Optional, Sequence, Union
+from typing import Literal
 
 import h5py
-import hdf5plugin
+import hdf5plugin  # noqa: F401  # side-effect import: registers HDF5 blosc filters for shard I/O
 import numpy as np
 import torch
 from lightning import LightningDataModule
 
 from synth_setter.data.ot import _hungarian_match
+from synth_setter.pipeline import r2_io
 
 
 class SurgeXTDataset(torch.utils.data.Dataset):
-    mean: Optional[np.ndarray] = None
-    std: Optional[np.ndarray] = None
+    mean: np.ndarray | None = None
+    std: np.ndarray | None = None
 
     def __init__(
         self,
-        dataset_file: Union[str, Path],
+        dataset_file: str | Path,
         batch_size: int,
         ot: bool = True,
         read_audio: bool = False,
@@ -49,7 +51,7 @@ class SurgeXTDataset(torch.utils.data.Dataset):
         if use_saved_mean_and_variance:
             self._load_dataset_statistics(dataset_file)
 
-    def _load_dataset_statistics(self, dataset_file: Union[str, Path]):
+    def _load_dataset_statistics(self, dataset_file: str | Path):
         # for /path/to/train.h5 we would expect to find /path/to/stats.npz
         # if not, we throw an error
         stats_file = SurgeXTDataset.get_stats_file_path(dataset_file)
@@ -64,7 +66,7 @@ class SurgeXTDataset(torch.utils.data.Dataset):
             self.std = stats["std"]
 
     @staticmethod
-    def get_stats_file_path(dataset_file: Union[str, Path]) -> Path:
+    def get_stats_file_path(dataset_file: str | Path) -> Path:
         dataset_file = Path(dataset_file)
         data_dir = dataset_file.parent
         return data_dir / "stats.npz"
@@ -76,9 +78,7 @@ class SurgeXTDataset(torch.utils.data.Dataset):
         return self.dataset_file["audio"].shape[0] // self.batch_size
 
     def _get_fake_item(self):
-        audio = (
-            torch.randn(self.batch_size, 2, 44100 * 4) if not self.read_audio else None
-        )
+        audio = torch.randn(self.batch_size, 2, 44100 * 4) if not self.read_audio else None
         mel_spec = torch.randn(self.batch_size, 2, 128, 401) if self.read_mel else None
         m2l = torch.randn(self.batch_size, 128, 42) if self.read_m2l else None
         param_array = torch.rand(self.batch_size, 189)
@@ -96,7 +96,7 @@ class SurgeXTDataset(torch.utils.data.Dataset):
             audio=audio,
         )
 
-    def _index_dataset(self, ds: h5py.Dataset, idx: Union[int, Sequence[int]]):
+    def _index_dataset(self, ds: h5py.Dataset, idx: int | Sequence[int]):
         if self.repeat_first_batch:
             return ds[: self.batch_size]
         if isinstance(idx, int):
@@ -110,7 +110,7 @@ class SurgeXTDataset(torch.utils.data.Dataset):
 
         return ds[idx]
 
-    def __getitem__(self, idx: Union[int, Sequence[int]]):
+    def __getitem__(self, idx: int | Sequence[int]):
         if self.fake:
             return self._get_fake_item()
 
@@ -185,8 +185,7 @@ class WithinChunkShuffledSampler(torch.utils.data.Sampler):
             group_sizes.append(remaining * self.batch_size)
 
         indices = [
-            np.random.permutation(group_size).reshape(-1, self.batch_size)
-            + i * samples_per_group
+            np.random.permutation(group_size).reshape(-1, self.batch_size) + i * samples_per_group
             for i, group_size in enumerate(group_sizes)
         ]
 
@@ -235,31 +234,47 @@ class ShiftedBatchSampler(torch.utils.data.BatchSampler):
 class SurgeDataModule(LightningDataModule):
     def __init__(
         self,
-        dataset_root: Union[str, Path],
+        dataset_root: str | Path,
+        download_dataset_root_uri: str | None = None,
         use_saved_mean_and_variance: bool = True,
         batch_size: int = 1024,
         ot: bool = True,
         num_workers: int = 0,
         fake: bool = False,
         repeat_first_batch: bool = False,
-        predict_file: Optional[str] = None,
+        predict_file: str | None = None,
         conditioning: Literal["mel", "m2l"] = "mel",
         pin_memory: bool = True,
     ):
         super().__init__()
 
         self.dataset_root = Path(dataset_root)
+        self.download_dataset_root_uri = download_dataset_root_uri
         self.use_saved_mean_and_variance = use_saved_mean_and_variance
         self.batch_size = batch_size
         self.ot = ot
         self.num_workers = num_workers
         self.fake = fake
         self.repeat_first_batch = repeat_first_batch
-        self.predict_file = predict_file
+        self.predict_file = (
+            predict_file if predict_file is not None else self.dataset_root / "test.h5"
+        )
         self.conditioning = conditioning
         self.pin_memory = pin_memory
 
-    def setup(self, stage: Optional[str] = None):
+    def prepare_data(self) -> None:
+        """Hydrate ``dataset_root`` from R2 when a download URI is configured.
+
+        Lightning calls this rank-0-only, before ``setup``, so the no-clobber R2
+        copy runs once even under DDP. Opt-in: a ``None`` URI is a no-op and the
+        local ``dataset_root`` is used as-is.
+        """
+        if not self.download_dataset_root_uri:
+            return
+        r2_io.ensure_r2_env_loaded()
+        r2_io.download_dir_no_overwrite(self.download_dataset_root_uri, self.dataset_root)
+
+    def setup(self, stage: str | None = None):
         self.train_dataset = SurgeXTDataset(
             self.dataset_root / "train.h5",
             batch_size=self.batch_size,
@@ -290,19 +305,16 @@ class SurgeDataModule(LightningDataModule):
             read_mel=self.conditioning == "mel",
             read_m2l=self.conditioning == "m2l",
         )
-        if self.predict_file is not None:
-            self.predict_dataset = SurgeXTDataset(
-                self.predict_file,
-                batch_size=self.batch_size,
-                ot=False,
-                read_audio=True,
-                use_saved_mean_and_variance=self.use_saved_mean_and_variance,
-                fake=self.fake,
-                read_mel=self.conditioning == "mel",
-                read_m2l=self.conditioning == "m2l",
-            )
-        else:
-            self.predict_dataset = None
+        self.predict_dataset = SurgeXTDataset(
+            self.predict_file,
+            batch_size=self.batch_size,
+            ot=False,
+            read_audio=True,
+            use_saved_mean_and_variance=self.use_saved_mean_and_variance,
+            fake=self.fake,
+            read_mel=self.conditioning == "mel",
+            read_m2l=self.conditioning == "m2l",
+        )
 
     def train_dataloader(self):
         return torch.utils.data.DataLoader(
@@ -345,7 +357,8 @@ class SurgeDataModule(LightningDataModule):
             pin_memory=self.pin_memory,
         )
 
-    def teardown(self, stage: Optional[str] = None):
+    def teardown(self, stage: str | None = None):
         self.train_dataset.dataset_file.close()
         self.val_dataset.dataset_file.close()
         self.test_dataset.dataset_file.close()
+        self.predict_dataset.dataset_file.close()

--- a/src/synth_setter/data/surge_datamodule.py
+++ b/src/synth_setter/data/surge_datamodule.py
@@ -358,7 +358,12 @@ class SurgeDataModule(LightningDataModule):
         )
 
     def teardown(self, stage: str | None = None):
-        self.train_dataset.dataset_file.close()
-        self.val_dataset.dataset_file.close()
-        self.test_dataset.dataset_file.close()
-        self.predict_dataset.dataset_file.close()
+        # fake mode leaves dataset_file None (no h5 opened), so guard each close.
+        for dataset in (
+            self.train_dataset,
+            self.val_dataset,
+            self.test_dataset,
+            self.predict_dataset,
+        ):
+            if dataset.dataset_file is not None:
+                dataset.dataset_file.close()

--- a/src/synth_setter/data/surge_datamodule.py
+++ b/src/synth_setter/data/surge_datamodule.py
@@ -78,7 +78,7 @@ class SurgeXTDataset(torch.utils.data.Dataset):
         return self.dataset_file["audio"].shape[0] // self.batch_size
 
     def _get_fake_item(self):
-        audio = torch.randn(self.batch_size, 2, 44100 * 4) if not self.read_audio else None
+        audio = torch.randn(self.batch_size, 2, 44100 * 4) if self.read_audio else None
         mel_spec = torch.randn(self.batch_size, 2, 128, 401) if self.read_mel else None
         m2l = torch.randn(self.batch_size, 128, 42) if self.read_m2l else None
         param_array = torch.rand(self.batch_size, 189)

--- a/src/synth_setter/pipeline/r2_io.py
+++ b/src/synth_setter/pipeline/r2_io.py
@@ -23,6 +23,7 @@ from synth_setter.pipeline.constants import R2_URI_SCHEME, RCLONE_REMOTE
 
 __all__ = [
     "R2_URI_SCHEME",
+    "download_dir_no_overwrite",
     "download_to_path",
     "downloaded_to_tempfile",
     "ensure_r2_env_loaded",
@@ -171,11 +172,27 @@ _to_rclone_path = to_rclone_path
 
 
 def download_dir_no_overwrite(r2_uri: str, dest_path: Path) -> None:
-    args = [  # noqa: S607
+    """Copy every object under an R2 prefix into a local directory, never clobbering.
+
+    Unlike :func:`download_to_path` (single object → file), this is a directory
+    copy. ``--immutable`` hard-fails if a destination file already exists with a
+    different size/mtime/checksum (rather than silently overwriting or skipping),
+    so re-running against a populated dataset root surfaces drift instead of
+    masking it. Reliability flags mirror the upload helpers so a transient blip
+    retries instead of failing the eval outright.
+
+    :param r2_uri: ``r2://`` directory prefix; every object beneath it is copied.
+    :param dest_path: Local destination directory, created by rclone if absent.
+    """
+    args = [  # noqa: S607 — rclone resolved by image's PATH
         "rclone",
         "copy",
+        "-vv",
         "--immutable",
         "--checksum",
+        "--contimeout=30s",
+        "--timeout=300s",
+        "--retries=3",
         _to_rclone_path(r2_uri),
         str(dest_path),
     ]

--- a/src/synth_setter/pipeline/r2_io.py
+++ b/src/synth_setter/pipeline/r2_io.py
@@ -170,6 +170,18 @@ def to_rclone_path(r2_uri: str) -> str:
 _to_rclone_path = to_rclone_path
 
 
+def download_dir_no_overwrite(r2_uri: str, dest_path: Path) -> None:
+    args = [  # noqa: S607
+        "rclone",
+        "copy",
+        "--immutable",
+        "--checksum",
+        _to_rclone_path(r2_uri),
+        str(dest_path),
+    ]
+    subprocess.check_call(args)  # noqa: S603 — args from validated URI
+
+
 def download_to_path(r2_uri: str, dest_path: Path) -> None:
     """Download an R2 object to a specific local file path.
 

--- a/sweeps/generate_dataset_cadence.yaml
+++ b/sweeps/generate_dataset_cadence.yaml
@@ -6,7 +6,7 @@ project: synth-setter
 command:
   - ${interpreter}
   - ${program}
-  - experiment=generate_dataset/smoke-shard
+  - experiment=generate_dataset/smoke-shard-with-oracle-eval
   - ${args_no_hyphens}
 name: generate_dataset_cadence_sweep
 method: grid
@@ -14,7 +14,7 @@ method: grid
 # legibility on runs that do log it.
 metric:
   goal: minimize
-  name: render.samples_per_shard
+  name: generation.samples_per_second
 parameters:
   render.plugin_reload_cadence:
     values:

--- a/sweeps/generate_dataset_cadence.yaml
+++ b/sweeps/generate_dataset_cadence.yaml
@@ -14,7 +14,7 @@ method: grid
 # legibility on runs that do log it.
 metric:
   goal: minimize
-  name: generation.samples_per_second
+  name: generation/samples_per_second
 parameters:
   render.plugin_reload_cadence:
     values:

--- a/tests/data/test_surge_datamodule.py
+++ b/tests/data/test_surge_datamodule.py
@@ -98,13 +98,7 @@ def _set_up_module(**kwargs: object) -> Iterator[SurgeDataModule]:
     try:
         yield module
     finally:
-        # SurgeDataModule.teardown() blindly closes every split's dataset_file
-        # handle; in fake mode those are None and the close call would raise.
-        # Tests that exercise teardown's real-mode behavior do so directly
-        # (see test_teardown_closes_open_h5_handles) — skip it here when the
-        # caller asked for fake mode.
-        if not module.fake:
-            module.teardown()
+        module.teardown()
 
 
 def _unwrap(maybe_tensor: torch.Tensor | None) -> torch.Tensor:

--- a/tests/data/test_surge_datamodule.py
+++ b/tests/data/test_surge_datamodule.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import contextlib
 import random
+import shutil
 from collections.abc import Iterator
 from pathlib import Path
 from unittest.mock import patch
@@ -55,15 +56,38 @@ _NUM_PARAMS = 11
 _ALL_TENSOR_KEYS = ("audio", "mel_spec", "m2l", "params", "noise")
 
 
+@pytest.fixture()
+def local_r2_remote(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Back the ``r2:`` rclone remote with the local filesystem for real-binary e2e.
+
+    ``RCLONE_CONFIG_R2_TYPE=local`` resolves ``r2://<bucket>/<key>`` to
+    ``<cwd>/<bucket>/<key>``, and the three secret keys satisfy
+    ``ensure_r2_env_loaded``'s presence check (their values are unused by the
+    local backend). Skips when ``rclone`` is absent.
+
+    :param tmp_path: Pytest tmp dir; the returned subdir is the fake R2 root.
+    :param monkeypatch: Sets the rclone env vars and chdirs into the remote root.
+    :return: The fake R2 root; ``r2://<bucket>/<key>`` materializes under it.
+    """
+    if shutil.which("rclone") is None:
+        pytest.skip("rclone binary not available on PATH")
+    remote_root = tmp_path / "r2"
+    remote_root.mkdir()
+    monkeypatch.setenv("RCLONE_CONFIG_R2_TYPE", "local")
+    monkeypatch.setenv("RCLONE_CONFIG_R2_ACCESS_KEY_ID", "stub")
+    monkeypatch.setenv("RCLONE_CONFIG_R2_SECRET_ACCESS_KEY", "stub")
+    monkeypatch.setenv("RCLONE_CONFIG_R2_ENDPOINT", "stub")
+    monkeypatch.chdir(remote_root)
+    return remote_root
+
+
 @contextlib.contextmanager
 def _set_up_module(**kwargs: object) -> Iterator[SurgeDataModule]:
     """Construct a ``SurgeDataModule`` from ``**kwargs``, ``setup``, yield, then ``teardown``.
 
     Encapsulates the setup/teardown try/finally pattern every
     ``TestSurgeDataModule`` test needs so a forgotten ``teardown`` can't leak
-    h5py handles into the next test. Also closes the ``predict_dataset``'s
-    h5py file when one was opened, since ``teardown`` only closes the three
-    train/val/test splits.
+    h5py handles into the next test.
 
     :param \\*\\*kwargs: Forwarded to ``SurgeDataModule``.
     :yields: The set-up datamodule for assertion work inside the ``with`` block.
@@ -74,16 +98,13 @@ def _set_up_module(**kwargs: object) -> Iterator[SurgeDataModule]:
     try:
         yield module
     finally:
-        # SurgeDataModule.teardown() blindly closes train/val/test dataset_file
-        # handles; in fake mode those are None and the close call would raise.
+        # SurgeDataModule.teardown() blindly closes every split's dataset_file
+        # handle; in fake mode those are None and the close call would raise.
         # Tests that exercise teardown's real-mode behavior do so directly
         # (see test_teardown_closes_open_h5_handles) — skip it here when the
         # caller asked for fake mode.
         if not module.fake:
             module.teardown()
-        predict_dataset = module.predict_dataset
-        if predict_dataset is not None and predict_dataset.dataset_file is not None:
-            predict_dataset.dataset_file.close()
 
 
 def _unwrap(maybe_tensor: torch.Tensor | None) -> torch.Tensor:
@@ -819,6 +840,47 @@ class TestSurgeDataModule:
         assert module.dataset_root == tmp_path
         assert isinstance(module.dataset_root, Path)
 
+    def test_prepare_data_hydrates_dataset_root_from_r2_when_uri_set(
+        self, local_r2_remote: Path, tmp_path: Path
+    ) -> None:
+        """``prepare_data`` with a ``download_dataset_root_uri`` copies the R2 prefix into
+        ``dataset_root``.
+
+        :param local_r2_remote: Real rclone remote backed by the local filesystem.
+        :param tmp_path: Holds the (initially absent) download destination root.
+        """
+        remote_prefix = local_r2_remote / "intermediate-data" / "dataset"
+        remote_prefix.mkdir(parents=True)
+        (remote_prefix / "train.h5").write_bytes(b"train-bytes")
+        (remote_prefix / "stats.npz").write_bytes(b"stats-bytes")
+        dataset_root = tmp_path / "downloaded"
+
+        module = SurgeDataModule(
+            dataset_root=str(dataset_root),
+            download_dataset_root_uri="r2://intermediate-data/dataset",
+        )
+        module.prepare_data()
+
+        assert (dataset_root / "train.h5").read_bytes() == b"train-bytes"
+        assert (dataset_root / "stats.npz").read_bytes() == b"stats-bytes"
+
+    def test_prepare_data_no_download_when_uri_none(
+        self, local_r2_remote: Path, tmp_path: Path
+    ) -> None:
+        """Default ``None`` URI leaves ``dataset_root`` untouched.
+
+        :param local_r2_remote: Real rclone remote — present so a regression copies rather than
+            hangs.
+        :param tmp_path: Holds the pre-existing, empty dataset root.
+        """
+        dataset_root = tmp_path / "downloaded"
+        dataset_root.mkdir()
+
+        module = SurgeDataModule(dataset_root=str(dataset_root))
+        module.prepare_data()
+
+        assert list(dataset_root.iterdir()) == []
+
     def test_setup_creates_train_val_test_splits(self, dataset_root: Path) -> None:
         """``setup()`` opens the three required splits and exposes them as attrs.
 
@@ -829,13 +891,14 @@ class TestSurgeDataModule:
             assert isinstance(module.val_dataset, SurgeXTDataset)
             assert isinstance(module.test_dataset, SurgeXTDataset)
 
-    def test_setup_without_predict_file_leaves_predict_none(self, dataset_root: Path) -> None:
-        """``predict_file=None`` leaves ``predict_dataset`` as ``None``.
+    def test_setup_without_predict_file_defaults_to_test_split(self, dataset_root: Path) -> None:
+        """No ``predict_file``: ``predict_dataset`` defaults to the ``test.h5`` split.
 
         :param dataset_root: Fixture-provided dataset-root directory.
         """
         with _set_up_module(dataset_root=dataset_root, batch_size=2, ot=False) as module:
-            assert module.predict_dataset is None
+            assert module.predict_file == dataset_root / "test.h5"
+            assert isinstance(module.predict_dataset, SurgeXTDataset)
 
     def test_setup_with_predict_file_builds_predict_dataset_with_audio(
         self, dataset_root: Path
@@ -996,7 +1059,7 @@ class TestSurgeDataModule:
             assert loader.pin_memory is True
 
     def test_teardown_closes_open_h5_handles(self, dataset_root: Path) -> None:
-        """``teardown`` closes the three split files so the next setup can reopen them.
+        """``teardown`` closes every split file so the next setup can reopen them.
 
         :param dataset_root: Fixture-provided dataset-root directory.
         """
@@ -1007,6 +1070,7 @@ class TestSurgeDataModule:
         assert not module.train_dataset.dataset_file
         assert not module.val_dataset.dataset_file
         assert not module.test_dataset.dataset_file
+        assert not module.predict_dataset.dataset_file
 
     def test_fake_mode_setup_does_not_require_dataset_files(self, tmp_path: Path) -> None:
         """``fake=True`` setup never touches the dataset_root, so a fresh dir is enough.

--- a/tests/data/test_surge_datamodule.py
+++ b/tests/data/test_surge_datamodule.py
@@ -253,34 +253,26 @@ class TestSurgeXTDatasetFakeMode:
         assert len(small) == 10000
         assert len(large) == 10000
 
-    def test_fake_mode_default_flags_populate_mel_audio_params_noise(self) -> None:
-        """With default flags ``audio``/``mel_spec``/``params``/``noise`` are populated; ``m2l`` is
-        None.
+    def test_fake_mode_default_flags_populate_mel_params_noise(self) -> None:
+        """With default flags ``mel_spec``/``params``/``noise`` are populated; ``audio``/``m2l``
+        are None.
 
-        ``audio`` is populated here even though ``read_audio`` defaults to
-        False — see ``test_fake_mode_read_audio_true_returns_none_audio``
-        for the inverse pin on the asymmetric flag.
+        ``read_audio`` and ``read_m2l`` both default to False, so their slots
+        drop to None — the same flag→slot mapping as real mode.
         """
         dataset = SurgeXTDataset("ignored", batch_size=3, fake=True)
         item = dataset[0]
+        assert item["audio"] is None
         assert item["m2l"] is None
-        assert _unwrap(item["audio"]).shape == (3, 2, 44100 * 4)
         assert _unwrap(item["mel_spec"]).shape == (3, 2, 128, 401)
         assert _unwrap(item["params"]).shape == (3, 189)
         assert _unwrap(item["noise"]).shape == (3, 189)
 
-    def test_fake_mode_read_audio_true_returns_none_audio(self) -> None:
-        """Pin the asymmetric fake-mode contract: ``read_audio=True`` returns audio=None.
-
-        This is the *current* (and surprising) behavior of ``_get_fake_item``:
-        the audio ternary inverts the flag (``... if not self.read_audio else None``)
-        so the real-mode contract ``read_audio=True -> audio populated`` does
-        not hold in fake mode. Pinned here so future changes flip the test
-        either way — the asymmetry is intentional to surface in review.
-        """
+    def test_fake_mode_read_audio_true_returns_audio_tensor(self) -> None:
+        """``read_audio=True`` populates the ``audio`` slot, mirroring real mode."""
         dataset = SurgeXTDataset("ignored", batch_size=2, fake=True, read_audio=True)
         item = dataset[0]
-        assert item["audio"] is None
+        assert _unwrap(item["audio"]).shape == (2, 2, 44100 * 4)
 
     def test_fake_mode_read_m2l_returns_m2l_tensor(self) -> None:
         """``read_m2l=True`` populates the ``m2l`` slot with the documented shape."""
@@ -295,7 +287,7 @@ class TestSurgeXTDatasetFakeMode:
 
     def test_fake_mode_rescale_params_maps_into_minus_one_to_one(self) -> None:
         """``rescale_params=True`` rescales ``torch.rand`` from [0, 1) into [-1, 1)."""
-        # read_mel=False + read_audio=True skips the ~190 MB mel/audio
+        # read_mel=False + read_audio=False skips the ~190 MB mel/audio
         # allocations that fake mode would otherwise build at batch_size=128;
         # this test only inspects params.
         dataset = SurgeXTDataset(
@@ -304,7 +296,7 @@ class TestSurgeXTDatasetFakeMode:
             fake=True,
             rescale_params=True,
             read_mel=False,
-            read_audio=True,
+            read_audio=False,
         )
         params = _unwrap(dataset[0]["params"])
         assert params.min().item() >= -1.0
@@ -323,7 +315,7 @@ class TestSurgeXTDatasetFakeMode:
             fake=True,
             rescale_params=False,
             read_mel=False,
-            read_audio=True,
+            read_audio=False,
         )
         params = _unwrap(dataset[0]["params"])
         assert params.min().item() >= 0.0

--- a/tests/integration/test_generate_dataset_cli_wandb_e2e.py
+++ b/tests/integration/test_generate_dataset_cli_wandb_e2e.py
@@ -369,21 +369,19 @@ def test_oracle_eval_inline_resumes_generate_wandb_run(
 
     One CLI invocation with ``oracle_eval_inline=true`` +
     ``finalize_inline=true`` under ``WANDB_MODE=offline``. After the CLI
-    exits, the launcher's hydra dir and the operator workspace's
-    ``oracle_eval/<run_id>/`` dir each hold one ``offline-run-*-<run_id>``
-    directory; the two ``<run_id>`` slugs must match (the eval child
-    resumed the same wandb run). Generate's dir must carry shard +
-    summary history rows; eval's dir must carry at least one ``test/*``
-    row from Lightning's ``trainer.test``.
+    exits, the launcher's hydra dir holds generate's
+    ``offline-run-*-<run_id>``, and its ``oracle_eval/<run_id>/`` subdir
+    holds the eval's; the two ``<run_id>`` slugs must match (the eval
+    child resumed the same wandb run). Generate's dir must carry shard +
+    summary history rows; eval's dir must carry at least one ``audio/*``
+    row from the predict-mode oracle eval's audio metrics.
 
     :param cli_env: ``(hydra_run_dir, r2_prefix)`` from the fixture — gates
         skip conditions and owns R2 cleanup.
     """
     hydra_run_dir, prefix = cli_env
-    # ``operator_workspace()`` honors ``$SYNTH_SETTER_WORKSPACE`` and
-    # decides where ``main()`` writes ``oracle_eval/<run_id>/``; pin it to
-    # the fixture's tmp_path so the eval's wandb dir is reachable from the
-    # test without depending on the checkout-root walk.
+    # Pin the operator workspace ($PROJECT_ROOT) to tmp so the generate run's
+    # paths.root_dir never touches the checkout.
     workspace = hydra_run_dir.parent
     result = _run_cli(
         hydra_run_dir=hydra_run_dir,
@@ -401,12 +399,14 @@ def test_oracle_eval_inline_resumes_generate_wandb_run(
     generate_run_dir = _find_offline_run_dir(hydra_run_dir)
     generate_run_id = generate_run_dir.name.split("-", 3)[-1]
 
-    eval_workspace_dir = workspace / "oracle_eval" / generate_run_id
-    assert eval_workspace_dir.is_dir(), (
-        f"expected eval workspace dir at {eval_workspace_dir}; "
+    # main() writes oracle_eval/<run_id>/ under cfg.paths.output_dir
+    # (= ${hydra:runtime.output_dir}), which the fixture pins to hydra_run_dir.
+    eval_output_dir = hydra_run_dir / "oracle_eval" / generate_run_id
+    assert eval_output_dir.is_dir(), (
+        f"expected eval output dir at {eval_output_dir}; "
         f"main()'s oracle_eval_inline branch did not run with the launcher's run_id"
     )
-    eval_run_dir = _find_offline_run_dir(eval_workspace_dir)
+    eval_run_dir = _find_offline_run_dir(eval_output_dir)
     eval_run_id = eval_run_dir.name.split("-", 3)[-1]
     assert eval_run_id == generate_run_id, (
         f"eval wandb run id {eval_run_id!r} does not match generate's "
@@ -425,7 +425,7 @@ def test_oracle_eval_inline_resumes_generate_wandb_run(
 
     eval_binary = _single_wandb_binary(eval_run_dir)
     eval_rows = read_history_rows(eval_binary)
-    assert any(any(k.startswith("test/") for k in r) for r in eval_rows), (
-        f"eval dir has no test/* history rows in {eval_binary}; "
-        f"oracle eval did not log Lightning test_step metrics to the resumed run"
+    assert any(any(k.startswith("audio/") for k in r) for r in eval_rows), (
+        f"eval dir has no audio/* history rows in {eval_binary}; "
+        f"the predict-mode oracle eval did not log audio metrics to the resumed run"
     )

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1884,6 +1884,8 @@ class TestMainDispatchBranches:
             f"render.plugin_path={TEST_PLUGIN_VST3}",
             "finalize_inline=true",
             "oracle_eval_inline=true",
+            # smoke-shard now defaults to [4, 4, 4]; pin a zero split to exercise the guard.
+            "train_val_test_sizes=[4,0,0]",
         ]
         monkeypatch.setattr("sys.argv", argv)
         monkeypatch.setenv("HYDRA_FULL_ERROR", "1")

--- a/tests/pipeline/test_entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/test_entrypoints/test_generate_dataset.py
@@ -1730,10 +1730,10 @@ class TestMainDispatchBranches:
         """Helper subprocesses ``synth_setter.cli.eval`` with the contract argv.
 
         Pins the load-bearing overrides (``experiment=surge/fake_oracle``,
-        ``data.dataset_root``, ``ckpt_path=null``, ``mode=test``) plus the
-        wandb-resume trio that routes the eval's ``test/*`` metrics onto the
-        generate run. Runs the helper directly so cfg-resolution noise can't
-        mask an argv drift.
+        ``data.dataset_root``, ``ckpt_path=null``, ``mode=predict``,
+        ``render=surge_simple``) plus the wandb-resume trio that routes the
+        eval's ``audio/*`` metrics onto the generate run. Runs the helper
+        directly so cfg-resolution noise can't mask an argv drift.
 
         :param monkeypatch: Patches the module's ``subprocess.run``.
         :param tmp_path: Stands in for the finalize download directory.
@@ -1756,17 +1756,18 @@ class TestMainDispatchBranches:
         assert f"hydra.run.dir={tmp_path}" in called_argv
         assert "ckpt_path=null" in called_argv
         # The eval resumes the generate run rather than opening a fresh one, so
-        # its test/* metrics share the run id (logger=null crashed Hydra — see #1331).
+        # its audio/* metrics share the run id (logger=null crashed Hydra — see #1331).
         assert "logger=wandb" in called_argv
         # id exists in logger/wandb.yaml (plain override); resume is absent (+append).
         assert "logger.wandb.id=some-run-id" in called_argv
         assert "+logger.wandb.resume=must" in called_argv
-        # surge data config marks predict_file mandatory; mode=test never reads it.
-        assert "data.predict_file=null" in called_argv
+        # render_vst=true re-renders predicted params; select the surge_simple
+        # group (eval.yaml defaults render to null) matching the smoke dataset.
+        assert "render=surge_simple" in called_argv
         # batch_size=1 keeps the smoke-sized test split (4 samples) from
         # flooring to zero batches under the 128 default — see #1331.
         assert "data.batch_size=1" in called_argv
-        assert "mode=test" in called_argv
+        assert "mode=predict" in called_argv
 
     def test_main_oracle_eval_inline_default_false_skips(
         self,

--- a/tests/pipeline/test_r2_io.py
+++ b/tests/pipeline/test_r2_io.py
@@ -110,6 +110,56 @@ class TestDownloadToPath:
             r2_io.download_to_path("local-spec.json", tmp_path / "out.json")
 
 
+class TestDownloadDirNoOverwrite:
+    """Tests for download_dir_no_overwrite — prefix→directory copy."""
+
+    def test_lands_remote_tree_under_dest_dir(self, fake_r2_remote: Path, tmp_path: Path) -> None:
+        """Every object under the prefix is copied into ``dest_path``.
+
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        :param tmp_path: Pytest tmp dir used for the download destination.
+        """
+        prefix = fake_r2_remote / "bucket" / "dataset"
+        prefix.mkdir(parents=True)
+        (prefix / "train.h5").write_text("train")
+        (prefix / "stats.npz").write_text("stats")
+        dest = tmp_path / "root"
+
+        r2_io.download_dir_no_overwrite("r2://bucket/dataset", dest)
+
+        assert (dest / "train.h5").read_text() == "train"
+        assert (dest / "stats.npz").read_text() == "stats"
+
+    def test_rejects_non_r2_uri(self, tmp_path: Path) -> None:
+        """A local-path source is rejected — caller must branch on is_r2_uri.
+
+        :param tmp_path: Pytest tmp dir used to build a local destination path.
+        """
+        with pytest.raises(ValueError, match="not an r2:// URI"):
+            r2_io.download_dir_no_overwrite("local-dir", tmp_path / "root")
+
+    def test_command_carries_immutable_and_reliability_flags(self, tmp_path: Path) -> None:
+        """Pin the rclone verb + ``--immutable`` + reliability-flag set.
+
+        ``--immutable`` is the entire point of this helper (no-clobber) and is
+        unobservable from filesystem state alone; the reliability flags must
+        match the upload helpers so a transient blip retries instead of failing
+        the eval. One mock-based argv assertion guards both invariants.
+
+        :param tmp_path: Pytest tmp dir used for the download destination.
+        """
+        with patch.object(r2_io.subprocess, "check_call") as mock_call:
+            r2_io.download_dir_no_overwrite("r2://bucket/dataset", tmp_path / "root")
+        args = mock_call.call_args[0][0]
+        assert args[:2] == ["rclone", "copy"]
+        assert "--immutable" in args
+        assert "--checksum" in args
+        assert "-vv" in args
+        assert "--contimeout=30s" in args
+        assert "--timeout=300s" in args
+        assert "--retries=3" in args
+
+
 class TestUploadToUri:
     """Tests for upload_to_uri — file→file upload with reliability flags."""
 

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -97,9 +97,10 @@ class TestWandbConfigResolvesFromEnv:
 
 # Volatile cfg branches that legitimately differ between the fixture builder and the YAML
 # compose: ``paths`` is filesystem-anchored via ``operator_workspace()``, ``hydra`` carries
-# the per-invocation runtime metadata, and ``task_name`` is interpolated from the entry-point
-# script name (test runner vs. ``train.py``).
-_VOLATILE_TOP_KEYS = ("paths", "hydra", "task_name")
+# the per-invocation runtime metadata, ``task_name`` is interpolated from the entry-point
+# script name (test runner vs. ``train.py``), and ``render`` is an eval-only group (null
+# here, selected per-run in predict mode) outside the train cfg shape this contract pins.
+_VOLATILE_TOP_KEYS = ("paths", "hydra", "task_name", "render")
 
 
 def _strip_volatile(cfg_dict: dict[Any, Any]) -> dict[Any, Any]:

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,8 +1,10 @@
 """Tests for the ``synth-setter-eval`` CLI entrypoint."""
 
+import json
 import math
 import os
 import shutil
+import subprocess
 import sys
 from contextlib import contextmanager
 from pathlib import Path
@@ -51,6 +53,8 @@ def test_evaluate_runs_oracle_with_null_ckpt_path(
             overrides=[
                 "experiment=surge/test-mps-fake-oracle",
                 "trainer=cpu",
+                # The experiment defaults to mode=predict; this invariant is test-mode.
+                "mode=test",
                 f"model.net.d_out={len(param_specs['surge_4'])}",
                 "callbacks.log_per_param_mse.param_spec=surge_4",
             ],
@@ -88,7 +92,6 @@ def test_dump_metric_dict_writes_json_with_coerced_scalars(tmp_path: Path) -> No
 
     :param tmp_path: Hydra-style output dir; the ``metrics/`` subdir lands under it.
     """
-    import json
 
     import numpy as np
 
@@ -178,6 +181,80 @@ def test_download_eval_dataset_noop_when_uri_null(local_r2_remote: Path, tmp_pat
     eval_mod._download_eval_dataset(cfg)
 
     assert list(dataset_root.iterdir()) == []
+
+
+@pytest.mark.requires_vst
+@pytest.mark.slow
+def test_eval_cli_downloads_dataset_from_r2_then_scores_oracle(
+    tmp_path: Path, surge_xt_smoke_datasets: Path
+) -> None:
+    """End-to-end through the ``synth-setter-eval`` CLI: R2 prefetch then oracle scoring.
+
+    No in-process shortcuts and no mocks — the real entrypoint runs with real
+    ``rclone`` (local-backed remote). A dataset staged under an ``r2://`` prefix is
+    downloaded into an initially-absent ``data.dataset_root``, and the fake oracle's
+    exact-zero ``test/param_mse`` reaches ``metrics.json``. Proves the new
+    ``evaluation.download_dataset_root_uri`` gate composes with eval through ``main``.
+
+    :param tmp_path: Root for the fake R2 remote, the download target, and the output dir.
+    :param surge_xt_smoke_datasets: Source ``{train,val,test}.h5`` + ``stats.npz``.
+    """
+    if shutil.which("rclone") is None:
+        pytest.skip("rclone binary not available on PATH")
+
+    remote_root = tmp_path / "r2"
+    staged = remote_root / "intermediate-data" / "dataset"
+    staged.mkdir(parents=True)
+    splits_and_stats = ("train.h5", "val.h5", "test.h5", "stats.npz")
+    for name in splits_and_stats:
+        shutil.copy(surge_xt_smoke_datasets / name, staged / name)
+
+    dataset_root = tmp_path / "downloaded"
+    output_dir = tmp_path / "out"
+
+    env = {
+        **os.environ,
+        "RCLONE_CONFIG_R2_TYPE": "local",
+        "RCLONE_CONFIG_R2_ACCESS_KEY_ID": "stub",
+        "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY": "stub",
+        "RCLONE_CONFIG_R2_ENDPOINT": "stub",
+    }
+    proc = subprocess.run(  # noqa: S603 — controlled argv
+        [
+            sys.executable,
+            "-m",
+            "synth_setter.cli.eval",
+            "experiment=surge/test-mps-fake-oracle",
+            "trainer=cpu",
+            "mode=test",
+            # mode=test never renders; null satisfies the resolver that the
+            # experiment's mandatory `render: ???` would otherwise trip.
+            "render=null",
+            "hydra.job.chdir=false",
+            f"model.net.d_out={len(param_specs['surge_4'])}",
+            "callbacks.log_per_param_mse.param_spec=surge_4",
+            "evaluation.download_dataset_root_uri=r2://intermediate-data/dataset",
+            f"data.dataset_root={dataset_root}",
+            f"data.predict_file={dataset_root}/test.h5",
+            "data.batch_size=1",
+            "data.num_workers=0",
+            "ckpt_path=null",
+            f"paths.output_dir={output_dir}",
+            f"hydra.run.dir={output_dir}",
+        ],
+        cwd=remote_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+    for name in splits_and_stats:
+        assert (dataset_root / name).is_file(), f"{name} was not downloaded from R2"
+
+    metrics = json.loads((output_dir / "metrics" / "metrics.json").read_text())
+    assert metrics["test/param_mse"] == 0.0
 
 
 @pytest.mark.gpu

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -112,77 +112,6 @@ def test_dump_metric_dict_writes_json_with_coerced_scalars(tmp_path: Path) -> No
     assert payload["raw/string"] == "v1"
 
 
-@pytest.fixture()
-def local_r2_remote(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
-    """Back the ``r2:`` rclone remote with the local filesystem for real-binary e2e.
-
-    Mirrors ``tests/pipeline``'s ``fake_r2_remote``: ``RCLONE_CONFIG_R2_TYPE=local``
-    resolves ``r2://<bucket>/<key>`` to ``<cwd>/<bucket>/<key>``, and the three
-    secret keys satisfy ``ensure_r2_env_loaded``'s presence check (their values
-    are unused by the local backend). Skips when ``rclone`` is absent.
-
-    :param tmp_path: Pytest tmp dir; the returned subdir is the fake R2 root.
-    :param monkeypatch: Sets the rclone env vars and chdirs into the remote root.
-    :return: The fake R2 root; ``r2://<bucket>/<key>`` materializes under it.
-    """
-    if shutil.which("rclone") is None:
-        pytest.skip("rclone binary not available on PATH")
-    remote_root = tmp_path / "r2"
-    remote_root.mkdir()
-    monkeypatch.setenv("RCLONE_CONFIG_R2_TYPE", "local")
-    monkeypatch.setenv("RCLONE_CONFIG_R2_ACCESS_KEY_ID", "stub")
-    monkeypatch.setenv("RCLONE_CONFIG_R2_SECRET_ACCESS_KEY", "stub")
-    monkeypatch.setenv("RCLONE_CONFIG_R2_ENDPOINT", "stub")
-    monkeypatch.chdir(remote_root)
-    return remote_root
-
-
-def test_download_eval_dataset_hydrates_root_from_r2(
-    local_r2_remote: Path, tmp_path: Path
-) -> None:
-    """Gate on: the configured R2 prefix is copied into ``data.dataset_root``.
-
-    :param local_r2_remote: Real rclone remote backed by the local filesystem.
-    :param tmp_path: Holds the (initially absent) download destination root.
-    """
-    remote_prefix = local_r2_remote / "intermediate-data" / "dataset"
-    remote_prefix.mkdir(parents=True)
-    (remote_prefix / "train.h5").write_bytes(b"train-bytes")
-    (remote_prefix / "stats.npz").write_bytes(b"stats-bytes")
-    dataset_root = tmp_path / "downloaded"
-
-    cfg = OmegaConf.create(
-        {
-            "evaluation": {"download_dataset_root_uri": "r2://intermediate-data/dataset"},
-            "data": {"dataset_root": str(dataset_root)},
-        }
-    )
-    eval_mod._download_eval_dataset(cfg)
-
-    assert (dataset_root / "train.h5").read_bytes() == b"train-bytes"
-    assert (dataset_root / "stats.npz").read_bytes() == b"stats-bytes"
-
-
-def test_download_eval_dataset_noop_when_uri_null(local_r2_remote: Path, tmp_path: Path) -> None:
-    """Gate off (default ``null``): ``data.dataset_root`` is left untouched.
-
-    :param local_r2_remote: Real rclone remote — present so a regression copies rather than hangs.
-    :param tmp_path: Holds the pre-existing, empty dataset root.
-    """
-    dataset_root = tmp_path / "downloaded"
-    dataset_root.mkdir()
-
-    cfg = OmegaConf.create(
-        {
-            "evaluation": {"download_dataset_root_uri": None},
-            "data": {"dataset_root": str(dataset_root)},
-        }
-    )
-    eval_mod._download_eval_dataset(cfg)
-
-    assert list(dataset_root.iterdir()) == []
-
-
 @pytest.mark.requires_vst
 @pytest.mark.slow
 def test_eval_cli_downloads_dataset_from_r2_then_scores_oracle(
@@ -227,13 +156,12 @@ def test_eval_cli_downloads_dataset_from_r2_then_scores_oracle(
             "experiment=surge/test-mps-fake-oracle",
             "trainer=cpu",
             "mode=test",
-            # mode=test never renders; null satisfies the resolver that the
-            # experiment's mandatory `render: ???` would otherwise trip.
-            "render=null",
+            # render defaults to null and is read only in mode=predict's
+            # postprocessing, so mode=test needs no render group.
             "hydra.job.chdir=false",
             f"model.net.d_out={len(param_specs['surge_4'])}",
             "callbacks.log_per_param_mse.param_spec=surge_4",
-            "evaluation.download_dataset_root_uri=r2://intermediate-data/dataset",
+            "data.download_dataset_root_uri=r2://intermediate-data/dataset",
             f"data.dataset_root={dataset_root}",
             f"data.predict_file={dataset_root}/test.h5",
             "data.batch_size=1",

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -2,6 +2,7 @@
 
 import math
 import os
+import shutil
 import sys
 from contextlib import contextmanager
 from pathlib import Path
@@ -106,6 +107,77 @@ def test_dump_metric_dict_writes_json_with_coerced_scalars(tmp_path: Path) -> No
     assert payload["test/per_param_mse"] == [0.0, 0.0, 0.0, 0.0]
     assert payload["audio/mss_mean"] == pytest.approx(0.5)
     assert payload["raw/string"] == "v1"
+
+
+@pytest.fixture()
+def local_r2_remote(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Back the ``r2:`` rclone remote with the local filesystem for real-binary e2e.
+
+    Mirrors ``tests/pipeline``'s ``fake_r2_remote``: ``RCLONE_CONFIG_R2_TYPE=local``
+    resolves ``r2://<bucket>/<key>`` to ``<cwd>/<bucket>/<key>``, and the three
+    secret keys satisfy ``ensure_r2_env_loaded``'s presence check (their values
+    are unused by the local backend). Skips when ``rclone`` is absent.
+
+    :param tmp_path: Pytest tmp dir; the returned subdir is the fake R2 root.
+    :param monkeypatch: Sets the rclone env vars and chdirs into the remote root.
+    :return: The fake R2 root; ``r2://<bucket>/<key>`` materializes under it.
+    """
+    if shutil.which("rclone") is None:
+        pytest.skip("rclone binary not available on PATH")
+    remote_root = tmp_path / "r2"
+    remote_root.mkdir()
+    monkeypatch.setenv("RCLONE_CONFIG_R2_TYPE", "local")
+    monkeypatch.setenv("RCLONE_CONFIG_R2_ACCESS_KEY_ID", "stub")
+    monkeypatch.setenv("RCLONE_CONFIG_R2_SECRET_ACCESS_KEY", "stub")
+    monkeypatch.setenv("RCLONE_CONFIG_R2_ENDPOINT", "stub")
+    monkeypatch.chdir(remote_root)
+    return remote_root
+
+
+def test_download_eval_dataset_hydrates_root_from_r2(
+    local_r2_remote: Path, tmp_path: Path
+) -> None:
+    """Gate on: the configured R2 prefix is copied into ``data.dataset_root``.
+
+    :param local_r2_remote: Real rclone remote backed by the local filesystem.
+    :param tmp_path: Holds the (initially absent) download destination root.
+    """
+    remote_prefix = local_r2_remote / "intermediate-data" / "dataset"
+    remote_prefix.mkdir(parents=True)
+    (remote_prefix / "train.h5").write_bytes(b"train-bytes")
+    (remote_prefix / "stats.npz").write_bytes(b"stats-bytes")
+    dataset_root = tmp_path / "downloaded"
+
+    cfg = OmegaConf.create(
+        {
+            "evaluation": {"download_dataset_root_uri": "r2://intermediate-data/dataset"},
+            "data": {"dataset_root": str(dataset_root)},
+        }
+    )
+    eval_mod._download_eval_dataset(cfg)
+
+    assert (dataset_root / "train.h5").read_bytes() == b"train-bytes"
+    assert (dataset_root / "stats.npz").read_bytes() == b"stats-bytes"
+
+
+def test_download_eval_dataset_noop_when_uri_null(local_r2_remote: Path, tmp_path: Path) -> None:
+    """Gate off (default ``null``): ``data.dataset_root`` is left untouched.
+
+    :param local_r2_remote: Real rclone remote — present so a regression copies rather than hangs.
+    :param tmp_path: Holds the pre-existing, empty dataset root.
+    """
+    dataset_root = tmp_path / "downloaded"
+    dataset_root.mkdir()
+
+    cfg = OmegaConf.create(
+        {
+            "evaluation": {"download_dataset_root_uri": None},
+            "data": {"dataset_root": str(dataset_root)},
+        }
+    )
+    eval_mod._download_eval_dataset(cfg)
+
+    assert list(dataset_root.iterdir()) == []
 
 
 @pytest.mark.gpu

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -123,7 +123,7 @@ def test_eval_cli_downloads_dataset_from_r2_then_scores_oracle(
     ``rclone`` (local-backed remote). A dataset staged under an ``r2://`` prefix is
     downloaded into an initially-absent ``data.dataset_root``, and the fake oracle's
     exact-zero ``test/param_mse`` reaches ``metrics.json``. Proves the new
-    ``evaluation.download_dataset_root_uri`` gate composes with eval through ``main``.
+    ``data.download_dataset_root_uri`` gate composes with eval through ``main``.
 
     :param tmp_path: Root for the fake R2 remote, the download target, and the output dir.
     :param surge_xt_smoke_datasets: Source ``{train,val,test}.h5`` + ``stats.npz``.

--- a/uv.lock
+++ b/uv.lock
@@ -6022,7 +6022,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.12.0"
+version = "8.12.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },

--- a/uv.lock
+++ b/uv.lock
@@ -6022,7 +6022,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.12.3"
+version = "8.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What does this PR do?

Closes #91

Wires up an end-to-end **eval-from-R2** path and an **inline oracle-eval** step in
the dataset-generation pipeline, so a single `synth-setter-generate-dataset` run can
go generate → finalize → score, and `synth-setter-eval` can hydrate its dataset from
R2 before running.

### 1. Dataset download owned by the datamodule
- New `data.download_dataset_root_uri` (defaults to `null`) on the `surge*.yaml` data
  configs. When set, `SurgeDataModule.prepare_data()` loads R2 creds and copies the
  prefix into `data.dataset_root` — Lightning's **rank-0** hook, so it runs once even
  under DDP (matching the `kosc`/`ksin`/`fm` datamodules). `null` is a no-op.
- `eval`/`train` build the datamodule with plain `hydra.utils.instantiate(cfg.data)`;
  no bespoke download/instantiate helpers in the CLI entrypoints.
- `r2_io.download_dir_no_overwrite()` — `rclone copy --immutable --checksum` plus the
  module's reliability flags (`-vv --contimeout=30s --timeout=300s --retries=3`): a
  pre-existing local root is never clobbered, transient blips retry. Exported in `__all__`.

### 2. Inline oracle-eval in the generate sweep
- `generate_dataset/smoke-shard-with-oracle-eval.yaml` runs generate → finalize →
  inline oracle-eval (`mode=predict`, `render=surge_simple`). The eval **resumes the
  generate-phase W&B run** (`logger.wandb.id=<run_id> +logger.wandb.resume=must`) and
  appends `audio/*` audio-similarity metrics, written under
  `<output_dir>/oracle_eval/<run_id>/`.
- `surge/fake_oracle.yaml` is rewired to a predict-mode VST eval (`mode: predict`,
  `render_vst: true`, `compute_metrics: true`, `ckpt_path: null`, cpu trainer);
  `surge/test-mps-fake-oracle.yaml` mirrors it for the cfg-lockstep contract.
- `generate_dataset_cadence` sweep points at `smoke-shard-with-oracle-eval` and grids
  the render `gui_toggle_cadence` / `plugin_reload_cadence` knobs.

### Supporting changes
- `surge_datamodule`: `predict_file` defaults to `<dataset_root>/test.h5`; the predict
  split is always built and `teardown` closes its h5 handle. Fixed an inverted
  fake-mode `audio` conditional (`read_audio=True` now populates audio, mirroring real
  mode). PEP-604 type modernization.
- `data/*.yaml`: anchor `dataset_root` to `${hydra:runtime.output_dir}/data` (the
  resolver form composes under `@hydra.main`; the dot-lookup form does not).
- `generate_dataset.spec_from_cfg`: mask non-spec keys **before** `resolve=True` so the
  `${hydra:...}` anchor isn't evaluated outside `@hydra.main`.
- `smoke-shard.yaml`: `train_val_test_sizes` `[12, 0, 0]` → `[4, 4, 4]` so every split
  is non-empty (the inline eval opens train/val/test `.h5`).
- Docs: `wandb-integration.md` §5f + `doc-map.yaml` synced to predict-mode `audio/*`.

### Tests (real `rclone` against a local-backed remote, no mocks)
- `TestDownloadDirNoOverwrite` — prefix→dir copy, non-`r2://` rejection, argv-shape.
- `test_prepare_data_*` — `prepare_data()` hydrates `dataset_root` when set, no-op when `null`.
- `test_eval_cli_downloads_dataset_from_r2_then_scores_oracle` — end-to-end through the
  `synth-setter-eval` CLI.
- `test_oracle_eval_inline_resumes_generate_wandb_run` — full generate→finalize→eval
  CLI, asserting the resumed run id and `audio/*` history rows.

> `data.dataset_root` defaults to the per-run Hydra dir so the sweep composes; the
> re-download tradeoff when a fixed `download_dataset_root_uri` is set is tracked in #1357.