### PR TITLE
feat(ci-automation): enforce the PR readiness loop via a Stop hook + /pr-readiness skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -96,6 +96,19 @@
         ]
       }
     ],
+    "Stop": [
+      {
+        "description": "PR-readiness gate: on Stop, if there's an open PR for the current branch whose readiness gates don't hold, blocks the turn from ending (exit 2) so the agent keeps driving the loop instead of treating 'I pushed the fix' as 'the PR is ready'. Checks gate 1 (CI green via `gh pr checks`) and gate 2 (`mergeable=MERGEABLE`) deterministically; the block message points to /pr-readiness + docs/pr-readiness-loop.md for gate 3 (every review comment answered) and gate 4 (no fresh Copilot findings). No-op outside a repo, in the primary checkout, with no PR, or in a headless/CI context (PR_READINESS_HEADLESS — exported by _lib.sh's run_agent_prompt — / CI / a .agent-reviews/worktrees/ cwd) so the pr-review-resolver and doc-drift detached-worktree agents never deadlock. Escape hatch PR_READINESS_GATE: block default / warn (loud stderr, exit 0) / off (no-op).",
+        "hooks": [
+          {
+            "type": "command",
+            "timeout": 30,
+            "statusMessage": "Checking PR readiness gates...",
+            "command": "bash agent/hooks/pr-readiness-stop.sh"
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",

--- a/.claude/skills/pr-readiness/SKILL.md
+++ b/.claude/skills/pr-readiness/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: pr-readiness
+description: >-
+  Compatibility shim for the shared pr-readiness skill.
+---
+
+# pr-readiness
+
+Read and follow `agent/skills/pr-readiness/SKILL.md`. The `agent/` copy is the
+canonical implementation shared by Claude and Codex.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,14 +131,19 @@ unintended shell expansion. A `PreToolUse` hook
   comment has an inline reply ∧ no fresh Copilot findings — see
   `/pr-preflight`.
 - **After every push, drive the readiness loop until all four gates hold.**
-  "I pushed the fix" is not "the PR is ready." Watch CI (`gh pr checks <N> --watch` or `/loop`); on red, diagnose, fix, push, repeat. Reply inline on
-  every open review comment via `/pr-review-resolver`. Then wait ~60s (allow
-  15 min) for Copilot's post-push review on **both**
-  `repos/<OWNER>/<REPO>/pulls/<N>/comments` and
-  `repos/<OWNER>/<REPO>/pulls/<N>/reviews`; address any new findings and
-  loop. If Copilot is silent past 15 min, manually re-request and repeat at
-  most once. Full procedure (commands, endpoints, traps) in
-  [`docs/pr-readiness-loop.md`](docs/pr-readiness-loop.md).
+  "I pushed the fix" is not "the PR is ready." Run `/pr-readiness` to drive the
+  loop: watch CI (`gh pr checks <N> --watch` or `/loop`) and fix red; confirm
+  `mergeable=MERGEABLE`; reply inline on every open review comment via
+  `/pr-review-resolver`; then wait ~60s (allow 15 min) for Copilot's post-push
+  review on **both** `repos/<OWNER>/<REPO>/pulls/<N>/comments` and
+  `repos/<OWNER>/<REPO>/pulls/<N>/reviews`; address any new findings and loop.
+  If Copilot is silent past 15 min, manually re-request and repeat at most
+  once. Full procedure (commands, endpoints, traps) in
+  [`docs/pr-readiness-loop.md`](docs/pr-readiness-loop.md). A `Stop` hook
+  (`agent/hooks/pr-readiness-stop.sh`) enforces this: it blocks ending the turn
+  while gates 1-2 (CI green, `mergeable`) fail for the branch's open PR, and
+  points back here for gates 3-4 (`PR_READINESS_GATE`: `block` default /
+  `warn` / `off`).
 - **Always reply inline** on each open PR review comment (humans + Copilot),
   with a fix-commit SHA or justification. Use `/pr-review-resolver`.
 - **Advisory rewakes carry an origin-HEAD stamp.** The `pr-review-resolver`

--- a/agent/hooks/_lib.sh
+++ b/agent/hooks/_lib.sh
@@ -139,6 +139,10 @@ run_agent_prompt() {
       return 127
       ;;
   esac
+  # Mark the spawned agent's session headless so its Stop hook
+  # (pr-readiness-stop.sh) never blocks — the resolver/doc-drift runners must
+  # finish and rewake the parent, not deadlock on their own readiness gates.
+  export PR_READINESS_HEADLESS=1
   if [[ -n "$timeout_bin" ]]; then
     "$timeout_bin" --kill-after=10 "$timeout_secs" "${cmd[@]}"
   else

--- a/agent/hooks/pr-readiness-stop.sh
+++ b/agent/hooks/pr-readiness-stop.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# pr-readiness-stop.sh — Stop hook enforcing docs/pr-readiness-loop.md. When a
+# turn tries to end while an open PR for the current branch has unmet readiness
+# gates, blocks the Stop (exit 2) with a message so the agent keeps driving the
+# loop instead of treating "I pushed the fix" as "the PR is ready".
+#
+# Modes (PR_READINESS_GATE):
+#   block  default — exit 2 with the failing-gate message
+#   warn   loud stderr, exit 0 (never blocks)
+#   off    no-op
+#
+# Deterministic vs delegated: gate 1 (CI green) and gate 2
+# (mergeable=MERGEABLE) are checked here against `gh pr checks` / `gh pr view`.
+# Gates 3 (every review comment answered) and 4 (no fresh Copilot findings) are
+# not robustly decidable in bash — the block message points the agent at
+# /pr-readiness and docs/pr-readiness-loop.md for those.
+set -euo pipefail
+
+# shellcheck disable=SC2034  # read by log() in _lib.sh via ${HOOK_NAME:-unknown}
+readonly HOOK_NAME="pr-readiness-stop"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+readonly SCRIPT_DIR
+
+[[ -f "${SCRIPT_DIR}/_lib.sh" ]] && {
+  # shellcheck source=agent/hooks/_lib.sh
+  # shellcheck disable=SC1091
+  source "${SCRIPT_DIR}/_lib.sh"
+}
+
+# `in_headless_context` reports whether this turn belongs to a headless runner
+# whose Stop must never block. Three independent signals, any one suffices:
+#   - PR_READINESS_HEADLESS — exported by _lib.sh's run_agent_prompt, the single
+#     chokepoint the pr-review-resolver/doc-drift hooks spawn agents through.
+#   - CI — set by GitHub Actions and most CI runners.
+#   - cwd under .agent-reviews/worktrees/ — the detached worktree those headless
+#     agents run in, a fallback for runners that bypass run_agent_prompt.
+in_headless_context() {
+  [[ -n "${PR_READINESS_HEADLESS:-}" ]] && return 0
+  [[ -n "${CI:-}" ]] && return 0
+  case "$PWD" in
+    */.agent-reviews/worktrees/*) return 0 ;;
+  esac
+  return 1
+}
+
+# `in_primary_checkout` mirrors worktree-guard's detection: git's per-worktree
+# git dir equals the common git dir only in the primary checkout. Returns 1
+# (not primary) on any resolution failure so a probe error can't force a block.
+in_primary_checkout() {
+  local git_dir common_dir abs_git_dir abs_common_dir
+  git_dir=$(git rev-parse --git-dir 2>/dev/null) || return 1
+  common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || return 1
+  abs_git_dir=$(cd "$git_dir" 2>/dev/null && pwd) || return 1
+  abs_common_dir=$(cd "$common_dir" 2>/dev/null && pwd) || return 1
+  [[ "$abs_git_dir" == "$abs_common_dir" ]]
+}
+
+# `ci_is_green` returns 0 only when every check has concluded successfully.
+# `gh pr checks` exits non-zero while checks are pending (8) or failing (1);
+# both count as "gate not yet holding" per docs/pr-readiness-loop.md — the hook
+# does not sleep, it tells the agent to watch/loop.
+ci_is_green() {
+  gh pr checks "$1" >/dev/null 2>&1
+}
+
+main() {
+  # Drain stdin before any dispatch so off/headless early-exits don't leave the
+  # harness's JSON write blocked on a full pipe (SIGPIPE under pipefail).
+  cat >/dev/null 2>&1 || true
+
+  local mode="${PR_READINESS_GATE:-block}"
+  case "$mode" in
+    off) exit 0 ;;
+    block|warn) ;;
+    *)
+      printf 'pr-readiness-stop: ignoring unknown PR_READINESS_GATE=%s (use block|warn|off)\n' "$mode" >&2
+      exit 0
+      ;;
+  esac
+
+  in_headless_context && exit 0
+  command -v gh >/dev/null 2>&1 || exit 0
+  in_primary_checkout && exit 0
+
+  local branch pr
+  branch=$(git branch --show-current 2>/dev/null || true)
+  [[ -n "$branch" ]] || exit 0
+  pr=$(gh pr view "$branch" --json number -q .number 2>/dev/null || true)
+  [[ -n "$pr" ]] || exit 0
+
+  local mergeable failed_gate=""
+  if ! ci_is_green "$pr"; then
+    failed_gate="Gate 1 (CI not fully green — checks failing or still pending)"
+  else
+    mergeable=$(gh pr view "$pr" --json mergeable -q .mergeable 2>/dev/null || true)
+    if [[ "$mergeable" != "MERGEABLE" ]]; then
+      failed_gate="Gate 2 (mergeable=${mergeable:-UNKNOWN}, want MERGEABLE)"
+    fi
+  fi
+
+  [[ -z "$failed_gate" ]] && exit 0
+
+  declare -F ensure_reviews_dir >/dev/null 2>&1 && ensure_reviews_dir
+  declare -F log >/dev/null 2>&1 && log "blocking Stop for PR #${pr} (branch ${branch}): ${failed_gate}"
+
+  local prefix override_hint
+  if [[ "$mode" == "block" ]]; then
+    prefix="BLOCKED"
+    override_hint="Override: PR_READINESS_GATE=warn (advisory only) or =off (no-op)."
+  else
+    prefix="WARNING"
+    override_hint="Override: PR_READINESS_GATE=off (no-op) or =block (fail-fast)."
+  fi
+
+  cat >&2 <<EOF
+${prefix}: PR #${pr} (branch ${branch}) is not ready — ${failed_gate}.
+AGENTS.md "After every push, drive the readiness loop until all four gates
+hold." Do not end the turn yet.
+
+Run /pr-readiness to drive the loop (watch CI, check mergeable, reply inline to
+every open review comment, wait for Copilot). This hook checks gates 1-2 only;
+also confirm gate 3 (every open review comment has an inline reply) and gate 4
+(no fresh Copilot findings since the last push) — see docs/pr-readiness-loop.md.
+
+${override_hint}
+EOF
+
+  [[ "$mode" == "block" ]] && exit 2
+  exit 0
+}
+
+main "$@"

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -31,6 +31,7 @@ cp agent/hooks/_lib.sh \
    agent/hooks/verify-gh-taxonomy.sh \
    agent/hooks/worktree-guard.sh \
    agent/hooks/session-start-cwd-banner.sh \
+   agent/hooks/pr-readiness-stop.sh \
    "$SANDBOX/agent/hooks/"
 cp agent/_shared/review_sentinel.py "$SANDBOX/agent/_shared/"
 cd "$SANDBOX"
@@ -71,12 +72,22 @@ EOF
 # `gh` stub: $GH_STUB_PR governs `gh pr view`'s number output. When
 # $GH_STUB_LOG is set, every invocation appends its argv there so tests can
 # assert explicit-branch arg passing (`gh pr view <branch>`).
+# pr-readiness-stop.sh adds two more knobs: $GH_STUB_CHECKS_EXIT is the exit
+# code for `gh pr checks` (0 = green; non-zero = failing/pending), and
+# $GH_STUB_MERGEABLE is the value `gh pr view --json mergeable` reports.
 cat > "$STUBS/gh" <<'EOF'
 #!/usr/bin/env bash
 if [[ -n "${GH_STUB_LOG:-}" ]]; then
   printf '%s\n' "$*" >> "$GH_STUB_LOG"
 fi
+if [[ "$1" == "pr" && "$2" == "checks" ]]; then
+  exit "${GH_STUB_CHECKS_EXIT:-0}"
+fi
 if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  if [[ "$*" == *"mergeable"* ]]; then
+    echo "${GH_STUB_MERGEABLE:-MERGEABLE}"
+    exit 0
+  fi
   if [[ -n "${GH_STUB_PR:-}" ]]; then
     echo "${GH_STUB_PR}"
     exit 0
@@ -1267,6 +1278,195 @@ T_session_start_banner_remediation_path_is_absolute_from_subdir() {
   return 0
 }
 it "session-start-banner: remediation path anchored to primary_root (works from any subdir)" T_session_start_banner_remediation_path_is_absolute_from_subdir
+
+# ===========================================================================
+# pr-readiness-stop.sh — Stop-hook gate enforcement + no-op contexts
+# ===========================================================================
+#
+# The sandbox repo is itself a primary checkout, so gate-blocking cases run the
+# hook from a linked worktree (the hook no-ops in the primary). A feature
+# branch with an open PR is simulated via GH_STUB_PR; CI/mergeable outcomes via
+# GH_STUB_CHECKS_EXIT / GH_STUB_MERGEABLE.
+
+readiness_linked_worktree() {
+  # Usage: readiness_linked_worktree <branch>
+  # Echoes the path of a fresh linked worktree on <branch>. reset_sandbox tears
+  # down linked worktrees between tests.
+  local branch="$1" wt
+  wt="$TEST_DIR/readiness-wt-${branch}"
+  rm -rf "$wt"
+  git worktree add -q -b "$branch" "$wt" >/dev/null 2>&1
+  printf '%s\n' "$wt"
+}
+
+T_readiness_no_op_in_primary() {
+  local out stderr_file
+  stderr_file="$TEST_DIR/rd_stderr.txt"
+  export GH_STUB_PR=42 GH_STUB_CHECKS_EXIT=1
+  out=$(echo '' | bash agent/hooks/pr-readiness-stop.sh 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0 in primary, got: $out"; return 1; }
+  [[ -z "$(cat "$stderr_file")" ]] || { echo "primary checkout should be silent; got: $(cat "$stderr_file")"; return 1; }
+}
+it "pr-readiness-stop: in primary checkout → exit 0, silent (never blocks the primary)" T_readiness_no_op_in_primary
+
+T_readiness_no_op_outside_repo() {
+  local out scratch
+  scratch=$(mktemp -d "$TEST_DIR/rd-no-git-XXXX")
+  export GH_STUB_PR=42 GH_STUB_CHECKS_EXIT=1
+  out=$(cd "$scratch" && echo '' | bash "$SANDBOX/agent/hooks/pr-readiness-stop.sh" 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0 outside repo, got: $out"; return 1; }
+}
+it "pr-readiness-stop: outside any git repo → exit 0" T_readiness_no_op_outside_repo
+
+T_readiness_no_op_no_pr() {
+  local out wt
+  unset GH_STUB_PR
+  export GH_STUB_CHECKS_EXIT=1
+  wt=$(readiness_linked_worktree "rd-no-pr")
+  out=$(cd "$wt" && echo '' | bash "$SANDBOX/agent/hooks/pr-readiness-stop.sh" 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0 with no PR, got: $out"; return 1; }
+}
+it "pr-readiness-stop: no open PR for the branch → exit 0" T_readiness_no_op_no_pr
+
+T_readiness_no_op_headless_env_marker() {
+  local out wt
+  export GH_STUB_PR=42 GH_STUB_CHECKS_EXIT=1 PR_READINESS_HEADLESS=1
+  wt=$(readiness_linked_worktree "rd-headless")
+  out=$(cd "$wt" && echo '' | bash "$SANDBOX/agent/hooks/pr-readiness-stop.sh" 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || {
+    echo "headless marker must prevent a block (deadlock guard), got: $out"
+    return 1
+  }
+}
+it "pr-readiness-stop: PR_READINESS_HEADLESS=1 → exit 0 even with a failing gate (no deadlock)" T_readiness_no_op_headless_env_marker
+
+T_readiness_no_op_in_ci() {
+  local out wt
+  export GH_STUB_PR=42 GH_STUB_CHECKS_EXIT=1 CI=true
+  wt=$(readiness_linked_worktree "rd-ci")
+  out=$(cd "$wt" && echo '' | bash "$SANDBOX/agent/hooks/pr-readiness-stop.sh" 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "CI context must not block, got: $out"; return 1; }
+}
+it "pr-readiness-stop: CI=true → exit 0 even with a failing gate" T_readiness_no_op_in_ci
+
+T_readiness_no_op_in_headless_worktree_cwd() {
+  local out wt nested
+  export GH_STUB_PR=42 GH_STUB_CHECKS_EXIT=1
+  unset PR_READINESS_HEADLESS CI
+  wt=$(readiness_linked_worktree "rd-wt-cwd")
+  # A path matching .agent-reviews/worktrees/ is the detached worktree the
+  # resolver/doc-drift headless agents run in.
+  nested="$wt/.agent-reviews/worktrees/resolver-abc123"
+  mkdir -p "$nested"
+  out=$(cd "$nested" && echo '' | bash "$SANDBOX/agent/hooks/pr-readiness-stop.sh" 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || {
+    echo "cwd under .agent-reviews/worktrees/ must not block, got: $out"
+    return 1
+  }
+}
+it "pr-readiness-stop: cwd under .agent-reviews/worktrees/ → exit 0 (headless runner cwd)" T_readiness_no_op_in_headless_worktree_cwd
+
+T_readiness_blocks_on_red_ci() {
+  local out stderr_file wt
+  stderr_file="$TEST_DIR/rd_stderr.txt"
+  export GH_STUB_PR=42 GH_STUB_CHECKS_EXIT=1 GH_STUB_MERGEABLE=MERGEABLE
+  unset PR_READINESS_HEADLESS CI
+  wt=$(readiness_linked_worktree "rd-red-ci")
+  out=$(cd "$wt" && echo '' | bash "$SANDBOX/agent/hooks/pr-readiness-stop.sh" 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:2" ]] || { echo "expected EXIT:2 on red CI, got: $out"; return 1; }
+  grep -q "Gate 1" "$stderr_file" || { echo "stderr should name Gate 1; got: $(cat "$stderr_file")"; return 1; }
+  grep -q "/pr-readiness" "$stderr_file" || { echo "stderr should point to /pr-readiness"; return 1; }
+  grep -q "docs/pr-readiness-loop.md" "$stderr_file" || { echo "stderr should point to the loop doc"; return 1; }
+}
+it "pr-readiness-stop: red CI (gate 1) → exit 2 naming Gate 1 + pointers" T_readiness_blocks_on_red_ci
+
+T_readiness_blocks_on_not_mergeable() {
+  local out stderr_file wt
+  stderr_file="$TEST_DIR/rd_stderr.txt"
+  export GH_STUB_PR=42 GH_STUB_CHECKS_EXIT=0 GH_STUB_MERGEABLE=CONFLICTING
+  unset PR_READINESS_HEADLESS CI
+  wt=$(readiness_linked_worktree "rd-conflict")
+  out=$(cd "$wt" && echo '' | bash "$SANDBOX/agent/hooks/pr-readiness-stop.sh" 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:2" ]] || { echo "expected EXIT:2 on CONFLICTING, got: $out"; return 1; }
+  grep -q "Gate 2" "$stderr_file" || { echo "stderr should name Gate 2; got: $(cat "$stderr_file")"; return 1; }
+  grep -q "CONFLICTING" "$stderr_file" || { echo "stderr should report the mergeable value"; return 1; }
+}
+it "pr-readiness-stop: green CI but mergeable=CONFLICTING (gate 2) → exit 2 naming Gate 2" T_readiness_blocks_on_not_mergeable
+
+T_readiness_blocks_on_unknown_mergeable() {
+  local out stderr_file wt
+  stderr_file="$TEST_DIR/rd_stderr.txt"
+  export GH_STUB_PR=42 GH_STUB_CHECKS_EXIT=0 GH_STUB_MERGEABLE=UNKNOWN
+  unset PR_READINESS_HEADLESS CI
+  wt=$(readiness_linked_worktree "rd-unknown")
+  out=$(cd "$wt" && echo '' | bash "$SANDBOX/agent/hooks/pr-readiness-stop.sh" 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:2" ]] || { echo "expected EXIT:2 on UNKNOWN, got: $out"; return 1; }
+  grep -q "Gate 2" "$stderr_file" || { echo "stderr should name Gate 2 for UNKNOWN; got: $(cat "$stderr_file")"; return 1; }
+}
+it "pr-readiness-stop: mergeable=UNKNOWN is not a pass (gate 2) → exit 2" T_readiness_blocks_on_unknown_mergeable
+
+T_readiness_passes_when_gates_hold() {
+  local out stderr_file wt
+  stderr_file="$TEST_DIR/rd_stderr.txt"
+  export GH_STUB_PR=42 GH_STUB_CHECKS_EXIT=0 GH_STUB_MERGEABLE=MERGEABLE
+  unset PR_READINESS_HEADLESS CI
+  wt=$(readiness_linked_worktree "rd-green")
+  out=$(cd "$wt" && echo '' | bash "$SANDBOX/agent/hooks/pr-readiness-stop.sh" 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0 when gates 1-2 hold, got: $out"; return 1; }
+  [[ -z "$(cat "$stderr_file")" ]] || { echo "passing case should be silent; got: $(cat "$stderr_file")"; return 1; }
+}
+it "pr-readiness-stop: green CI + MERGEABLE → exit 0, silent (gates 1-2 hold)" T_readiness_passes_when_gates_hold
+
+T_readiness_warn_mode_never_blocks() {
+  local out stderr_file wt
+  stderr_file="$TEST_DIR/rd_stderr.txt"
+  export GH_STUB_PR=42 GH_STUB_CHECKS_EXIT=1 PR_READINESS_GATE=warn
+  unset PR_READINESS_HEADLESS CI
+  wt=$(readiness_linked_worktree "rd-warn")
+  out=$(cd "$wt" && echo '' | bash "$SANDBOX/agent/hooks/pr-readiness-stop.sh" 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "warn mode must exit 0, got: $out"; return 1; }
+  grep -q "WARNING" "$stderr_file" || { echo "warn mode should print WARNING; got: $(cat "$stderr_file")"; return 1; }
+}
+it "pr-readiness-stop: PR_READINESS_GATE=warn with failing gate → exit 0 with WARNING" T_readiness_warn_mode_never_blocks
+
+T_readiness_off_mode_silent() {
+  local out stderr_file wt
+  stderr_file="$TEST_DIR/rd_stderr.txt"
+  export GH_STUB_PR=42 GH_STUB_CHECKS_EXIT=1 PR_READINESS_GATE=off
+  unset PR_READINESS_HEADLESS CI
+  wt=$(readiness_linked_worktree "rd-off")
+  out=$(cd "$wt" && echo '' | bash "$SANDBOX/agent/hooks/pr-readiness-stop.sh" 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "off mode must exit 0, got: $out"; return 1; }
+  [[ -z "$(cat "$stderr_file")" ]] || { echo "off mode should be silent; got: $(cat "$stderr_file")"; return 1; }
+}
+it "pr-readiness-stop: PR_READINESS_GATE=off → exit 0, silent (escape hatch)" T_readiness_off_mode_silent
+
+T_readiness_unknown_mode_falls_back_silent() {
+  local out stderr_file wt
+  stderr_file="$TEST_DIR/rd_stderr.txt"
+  export GH_STUB_PR=42 GH_STUB_CHECKS_EXIT=1 PR_READINESS_GATE=bogus
+  unset PR_READINESS_HEADLESS CI
+  wt=$(readiness_linked_worktree "rd-bogus")
+  out=$(cd "$wt" && echo '' | bash "$SANDBOX/agent/hooks/pr-readiness-stop.sh" 2>"$stderr_file"; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "unknown mode must not block, got: $out"; return 1; }
+  grep -q "ignoring unknown PR_READINESS_GATE=bogus" "$stderr_file" || {
+    echo "unknown mode should log the fallback; got: $(cat "$stderr_file")"
+    return 1
+  }
+}
+it "pr-readiness-stop: unknown PR_READINESS_GATE value → exit 0 (never blocks via typo)" T_readiness_unknown_mode_falls_back_silent
+
+T_readiness_drains_large_stdin() {
+  # Regression guard mirroring worktree-guard's: off/headless early-exits must
+  # drain stdin so the harness's JSON write doesn't SIGPIPE.
+  local exit_code
+  set +e
+  head -c 131072 /dev/zero | PR_READINESS_GATE=off bash agent/hooks/pr-readiness-stop.sh >/dev/null 2>&1
+  exit_code=$?
+  set -e
+  [[ "$exit_code" == "0" ]] || { echo "off-mode pipeline exit was $exit_code (likely SIGPIPE)"; return 1; }
+}
+it "pr-readiness-stop: off mode drains stdin before exiting (no SIGPIPE risk)" T_readiness_drains_large_stdin
 
 # ===========================================================================
 # Run

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -1441,7 +1441,7 @@ T_readiness_off_mode_silent() {
 }
 it "pr-readiness-stop: PR_READINESS_GATE=off → exit 0, silent (escape hatch)" T_readiness_off_mode_silent
 
-T_readiness_unknown_mode_falls_back_silent() {
+T_readiness_unknown_mode_logs_and_exits_zero() {
   local out stderr_file wt
   stderr_file="$TEST_DIR/rd_stderr.txt"
   export GH_STUB_PR=42 GH_STUB_CHECKS_EXIT=1 PR_READINESS_GATE=bogus
@@ -1454,7 +1454,7 @@ T_readiness_unknown_mode_falls_back_silent() {
     return 1
   }
 }
-it "pr-readiness-stop: unknown PR_READINESS_GATE value → exit 0 (never blocks via typo)" T_readiness_unknown_mode_falls_back_silent
+it "pr-readiness-stop: unknown PR_READINESS_GATE value → exit 0 (never blocks via typo)" T_readiness_unknown_mode_logs_and_exits_zero
 
 T_readiness_drains_large_stdin() {
   # Regression guard mirroring worktree-guard's: off/headless early-exits must

--- a/agent/skills/pr-readiness/SKILL.md
+++ b/agent/skills/pr-readiness/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: pr-readiness
+description: >-
+  Drive a pushed PR through the four readiness gates until it is genuinely
+  ready — watch CI, fix red, confirm mergeable, reply inline to every open
+  review comment, and wait out Copilot's re-review. Use this skill after every
+  push to a PR branch, when the pr-readiness-stop hook blocks a turn, or when
+  the user says "drive the PR to ready", "is this PR ready", "finish the
+  readiness loop", "/pr-readiness", or anything about getting a PR past CI +
+  review + Copilot. Implements docs/pr-readiness-loop.md as an invocable
+  procedure.
+---
+
+# pr-readiness — drive the PR readiness loop
+
+Run the loop in [`docs/pr-readiness-loop.md`](../../../docs/pr-readiness-loop.md)
+until all four gates hold. That doc is canonical — read it for the exact
+commands, endpoints, and traps. This skill is the invocable driver; do not
+duplicate the doc's prose, follow it.
+
+"I pushed the fix" is **not** "the PR is ready." Do not stop after the first
+push.
+
+## The four gates
+
+A PR is ready only when **all four** hold (AND-ed):
+
+1. **CI fully green** — every required and optional check passing. Pending or
+   errored counts as not ready.
+2. **`mergeable=MERGEABLE`** — `UNKNOWN` and `CONFLICTING` both fail.
+3. **Every open review comment has an inline reply** — humans and Copilot.
+4. **No fresh Copilot findings since the last push.**
+
+## Procedure
+
+Resolve the PR once up front:
+
+```bash
+PR=$(gh pr view "$(git branch --show-current)" --json number -q .number)
+```
+
+Then iterate until all four gates hold. Use `/loop` for the waiting steps
+(e.g. `/loop 2m gh pr checks "$PR"`).
+
+1. **Watch CI** — `gh pr checks "$PR" --watch`. On any failure, diagnose, fix,
+   commit, push, and return to step 1. Never move on with red CI.
+
+2. **Check mergeability** — `gh pr view "$PR" --json mergeable -q .mergeable`:
+
+   - `CONFLICTING` → rebase or merge the base branch, resolve, push, back to 1.
+   - `UNKNOWN` → GitHub is still computing; poll again.
+   - `MERGEABLE` → continue.
+
+3. **Reply inline to every open review comment.** Delegate to
+   `/pr-review-resolver`, which triages each comment, fixes what's actionable,
+   and replies inline with the fix-commit SHA or a justification. If any reply
+   required a code change, push and return to step 1.
+
+4. **Wait for Copilot's post-push review** (~60s, allow up to 15 min). Check
+   both the inline-comments and top-level reviews endpoints
+   (docs/pr-readiness-loop.md step 6). Filter to findings newer than your last
+   push. Address new actionable findings as in step 3, then loop. A "no
+   findings" review is silence, not a comment. If 15 min elapse with no
+   activity, manually re-request Copilot per step 6a (at most once).
+
+5. **Done** only when all four gates hold simultaneously.
+
+## Relationship to the Stop hook
+
+`agent/hooks/pr-readiness-stop.sh` blocks the turn from ending while gates 1-2
+fail; it cannot decide gates 3-4 in bash, so it points here. Running this skill
+to completion is what clears the block.

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -167,6 +167,7 @@ _EXPECTED_SHARED_HOOK_COMMANDS: tuple[tuple[str, str], ...] = (
     ("No-baseline-additions", "bash agent/hooks/no-baseline-additions.sh"),
     ("No-yaml-run-comments", "bash agent/hooks/no-yaml-run-comments.sh"),
     ("PR review resolver", "bash agent/hooks/pr-review-resolver.sh"),
+    ("PR-readiness gate", "bash agent/hooks/pr-readiness-stop.sh"),
     ("Taxonomy verification", "bash agent/hooks/verify-gh-taxonomy.sh"),
     ("Worktree guard", "bash agent/hooks/worktree-guard.sh"),
     ("Worktree-status banner", "bash agent/hooks/session-start-cwd-banner.sh"),


### PR DESCRIPTION
## Summary

The PR readiness loop (`AGENTS.md` `## PRs`, full procedure in `docs/pr-readiness-loop.md`) was advisory prose that agents silently skipped — "I pushed the fix" got treated as "the PR is ready". This adds two enforcement mechanisms.

### 1. Stop hook — `agent/hooks/pr-readiness-stop.sh`

On `Stop`, if the current branch has an open PR whose readiness gates don't hold, blocks the turn from ending (exit 2) with a message naming the failed gate and pointing to `/pr-readiness` + `docs/pr-readiness-loop.md`.

- **No-op** outside a git repo, in the primary checkout, with no PR, or in a headless/CI context — so the `pr-review-resolver` and `doc-drift` detached-worktree agents never deadlock.
- **Escape hatch** `PR_READINESS_GATE`: `block` (default) / `warn` (loud stderr, exit 0) / `off` (no-op), modeled on `WORKTREE_GUARD_MODE`.

### 2. `/pr-readiness` skill

User-invocable driver for the full loop (watch CI, fix red, confirm `mergeable`, reply inline via `/pr-review-resolver`, wait for Copilot, loop). Canonical at `agent/skills/pr-readiness/SKILL.md` with a `.claude/skills/` shim.

## Gate enforcement split

| Gate | Where enforced |
| --- | --- |
| 1 — CI fully green | **Deterministic** in the hook (`gh pr checks`) |
| 2 — `mergeable=MERGEABLE` | **Deterministic** in the hook (`gh pr view --json mergeable`; `UNKNOWN`/`CONFLICTING` both fail) |
| 3 — every review comment answered | **Delegated** to `/pr-readiness` (not robustly decidable in bash) |
| 4 — no fresh Copilot findings | **Delegated** to `/pr-readiness` |

The hook is honest in code comments and its block message about checking gates 1-2 only and delegating 3-4.

## Headless deadlock guard

`run_agent_prompt` in `agent/hooks/_lib.sh` now exports `PR_READINESS_HEADLESS=1` at the single chokepoint all headless runners spawn through, so their sessions' Stop hook no-ops. Belt-and-suspenders: the hook also treats `CI` and a `.agent-reviews/worktrees/` cwd as headless.

## Also

- `.claude/settings.json`: registered the `Stop` hook with a verbose house-style description.
- `AGENTS.md`: readiness-loop bullet now references `/pr-readiness` and the Stop-hook enforcement.
- `agent/hooks/test.sh`: 14 new tests (every no-op context, each failing gate, the passing case, all three modes, unknown-mode fallback, stdin drain). `tests/claude_hooks/test_settings_hooks.py`: added the hook to the shared-path allowlist.

## Verification

`bash agent/hooks/test.sh` — 14 new tests green (1 pre-existing unrelated session-start-banner failure, reproduces on `main` from a nested-worktree cwd). `pytest tests/claude_hooks/test_settings_hooks.py` — 115 passed. `pre-commit` clean on all changed files.

Refs #1346