### PR TITLE
test(testing): harden offline-wandb history read against async flush race

### DIFF
--- a/tests/helpers/wandb_offline.py
+++ b/tests/helpers/wandb_offline.py
@@ -14,6 +14,8 @@ updating one site.
 
 from __future__ import annotations
 
+import time
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -33,31 +35,70 @@ except ImportError as exc:  # pragma: no cover — guards a future wandb upgrade
     )
 
 
-def read_history_rows(wandb_binary: Path) -> list[dict[str, str]]:
+_FLUSH_TIMEOUT_S = 10.0
+_FLUSH_POLL_S = 0.05
+
+
+def read_history_rows(
+    wandb_binary: Path,
+    *,
+    until: Callable[[list[dict[str, str]]], bool] | None = None,
+    timeout_s: float = _FLUSH_TIMEOUT_S,
+) -> list[dict[str, str]]:
     """Decode history records in a wandb offline ``run-*.wandb`` binary.
 
     Slash-paths arrive as ``nested_key`` (e.g. ``['shard', 'bytes']``); the
     rejoiner reconstructs the keys callers passed to ``log_metrics`` so the
     caller's assertions read like the production payload.
 
+    The offline writer flushes history asynchronously, so a single scan can
+    race ahead of the records (a conda-only 0-rows flake). Pass ``until`` to
+    re-scan until the predicate holds; on timeout the last scan is returned so
+    the caller's own assertion reports the shortfall.
+
     :param wandb_binary: Path to the offline ``run-*.wandb`` file.
+    :param until: Predicate over the decoded rows; when omitted the binary is
+        scanned exactly once (no polling).
+    :param timeout_s: Upper bound on flush polling; ignored when ``until`` is
+        ``None``.
     :returns: One dict per history record; values are JSON-encoded strings
         (as the datastore stores them).
     """
+    if until is None:
+        return _scan_history_rows(wandb_binary)
+    deadline = time.monotonic() + timeout_s
+    while True:
+        rows = _scan_history_rows(wandb_binary)
+        if until(rows) or time.monotonic() >= deadline:
+            return rows
+        time.sleep(_FLUSH_POLL_S)
+
+
+def _scan_history_rows(wandb_binary: Path) -> list[dict[str, str]]:
+    """Single-pass decode of the datastore binary's history records.
+
+    :param wandb_binary: Path to the offline ``run-*.wandb`` file.
+    :returns: One dict per history record found in this scan.
+    """
     ds = wandb_datastore.DataStore()
     ds.open_for_scan(str(wandb_binary))
-    rows: list[dict[str, str]] = []
-    while True:
-        data = ds.scan_data()
-        if data is None:
-            break
-        rec = wandb_pb.Record()  # pyright: ignore[reportAttributeAccessIssue]
-        rec.ParseFromString(data)
-        if not rec.HasField("history"):
-            continue
-        row: dict[str, str] = {}
-        for item in rec.history.item:
-            key = item.key if item.key else "/".join(item.nested_key)
-            row[key] = item.value_json
-        rows.append(row)
-    return rows
+    # ``open_for_scan`` opens a file handle; close it each pass so the polling
+    # loop in ``read_history_rows`` can't leak one handle per re-scan.
+    try:
+        rows: list[dict[str, str]] = []
+        while True:
+            data = ds.scan_data()
+            if data is None:
+                break
+            rec = wandb_pb.Record()  # pyright: ignore[reportAttributeAccessIssue]
+            rec.ParseFromString(data)
+            if not rec.HasField("history"):
+                continue
+            row: dict[str, str] = {}
+            for item in rec.history.item:
+                key = item.key if item.key else "/".join(item.nested_key)
+                row[key] = item.value_json
+            rows.append(row)
+        return rows
+    finally:
+        ds.close()

