### PR TITLE
fix(eval): inline oracle-eval fetches whole dataset root so VDS split shards resolve

### DIFF
--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -32,7 +32,7 @@ from omegaconf import DictConfig, OmegaConf
 from synth_setter.cli.finalize_dataset import finalize_from_spec
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.pipeline import r2_io
-from synth_setter.pipeline.constants import STATS_NPZ_FILENAME, WORKER_SPEC_URI_ENV
+from synth_setter.pipeline.constants import WORKER_SPEC_URI_ENV
 from synth_setter.pipeline.partitioning import (
     available_cpus,
     get_my_shards,
@@ -60,20 +60,20 @@ _WORKER_REPO_ROOT = "/home/build/synth-setter"
 _ORACLE_EVAL_TIMEOUT_SECONDS = 600
 
 
-def _download_finalized_splits(spec: DatasetSpec, dest: Path) -> None:
-    """Download ``{train,val,test}.h5`` + ``stats.npz`` into ``dest``.
+def _download_dataset_root(spec: DatasetSpec, dest: Path) -> None:
+    """Download the whole finalized dataset root from R2 into ``dest``.
 
-    The eval datamodule loads normalization stats from ``dest/stats.npz``
-    (``use_saved_mean_and_variance=true``), so it must land beside the splits.
+    Fetches every object under ``spec.r2`` — the split ``.h5`` files,
+    ``stats.npz``, and the ``shard-*.h5`` files. The splits are HDF5 virtual
+    datasets that reference the shards by basename, so the shards must land
+    beside them or the eval datamodule reads dangling mappings (zeros, then an
+    ``insufficient elements`` OSError). The datamodule also loads normalization
+    stats from ``dest/stats.npz`` (``use_saved_mean_and_variance=true``).
 
-    :param spec: Resolves the R2 URIs via ``spec.r2.split_h5_uri`` /
-        ``spec.r2.stats_uri``.
-    :param dest: Local directory to receive the splits and stats file.
+    :param spec: Resolves the dataset-root prefix via ``spec.r2.dataset_root_uri``.
+    :param dest: Local directory to receive the dataset root (created by rclone).
     """
-    dest.mkdir(parents=True, exist_ok=True)
-    for split in ("train", "val", "test"):
-        r2_io.download_to_path(spec.r2.split_h5_uri(split), dest / f"{split}.h5")
-    r2_io.download_to_path(spec.r2.stats_uri(), dest / STATS_NPZ_FILENAME)
+    r2_io.download_dir_no_overwrite(spec.r2.dataset_root_uri(), dest)
 
 
 def _run_oracle_eval_subprocess(dataset_root: Path, run_id: str) -> None:
@@ -761,7 +761,7 @@ def main(cfg: DictConfig) -> None:
             finalize_from_spec(spec, Path(cfg.paths.output_dir))
         if cfg.oracle_eval_inline:
             eval_dir = Path(cfg.paths.output_dir) / "oracle_eval" / spec.run_id
-            _download_finalized_splits(spec, eval_dir)
+            _download_dataset_root(spec, eval_dir)
             _run_oracle_eval_subprocess(eval_dir, spec.run_id)
         return
 

--- a/src/synth_setter/pipeline/schemas/r2_location.py
+++ b/src/synth_setter/pipeline/schemas/r2_location.py
@@ -164,6 +164,19 @@ class R2Location(BaseModel):
         """
         return f"{R2_URI_SCHEME}{self.bucket}/{self.prefix}{name}"
 
+    def dataset_root_uri(self) -> str:
+        """R2 URI of the dataset-root prefix itself: ``r2://<bucket>/<prefix>``.
+
+        The directory-level analogue of the per-object helpers — shards, splits,
+        and ``stats.npz`` all live flat beneath this prefix, so a recursive copy
+        of it fetches the whole dataset root. Split ``.h5`` files are HDF5 virtual
+        datasets that reference the shards by basename, so a consumer must fetch
+        the root (not just the splits) to keep those mappings resolvable.
+
+        :returns: ``r2://<bucket>/<prefix>`` URI string (trailing slash preserved).
+        """
+        return self._under_prefix("")
+
     def shard_uri(self, shard: ShardSpec) -> str:
         """Return the canonical R2 URI for ``shard``: ``r2://<bucket>/<prefix><filename>``.
 

--- a/tests/pipeline/entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset.py
@@ -1626,7 +1626,7 @@ class TestMainDispatchBranches:
 
         Asserts the eval helper fires once with ``dataset_root`` under
         ``_OPERATOR_WORKSPACE/oracle_eval/<run_id>/`` and that
-        ``_download_finalized_splits`` populates the same path first.
+        ``_download_dataset_root`` populates the same path first.
 
         :param monkeypatch: Patches argv + the four module-level seams.
         """
@@ -1646,7 +1646,7 @@ class TestMainDispatchBranches:
         monkeypatch.setattr(gd, "generate", lambda _spec, _work_dir, _loggers: None)
         monkeypatch.setattr(gd, "finalize_from_spec", MagicMock())
         download_mock = MagicMock()
-        monkeypatch.setattr(gd, "_download_finalized_splits", download_mock)
+        monkeypatch.setattr(gd, "_download_dataset_root", download_mock)
         oracle_mock = MagicMock()
         monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
 
@@ -1662,36 +1662,40 @@ class TestMainDispatchBranches:
         _, downloaded_dest = download_mock.call_args[0]
         assert downloaded_dest == dataset_root
 
-    def test_download_finalized_splits_fetches_stats_npz_beside_splits(
+    def test_download_dataset_root_fetches_shards_beside_splits(
         self,
         spec: DatasetSpec,
-        monkeypatch: pytest.MonkeyPatch,
+        fake_r2_remote: Path,
         tmp_path: Path,
     ) -> None:
-        """Finalize download lands ``stats.npz`` in the same dir as the splits.
+        """The download fetches the whole dataset root — shards, not just splits + stats.
 
-        The eval datamodule loads normalization stats from
-        ``<dataset_root>/stats.npz`` (``use_saved_mean_and_variance=true``);
-        without it the inline oracle eval crashes — see #1331.
+        Split ``.h5`` files are HDF5 virtual datasets that reference the shards
+        by basename, so the eval reads dangling mappings unless the shards land
+        beside them. A splits-only download leaves those mappings unresolvable.
+        Staged through the real rclone passthrough and asserted on materialized
+        files rather than a mock's call list.
 
-        :param spec: Fixture-provided ``DatasetSpec``; resolves the R2 URIs.
-        :param monkeypatch: Patches the module's ``r2_io.download_to_path``.
-        :param tmp_path: Destination dir for the downloaded artifacts.
+        :param spec: Fixture-provided ``DatasetSpec``; resolves the dataset-root URI.
+        :param fake_r2_remote: Local-typed R2 remote rooted at a tmp dir.
+        :param tmp_path: Destination dir for the downloaded dataset root.
         """
         import synth_setter.cli.generate_dataset as gd
 
-        downloads: dict[Path, str] = {}
-        monkeypatch.setattr(
-            gd.r2_io,
-            "download_to_path",
-            lambda uri, dest: downloads.__setitem__(Path(dest), uri),
-        )
+        remote_root = fake_r2_remote / spec.r2.bucket / spec.r2.prefix
+        remote_root.mkdir(parents=True)
+        for name in ("train.h5", "val.h5", "test.h5", "stats.npz"):
+            (remote_root / name).write_text(name)
+        for shard in spec.shards:
+            (remote_root / shard.filename).write_text("shard-bytes")
+        dest = tmp_path / "eval"
 
-        gd._download_finalized_splits(spec, tmp_path)
+        gd._download_dataset_root(spec, dest)
 
-        assert downloads[tmp_path / "stats.npz"] == spec.r2.stats_uri()
-        for split in ("train", "val", "test"):
-            assert downloads[tmp_path / f"{split}.h5"] == spec.r2.split_h5_uri(split)
+        assert (dest / "test.h5").read_text() == "test.h5"
+        assert (dest / "stats.npz").read_text() == "stats.npz"
+        for shard in spec.shards:
+            assert (dest / shard.filename).is_file()
 
     def test_run_oracle_eval_subprocess_builds_expected_argv(
         self,
@@ -1761,7 +1765,7 @@ class TestMainDispatchBranches:
         monkeypatch.setattr(gd, "finalize_from_spec", MagicMock())
         download_mock = MagicMock()
         oracle_mock = MagicMock()
-        monkeypatch.setattr(gd, "_download_finalized_splits", download_mock)
+        monkeypatch.setattr(gd, "_download_dataset_root", download_mock)
         monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
 
         gd.main()

--- a/tests/pipeline/schemas/test_r2_location.py
+++ b/tests/pipeline/schemas/test_r2_location.py
@@ -203,6 +203,15 @@ class TestR2LocationLayoutHelpers:
         loc = R2Location(bucket="intermediate-data", prefix="data/run/")
         assert loc.stats_uri() == "r2://intermediate-data/data/run/stats.npz"
 
+    def test_dataset_root_uri(self) -> None:
+        """``dataset_root_uri()`` returns the bare prefix ``r2://<bucket>/<prefix>``.
+
+        The trailing slash is preserved so a recursive ``rclone copy`` of the
+        prefix fetches the whole dataset root (shards + splits + stats).
+        """
+        loc = R2Location(bucket="intermediate-data", prefix="data/run/")
+        assert loc.dataset_root_uri() == "r2://intermediate-data/data/run/"
+
     def test_worker_staged_shard_uri(self) -> None:
         """Joins shard_id, worker_id, attempt_uuid, ext under metadata/workers/shards/."""
         loc = R2Location(bucket="intermediate-data", prefix="data/run/")
@@ -243,6 +252,7 @@ class TestR2LocationLayoutHelpers:
         assert loc.split_h5_uri("train").startswith(expected_root)
         assert loc.split_wds_brace_uri((0, 1)).startswith(expected_root)
         assert loc.stats_uri().startswith(expected_root)
+        assert loc.dataset_root_uri().startswith(expected_root)
         assert loc.worker_staged_shard_uri(
             shard_id=0, worker_id="w", attempt_uuid="u", ext=".h5"
         ).startswith(expected_root)


### PR DESCRIPTION
## Problem

The inline oracle-eval (added in #1338) crashes during `mode=predict` reading the `audio` dataset:

```
OSError: Can't synchronously read data (insufficient elements in destination selection)
  surge_datamodule.py:106  ds[start_idx:end_idx]   # the "audio" dataset
```

It surfaces when running the `generate_dataset_cadence` sweep with `oracle_eval_inline=true`.

## Root cause

The finalized `{train,val,test}.h5` splits are **HDF5 virtual datasets** (`reshard.py`) that reference the source `shard-*.h5` files **by relative basename** — they hold no data themselves (`storage_size=0`) and only resolve when the shards are co-located. `_download_finalized_splits` downloaded only the three split files + `stats.npz` into a fresh `oracle_eval/<run_id>/` directory, **without the shards**. The dangling virtual mappings read back fill-value zeros for the first row and raise `insufficient elements` for the rest.

Verified empirically: the run-dir `test.h5` (shards beside it) reads real audio; the relocated `oracle_eval/` copy fails on `audio[1:2]`. The datamodule reads correctly — the data simply wasn't co-located.

## Fix

Download the **whole dataset-root prefix** (shards + splits + stats) via `r2_io.download_dir_no_overwrite`, so the virtual mappings resolve. Adds `R2Location.dataset_root_uri()` for the prefix-level URI and renames the helper `_download_finalized_splits` → `_download_dataset_root` to match its new behavior.

## Tests

- `test_dataset_root_uri` pins the bare-prefix URI (trailing slash preserved).
- `test_download_dataset_root_fetches_shards_beside_splits` — state-based via the real-rclone `fake_r2_remote` fixture; asserts the shards land beside the splits. Verified to FAIL against the old splits-only implementation and PASS against the fix. `stats.npz` coverage preserved.
- `make format` clean (ruff, pyright, pydoclint, …); 182 tests pass across the touched suites.

Fixes #1396
