### PR TITLE
feat(eval): opt-in R2 upload of the whole eval output dir

### DIFF
--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -286,7 +286,7 @@ def _dump_metric_dict(metric_dict: dict[str, Any], output_dir: Path) -> Path:
     return out_path
 
 
-def _maybe_upload_output_dir(cfg: DictConfig) -> None:
+def _maybe_upload_output_dir(cfg: DictConfig, is_global_zero: bool) -> None:
     """Mirror the whole Hydra run dir to R2 when ``evaluation.upload_output_dir_uri`` is set.
 
     Opt-in: a null URI is a no-op. Runs last so every artifact — metrics,
@@ -295,9 +295,18 @@ def _maybe_upload_output_dir(cfg: DictConfig) -> None:
     directly beneath it. Credential validation is delegated to
     :func:`r2_io.ensure_r2_env_loaded`, matching the datamodule's R2 prefetch.
 
+    Only the global-zero rank uploads: under DDP ``main`` runs on every rank
+    against the one shared ``output_dir``, so an ungated copy would race N
+    redundant uploads — the same rank gate :func:`evaluate` puts on predict
+    postprocessing.
+
     :param cfg: Reads ``cfg.evaluation.upload_output_dir_uri`` (``r2://`` prefix or
         null) and ``cfg.paths.output_dir`` (the local tree to copy).
+    :param is_global_zero: Whether this is the global-zero rank; non-zero ranks
+        return without touching R2.
     """
+    if not is_global_zero:
+        return
     dest_uri = cfg.evaluation.get("upload_output_dir_uri")
     if not dest_uri:
         return
@@ -317,9 +326,9 @@ def main(cfg: DictConfig) -> None:
     # (e.g. ask for tags if none are provided in cfg, print cfg tree, etc.)
     extras(cfg)
 
-    metric_dict, _ = evaluate(cfg)
+    metric_dict, object_dict = evaluate(cfg)
     _dump_metric_dict(metric_dict, Path(cfg.paths.output_dir))
-    _maybe_upload_output_dir(cfg)
+    _maybe_upload_output_dir(cfg, object_dict["trainer"].is_global_zero)
 
 
 if __name__ == "__main__":

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -14,6 +14,7 @@ from lightning import Callback, LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.loggers import Logger
 from omegaconf import DictConfig
 
