### PR TITLE
automation(claude): Default Claude Code permission mode to "auto" in committed .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "permissions": { "defaultMode": "auto" },
   "enabledPlugins": { "tinaudio-synth-setter-skills@tinaudio-skills": true },
   "extraKnownMarketplaces": {
     "tinaudio-skills": {


### PR DESCRIPTION
## What

Adds `"permissions": { "defaultMode": "auto" }` to the committed `.claude/settings.json` so every checkout / devcontainer that mounts the repo defaults Claude Code to **auto** permission mode.

In auto mode an LLM classifier auto-approves safe actions (edits and most bash) and only prompts for risky or destructive ones. The repo's `PreToolUse` guardrail hooks (worktree-guard, git-commit-trailer-check, pre-pr-review-gate, no-baseline-additions, no-yaml-run-comments) fire in **every** permission mode, so no existing guardrail is bypassed.

## Why

Removes the per-session permission-mode toggle for everyone working in the devcontainer; the safe-by-classifier default matches how the repo is already used.

## Scope

One key added; no change to existing hooks, plugins, or marketplaces. `"auto"` is a schema-valid `permissions.defaultMode` enum value.

## Review

Pre-PR `repo-review-full-no-comments`: 1 BLOCK (resolved — false positive; `"auto"` is a valid enum value per the live settings schema) and 2 WARN (acknowledged — intentional committed-scope choice; guardrail hooks unaffected).

Fixes #1386
