### PR TITLE
ci(pipeline): emit full Hydra tracebacks from datagen launcher CI workflows

### DIFF
--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -429,6 +429,7 @@ jobs:
           INPUT_HYDRA_OVERRIDES: ${{ inputs.hydra_overrides }}
           INPUT_RUN_ID: ${{ inputs.run_id || format('{0}-{1}', github.run_id, github.run_attempt) }}
           SYNTH_SETTER_CI_MODE: "1"
+          HYDRA_FULL_ERROR: "1"
         run: |
           set -euo pipefail
           OVERRIDES=(
@@ -553,6 +554,7 @@ jobs:
           LOCAL_OVERRIDE: ${{ inputs.local && 'skypilot_launch.local=true' || '' }}
           HYDRA_OVERRIDES_EXTRA: ${{ inputs.hydra_overrides }}
           INPUT_RUN_ID: ${{ inputs.run_id || format('{0}-{1}', github.run_id, github.run_attempt) }}
+          HYDRA_FULL_ERROR: "1"
         run: |
           set -euo pipefail
           docker run --rm \
@@ -581,6 +583,7 @@ jobs:
             -e LOCAL_OVERRIDE \
             -e HYDRA_OVERRIDES_EXTRA \
             -e INPUT_RUN_ID \
+            -e HYDRA_FULL_ERROR \
             "${IMAGE}" \
             bash -c '
               set -euo pipefail

--- a/.github/workflows/test-skypilot-debug.yml
+++ b/.github/workflows/test-skypilot-debug.yml
@@ -388,6 +388,7 @@ jobs:
           CONFIG_PATH: ${{ matrix.config }}
           TEMPLATE: ${{ matrix.template }}
           LOG_PATH: /tmp/debug-pure-sky-${{ matrix.cluster_suffix }}.log
+          HYDRA_FULL_ERROR: "1"
         run: |
           set -euo pipefail
           uv run synth-setter-generate-dataset \
@@ -408,6 +409,7 @@ jobs:
           CONFIG_PATH: ${{ matrix.config }}
           TEMPLATE: ${{ matrix.template }}
           LOG_PATH: /tmp/debug-pure-sky-${{ matrix.cluster_suffix }}.log
+          HYDRA_FULL_ERROR: "1"
         run: |
           set -euo pipefail
           docker pull "$IMAGE"
@@ -422,6 +424,7 @@ jobs:
             -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
             -e RCLONE_CONFIG_R2_ENDPOINT \
             -e R2_ACCOUNT_ID \
+            -e HYDRA_FULL_ERROR \
             "$IMAGE" \
             bash -c '
               set -euo pipefail


### PR DESCRIPTION
## Summary

The datagen launcher entrypoint `synth-setter-generate-dataset` (`src/synth_setter/cli/generate_dataset.py`) is wrapped in `@hydra.main`. When the launcher fails (spec materialize, R2 upload, or SkyPilot dispatch), Hydra's decorator suppresses the traceback and prints only a one-line summary unless `HYDRA_FULL_ERROR=1` is in the environment. Several CI workflows that drive this entrypoint did not set it, so launcher-side failures surfaced as truncated, hard-to-debug errors.

## Changes

Export `HYDRA_FULL_ERROR=1` at every CI call site that invokes the `@hydra.main` entrypoint:

- **`generate-dataset-shards.yaml`** — `gen_local` (host) and `gen_docker` (in-container, forwarded via `-e HYDRA_FULL_ERROR`). This reusable also covers `test-dataset-generation.yml`, which dispatches through it.
- **`test-skypilot-debug.yml`** — `launcher-runner` and `launcher-docker` modes.

## Intentionally out of scope

`spec-materialization.yml`, `test-spec-materialization.yml`, and `validate-dataset-shards.yaml` call `materialize_spec` / `validate_spec` / `validate_shard` — none is a `@hydra.main`. `materialize_spec` uses the Hydra compose API (and already catches `HydraException`); the others aren't Hydra entrypoints. `HYDRA_FULL_ERROR` would be inert there, so they are left untouched.

## Testing

- `pytest tests/infra/test_generate_dataset_shards_hydra_overrides_validation.py` — 36 passed
- `pre-commit run` on both workflows — all hooks pass (incl. actionlint "Validate GitHub Workflows")
- `/repo-review-full-no-comments` — 0 BLOCK across 5 skills (code-health, synth-setter-project-standards, gha-workflow-validator, comment-hygiene, shell-style); 1 non-actionable advisory WARN (per-step env duplication, which cannot be hoisted without leaking into non-Hydra docker steps).

Refs #353