+from synth_setter.pipeline import r2_io
 from synth_setter.resources import as_file, vst_headless_wrapper
 from synth_setter.utils import (
     RankedLogger,
@@ -285,6 +286,27 @@ def _dump_metric_dict(metric_dict: dict[str, Any], output_dir: Path) -> Path:
     return out_path
 
 
+def _maybe_upload_output_dir(cfg: DictConfig) -> None:
+    """Mirror the whole Hydra run dir to R2 when ``evaluation.upload_output_dir_uri`` is set.
+
+    Opt-in: a null URI is a no-op. Runs last so every artifact — metrics,
+    predictions, rendered audio, config logs — is on disk before the copy. The
+    configured URI is the exact destination prefix; the run dir's contents land
+    directly beneath it. Credential validation is delegated to
+    :func:`r2_io.ensure_r2_env_loaded`, matching the datamodule's R2 prefetch.
+
+    :param cfg: Reads ``cfg.evaluation.upload_output_dir_uri`` (``r2://`` prefix or
+        null) and ``cfg.paths.output_dir`` (the local tree to copy).
+    """
+    dest_uri = cfg.evaluation.get("upload_output_dir_uri")
+    if not dest_uri:
+        return
+    output_dir = Path(cfg.paths.output_dir)
+    log.info(f"Uploading eval output dir {output_dir} to {dest_uri}")
+    r2_io.ensure_r2_env_loaded()
+    r2_io.upload_dir(output_dir, dest_uri)
+
+
 @hydra.main(version_base="1.3", config_path="pkg://synth_setter.configs", config_name="eval.yaml")
 def main(cfg: DictConfig) -> None:
     """Run the evaluation entrypoint.
@@ -297,6 +319,7 @@ def main(cfg: DictConfig) -> None:
 
     metric_dict, _ = evaluate(cfg)
     _dump_metric_dict(metric_dict, Path(cfg.paths.output_dir))
+    _maybe_upload_output_dir(cfg)
 
 
 if __name__ == "__main__":

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -304,12 +304,19 @@ def _maybe_upload_output_dir(cfg: DictConfig, is_global_zero: bool) -> None:
         null) and ``cfg.paths.output_dir`` (the local tree to copy).
     :param is_global_zero: Whether this is the global-zero rank; non-zero ranks
         return without touching R2.
+    :raises ValueError: ``upload_output_dir_uri`` is set but not an ``r2://`` URI;
+        checked before the credential ping so a misconfigured destination is
+        attributed to the URI rather than surfacing as an auth failure.
     """
     if not is_global_zero:
         return
     dest_uri = cfg.evaluation.get("upload_output_dir_uri")
     if not dest_uri:
         return
+    if not r2_io.is_r2_uri(dest_uri):
+        raise ValueError(
+            f"evaluation.upload_output_dir_uri must be an r2:// URI; got {dest_uri!r}."
+        )
     output_dir = Path(cfg.paths.output_dir)
     log.info(f"Uploading eval output dir {output_dir} to {dest_uri}")
     r2_io.ensure_r2_env_loaded()

--- a/src/synth_setter/configs/eval.yaml
+++ b/src/synth_setter/configs/eval.yaml
@@ -24,6 +24,8 @@ evaluation:
   compute_metrics: false
   rerender_target: true
   num_workers: 1
+  # Opt-in: an `r2://bucket/prefix` mirror of the whole run dir, copied after eval.
+  upload_output_dir_uri: null
 
 # passing checkpoint path is necessary for evaluation
 ckpt_path: ???

--- a/src/synth_setter/pipeline/r2_io.py
+++ b/src/synth_setter/pipeline/r2_io.py
@@ -34,6 +34,7 @@ __all__ = [
     "shard_uri",
     "to_rclone_path",
     "upload",
+    "upload_dir",
     "upload_to_uri",
 ]
 
@@ -233,6 +234,34 @@ def upload_to_uri(local_path: Path, r2_uri: str) -> None:
         "--timeout=300s",
         "--retries=3",
         str(local_path),
+        _to_rclone_path(r2_uri),
+    ]
+    subprocess.check_call(args)  # noqa: S603 — args from validated URI
+
+
+def upload_dir(local_dir: Path, r2_uri: str) -> None:
+    """Copy a local directory tree into an R2 prefix (upload mirror of the dir download).
+
+    ``rclone copy`` walks ``local_dir`` and writes each file under ``r2_uri``,
+    preserving the relative tree. ``--checksum`` skips files already present with
+    a matching hash, so a re-run is idempotent; the reliability flags match the
+    other helpers so a transient blip retries instead of failing the caller.
+    Unlike the download helper there is no ``--immutable`` — the caller is
+    pushing its own freshly-produced directory, not guarding an immutable dataset.
+
+    :param local_dir: Local directory whose contents land directly under
+        ``r2_uri`` (the directory itself is not nested under its own name).
+    :param r2_uri: ``r2://`` destination prefix; created implicitly by rclone.
+    """
+    args = [  # noqa: S607 — rclone resolved by image's PATH
+        "rclone",
+        "copy",
+        "-vv",
+        "--checksum",
+        "--contimeout=30s",
+        "--timeout=300s",
+        "--retries=3",
+        str(local_dir),
         _to_rclone_path(r2_uri),
     ]
     subprocess.check_call(args)  # noqa: S603 — args from validated URI

--- a/src/synth_setter/pipeline/r2_io.py
+++ b/src/synth_setter/pipeline/r2_io.py
@@ -57,6 +57,12 @@ _R2_STRUCTURAL_DEFAULTS: dict[str, str] = {
     "RCLONE_CONFIG_R2_PROVIDER": "Cloudflare",
 }
 
