### PR TITLE
build(devcontainer): set WANDB_DATA_DIR so wandb artifact staging is writable

### DIFF
--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -490,6 +490,10 @@ USER $USERNAME
 # these dev-writable dirs ahead of system binaries.
 ENV PATH="$PATH:/home/${USERNAME}/.npm-global/bin:/home/${USERNAME}/.local/bin"
 
+# wandb's default staging dir (~/.local/share/wandb) isn't writable at runtime in
+# the devcontainer (see #1423); stage under .cache, which wandb creates on demand.
+ENV WANDB_DATA_DIR="/home/${USERNAME}/.cache/wandb"
+
 # dev's `npm install -g` would EACCES on the root-owned global tree (claude-code
 # is baked in as root); a per-user prefix sends it to a writable one. $HOME is
 # unset after USER, so export it per-RUN (not ENV — that leaks to root sessions).


### PR DESCRIPTION
## What

Set `WANDB_DATA_DIR=/home/${USERNAME}/.cache/wandb` in the `devcontainer-tools` stage of
`docker/ubuntu22_04/Dockerfile`, alongside the other per-user `ENV`s.

## Why

In the devcontainer, `log_spec_artifact` fails on `WandbLogger`:

```
log_spec_artifact failed on WandbLogger: Unable to write staging files to
/home/dev/.local/share/wandb/artifacts/staging. To fix this problem, please set
WANDB_DATA_DIR to a directory where you have the necessary write access.
```

wandb stages artifact uploads under `WANDB_DATA_DIR` (default
`~/.local/share/wandb`), and that staging path is not writable at runtime in the
container. Pointing `WANDB_DATA_DIR` at `.cache` — a conventional, dev-owned
ephemeral location — lets wandb create the `wandb/artifacts/staging` subtree on
demand. No extra `mkdir`/`chown` layer is needed.

The fix lives in the base image rather than `.devcontainer/Dockerfile` so it is
shared across all variants and respects the `${USERNAME}` ARG. It takes effect
once `tinaudio/synth-setter:devcontainer-tools` is rebuilt/republished and
devcontainers are rebuilt from the new image.

## Test

Pre-PR gate: `/repo-review-full-no-comments` — 0 BLOCK, 0 WARN after addressing
a comment-hygiene note on the rationale wording. No automated test applies to an
image `ENV`; functional verification is rebuilding the devcontainer and
confirming `log_spec_artifact` uploads the input-spec artifact without the
staging-write error.

Fixes #1423