### PR TITLE
ci(ci-automation): reclaim CodeQL tool-cache before kind load on skypilot-local row

### DIFF
--- a/.github/workflows/generate-dataset-shards.yaml
+++ b/.github/workflows/generate-dataset-shards.yaml
@@ -262,6 +262,19 @@ jobs:
           docker-images: true
           swap-storage: true
 
+      # `free-disk-space` keeps `/opt/hostedtoolcache` (tool-cache: false) because
+      # `helm/kind-action` aborts when that directory is missing. CodeQL is the
+      # largest unused subtree under it (~5 GB) and this row never runs it, so
+      # purge only that subdir: the parent dir stays present for kind-action, and
+      # Python (resolved from the cache by the later setup-python step) is left
+      # intact. `df -h /` is best-effort diagnostics — see the kind-load step.
+      - name: Purge unused CodeQL tool-cache for kind headroom (skypilot-local row)
+        if: ${{ inputs.provider == 'skypilot-local' }}
+        run: |
+          set -euo pipefail
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          df -h / || true
+
       # A2 (#1164): pull the worker image in the background so the kind binary
       # install + Python / uv setup can run in parallel. The pull only fills
       # the host Docker cache; nothing downstream of this step reads from it
@@ -384,9 +397,15 @@ jobs:
           fi
           echo "docker pull completed for ${IMAGE}"
 
+      # `kind load` shells to `docker save` under `/var/lib/docker/tmp/`, so log
+      # the root-fs margin first — a future ENOSPC here (#1278) then shows the
+      # headroom at the moment that matters instead of only the post-reclaim total.
       - name: Load dev-snapshot image into kind (skypilot-local row)
         if: ${{ inputs.provider == 'skypilot-local' }}
-        run: kind load docker-image "${IMAGE}" --name skypilot
+        run: |
+          set -euo pipefail
+          df -h / || true
+          kind load docker-image "${IMAGE}" --name skypilot
 
       # SYNTH_SETTER_CI_MODE=1 activates the launcher's
       # `_ensure_ci_sky_config()` (in src/synth_setter/pipeline/skypilot_launch.py),


### PR DESCRIPTION
## Summary

Re-add a targeted `rm -rf /opt/hostedtoolcache/CodeQL` (~5 GB) on the
`skypilot-local` row of `generate-dataset-shards.yaml`, just after the
existing `jlumbroso/free-disk-space` step, plus `df -h /` instrumentation
in that step and at the head of the `kind load` step.

## Why

The `skypilot-local` row intermittently fails at **Load dev-snapshot image
into kind** with `no space left on device`. `kind load docker-image` shells
to `docker save` under `/var/lib/docker/tmp/` before re-extracting the CUDA
image into the kind node's containerd (~30 GB peak on `/`).

PR #1280 hand-purged `/opt/hostedtoolcache/CodeQL` (~5 GB). PR #1292 replaced
that with `jlumbroso/free-disk-space` at `tool-cache: false` — which retains
**all** of `/opt/hostedtoolcache` (the action can only delete the whole dir,
and `helm/kind-action` aborts when it is missing), silently dropping the
~5 GB CodeQL reclaim. This restores it by deleting only the unused CodeQL
subtree: the parent dir stays present for kind-action, and `Python`
(resolved from the cache by the later `setup-python` step) is left intact.

`df -h /` now prints the root-fs margin at the moment that matters, so a
future ENOSPC shows the headroom in the run log instead of only the
post-reclaim total.

This is a **band-aid**. The root fix — a CPU-torch `dev-snapshot` variant
for this GPU-less row (it runs `sky local up --no-gpus` and never executes a
CUDA kernel), which would drop the ~4.4 GB CUDA-venv layer — remains tracked
on the issue.

## Scope / safety

- Gated on `inputs.provider == 'skypilot-local'`; runpod/oci rows (`docker
  run`, no `kind load`) are untouched.
- `rm -rf` is idempotent on a missing path, so the step stays green if the
  action ever stops shipping CodeQL.
- `df -h /` is best-effort (`|| true`) so the diagnostic can't mask the real
  step under `set -euo pipefail`.

## Test plan

- [ ] Dispatch *Test Dataset Generation* / *Test Dataset Finalization* against
      this branch and confirm the *Load dev-snapshot image into kind* step
      succeeds with visible `df -h /` headroom in the log.
- [x] `pre-commit` (Validate GitHub Workflows + prettier) passes on the file.
- [x] `/repo-review-full-no-comments`: 0 BLOCK across 5 skills; comment-hygiene
      and shell-style WARNs applied before opening.

Refs #1278