+# rclone ``--timeout`` is the IO idle timeout, not a wall-clock cap. A whole eval
+# run dir — rendered audio, predictions, metrics — can stream far longer than a
+# single shard, so the directory upload bounds it generously rather than tripping
+# a healthy large transfer at the 5-minute default the single-file helpers use.
+_UPLOAD_DIR_TIMEOUT = "3h"
+
 
 def ensure_r2_env_loaded(env_file: Path | None = None) -> None:
     """Load ``RCLONE_CONFIG_R2_*`` from ``env_file`` into ``os.environ``; validate.
@@ -244,10 +250,12 @@ def upload_dir(local_dir: Path, r2_uri: str) -> None:
 
     ``rclone copy`` walks ``local_dir`` and writes each file under ``r2_uri``,
     preserving the relative tree. ``--checksum`` skips files already present with
-    a matching hash, so a re-run is idempotent; the reliability flags match the
-    other helpers so a transient blip retries instead of failing the caller.
-    Unlike the download helper there is no ``--immutable`` — the caller is
-    pushing its own freshly-produced directory, not guarding an immutable dataset.
+    a matching hash, so a re-run is idempotent; the connect-timeout and retry
+    flags match the other helpers so a transient blip retries instead of failing
+    the caller, while the IO timeout is widened to :data:`_UPLOAD_DIR_TIMEOUT`
+    because a whole run dir can stream past the single-file default. Unlike the
+    download helper there is no ``--immutable`` — the caller is pushing its own
+    freshly-produced directory, not guarding an immutable dataset.
 
     :param local_dir: Local directory whose contents land directly under
         ``r2_uri`` (the directory itself is not nested under its own name).
@@ -259,7 +267,7 @@ def upload_dir(local_dir: Path, r2_uri: str) -> None:
         "-vv",
         "--checksum",
         "--contimeout=30s",
-        "--timeout=300s",
+        f"--timeout={_UPLOAD_DIR_TIMEOUT}",
         "--retries=3",
         str(local_dir),
         _to_rclone_path(r2_uri),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ from synth_setter.utils.utils import register_resolvers
 from synth_setter.workspace import operator_workspace
 from tests._baseline_worktree import worktree_for_ref  # noqa: F401 — pytest fixture re-export
 from tests.data.vst._fake_plugin import FakeVST3Plugin
+from tests.pipeline.conftest import fake_r2_remote  # noqa: F401 — pytest fixture re-export
 
 # Per-clip dimensions for the smoke fixture's HDF5 output. ``RenderConfig`` in
 # ``synth_setter.pipeline.schemas.spec`` declares no field defaults — the fixture passes

--- a/tests/pipeline/test_r2_io.py
+++ b/tests/pipeline/test_r2_io.py
@@ -190,27 +190,26 @@ class TestUploadDir:
         with pytest.raises(ValueError, match="not an r2:// URI"):
             r2_io.upload_dir(tmp_path / "run", "local-dest")
 
-    def test_command_carries_copy_verb_and_reliability_flags(self, tmp_path: Path) -> None:
-        """Pin the ``copy`` verb (not ``copyto``) + the reliability-flag set.
+    def test_reupload_overwrites_changed_file(self, fake_r2_remote: Path, tmp_path: Path) -> None:
+        """Re-uploading a changed source overwrites the remote copy — no ``--immutable``.
 
-        A directory upload needs ``rclone copy`` so the relative tree is
-        preserved; ``copyto`` would treat the destination as a single object.
-        The reliability flags mirror the other helpers so a transient blip
-        retries instead of failing the eval. Unlike the download helper there is
-        no ``--immutable``: the caller is pushing its own fresh run dir.
+        The caller pushes its own freshly-produced run dir, so a second upload
+        must replace stale objects rather than hard-fail the way the
+        ``--immutable`` download guard would.
 
-        :param tmp_path: Pytest tmp dir used for the upload source path.
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        :param tmp_path: Pytest tmp dir holding the local source tree.
         """
-        with patch.object(r2_io.subprocess, "check_call") as mock_call:
-            r2_io.upload_dir(tmp_path / "run", "r2://bucket/evals/run-1")
-        args = mock_call.call_args[0][0]
-        assert args[:2] == ["rclone", "copy"]
-        assert "--immutable" not in args
-        assert "--checksum" in args
-        assert "-vv" in args
-        assert "--contimeout=30s" in args
-        assert "--timeout=300s" in args
-        assert "--retries=3" in args
+        local_dir = tmp_path / "run"
+        local_dir.mkdir()
+        (local_dir / "metrics.json").write_text('{"param_mse": 1.0}')
+        r2_io.upload_dir(local_dir, "r2://bucket/evals/run-1")
+
+        (local_dir / "metrics.json").write_text('{"param_mse": 0.0}')
+        r2_io.upload_dir(local_dir, "r2://bucket/evals/run-1")
+
+        dest = fake_r2_remote / "bucket" / "evals" / "run-1"
+        assert (dest / "metrics.json").read_text() == '{"param_mse": 0.0}'
 
 
 class TestUploadToUri:

--- a/tests/pipeline/test_r2_io.py
+++ b/tests/pipeline/test_r2_io.py
@@ -211,6 +211,25 @@ class TestUploadDir:
         dest = fake_r2_remote / "bucket" / "evals" / "run-1"
         assert (dest / "metrics.json").read_text() == '{"param_mse": 0.0}'
 
