### PR TITLE
feat(ci-automation): mirror plugins/ symlink into fresh worktrees

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,24 @@ install-surge-xt: ## Download Surge XT VST3 into plugins/ (skipped if already pr
 	esac; \
 	echo "Installed $$DEST"
 
+link-plugins: ## Mirror the primary checkout's plugins/ into the current worktree (no-op in primary)
+	@set -e; \
+	primary="$$(cd "$$(dirname "$$(git rev-parse --git-common-dir)")" && pwd)"; \
+	here="$$(git rev-parse --show-toplevel)"; \
+	if [ "$$primary" = "$$here" ]; then \
+		echo "In primary checkout — nothing to link."; exit 0; \
+	fi; \
+	if [ ! -d "$$primary/plugins" ]; then \
+		echo "No $$primary/plugins to mirror — run 'make install-surge-xt' in the primary first."; exit 0; \
+	fi; \
+	mkdir -p "$$here/plugins"; \
+	for entry in "$$primary"/plugins/*; do \
+		[ -e "$$entry" ] || continue; \
+		name="$$(basename "$$entry")"; \
+		ln -sfn "$$entry" "$$here/plugins/$$name"; \
+		echo "linked plugins/$$name -> $$entry"; \
+	done
+
 # Mirrors the --cov flags used by .github/workflows/test.yml so local
 # coverage runs reproduce CI output (xml report feeds Codecov; html is for
 # local browsing).

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ link-plugins: ## Mirror the primary checkout's plugins/ into the current worktre
 	fi; \
 	mkdir -p "$$here/plugins"; \
 	for entry in "$$primary"/plugins/*; do \
-		[ -e "$$entry" ] || continue; \
+		[ -e "$$entry" ] || [ -L "$$entry" ] || continue; \
 		name="$$(basename "$$entry")"; \
 		ln -sfn "$$entry" "$$here/plugins/$$name"; \
 		echo "linked plugins/$$name -> $$entry"; \

--- a/agent/hooks/session-start-cwd-banner.sh
+++ b/agent/hooks/session-start-cwd-banner.sh
@@ -48,7 +48,7 @@ main() {
     # matching the primary-edit guard's remediation and `_lib.sh` convention.
     printf 'Spawn a worktree before editing:\n'
     # Anchor to $primary_root so the command works even when the session started in a subdir.
-    printf '  git worktree add --detach %s/.claude/worktrees/%s && cd %s/.claude/worktrees/%s\n' \
+    printf '  git worktree add --detach %s/.claude/worktrees/%s && cd %s/.claude/worktrees/%s && make link-plugins\n' \
       "$primary_root" "$slug" "$primary_root" "$slug"
   else
     printf '  status   : isolated worktree (OK)\n'

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -1176,7 +1176,7 @@ T_worktree_guard_remediation_path_is_absolute_from_subdir() {
   out=$(cd "$subdir" && echo '' | bash "$SANDBOX/agent/hooks/worktree-guard.sh" 2>"$stderr_file"; echo "EXIT:$?")
   [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
   grep -q "WARNING" "$stderr_file" || { echo "subdir cwd should still WARN; got: $(cat "$stderr_file")"; return 1; }
-  grep -qE "git worktree add --detach ${SANDBOX}/\\.claude/worktrees/" "$stderr_file" || {
+  grep -qE "git worktree add --detach '${SANDBOX}/\\.claude/worktrees/[^']+'" "$stderr_file" || {
     echo "remediation must anchor at \$primary_root (${SANDBOX}); got: $(cat "$stderr_file")"
     return 1
   }
@@ -1262,7 +1262,7 @@ T_session_start_banner_remediation_path_is_absolute_from_subdir() {
   out=$(cd "$subdir" && bash "$SANDBOX/agent/hooks/session-start-cwd-banner.sh" </dev/null 2>&1; echo "EXIT:$?")
   [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
   [[ "$out" == *"PRIMARY CHECKOUT"* ]] || { echo "subdir cwd should still flag PRIMARY; got: $out"; return 1; }
-  echo "$out" | grep -qE "git worktree add --detach '?${SANDBOX}/\\.claude/worktrees/" || {
+  echo "$out" | grep -qE "git worktree add --detach '${SANDBOX}/\\.claude/worktrees/[^']+'" || {
     echo "remediation must anchor at \$primary_root (${SANDBOX}); got: $out"
     return 1
   }

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -1058,6 +1058,7 @@ T_worktree_guard_warns_in_primary() {
   [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
   grep -q "WARNING" "$stderr_file" || { echo "stderr should contain WARNING; got: $(cat "$stderr_file")"; return 1; }
   grep -q "git worktree add" "$stderr_file" || { echo "stderr should suggest 'git worktree add'"; return 1; }
+  grep -q "make link-plugins" "$stderr_file" || { echo "remediation should chain 'make link-plugins' so the new worktree gets the VST symlink; got: $(cat "$stderr_file")"; return 1; }
 }
 it "worktree-guard: edit in primary (warn mode default) → exit 0 with WARNING + remediation on stderr" T_worktree_guard_warns_in_primary
 
@@ -1197,6 +1198,7 @@ T_session_start_banner_in_primary() {
   [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
   [[ "$out" == *"PRIMARY CHECKOUT"* ]] || { echo "banner should flag PRIMARY CHECKOUT; got: $out"; return 1; }
   [[ "$out" == *"git worktree add"* ]] || { echo "banner should suggest 'git worktree add'; got: $out"; return 1; }
+  [[ "$out" == *"make link-plugins"* ]] || { echo "spawn command should chain 'make link-plugins' so the new worktree gets the VST symlink; got: $out"; return 1; }
 }
 it "session-start-banner: in primary → stdout flags PRIMARY CHECKOUT and shows remediation" T_session_start_banner_in_primary
 

--- a/agent/hooks/worktree-guard.sh
+++ b/agent/hooks/worktree-guard.sh
@@ -85,7 +85,7 @@ isolated worktree before editing.
 
 Recommended (current HEAD: ${branch_label}):
   git worktree add --detach ${primary_root}/.claude/worktrees/${slug}
-  cd ${primary_root}/.claude/worktrees/${slug}
+  cd ${primary_root}/.claude/worktrees/${slug} && make link-plugins
 
 ${override_hint}
 EOF

--- a/agent/hooks/worktree-guard.sh
+++ b/agent/hooks/worktree-guard.sh
@@ -84,8 +84,8 @@ AGENTS.md "Always" rule: the primary checkout is read-only; switch to an
 isolated worktree before editing.
 
 Recommended (current HEAD: ${branch_label}):
-  git worktree add --detach ${primary_root}/.claude/worktrees/${slug}
-  cd ${primary_root}/.claude/worktrees/${slug} && make link-plugins
+  git worktree add --detach '${primary_root}/.claude/worktrees/${slug}'
+  cd '${primary_root}/.claude/worktrees/${slug}' && uv sync && make link-plugins
 
 ${override_hint}
 EOF

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -217,7 +217,7 @@ docs:
     description: Onboarding — local dev, Codespaces, and dev container flows
     sources:
       - pattern: "Makefile"
-        covers: "Local dev targets — install (uv + .venv + deps + pre-commit), install-surge-xt (download + md5 verify + extract Surge XT VST3), SURGE_XT_VERSION + related vars"
+        covers: "Local dev targets — install (uv + .venv + deps + pre-commit), install-surge-xt (download + md5 verify + extract Surge XT VST3), link-plugins (mirror primary's plugins/ into a worktree), SURGE_XT_VERSION + related vars"
         scope: "local-dev"
       - pattern: ".devcontainer/cpu/devcontainer.json"
         covers: "CPU dev container config — remoteUser, mounts (bash-history named volume + per-user tmux-resurrect named volumes for dev and root + plugins/ anonymous overlay), --env-file .env, initializeCommand, postCreateCommand, VS Code terminal profile defaulting to tmux"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -754,7 +754,7 @@ devcontainer up --workspace-folder .
 ```bash
 # Inside the container, starting from the workspace root on main:
 git worktree add .claude/worktrees/my-feature -b feat/my-feature
-cd .claude/worktrees/my-feature
+cd .claude/worktrees/my-feature && make link-plugins
 ```
 
 This is the supported local pattern. Mounting a worktree directly from the
@@ -778,6 +778,10 @@ the failure surfaces immediately rather than partway through `post-create`.
   VST-dependent tests. Host edits under `plugins/` are not visible
   inside the container; container edits under `plugins/` are not
   visible on the host.
+- A fresh worktree starts without `plugins/` (it's gitignored, so
+  `git worktree add` doesn't copy it). `make link-plugins` mirrors the
+  primary checkout's `plugins/` entries into the worktree (no-op in the
+  primary) — that's why the spawn command above chains it.
 
 ### B.3. macOS VM (Tart)
 

--- a/tests/infra/test_worktree_plugin_links.py
+++ b/tests/infra/test_worktree_plugin_links.py
@@ -150,3 +150,27 @@ def test_link_plugins_skips_when_primary_has_no_plugins(tmp_path: Path) -> None:
 
     assert "No" in stdout and "install-surge-xt" in stdout
     assert not (worktree / "plugins").exists()
+
+
+def test_link_plugins_mirrors_a_broken_symlink(tmp_path: Path) -> None:
+    """`make link-plugins` mirrors a primary entry even when its symlink target is missing.
+
+    A primary whose system VST isn't installed has a dangling `plugins/<x>.vst3`; the worktree
+    should still receive the (equally dangling) link, not silently skip it.
+
+    :param tmp_path: holds the primary checkout (dangling plugin symlink) and its worktree.
+    """
+    primary = tmp_path / "primary"
+    _init_primary_repo(primary)
+    (primary / "plugins").mkdir()
+    (primary / "plugins" / "Surge XT.vst3").symlink_to(tmp_path / "absent" / "Surge XT.vst3")
+    worktree = tmp_path / "wt"
+    _git(primary, "worktree", "add", "--detach", "-q", str(worktree))
+
+    _make_link_plugins(worktree)
+
+    linked = worktree / "plugins" / "Surge XT.vst3"
+    assert linked.is_symlink()
+    assert not linked.exists(), (
+        "target is still absent — the dangling link is mirrored, not resolved"
+    )

--- a/tests/infra/test_worktree_plugin_links.py
+++ b/tests/infra/test_worktree_plugin_links.py
@@ -2,8 +2,8 @@
 
 `plugins/` is gitignored, so `git worktree add` produces a worktree without the
 `plugins/<plugin>.vst3` symlink that configs/CLI resolve relative to cwd. The target backfills it;
-the spawn command printed by the SessionStart banner and worktree-guard chains `&& make link-
-plugins` so the link appears naturally.
+the spawn command printed by the SessionStart banner and worktree-guard chains it on so the link
+appears naturally.
 """
 
 from __future__ import annotations
@@ -15,6 +15,11 @@ from pathlib import Path
 import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+pytestmark = pytest.mark.infra
+
+# Bound subprocess calls so a hung git/make can't wedge the suite.
+_TIMEOUT_S = 60
 
 
 def _git(repo: Path, *args: str) -> None:
@@ -28,6 +33,7 @@ def _git(repo: Path, *args: str) -> None:
         check=True,
         capture_output=True,
         text=True,
+        timeout=_TIMEOUT_S,
     )
 
 
@@ -43,6 +49,7 @@ def _make_link_plugins(cwd: Path) -> str:
         check=True,
         capture_output=True,
         text=True,
+        timeout=_TIMEOUT_S,
     ).stdout
 
 

--- a/tests/infra/test_worktree_plugin_links.py
+++ b/tests/infra/test_worktree_plugin_links.py
@@ -1,0 +1,141 @@
+"""`make link-plugins` mirrors the primary checkout's gitignored plugins/ into a fresh worktree.
+
+`plugins/` is gitignored, so `git worktree add` produces a worktree without the
+`plugins/<plugin>.vst3` symlink that configs/CLI resolve relative to cwd. The target backfills it;
+the spawn command printed by the SessionStart banner and worktree-guard chains `&& make link-
+plugins` so the link appears naturally.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _git(repo: Path, *args: str) -> None:
+    """Run a git subcommand in ``repo``, raising on non-zero exit.
+
+    :param repo: checkout the subcommand runs against (``git -C``).
+    :param *args: subcommand and its arguments.
+    """
+    subprocess.run(  # noqa: S603 — fixed argv, no shell
+        ["git", "-C", str(repo), *args],  # noqa: S607 — git on PATH
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_link_plugins(cwd: Path) -> str:
+    """Run ``make link-plugins`` in ``cwd``, returning its stdout.
+
+    :param cwd: directory to run the target from (a primary checkout or worktree).
+    :returns: the target's stdout (the linked/no-op message lines).
+    """
+    return subprocess.run(  # noqa: S603 — fixed argv, no shell
+        ["make", "link-plugins"],  # noqa: S607 — make on PATH
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+
+
+def _init_primary_repo(path: Path) -> None:
+    """Init a committed git checkout at ``path`` with the project Makefile.
+
+    :param path: empty directory to turn into the primary checkout.
+    """
+    path.mkdir()
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "test")
+    shutil.copy(PROJECT_ROOT / "Makefile", path / "Makefile")
+    _git(path, "add", "Makefile")
+    _git(path, "commit", "-qm", "init")
+
+
+@pytest.fixture
+def primary_with_plugin(tmp_path: Path) -> tuple[Path, Path]:
+    """Build a committed primary checkout whose untracked plugins/ holds one symlinked VST.
+
+    Mirrors the real layout: the entry is a symlink to an out-of-tree target (as
+    the primary's `Surge XT.vst3 -> /usr/lib/vst3/...` is), and plugins/ is
+    untracked so a fresh worktree won't receive it.
+
+    :param tmp_path: holds the throwaway checkout, its worktrees, and the VST target.
+    :returns: ``(primary_root, vst_target)`` — the checkout and the file the
+        mirrored symlink must ultimately resolve to.
+    """
+    primary = tmp_path / "primary"
+    _init_primary_repo(primary)
+
+    vst_target = tmp_path / "system" / "Surge XT.vst3"
+    vst_target.parent.mkdir()
+    vst_target.write_text("vst")
+    (primary / "plugins").mkdir()
+    (primary / "plugins" / "Surge XT.vst3").symlink_to(vst_target)
+    return primary, vst_target
+
+
+def test_link_plugins_mirrors_primary_into_worktree(
+    primary_with_plugin: tuple[Path, Path], tmp_path: Path
+) -> None:
+    """`make link-plugins` symlinks each primary plugins/ entry into the worktree, idempotently.
+
+    :param primary_with_plugin: ``(primary_root, vst_target)`` fixture.
+    :param tmp_path: holds the worktree added off the primary.
+    """
+    primary, vst_target = primary_with_plugin
+    worktree = tmp_path / "wt"
+    _git(primary, "worktree", "add", "--detach", "-q", str(worktree))
+    assert not (worktree / "plugins").exists(), (
+        "precondition: gitignored plugins/ absent in fresh worktree"
+    )
+
+    _make_link_plugins(worktree)
+    linked = worktree / "plugins" / "Surge XT.vst3"
+    assert linked.is_symlink()
+    assert linked.resolve() == vst_target.resolve()
+
+    # `ln -sfn` must overwrite the stale link rather than fail or nest into it.
+    _make_link_plugins(worktree)
+    assert linked.is_symlink()
+    assert linked.resolve() == vst_target.resolve()
+
+
+def test_link_plugins_is_noop_in_primary(primary_with_plugin: tuple[Path, Path]) -> None:
+    """`make link-plugins` leaves the primary's plugins/ untouched.
+
+    :param primary_with_plugin: ``(primary_root, vst_target)`` fixture.
+    """
+    primary, vst_target = primary_with_plugin
+    plugins = primary / "plugins"
+    before = sorted(p.name for p in plugins.iterdir())
+
+    stdout = _make_link_plugins(primary)
+
+    assert "nothing to link" in stdout
+    assert sorted(p.name for p in plugins.iterdir()) == before
+    assert (plugins / "Surge XT.vst3").resolve() == vst_target.resolve()
+
+
+def test_link_plugins_skips_when_primary_has_no_plugins(tmp_path: Path) -> None:
+    """`make link-plugins` exits cleanly without creating plugins/ when the primary has none.
+
+    :param tmp_path: holds the primary checkout (no plugins/) and its worktree.
+    """
+    primary = tmp_path / "primary"
+    _init_primary_repo(primary)
+    worktree = tmp_path / "wt"
+    _git(primary, "worktree", "add", "--detach", "-q", str(worktree))
+
+    stdout = _make_link_plugins(worktree)
+
+    assert "No" in stdout and "install-surge-xt" in stdout
+    assert not (worktree / "plugins").exists()

--- a/tests/infra/test_worktree_plugin_links.py
+++ b/tests/infra/test_worktree_plugin_links.py
@@ -21,6 +21,10 @@ pytestmark = pytest.mark.infra
 # Bound subprocess calls so a hung git/make can't wedge the suite.
 _TIMEOUT_S = 60
 
+for _tool in ("git", "make"):
+    if shutil.which(_tool) is None:
+        pytest.skip(f"{_tool} not on PATH", allow_module_level=True)
+
 
 def _git(repo: Path, *args: str) -> None:
     """Run a git subcommand in ``repo``, raising on non-zero exit.


### PR DESCRIPTION
## Problem

`plugins/` is gitignored (`.gitignore`: `/plugins/`), so `git worktree add` produces a worktree with an empty `plugins/` — missing the `plugins/Surge XT.vst3` symlink that configs/CLI resolve relative to cwd. Agents spinning up a fresh worktree hit "VST not found" and have to recreate it by hand (as CI / `make install-surge-xt` do in the primary checkout).

## Fix

- **`make link-plugins`** — new Makefile target that mirrors each entry in the primary checkout's `plugins/` into the current worktree as a symlink (`ln -sfn` to the primary's entry, so it resolves whether the primary holds a symlink or a real extracted `.vst3` dir). No-op in the primary; clear hint if the primary has no `plugins/`.
- **Hooks** — the worktree-spawn command printed by `agent/hooks/session-start-cwd-banner.sh` and the `agent/hooks/worktree-guard.sh` remediation now end with `&& make link-plugins`, so the symlink is created as part of the standard spawn flow:
  ```
  git worktree add --detach <root>/.claude/worktrees/<slug> && cd <root>/.claude/worktrees/<slug> && make link-plugins
  ```

The target is the single source of truth; the hooks reference it only by name, so `agent/hooks/` stays hooks-only. The existing `docker/ubuntu22_04/ensure_plugin_symlinks.sh` (docker bind-mount recovery, links to the system path) is left untouched — different intent.

## Tests

- `agent/hooks/test.sh`: banner + guard now pin the `make link-plugins` suffix.
- `tests/infra/test_worktree_plugin_links.py`: hermetic coverage of the real recipe — copies `Makefile` into a throwaway repo, adds a worktree, and asserts (1) the mirror + `ln -sfn` idempotency, (2) the primary no-op leaves `plugins/` untouched, (3) the missing-`plugins/` case exits cleanly without creating `plugins/`.

## Verified locally

- `make link-plugins` in a real worktree: `plugins/Surge XT.vst3 -> <primary>/plugins/Surge XT.vst3 -> /usr/lib/vst3/Surge XT.vst3`
- Hook suite green (67 passed); infra tests green (3 passed)
- Full pre-commit (shellcheck, ruff, pydoclint, interrogate, pyright) on all changed files

Refs #1343