### PR TITLE
chore(devcontainer): give each git worktree its own uv venv

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -125,16 +125,17 @@ done
 pre-commit install
 
 # Per-worktree venv isolation. The image bakes VIRTUAL_ENV=/venv/main onto
-# PATH, so every shell — and every git worktree — shares one editable install;
-# whichever worktree last ran `uv sync` owns it. This snippet activates a
-# worktree-local ./.venv when present, shadowing /venv/main. The agent harness
-# re-sources ~/.bashrc each shell and preserves cwd, so the active venv tracks
-# the current worktree. grep-guarded to stay idempotent across re-runs.
-if ! grep -q 'Per-worktree venv isolation' "$HOME/.bashrc"; then
+# PATH, so every git worktree shares one editable install — whichever ran
+# `uv sync` last owns it. Activate a worktree-local ./.venv when present,
+# shadowing /venv/main. The harness re-sources ~/.bashrc per shell and keeps
+# cwd, so the active venv tracks the worktree. `-qs`: an absent ~/.bashrc is
+# the not-yet-installed case, not an error. See #1339.
+if ! grep -qs 'Per-worktree venv isolation' "$HOME/.bashrc"; then
   cat >>"$HOME/.bashrc" <<'EOF'
 
 # Per-worktree venv isolation — see .devcontainer/post-create.sh.
-if [[ -f "$PWD/.venv/bin/activate" ]]; then
+# The VIRTUAL_ENV guard skips re-activation so re-sourcing can't stack PATH.
+if [[ -f "$PWD/.venv/bin/activate" && "${VIRTUAL_ENV:-}" != "$PWD/.venv" ]]; then
   unset VIRTUAL_ENV
   source "$PWD/.venv/bin/activate"
 fi

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -126,19 +126,27 @@ pre-commit install
 
 # Per-worktree venv isolation. The image bakes VIRTUAL_ENV=/venv/main onto
 # PATH, so every git worktree shares one editable install — whichever ran
-# `uv sync` last owns it. Activate a worktree-local ./.venv when present,
-# shadowing /venv/main. The harness re-sources ~/.bashrc per shell and keeps
-# cwd, so the active venv tracks the worktree. `-qs`: an absent ~/.bashrc is
-# the not-yet-installed case, not an error. See #1339.
+# `uv sync` last owns it. Walk up to the .project-root anchor and activate
+# that worktree's ./.venv when present, shadowing /venv/main. The harness
+# re-sources ~/.bashrc per shell and keeps cwd, so the active venv tracks the
+# worktree. `-qs`: an absent ~/.bashrc is the not-yet-installed case, not an
+# error. See #1339.
 if ! grep -qs 'Per-worktree venv isolation' "$HOME/.bashrc"; then
   cat >>"$HOME/.bashrc" <<'EOF'
 
 # Per-worktree venv isolation — see .devcontainer/post-create.sh.
-# The VIRTUAL_ENV guard skips re-activation so re-sourcing can't stack PATH.
-if [[ -f "$PWD/.venv/bin/activate" && "${VIRTUAL_ENV:-}" != "$PWD/.venv" ]]; then
+# Walk up to .project-root so activation works from any subdir, not just the
+# worktree root. The VIRTUAL_ENV guard skips re-activation so re-sourcing
+# can't stack PATH.
+__ss_root="$PWD"
+while [[ "$__ss_root" != "/" && ! -f "$__ss_root/.project-root" ]]; do
+  __ss_root="$(dirname "$__ss_root")"
+done
+if [[ -f "$__ss_root/.venv/bin/activate" && "${VIRTUAL_ENV:-}" != "$__ss_root/.venv" ]]; then
   unset VIRTUAL_ENV
-  source "$PWD/.venv/bin/activate"
+  source "$__ss_root/.venv/bin/activate"
 fi
+unset __ss_root
 EOF
 fi
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -124,4 +124,21 @@ for scope in --global --local --worktree; do
 done
 pre-commit install
 
+# Per-worktree venv isolation. The image bakes VIRTUAL_ENV=/venv/main onto
+# PATH, so every shell — and every git worktree — shares one editable install;
+# whichever worktree last ran `uv sync` owns it. This snippet activates a
+# worktree-local ./.venv when present, shadowing /venv/main. The agent harness
+# re-sources ~/.bashrc each shell and preserves cwd, so the active venv tracks
+# the current worktree. grep-guarded to stay idempotent across re-runs.
+if ! grep -q 'Per-worktree venv isolation' "$HOME/.bashrc"; then
+  cat >>"$HOME/.bashrc" <<'EOF'
+
+# Per-worktree venv isolation — see .devcontainer/post-create.sh.
+if [[ -f "$PWD/.venv/bin/activate" ]]; then
+  unset VIRTUAL_ENV
+  source "$PWD/.venv/bin/activate"
+fi
+EOF
+fi
+
 echo "Dev container ready. Run 'make test-fast' to verify."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,11 @@ Architecture: [docs/architecture.md](docs/architecture.md).
   banner on startup/resume/clear/compact; a `PreToolUse` hook
   (`agent/hooks/worktree-guard.sh`) warns on Edit/Write inside the primary
   checkout (`WORKTREE_GUARD_MODE`: `warn` default / `block` / `off`).