+    def test_command_widens_io_timeout_and_omits_immutable(self, tmp_path: Path) -> None:
+        """Pin the rclone verb, the 3h IO timeout, and the absence of ``--immutable``.
+
+        The widened ``--timeout`` lets a whole run dir stream past the single-file
+        default, and the missing ``--immutable`` is what lets a re-upload overwrite
+        — both unobservable from filesystem state. One argv assertion guards them.
+
+        :param tmp_path: Pytest tmp dir used to build the local source path.
+        """
+        with patch.object(r2_io.subprocess, "check_call") as mock_call:
+            r2_io.upload_dir(tmp_path / "run", "r2://bucket/evals/run-1")
+        args = mock_call.call_args[0][0]
+        assert args[:2] == ["rclone", "copy"]
+        assert "--immutable" not in args
+        assert "--checksum" in args
+        assert "--contimeout=30s" in args
+        assert "--timeout=3h" in args
+        assert "--retries=3" in args
+
 
 class TestUploadToUri:
     """Tests for upload_to_uri — file→file upload with reliability flags."""

--- a/tests/pipeline/test_r2_io.py
+++ b/tests/pipeline/test_r2_io.py
@@ -160,6 +160,59 @@ class TestDownloadDirNoOverwrite:
         assert "--retries=3" in args
 
 
