### PR TITLE
build(devcontainer): add Codex, Antigravity & zellij CLIs + per-user npm prefix

### DIFF
--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -443,6 +443,27 @@ RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
  && npm --version \
  && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
 
+# Zellij terminal multiplexer (https://github.com/zellij-org/zellij) — not in
+# the Ubuntu 22.04 apt repos, so install the upstream static musl binary,
+# verified against a pinned per-arch SHA256 (run `sha256sum` on the release
+# tarballs to refresh these when bumping ZELLIJ_VERSION).
+ARG TARGETARCH
+ARG ZELLIJ_VERSION=v0.44.3
+ARG ZELLIJ_SHA256_X86_64=0f7c346788627f506c0a28296517768633cff24fc822a739f8264b640ecad751
+ARG ZELLIJ_SHA256_AARCH64=15e6534d42644d66973d136c590c49739dcfd6a1a2a0d3d917973f16c81b45fb
+RUN case "${TARGETARCH:-}" in \
+      amd64) zellij_arch=x86_64;  zellij_sha=${ZELLIJ_SHA256_X86_64}  ;; \
+      arm64) zellij_arch=aarch64; zellij_sha=${ZELLIJ_SHA256_AARCH64} ;; \
+      *) echo "ERROR: unsupported TARGETARCH for zellij: ${TARGETARCH:-<unset>}" >&2; exit 1 ;; \
+    esac && \
+    url="https://github.com/zellij-org/zellij/releases/download/${ZELLIJ_VERSION}/zellij-${zellij_arch}-unknown-linux-musl.tar.gz" && \
+    wget -q -O /tmp/zellij.tar.gz "$url" && \
+    echo "${zellij_sha}  /tmp/zellij.tar.gz" | sha256sum -c - && \
+    tar -xzf /tmp/zellij.tar.gz -C /usr/local/bin zellij && \
+    rm /tmp/zellij.tar.gz && \
+    chmod +x /usr/local/bin/zellij && \
+    zellij --version
+
 ARG USERNAME=dev
 ARG USER_UID=1000
 ARG USER_GID=$USER_UID
@@ -464,6 +485,30 @@ RUN mkdir -p /commandhistory \
 
 # --- Non-root dev user ---
 USER $USERNAME
+
+# Appended, not prepended: root-default devcontainer sessions must not resolve
+# these dev-writable dirs ahead of system binaries.
+ENV PATH="$PATH:/home/${USERNAME}/.npm-global/bin:/home/${USERNAME}/.local/bin"
+
+# dev's `npm install -g` would EACCES on the root-owned global tree (claude-code
+# is baked in as root); a per-user prefix sends it to a writable one. $HOME is
+# unset after USER, so export it per-RUN (not ENV — that leaks to root sessions).
+ARG CODEX_VERSION=latest
+RUN export HOME="/home/${USERNAME}" \
+ && npm config set prefix "/home/${USERNAME}/.npm-global" \
+ && npm install -g "@openai/codex@${CODEX_VERSION}" \
+ && npm cache clean --force \
+ && codex --version
+
+# Antigravity (Google) ships the standalone `agy` binary, not on npm; its
+# installer fetches a SHA512-verified release into ~/.local/bin (upstream
+# latest — no version flag). Fetched to a file, not piped to bash, so a curl
+# failure is distinguishable from a script failure.
+RUN export HOME="/home/${USERNAME}" \
+ && curl -fsSL https://antigravity.google/cli/install.sh -o /tmp/agy-install.sh \
+ && bash /tmp/agy-install.sh \
+ && rm /tmp/agy-install.sh \
+ && agy --version
 
 FROM dev-base AS freeze-deps
 # Record package versions for audit / reproducibility

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -1,6 +1,6 @@
 # Docker Reference
 
-> **Last verified:** 2026-05-11
+> **Last verified:** 2026-06-02
 
 How to build, run, and debug Docker images for the synth-setter training
 pipeline. Intended for developers working locally or in CI environments.
@@ -104,7 +104,7 @@ make docker-build-dev-snapshot \
   GIT_REF="$(git rev-parse HEAD)" \
   DOCKER_BUILD_FLAGS="--load"
 
