### PR TITLE
ci(pipeline): fix. defer omegaconf import so the validate_spec minimal-env CI job imports cleanly

### DIFF
--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -15,9 +15,8 @@ import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
-from omegaconf import DictConfig, OmegaConf
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -34,6 +33,9 @@ from synth_setter.pipeline.schemas.prefix import (
     make_r2_prefix,
 )
 from synth_setter.pipeline.schemas.r2_location import R2Location
+
+if TYPE_CHECKING:
+    from omegaconf import DictConfig
 
 __all__ = [
     "EXTENSION_TO_OUTPUT_FORMAT",
@@ -608,6 +610,10 @@ class DatasetSpec(BaseModel):
             which ``masked_copy`` rejects with ``ValueError``) or the masked cfg
             did not resolve to a mapping — both normalized to one stable type.
         """
+        # Lazy import: omegaconf is absent from the minimal-env CI install that
+        # runs `validate_spec`, which imports this module but never calls this.
+        from omegaconf import OmegaConf
+
         spec_keys = [k for k in cfg if isinstance(k, str) and k in cls.model_fields]
         try:
             masked = OmegaConf.masked_copy(cfg, spec_keys)

--- a/tests/pipeline/schemas/test_dataset_spec.py
+++ b/tests/pipeline/schemas/test_dataset_spec.py
@@ -816,6 +816,33 @@ class TestSpecImportStaysLauncherPure:
             f"stdout={result.stdout}\nstderr={result.stderr}"
         )
 
+    def test_bare_spec_import_does_not_pull_omegaconf(self) -> None:
+        """Bare spec import must not load ``omegaconf`` at module level.
+
+        ``omegaconf`` is only needed by ``DatasetSpec.from_hydra_cfg`` and runs
+        lazily inside it. The CI ``validate_spec`` job installs a minimal env
+        (pydantic + python-dotenv, no omegaconf); promoting the import back to
+        module level fails this test before that job breaks at runtime.
+        """
+        script = (
+            "import sys\n"
+            "import synth_setter.pipeline.schemas.spec  # noqa: F401\n"
+            "assert 'omegaconf' not in sys.modules, (\n"
+            "    'omegaconf leaked into spec module import; this breaks the '\n"
+            "    'validate_spec minimal-env contract'\n"
+            ")\n"
+        )
+        result = subprocess.run(  # noqa: S603 — sys.executable + literal script
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, (
+            f"bare spec import now pulls omegaconf:\n"
+            f"stdout={result.stdout}\nstderr={result.stderr}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Stronger pedalboard-free invariant — construction + serialization must not


### PR DESCRIPTION
## Problem

The scheduled *Test Dataset Generation* run failed in the `Validate spec structure` job (`validate-dataset-shards.yaml`) with:

```
ModuleNotFoundError: No module named 'omegaconf'
  File ".../pipeline/ci/validate_spec.py", line 14, in <module>
    from synth_setter.pipeline.schemas.spec import (...)
  File ".../pipeline/schemas/spec.py", line 20, in <module>
    from omegaconf import DictConfig, OmegaConf
```

That job deliberately installs a minimal env (`pip install --no-deps -e .` + `pydantic` + `python-dotenv`, no omegaconf) so the structural check stays fast. #1390 added a **module-level** `from omegaconf import DictConfig, OmegaConf` to `spec.py` for the new `DatasetSpec.from_hydra_cfg`, which runs on every import of the module — including `validate_spec`'s import chain — breaking the minimal-env contract.

## Fix

- Move `OmegaConf` to a **lazy import inside `from_hydra_cfg`** (its only runtime user).
- Move `DictConfig` to a `TYPE_CHECKING` block — the `cfg: DictConfig` annotation is already a string under `from __future__ import annotations`, so no runtime symbol is needed.
- Add `test_bare_spec_import_does_not_pull_omegaconf`, a subprocess import-purity test mirroring the existing launcher-pure checks, so a future re-promotion of the import fails locally before CI breaks.

This is the interim unblock; the long-term `pipeline-ci` dependency group that removes the `--no-deps` hack class is tracked separately and being implemented in parallel.

Refs #1139

## Test plan

- `uv run pytest tests/pipeline/schemas/test_dataset_spec.py tests/pipeline/ci_validate/test_validate_spec.py` — 104 passed.
- New test confirmed RED before the fix, GREEN after.
- `make format` clean (ruff, pyright, pydoclint, …).
- Pre-PR `/repo-review-full-no-comments`: 0 BLOCK, 1 stylistic WARN across 7 skills.
