### PR TITLE
fix(eval): use configured render vals in oracle predict_vst_audio

### DIFF
--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -139,6 +139,18 @@ def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: D
             ]
             if cfg.render.get("plugin_path"):
                 args += ["--plugin_path", cfg.render.plugin_path]
+            # Forward the remaining render fields predict_vst_audio renders with so the
+            # re-render matches the dataset's generation render rather than this module's
+            # CLI defaults. Gated like plugin_path so a partial render cfg still works.
+            for flag, key in (
+                ("--sample_rate", "sample_rate"),
+                ("--channels", "channels"),
+                ("--velocity", "velocity"),
+                ("--signal_duration_seconds", "signal_duration_seconds"),
+            ):
+                value = cfg.render.get(key)
+                if value is not None:
+                    args += [flag, str(value)]
             if cfg.evaluation.rerender_target:
                 args.append("-t")
             log.info(f"Rendering predicted audio: {args}")

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -70,11 +70,16 @@ def _run_oracle_eval_subprocess(
     *,
     param_spec_name: str,
     preset_path: str,
+    plugin_path: str,
 ) -> None:
     """Run the fake-oracle eval over ``dataset_root`` to verify the param-array round-trip.
 
     ``check=True`` so a non-zero eval exit (or wall-clock timeout) propagates
     to the caller.
+
+    The eval re-renders predictions via ``predict_vst_audio``, which reads exactly
+    ``param_spec_name`` / ``preset_path`` / ``plugin_path`` from ``cfg.render``; all
+    three are passed through from the generation render so the re-render matches it.
 
     :param dataset_root: Dir holding the finalized HDF5 splits, their source
         shards, and ``stats.npz``. The splits are virtual datasets that
@@ -89,6 +94,8 @@ def _run_oracle_eval_subprocess(
         eval must re-render predictions through this same spec.
     :param preset_path: ``render.preset_path`` used at generation; paired with
         ``param_spec_name`` so the re-render preset matches.
+    :param plugin_path: ``render.plugin_path`` used at generation; re-rendering
+        with a different plugin binary would invalidate the ``audio/*`` metrics.
     :raises FileNotFoundError: ``dataset_root`` is missing any finalized split
         or ``stats.npz`` — e.g. a resume where ``finalize_from_spec``
         short-circuited on an existing R2 marker without repopulating it.
@@ -111,12 +118,13 @@ def _run_oracle_eval_subprocess(
         "ckpt_path=null",
         "logger=wandb",
         # eval.yaml leaves render null; render_vst=true re-renders predicted
-        # params. Take the surge_simple group's structural render fields, then
-        # override the param spec + preset to match the dataset's generation
-        # render so the round-trip uses the same spec.
+        # params. Take the surge_simple group for structure, then override the
+        # three fields predict_vst_audio reads (param spec, preset, plugin) to
+        # the dataset's generation render so the round-trip matches it exactly.
         "render=surge_simple",
         f"render.param_spec_name={param_spec_name}",
         f"render.preset_path={preset_path}",
+        f"render.plugin_path={plugin_path}",
         # id already exists in logger/wandb.yaml (id: null) so a plain
         # override suffices; resume is absent there and needs +append.
         f"logger.wandb.id={run_id}",
@@ -132,11 +140,12 @@ def _run_oracle_eval_subprocess(
 
 
 def _unsupported_cadence_reason(render_cfg: DictConfig) -> str | None:
-    """Return why this render cadence combination is schema-invalid, else ``None``.
+    """Return the reason if ``gui_toggle_cadence=always_on`` lacks ``plugin_reload_cadence=once``.
 
-    Mirrors ``RenderConfig._always_on_requires_plugin_reload_once`` so ``main`` can
-    skip a wandb-grid cell the validator would otherwise raise on. Kept in sync
-    with that validator by hand.
+    Covers only that one combination — it mirrors
+    ``RenderConfig._always_on_requires_plugin_reload_once`` so ``main`` can skip the
+    grid cell that validator would raise on. Other ``RenderConfig`` validation errors
+    are not pre-empted here. Kept in sync with that validator by hand.
 
     :param render_cfg: Composed ``render`` group; reads ``gui_toggle_cadence`` and
         ``plugin_reload_cadence``.
@@ -757,9 +766,10 @@ def main(cfg: DictConfig) -> None:
     the launcher/worker composition matches byte-for-byte; ``HydraConfig`` is
     the authoritative source for the operator's task overrides.
 
-    A schema-invalid render cadence combination (see
-    :func:`_unsupported_cadence_reason`) is a logged no-op rather than a raise,
-    so a wandb grid sweep can enumerate the cell without failing the trial.
+    The one schema-invalid cadence cell ``gui_toggle_cadence=always_on`` +
+    ``plugin_reload_cadence!=once`` (see :func:`_unsupported_cadence_reason`) is a
+    logged no-op rather than a raise, so a wandb grid sweep can enumerate it without
+    failing the trial; other ``RenderConfig`` validation errors still raise.
 
     :param cfg: Hydra-composed dataset cfg.
     :raises ValueError: ``oracle_eval_inline=true`` without
@@ -830,6 +840,7 @@ def main(cfg: DictConfig) -> None:
                 spec.run_id,
                 param_spec_name=spec.render.param_spec_name,
                 preset_path=spec.render.preset_path,
+                plugin_path=spec.render.plugin_path,
             )
         return
 

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -63,7 +63,14 @@ _ORACLE_EVAL_TIMEOUT_SECONDS = 600
 _ORACLE_EVAL_REQUIRED_ARTIFACTS = ("train.h5", "val.h5", "test.h5", STATS_NPZ_FILENAME)
 
 
-def _run_oracle_eval_subprocess(dataset_root: Path, run_dir: Path, run_id: str) -> None:
+def _run_oracle_eval_subprocess(
+    dataset_root: Path,
+    run_dir: Path,
+    run_id: str,
+    *,
+    param_spec_name: str,
+    preset_path: str,
+) -> None:
     """Run the fake-oracle eval over ``dataset_root`` to verify the param-array round-trip.
 
     ``check=True`` so a non-zero eval exit (or wall-clock timeout) propagates
