### PR TITLE
chore(ci-automation): centralize remaining inline rclone installs via setup-r2 install-rclone

### DIFF
--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -183,16 +183,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      # rclone runs inside the worker container/pod, so no host install here;
-      # setup-r2 exports the `RCLONE_CONFIG_R2_*` env every downstream consumer
-      # reads — the launcher's cred bootstrap + rclone upload (native and
-      # in-container) and the `docker run -e <VAR>` shard-validation forward.
+      # setup-r2 exports RCLONE_CONFIG_R2_* for every downstream consumer; only
+      # skypilot-local runs `rclone copyto` on the runner, so only it installs
+      # rclone — runpod/oci run it in the worker container/pod.
       - name: Set up R2
         uses: ./.github/actions/setup-r2
         with:
           access-key-id: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
           secret-access-key: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
           endpoint: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+          install-rclone: ${{ inputs.provider == 'skypilot-local' }}
 
       # Reject hydra_overrides containing anything outside the allowed character
       # class. The docker (runpod/oci) row expands `$HYDRA_OVERRIDES_EXTRA`
@@ -355,7 +355,6 @@ jobs:
           set -euo pipefail
           uv sync --frozen --extra cpu --no-default-groups --group dev
           echo "${UV_PROJECT_ENVIRONMENT}/bin" >> "${GITHUB_PATH}"
-          sudo apt-get install -y -qq rclone
 
       - name: sky local up (skypilot-local row)
         if: ${{ inputs.provider == 'skypilot-local' }}

--- a/.github/workflows/test-skypilot-debug.yml
+++ b/.github/workflows/test-skypilot-debug.yml
@@ -223,16 +223,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      # rclone runs inside the worker pod/container, not on the runner; setup-r2
-      # exports the `RCLONE_CONFIG_R2_*` env every probe row reads — inline-sky
-      # and launcher-runner via `os.environ` into `task.update_envs`, and
-      # launcher-docker via value-less `docker run -e <VAR>` forwarding.
+      # setup-r2 exports RCLONE_CONFIG_R2_* for every probe row; only
+      # launcher-runner runs `rclone copyto` on the runner (spec_io.upload_spec),
+      # so only it installs rclone — other rows ship/run it on the worker.
       - name: Set up R2
         uses: ./.github/actions/setup-r2
         with:
           access-key-id: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
           secret-access-key: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
           endpoint: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+          install-rclone: ${{ matrix.mode == 'launcher-runner' }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -366,15 +366,6 @@ jobs:
       - name: Install launcher deps (launcher-runner mode)
         if: matrix.mode == 'launcher-runner'
         run: uv sync --frozen --extra cpu --no-default-groups --group dev
-
-      # `spec_io.upload_spec` shells out to `rclone copyto` to ship the
-      # materialized spec to R2. The dev-snapshot image has rclone baked in,
-      # but the bare GH-actions runner doesn't — install it for
-      # launcher-runner mode only. launcher-docker mode runs the launcher
-      # inside the image and skips this.
-      - name: Install rclone (launcher-runner mode)
-        if: matrix.mode == 'launcher-runner'
-        run: sudo apt-get update -qq && sudo apt-get install -y -qq rclone
 
       # Launcher invokes the cred-bootstrap script itself (capturing stdout
       # via subprocess.run) and bridges RCLONE_CONFIG_R2_* from worker_env


### PR DESCRIPTION
## What

Follow-up to #1383, which migrated the 5 deferred R2 workflows onto the `setup-r2` composite but left two **native** lanes installing rclone with a separate inline `apt-get install rclone` step instead of the composite's `install-rclone` input. Copilot flagged both on that PR; #1381's acceptance criteria ("with `install-rclone: true` on native runners") called for exactly this.

This drives `install-rclone` from each lane's selector so rclone lands only where the launcher runs `rclone copyto` on the runner itself:

- `test-skypilot-debug.yml` — `install-rclone: ${{ matrix.mode == 'launcher-runner' }}`, dropping the standalone `Install rclone (launcher-runner mode)` step.
- `generate-dataset-shards.yaml` — `install-rclone: ${{ inputs.provider == 'skypilot-local' }}`, dropping the inline `apt-get install rclone` from the launcher-deps step.

The boolean expressions render the GHA strings `true`/`false`, which the composite's `if: inputs.install-rclone == 'true'` consumes. The gated rows exactly match the rows that previously ran the inline install — docker/pod rows keep the default (rclone ships in the image / runs on the worker). No behavior change.

As a minor side benefit, the `generate-dataset-shards.yaml` inline step ran `apt-get install` without an `apt-get update`; the composite runs `update && install`, removing a latent stale-index risk.

## Validation

- `make test-infra` green (90 passed, 5 skipped), including `test_setup_r2_action.py` (`test_setup_r2_install_rclone_is_opt_in`, `test_setup_r2_callers_do_not_reinline_r2_env`).
- `pre-commit` green on both changed files (Validate GitHub Workflows, prettier, codespell).
- `/repo-review-full-no-comments` (5 parallel passes) returned 0 BLOCK; the only WARNs were comment-hygiene nits on the touched comments, applied before pushing.

Refs #1392

## Out of scope

`check-auth.yml` and `r2-auth-probe.yaml` keep their inline `apt-get install rclone` — #1383 deliberately left both un-converted (check-auth bundles the R2 trio into `write_provider_creds.sh` with non-R2 creds; r2-auth-probe intentionally omits `RCLONE_CONFIG_R2_TYPE`/`_PROVIDER` to exercise the structural `setdefault`). This PR scopes the "no inline install" claim to the two converted lanes only.
