### PR TITLE
docs(claude-md): re-add condensed comment-hygiene block to AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Architecture: [docs/architecture.md](docs/architecture.md).
   rules to make CI green is forbidden — see
   [`### Lint exceptions are append-frozen`](#lint-exceptions-are-append-frozen).
 
-## Comments
+## Comment hygiene
 
 Code says **what**; comments say **why** — add prose only when it carries a
 constraint, unit, semantic, or rationale that names and types can't, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,15 @@ Architecture: [docs/architecture.md](docs/architecture.md).
   rules to make CI green is forbidden — see
   [`### Lint exceptions are append-frozen`](#lint-exceptions-are-append-frozen).
 
+## Comments
+
+Code says **what**; comments say **why** — add prose only when it carries a
+constraint, unit, semantic, or rationale that names and types can't, and
+describe only current behavior (history belongs in the commit message). Keep
+comments to one line (cap two), open docstrings with the contract, and supply
+`:param:` / `:returns:` / `:raises:` semantics wherever pydoclint expects them —
+full rules in the `comment-hygiene` skill.
+
 ## Testing
 
 - `make test-fast` is the default CPU loop; `@pytest.mark.slow` for slow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,11 @@ Never run `make docker-*` or RunPod commands without asking — they spend money
 
 </important>
 
+<important if="you are writing inline comments or docstrings">
+
+Code says **what**; comments say **why** — add prose only when it carries a constraint, unit, semantic, or rationale that names and types can't, and describe only current behavior (history belongs in the commit message). Keep comments to one line (cap two), open docstrings with the contract, and supply `:param:` / `:returns:` / `:raises:` semantics wherever pydoclint expects them — full rules in the `comment-hygiene` skill.
+</important>
+
 <important if="you are starting any non-trivial change">
 
 YAGNI. Start minimal and expand only when asked — don't add a class, config schema, or pattern speculatively. Ask "do we need this *now*?" and default to no. Present a plan before writing code.


### PR DESCRIPTION
## What

Re-add a condensed comment-hygiene pointer that the #1369 restructure dropped, in both instruction files:

- **`AGENTS.md`** (canonical) — a plain `## Comment hygiene` section.
- **`CLAUDE.md`** — a matching `<important if="you are writing inline comments or docstrings">` block.

Both are two sentences and defer the full rules to the `comment-hygiene` skill.

## Why

#1369 cloned `AGENTS.md` into `CLAUDE.md`, and in doing so dropped the Claude-only comment-hygiene section the old `CLAUDE.md` carried (`AGENTS.md` never had it). The #1369 reviewer note flagged this and asked whether to re-add it. This restores the always-loaded guidance while keeping the skill as the source of truth, and now lands it in the canonical file too so Claude and Codex share it.

The AGENTS.md heading is `## Comment hygiene` to match the name `agent/skills/repo-review/SKILL.md:86` already cross-references.

## Notes for reviewers

- Docs-only change (exempt from the tdd/code-health implementation gate).
- Pre-PR review (`/repo-review-full-no-comments`): 0 BLOCK, 3 WARN — all deliberate (AGENTS.md-canonical/CLAUDE.md mirror DRY, compact `</important>` close matching existing blocks, stylistic density) and documented in the review report.

Fixes #1373