### PR TITLE
fix(eval): inline oracle-eval reads finalized VDS splits in place from the local run dir (no R2 download)

### DIFF
--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -32,7 +32,7 @@ from omegaconf import DictConfig, OmegaConf
 from synth_setter.cli.finalize_dataset import finalize_from_spec
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.pipeline import r2_io
-from synth_setter.pipeline.constants import WORKER_SPEC_URI_ENV
+from synth_setter.pipeline.constants import STATS_NPZ_FILENAME, WORKER_SPEC_URI_ENV
 from synth_setter.pipeline.partitioning import (
     available_cpus,
     get_my_shards,
@@ -59,6 +59,9 @@ _WORKER_REPO_ROOT = "/home/build/synth-setter"
 # Smoke-shard-sized; longer eval runs belong on the dispatch path, not inline.
 _ORACLE_EVAL_TIMEOUT_SECONDS = 600
 
+# Finalized artifacts the eval datamodule opens; all must sit in dataset_root.
+_ORACLE_EVAL_REQUIRED_ARTIFACTS = ("train.h5", "val.h5", "test.h5", STATS_NPZ_FILENAME)
+
 
 def _run_oracle_eval_subprocess(dataset_root: Path, run_dir: Path, run_id: str) -> None:
     """Run the fake-oracle eval over ``dataset_root`` to verify the param-array round-trip.
@@ -75,7 +78,18 @@ def _run_oracle_eval_subprocess(dataset_root: Path, run_dir: Path, run_id: str) 
         artifacts don't mix with the dataset files.
     :param run_id: Canonical ``spec.run_id``; the eval resumes this wandb run
         so its ``audio/*`` metrics land on the generate phase's run.
+    :raises FileNotFoundError: ``dataset_root`` is missing any finalized split
+        or ``stats.npz`` — e.g. a resume where ``finalize_from_spec``
+        short-circuited on an existing R2 marker without repopulating it.
     """
+    missing = [n for n in _ORACLE_EVAL_REQUIRED_ARTIFACTS if not (dataset_root / n).is_file()]
+    if missing:
+        raise FileNotFoundError(
+            f"inline oracle-eval expects the finalized splits + stats in {dataset_root}, "
+            f"but {missing} are absent. finalize_from_spec short-circuits when R2 already "
+            f"holds the dataset.complete marker, leaving output_dir unpopulated on a resume; "
+            f"rerun with a fresh paths.output_dir."
+        )
     argv = [
         sys.executable,
         "-m",

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -32,7 +32,7 @@ from omegaconf import DictConfig, OmegaConf
 from synth_setter.cli.finalize_dataset import finalize_from_spec
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.pipeline import r2_io
-from synth_setter.pipeline.constants import STATS_NPZ_FILENAME, WORKER_SPEC_URI_ENV
+from synth_setter.pipeline.constants import WORKER_SPEC_URI_ENV
 from synth_setter.pipeline.partitioning import (
     available_cpus,
     get_my_shards,
@@ -60,29 +60,19 @@ _WORKER_REPO_ROOT = "/home/build/synth-setter"
 _ORACLE_EVAL_TIMEOUT_SECONDS = 600
 
 
-def _download_finalized_splits(spec: DatasetSpec, dest: Path) -> None:
-    """Download ``{train,val,test}.h5`` + ``stats.npz`` into ``dest``.
-
-    The eval datamodule loads normalization stats from ``dest/stats.npz``
-    (``use_saved_mean_and_variance=true``), so it must land beside the splits.
-
-    :param spec: Resolves the R2 URIs via ``spec.r2.split_h5_uri`` /
-        ``spec.r2.stats_uri``.
-    :param dest: Local directory to receive the splits and stats file.
-    """
-    dest.mkdir(parents=True, exist_ok=True)
-    for split in ("train", "val", "test"):
-        r2_io.download_to_path(spec.r2.split_h5_uri(split), dest / f"{split}.h5")
-    r2_io.download_to_path(spec.r2.stats_uri(), dest / STATS_NPZ_FILENAME)
-
-
-def _run_oracle_eval_subprocess(dataset_root: Path, run_id: str) -> None:
-    """Run the fake-oracle eval on ``dataset_root`` to verify the param-array round-trip.
+def _run_oracle_eval_subprocess(dataset_root: Path, run_dir: Path, run_id: str) -> None:
+    """Run the fake-oracle eval over ``dataset_root`` to verify the param-array round-trip.
 
     ``check=True`` so a non-zero eval exit (or wall-clock timeout) propagates
     to the caller.
 
-    :param dataset_root: Holds the finalized HDF5 splits the eval datamodule reads.
+    :param dataset_root: Dir holding the finalized HDF5 splits, their source
+        shards, and ``stats.npz``. The splits are virtual datasets that
+        reference the shards by basename, so they resolve only when read in
+        place beside those shards.
+    :param run_dir: Hydra per-run dir for the eval's own outputs (predictions,
+        ``metrics/metrics.json``), kept separate from ``dataset_root`` so eval
+        artifacts don't mix with the dataset files.
     :param run_id: Canonical ``spec.run_id``; the eval resumes this wandb run
         so its ``audio/*`` metrics land on the generate phase's run.
     """
@@ -92,7 +82,7 @@ def _run_oracle_eval_subprocess(dataset_root: Path, run_id: str) -> None:
         "synth_setter.cli.eval",
         "experiment=surge/fake_oracle",
         f"datamodule.dataset_root={dataset_root}",
-        f"hydra.run.dir={dataset_root}",
+        f"hydra.run.dir={run_dir}",
         "ckpt_path=null",
         "logger=wandb",
         # eval.yaml defaults render to null; render_vst=true re-renders the
@@ -760,9 +750,12 @@ def main(cfg: DictConfig) -> None:
         if cfg.finalize_inline:
             finalize_from_spec(spec, Path(cfg.paths.output_dir))
         if cfg.oracle_eval_inline:
-            eval_dir = Path(cfg.paths.output_dir) / "oracle_eval" / spec.run_id
-            _download_finalized_splits(spec, eval_dir)
-            _run_oracle_eval_subprocess(eval_dir, spec.run_id)
+            # generate + finalize already wrote the shards, VDS splits, and
+            # stats.npz into output_dir; the splits reference the shards by
+            # basename, so read them in place — no R2 round-trip.
+            output_dir = Path(cfg.paths.output_dir)
+            eval_run_dir = output_dir / "oracle_eval" / spec.run_id
+            _run_oracle_eval_subprocess(output_dir, eval_run_dir, spec.run_id)
         return
 
     if cfg.finalize_inline or cfg.oracle_eval_inline:

--- a/tests/pipeline/entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset.py
@@ -28,6 +28,7 @@ the cfg-composition surface isolated from R2.
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 import sys
 import threading
@@ -1652,16 +1653,28 @@ class TestMainDispatchBranches:
         oracle_mock = MagicMock()
         monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
 
+        # Capture the resolved output_dir so the eval's dataset_root can be
+        # pinned to the exact dir generate+finalize wrote the shards into.
+        observed: dict[str, Path] = {}
+        real_spec_from_cfg = gd.spec_from_cfg
+
+        def _capture_output_dir(cfg: object) -> DatasetSpec:
+            observed["output_dir"] = Path(cfg.paths.output_dir)  # type: ignore[attr-defined]
+            return real_spec_from_cfg(cfg)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(gd, "spec_from_cfg", _capture_output_dir)
+
         gd.main()
 
         oracle_mock.assert_called_once()
         dataset_root, run_dir, _run_id = oracle_mock.call_args[0]
         assert isinstance(dataset_root, Path)
+        # The eval reads in place from the Hydra output_dir where the shards and
+        # VDS splits already live — not a downloaded copy under oracle_eval/.
+        assert dataset_root == observed["output_dir"]
         assert run_dir.parent.name == "oracle_eval", (
             f"eval run dir should land under <output_dir>/oracle_eval/<run_id>/; got {run_dir!r}"
         )
-        # Data is read in place from output_dir (the run dir's grandparent), not
-        # a downloaded copy under oracle_eval/.
         assert run_dir.parent.parent == dataset_root
 
     def test_run_oracle_eval_subprocess_builds_expected_argv(
@@ -1904,17 +1917,16 @@ class TestMainDispatchBranches:
 def _write_vds_split_with_shard(data_dir: Path) -> np.ndarray:
     """Write a real shard + a VDS ``test.h5`` + ``stats.npz`` into ``data_dir``.
 
-    Mirrors :func:`synth_setter.pipeline.data.reshard._write_split`: the split's
+    Follows the basename-VDS contract of
+    :func:`synth_setter.pipeline.data.reshard._write_split`: the split's
     ``audio`` / ``param_array`` are HDF5 virtual datasets whose source is the
     shard referenced **by basename**, so they resolve only when the shard sits
-    beside the split. This is the exact on-disk shape the inline oracle-eval
-    reads (#1396).
+    beside the split — the on-disk shape the inline oracle-eval reads (#1396).
 
     :param data_dir: Destination dir; receives ``shard-000000.h5``,
         ``test.h5``, and ``stats.npz``.
     :returns: The shard's ``audio`` array (``float16``) so callers can assert
         the read resolves to the real bytes.
-    :rtype: numpy.ndarray
     """
     rows, channels, samples, num_params = 2, 2, 8, 4
     audio_dtype = DATASET_FIELD_DTYPES["audio"]
@@ -1940,22 +1952,22 @@ def _write_vds_split_with_shard(data_dir: Path) -> np.ndarray:
             layout[0:rows] = h5py.VirtualSource(shard.name, key, shape=(rows, *tail), dtype=dtype)
             f.create_virtual_dataset(key, layout)
 
-    np.savez(data_dir / STATS_NPZ_FILENAME, mean=np.zeros(1), std=np.ones(1))
+    np.savez(
+        data_dir / STATS_NPZ_FILENAME,
+        mean=np.zeros(1, dtype=np.float32),
+        std=np.ones(1, dtype=np.float32),
+    )
     return audio
 
 
 class TestInlineOracleEvalVdsInPlaceRead:
     """Behavioral proof for #1396: the inline eval reads the VDS splits in place.
 
-    The finalized ``{split}.h5`` files are HDF5 virtual datasets that reference
-    their source shards by basename. The old inline path downloaded only the
-    split + ``stats.npz`` into a fresh ``oracle_eval/<run_id>/`` dir, so the
-    virtual mappings dangled and ``mode=predict`` read the audio dataset as
-    fill-value zeros — crashing the eval. The fix points ``dataset_root`` at the
-    local ``output_dir`` where ``generate`` + ``finalize`` already co-located the
-    shards. These tests drive the real predict read path
-    (:class:`SurgeXTDataset` with ``read_audio=True``) to pin both halves of
-    that contract.
+    The finalized ``{split}.h5`` files are HDF5 virtual datasets referencing
+    their source shards by basename, so ``mode=predict`` reads the audio dataset
+    as fill-value zeros unless the shards sit beside the split. These tests drive
+    the real predict read path (:class:`SurgeXTDataset` with ``read_audio=True``)
+    to pin that the read resolves to real bytes only when co-located.
     """
 
     def test_predict_audio_read_vds_split_beside_shards_returns_shard_data(
@@ -2002,8 +2014,6 @@ class TestInlineOracleEvalVdsInPlaceRead:
 
         :param tmp_path: Roots the populated source dir and the split-only copy.
         """
-        import shutil
-
         from synth_setter.data.surge_datamodule import SurgeXTDataset
 
         source_dir = tmp_path / "source"

--- a/tests/pipeline/entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset.py
@@ -37,12 +37,16 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import h5py
+import numpy as np
 import pytest
 
 from synth_setter.cli.generate_dataset import (
     build_generate_args,
     generate,
 )
+from synth_setter.data.vst.shapes import DATASET_FIELD_DTYPES
+from synth_setter.pipeline.constants import STATS_NPZ_FILENAME
 from synth_setter.pipeline.schemas.spec import DatasetSpec, RenderConfig
 from synth_setter.resources import vst_headless_wrapper
 from tests.helpers.render_subprocess import (
@@ -1894,6 +1898,140 @@ class TestMainDispatchBranches:
         assert len(ignored_lines) == 1, (
             f"expected exactly one INFO log mentioning 'oracle_eval_inline=True' + 'ignored'; "
             f"got messages: {info_messages!r}"
+        )
+
+
+def _write_vds_split_with_shard(data_dir: Path) -> np.ndarray:
+    """Write a real shard + a VDS ``test.h5`` + ``stats.npz`` into ``data_dir``.
+
+    Mirrors :func:`synth_setter.pipeline.data.reshard._write_split`: the split's
+    ``audio`` / ``param_array`` are HDF5 virtual datasets whose source is the
+    shard referenced **by basename**, so they resolve only when the shard sits
+    beside the split. This is the exact on-disk shape the inline oracle-eval
+    reads (#1396).
+
+    :param data_dir: Destination dir; receives ``shard-000000.h5``,
+        ``test.h5``, and ``stats.npz``.
+    :returns: The shard's ``audio`` array (``float16``) so callers can assert
+        the read resolves to the real bytes.
+    :rtype: numpy.ndarray
+    """
+    rows, channels, samples, num_params = 2, 2, 8, 4
+    audio_dtype = DATASET_FIELD_DTYPES["audio"]
+    param_dtype = DATASET_FIELD_DTYPES["param_array"]
+    # Distinct per-element values so a fill-value (zeros) read is unmistakable.
+    audio = (np.arange(rows * channels * samples, dtype=audio_dtype) + 1.0).reshape(
+        rows, channels, samples
+    )
+    param = (np.arange(rows * num_params, dtype=param_dtype) + 1.0).reshape(rows, num_params)
+
+    shard = data_dir / "shard-000000.h5"
+    with h5py.File(shard, "w") as f:
+        f.create_dataset("audio", data=audio)
+        f.create_dataset("param_array", data=param)
+
+    fields = (
+        ("audio", audio_dtype, (channels, samples)),
+        ("param_array", param_dtype, (num_params,)),
+    )
+    with h5py.File(data_dir / "test.h5", "w", libver="latest") as f:
+        for key, dtype, tail in fields:
+            layout = h5py.VirtualLayout(shape=(rows, *tail), dtype=dtype)
+            layout[0:rows] = h5py.VirtualSource(shard.name, key, shape=(rows, *tail), dtype=dtype)
+            f.create_virtual_dataset(key, layout)
+
+    np.savez(data_dir / STATS_NPZ_FILENAME, mean=np.zeros(1), std=np.ones(1))
+    return audio
+
+
+class TestInlineOracleEvalVdsInPlaceRead:
+    """Behavioral proof for #1396: the inline eval reads the VDS splits in place.
+
+    The finalized ``{split}.h5`` files are HDF5 virtual datasets that reference
+    their source shards by basename. The old inline path downloaded only the
+    split + ``stats.npz`` into a fresh ``oracle_eval/<run_id>/`` dir, so the
+    virtual mappings dangled and ``mode=predict`` read the audio dataset as
+    fill-value zeros — crashing the eval. The fix points ``dataset_root`` at the
+    local ``output_dir`` where ``generate`` + ``finalize`` already co-located the
+    shards. These tests drive the real predict read path
+    (:class:`SurgeXTDataset` with ``read_audio=True``) to pin both halves of
+    that contract.
+    """
+
+    def test_predict_audio_read_vds_split_beside_shards_returns_shard_data(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """With the shard co-located, the predict-row audio read resolves to real bytes.
+
+        Reads row ``1`` — the slice that crashed in production after row 0's
+        fill-value zeros — through the same datamodule the eval uses.
+
+        :param tmp_path: Holds the co-located shard, VDS split, and stats.
+        """
+        from synth_setter.data.surge_datamodule import SurgeXTDataset
+
+        audio = _write_vds_split_with_shard(tmp_path)
+        dataset = SurgeXTDataset(
+            tmp_path / "test.h5",
+            batch_size=1,
+            ot=False,
+            read_audio=True,
+            read_mel=False,
+            use_saved_mean_and_variance=True,
+        )
+
+        assert dataset.dataset_file is not None
+        audio_ds = dataset.dataset_file["audio"]
+        assert isinstance(audio_ds, h5py.Dataset) and audio_ds.is_virtual, (
+            "split must be a virtual dataset"
+        )
+        audio_item = dataset[1]["audio"]
+        assert audio_item is not None
+        np.testing.assert_array_equal(audio_item.numpy(), audio[1:2].astype(np.float32))
+
+    def test_predict_audio_read_vds_split_without_shards_returns_dangling_zeros(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Without the shard beside it, the same read dangles to fill-value zeros.
+
+        Reproduces the #1396 failure mode: copying only the split + stats away from the shards (as
+        the old download did) makes the audio unreadable, so the read returns zeros instead of the
+        shard bytes.
+
+        :param tmp_path: Roots the populated source dir and the split-only copy.
+        """
+        import shutil
+
+        from synth_setter.data.surge_datamodule import SurgeXTDataset
+
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        audio = _write_vds_split_with_shard(source_dir)
+
+        split_only = tmp_path / "split_only"
+        split_only.mkdir()
+        shutil.copy(source_dir / "test.h5", split_only / "test.h5")
+        shutil.copy(source_dir / STATS_NPZ_FILENAME, split_only / STATS_NPZ_FILENAME)
+
+        dataset = SurgeXTDataset(
+            split_only / "test.h5",
+            batch_size=1,
+            ot=False,
+            read_audio=True,
+            read_mel=False,
+            use_saved_mean_and_variance=True,
+        )
+
+        dangling_item = dataset[1]["audio"]
+        assert dangling_item is not None
+        dangling = dangling_item.numpy()
+        assert np.array_equal(dangling, np.zeros_like(dangling)), (
+            "dangling VDS read should fall back to fill-value zeros"
+        )
+        assert not np.array_equal(dangling, audio[1:2].astype(np.float32)), (
+            "without co-located shards the read must not reach the real audio"
         )
 
 

--- a/tests/pipeline/entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset.py
@@ -1699,6 +1699,9 @@ class TestMainDispatchBranches:
         monkeypatch.setattr(gd.subprocess, "run", run_mock)
 
         dataset_root = tmp_path / "data"
+        dataset_root.mkdir()
+        for name in ("train.h5", "val.h5", "test.h5", "stats.npz"):
+            (dataset_root / name).touch()
         run_dir = tmp_path / "oracle_eval" / "some-run-id"
         gd._run_oracle_eval_subprocess(dataset_root, run_dir, "some-run-id")
 
@@ -1728,6 +1731,31 @@ class TestMainDispatchBranches:
         # flooring to zero batches under the 128 default — see #1331.
         assert "datamodule.batch_size=1" in called_argv
         assert "mode=predict" in called_argv
+
+    def test_run_oracle_eval_subprocess_missing_local_artifacts_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """Unpopulated ``dataset_root`` ⇒ clear ``FileNotFoundError``, no eval subprocess.
+
+        ``finalize_from_spec`` short-circuits when R2 already holds the
+        ``dataset.complete`` marker, leaving ``output_dir`` without the splits
+        on a resume; the preflight turns the downstream low-signal HDF5 read
+        error into an actionable one before shelling out.
+
+        :param monkeypatch: Patches ``subprocess.run`` to assert it never fires.
+        :param tmp_path: Empty stand-in for an unpopulated ``output_dir``.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        run_mock = MagicMock()
+        monkeypatch.setattr(gd.subprocess, "run", run_mock)
+
+        with pytest.raises(FileNotFoundError, match=r"test\.h5"):
+            gd._run_oracle_eval_subprocess(tmp_path, tmp_path / "oracle_eval" / "rid", "rid")
+
+        run_mock.assert_not_called()
 
     def test_main_oracle_eval_inline_default_false_skips(
         self,

--- a/tests/pipeline/entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset.py
@@ -1931,11 +1931,12 @@ def _write_vds_split_with_shard(data_dir: Path) -> np.ndarray:
     rows, channels, samples, num_params = 2, 2, 8, 4
     audio_dtype = DATASET_FIELD_DTYPES["audio"]
     param_dtype = DATASET_FIELD_DTYPES["param_array"]
-    # Distinct per-element values so a fill-value (zeros) read is unmistakable.
-    audio = (np.arange(rows * channels * samples, dtype=audio_dtype) + 1.0).reshape(
+    # Start at 1 so every value is distinct and nonzero (a fill-value zeros read
+    # is then unmistakable) while staying in the field dtype — no scalar promotion.
+    audio = np.arange(1, rows * channels * samples + 1, dtype=audio_dtype).reshape(
         rows, channels, samples
     )
-    param = (np.arange(rows * num_params, dtype=param_dtype) + 1.0).reshape(rows, num_params)
+    param = np.arange(1, rows * num_params + 1, dtype=param_dtype).reshape(rows, num_params)
 
     shard = data_dir / "shard-000000.h5"
     with h5py.File(shard, "w") as f:

--- a/tests/pipeline/entrypoints/test_generate_dataset.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset.py
@@ -1624,11 +1624,11 @@ class TestMainDispatchBranches:
     ) -> None:
         """oracle_eval_inline=true on the local-run branch shells out to synth-setter-eval.
 
-        Asserts the eval helper fires once with ``dataset_root`` under
-        ``_OPERATOR_WORKSPACE/oracle_eval/<run_id>/`` and that
-        ``_download_finalized_splits`` populates the same path first.
+        Asserts the eval helper fires once reading the data **in place** from
+        ``cfg.paths.output_dir`` (no download), with its Hydra run dir isolated
+        under ``output_dir/oracle_eval/<run_id>/``.
 
-        :param monkeypatch: Patches argv + the four module-level seams.
+        :param monkeypatch: Patches argv + the three module-level seams.
         """
         import synth_setter.cli.generate_dataset as gd
 
@@ -1645,53 +1645,20 @@ class TestMainDispatchBranches:
         monkeypatch.setattr("sys.argv", argv)
         monkeypatch.setattr(gd, "generate", lambda _spec, _work_dir, _loggers: None)
         monkeypatch.setattr(gd, "finalize_from_spec", MagicMock())
-        download_mock = MagicMock()
-        monkeypatch.setattr(gd, "_download_finalized_splits", download_mock)
         oracle_mock = MagicMock()
         monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
 
         gd.main()
 
         oracle_mock.assert_called_once()
-        dataset_root = oracle_mock.call_args[0][0]
+        dataset_root, run_dir, _run_id = oracle_mock.call_args[0]
         assert isinstance(dataset_root, Path)
-        assert dataset_root.parent.name == "oracle_eval", (
-            f"dataset_root should land under <workspace>/oracle_eval/<run_id>/; got {dataset_root!r}"
+        assert run_dir.parent.name == "oracle_eval", (
+            f"eval run dir should land under <output_dir>/oracle_eval/<run_id>/; got {run_dir!r}"
         )
-        download_mock.assert_called_once()
-        _, downloaded_dest = download_mock.call_args[0]
-        assert downloaded_dest == dataset_root
-
-    def test_download_finalized_splits_fetches_stats_npz_beside_splits(
-        self,
-        spec: DatasetSpec,
-        monkeypatch: pytest.MonkeyPatch,
-        tmp_path: Path,
-    ) -> None:
-        """Finalize download lands ``stats.npz`` in the same dir as the splits.
-
-        The eval datamodule loads normalization stats from
-        ``<dataset_root>/stats.npz`` (``use_saved_mean_and_variance=true``);
-        without it the inline oracle eval crashes — see #1331.
-
-        :param spec: Fixture-provided ``DatasetSpec``; resolves the R2 URIs.
-        :param monkeypatch: Patches the module's ``r2_io.download_to_path``.
-        :param tmp_path: Destination dir for the downloaded artifacts.
-        """
-        import synth_setter.cli.generate_dataset as gd
-
-        downloads: dict[Path, str] = {}
-        monkeypatch.setattr(
-            gd.r2_io,
-            "download_to_path",
-            lambda uri, dest: downloads.__setitem__(Path(dest), uri),
-        )
-
-        gd._download_finalized_splits(spec, tmp_path)
-
-        assert downloads[tmp_path / "stats.npz"] == spec.r2.stats_uri()
-        for split in ("train", "val", "test"):
-            assert downloads[tmp_path / f"{split}.h5"] == spec.r2.split_h5_uri(split)
+        # Data is read in place from output_dir (the run dir's grandparent), not
+        # a downloaded copy under oracle_eval/.
+        assert run_dir.parent.parent == dataset_root
 
     def test_run_oracle_eval_subprocess_builds_expected_argv(
         self,
@@ -1707,24 +1674,29 @@ class TestMainDispatchBranches:
         directly so cfg-resolution noise can't mask an argv drift.
 
         :param monkeypatch: Patches the module's ``subprocess.run``.
-        :param tmp_path: Stands in for the finalize download directory.
+        :param tmp_path: Roots the distinct dataset-root and eval run dirs.
         """
         import synth_setter.cli.generate_dataset as gd
 
         run_mock = MagicMock()
         monkeypatch.setattr(gd.subprocess, "run", run_mock)
 
-        gd._run_oracle_eval_subprocess(tmp_path, "some-run-id")
+        dataset_root = tmp_path / "data"
+        run_dir = tmp_path / "oracle_eval" / "some-run-id"
+        gd._run_oracle_eval_subprocess(dataset_root, run_dir, "some-run-id")
 
         run_mock.assert_called_once()
         called_argv = run_mock.call_args[0][0]
         assert "-m" in called_argv
         assert "synth_setter.cli.eval" in called_argv
         assert "experiment=surge/fake_oracle" in called_argv
-        assert f"datamodule.dataset_root={tmp_path}" in called_argv
-        # Pins the Hydra per-run dir to the same path as datamodule.dataset_root so
-        # the workflow's metrics.json glob lands at <tmp_path>/metrics/metrics.json.
-        assert f"hydra.run.dir={tmp_path}" in called_argv
+        # Data dir and the eval's Hydra run dir are DISTINCT: the split virtual
+        # datasets are read in place beside their shards, while eval outputs
+        # (incl. metrics/metrics.json the workflow globs) land under the
+        # oracle_eval/<run_id> run dir.
+        assert f"datamodule.dataset_root={dataset_root}" in called_argv
+        assert f"hydra.run.dir={run_dir}" in called_argv
+        assert dataset_root != run_dir
         assert "ckpt_path=null" in called_argv
         # The eval resumes the generate run rather than opening a fresh one, so
         # its audio/* metrics share the run id (logger=null crashed Hydra — see #1331).
@@ -1744,9 +1716,9 @@ class TestMainDispatchBranches:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Opt-in invariant: default false ⇒ neither download nor eval subprocess fires.
+        """Opt-in invariant: default false ⇒ the eval subprocess never fires.
 
-        :param monkeypatch: Patches argv + the four module-level seams.
+        :param monkeypatch: Patches argv + the three module-level seams.
         """
         import synth_setter.cli.generate_dataset as gd
 
@@ -1759,14 +1731,11 @@ class TestMainDispatchBranches:
         monkeypatch.setattr("sys.argv", argv)
         monkeypatch.setattr(gd, "generate", lambda _spec, _work_dir, _loggers: None)
         monkeypatch.setattr(gd, "finalize_from_spec", MagicMock())
-        download_mock = MagicMock()
         oracle_mock = MagicMock()
-        monkeypatch.setattr(gd, "_download_finalized_splits", download_mock)
         monkeypatch.setattr(gd, "_run_oracle_eval_subprocess", oracle_mock)
 
         gd.main()
 
-        download_mock.assert_not_called()
         oracle_mock.assert_not_called()
 
     def test_main_oracle_eval_inline_requires_finalize_inline(

--- a/uv.lock
+++ b/uv.lock
@@ -6022,7 +6022,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.15.0"
+version = "8.15.1"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Problem

The inline oracle-eval (added in #1338) crashes during `mode=predict` reading the `audio` dataset:

```
OSError: Can't synchronously read data (insufficient elements in destination selection)
  surge_datamodule.py  ds[start_idx:end_idx]   # the "audio" dataset
```

It surfaces when running `generate_dataset` with `oracle_eval_inline=true`.

## Root cause

The finalized `{train,val,test}.h5` splits are **HDF5 virtual datasets** (`reshard.py`) that reference the source `shard-*.h5` files **by relative basename** — they hold no data themselves and only resolve when the shards are co-located. The inline path downloaded only the three split files + `stats.npz` into a fresh `oracle_eval/<run_id>/` directory, **without the shards**. The dangling virtual mappings read back fill-value zeros for the first row and raise `insufficient elements` for the rest.

## Fix — read the local run dir in place (no R2 round-trip)

`oracle_eval_inline` only runs on the **local-run branch** (`compute_template is None`), where `generate()` + `finalize_from_spec()` have *already* written the shards, VDS splits, and `stats.npz` into `cfg.paths.output_dir`. So instead of re-fetching anything from R2, point the eval's `datamodule.dataset_root` at that `output_dir` — the splits resolve against their co-located shards in place.

To keep eval artifacts out of the dataset dir, `hydra.run.dir` is **decoupled** from `dataset_root`: it stays at `output_dir/oracle_eval/<run_id>` (so the workflow's `*/oracle_eval/*/metrics/metrics.json` glob still resolves), while `dataset_root` points at `output_dir`. The now-dead `_download_finalized_splits` helper and its `STATS_NPZ_FILENAME` import are removed.

## Relationship to #1397 (this is the alternative)

Both PRs fix #1396. They take opposite approaches — pick one:

|                      | #1397 (download whole dataset root)                        | **This PR (read local run dir)**                    |
| -------------------- | ---------------------------------------------------------- | --------------------------------------------------- |
| Source of the shards | re-downloads the whole R2 prefix (shards + splits + stats) | reads what `generate`+`finalize` just wrote locally |
| R2 traffic           | one full dataset-root round-trip                           | none                                                |
| Coupling             | works regardless of local state                            | tied to the inline, same-process local-run branch   |

**Trade-off.** This approach is smaller and skips a redundant R2 round-trip, but it relies on the shards still being present in `output_dir` at eval time. That holds for the inline same-process flow (`oracle_eval_inline` is local-only and runs right after `finalize`). The one resume edge — `finalize_from_spec` early-returning on an existing R2 `dataset.complete` marker without repopulating `output_dir` — is now caught by a preflight in `_run_oracle_eval_subprocess` that raises a clear `FileNotFoundError` (naming the missing splits/stats and the cause) instead of failing deep in the eval. #1397's unconditional re-download still *recovers* from that state rather than erroring; that recover-vs-fail-fast asymmetry is the core decision between the two PRs.

## Tests

New behavioral coverage in `TestInlineOracleEvalVdsInPlaceRead` drives the **real** predict read path (`SurgeXTDataset(read_audio=True)`) over a genuine shard + a genuine VDS split that references it by basename (mirroring `reshard._write_split`):

- shard co-located → the predict-row audio read resolves to the real shard bytes;
- split copied away from the shard → the same read dangles to fill-value zeros (the exact #1396 failure mode).

The dispatch test additionally captures `cfg.paths.output_dir` and asserts the eval is wired with `dataset_root == output_dir` and a distinct `oracle_eval/<run_id>` run dir, so a regression that re-points the eval at a shard-less dir is caught directly. The obsolete `_download_finalized_splits` test is removed.

`make format` clean (ruff, ruff-format, pyright, pydoclint, …); the full `test_generate_dataset.py` suite (67 tests) passes.

## Verification

On-PR CI does not exercise `oracle_eval_inline` (the generate+finalize smoke jobs run with no oracle eval). End-to-end proof — running generate→finalize→`oracle_eval_inline` on the smoke shard and confirming `audio/*` metrics log without `insufficient elements` — is posted separately via `/pr-checkbox` Level-1.

Fixes #1396
