### PR TITLE
chore(ci): add uv-lock pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,6 +92,12 @@ repos:
     hooks:
       - id: validate-pyproject
 
+  # uv: keep uv.lock in sync with pyproject.toml
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.11.18
+    hooks:
+      - id: uv-lock
+
   # gitlint: lints commit messages for conventional commits compliance
   - repo: https://github.com/jorisroovers/gitlint
     rev: v0.19.1

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -21,6 +21,8 @@ docs:
         covers: "Committed universal lockfile (macOS + Linux + Windows resolution); regenerate with `uv lock` after pyproject edits and review the diff in PRs"
       - pattern: ".github/workflows/uv-lock-check.yml"
         covers: "macOS + Linux matrix running `uv lock --check` on every PR that touches pyproject.toml or uv.lock; catches stale-lock drift"
+      - pattern: ".pre-commit-config.yaml"
+        covers: "uv-lock hook (astral-sh/uv-pre-commit) relocking uv.lock on every commit; the local lock-sync gate that complements uv-lock-check.yml"
       - pattern: "docker/ubuntu22_04/Dockerfile"
         covers: "Container install via `uv sync --frozen --extra ${TORCH_BACKEND} --no-install-project` against the committed lock; dev-base stage installs the package editable on top"
 

--- a/docs/reference/dependency-management.md
+++ b/docs/reference/dependency-management.md
@@ -20,7 +20,9 @@ it can.
 
 `.github/workflows/uv-lock-check.yml` runs `uv lock --check` on macOS + Linux
 for every PR that touches `pyproject.toml` or `uv.lock`; a stale lock is
-what it catches.
+what it catches. Locally, the `uv-lock` pre-commit hook
+(`astral-sh/uv-pre-commit` in `.pre-commit-config.yaml`) relocks `uv.lock` on
+every commit, so most drift is caught before it reaches CI.
 
 ## Mac: no backend flag
 
@@ -76,7 +78,8 @@ How to avoid it on Linux:
 
 - Add, remove, or rebound a dependency in `pyproject.toml`.
 - Want to pick up a security fix or bug fix from upstream.
-- See `uv lock --check` fail in CI on a PR you didn't expect to bump deps.
+- See the `uv-lock` pre-commit hook relock, or `uv lock --check` fail in CI,
+  on a change you didn't expect to bump deps.
 
 **Regenerate on a Mac or GPU box, not on a `--extra cpu` Linux env.** A lock
 made under `--extra cpu` will pin the CPU torch as the default-resolution
@@ -133,5 +136,7 @@ and `uv.lock` in the same commit.
 - [`uv.lock`](../../uv.lock) — the universal lockfile (macOS + Linux + Windows).
 - [`.github/workflows/uv-lock-check.yml`](../../.github/workflows/uv-lock-check.yml) —
   the per-OS lock-sync gate.
+- [`.pre-commit-config.yaml`](../../.pre-commit-config.yaml) — the `uv-lock`
+  hook, the local lock-sync gate.
 - [`docs/getting-started.md`](../getting-started.md) — first-install
   walkthrough.

--- a/uv.lock
+++ b/uv.lock
@@ -6022,7 +6022,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.13.0"
+version = "8.14.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## What

Adds [`astral-sh/uv-pre-commit`](https://github.com/astral-sh/uv-pre-commit) (rev `0.11.18`) and enables the `uv-lock` hook so `uv.lock` is kept in sync with `pyproject.toml` on every commit.

## Why

Without this hook, `uv.lock` can silently drift from `pyproject.toml`. Enabling it surfaced exactly that drift: the lockfile recorded the project at `8.13.0` while `pyproject.toml` declares `8.14.0`. This PR includes the resulting relock so the hook passes in CI.

## Changes

- `.pre-commit-config.yaml`: add the `uv-lock` hook (placed next to `validate-pyproject`).
- `uv.lock`: relock project version `8.13.0` → `8.14.0`.

Refs #1243