### PR TITLE
automation: repo-review-full requests changes when BLOCK findings exist

### DIFF
--- a/agent/skills/_shared/post_review.py
+++ b/agent/skills/_shared/post_review.py
@@ -21,8 +21,12 @@ Input format on stdin:
       ]
     }
 
-The submitted review uses event=COMMENT so threads stay open (not approved or
-rejected).
+The review event comes from the request's optional top-level ``event`` field
+(default ``COMMENT``; one of ``COMMENT`` / ``REQUEST_CHANGES`` / ``APPROVE``).
+GitHub rejects ``REQUEST_CHANGES`` and ``APPROVE`` on the bot's own PR with an
+HTTP 422, so ``submit_review`` retries once as ``COMMENT`` with a banner
+prepended to the body — preserving the finding threads even when the API won't
+let the bot formally request changes.
 
 Typical invocation::
 
@@ -277,44 +281,63 @@ def anchor_finding(
     )
 
 
+_VALID_EVENTS = frozenset({"COMMENT", "REQUEST_CHANGES", "APPROVE"})
+
+
 def build_review_payload(
-    review_body: str, anchored: list[AnchoredComment], orphaned: list[Finding]
+    review_body: str,
+    anchored: list[AnchoredComment],
+    orphaned: list[Finding],
+    event: str = "COMMENT",
 ) -> dict[str, object]:
     """Compose the JSON body for POST /repos/.../pulls/N/reviews.
 
     :param review_body: Top-level review body markdown.
     :param anchored: Findings that can be posted as inline comments.
     :param orphaned: Findings whose files are outside the PR diff.
-    :returns: GitHub review API payload.
+    :param event: Review event; one of COMMENT, REQUEST_CHANGES, APPROVE.
+    :returns: GitHub review API payload. The ``comments`` key is omitted for
+        APPROVE with no findings, which GitHub requires.
     :rtype: dict[str, object]
+    :raises ValueError: If ``event`` is not a recognized GitHub review event.
     """
+    if event not in _VALID_EVENTS:
+        raise ValueError(
+            f"unsupported review event: {event!r}; expected one of {sorted(_VALID_EVENTS)}"
+        )
     body = review_body
     if orphaned:
         body += "\n\n## Findings on files outside the diff\n\n"
         for finding in orphaned:
             indented = finding.body.replace("\n", "\n  ")
             body += f"- `{finding.path}:{finding.line}` — {indented}\n"
-    return {
-        "body": body,
-        "event": "COMMENT",
-        "comments": [
-            {"path": comment.path, "line": comment.line, "body": comment.body}
-            for comment in anchored
-        ],
-    }
+    comments = [
+        {"path": comment.path, "line": comment.line, "body": comment.body} for comment in anchored
+    ]
+    payload: dict[str, object] = {"body": body, "event": event}
+    # GitHub rejects APPROVE carrying an empty `comments`; omit the key in that case.
+    if comments or event != "APPROVE":
+        payload["comments"] = comments
+    return payload
 
 
-def submit_review(repo: str, pr_number: int, payload: dict[str, object]) -> dict[str, object]:
-    """POST the review and return the parsed response.
+_SELF_REVIEW_422_RE = re.compile(
+    r"can not (?:request changes|approve) (?:on )?your own", re.IGNORECASE
+)
+
+
+def _post_review(
+    repo: str, pr_number: int, payload: dict[str, object]
+) -> subprocess.CompletedProcess[str]:
+    """POST one review payload via `gh api` without inspecting the outcome.
 
     :param repo: GitHub repository in `owner/name` form.
     :param pr_number: Pull request number.
     :param payload: GitHub review API payload.
