### PR TITLE
refactor(tools): remove unused instantiate_datamodule from plot_param2tok

### DIFF
--- a/src/synth_setter/tools/plot_param2tok.py
+++ b/src/synth_setter/tools/plot_param2tok.py
@@ -68,15 +68,6 @@ def instantiate_model(
     return model
 
 
-def instantiate_datamodule(data_cfg: DictConfig):
-    logger.info("Instantiating datamodule with config:")
-    logger.info(OmegaConf.to_yaml(data_cfg))
-    dm = hydra.utils.instantiate(data_cfg)
-    dm.setup("fit")
-
-    return dm
-
-
 def sort_assignment(assignment: np.ndarray):
     assignment = np.abs(assignment)
     idxs = np.argsort(assignment, axis=-1)


### PR DESCRIPTION
Removes the unused `instantiate_datamodule` function from `src/synth_setter/tools/plot_param2tok.py`. It was defined but never called — `main()` only instantiates the model via `instantiate_model(cfg.model, ...)`.

No imports become unused (`hydra`, `OmegaConf`, `DictConfig`, `logger` are all still used by `instantiate_model`/`main`), and `ruff check` is clean. No behavior change. The same-named function in `model_from_wandb.py` is a separate function and is untouched.

Closes #1358