--- a/tests/integration/test_generate_dataset_cli_wandb_e2e.py
+++ b/tests/integration/test_generate_dataset_cli_wandb_e2e.py
@@ -250,7 +250,13 @@ def test_phase_1_and_2_cli_emits_run_id_plus_shard_and_summary_history(
     assert len(wandb_binaries) == 1, (
         f"expected exactly one .wandb binary under {run_dir}; got {wandb_binaries}"
     )
-    rows = read_history_rows(wandb_binaries[0])
+    rows = read_history_rows(
+        wandb_binaries[0],
+        until=lambda scanned: (
+            sum("shard/bytes" in r for r in scanned) >= _SMOKE_NUM_SHARDS
+            and any("shards/rendered" in r for r in scanned)
+        ),
+    )
 
     shard_rows = [r for r in rows if "shard/bytes" in r]
     assert len(shard_rows) == _SMOKE_NUM_SHARDS, (
@@ -415,7 +421,13 @@ def test_oracle_eval_inline_resumes_generate_wandb_run(
     )
 
     generate_binary = _single_wandb_binary(generate_run_dir)
-    generate_rows = read_history_rows(generate_binary)
+    generate_rows = read_history_rows(
+        generate_binary,
+        until=lambda scanned: (
+            any("shard/bytes" in r for r in scanned)
+            and any("shards/rendered" in r for r in scanned)
+        ),
+    )
     assert any("shard/bytes" in r for r in generate_rows), (
         f"generate dir missing per-shard history rows in {generate_binary}"
     )
@@ -424,7 +436,10 @@ def test_oracle_eval_inline_resumes_generate_wandb_run(
     )
 
     eval_binary = _single_wandb_binary(eval_run_dir)
-    eval_rows = read_history_rows(eval_binary)
+    eval_rows = read_history_rows(
+        eval_binary,
+        until=lambda scanned: any(any(k.startswith("audio/") for k in r) for r in scanned),
+    )
     assert any(any(k.startswith("audio/") for k in r) for r in eval_rows), (
         f"eval dir has no audio/* history rows in {eval_binary}; "
         f"the predict-mode oracle eval did not log audio metrics to the resumed run"

--- a/tests/test_generate_dataset_wandb.py
+++ b/tests/test_generate_dataset_wandb.py
@@ -175,7 +175,13 @@ def test_generate_logs_per_shard_and_summary_metrics_offline(
     )
     assert len(binary_files) == 1, f"expected exactly one .wandb binary, found {binary_files}"
 
-    rows = read_history_rows(Path(binary_files[0]))
+    rows = read_history_rows(
+        Path(binary_files[0]),
+        until=lambda scanned: (
+            sum("shard/bytes" in r for r in scanned) >= spec.num_shards
+            and any("shards/rendered" in r for r in scanned)
+        ),
+    )
     shard_rows = [r for r in rows if "shard/bytes" in r]
     assert len(shard_rows) == spec.num_shards, (
         f"expected {spec.num_shards} per-shard history rows, got {len(shard_rows)}: {shard_rows}"

--- a/tests/test_wandb_offline_helper.py
+++ b/tests/test_wandb_offline_helper.py
@@ -1,0 +1,111 @@
+"""Unit tests for the offline-wandb history decoder's flush-race polling.
+
+The offline writer serializes history records to the ``run-*.wandb`` binary
+asynchronously, so a single-shot read can land before the records flush
+(observed as a conda-only 0-rows flake). ``read_history_rows(until=...)``
+polls until the caller's predicate holds; these tests pin that retry contract
+by stubbing the per-attempt scan and freezing the clock so no real datastore
+binary or wall-clock wait is needed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.helpers import wandb_offline
+
+
+def test_until_predicate_retries_until_rows_materialize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty early scans are retried — one ``sleep`` per gap — until the predicate holds.
+
+    :param monkeypatch: Replaces the per-attempt scan and counts ``sleep`` so
+        the flush lag is simulated without a real binary or wall-clock wait.
+    """
+    scans = iter([[], [], [{"shard/bytes": "1024"}]])
+    scan_count = 0
+    sleep_count = 0
+
+    def _scan(_path: Path) -> list[dict[str, str]]:
+        nonlocal scan_count
+        scan_count += 1
+        return next(scans)
+
+    def _sleep(_s: float) -> None:
+        nonlocal sleep_count
+        sleep_count += 1
+
+    monkeypatch.setattr(wandb_offline, "_scan_history_rows", _scan)
+    monkeypatch.setattr(wandb_offline.time, "sleep", _sleep)
+
+    rows = wandb_offline.read_history_rows(
+        Path("ignored.wandb"),
+        until=lambda scanned: any("shard/bytes" in r for r in scanned),
+    )
+
+    assert rows == [{"shard/bytes": "1024"}]
+    assert scan_count == 3
+    assert sleep_count == 2
+
+
+def test_until_predicate_polls_to_deadline_then_returns_last_scan(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A never-satisfied predicate keeps polling until the deadline, then returns the last scan.
+
+    Drives a fake monotonic clock that advances one second per reading; with
+    ``timeout_s=2.5`` the deadline is crossed only after several polls, so this
+    pins the loop's deadline exit (not a first-iteration short-circuit) and
+    that the unsatisfied caller still receives rows to assert against.
+
+    :param monkeypatch: Stubs the scan to stay empty, advances a fake clock,
+        and freezes ``sleep`` so the timeout is reached without real elapsed
+        time.
+    """
+    ticks = iter(range(100))
+    scan_count = 0
+
+    def _scan(_path: Path) -> list[dict[str, str]]:
+        nonlocal scan_count
+        scan_count += 1
+        return []
+
+    monkeypatch.setattr(wandb_offline, "_scan_history_rows", _scan)
+    monkeypatch.setattr(wandb_offline.time, "monotonic", lambda: float(next(ticks)))
+    monkeypatch.setattr(wandb_offline.time, "sleep", lambda _s: None)
+
+    rows = wandb_offline.read_history_rows(
+        Path("ignored.wandb"),
+        until=lambda scanned: len(scanned) > 0,
+        timeout_s=2.5,
+    )
+
+    assert rows == []
+    assert scan_count > 1
+
+
+def test_without_predicate_reads_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Omitting ``until`` keeps the single-shot contract — one scan, never sleeps.
+
+    :param monkeypatch: Counts scan invocations and fails ``sleep`` to prove no
+        retry loop runs.
+    """
+    scan_count = 0
+
+    def _scan(_path: Path) -> list[dict[str, str]]:
+        nonlocal scan_count
+        scan_count += 1
+        return []
+
+    monkeypatch.setattr(wandb_offline, "_scan_history_rows", _scan)
+    monkeypatch.setattr(
+        wandb_offline.time, "sleep", lambda _s: pytest.fail("single-shot read must not sleep")
+    )
+
+    rows = wandb_offline.read_history_rows(Path("ignored.wandb"))
+
+    assert rows == []
+    assert scan_count == 1


### PR DESCRIPTION
## What & why

`tests/test_generate_dataset_wandb.py::test_generate_logs_per_shard_and_summary_metrics_offline` flaked on the **conda** CI job ([run 26850084587](https://github.com/tinaudio/synth-setter/actions/runs/26850084587/job/79179729041)) with `expected 2 per-shard history rows, got 0`. The same commit passed `run_tests_conda` on `main` and the identical test passed on MPS, ubuntu (3.10/3.11), and macOS in the same run — a non-deterministic flake, not a regression. The triggering PR (#1363) was a config-only change unrelated to wandb.

**Root cause:** `tests/helpers/wandb_offline.read_history_rows` decoded the offline `run-*.wandb` datastore in a single pass right after `generate()` returned. The wandb offline writer flushes history records asynchronously, so on a slower (conda-resolved) writer the scan races ahead of the records and sees zero rows. The all-or-nothing "0 rows" shape is the tell of a flush race rather than a decode bug.

## Change

- `read_history_rows` gains an optional `until=<predicate>`: when passed, it re-scans until the predicate holds or `timeout_s` (default 10s, 50ms poll) elapses, **returning the last scan on timeout** so the caller's own assertion still reports the real shortfall. `until=None` keeps the exact single-shot behavior.
- Split the decode into `_scan_history_rows` (the unchanged single pass) and close the datastore handle each scan so the polling loop can't leak a file handle per re-scan.
- Wired the predicate into all four offline-wandb consumers (the originally-failing test + 3 e2e call sites), each matching what it then asserts.
- New `tests/test_wandb_offline_helper.py` pins the retry / deadline-timeout / single-shot paths deterministically (stubbed scan + fake clock, asserting scan and sleep counts).

## Verification

- `test_generate_dataset_wandb.py` (both offline tests) + 3 new helper tests: pass.
- The originally-failing test run 100× under xdist: 100/100 before and after locally — this Linux/non-conda env (matching the CI jobs that passed) cannot reproduce the conda-specific race, so the deterministic proof is in the unit tests, which simulate the flush lag directly. No regression / no slowdown (happy path returns on the first scan).
- pre-commit (ruff, pyright, pydoclint, docformatter, interrogate, codespell) clean.

Fixes #1378