### PR TITLE
test(eval): align inline oracle-eval e2e with current behavior

### DIFF
--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -56,7 +56,7 @@ docs:
       - pattern: "src/synth_setter/cli/eval.py"
         covers: "Checkpoint resolution from W&B, evaluation logging"
       - pattern: "src/synth_setter/cli/generate_dataset.py"
-        covers: "WandbLogger lifecycle for dataset generation: spec → hyperparams + dataset-spec artifact, per-shard + summary history rows, run id pinned to spec.run_id, inline oracle eval resuming the run to append test/* rows"
+        covers: "WandbLogger lifecycle for dataset generation: spec → hyperparams + dataset-spec artifact, per-shard + summary history rows, run id pinned to spec.run_id, inline oracle eval resuming the run to append audio/* rows"
       - pattern: "src/synth_setter/configs/dataset.yaml"
         covers: "Default `logger: wandb` for dataset generation; entity/project sourced from logger/wandb.yaml"
       - pattern: "sweeps/**"

--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -260,11 +260,11 @@ Each trial subprocess opens its own wandb run with `id = spec.run_id`; the
 When `oracle_eval_inline=true`, the local-run path shells out to
 `synth_setter.cli.eval` after `generate(...)` has closed its run.
 `_run_oracle_eval_subprocess` (`src/synth_setter/cli/generate_dataset.py`)
-re-opens the same run via `+logger.wandb.id=<spec.run_id> +logger.wandb.resume=must`, so Lightning's `trainer.test` deposits `test/*`
-metrics (e.g. `test/param_mse` from the surge fake-oracle) onto the generate
-run — a `wandb sync` then merges both phases under one run id. The eval
-subprocess inherits `WANDB_MODE` from the launcher, so its offline/online
-posture follows the parent's.
+re-opens the same run via `logger.wandb.id=<spec.run_id> +logger.wandb.resume=must`, runs `mode=predict` with `render=surge_simple` to
+re-render the predicted params, and deposits `audio/*` audio-similarity
+metrics onto the generate run — a `wandb sync` then merges both phases under
+one run id. The eval subprocess inherits `WANDB_MODE` from the launcher, so
+its offline/online posture follows the parent's.
 
 ______________________________________________________________________
 

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -22,13 +22,13 @@ from pathlib import Path
 from typing import Any
 
 import hydra
+import wandb
 from hydra.core.hydra_config import HydraConfig
 from lightning.pytorch.loggers import Logger
 from lightning.pytorch.loggers.wandb import WandbLogger
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
-import wandb
 from synth_setter.cli.finalize_dataset import finalize_from_spec
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.pipeline import r2_io
@@ -99,7 +99,7 @@ def _run_oracle_eval_subprocess(dataset_root: Path, run_id: str) -> None:
 
     :param dataset_root: Holds the finalized HDF5 splits the eval datamodule reads.
     :param run_id: Canonical ``spec.run_id``; the eval resumes this wandb run
