### PR TITLE
chore(ci-automation): apply setup-r2 composite to the 7 deferred R2 workflows

### DIFF
--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -183,6 +183,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # rclone runs inside the worker container/pod, so no host install here;
+      # setup-r2 exports the `RCLONE_CONFIG_R2_*` env every downstream consumer
+      # reads — the launcher's cred bootstrap + rclone upload (native and
+      # in-container) and the `docker run -e <VAR>` shard-validation forward.
+      - name: Set up R2
+        uses: ./.github/actions/setup-r2
+        with:
+          access-key-id: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+          endpoint: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+
       # Reject hydra_overrides containing anything outside the allowed character
       # class. The docker (runpod/oci) row expands `$HYDRA_OVERRIDES_EXTRA`
       # unquoted inside `bash -c`, so an unrestricted value like
@@ -409,9 +420,6 @@ jobs:
         if: ${{ inputs.provider == 'skypilot-local' }}
         timeout-minutes: 40
         env:
-          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
-          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
-          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           CLUSTER_NAME: ${{ steps.cluster.outputs.name }}
           WORKER_GIT_REF: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -538,9 +546,6 @@ jobs:
           OCI_FINGERPRINT: ${{ secrets.OCI_FINGERPRINT }}
           OCI_REGION: ${{ secrets.OCI_REGION }}
           OCI_API_KEY_PEM: ${{ secrets.OCI_API_KEY_PEM }}
-          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
-          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
-          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
           WORKER_GIT_REF: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -670,15 +675,12 @@ jobs:
       - name: Validate all shards from R2
         env:
           SPEC_URI: ${{ steps.spec_uri.outputs.spec_uri }}
-          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
-          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
-          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
         run: |
           set -euo pipefail
           docker run --rm \
             -v "${{ github.workspace }}:/home/build/synth-setter:ro" \
-            -e RCLONE_CONFIG_R2_TYPE=s3 \
-            -e RCLONE_CONFIG_R2_PROVIDER=Cloudflare \
+            -e RCLONE_CONFIG_R2_TYPE \
+            -e RCLONE_CONFIG_R2_PROVIDER \
             -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
             -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
             -e RCLONE_CONFIG_R2_ENDPOINT \

--- a/.github/workflows/oci-image-bake.yaml
+++ b/.github/workflows/oci-image-bake.yaml
@@ -124,6 +124,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # rclone runs inside the worker pod, not on the runner; setup-r2 exports
+      # the `RCLONE_CONFIG_R2_*` env both the cred bootstrap and the SkyPilot
+      # launch step read (via `write_provider_creds.sh` and `os.environ`,
+      # respectively) and forward into the pod through `task.update_envs`.
+      - name: Set up R2
+        uses: ./.github/actions/setup-r2
+        with:
+          access-key-id: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+          endpoint: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -145,9 +156,6 @@ jobs:
       # both halves of the workflow.
       - name: Bootstrap OCI credentials
         env:
-          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
-          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
-          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           OCI_USER_OCID: ${{ secrets.OCI_USER_OCID }}
           OCI_TENANCY_OCID: ${{ secrets.OCI_TENANCY_OCID }}
@@ -201,9 +209,6 @@ jobs:
           CLUSTER_NAME: ${{ steps.cluster.outputs.name }}
           TEMPLATE: ${{ env.SOURCE_TEMPLATE }}
           DEADLINE: ${{ env.LAUNCH_DEADLINE_SECONDS }}
-          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
-          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
-          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
         run: |
           set -euo pipefail
           python - <<'PY'