-    :returns: Parsed JSON response from GitHub.
-    :rtype: dict[str, object]
+    :returns: The completed `gh api` process.
+    :rtype: subprocess.CompletedProcess[str]
     """
-    payload_json = json.dumps(payload)
-    result = subprocess.run(  # noqa: S603
+    return subprocess.run(  # noqa: S603
         [
             gh_executable(),
             "api",
@@ -324,15 +347,44 @@ def submit_review(repo: str, pr_number: int, payload: dict[str, object]) -> dict
             "--input",
             "-",
         ],
-        input=payload_json,
+        input=json.dumps(payload),
         capture_output=True,
         text=True,
         check=False,
     )
-    if result.returncode != 0:
-        sys.stderr.write(result.stderr)
-        sys.exit(result.returncode)
-    return json.loads(result.stdout)
+
+
+def submit_review(
+    repo: str, pr_number: int, payload: dict[str, object], fallback_banner: str
+) -> dict[str, object]:
+    """POST the review, falling back to COMMENT on a self-review 422.
+
+    GitHub rejects REQUEST_CHANGES/APPROVE on the bot's own PR with an HTTP 422.
+    On that specific failure, retry once as COMMENT with ``fallback_banner``
+    prepended to the body so the blocking intent stays visible.
+
+    :param repo: GitHub repository in `owner/name` form.
+    :param pr_number: Pull request number.
+    :param payload: GitHub review API payload.
+    :param fallback_banner: Banner prepended to the body on the COMMENT retry.
+    :returns: Parsed JSON response from GitHub.
+    :rtype: dict[str, object]
+    """
+    result = _post_review(repo, pr_number, payload)
+    if result.returncode == 0:
+        return json.loads(result.stdout)
+    if _SELF_REVIEW_422_RE.search(result.stderr):
+        sys.stderr.write(
+            "Self-review 422: falling back to event=COMMENT with a blocking banner.\n"
+        )
+        retry = dict(payload)
+        retry["event"] = "COMMENT"
+        retry["body"] = f"{fallback_banner}\n\n{payload.get('body', '')}"
+        result = _post_review(repo, pr_number, retry)
+        if result.returncode == 0:
+            return json.loads(result.stdout)
+    sys.stderr.write(result.stderr)
+    sys.exit(result.returncode)
 
 
 def main() -> int:
@@ -353,6 +405,7 @@ def main() -> int:
     repo: str = request["repo"]
     pr_number: int = int(request["pr_number"])
     review_body: str = request.get("review_body", "")
+    event: str = request.get("event", "COMMENT")
     findings = [Finding(**raw) for raw in request["findings"]]
 
     diff_text = fetch_diff(repo, pr_number)
@@ -367,7 +420,7 @@ def main() -> int:
         else:
             anchored.append(result)
 
-    payload = build_review_payload(review_body, anchored, orphaned)
+    payload = build_review_payload(review_body, anchored, orphaned, event=event)
 
     sys.stderr.write(
         f"Resolved {len(anchored)} inline anchor(s) "
@@ -380,7 +433,11 @@ def main() -> int:
         sys.stdout.write("\n")
         return 0
 
-    response = submit_review(repo, pr_number, payload)
+    block_count = review_body.count(":block]") + sum(f.body.count(":block]") for f in findings)
+    banner = (
+        f"⛔ {block_count} BLOCKING finding(s) — changes required (self-review: posted as COMMENT)"
+    )
+    response = submit_review(repo, pr_number, payload, fallback_banner=banner)
     html_url = response.get("html_url")
     sys.stdout.write(html_url if isinstance(html_url, str) else json.dumps(response))
     sys.stdout.write("\n")

--- a/agent/skills/_shared/post_review.py
+++ b/agent/skills/_shared/post_review.py
@@ -375,7 +375,7 @@ def submit_review(
         return json.loads(result.stdout)
     if _SELF_REVIEW_422_RE.search(result.stderr):
         sys.stderr.write(
-            "Self-review 422: falling back to event=COMMENT with a blocking banner.\n"
+            "Self-review 422: falling back to event=COMMENT with the fallback banner.\n"
         )
         retry = dict(payload)
         retry["event"] = "COMMENT"
@@ -433,10 +433,16 @@ def main() -> int:
         sys.stdout.write("\n")
         return 0
 
-    block_count = review_body.count(":block]") + sum(f.body.count(":block]") for f in findings)
-    banner = (
-        f"⛔ {block_count} BLOCKING finding(s) — changes required (self-review: posted as COMMENT)"
-    )
+    # Only REQUEST_CHANGES/APPROVE can 422 on a self-review; phrase the banner to match
+    # the intent GitHub refused (an APPROVE downgrade carries no "changes required").
+    if event == "APPROVE":
+        banner = "✅ No findings (self-review: APPROVE not allowed on own PR — posted as COMMENT)"
+    else:
+        block_count = review_body.count(":block]") + sum(f.body.count(":block]") for f in findings)
+        banner = (
+            f"⛔ {block_count} BLOCKING finding(s) — changes required "
+            "(self-review: posted as COMMENT)"
+        )
     response = submit_review(repo, pr_number, payload, fallback_banner=banner)
     html_url = response.get("html_url")
     sys.stdout.write(html_url if isinstance(html_url, str) else json.dumps(response))

--- a/agent/skills/_shared/repo-review-full-analysis.md
+++ b/agent/skills/_shared/repo-review-full-analysis.md
@@ -152,6 +152,8 @@ Transform each Step 2 BLOCK line into one bullet under `## PR health`: strip the
 
 The exact wording of `review_body` is up to the calling skill — `repo-review-full` writes the "posted below as an individual unresolved thread" phrasing; `repo-review-full-no-comments` writes a variant that says nothing was posted. Both reuse the `## PR health` bullet format.
 
+When the calling skill submits via `post_review.py` (i.e. `repo-review-full`), add a top-level `"event"`: `REQUEST_CHANGES` if any finding is a BLOCK (any `[*:block]`, including the folded PR-health BLOCKs), else `COMMENT` if any WARN exists, else `APPROVE`. `repo-review-full-no-comments` renders to chat and never posts, so it omits `"event"`.
+
 Write the JSON to a temp file:
 
 ```bash

--- a/agent/skills/repo-review-full/SKILL.md
+++ b/agent/skills/repo-review-full/SKILL.md
@@ -26,6 +26,11 @@ When the shared file says "the calling skill," that's this skill:
 - Phrase the `review_body` lead-in to reflect that every BLOCK/WARN is being
   posted as an unresolved inline thread (sample wording is already in the
   shared file).
+- Set the top-level `"event"` field in the JSON payload: `REQUEST_CHANGES` if
+  any finding is a BLOCK (any `[*:block]`, including the folded PR-health
+  BLOCKs), else `COMMENT` if any WARN exists, else `APPROVE`. The self-review
+  COMMENT fallback (when the bot is the PR author) is automatic in
+  `post_review.py`.
 
 Return here once Step 6 has produced the JSON payload on disk.
 
@@ -40,7 +45,7 @@ python3 agent/skills/_shared/post_review.py < /tmp/repo-review-full-findings.jso
 - Anchors each finding to its target line if that line falls inside a diff hunk.
 - Falls back to the nearest in-hunk line on the same file with a cross-ref note prepended to the body.
 - Rolls orphan findings (file outside the diff) into the review body under `## Findings on files outside the diff`.
-- Submits as `event=COMMENT`. Threads stay unresolved.
+- Submits with the payload's `event` (REQUEST_CHANGES / COMMENT / APPROVE). On a self-review 422 (the bot is the PR author) it retries once as `event=COMMENT` with a `⛔ N BLOCKING finding(s)` banner prepended, so the blocking intent stays visible. Threads stay unresolved.
 
 Report the helper's `html_url` back to the user along with a one-line summary (`Posted N findings: B BLOCK + W WARN across K skills; PR-health flags: <M merge-conflict / F failing-check>`). If PR-health found nothing, drop the trailing `; PR-health flags: ...` clause.
 

--- a/agent/skills/repo-review-full/SKILL.md
+++ b/agent/skills/repo-review-full/SKILL.md
@@ -45,7 +45,7 @@ python3 agent/skills/_shared/post_review.py < /tmp/repo-review-full-findings.jso
 - Anchors each finding to its target line if that line falls inside a diff hunk.
 - Falls back to the nearest in-hunk line on the same file with a cross-ref note prepended to the body.
 - Rolls orphan findings (file outside the diff) into the review body under `## Findings on files outside the diff`.
-- Submits with the payload's `event` (REQUEST_CHANGES / COMMENT / APPROVE). On a self-review 422 (the bot is the PR author) it retries once as `event=COMMENT` with a `⛔ N BLOCKING finding(s)` banner prepended, so the blocking intent stays visible. Threads stay unresolved.
+- Submits with the payload's `event` (REQUEST_CHANGES / COMMENT / APPROVE). On a self-review 422 (the bot is the PR author) it retries once as `event=COMMENT` with an event-aware intent banner prepended — `⛔ N BLOCKING finding(s) — changes required` for a REQUEST_CHANGES downgrade, `✅ No findings` for an APPROVE downgrade — so the original intent stays visible. Threads stay unresolved.
 
 Report the helper's `html_url` back to the user along with a one-line summary (`Posted N findings: B BLOCK + W WARN across K skills; PR-health flags: <M merge-conflict / F failing-check>`). If PR-health found nothing, drop the trailing `; PR-health flags: ...` clause.
 

--- a/tests/claude_hooks/test_post_review_event.py
+++ b/tests/claude_hooks/test_post_review_event.py
@@ -47,11 +47,11 @@ def helper() -> ModuleType:
 
 
 def test_build_review_payload_event_defaults_to_comment(helper: ModuleType) -> None:
-    """An explicit COMMENT event is set on the payload.
+    """The event defaults to COMMENT when the argument is omitted.
 
     :param helper: The loaded ``post_review`` module.
     """
