### PR TITLE
test: deflake wandb artifact test

### DIFF
--- a/tests/helpers/wandb_offline.py
+++ b/tests/helpers/wandb_offline.py
@@ -17,9 +17,12 @@ from __future__ import annotations
 import time
 from collections.abc import Callable
 from pathlib import Path
+from typing import TypeVar
 
 import pytest
 import wandb
+
+_T = TypeVar("_T")
 
 # Verified against wandb 0.26.x. ``wandb.proto.wandb_internal_pb2.Record`` and
 # ``wandb.sdk.internal.datastore.DataStore`` are wandb internals — a future
@@ -39,6 +42,58 @@ _FLUSH_TIMEOUT_S = 10.0
 _FLUSH_POLL_S = 0.05
 
 
+def _poll_until(
+    read_once: Callable[[], _T],
+    until: Callable[[_T], bool] | None,
+    timeout_s: float,
+) -> _T:
+    """Re-invoke ``read_once`` until ``until`` holds, or return its last result at ``timeout_s``.
+
+    The offline writer flushes the ``run-*.wandb`` datastore asynchronously, so
+    a read right after ``wandb.finish()`` can race ahead and capture a
+    not-yet-flushed binary (the conda-only 0-records flake). On timeout the last
+    read is returned, not raised, so the caller's own assertion reports the
+    shortfall.
+
+    :param read_once: Single read; must be safe to call repeatedly.
+    :param until: Predicate over a read; when ``None`` ``read_once`` runs exactly
+        once (no polling).
+    :param timeout_s: Upper bound on polling; ignored when ``until`` is ``None``.
+    :returns: The result of the final ``read_once`` call.
+    """
+    if until is None:
+        return read_once()
+    deadline = time.monotonic() + timeout_s
+    while True:
+        result = read_once()
+        if until(result) or time.monotonic() >= deadline:
+            return result
+        time.sleep(_FLUSH_POLL_S)
+
+
+def read_run_binary(
+    wandb_binary: Path,
+    *,
+    until: Callable[[bytes], bool] | None = None,
+    timeout_s: float = _FLUSH_TIMEOUT_S,
+) -> bytes:
+    """Read an offline ``run-*.wandb`` binary, optionally polling until flushed.
+
+    Raw-bytes sibling of ``read_history_rows`` for assertions on records the
+    datastore decoder doesn't surface (e.g. artifact name/type). Pass ``until``
+    to re-read until the predicate holds — see ``_poll_until`` for the
+    flush-race rationale and the on-timeout semantics.
+
+    :param wandb_binary: Path to the offline ``run-*.wandb`` file.
+    :param until: Predicate over the raw bytes; when omitted the file is read
+        exactly once (no polling).
+    :param timeout_s: Upper bound on flush polling; ignored when ``until`` is
+        ``None``.
+    :returns: Bytes from the final read (the last poll on timeout).
+    """
+    return _poll_until(wandb_binary.read_bytes, until, timeout_s)
+
+
 def read_history_rows(
     wandb_binary: Path,
     *,
@@ -49,12 +104,9 @@ def read_history_rows(
 
     Slash-paths arrive as ``nested_key`` (e.g. ``['shard', 'bytes']``); the
     rejoiner reconstructs the keys callers passed to ``log_metrics`` so the
-    caller's assertions read like the production payload.
-
-    The offline writer flushes history asynchronously, so a single scan can
-    race ahead of the records (a conda-only 0-rows flake). Pass ``until`` to
-    re-scan until the predicate holds; on timeout the last scan is returned so
-    the caller's own assertion reports the shortfall.
+    caller's assertions read like the production payload. Pass ``until`` to
+    re-scan until the predicate holds — see ``_poll_until`` for the flush-race
+    rationale and the on-timeout semantics.
 
     :param wandb_binary: Path to the offline ``run-*.wandb`` file.
     :param until: Predicate over the decoded rows; when omitted the binary is
@@ -64,14 +116,7 @@ def read_history_rows(
     :returns: One dict per history record; values are JSON-encoded strings
         (as the datastore stores them).
     """
-    if until is None:
-        return _scan_history_rows(wandb_binary)
-    deadline = time.monotonic() + timeout_s
-    while True:
-        rows = _scan_history_rows(wandb_binary)
-        if until(rows) or time.monotonic() >= deadline:
-            return rows
-        time.sleep(_FLUSH_POLL_S)
+    return _poll_until(lambda: _scan_history_rows(wandb_binary), until, timeout_s)
 
 
 def _scan_history_rows(wandb_binary: Path) -> list[dict[str, str]]:

--- a/tests/test_generate_dataset_wandb.py
+++ b/tests/test_generate_dataset_wandb.py
@@ -20,7 +20,7 @@ from lightning.pytorch.loggers.wandb import WandbLogger
 
 from synth_setter.cli.generate_dataset import generate
 from synth_setter.pipeline.schemas.spec import DatasetSpec
-from tests.helpers.wandb_offline import read_history_rows
+from tests.helpers.wandb_offline import read_history_rows, read_run_binary
 
 
 def _build_spec() -> DatasetSpec:
@@ -62,13 +62,20 @@ def _build_spec() -> DatasetSpec:
     return DatasetSpec(**kwargs)  # type: ignore[arg-type]
 
 
-def _scrub_wandb_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Drop ambient ``WANDB_*`` env so a host dotenv can't steer the offline run.
+def _offline_wandb_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Pin a hermetic offline wandb env so a host dotenv or home dir can't steer the run.
 
-    :param monkeypatch: ``delenv`` is applied per-key for the calling test.
+    Scrubs ambient ``WANDB_*`` env, forces ``WANDB_MODE=offline``, and points
+    ``WANDB_DATA_DIR`` at ``tmp_path`` so artifact staging never falls back to a
+    (possibly read-only) ``~/.local/share/wandb``.
+
+    :param monkeypatch: ``delenv`` / ``setenv`` are applied for the calling test.
+    :param tmp_path: Per-test tmp dir hosting the offline run and artifact staging.
     """
     for key in [k for k in os.environ if k.startswith("WANDB_")]:
         monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("WANDB_MODE", "offline")
+    monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path / "wandb-data"))
 
 
 @pytest.fixture(autouse=True)
@@ -87,11 +94,10 @@ def test_generate_logs_spec_as_hyperparams_and_artifact_offline(
 
     :param tmp_path: Per-test tmp dir; the offline run lands at
         ``tmp_path/wandb/offline-run-*-<run_id>``.
-    :param monkeypatch: Used to scrub ambient ``WANDB_*`` env and stub
+    :param monkeypatch: Used to pin a hermetic offline ``WANDB_*`` env and stub
         ``object_size`` + ``extract_renderer_version``.
     """
-    _scrub_wandb_env(monkeypatch)
-    monkeypatch.setenv("WANDB_MODE", "offline")
+    _offline_wandb_env(monkeypatch, tmp_path)
 
     spec = _build_spec()
 
@@ -111,8 +117,9 @@ def test_generate_logs_spec_as_hyperparams_and_artifact_offline(
     )
 
     generate(spec, tmp_path, [wandb_logger])
-    # ``generate``'s finally block calls ``wandb.finish()``, so the offline
-    # ``.wandb`` binary is already flushed before the assertions run.
+    # ``generate``'s finally block calls ``wandb.finish()``, which closes the
+    # run; the offline writer still flushes the ``.wandb`` binary asynchronously
+    # (handled by the polling read below).
     assert wandb.run is None, "generate() did not close the wandb run on return"
 
     offline_dirs = list((tmp_path / "wandb").glob(f"offline-run-*-{spec.run_id}"))
@@ -124,8 +131,13 @@ def test_generate_logs_spec_as_hyperparams_and_artifact_offline(
     assert len(binary_files) == 1, (
         f"expected one .wandb binary in {offline_dirs[0]}, found {binary_files}"
     )
-    payload = Path(binary_files[0]).read_bytes()
+    # The offline writer flushes the artifact record asynchronously, so poll
+    # the binary until both markers land rather than reading once and racing.
     artifact_name = f"{spec.task_name}-input-spec"
+    payload = read_run_binary(
+        Path(binary_files[0]),
+        until=lambda data: artifact_name.encode() in data and b"dataset-spec" in data,
+    )
     assert artifact_name.encode() in payload, (
         f"artifact name {artifact_name!r} not recorded in offline run binary"
     )
@@ -145,11 +157,10 @@ def test_generate_logs_per_shard_and_summary_metrics_offline(
 
     :param tmp_path: Per-test tmp dir; the offline run lands at
         ``tmp_path/wandb/offline-run-*-<run_id>``.
-    :param monkeypatch: Used to scrub ambient ``WANDB_*`` env and stub
+    :param monkeypatch: Used to pin a hermetic offline ``WANDB_*`` env and stub
         ``object_size`` + ``extract_renderer_version``.
     """
-    _scrub_wandb_env(monkeypatch)
-    monkeypatch.setenv("WANDB_MODE", "offline")
+    _offline_wandb_env(monkeypatch, tmp_path)
 
     spec = _build_spec()
 

--- a/tests/test_wandb_offline_helper.py
+++ b/tests/test_wandb_offline_helper.py
@@ -1,11 +1,12 @@
-"""Unit tests for the offline-wandb history decoder's flush-race polling.
+"""Unit tests for the offline-wandb readers' flush-race polling.
 
-The offline writer serializes history records to the ``run-*.wandb`` binary
-asynchronously, so a single-shot read can land before the records flush
-(observed as a conda-only 0-rows flake). ``read_history_rows(until=...)``
-polls until the caller's predicate holds; these tests pin that retry contract
-by stubbing the per-attempt scan and freezing the clock so no real datastore
-binary or wall-clock wait is needed.
+The offline writer serializes records to the ``run-*.wandb`` binary
+asynchronously, so a single-shot read can land before they flush (observed as a
+conda-only 0-records flake). Both ``read_history_rows`` (decoded rows) and
+``read_run_binary`` (raw bytes) poll until the caller's predicate holds via the
+shared ``_poll_until`` loop; these tests pin that retry contract by stubbing the
+per-attempt read and freezing the clock so no real datastore binary or
+wall-clock wait is needed.
 """
 
 from __future__ import annotations
@@ -109,3 +110,99 @@ def test_without_predicate_reads_once(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert rows == []
     assert scan_count == 1
+
+
+def test_run_binary_until_predicate_retries_until_record_flushes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Header-only early reads are retried — one ``sleep`` per gap — until the marker lands.
+
+    Mirrors the history-row retry contract for the raw-bytes ``read_run_binary``
+    path, which assertions on artifact records (absent from the decoded rows)
+    rely on.
+
+    :param monkeypatch: Replaces ``Path.read_bytes`` and counts ``sleep`` so the
+        flush lag is simulated without a real binary or wall-clock wait.
+    """
+    reads = iter([b":W&B", b":W&B", b":W&B...my-artifact...dataset-spec"])
+    read_count = 0
+    sleep_count = 0
+
+    def _read(_self: Path) -> bytes:
+        nonlocal read_count
+        read_count += 1
+        return next(reads)
+
+    def _sleep(_s: float) -> None:
+        nonlocal sleep_count
+        sleep_count += 1
+
+    monkeypatch.setattr(Path, "read_bytes", _read)
+    monkeypatch.setattr(wandb_offline.time, "sleep", _sleep)
+
+    payload = wandb_offline.read_run_binary(
+        Path("ignored.wandb"),
+        until=lambda data: b"my-artifact" in data and b"dataset-spec" in data,
+    )
+
+    assert payload == b":W&B...my-artifact...dataset-spec"
+    assert read_count == 3
+    assert sleep_count == 2
+
+
+def test_run_binary_until_predicate_polls_to_deadline_then_returns_last_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A never-satisfied predicate polls to the deadline, then returns the last (header-only) read.
+
+    Pins that a genuine never-flushed record returns bytes for the caller's own
+    assertion to fail on, rather than hanging or raising.
+
+    :param monkeypatch: Stubs ``read_bytes`` to stay header-only, advances a fake
+        clock, and freezes ``sleep`` so the timeout is reached instantly.
+    """
+    ticks = iter(range(100))
+    read_count = 0
+
+    def _read(_self: Path) -> bytes:
+        nonlocal read_count
+        read_count += 1
+        return b":W&B"
+
+    monkeypatch.setattr(Path, "read_bytes", _read)
+    monkeypatch.setattr(wandb_offline.time, "monotonic", lambda: float(next(ticks)))
+    monkeypatch.setattr(wandb_offline.time, "sleep", lambda _s: None)
+
+    payload = wandb_offline.read_run_binary(
+        Path("ignored.wandb"),
+        until=lambda data: b"never" in data,
+        timeout_s=2.5,
+    )
+
+    assert payload == b":W&B"
+    # Pins the deadline-exit branch, not a first-iteration short-circuit.
+    assert read_count > 1
+
+
+def test_run_binary_without_predicate_reads_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Omitting ``until`` keeps the single-shot contract — one read, never sleeps.
+
+    :param monkeypatch: Counts ``read_bytes`` invocations and fails ``sleep`` to
+        prove no retry loop runs.
+    """
+    read_count = 0
+
+    def _read(_self: Path) -> bytes:
+        nonlocal read_count
+        read_count += 1
+        return b":W&B"
+
+    monkeypatch.setattr(Path, "read_bytes", _read)
+    monkeypatch.setattr(
+        wandb_offline.time, "sleep", lambda _s: pytest.fail("single-shot read must not sleep")
+    )
+
+    payload = wandb_offline.read_run_binary(Path("ignored.wandb"))
+
+    assert payload == b":W&B"
+    assert read_count == 1


### PR DESCRIPTION
## Problem

`tests/test_generate_dataset_wandb.py::test_generate_logs_spec_as_hyperparams_and_artifact_offline` fails intermittently in CI ([run 26934582939](https://github.com/tinaudio/synth-setter/actions/runs/26934582939/job/79461229708?pr=1427)):

```
AssertionError: artifact name 'wandb-track-test-input-spec' not recorded in offline run binary
assert b'wandb-track-test-input-spec' in b':W&B\xe1\xbe\x00'
```

## Root cause

The test read the offline `run-*.wandb` binary exactly once, immediately after `generate()` returned. The wandb offline writer flushes its datastore records **asynchronously**, so the read could race ahead and capture only the 6-byte datastore header (`b':W&B\xe1\xbe\x00'`) with zero records — the same 0-records flake `read_history_rows` already guards against with polling. The sibling metrics test in the same file was already poll-based; the artifact test was the lone single-read holdout.

## Fix

- Add `read_run_binary(until=...)` to `tests/helpers/wandb_offline.py` — a raw-bytes sibling of `read_history_rows` (needed because the artifact name/type live in records the datastore decoder doesn't surface) — and poll until both artifact markers land before asserting. On timeout it returns the last read, so a genuinely-missing record still fails via the caller's own assertion with a useful message.
- Extract the shared poll-until-deadline loop into `_poll_until` so both readers delegate to one implementation; pin `read_run_binary`'s retry / deadline / single-shot contract with three unit tests in `tests/test_wandb_offline_helper.py` (mirroring the existing history-row trio).
- Pin a hermetic offline env via `_offline_wandb_env`: the env scrubber was also dropping `WANDB_DATA_DIR`, so artifact staging fell back to `~/.local/share/wandb` and failed wherever that path is read-only. Pointing it at `tmp_path` makes staging per-test and writable. **This is defensive** — CI's staging dir was writable, so the CI flake was purely the async-flush race; this hardens a second, untriggered failure mode (and makes the test reproducible on read-only-home hosts).

## Verification

Test-only change. Previously failing 100% locally (read-only home) and intermittently in CI. After the fix: 30/30 green on the offline test (in a read-only-home env, which also proves the hermeticity fix), the 3 new helper tests pass, and an adversarial short-circuit mutant of `_poll_until` is caught by the strengthened poll-count assertions. See the **Verification Results** comment for full evidence. `make format` clean.

Fixes #1434