-        so its ``test/*`` metrics land on the generate phase's run.
+        so its ``audio/*`` metrics land on the generate phase's run.
     """
     argv = [
         sys.executable,
@@ -120,7 +120,7 @@ def _run_oracle_eval_subprocess(dataset_root: Path, run_id: str) -> None:
         "+logger.wandb.resume=must",
         # SurgeXTDataset floors len to samples // batch_size; the 128 default
         # would yield zero batches on the smoke-sized test split (4 samples),
-        # so test_step never runs and no test/* metric is logged — see #1331.
+        # so predict_step never runs and no audio/* metric is logged — see #1331.
         "data.batch_size=1",
         "mode=predict",
     ]

--- a/tests/integration/test_generate_dataset_cli_wandb_e2e.py
+++ b/tests/integration/test_generate_dataset_cli_wandb_e2e.py
@@ -369,21 +369,19 @@ def test_oracle_eval_inline_resumes_generate_wandb_run(
 
     One CLI invocation with ``oracle_eval_inline=true`` +
     ``finalize_inline=true`` under ``WANDB_MODE=offline``. After the CLI
-    exits, the launcher's hydra dir and the operator workspace's
-    ``oracle_eval/<run_id>/`` dir each hold one ``offline-run-*-<run_id>``
-    directory; the two ``<run_id>`` slugs must match (the eval child
-    resumed the same wandb run). Generate's dir must carry shard +
-    summary history rows; eval's dir must carry at least one ``test/*``
-    row from Lightning's ``trainer.test``.
+    exits, the launcher's hydra dir holds generate's
+    ``offline-run-*-<run_id>``, and its ``oracle_eval/<run_id>/`` subdir
+    holds the eval's; the two ``<run_id>`` slugs must match (the eval
+    child resumed the same wandb run). Generate's dir must carry shard +
+    summary history rows; eval's dir must carry at least one ``audio/*``
+    row from the predict-mode oracle eval's audio metrics.
 
     :param cli_env: ``(hydra_run_dir, r2_prefix)`` from the fixture — gates
         skip conditions and owns R2 cleanup.
     """
     hydra_run_dir, prefix = cli_env
-    # ``operator_workspace()`` honors ``$SYNTH_SETTER_WORKSPACE`` and
-    # decides where ``main()`` writes ``oracle_eval/<run_id>/``; pin it to
-    # the fixture's tmp_path so the eval's wandb dir is reachable from the
-    # test without depending on the checkout-root walk.
+    # Pin the operator workspace ($PROJECT_ROOT) to tmp so the generate run's
+    # paths.root_dir never touches the checkout.
     workspace = hydra_run_dir.parent
     result = _run_cli(
         hydra_run_dir=hydra_run_dir,
@@ -401,12 +399,14 @@ def test_oracle_eval_inline_resumes_generate_wandb_run(
     generate_run_dir = _find_offline_run_dir(hydra_run_dir)
     generate_run_id = generate_run_dir.name.split("-", 3)[-1]
 
-    eval_workspace_dir = workspace / "oracle_eval" / generate_run_id
-    assert eval_workspace_dir.is_dir(), (
-        f"expected eval workspace dir at {eval_workspace_dir}; "
+    # main() writes oracle_eval/<run_id>/ under cfg.paths.output_dir
+    # (= ${hydra:runtime.output_dir}), which the fixture pins to hydra_run_dir.
+    eval_output_dir = hydra_run_dir / "oracle_eval" / generate_run_id
+    assert eval_output_dir.is_dir(), (
+        f"expected eval output dir at {eval_output_dir}; "
         f"main()'s oracle_eval_inline branch did not run with the launcher's run_id"
     )
-    eval_run_dir = _find_offline_run_dir(eval_workspace_dir)
+    eval_run_dir = _find_offline_run_dir(eval_output_dir)
     eval_run_id = eval_run_dir.name.split("-", 3)[-1]
     assert eval_run_id == generate_run_id, (
         f"eval wandb run id {eval_run_id!r} does not match generate's "
@@ -425,7 +425,7 @@ def test_oracle_eval_inline_resumes_generate_wandb_run(
 
     eval_binary = _single_wandb_binary(eval_run_dir)
     eval_rows = read_history_rows(eval_binary)
-    assert any(any(k.startswith("test/") for k in r) for r in eval_rows), (
-        f"eval dir has no test/* history rows in {eval_binary}; "
-        f"oracle eval did not log Lightning test_step metrics to the resumed run"
+    assert any(any(k.startswith("audio/") for k in r) for r in eval_rows), (
+        f"eval dir has no audio/* history rows in {eval_binary}; "
+        f"the predict-mode oracle eval did not log audio metrics to the resumed run"
     )


### PR DESCRIPTION
## Summary

Fixes the pre-existing failure in `test_oracle_eval_inline_resumes_generate_wandb_run` (surfaced while verifying #1341). The test was added in #1335 and is gated `slow`+`r2`, so it never ran in CI and drifted from the code on two points:

1. **oracle_eval dir location.** The test looked for `oracle_eval/<run_id>/` under `operator_workspace()` / `$SYNTH_SETTER_WORKSPACE`, but `generate_dataset.main()` writes it under `cfg.paths.output_dir` (= `${hydra:runtime.output_dir}`, the per-run hydra dir, which is gitignored). The code is correct — `operator_workspace()` defaults to the checkout root, which would write `oracle_eval/` into the repo. The test now asserts against the launcher's hydra dir (and the local is renamed `eval_output_dir`).
2. **eval metrics namespace.** The test asserted `test/*` history rows from Lightning's `trainer.test`, but the inline eval now runs `mode=predict` and logs `audio/*` metrics via `wandb.run.log` (eval.py:83). The test now asserts `audio/*`.

Also corrects the matching stale `test/*` / `test_step` references in `_run_oracle_eval_subprocess`'s docstring and a comment (doc-side of the same drift). Comment- and test-only — no behavior change.

## Test plan

```
$ uv run pytest "tests/integration/test_generate_dataset_cli_wandb_e2e.py::test_oracle_eval_inline_resumes_generate_wandb_run" -m "" -p no:randomly -q
1 passed in 202.46s
```

End-to-end: one CLI invocation runs generate → finalize → inline oracle-eval (`mode=predict`), the eval resumes the generate wandb run, and `audio/*` rows land in the resumed run's history. (Requires the gitignored `plugins/Surge XT.vst3` symlink that `make`/CI set up.)

Refs #91