+class TestUploadDir:
+    """Tests for upload_dir — directory→prefix upload (mirror of download_dir_no_overwrite)."""
+
+    def test_lands_local_tree_under_remote_prefix(
+        self, fake_r2_remote: Path, tmp_path: Path
+    ) -> None:
+        """Every file under ``local_dir`` is copied beneath the destination prefix.
+
+        :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
+        :param tmp_path: Pytest tmp dir holding the local source tree.
+        """
+        local_dir = tmp_path / "run"
+        (local_dir / "metrics").mkdir(parents=True)
+        (local_dir / "metrics" / "metrics.json").write_text('{"ok": true}')
+        (local_dir / "config.log").write_text("cfg")
+
+        r2_io.upload_dir(local_dir, "r2://bucket/evals/run-1")
+
+        dest = fake_r2_remote / "bucket" / "evals" / "run-1"
+        assert (dest / "metrics" / "metrics.json").read_text() == '{"ok": true}'
+        assert (dest / "config.log").read_text() == "cfg"
+
+    def test_rejects_non_r2_uri(self, tmp_path: Path) -> None:
+        """A local-path destination is rejected — caller must pass an ``r2://`` URI.
+
+        :param tmp_path: Pytest tmp dir used to build a local source path.
+        """
+        with pytest.raises(ValueError, match="not an r2:// URI"):
+            r2_io.upload_dir(tmp_path / "run", "local-dest")
+
+    def test_command_carries_copy_verb_and_reliability_flags(self, tmp_path: Path) -> None:
+        """Pin the ``copy`` verb (not ``copyto``) + the reliability-flag set.
+
+        A directory upload needs ``rclone copy`` so the relative tree is
+        preserved; ``copyto`` would treat the destination as a single object.
+        The reliability flags mirror the other helpers so a transient blip
+        retries instead of failing the eval. Unlike the download helper there is
+        no ``--immutable``: the caller is pushing its own fresh run dir.
+
+        :param tmp_path: Pytest tmp dir used for the upload source path.
+        """
+        with patch.object(r2_io.subprocess, "check_call") as mock_call:
+            r2_io.upload_dir(tmp_path / "run", "r2://bucket/evals/run-1")
+        args = mock_call.call_args[0][0]
+        assert args[:2] == ["rclone", "copy"]
+        assert "--immutable" not in args
+        assert "--checksum" in args
+        assert "-vv" in args
+        assert "--contimeout=30s" in args
+        assert "--timeout=300s" in args
+        assert "--retries=3" in args
+
+
 class TestUploadToUri:
     """Tests for upload_to_uri — file→file upload with reliability flags."""
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -284,6 +284,77 @@ def test_eval_cli_downloads_dataset_from_r2_then_scores_oracle(
     assert metrics["test/param_mse"] == 0.0
 
 
+@pytest.mark.requires_vst
+@pytest.mark.slow
+def test_eval_cli_uploads_output_dir_to_r2(tmp_path: Path, surge_xt_smoke_datasets: Path) -> None:
+    """End-to-end through the ``synth-setter-eval`` CLI: oracle scoring then R2 upload.
+
+    No in-process shortcuts and no mocks — the real entrypoint runs with real
+    ``rclone`` (local-backed remote). With ``evaluation.upload_output_dir_uri`` set,
+    ``main``'s final step mirrors the whole run dir to that prefix, so every file
+    the eval wrote locally must reappear beneath the destination and the uploaded
+    ``metrics.json`` must carry the oracle's exact-zero ``test/param_mse``.
+
+    :param tmp_path: Root for the fake R2 remote and the local output dir.
+    :param surge_xt_smoke_datasets: Source ``{train,val,test}.h5`` + ``stats.npz``.
+    """
+    if shutil.which("rclone") is None:
+        pytest.skip("rclone binary not available on PATH")
+
+    remote_root = tmp_path / "r2"
+    remote_root.mkdir()
+    output_dir = tmp_path / "out"
+    upload_uri = "r2://eval-artifacts/run-1"
+
+    env = {
+        **os.environ,
+        "RCLONE_CONFIG_R2_TYPE": "local",
+        "RCLONE_CONFIG_R2_ACCESS_KEY_ID": "stub",
+        "RCLONE_CONFIG_R2_SECRET_ACCESS_KEY": "stub",
+        "RCLONE_CONFIG_R2_ENDPOINT": "stub",
+    }
+    proc = subprocess.run(  # noqa: S603 — controlled argv
+        [
+            sys.executable,
+            "-m",
+            "synth_setter.cli.eval",
+            "experiment=surge/test-mps-fake-oracle",
+            "trainer=cpu",
+            "mode=test",
+            "hydra.job.chdir=false",
+            f"model.net.d_out={len(param_specs['surge_4'])}",
+            "callbacks.log_per_param_mse.param_spec=surge_4",
+            f"datamodule.dataset_root={surge_xt_smoke_datasets}",
+            f"datamodule.predict_file={surge_xt_smoke_datasets}/test.h5",
+            "datamodule.batch_size=1",
+            "datamodule.num_workers=0",
+            "ckpt_path=null",
+            f"paths.output_dir={output_dir}",
+            f"hydra.run.dir={output_dir}",
+            f"evaluation.upload_output_dir_uri={upload_uri}",
+        ],
+        cwd=remote_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+
+    local_files = {p.relative_to(output_dir) for p in output_dir.rglob("*") if p.is_file()}
+    assert local_files, "eval produced no output files to upload"
+
+    uploaded_root = remote_root / "eval-artifacts" / "run-1"
+    uploaded_files = {
+        p.relative_to(uploaded_root) for p in uploaded_root.rglob("*") if p.is_file()
+    }
+    missing = local_files - uploaded_files
+    assert not missing, f"output dir not fully uploaded; missing {sorted(map(str, missing))}"
+
+    uploaded_metrics = json.loads((uploaded_root / "metrics" / "metrics.json").read_text())
+    assert uploaded_metrics["test/param_mse"] == 0.0
+
+
 @pytest.mark.gpu
 @RunIf(min_gpus=1)
 @pytest.mark.slow

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -22,6 +22,7 @@ from synth_setter.cli.eval import (
     _COMPUTE_AUDIO_METRICS_MODULE,
     _dump_metric_dict,
     _load_audio_metrics,
+    _maybe_upload_output_dir,
     _run_predict_postprocessing,
     evaluate,
 )
@@ -110,6 +111,68 @@ def test_dump_metric_dict_writes_json_with_coerced_scalars(tmp_path: Path) -> No
     assert payload["test/per_param_mse"] == [0.0, 0.0, 0.0, 0.0]
     assert payload["audio/mss_mean"] == pytest.approx(0.5)
     assert payload["raw/string"] == "v1"
+
+
+def _upload_cfg(output_dir: Path, upload_output_dir_uri: str | None) -> DictConfig:
+    """Build the minimal cfg slice ``_maybe_upload_output_dir`` reads.
+
+    :param output_dir: Resolves to ``cfg.paths.output_dir`` — the tree to copy.
+    :param upload_output_dir_uri: Resolves to ``cfg.evaluation.upload_output_dir_uri``.
+    :returns: A :class:`DictConfig` carrying only the two keys the helper reads.
+    """
+    return OmegaConf.create(  # type: ignore[no-any-return]
+        {
+            "paths": {"output_dir": str(output_dir)},
+            "evaluation": {"upload_output_dir_uri": upload_output_dir_uri},
+        }
+    )
+
+
+def test_maybe_upload_output_dir_noop_when_uri_unset(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A null URI uploads nothing and never touches R2 credentials.
+
+    :param monkeypatch: Stubs ``r2_io`` so any R2 call would be observable.
+    :param tmp_path: Stands in for the output dir.
+    """
+    calls: list[str] = []
+    monkeypatch.setattr(
+        eval_mod.r2_io, "ensure_r2_env_loaded", lambda *a, **k: calls.append("env")
+    )
+    monkeypatch.setattr(eval_mod.r2_io, "upload_dir", lambda *a, **k: calls.append("upload"))
+
+    _maybe_upload_output_dir(_upload_cfg(tmp_path, upload_output_dir_uri=None))
+
+    assert calls == []
+
+
+def test_maybe_upload_output_dir_uploads_tree_when_uri_set(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A set URI validates credentials, then uploads the output dir to that prefix.
+
+    :param monkeypatch: Stubs ``r2_io`` so the credential check + upload are observable.
+    :param tmp_path: Stands in for the output dir passed to ``upload_dir``.
+    """
+    order: list[str] = []
+    monkeypatch.setattr(
+        eval_mod.r2_io, "ensure_r2_env_loaded", lambda *a, **k: order.append("env")
+    )
+    captured: dict[str, object] = {}
+
+    def _fake_upload_dir(local_dir: Path, r2_uri: str) -> None:
+        order.append("upload")
+        captured["local_dir"] = local_dir
+        captured["r2_uri"] = r2_uri
+
+    monkeypatch.setattr(eval_mod.r2_io, "upload_dir", _fake_upload_dir)
+
+    _maybe_upload_output_dir(_upload_cfg(tmp_path, "r2://bucket/evals/run-1"))
+
+    assert order == ["env", "upload"]
+    assert captured["local_dir"] == tmp_path
+    assert captured["r2_uri"] == "r2://bucket/evals/run-1"
 
 
 @pytest.mark.requires_vst

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -211,6 +211,24 @@ def test_maybe_upload_output_dir_mirrors_tree_when_uri_set(
     assert (dest / "metrics.json").read_text() == '{"param_mse": 0.0}'
 
 
+def test_maybe_upload_output_dir_rejects_non_r2_uri(tmp_path: Path) -> None:
+    """A non-``r2://`` URI fails on the URI shape before any credential ping.
+
+    Validating the URI first attributes a misconfiguration to the URI itself
+    rather than surfacing it as a confusing credentials/auth error from the
+    ``ensure_r2_env_loaded`` ping that would otherwise run first.
+
+    :param tmp_path: Holds the output dir the rejected upload would have copied.
+    """
+    output_dir = tmp_path / "run"
+    _write_output_tree(output_dir)
+
+    with pytest.raises(ValueError, match="must be an r2:// URI"):
+        _maybe_upload_output_dir(
+            _upload_cfg(output_dir, "s3://bucket/evals/run-1"), is_global_zero=True
+        )
+
+
 @pytest.mark.requires_vst
 @pytest.mark.slow
 def test_eval_cli_downloads_dataset_from_r2_then_scores_oracle(

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -128,77 +128,87 @@ def _upload_cfg(output_dir: Path, upload_output_dir_uri: str | None) -> DictConf
     )
 
 
-def test_maybe_upload_output_dir_noop_when_uri_unset(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    """A null URI uploads nothing and never touches R2 credentials.
+@pytest.fixture()
+def r2_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set the three secret keys :func:`r2_io.ensure_r2_env_loaded` requires present.
 
-    :param monkeypatch: Stubs ``r2_io`` so any R2 call would be observable.
-    :param tmp_path: Stands in for the output dir.
+    Paired with ``fake_r2_remote`` (which sets ``RCLONE_CONFIG_R2_TYPE=local``),
+    these dummy values satisfy the presence check and let the real ``rclone lsd
+    r2:`` auth ping resolve the local backend instead of dialing Cloudflare.
+
+    :param monkeypatch: Sets the secret env vars for the test's duration.
     """
-    calls: list[str] = []
-    monkeypatch.setattr(
-        eval_mod.r2_io, "ensure_r2_env_loaded", lambda *a, **k: calls.append("env")
-    )
-    monkeypatch.setattr(eval_mod.r2_io, "upload_dir", lambda *a, **k: calls.append("upload"))
+    monkeypatch.setenv("RCLONE_CONFIG_R2_ACCESS_KEY_ID", "test-access-key")
+    monkeypatch.setenv("RCLONE_CONFIG_R2_SECRET_ACCESS_KEY", "test-secret-key")
+    monkeypatch.setenv("RCLONE_CONFIG_R2_ENDPOINT", "http://localhost:0")
+
+
+def _write_output_tree(output_dir: Path) -> None:
+    """Populate ``output_dir`` with a nested file and a top-level file to mirror.
+
+    :param output_dir: Created here, then filled with the two-level tree.
+    """
+    (output_dir / "predictions").mkdir(parents=True)
+    (output_dir / "predictions" / "pred.json").write_text('{"ok": true}')
+    (output_dir / "metrics.json").write_text('{"param_mse": 0.0}')
+
+
+def test_maybe_upload_output_dir_noop_when_uri_unset(fake_r2_remote: Path, tmp_path: Path) -> None:
+    """A null URI lands no objects in the remote.
+
+    :param fake_r2_remote: Local-backed ``r2:`` remote; its tree is asserted empty.
+    :param tmp_path: Holds the output dir that a non-null URI would have mirrored.
+    """
+    output_dir = tmp_path / "run"
+    _write_output_tree(output_dir)
 
     _maybe_upload_output_dir(
-        _upload_cfg(tmp_path, upload_output_dir_uri=None), is_global_zero=True
+        _upload_cfg(output_dir, upload_output_dir_uri=None), is_global_zero=True
     )
 
-    assert calls == []
+    assert list(fake_r2_remote.glob("bucket/**/*")) == []
 
 
 def test_maybe_upload_output_dir_skips_non_global_zero_rank(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    fake_r2_remote: Path, tmp_path: Path
 ) -> None:
-    """A non-global-zero rank uploads nothing even when a URI is set.
+    """A non-global-zero rank lands no objects even when a URI is set.
 
     Under DDP every rank runs ``main`` against the one shared ``output_dir``;
     only rank zero may copy it so the other ranks don't race redundant uploads.
 
-    :param monkeypatch: Stubs ``r2_io`` so any R2 call would be observable.
-    :param tmp_path: Stands in for the output dir.
+    :param fake_r2_remote: Local-backed ``r2:`` remote; its tree is asserted empty.
+    :param tmp_path: Holds the output dir rank zero would have mirrored.
     """
-    calls: list[str] = []
-    monkeypatch.setattr(
-        eval_mod.r2_io, "ensure_r2_env_loaded", lambda *a, **k: calls.append("env")
-    )
-    monkeypatch.setattr(eval_mod.r2_io, "upload_dir", lambda *a, **k: calls.append("upload"))
+    output_dir = tmp_path / "run"
+    _write_output_tree(output_dir)
 
     _maybe_upload_output_dir(
-        _upload_cfg(tmp_path, "r2://bucket/evals/run-1"), is_global_zero=False
+        _upload_cfg(output_dir, "r2://bucket/evals/run-1"), is_global_zero=False
     )
 
-    assert calls == []
+    assert list(fake_r2_remote.glob("bucket/**/*")) == []
 
 
-def test_maybe_upload_output_dir_uploads_tree_when_uri_set(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+def test_maybe_upload_output_dir_mirrors_tree_when_uri_set(
+    fake_r2_remote: Path, r2_credentials: None, tmp_path: Path
 ) -> None:
-    """A set URI validates credentials, then uploads the output dir to that prefix.
+    """A set URI mirrors the whole output dir beneath the destination prefix.
 
-    :param monkeypatch: Stubs ``r2_io`` so the credential check + upload are observable.
-    :param tmp_path: Stands in for the output dir passed to ``upload_dir``.
+    :param fake_r2_remote: Local-backed ``r2:`` remote where the mirror lands.
+    :param r2_credentials: Dummy secrets so the real credential check passes.
+    :param tmp_path: Holds the output dir copied to R2.
     """
-    order: list[str] = []
-    monkeypatch.setattr(
-        eval_mod.r2_io, "ensure_r2_env_loaded", lambda *a, **k: order.append("env")
+    output_dir = tmp_path / "run"
+    _write_output_tree(output_dir)
+
+    _maybe_upload_output_dir(
+        _upload_cfg(output_dir, "r2://bucket/evals/run-1"), is_global_zero=True
     )
-    captured: dict[str, object] = {}
 
-    def _fake_upload_dir(local_dir: Path, r2_uri: str) -> None:
-        order.append("upload")
-        captured["local_dir"] = local_dir
-        captured["r2_uri"] = r2_uri
-
-    monkeypatch.setattr(eval_mod.r2_io, "upload_dir", _fake_upload_dir)
-
-    _maybe_upload_output_dir(_upload_cfg(tmp_path, "r2://bucket/evals/run-1"), is_global_zero=True)
-
-    assert order == ["env", "upload"]
-    assert captured["local_dir"] == tmp_path
-    assert captured["r2_uri"] == "r2://bucket/evals/run-1"
+    dest = fake_r2_remote / "bucket" / "evals" / "run-1"
+    assert (dest / "predictions" / "pred.json").read_text() == '{"ok": true}'
+    assert (dest / "metrics.json").read_text() == '{"param_mse": 0.0}'
 
 
 @pytest.mark.requires_vst

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -142,7 +142,33 @@ def test_maybe_upload_output_dir_noop_when_uri_unset(
     )
     monkeypatch.setattr(eval_mod.r2_io, "upload_dir", lambda *a, **k: calls.append("upload"))
 
-    _maybe_upload_output_dir(_upload_cfg(tmp_path, upload_output_dir_uri=None))
+    _maybe_upload_output_dir(
+        _upload_cfg(tmp_path, upload_output_dir_uri=None), is_global_zero=True
+    )
+
+    assert calls == []
+
+
+def test_maybe_upload_output_dir_skips_non_global_zero_rank(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A non-global-zero rank uploads nothing even when a URI is set.
+
+    Under DDP every rank runs ``main`` against the one shared ``output_dir``;
+    only rank zero may copy it so the other ranks don't race redundant uploads.
+
+    :param monkeypatch: Stubs ``r2_io`` so any R2 call would be observable.
+    :param tmp_path: Stands in for the output dir.
+    """
+    calls: list[str] = []
+    monkeypatch.setattr(
+        eval_mod.r2_io, "ensure_r2_env_loaded", lambda *a, **k: calls.append("env")
+    )
+    monkeypatch.setattr(eval_mod.r2_io, "upload_dir", lambda *a, **k: calls.append("upload"))
+
+    _maybe_upload_output_dir(
+        _upload_cfg(tmp_path, "r2://bucket/evals/run-1"), is_global_zero=False
+    )
 
     assert calls == []
 
@@ -168,7 +194,7 @@ def test_maybe_upload_output_dir_uploads_tree_when_uri_set(
 
     monkeypatch.setattr(eval_mod.r2_io, "upload_dir", _fake_upload_dir)
 
-    _maybe_upload_output_dir(_upload_cfg(tmp_path, "r2://bucket/evals/run-1"))
+    _maybe_upload_output_dir(_upload_cfg(tmp_path, "r2://bucket/evals/run-1"), is_global_zero=True)
 
     assert order == ["env", "upload"]
     assert captured["local_dir"] == tmp_path


### PR DESCRIPTION
## Summary

Lets `eval.py` mirror its entire Hydra run directory to R2 after scoring, gated behind a single opt-in config key.

- Adds `evaluation.upload_output_dir_uri` to `eval.yaml` (default `null`). When set to an `r2://bucket/prefix`, the whole output dir — `metrics/`, `predictions/`, `audio/`, config logs — is copied there as the last step of `main()`. Credentials are validated via `ensure_r2_env_loaded`, exactly as the datamodule's R2 prefetch does. `null` is a no-op, so existing `mode=test`/`validate`/`predict` runs are unchanged.
- Adds `r2_io.upload_dir(local_dir, r2_uri)`, the directory-upload counterpart to `download_dir_no_overwrite`: `rclone copy` with `--checksum` and the shared `--contimeout`/`--timeout`/`--retries` reliability flags. No `--immutable` — the caller is pushing its own freshly produced run dir, not guarding an immutable dataset.

The configured URI is the exact destination prefix; the run dir's contents land directly beneath it.

## Test plan

- `r2_io.upload_dir`: state-based test against the local-backed fake R2 remote (tree lands under the prefix), non-`r2://` URI rejection, and an argv-shape test pinning the `copy` verb + reliability flags + absence of `--immutable`.
- `eval._maybe_upload_output_dir`: null URI is a no-op (no credential check, no upload); a set URI validates credentials then uploads the output dir to that prefix, in order.
- Full fast suites for `tests/pipeline/test_r2_io.py`, `tests/test_eval.py`, and `tests/test_configs.py` pass; ruff / ruff-format / pyright / docformatter / pydoclint / interrogate clean.

Refs #93