### PR TITLE
build: keep VS Code from deleting unused imports (F401) on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,12 @@
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "ruff.importStrategy": "fromEnvironment",
 
+  "ruff.configuration": {
+    "lint": {
+      "unfixable": ["F401"]
+    }
+  },
+
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",
     "editor.formatOnSave": true,


### PR DESCRIPTION
## What

Adds an **editor-server-only** ruff override to `.vscode/settings.json` so the VS Code ruff LSP stops auto-deleting unused imports (F401) on save:

```json
"ruff.configuration": { "lint": { "unfixable": ["F401"] } }
```

## Why

The committed settings run `source.fixAll.ruff` on save, which applies the F401 autofix — so an import you've typed but not yet used is deleted out from under you mid-edit.

## Scope of the behavior change

Only the in-editor ruff LSP is affected:

- ✅ All other on-save autofixes and import sorting keep working.
- ✅ CLI `ruff check --fix` and the pre-commit `ruff` hook read `pyproject.toml` (no `unfixable`) and **still strip** unused imports.
- ✅ F401 stays visible as an editor diagnostic squiggle — it's just no longer auto-deleted.

Verified `check-json` pre-commit passes (strict JSON, no comments).

Refs #1431