### PR TITLE
docs(claude-md): drop 'never commit without explicit permission' line

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,8 +28,7 @@ Architecture: [docs/architecture.md](docs/architecture.md).
 - **Always verify the branch before push.** Run `git branch --show-current`
   and confirm it matches the target PR branch. A hook prints the branch on
   every `git commit`; don't ignore it.
-- **Never commit without explicit permission.** The user opts in. Pre-commit
-  hooks must not be skipped — see [`### Commits`](#commits).
+- **Pre-commit hooks must not be skipped** — see [`### Commits`](#commits).
 - **Never run `make docker-*` or RunPod commands without asking.** These
   spend money and burn cluster state.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,6 @@ Invoke in order: `/tdd-implementation` (drive it test-first) → `/code-health` 
 - Run `make format` first; pre-commit (ruff, ruff-format, pydoclint, prettier, mdformat, gitlint) is authoritative. **Never `--no-verify` / `-n`**, and never suppress a rule to make CI green — fix the underlying cause.
 - **Never add `Co-Authored-By` or agent-attribution trailers** ("Generated with …", "Claude …"). A `PreToolUse` hook (`agent/hooks/git-commit-trailer-check.sh`) blocks them.
 - **Verify the branch before push:** `git branch --show-current` must match the target PR branch.
-- **Never commit without explicit permission.** The user opts in.
 
 </important>
 


### PR DESCRIPTION
## What

Removes the standing instruction that the agent must obtain explicit permission before every commit, from both `CLAUDE.md` and `AGENTS.md`.

In `AGENTS.md` the bullet that carried this line also covered pre-commit hooks; that clause is retained as its own bullet.

## Why

Per the repo owner, the explicit-per-commit-permission gate is being dropped.

Closes #1379