-    payload = helper.build_review_payload("body", [], [], event="COMMENT")
+    payload = helper.build_review_payload("body", [], [])
     assert payload["event"] == "COMMENT"
 
 

--- a/tests/claude_hooks/test_post_review_event.py
+++ b/tests/claude_hooks/test_post_review_event.py
@@ -1,0 +1,149 @@
+"""Unit tests for event derivation and self-review fallback in ``post_review.py``.
+
+The helper backs ``/repo-review-full``: the calling skill sets a top-level
+``event`` (REQUEST_CHANGES when any BLOCK finding exists, COMMENT for WARN-only,
+APPROVE when clean). GitHub rejects REQUEST_CHANGES/APPROVE on the bot's own PR
+with an HTTP 422, so ``submit_review`` must retry once as a plain COMMENT with a
+loud banner prepended. These tests pin the payload shape and the fallback.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_HELPER_PATH = _REPO_ROOT / "agent" / "skills" / "_shared" / "post_review.py"
+
+
+def _load_helper() -> ModuleType:
+    """Import ``post_review`` directly by path so the test avoids sys.path edits.
+
+    :returns: The imported module.
+    :raises RuntimeError: If the helper file can't be located by ``importlib``.
+    """
+    spec = importlib.util.spec_from_file_location("post_review", _HELPER_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not locate {_HELPER_PATH} via importlib")
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so the module's dataclasses can resolve their own __module__.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def helper() -> ModuleType:
+    """Load ``post_review`` once per module via path-based import.
+
+    :returns: The imported module.
+    """
+    return _load_helper()
+
+
+def test_build_review_payload_event_defaults_to_comment(helper: ModuleType) -> None:
+    payload = helper.build_review_payload("body", [], [], event="COMMENT")
+    assert payload["event"] == "COMMENT"
+
+
+def test_build_review_payload_request_changes_passes_through(helper: ModuleType) -> None:
+    payload = helper.build_review_payload("body", [], [], event="REQUEST_CHANGES")
+    assert payload["event"] == "REQUEST_CHANGES"
+
+
+def test_build_review_payload_invalid_event_raises(helper: ModuleType) -> None:
+    with pytest.raises(ValueError, match="event"):
+        helper.build_review_payload("body", [], [], event="LGTM")
+
+
+def test_build_review_payload_approve_with_no_findings_omits_comments(
+    helper: ModuleType,
+) -> None:
+    payload = helper.build_review_payload("clean", [], [], event="APPROVE")
+    assert payload["event"] == "APPROVE"
+    assert "comments" not in payload
+
+
+def test_build_review_payload_comment_keeps_empty_comments_key(helper: ModuleType) -> None:
+    payload = helper.build_review_payload("body", [], [], event="COMMENT")
+    assert payload["comments"] == []
+
+
+def _fake_run_factory(responses: list[SimpleNamespace]) -> tuple:
+    """Build a fake ``subprocess.run`` that returns queued responses in order.
+
+    :param responses: Queued ``CompletedProcess``-like results, consumed FIFO.
+    :returns: The fake callable and a list recording each invocation's stdin.
+    """
+    calls: list[str] = []
+
+    def fake_run(*_args: object, **kwargs: object) -> SimpleNamespace:
+        calls.append(str(kwargs.get("input")))
+        return responses.pop(0)
+
+    return fake_run, calls
+
+
+def test_submit_review_self_review_422_falls_back_to_comment(
+    helper: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    err_422 = SimpleNamespace(
+        returncode=1,
+        stdout="",
+        stderr="HTTP 422: Can not request changes on your own pull request",
+    )
+    ok = SimpleNamespace(
+        returncode=0,
+        stdout=json.dumps({"html_url": "https://example/r/1"}),
+        stderr="",
+    )
+    fake_run, calls = _fake_run_factory([err_422, ok])
+    monkeypatch.setattr(helper.subprocess, "run", fake_run)
+    monkeypatch.setattr(helper, "gh_executable", lambda: "/usr/bin/gh")
+
+    payload = {"body": "Original review.", "event": "REQUEST_CHANGES", "comments": []}
+    response = helper.submit_review("o/r", 7, payload, fallback_banner="⛔ BANNER")
+
+    assert response["html_url"] == "https://example/r/1"
+    assert len(calls) == 2
+    retried = json.loads(calls[1])
+    assert retried["event"] == "COMMENT"
+    assert retried["body"].startswith("⛔ BANNER")
+    assert "Original review." in retried["body"]
+
+
+def test_submit_review_success_does_not_retry(
+    helper: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ok = SimpleNamespace(
+        returncode=0,
+        stdout=json.dumps({"html_url": "https://example/r/2"}),
+        stderr="",
+    )
+    fake_run, calls = _fake_run_factory([ok])
+    monkeypatch.setattr(helper.subprocess, "run", fake_run)
+    monkeypatch.setattr(helper, "gh_executable", lambda: "/usr/bin/gh")
+
+    payload = {"body": "b", "event": "REQUEST_CHANGES", "comments": []}
+    response = helper.submit_review("o/r", 7, payload, fallback_banner="x")
+
+    assert response["html_url"] == "https://example/r/2"
+    assert len(calls) == 1
+
+
+def test_submit_review_non_self_422_exits(
+    helper: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    err = SimpleNamespace(returncode=1, stdout="", stderr="HTTP 404: Not Found")
+    fake_run, _calls = _fake_run_factory([err])
+    monkeypatch.setattr(helper.subprocess, "run", fake_run)
+    monkeypatch.setattr(helper, "gh_executable", lambda: "/usr/bin/gh")
+
+    payload = {"body": "b", "event": "REQUEST_CHANGES", "comments": []}
+    with pytest.raises(SystemExit):
+        helper.submit_review("o/r", 7, payload, fallback_banner="x")

--- a/tests/claude_hooks/test_post_review_event.py
+++ b/tests/claude_hooks/test_post_review_event.py
@@ -47,16 +47,28 @@ def helper() -> ModuleType:
 
 
 def test_build_review_payload_event_defaults_to_comment(helper: ModuleType) -> None:
+    """An explicit COMMENT event is set on the payload.
+
+    :param helper: The loaded ``post_review`` module.
+    """
     payload = helper.build_review_payload("body", [], [], event="COMMENT")
     assert payload["event"] == "COMMENT"
 
 
 def test_build_review_payload_request_changes_passes_through(helper: ModuleType) -> None:
+    """REQUEST_CHANGES is carried through to the payload event.
+
+    :param helper: The loaded ``post_review`` module.
+    """
     payload = helper.build_review_payload("body", [], [], event="REQUEST_CHANGES")
     assert payload["event"] == "REQUEST_CHANGES"
 
 
 def test_build_review_payload_invalid_event_raises(helper: ModuleType) -> None:
+    """An unrecognized event value raises ValueError.
+
+    :param helper: The loaded ``post_review`` module.
+    """
     with pytest.raises(ValueError, match="event"):
         helper.build_review_payload("body", [], [], event="LGTM")
 
@@ -64,12 +76,20 @@ def test_build_review_payload_invalid_event_raises(helper: ModuleType) -> None:
 def test_build_review_payload_approve_with_no_findings_omits_comments(
     helper: ModuleType,
 ) -> None:
+    """APPROVE with no findings omits the comments key (GitHub rejects it otherwise).
+
+    :param helper: The loaded ``post_review`` module.
+    """
     payload = helper.build_review_payload("clean", [], [], event="APPROVE")
     assert payload["event"] == "APPROVE"
     assert "comments" not in payload
 
 
 def test_build_review_payload_comment_keeps_empty_comments_key(helper: ModuleType) -> None:
+    """COMMENT keeps an empty comments list rather than dropping the key.
+
+    :param helper: The loaded ``post_review`` module.
+    """
     payload = helper.build_review_payload("body", [], [], event="COMMENT")
     assert payload["comments"] == []
 
@@ -92,6 +112,11 @@ def _fake_run_factory(responses: list[SimpleNamespace]) -> tuple:
 def test_submit_review_self_review_422_falls_back_to_comment(
     helper: ModuleType, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """A self-review 422 retries once as COMMENT with the banner prepended.
