### PR TITLE
fix(config): make fake_oracle param_spec compose without a render group

### DIFF
--- a/src/synth_setter/configs/experiment/surge/fake_oracle.yaml
+++ b/src/synth_setter/configs/experiment/surge/fake_oracle.yaml
@@ -26,9 +26,9 @@ tags:
 callbacks:
   log_per_param_mse:
     _target_: synth_setter.utils.callbacks.LogPerParamMSE
-    # Track the render group's spec so per-param MSE labels match the rendered
-    # params; this experiment always selects a render group (render_vst: true).
-    param_spec: ${render.param_spec_name}
+    # Track the render group's spec for per-param MSE labels; fall back to
+    # surge_xt when no render group is composed so the callback still instantiates.
+    param_spec: ${oc.select:render.param_spec_name,surge_xt}
   plot_proj_ii: null
 
 datamodule:


### PR DESCRIPTION
## What does this PR do?

Closes #1368

Follow-up to #1363 (merged). That PR set `param_spec: ${render.param_spec_name}` in `configs/experiment/surge/fake_oracle.yaml` so the per-param MSE spec tracks the selected render group. But `render` is null in `eval.yaml` and absent in `train.yaml`, so instantiating the `LogPerParamMSE` callback for `experiment=surge/fake_oracle` **without** a render override raised an interpolation error — before the intended `render_vst` runtime check (flagged by Copilot review on #1363).

### Fix
`param_spec: ${oc.select:render.param_spec_name,surge_xt}` — composes/instantiates cleanly when no render group is present (falls back to `surge_xt`, a valid registry key), and still follows the render group's spec (e.g. `surge_simple`) when one is selected. `oc.select` is already an established pattern in this repo (`configs/hydra/default.yaml`).

### Verification
- Composes + instantiates the `LogPerParamMSE` callback in all four cases: `render=surge_simple`→`surge_simple`, `render=surge_xt`→`surge_xt`, `eval.yaml` (render null)→`surge_xt`, `train.yaml` (render absent)→`surge_xt`.
- `tests/test_configs.py` + `tests/models/test_surge_fake_oracle_module.py` — 26 pass (incl. the fake_oracle cfg-lockstep contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)