@@ -78,6 +85,10 @@ def _run_oracle_eval_subprocess(dataset_root: Path, run_dir: Path, run_id: str) 
         artifacts don't mix with the dataset files.
     :param run_id: Canonical ``spec.run_id``; the eval resumes this wandb run
         so its ``audio/*`` metrics land on the generate phase's run.
+    :param param_spec_name: ``render.param_spec_name`` used at generation; the
+        eval must re-render predictions through this same spec.
+    :param preset_path: ``render.preset_path`` used at generation; paired with
+        ``param_spec_name`` so the re-render preset matches.
     :raises FileNotFoundError: ``dataset_root`` is missing any finalized split
         or ``stats.npz`` — e.g. a resume where ``finalize_from_spec``
         short-circuited on an existing R2 marker without repopulating it.
@@ -99,10 +110,13 @@ def _run_oracle_eval_subprocess(dataset_root: Path, run_dir: Path, run_id: str) 
         f"hydra.run.dir={run_dir}",
         "ckpt_path=null",
         "logger=wandb",
-        # eval.yaml defaults render to null; render_vst=true re-renders the
-        # predicted params, so select the surge_simple group the smoke shard
-        # was generated with (param spec + preset must match the dataset).
+        # eval.yaml leaves render null; render_vst=true re-renders predicted
+        # params. Take the surge_simple group's structural render fields, then
+        # override the param spec + preset to match the dataset's generation
+        # render so the round-trip uses the same spec.
         "render=surge_simple",
+        f"render.param_spec_name={param_spec_name}",
+        f"render.preset_path={preset_path}",
         # id already exists in logger/wandb.yaml (id: null) so a plain
         # override suffices; resume is absent there and needs +append.
         f"logger.wandb.id={run_id}",
@@ -115,6 +129,29 @@ def _run_oracle_eval_subprocess(dataset_root: Path, run_dir: Path, run_id: str) 
     ]
     logger.info(f"oracle_eval_inline subprocess: {argv}")
     subprocess.run(argv, check=True, timeout=_ORACLE_EVAL_TIMEOUT_SECONDS)  # noqa: S603
+
+
+def _unsupported_cadence_reason(render_cfg: DictConfig) -> str | None:
+    """Return why this render cadence combination is schema-invalid, else ``None``.
+
+    Mirrors ``RenderConfig._always_on_requires_plugin_reload_once`` so ``main`` can
+    skip a wandb-grid cell the validator would otherwise raise on. Kept in sync
+    with that validator by hand.
+
+    :param render_cfg: Composed ``render`` group; reads ``gui_toggle_cadence`` and
+        ``plugin_reload_cadence``.
+    :returns: A reason string when the combination is unsupported, else ``None``.
+    """
+    if (
+        render_cfg.get("gui_toggle_cadence") == "always_on"
+        and render_cfg.get("plugin_reload_cadence") != "once"
+    ):
+        reload_cadence = render_cfg.get("plugin_reload_cadence")
+        return (
+            f"gui_toggle_cadence=always_on requires plugin_reload_cadence=once, "
+            f"got plugin_reload_cadence={reload_cadence!r}"
+        )
+    return None
 
 
 def _rclone_copy(src: str, dest: str) -> None:
@@ -720,12 +757,26 @@ def main(cfg: DictConfig) -> None:
     the launcher/worker composition matches byte-for-byte; ``HydraConfig`` is
     the authoritative source for the operator's task overrides.
 
+    A schema-invalid render cadence combination (see
+    :func:`_unsupported_cadence_reason`) is a logged no-op rather than a raise,
+    so a wandb grid sweep can enumerate the cell without failing the trial.
+
     :param cfg: Hydra-composed dataset cfg.
     :raises ValueError: ``oracle_eval_inline=true`` without
         ``finalize_inline=true``, with ``output_format!=hdf5``, or with
         a zero-size train / val / test split (the eval datamodule opens
         all three split files unconditionally).
     """
+    render_cfg = cfg.get("render")
+    skip_reason = None if render_cfg is None else _unsupported_cadence_reason(render_cfg)
+    if skip_reason is not None:
+        logger.warning(
+            f"skipping run: unsupported render cadence combination ({skip_reason}). "
+            "No dataset generated — a no-op so a wandb grid sweep can enumerate this "
+            "cell without failing the trial."
+        )
+        return
+
     overrides = list(HydraConfig.get().overrides.task)
     spec = spec_from_cfg(cfg)
     sky_cfg = _sky_cfg_from_dataset_cfg(cfg)
@@ -773,7 +824,13 @@ def main(cfg: DictConfig) -> None:
             # basename, so read them in place — no R2 round-trip.
             output_dir = Path(cfg.paths.output_dir)
             eval_run_dir = output_dir / "oracle_eval" / spec.run_id
-            _run_oracle_eval_subprocess(output_dir, eval_run_dir, spec.run_id)
+            _run_oracle_eval_subprocess(
+                output_dir,
+                eval_run_dir,
+                spec.run_id,
+                param_spec_name=spec.render.param_spec_name,
+                preset_path=spec.render.preset_path,
+            )
         return
 
     if cfg.finalize_inline or cfg.oracle_eval_inline:

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -39,7 +39,7 @@ from synth_setter.pipeline.partitioning import (
     read_rank_world_from_env,
 )
 from synth_setter.pipeline.schemas.skypilot_launch import SkypilotLaunchConfig
-from synth_setter.pipeline.schemas.spec import DatasetSpec, ShardSpec
+from synth_setter.pipeline.schemas.spec import DatasetSpec, RenderConfig, ShardSpec
 from synth_setter.pipeline.spec_io import (
     upload_spec,
     write_spec_locally,
@@ -68,18 +68,12 @@ def _run_oracle_eval_subprocess(
     run_dir: Path,
     run_id: str,
     *,
-    param_spec_name: str,
-    preset_path: str,
-    plugin_path: str,
+    render: RenderConfig,
 ) -> None:
     """Run the fake-oracle eval over ``dataset_root`` to verify the param-array round-trip.
 
     ``check=True`` so a non-zero eval exit (or wall-clock timeout) propagates
     to the caller.
-
-    The eval re-renders predictions via ``predict_vst_audio``, which reads exactly
-    ``param_spec_name`` / ``preset_path`` / ``plugin_path`` from ``cfg.render``; all
-    three are passed through from the generation render so the re-render matches it.
 
     :param dataset_root: Dir holding the finalized HDF5 splits, their source
         shards, and ``stats.npz``. The splits are virtual datasets that
@@ -90,12 +84,11 @@ def _run_oracle_eval_subprocess(
         artifacts don't mix with the dataset files.
     :param run_id: Canonical ``spec.run_id``; the eval resumes this wandb run
         so its ``audio/*`` metrics land on the generate phase's run.
-    :param param_spec_name: ``render.param_spec_name`` used at generation; the
-        eval must re-render predictions through this same spec.
-    :param preset_path: ``render.preset_path`` used at generation; paired with
-        ``param_spec_name`` so the re-render preset matches.
-    :param plugin_path: ``render.plugin_path`` used at generation; re-rendering
-        with a different plugin binary would invalidate the ``audio/*`` metrics.
+    :param render: The generation ``RenderConfig``. The eval re-renders
+        predictions via ``predict_vst_audio``; every render field it renders with
+        (param spec, preset, plugin, sample rate, channels, velocity, signal
+        duration) is overridden from this so the re-render matches generation
+        exactly rather than falling back to the render group / CLI defaults.
     :raises FileNotFoundError: ``dataset_root`` is missing any finalized split
         or ``stats.npz`` — e.g. a resume where ``finalize_from_spec``
         short-circuited on an existing R2 marker without repopulating it.
@@ -118,13 +111,17 @@ def _run_oracle_eval_subprocess(
         "ckpt_path=null",
         "logger=wandb",
         # eval.yaml leaves render null; render_vst=true re-renders predicted
-        # params. Take the surge_simple group for structure, then override the
-        # three fields predict_vst_audio reads (param spec, preset, plugin) to
-        # the dataset's generation render so the round-trip matches it exactly.
+        # params. Take the surge_simple group for structure, then override every
+        # render field predict_vst_audio renders with to the generation render so
+        # the round-trip matches it exactly (not the group / CLI defaults).
         "render=surge_simple",
-        f"render.param_spec_name={param_spec_name}",
-        f"render.preset_path={preset_path}",
-        f"render.plugin_path={plugin_path}",
+        f"render.param_spec_name={render.param_spec_name}",
+        f"render.preset_path={render.preset_path}",
+        f"render.plugin_path={render.plugin_path}",
+        f"render.sample_rate={render.sample_rate}",
+        f"render.channels={render.channels}",
+        f"render.velocity={render.velocity}",
+        f"render.signal_duration_seconds={render.signal_duration_seconds}",
         # id already exists in logger/wandb.yaml (id: null) so a plain
         # override suffices; resume is absent there and needs +append.
         f"logger.wandb.id={run_id}",
@@ -838,9 +835,7 @@ def main(cfg: DictConfig) -> None:
                 output_dir,
                 eval_run_dir,
                 spec.run_id,
-                param_spec_name=spec.render.param_spec_name,
-                preset_path=spec.render.preset_path,
-                plugin_path=spec.render.plugin_path,
+                render=spec.render,
             )
         return
 

--- a/sweeps/generate_dataset_cadence_surge_simple.yaml
+++ b/sweeps/generate_dataset_cadence_surge_simple.yaml
@@ -1,0 +1,35 @@
+program: src/synth_setter/cli/generate_dataset.py
+# Pinned in YAML — wandb sweep CLI does not support OmegaConf resolvers and ignores
+# WANDB_ENTITY / WANDB_PROJECT at sweep-creation time (those only steer wandb.init in each trial).
+entity: tinaudio
+project: synth-setter
+# Reduced (curated) param set. param_spec_name/preset are pinned explicitly so the sweep is
+# self-documenting and the inline oracle eval re-renders predictions through the same spec
+# the dataset was generated with.
+command:
+  - ${interpreter}
+  - ${program}
+  - experiment=generate_dataset/smoke-shard-with-oracle-eval
+  - render.param_spec_name=surge_simple
+  - render.preset_path=presets/surge-simple.vstpreset
+  - ${args_no_hyphens}
+name: generate_dataset_cadence_surge_simple
+method: grid
+# grid ignores `metric` at scheduling time; the field stays for dashboard
+# legibility on runs that do log it. mss_mean is the oracle-eval audio loss.
+metric:
+  goal: minimize
+  name: audio/mss_mean
+# 2x4 grid. The render x always_on cell is schema-invalid; generate_dataset logs a warning and
+# skips it, so the grid stays a plain cross-product. See #489.
+parameters:
+  render.plugin_reload_cadence:
+    values:
+      - once
+      - render
+  render.gui_toggle_cadence:
+    values:
+      - never
+      - once
+      - render
+      - "always_on"

--- a/sweeps/generate_dataset_cadence_surge_xt.yaml
+++ b/sweeps/generate_dataset_cadence_surge_xt.yaml
@@ -1,0 +1,34 @@
+program: src/synth_setter/cli/generate_dataset.py
+# Pinned in YAML — wandb sweep CLI does not support OmegaConf resolvers and ignores
+# WANDB_ENTITY / WANDB_PROJECT at sweep-creation time (those only steer wandb.init in each trial).
+entity: tinaudio
+project: synth-setter
+# Full Surge XT param set — overrides the smoke shard's surge_simple default for both generation
+# and the inline oracle eval. See #489.
+command:
+  - ${interpreter}
+  - ${program}
+  - experiment=generate_dataset/smoke-shard-with-oracle-eval
+  - render.param_spec_name=surge_xt
+  - render.preset_path=presets/surge-base.vstpreset
+  - ${args_no_hyphens}
+name: generate_dataset_cadence_surge_xt
+method: grid
+# grid ignores `metric` at scheduling time; the field stays for dashboard
+# legibility on runs that do log it. mss_mean is the oracle-eval audio loss.
+metric:
+  goal: minimize
+  name: audio/mss_mean
+# 2x4 grid. The render x always_on cell is schema-invalid; generate_dataset logs a warning and
+# skips it, so the grid stays a plain cross-product. See #489.
+parameters:
+  render.plugin_reload_cadence:
+    values:
+      - once
+      - render
+  render.gui_toggle_cadence:
+    values:
+      - never
+      - once
+      - render
+      - "always_on"

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -1692,6 +1692,10 @@ class TestMainDispatchBranches:
         oracle_mock.assert_called_once()
         dataset_root, run_dir, _run_id = oracle_mock.call_args[0]
         assert isinstance(dataset_root, Path)
+        # The generation render spec + preset flow through (keyword-only) so the
+        # eval re-renders predictions through the same spec; smoke-shard is surge_simple.
+        assert oracle_mock.call_args.kwargs["param_spec_name"] == "surge_simple"
+        assert oracle_mock.call_args.kwargs["preset_path"] == "presets/surge-simple.vstpreset"
         # The eval reads in place from the Hydra output_dir where the shards and
         # VDS splits already live — not a downloaded copy under oracle_eval/.
         assert dataset_root == observed["output_dir"]
@@ -1708,10 +1712,11 @@ class TestMainDispatchBranches:
         """Helper subprocesses ``synth_setter.cli.eval`` with the contract argv.
 
         Pins the load-bearing overrides (``experiment=surge/fake_oracle``,
-        ``datamodule.dataset_root``, ``ckpt_path=null``, ``mode=predict``,
-        ``render=surge_simple``) plus the wandb-resume trio that routes the
-        eval's ``audio/*`` metrics onto the generate run. Runs the helper
-        directly so cfg-resolution noise can't mask an argv drift.
+        ``datamodule.dataset_root``, ``ckpt_path=null``, ``mode=predict``), the
+        wandb-resume trio that routes the eval's ``audio/*`` metrics onto the
+        generate run, and the ``param_spec_name`` / ``preset_path`` passed through
+        from the generation render so the eval re-renders through that same spec.
+        Runs the helper directly so cfg-resolution noise can't mask an argv drift.
 
         :param monkeypatch: Patches the module's ``subprocess.run``.
         :param tmp_path: Roots the distinct dataset-root and eval run dirs.
@@ -1726,7 +1731,13 @@ class TestMainDispatchBranches:
         for name in ("train.h5", "val.h5", "test.h5", "stats.npz"):
             (dataset_root / name).touch()
         run_dir = tmp_path / "oracle_eval" / "some-run-id"
-        gd._run_oracle_eval_subprocess(dataset_root, run_dir, "some-run-id")
+        gd._run_oracle_eval_subprocess(
+            dataset_root,
+            run_dir,
+            "some-run-id",
+            param_spec_name="surge_xt",
+            preset_path="presets/surge-base.vstpreset",
+        )
 
         run_mock.assert_called_once()
         called_argv = run_mock.call_args[0][0]
@@ -1747,9 +1758,12 @@ class TestMainDispatchBranches:
         # id exists in logger/wandb.yaml (plain override); resume is absent (+append).
         assert "logger.wandb.id=some-run-id" in called_argv
         assert "+logger.wandb.resume=must" in called_argv
-        # render_vst=true re-renders predicted params; select the surge_simple
-        # group (eval.yaml defaults render to null) matching the smoke dataset.
+        # render_vst=true re-renders predicted params; surge_simple supplies the
+        # structural render fields, while param spec + preset are overridden to the
+        # generation render group so the dataset re-renders through its own spec.
         assert "render=surge_simple" in called_argv
+        assert "render.param_spec_name=surge_xt" in called_argv
+        assert "render.preset_path=presets/surge-base.vstpreset" in called_argv
         # batch_size=1 keeps the smoke-sized test split (4 samples) from
         # flooring to zero batches under the 128 default — see #1331.
         assert "datamodule.batch_size=1" in called_argv
@@ -1776,7 +1790,13 @@ class TestMainDispatchBranches:
         monkeypatch.setattr(gd.subprocess, "run", run_mock)
 
         with pytest.raises(FileNotFoundError, match=r"test\.h5"):
-            gd._run_oracle_eval_subprocess(tmp_path, tmp_path / "oracle_eval" / "rid", "rid")
+            gd._run_oracle_eval_subprocess(
+                tmp_path,
+                tmp_path / "oracle_eval" / "rid",
+                "rid",
+                param_spec_name="surge_simple",
+                preset_path="presets/surge-simple.vstpreset",
+            )
 
         run_mock.assert_not_called()
 
@@ -1805,6 +1825,40 @@ class TestMainDispatchBranches:
         gd.main()
 
         oracle_mock.assert_not_called()
+
+    def test_main_always_on_with_render_reload_skips_with_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``gui_toggle_cadence=always_on`` + ``plugin_reload_cadence=render`` is a no-op skip.
+
+        The render arm of a cadence grid sweep hits this schema-invalid cell; ``main``
+        logs a warning and returns before building the spec (which would otherwise raise
+        in ``RenderConfig``), so the wandb trial completes instead of crashing.
+
+        :param monkeypatch: Patches argv, the warning sink, and ``generate``.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+            "render.plugin_reload_cadence=render",
+            "render.gui_toggle_cadence=always_on",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+        warn_mock = MagicMock()
+        monkeypatch.setattr(gd.logger, "warning", warn_mock)
+        generate_mock = MagicMock()
+        monkeypatch.setattr(gd, "generate", generate_mock)
+
+        gd.main()
+
+        # Skipped before generation, with a warning naming the offending knob.
+        generate_mock.assert_not_called()
+        warn_mock.assert_called_once()
+        assert "always_on" in warn_mock.call_args[0][0]
 
     def test_main_oracle_eval_inline_requires_finalize_inline(
         self,

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -1692,10 +1692,13 @@ class TestMainDispatchBranches:
         oracle_mock.assert_called_once()
         dataset_root, run_dir, _run_id = oracle_mock.call_args[0]
         assert isinstance(dataset_root, Path)
-        # The generation render spec + preset flow through (keyword-only) so the
-        # eval re-renders predictions through the same spec; smoke-shard is surge_simple.
+        # The generation render's spec / preset / plugin flow through (keyword-only)
+        # so the eval re-renders through the same spec; smoke-shard is surge_simple.
         assert oracle_mock.call_args.kwargs["param_spec_name"] == "surge_simple"
         assert oracle_mock.call_args.kwargs["preset_path"] == "presets/surge-simple.vstpreset"
+        # plugin_path is the TEST_PLUGIN_VST3 this test overrode at generation —
+        # proving a non-default plugin flows through to the eval re-render.
+        assert oracle_mock.call_args.kwargs["plugin_path"] == str(TEST_PLUGIN_VST3)
         # The eval reads in place from the Hydra output_dir where the shards and
         # VDS splits already live — not a downloaded copy under oracle_eval/.
         assert dataset_root == observed["output_dir"]
@@ -1737,6 +1740,7 @@ class TestMainDispatchBranches:
             "some-run-id",
             param_spec_name="surge_xt",
             preset_path="presets/surge-base.vstpreset",
+            plugin_path="plugins/Surge XT.vst3",
         )
 
         run_mock.assert_called_once()
@@ -1764,6 +1768,7 @@ class TestMainDispatchBranches:
         assert "render=surge_simple" in called_argv
         assert "render.param_spec_name=surge_xt" in called_argv
         assert "render.preset_path=presets/surge-base.vstpreset" in called_argv
+        assert "render.plugin_path=plugins/Surge XT.vst3" in called_argv
         # batch_size=1 keeps the smoke-sized test split (4 samples) from
         # flooring to zero batches under the 128 default — see #1331.
         assert "datamodule.batch_size=1" in called_argv
@@ -1796,6 +1801,7 @@ class TestMainDispatchBranches:
                 "rid",
                 param_spec_name="surge_simple",
                 preset_path="presets/surge-simple.vstpreset",
+                plugin_path="plugins/Surge XT.vst3",
             )
 
         run_mock.assert_not_called()

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -1692,13 +1692,14 @@ class TestMainDispatchBranches:
         oracle_mock.assert_called_once()
         dataset_root, run_dir, _run_id = oracle_mock.call_args[0]
         assert isinstance(dataset_root, Path)
-        # The generation render's spec / preset / plugin flow through (keyword-only)
-        # so the eval re-renders through the same spec; smoke-shard is surge_simple.
-        assert oracle_mock.call_args.kwargs["param_spec_name"] == "surge_simple"
-        assert oracle_mock.call_args.kwargs["preset_path"] == "presets/surge-simple.vstpreset"
+        # The whole generation RenderConfig flows through (keyword-only) so the eval
+        # re-renders through the same spec; smoke-shard is surge_simple.
+        render_arg = oracle_mock.call_args.kwargs["render"]
+        assert render_arg.param_spec_name == "surge_simple"
+        assert render_arg.preset_path == "presets/surge-simple.vstpreset"
         # plugin_path is the TEST_PLUGIN_VST3 this test overrode at generation —
         # proving a non-default plugin flows through to the eval re-render.
-        assert oracle_mock.call_args.kwargs["plugin_path"] == str(TEST_PLUGIN_VST3)
+        assert render_arg.plugin_path == str(TEST_PLUGIN_VST3)
         # The eval reads in place from the Hydra output_dir where the shards and
         # VDS splits already live — not a downloaded copy under oracle_eval/.
         assert dataset_root == observed["output_dir"]
@@ -1711,18 +1712,20 @@ class TestMainDispatchBranches:
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
+        spec: DatasetSpec,
     ) -> None:
         """Helper subprocesses ``synth_setter.cli.eval`` with the contract argv.
 
         Pins the load-bearing overrides (``experiment=surge/fake_oracle``,
         ``datamodule.dataset_root``, ``ckpt_path=null``, ``mode=predict``), the
         wandb-resume trio that routes the eval's ``audio/*`` metrics onto the
-        generate run, and the ``param_spec_name`` / ``preset_path`` passed through
-        from the generation render so the eval re-renders through that same spec.
+        generate run, and every render field passed through from the generation
+        ``RenderConfig`` so the eval re-renders identically (here a surge_xt spec).
         Runs the helper directly so cfg-resolution noise can't mask an argv drift.
 
         :param monkeypatch: Patches the module's ``subprocess.run``.
         :param tmp_path: Roots the distinct dataset-root and eval run dirs.
+        :param spec: Source of a valid ``RenderConfig`` to derive the eval render from.
         """
         import synth_setter.cli.generate_dataset as gd
 
@@ -1734,14 +1737,14 @@ class TestMainDispatchBranches:
         for name in ("train.h5", "val.h5", "test.h5", "stats.npz"):
             (dataset_root / name).touch()
         run_dir = tmp_path / "oracle_eval" / "some-run-id"
-        gd._run_oracle_eval_subprocess(
-            dataset_root,
-            run_dir,
-            "some-run-id",
-            param_spec_name="surge_xt",
-            preset_path="presets/surge-base.vstpreset",
-            plugin_path="plugins/Surge XT.vst3",
+        render = spec.render.model_copy(
+            update={
+                "param_spec_name": "surge_xt",
+                "preset_path": "presets/surge-base.vstpreset",
+                "plugin_path": "plugins/Surge XT.vst3",
+            }
         )
+        gd._run_oracle_eval_subprocess(dataset_root, run_dir, "some-run-id", render=render)
 
         run_mock.assert_called_once()
         called_argv = run_mock.call_args[0][0]
@@ -1763,12 +1766,16 @@ class TestMainDispatchBranches:
         assert "logger.wandb.id=some-run-id" in called_argv
         assert "+logger.wandb.resume=must" in called_argv
         # render_vst=true re-renders predicted params; surge_simple supplies the
-        # structural render fields, while param spec + preset are overridden to the
-        # generation render group so the dataset re-renders through its own spec.
+        # group structure, while every render field predict_vst_audio renders with
+        # is overridden from the generation RenderConfig so the re-render matches it.
         assert "render=surge_simple" in called_argv
         assert "render.param_spec_name=surge_xt" in called_argv
         assert "render.preset_path=presets/surge-base.vstpreset" in called_argv
         assert "render.plugin_path=plugins/Surge XT.vst3" in called_argv
+        assert f"render.sample_rate={render.sample_rate}" in called_argv
+        assert f"render.channels={render.channels}" in called_argv
+        assert f"render.velocity={render.velocity}" in called_argv
+        assert f"render.signal_duration_seconds={render.signal_duration_seconds}" in called_argv
         # batch_size=1 keeps the smoke-sized test split (4 samples) from
         # flooring to zero batches under the 128 default — see #1331.
         assert "datamodule.batch_size=1" in called_argv
@@ -1778,6 +1785,7 @@ class TestMainDispatchBranches:
         self,
         monkeypatch: pytest.MonkeyPatch,
         tmp_path: Path,
+        spec: DatasetSpec,
     ) -> None:
         """Unpopulated ``dataset_root`` ⇒ clear ``FileNotFoundError``, no eval subprocess.
 
@@ -1788,6 +1796,7 @@ class TestMainDispatchBranches:
 
         :param monkeypatch: Patches ``subprocess.run`` to assert it never fires.
         :param tmp_path: Empty stand-in for an unpopulated ``output_dir``.
+        :param spec: Source of a valid ``RenderConfig`` for the call signature.
         """
         import synth_setter.cli.generate_dataset as gd
 
@@ -1799,9 +1808,7 @@ class TestMainDispatchBranches:
                 tmp_path,
                 tmp_path / "oracle_eval" / "rid",
                 "rid",
-                param_spec_name="surge_simple",
-                preset_path="presets/surge-simple.vstpreset",
-                plugin_path="plugins/Surge XT.vst3",
+                render=spec.render,
             )
 
         run_mock.assert_not_called()

--- a/tests/test_eval_postprocessing.py
+++ b/tests/test_eval_postprocessing.py
@@ -222,6 +222,50 @@ def test_postprocessing_plugin_path_gate(
     assert render_argv[plugin_idx + 1] == plugin_path
 
 
+def test_postprocessing_forwards_render_audio_fields(
+    monkeypatch: pytest.MonkeyPatch,
+    predictions_tree: Path,
+    captured_argv: list[list[str]],
+) -> None:
+    """Render fields predict_vst_audio renders with are forwarded from ``cfg.render``.
+
+    sample_rate / channels / velocity / signal_duration_seconds must reach the render
+    argv so the re-render matches the dataset's generation render instead of
+    predict_vst_audio's CLI defaults.
+
+    :param monkeypatch: Pins ``sys.platform`` to ``darwin`` so the wrapper prefix
+        doesn't shift the argv the test inspects.
+    :param predictions_tree: ``tmp_path`` with ``predictions/`` + ``audio/`` pre-created.
+    :param captured_argv: Captured argv list populated by the fixture.
+    """
+    monkeypatch.setattr(eval_mod.sys, "platform", "darwin")
+    cfg = _build_postprocess_cfg(
+        predictions_tree,
+        compute_metrics=False,
+        rerender_target=False,
+        render={
+            "param_spec_name": "surge/fake_oracle",
+            "preset_path": "preset.fxp",
+            "sample_rate": 22050,
+            "channels": 1,
+            "velocity": 64,
+            "signal_duration_seconds": 2.5,
+        },
+    )
+
+    _run_predict_postprocessing(cfg)
+
+    render_argv = captured_argv[0]
+    for flag, value in (
+        ("--sample_rate", "22050"),
+        ("--channels", "1"),
+        ("--velocity", "64"),
+        ("--signal_duration_seconds", "2.5"),
+    ):
+        assert flag in render_argv, f"{flag} not forwarded"
+        assert render_argv[render_argv.index(flag) + 1] == value
+
+
 def test_postprocessing_rerender_target_gate(
     monkeypatch: pytest.MonkeyPatch,
     predictions_tree: Path,

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -38,6 +38,8 @@ from tests.evaluation._oracle_helpers import ORACLE_AUDIO_METRIC_BOUNDS
 # only keys in ``metrics.json`` (see ``synth_setter.evaluation.compute_audio_metrics``).
 _ORACLE_AUDIO_METRICS = ("mss", "wmfcc", "sot", "rms")
 
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
 
 def test_cfg_dataset_composes_and_validates_as_dataset_spec(
     cfg_dataset: DictConfig,
@@ -98,6 +100,41 @@ def test_cfg_dataset_datasetsrc_with_wds_output_is_rejected(
 
     with pytest.raises(ValueError, match="supports output_format='hdf5' only"):
         spec_from_cfg(cfg_dataset)
+
+
+@pytest.mark.slow
+def test_main_skips_schema_invalid_cadence_cell_without_failing(
+    tmp_path: Path,
+) -> None:
+    """The CLI no-ops (exit 0) on a cadence grid cell ``RenderConfig`` rejects.
+
+    ``gui_toggle_cadence=always_on`` is valid only with ``plugin_reload_cadence=once``,
+    so the render arm of a cadence grid sweep hits an invalid cell. ``main`` logs a
+    warning and returns instead of raising, which a wandb grid relies on to keep the
+    trial from failing. Driven as a real subprocess so the whole entrypoint — Hydra
+    compose, ``RenderConfig`` validation, and the skip guard — is exercised; the skip
+    returns before any render, so no VST/R2 is needed.
+
+    :param tmp_path: Hydra run dir, kept out of the repo tree.
+    """
+    result = subprocess.run(  # noqa: S603 — fixed argv, no shell, trusted entrypoint
+        [
+            sys.executable,
+            "-m",
+            "synth_setter.cli.generate_dataset",
+            "experiment=generate_dataset/smoke-shard",
+            "render.plugin_reload_cadence=render",
+            "render.gui_toggle_cadence=always_on",
+            f"hydra.run.dir={tmp_path}",
+        ],
+        cwd=_REPO_ROOT,
+        env={**os.environ, "PROJECT_ROOT": str(_REPO_ROOT), "WANDB_MODE": "disabled"},
+        capture_output=True,
+        text=True,
+        timeout=300,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "skipping run" in (result.stdout + result.stderr)
 
 
 @pytest.mark.integration_r2

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -128,7 +128,14 @@ def test_main_skips_schema_invalid_cadence_cell_without_failing(
             f"hydra.run.dir={tmp_path}",
         ],
         cwd=_REPO_ROOT,
-        env={**os.environ, "PROJECT_ROOT": str(_REPO_ROOT), "WANDB_MODE": "disabled"},
+        # Prepend this worktree's src so the subprocess imports the same
+        # synth_setter / configs as the collected test, not a sibling editable install.
+        env={
+            **os.environ,
+            "PROJECT_ROOT": str(_REPO_ROOT),
+            "PYTHONPATH": f"{_REPO_ROOT / 'src'}:{os.environ.get('PYTHONPATH', '')}",
+            "WANDB_MODE": "disabled",
+        },
         capture_output=True,
         text=True,
         timeout=300,

--- a/uv.lock
+++ b/uv.lock
@@ -6022,7 +6022,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.15.2"
+version = "8.16.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What

Adds two W&B sweep configs that grid `render.plugin_reload_cadence` × `render.gui_toggle_cadence` through `generate_dataset` + the inline oracle eval, one per parameter set:

- `sweeps/generate_dataset_cadence_surge_simple.yaml` — reduced (curated) param set
- `sweeps/generate_dataset_cadence_surge_xt.yaml` — full Surge XT param set (the configuration where #489's every-other-render junk was originally measured)

Plus two supporting changes that make the full-set sweep produce valid results:

1. **Spec-aware oracle eval.** `_run_oracle_eval_subprocess` hardcoded `render=surge_simple`, so a `surge_xt` dataset (300 params) was re-rendered through the 92-param `surge_simple` spec, misaligning every `audio/*` metric. It now receives the generation render's `param_spec_name` + `preset_path` (keyword-only) and overrides the eval render group accordingly, so the round-trip re-renders through the same spec the dataset was generated with. `surge_simple` datasets are unaffected.
2. **Graceful skip of the schema-invalid grid cell.** The grid crosses both `plugin_reload_cadence` values with `gui_toggle_cadence`, but `gui_toggle_cadence=always_on` is schema-valid only with `plugin_reload_cadence=once`. `main()` now logs a warning and skips that one cell as a no-op (exit 0) instead of raising, so the grid stays a plain cross-product and the W&B trial completes rather than failing.

## Why

These sweeps quantify, with the oracle-eval audio losses (MSS/wMFCC/SOT/RMS), how the cadence knobs affect generated-data reproducibility — extending the earlier `surge_simple` study to the full `surge_xt` set. See the analysis being posted on #489.

## Testing

- `tests/pipeline/entrypoints/test_generate_dataset_unit.py` — argv passthrough (surge_xt) + dispatch (surge_simple via kwargs) + new always_on skip-with-warning.
- `tests/test_generate_dataset.py::test_main_skips_schema_invalid_cadence_cell_without_failing` — subprocess e2e: the CLI exits 0 with a skip warning on the invalid cell.
- The full surge_xt oracle-eval re-render was validated manually end-to-end (needs the VST3 plugin + GPU, not in CI); the surge_simple round-trip is the in-suite e2e (`test_oracle_eval_inline_resumes_generate_wandb_run`).

Refs #489
