### PR TITLE
automation: give headless review-agent runs an --allowedTools allowlist so gh works

### DIFF
--- a/agent/hooks/_lib.sh
+++ b/agent/hooks/_lib.sh
@@ -129,9 +129,27 @@ run_agent_prompt() {
   else
     log "no GNU timeout/gtimeout on PATH; running agent without timeout enforcement"
   fi
+  # No TTY in a detached worktree, so the permission prompt can't be answered
+  # and any not-preapproved tool is auto-denied — pass an explicit allowlist,
+  # shared by the resolver and doc-drift runners. AGENT_ALLOWED_TOOLS replaces
+  # it (space-separated; empty/unset keeps the default). File inspection goes
+  # through first-class Read/Grep/Glob, not Bash(sed/cat/…), so edits can't slip
+  # past the Edit|Write guard hooks.
+  local -a allowed
+  read -r -a allowed <<< "${AGENT_ALLOWED_TOOLS:-}"
+  if [[ ${#allowed[@]} -eq 0 ]]; then
+    allowed=(
+      "Bash(gh:*)" "Bash(git:*)" "Bash(jq:*)"
+      Read Edit Write Grep Glob LS
+      "Bash(make:*)" "Bash(python:*)" "Bash(python3:*)" "Bash(uv:*)" "Bash(pre-commit:*)"
+    )
+  fi
+  # The prompt precedes --allowedTools: the option is variadic, so anything
+  # after it is swallowed into the tool list instead of read as the prompt.
   local -a cmd
   case "$cli" in
-    claude) cmd=(claude -p "$prompt") ;;
+    claude) cmd=(claude -p "$prompt" --allowedTools "${allowed[@]}") ;;
+    # codex uses its own approval/sandbox model; it has no --allowedTools.
     codex)  cmd=(codex exec "$prompt") ;;
     *)
       printf 'No supported headless agent CLI found; install claude or codex (AGENT_HEADLESS=%s).\n' \

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -425,6 +425,50 @@ T_resolver_report_lands_in_main_repo() {
 }
 it "pr-review-resolver: report file lands in main repo .agent-reviews/, not the worktree" T_resolver_report_lands_in_main_repo
 
+T_resolver_headless_agent_gets_allowedtools_for_gh() {
+  local report
+  export RESOLVER_SLEEP_SECS=1 GH_STUB_PR=99
+  unset CLAUDE_STUB_PWD_FILE CLAUDE_STUB_HEAD_FILE AGENT_ALLOWED_TOOLS
+  resolver_setup_feature_branch "feature-allowedtools"
+  echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh >/dev/null 2>&1 || true
+  report=$(find .agent-reviews -maxdepth 1 -name 'pr-review-resolver-*.md' 2>/dev/null | head -1)
+  [[ -n "$report" ]] || { echo "no report written"; return 1; }
+  grep -q -- "--allowedTools" "$report" || {
+    echo "headless agent invoked without --allowedTools — gh would be auto-denied:"
+    cat "$report"
+    return 1
+  }
+  grep -q -- "Bash(gh:\*)" "$report" || {
+    echo "allowlist is missing Bash(gh:*) — the resolver can't fetch PR comments:"
+    cat "$report"
+    return 1
+  }
+}
+it "pr-review-resolver: headless agent gets --allowedTools incl. Bash(gh:*) so gh isn't auto-denied" T_resolver_headless_agent_gets_allowedtools_for_gh
+
+T_resolver_agent_allowed_tools_env_overrides_default() {
+  local report
+  export RESOLVER_SLEEP_SECS=1 GH_STUB_PR=99
+  unset CLAUDE_STUB_PWD_FILE CLAUDE_STUB_HEAD_FILE
+  export AGENT_ALLOWED_TOOLS="Bash(gh:*) Read"
+  resolver_setup_feature_branch "feature-allowedtools-override"
+  echo '{"tool_input":{"command":"git push"}}' | bash agent/hooks/pr-review-resolver.sh >/dev/null 2>&1 || true
+  report=$(find .agent-reviews -maxdepth 1 -name 'pr-review-resolver-*.md' 2>/dev/null | head -1)
+  [[ -n "$report" ]] || { echo "no report written"; return 1; }
+  grep -q -- "Bash(gh:\*) Read" "$report" || {
+    echo "AGENT_ALLOWED_TOOLS override not passed through to the agent:"
+    cat "$report"
+    return 1
+  }
+  grep -q -- "Bash(pre-commit:\*)" "$report" && {
+    echo "default allowlist leaked despite AGENT_ALLOWED_TOOLS override"
+    cat "$report"
+    return 1
+  }
+  return 0
+}
+it "pr-review-resolver: AGENT_ALLOWED_TOOLS overrides the default allowlist" T_resolver_agent_allowed_tools_env_overrides_default
+
 T_resolver_worktree_cleaned_up_after_exit() {
   export RESOLVER_SLEEP_SECS=1 GH_STUB_PR=99
   resolver_setup_feature_branch "feature-cleanup"


### PR DESCRIPTION
## What

The `pr-review-resolver` and `doc-drift` PostToolUse hooks launch `claude -p` headlessly via `run_agent_prompt` (`agent/hooks/_lib.sh`). Pass an explicit `--allowedTools` allowlist to that invocation so the agents can actually run their tools, overridable via `AGENT_ALLOWED_TOOLS`.

## Why

`claude -p` has no TTY, so the interactive permission prompt can't be answered and any not-preapproved tool is **auto-denied**. `pr-review-resolver` needs `gh` to fetch and reply to PR review comments — on PR #1374 it bailed with "This command requires approval" on every `gh` call and resolved nothing. The detached worktree also lacks the primary checkout's untracked `.claude/settings.local.json` (which grants `gh` interactively), and the committed `.claude/settings.json` has no `permissions` block.

## How

- Default allowlist: `gh`, `git`, `jq`, first-class `Read/Edit/Write/Grep/Glob/LS`, and `make/python/uv/pre-commit` for validating fixes. Shell-text utilities (`sed`, `cat`, …) are intentionally **excluded** — they're redundant with the first-class tools and `sed -i` could edit files past the `Edit|Write` PreToolUse guard hooks.
- Prompt is ordered before the variadic `--allowedTools` so it isn't swallowed.
- `AGENT_ALLOWED_TOOLS` (space-separated) replaces the default; empty/unset falls back via an array-length guard (also avoids a `set -u` empty-array error on stock macOS bash).
- PreToolUse safety hooks (trailer-check, baseline-freeze, worktree-guard, yaml-run) fire on top of the allowlist regardless, so commits stay guarded.

## Tests

Two new cases in `agent/hooks/test.sh` (full suite 83/0): the headless invocation carries `--allowedTools` incl. `Bash(gh:*)`, and `AGENT_ALLOWED_TOOLS` overrides the default.

## Notes for reviewers

- Pre-PR review (`/repo-review-full-no-comments`, 4 passes): 0 BLOCK, 6 WARN — all addressed in-commit except the deliberate `Bash(git:*)` breadth (guarded by PreToolUse hooks + detached-worktree isolation). Detail in the rendered report.

Fixes #1382