-# devcontainer-tools — dev-base + CLI tools, Node.js + Claude Code, dev user
+# devcontainer-tools — dev-base + CLI tools, Node.js + Claude Code/Codex/Antigravity, zellij, dev user
 # (see the "devcontainer-tools" stage in docker/ubuntu22_04/Dockerfile)
 make docker-build-devcontainer-tools \
   GIT_REF="$(git rev-parse HEAD)" \
@@ -115,7 +115,13 @@ The `devcontainer-tools` stage is a sibling of `dev-snapshot` — both stages
 build `FROM dev-base`, the shared parent that holds Surge XT, the venv, and
 the synth-setter source. `devcontainer-tools` adds interactive CLI tooling
 (see the stage's `apt-get install` list and the GitHub CLI install block),
-Node.js + `@anthropic-ai/claude-code` installed system-wide, a non-root
+Node.js + `@anthropic-ai/claude-code` installed system-wide, the OpenAI
+`@openai/codex` CLI installed for the `dev` user via a per-user npm prefix
+(`~/.npm-global`, on PATH) so later `npm install -g` runs avoid EACCES on the
+root-owned global tree, the Google Antigravity (`agy`) CLI installed by its
+upstream `install.sh` into `~/.local/bin` (also on PATH), the zellij
+terminal multiplexer (pinned upstream musl binary, SHA256-verified, in
+`/usr/local/bin`), a non-root
 `dev` user, chowns the baked uv venv at `/venv/main` to `dev` so
 `uv pip install` and editable installs work without sudo, and adds a
 `/commandhistory` directory (owned by `dev`) that


### PR DESCRIPTION
## What

Adds two coding-agent CLIs to the `devcontainer-tools` image and fixes the permission trap that blocks the `dev` user from installing more later.

- **Per-user npm prefix** — sets the `dev` user's npm prefix to `~/.npm-global` (writes `~/.npmrc`). Claude Code is baked in as root under the root-owned `/usr/local/lib/node_modules`, so a later `npm install -g` by `dev` hit `EACCES`. Global installs now land in a writable tree.
- **`@openai/codex`** — installed through that prefix, installed through that prefix; overridable via a new `ARG CODEX_VERSION` (default `latest`, matching `CLAUDE_CODE_VERSION`).
- **Google Antigravity** — ships as the standalone `agy` binary, *not* on npm, so it's installed via its official installer into `~/.local/bin`.
- **[zellij](https://github.com/zellij-org/zellij)** terminal multiplexer — not in the Ubuntu 22.04 apt repos, so installed as the upstream static musl binary (pinned `ZELLIJ_VERSION`, SHA256-verified per arch, matching the existing pueue pattern) into `/usr/local/bin`, system-wide for `dev` and root sessions.
- Both bin dirs are added to `PATH`; `docs/reference/docker.md` updated.

Scope is **user-level** (the `dev` user). Root-session devcontainers (`root_gpu`) are unaffected and keep using the system-wide Claude Code.

## Review

Ran `repo-review-full-no-comments` (code-health, synth-setter-project-standards, comment-hygiene, shell-style) — **0 BLOCK, 4 WARN**. Three WARNs fixed in this commit (pin codex via `ARG`, brace `${USERNAME}`, shorten the npm-prefix comment to two lines). One accepted:

- The Antigravity step pipes its published evergreen installer to `bash`, mirroring how the GitHub CLI is already fetched in this stage. There is no upstream checksum to pin for an evergreen installer, so it tracks upstream `latest` (symmetric with claude-code's `latest` default); the comment says so, and `agy --version` fails the build loudly if the installer or binary name drifts.

## Notes / risk

- I could not run a full image build here, so the Antigravity step is verified only against the documented installer behavior — **CI's `devcontainer-tools` image build is the real check.**
- `codex --version` and `agy --version` gate the respective `RUN` layers.

## Testing

- `pytest tests/infra/` — 69 passed, 5 skipped.
- `pre-commit run --files docker/ubuntu22_04/Dockerfile docs/reference/docker.md` — passed.

Refs #1351