+- **Each worktree gets its own `.venv`.** The spawn command runs `uv sync`;
+  `~/.bashrc` (installed by `.devcontainer/post-create.sh`) then activates
+  `./.venv` per directory, overriding the image's shared `/venv/main`. For
+  one-offs, `uv run <cmd>` targets the worktree env regardless of the
+  inherited `VIRTUAL_ENV`.
 - **Always verify the branch before push.** Run `git branch --show-current`
   and confirm it matches the target PR branch. A hook prints the branch on
   every `git commit`; don't ignore it.

--- a/agent/hooks/session-start-cwd-banner.sh
+++ b/agent/hooks/session-start-cwd-banner.sh
@@ -49,7 +49,8 @@ main() {
     printf 'Spawn a worktree before editing:\n'
     # Anchor to $primary_root so the command works even when the session started in a subdir.
     # `uv sync` builds the worktree's own .venv so it stops sharing the image's /venv/main.
-    printf '  git worktree add --detach %s/.claude/worktrees/%s && cd %s/.claude/worktrees/%s && uv sync\n' \
+    # Single-quote the emitted paths so the command survives a $primary_root with spaces.
+    printf "  git worktree add --detach '%s/.claude/worktrees/%s' && cd '%s/.claude/worktrees/%s' && uv sync\n" \
       "$primary_root" "$slug" "$primary_root" "$slug"
   else
     printf '  status   : isolated worktree (OK)\n'

--- a/agent/hooks/session-start-cwd-banner.sh
+++ b/agent/hooks/session-start-cwd-banner.sh
@@ -48,7 +48,8 @@ main() {
     # matching the primary-edit guard's remediation and `_lib.sh` convention.
     printf 'Spawn a worktree before editing:\n'
     # Anchor to $primary_root so the command works even when the session started in a subdir.
-    printf '  git worktree add --detach %s/.claude/worktrees/%s && cd %s/.claude/worktrees/%s\n' \
+    # `uv sync` builds the worktree's own .venv so it stops sharing the image's /venv/main.
+    printf '  git worktree add --detach %s/.claude/worktrees/%s && cd %s/.claude/worktrees/%s && uv sync\n' \
       "$primary_root" "$slug" "$primary_root" "$slug"
   else
     printf '  status   : isolated worktree (OK)\n'


### PR DESCRIPTION
## Problem

The dev image bakes `VIRTUAL_ENV=/venv/main` onto `PATH`, so every git worktree shares one editable install of `synth_setter`. Whichever worktree last ran `uv sync` owns the editable pointer (`__editable__.synth_setter.pth`), so code and Hydra config edits made in one worktree silently run against another worktree's source. This surfaced when a Hydra override (`data.ext=h5`) was rejected because the installed package came from a different branch's configs.

## Change

- **`.devcontainer/post-create.sh`** installs an idempotent `~/.bashrc` snippet that activates a worktree-local `./.venv` when present, shadowing `/venv/main`. The agent harness re-sources `~/.bashrc` each shell and preserves cwd, so the active venv tracks the current worktree. A `VIRTUAL_ENV` guard skips re-activation so re-sourcing can't stack `PATH` entries; `grep -qs` treats an absent `~/.bashrc` as not-yet-installed.
- **`agent/hooks/session-start-cwd-banner.sh`** — the `SessionStart` banner's spawn command now ends with `&& uv sync` so new worktrees build their own venv.
- **`AGENTS.md`** documents the per-worktree venv and the `uv run <cmd>` one-off path (targets `./.venv` regardless of the inherited `VIRTUAL_ENV`).

## Rollout note

`post-create.sh` runs only at container creation; existing containers/worktrees need a one-time `uv sync` (and re-run of the snippet installer) to pick this up.

## Review

Pre-PR dry-run review (code-health, synth-setter-project-standards, shell-style): 0 BLOCK, 5 WARN — 2 fixed in this branch (PATH-stacking guard, `grep -qs`), 3 accepted/documented.

Closes #1339