### PR TITLE
ci(testing): run Mutation Testing on Python 3.11 to fix mutmut pyproject parse

### DIFF
--- a/.github/workflows/mutmut.yaml
+++ b/.github/workflows/mutmut.yaml
@@ -27,10 +27,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up Python 3.10
+      # Requires 3.11+: mutmut parses pyproject.toml, and 3.10's legacy `toml`
+      # fallback crashes on the PEP 735 `dev` group's inline-table arrays — #1414.
+      - name: Set up Python 3.11
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/docs/testing/mutmut.md
+++ b/docs/testing/mutmut.md
@@ -6,6 +6,15 @@ This is the authoritative entry point — the CI workflow
 `.github/workflows/mutmut.yaml` runs it on Linux (`workflow_dispatch` + weekly
 cron).
 
+## Requires Python 3.11+
+
+mutmut parses the whole `pyproject.toml`. On Python 3.10 it falls back to the
+legacy `toml` library, which crashes (`IndexError` in `load_array`) on the
+PEP 735 `dev` group's mixed string/inline-table arrays; 3.11+ uses stdlib
+`tomllib`, which parses it cleanly ([#1414](https://github.com/tinaudio/synth-setter/issues/1414)).
+Run `make mutmut` under a 3.11+ interpreter — the CI workflow pins 3.11 for
+this reason.
+
 ## `also_copy` covers the full package
 
 mutmut copies the paths under `paths_to_mutate` into a `mutants/` sandbox and


### PR DESCRIPTION
## Problem

The **Mutation Testing** workflow (`.github/workflows/mutmut.yaml`, weekly cron) has failed every scheduled run since 2026-05-24. Both `mutmut run` and `mutmut results` crash before doing any mutation work:

```
File ".../toml/decoder.py", line 1002, in load_array
    a[b] = a[b] + ',' + a[b + 1]
IndexError: list index out of range
```

## Root cause

mutmut's `config_reader` parses the **entire** `pyproject.toml`. On Python **3.11+** it uses stdlib `tomllib`; on **3.10** it falls back to the legacy `toml` package (uiri/toml 0.10.2) — and the workflow pinned Python 3.10. That legacy parser has a bug on TOML arrays that **mix bare strings with inline tables**, which `pyproject.toml` now has:

- the PEP 735 `dev` group: `dev = ["ruff", …, { include-group = "docs" }, { include-group = "runtime" }]`
- the `[tool.uv.sources]` per-platform index lists

Bisected to the first failing commit `4d2c5c88` ("introduce uv.lock + hybrid PyTorch routing"), part of Epic #1243. Reproduced locally: 3.10 legacy `toml` raises `IndexError`; 3.11 / 3.12 stdlib `tomllib` parse the same file cleanly, and mutmut's exact `config_reader` code path loads `[tool.mutmut]` without error on 3.11.

## Fix

Bump only the Mutation Testing job to Python 3.11 so mutmut uses stdlib `tomllib`. `requires-python` is `>=3.10,<3.14`, so 3.11 is in range; `uv sync --frozen` resolves against the unchanged `uv.lock`. 3.10 behavioral coverage continues to live in `test.yml`'s 3.10/3.11 matrix.

## Verification

- Reproduced the `IndexError` on 3.10 and a clean parse on 3.11/3.12 against the repo's `pyproject.toml`.
- `gha-workflow-validator` + `pre-commit` (incl. "Validate GitHub Workflows") pass.
- `/repo-review-full-no-comments`: 0 BLOCK, 2 advisory WARN (both pre-existing / out of scope).

Refs #1414