--- a/.github/workflows/test-skypilot-debug.yml
+++ b/.github/workflows/test-skypilot-debug.yml
@@ -223,6 +223,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      # rclone runs inside the worker pod/container, not on the runner; setup-r2
+      # exports the `RCLONE_CONFIG_R2_*` env every probe row reads — inline-sky
+      # and launcher-runner via `os.environ` into `task.update_envs`, and
+      # launcher-docker via value-less `docker run -e <VAR>` forwarding.
+      - name: Set up R2
+        uses: ./.github/actions/setup-r2
+        with:
+          access-key-id: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+          endpoint: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -265,9 +276,6 @@ jobs:
           SKYPILOT_API_SERVER_ENDPOINT: ${{ secrets.SKYPILOT_API_SERVER_ENDPOINT }}
           PROVIDER: runpod
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
-          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
-          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
-          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_BUCKET: intermediate-data
           CLUSTER_NAME: ${{ matrix.cluster_prefix }}-${{ matrix.cluster_suffix }}-${{ github.run_id }}
@@ -383,9 +391,6 @@ jobs:
         env:
           SKYPILOT_API_SERVER_ENDPOINT: ${{ secrets.SKYPILOT_API_SERVER_ENDPOINT }}
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
-          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
-          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
-          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           PYTHONPATH: ${{ github.workspace }}
           CLUSTER_NAME: ${{ matrix.cluster_prefix }}-${{ matrix.cluster_suffix }}-${{ github.run_id }}
@@ -407,9 +412,6 @@ jobs:
         env:
           SKYPILOT_API_SERVER_ENDPOINT: ${{ secrets.SKYPILOT_API_SERVER_ENDPOINT }}
           RUNPOD_API_KEY: ${{ secrets.RUNPOD_API_KEY }}
-          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
-          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
-          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           CLUSTER_NAME: ${{ matrix.cluster_prefix }}-${{ matrix.cluster_suffix }}-${{ github.run_id }}
           CONFIG_PATH: ${{ matrix.config }}

--- a/.github/workflows/test-skypilot-local.yml
+++ b/.github/workflows/test-skypilot-local.yml
@@ -105,6 +105,16 @@ jobs:
       - name: sky local up
         run: uv run sky local up --no-gpus
 
+      # rclone runs inside the worker pod (not on the runner); setup-r2 only
+      # exports the `RCLONE_CONFIG_R2_*` env the `sky launch` step reads via
+      # `os.environ` and forwards into the pod through `task.update_envs`.
+      - name: Set up R2
+        uses: ./.github/actions/setup-r2
+        with:
+          access-key-id: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+          endpoint: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+
       # Launch the local-debug rclone task. R2 env vars are forwarded into
       # the worker pod via task.update_envs — same wiring the production
       # launcher uses on the cloud backends, so a regression here flags an
@@ -119,10 +129,6 @@ jobs:
       # — sharing the call from inside the same Python process is the
       # robust workaround.
       - name: sky launch (local-debug rclone task)
-        env:
-          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
-          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
-          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
         run: |
           set -o pipefail
           uv run python - <<'PY' 2>&1 | tee "$LOG_PATH"

--- a/.github/workflows/validate-dataset-shards.yaml
+++ b/.github/workflows/validate-dataset-shards.yaml
@@ -47,12 +47,6 @@ jobs:
     name: Validate spec structure
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    env:
-      RCLONE_CONFIG_R2_TYPE: s3
-      RCLONE_CONFIG_R2_PROVIDER: Cloudflare
-      RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
-      RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
-      RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -75,8 +69,15 @@ jobs:
           restore-keys: |
             pip-validate-spec-${{ runner.os }}-
 
-      - name: Install rclone
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
+      # Native runner with no preinstalled rclone; `validate_spec` reads the
+      # `RCLONE_CONFIG_R2_*` env this exports to pull the spec from R2.
+      - name: Set up R2
+        uses: ./.github/actions/setup-r2
+        with:
+          access-key-id: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+          endpoint: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+          install-rclone: "true"
 
       # synth_setter.pipeline.ci.validate_spec imports OUTPUT_FORMAT_TO_EXTENSION from
       # synth_setter.pipeline.schemas.spec (transitively pulls pydantic at module
@@ -110,18 +111,24 @@ jobs:
       - name: Pull dev-snapshot image
         run: docker pull "${IMAGE}"
 