+
+    :param helper: The loaded ``post_review`` module.
+    :param monkeypatch: Pytest fixture for patching ``subprocess.run``.
+    """
     err_422 = SimpleNamespace(
         returncode=1,
         stdout="",
@@ -120,6 +145,11 @@ def test_submit_review_self_review_422_falls_back_to_comment(
 def test_submit_review_success_does_not_retry(
     helper: ModuleType, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """A successful first submit does not trigger the fallback retry.
+
+    :param helper: The loaded ``post_review`` module.
+    :param monkeypatch: Pytest fixture for patching ``subprocess.run``.
+    """
     ok = SimpleNamespace(
         returncode=0,
         stdout=json.dumps({"html_url": "https://example/r/2"}),
@@ -139,6 +169,11 @@ def test_submit_review_success_does_not_retry(
 def test_submit_review_non_self_422_exits(
     helper: ModuleType, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """A non-self-review API error propagates as SystemExit (no fallback).
+
+    :param helper: The loaded ``post_review`` module.
+    :param monkeypatch: Pytest fixture for patching ``subprocess.run``.
+    """
     err = SimpleNamespace(returncode=1, stdout="", stderr="HTTP 404: Not Found")
     fake_run, _calls = _fake_run_factory([err])
     monkeypatch.setattr(helper.subprocess, "run", fake_run)

--- a/tests/claude_hooks/test_post_review_event.py
+++ b/tests/claude_hooks/test_post_review_event.py
@@ -142,6 +142,38 @@ def test_submit_review_self_review_422_falls_back_to_comment(
     assert "Original review." in retried["body"]
 
 
+def test_submit_review_self_approve_422_falls_back_to_comment(
+    helper: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A self-APPROVE 422 also falls back to COMMENT (regex covers approve + request-changes).
+
+    :param helper: The loaded ``post_review`` module.
+    :param monkeypatch: Pytest fixture for patching ``subprocess.run``.
+    """
+    err_422 = SimpleNamespace(
+        returncode=1,
+        stdout="",
+        stderr="HTTP 422: Can not approve your own pull request",
+    )
+    ok = SimpleNamespace(
+        returncode=0,
+        stdout=json.dumps({"html_url": "https://example/r/3"}),
+        stderr="",
+    )
+    fake_run, calls = _fake_run_factory([err_422, ok])
+    monkeypatch.setattr(helper.subprocess, "run", fake_run)
+    monkeypatch.setattr(helper, "gh_executable", lambda: "/usr/bin/gh")
+
+    payload = {"body": "Clean review.", "event": "APPROVE"}
+    response = helper.submit_review("o/r", 7, payload, fallback_banner="✅ No findings")
+
+    assert response["html_url"] == "https://example/r/3"
+    assert len(calls) == 2
+    retried = json.loads(calls[1])
+    assert retried["event"] == "COMMENT"
+    assert retried["body"].startswith("✅ No findings")
+
+
 def test_submit_review_success_does_not_retry(
     helper: ModuleType, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

`/repo-review-full` posted every review via `post_review.py` with a hardcoded `event=COMMENT`, so a BLOCK-laden review never requested changes. This aligns the full pipeline with the local `/review` skill: any BLOCK → `REQUEST_CHANGES`, WARN-only → `COMMENT`, none → `APPROVE`.

## Changes

- **`post_review.py`**: `build_review_payload` now reads an optional top-level `event` from the request (default `COMMENT`, validated against {COMMENT, REQUEST_CHANGES, APPROVE}, `ValueError` otherwise); APPROVE-with-no-findings still omits the `comments` key.
- **Self-review fallback**: GitHub rejects `REQUEST_CHANGES`/`APPROVE` on the bot's own PR with an HTTP 422. `submit_review` now attempts the requested event and, on a self-review 422, retries once as `event=COMMENT` with a loud `⛔ N BLOCKING finding(s) — changes required (self-review: posted as COMMENT)` banner prepended, preserving the finding threads so the blocking intent stays visible.
- **`repo-review-full/SKILL.md`** (+ shared analysis Step 6): instruct the skill to compute `event` (any `[*:block]`, including folded PR-health BLOCKs → REQUEST_CHANGES; else WARN → COMMENT; else APPROVE). The MVP `repo-review` skill is unchanged.
- Eight behavioral tests under `tests/claude_hooks/test_post_review_event.py` cover passthrough, invalid event, APPROVE-omits-comments, the self-review 422 fallback (banner + COMMENT), no-retry on success, and exit on a non-self 422.

Part of #1405