+      # rclone runs inside the container; setup-r2 only exports the
+      # `RCLONE_CONFIG_R2_*` values the `docker run -e <VAR>` lines forward.
+      - name: Set up R2
+        uses: ./.github/actions/setup-r2
+        with:
+          access-key-id: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+          endpoint: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+
       - name: Validate every shard via R2
         env:
           SPEC_URI: ${{ inputs.spec_uri }}
-          RCLONE_CONFIG_R2_ACCESS_KEY_ID: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
-          RCLONE_CONFIG_R2_SECRET_ACCESS_KEY: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
-          RCLONE_CONFIG_R2_ENDPOINT: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
         run: |
           set -euo pipefail
           docker run --rm \
             -v "${{ github.workspace }}:/home/build/synth-setter:ro" \
-            -e RCLONE_CONFIG_R2_TYPE=s3 \
-            -e RCLONE_CONFIG_R2_PROVIDER=Cloudflare \
+            -e RCLONE_CONFIG_R2_TYPE \
+            -e RCLONE_CONFIG_R2_PROVIDER \
             -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
             -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
             -e RCLONE_CONFIG_R2_ENDPOINT \


### PR DESCRIPTION
## What

Applies the existing `setup-r2` composite action (created in #1372) to the R2 workflows that PR deferred. Each converted workflow drops its inline `RCLONE_CONFIG_R2_*` env and lets `./.github/actions/setup-r2` export the vars to `$GITHUB_ENV`; docker callers switch to value-less `-e RCLONE_CONFIG_R2_*` forwarding, and native callers opt into `install-rclone: "true"` where they previously ran their own `apt-get install rclone`.

## Converted (5)

- `test-skypilot-local.yml` — `setup-r2` before the `sky launch` step; the task inherits R2 env from `$GITHUB_ENV` via `os.environ`.
- `test-skypilot-debug.yml` — single `setup-r2` after Checkout; all three matrix rows (inline-sky, launcher-runner, launcher-docker) inherit the R2 trio. RunPod matrix is workflow_dispatch-only and was not triggered.
- `oci-image-bake.yaml` — `setup-r2` early; the OCI cred bootstrap (`write_provider_creds.sh`) and the SkyPilot launch step both inherit R2 from `$GITHUB_ENV`. `R2_ACCOUNT_ID` + OCI secrets stay inline (non-R2). Billable OCI lane not triggered.
- `generate-dataset-shards.yaml` — `setup-r2` after Checkout; the `skypilot-local` / `runpod` / `oci` rows and the shard-validation docker step inherit R2. Validation docker `-e RCLONE_CONFIG_R2_TYPE=s3`/`=Cloudflare` literals switched to value-less forwarding.
- `validate-dataset-shards.yaml` — `validate-spec` job uses `install-rclone: "true"` (native); `validate-shard` docker step switches the `=s3`/`=Cloudflare` literals to value-less forwarding.

## Left un-converted (2) — correctness over completeness

- `check-auth.yml` — its `Bootstrap provider credentials` step feeds the R2 trio to `write_provider_creds.sh` alongside non-R2 secrets and must stay inline. Converting only the standalone `Verify R2 auth` step would leave the workflow both delegating to `setup-r2` and inlining `RCLONE_CONFIG_R2_ACCESS_KEY_ID:`, which `test_setup_r2_callers_do_not_reinline_r2_env` forbids. Per the issue's fallback, the workflow is left entirely un-converted so the invariant holds.
- `r2-auth-probe.yaml` — the probe deliberately omits `RCLONE_CONFIG_R2_TYPE`/`_PROVIDER` to exercise `ensure_r2_env_loaded`'s structural `setdefault` (see its header). `setup-r2` exports those literals, which would defeat the probe's entire purpose, so it stays as-is.

## Validation

- `make test-infra` green (90 passed, 5 skipped), including `test_setup_r2_callers_do_not_reinline_r2_env`.
- `pre-commit` green on all changed files (Validate GitHub Workflows, prettier, codespell).
- Every edited file parses; `gha-workflow-validator` confirms `./.github/actions/setup-r2` resolves in each.

Closes #1381
Refs #1372