### PR TITLE
refactor(schemas): type output_format as an OutputFormat enum with .extension

### DIFF
--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -842,7 +842,7 @@ No `check_tasks` method exists. Provider APIs answer the wrong question ("is the
 
 ### 7.10 Output Format: HDF5 vs WebDataset
 
-The pipeline supports two output formats, selected via `output_format` in the config and frozen in the spec. The format determines both what the worker emits and how training consumes the data — the renderer CLI dispatches on the shard's filename suffix (`.h5` → `make_hdf5_dataset`, `.tar` → `make_wds_dataset`) via `EXTENSION_TO_OUTPUT_FORMAT`.
+The pipeline supports two output formats, selected via `output_format` in the config and frozen in the spec. The format determines both what the worker emits and how training consumes the data — the renderer CLI dispatches on the shard's filename suffix (`.h5` → `make_hdf5_dataset`, `.tar` → `make_wds_dataset`) via `OutputFormat.from_extension`.
 
 **Why two formats:**
 
@@ -1419,7 +1419,7 @@ src/
 
     schemas/            # Pydantic models (implemented)
       __init__.py
-      spec.py           # DatasetSpec (unified config + runtime; built by its own from_hydra_cfg classmethod, called via spec_from_cfg in cli/generate_dataset.py), RenderConfig, ShardSpec; OUTPUT_FORMAT_TO_EXTENSION / EXTENSION_TO_OUTPUT_FORMAT inverse-pair dispatch maps (no consumer yet — shard writers/validators dispatch in PR-13)
+      spec.py           # DatasetSpec (unified config + runtime; built by its own from_hydra_cfg classmethod, called via spec_from_cfg in cli/generate_dataset.py), RenderConfig, ShardSpec; OutputFormat str-enum carrying format↔suffix dispatch (.extension property + .from_extension reverse lookup)
       shard_metadata.py # ShardMetadata — wds tar metadata.json sidecar (leaf module, no project imports)
       prefix.py         # DatasetConfigId, DatasetRunId, R2Prefix helpers
       image_config.py   # Docker image configuration

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -99,11 +99,11 @@ docs:
       - pattern: "src/synth_setter/pipeline/schemas/r2_location.py"
         covers: "`R2Location` nested R2-storage model (bucket + prefix_root + prefix) plus `uri()` / `rclone_prefix()` / `shard_uri()` helpers — the single source of R2 URI construction"
       - pattern: "src/synth_setter/pipeline/schemas/spec.py"
-        covers: "DatasetSpec (carries a nested `R2Location` via the `r2` field), RenderConfig, ShardSpec; OUTPUT_FORMAT_TO_EXTENSION / EXTENSION_TO_OUTPUT_FORMAT inverse-pair dispatch maps (DatasetSpec is built from a Hydra-composed cfg by the `DatasetSpec.from_hydra_cfg` classmethod, which masks the cfg to `model_fields` before `resolve=True`; `cli/generate_dataset.spec_from_cfg` is a thin wrapper over it; the suffix-dispatch maps are consumed by the renderer CLI's main() in data/vst/generate_vst_dataset.py — main() reads Path(data_file).suffix, looks it up in EXTENSION_TO_OUTPUT_FORMAT, and calls writers.make_hdf5_dataset or writers.make_wds_dataset)"
+        covers: "DatasetSpec (carries a nested `R2Location` via the `r2` field), RenderConfig, ShardSpec; `OutputFormat` str-enum carrying the format↔suffix dispatch via its `.extension` property and `.from_extension()` reverse lookup (DatasetSpec is built from a Hydra-composed cfg by the `DatasetSpec.from_hydra_cfg` classmethod, which masks the cfg to `model_fields` before `resolve=True`; `cli/generate_dataset.spec_from_cfg` is a thin wrapper over it; the suffix dispatch is consumed by the renderer CLI's main() in data/vst/generate_vst_dataset.py — main() reads Path(data_file).suffix, resolves it via OutputFormat.from_extension, and calls writers.make_hdf5_dataset or writers.make_wds_dataset)"
       - pattern: "src/synth_setter/pipeline/schemas/shard_metadata.py"
         covers: "ShardMetadata — strict pydantic sidecar payload written into wds tar shards as metadata.json and into HDF5 shards as audio.attrs; mirrored across both formats by make_hdf5_dataset / make_wds_dataset in writers.py."
       - pattern: "src/synth_setter/data/vst/writers.py"
-        covers: "make_hdf5_dataset + make_wds_dataset entrypoints; per-batch sample-save helpers; ShardMetadata sidecar wiring; CLI suffix dispatch via EXTENSION_TO_OUTPUT_FORMAT."
+        covers: "make_hdf5_dataset + make_wds_dataset entrypoints; per-batch sample-save helpers; ShardMetadata sidecar wiring; CLI suffix dispatch via OutputFormat.from_extension."
       - pattern: "src/synth_setter/data/vst/shapes.py"
         covers: "Shared shape primitives consumed by writers + (planned) shard validator — DATASET_FIELD_NAMES, mel-front-end constants, audio_dataset_shape / mel_dataset_shape / param_array_dataset_shape."
 

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -27,7 +27,7 @@ from synth_setter.pipeline.constants import (
 )
 from synth_setter.pipeline.data.reshard import reshard_dataset
 from synth_setter.pipeline.data.stats import get_stats_hdf5, stream_stats_wds
-from synth_setter.pipeline.schemas.spec import DatasetSpec
+from synth_setter.pipeline.schemas.spec import DatasetSpec, OutputFormat
 from synth_setter.pipeline.spec_io import load_spec_from_uri, write_spec_to_path
 from synth_setter.workspace import operator_workspace
 
@@ -176,9 +176,9 @@ def finalize_from_spec(spec: DatasetSpec, work_dir: Path) -> None:
         return
 
     work_dir.mkdir(parents=True, exist_ok=True)
-    if spec.output_format == "wds":
+    if spec.output_format is OutputFormat.WDS:
         finalize_wds(spec, work_dir)
-    elif spec.output_format == "hdf5":
+    elif spec.output_format is OutputFormat.HDF5:
         finalize_hdf5(spec, work_dir)
     else:
         raise ValueError(f"unsupported output_format: {spec.output_format!r}")

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -155,7 +155,7 @@ def build_generate_args(spec: DatasetSpec, shard: ShardSpec, output_dir: Path) -
     config field surfaces as a ``--<field>`` option automatically; adding a
     field on the model auto-extends the CLI invocation. The writer is dispatched
     on ``shard.filename``'s suffix inside the subprocess via
-    ``EXTENSION_TO_OUTPUT_FORMAT``. When ``spec.datasetsrc`` is set, the copy
+    ``OutputFormat.from_extension``. When ``spec.datasetsrc`` is set, the copy
     root is forwarded as ``--copy_dataset_root`` so the subprocess re-renders the
     same-named source shard's params instead of sampling fresh ones.
     """

--- a/src/synth_setter/data/vst/generate_vst_dataset.py
+++ b/src/synth_setter/data/vst/generate_vst_dataset.py
@@ -26,7 +26,7 @@ from synth_setter.data.vst.shapes import (
     param_array_dataset_shape,
 )
 from synth_setter.pipeline.schemas.spec import (
-    EXTENSION_TO_OUTPUT_FORMAT,
+    OutputFormat,
     RenderConfig,
 )
 
@@ -290,7 +290,7 @@ class _GenerateCliArgs(RenderConfig, BaseSettings):
     automatically — adding or removing a field on ``RenderConfig`` extends or
     shrinks the CLI surface without a parallel update here. Adds ``data_file``
     as the sole positional arg (the destination shard path; suffix selects
-    writer via ``EXTENSION_TO_OUTPUT_FORMAT``), and an optional
+    writer via ``OutputFormat.from_extension``), and an optional
     ``copy_dataset_root`` that triggers the param-copy path.
 
     .. attribute :: copy_dataset_root
@@ -315,7 +315,7 @@ def main() -> None:
     """Entry point — parse CLI args into a ``RenderConfig`` and render one shard.
 
     The writer is dispatched on ``data_file``'s suffix via
-    ``EXTENSION_TO_OUTPUT_FORMAT`` (``.h5`` → HDF5, ``.tar`` → wds). An unknown
+    ``OutputFormat.from_extension`` (``.h5`` → HDF5, ``.tar`` → wds). An unknown
     suffix raises ``SystemExit`` rather than silently producing a half-written
     file in the wrong format.
 
@@ -337,16 +337,17 @@ def main() -> None:
     render_cfg = RenderConfig(**args.model_dump(exclude={"data_file", "copy_dataset_root"}))
 
     suffix = Path(args.data_file).suffix
-    fmt = EXTENSION_TO_OUTPUT_FORMAT.get(suffix)
+    fmt = OutputFormat.from_extension(suffix)
     if fmt is None:
         raise SystemExit(
-            f"data_file must end in one of {sorted(EXTENSION_TO_OUTPUT_FORMAT)}, got {suffix!r}"
+            f"data_file must end in one of {sorted(f.extension for f in OutputFormat)}, "
+            f"got {suffix!r}"
         )
 
     fixed_synth_params_list = None
     fixed_note_params_list = None
     if args.copy_dataset_root is not None:
-        if fmt != "hdf5":
+        if fmt is not OutputFormat.HDF5:
             raise SystemExit(
                 "--copy_dataset_root supports hdf5 output only; the source params are "
                 f"read from a same-named HDF5 shard, but data_file suffix is {suffix!r}."
@@ -357,14 +358,14 @@ def main() -> None:
             source_shard, param_specs[render_cfg.param_spec_name]
         )
 
-    if fmt == "hdf5":
+    if fmt is OutputFormat.HDF5:
         make_hdf5_dataset(
             args.data_file,
             render_cfg,
             fixed_synth_params_list=fixed_synth_params_list,
             fixed_note_params_list=fixed_note_params_list,
         )
-    else:  # fmt == "wds", validated above
+    else:  # fmt is OutputFormat.WDS, validated above
         make_wds_dataset(
             args.data_file,
             render_cfg,

--- a/src/synth_setter/pipeline/ci/validate_shard.py
+++ b/src/synth_setter/pipeline/ci/validate_shard.py
@@ -2,7 +2,7 @@
 """Validate dataset shards against a DatasetSpec.
 
 Performs full per-shard validation. Each shard file is dispatched by its
-filename suffix via ``synth_setter.pipeline.schemas.spec.EXTENSION_TO_OUTPUT_FORMAT``
+filename suffix via ``synth_setter.pipeline.schemas.spec.OutputFormat.from_extension``
 to either the HDF5 path (``.h5``) or the wds tar path (``.tar``):
 
 - HDF5 path: each top-level dataset's full ``.shape`` matches the writer's
@@ -48,7 +48,7 @@ from synth_setter.data.vst.shapes import (
 )
 from synth_setter.pipeline.r2_io import downloaded_to_tempfile
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
-from synth_setter.pipeline.schemas.spec import EXTENSION_TO_OUTPUT_FORMAT, DatasetSpec
+from synth_setter.pipeline.schemas.spec import DatasetSpec, OutputFormat
 from synth_setter.pipeline.spec_io import read_spec_text
 
 _TAR_METADATA_MEMBER = "metadata.json"
@@ -177,7 +177,7 @@ def _expected_dataset_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
 def validate_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:
     """Validate one shard against a DatasetSpec, dispatching by filename suffix.
 
-    Suffix dispatch via ``EXTENSION_TO_OUTPUT_FORMAT``: ``.h5`` -> HDF5 path,
+    Suffix dispatch via ``OutputFormat.from_extension``: ``.h5`` -> HDF5 path,
     ``.tar`` -> tar/wds path. Any other suffix is rejected with an error
     naming the registered set so a typo or wrong-format file does not
     surface as a misleading "not valid HDF5".
@@ -190,14 +190,14 @@ def validate_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:
     if not shard_path.exists():
         return [f"shard file not found: {shard_path}"]
 
-    fmt = EXTENSION_TO_OUTPUT_FORMAT.get(shard_path.suffix)
-    if fmt == "hdf5":
+    fmt = OutputFormat.from_extension(shard_path.suffix)
+    if fmt is OutputFormat.HDF5:
         return _validate_h5_shard(shard_path, spec)
-    if fmt == "wds":
+    if fmt is OutputFormat.WDS:
         return _validate_tar_shard(shard_path, spec)
     return [
         f"unsupported shard suffix {shard_path.suffix!r} "
-        f"(expected one of: {sorted(EXTENSION_TO_OUTPUT_FORMAT)})"
+        f"(expected one of: {sorted(f.extension for f in OutputFormat)})"
     ]
 
 

--- a/src/synth_setter/pipeline/ci/validate_spec.py
+++ b/src/synth_setter/pipeline/ci/validate_spec.py
@@ -12,8 +12,8 @@ import sys
 from typing import Any
 
 from synth_setter.pipeline.schemas.spec import (
-    OUTPUT_FORMAT_TO_EXTENSION,
     DatasetSpec,
+    OutputFormat,
     RenderConfig,
 )
 from synth_setter.pipeline.spec_io import read_spec_text
@@ -25,6 +25,21 @@ _REQUIRED_TOP_LEVEL_FIELDS: tuple[str, ...] = tuple(
     sorted(set(DatasetSpec.model_fields) | set(DatasetSpec.model_computed_fields))
 )
 _REQUIRED_RENDER_FIELDS: tuple[str, ...] = tuple(sorted(RenderConfig.model_fields))
+
+
+def _parse_output_format(value: Any) -> OutputFormat | None:
+    """Coerce a raw spec-dict ``output_format`` value to ``OutputFormat``, or ``None``.
+
+    Validates the raw JSON value without constructing a ``DatasetSpec`` (these
+    checks run on the spec dict before model construction).
+
+    :param value: Raw ``output_format`` value from a spec dict.
+    :returns: The matching format, or ``None`` when ``value`` is not a known token.
+    """
+    try:
+        return OutputFormat(value)
+    except ValueError:
+        return None
 
 
 def validate_structure(spec: dict[str, Any]) -> list[str]:
@@ -52,10 +67,10 @@ def validate_structure(spec: dict[str, Any]) -> list[str]:
     if not (len(cv) == 40 and all(c in "0123456789abcdef" for c in cv)):
         errors.append(f"git_sha is not a valid 40-char hex SHA: {cv!r}")
 
-    if "output_format" in spec and spec["output_format"] not in OUTPUT_FORMAT_TO_EXTENSION:
+    raw_format = spec.get("output_format")
+    if raw_format is not None and _parse_output_format(raw_format) is None:
         errors.append(
-            f"output_format {spec['output_format']!r} is not one of "
-            f"{sorted(OUTPUT_FORMAT_TO_EXTENSION)}"
+            f"output_format {raw_format!r} is not one of {sorted(f.value for f in OutputFormat)}"
         )
 
     if not render.get("renderer_version"):
@@ -85,14 +100,15 @@ def validate_test_values(spec: dict[str, Any]) -> list[str]:
         errors.append(f"expected seeds [42, 43, 44], got {seeds}")
 
     filenames = [s["filename"] for s in shards]
-    output_format = spec.get("output_format", "hdf5")
-    ext = OUTPUT_FORMAT_TO_EXTENSION.get(output_format)
-    if ext is None:
+    raw_format = spec.get("output_format", OutputFormat.HDF5.value)
+    output_format = _parse_output_format(raw_format)
+    if output_format is None:
         errors.append(
-            f"cannot compute expected filenames: output_format {output_format!r} is not one of "
-            f"{sorted(OUTPUT_FORMAT_TO_EXTENSION)}"
+            f"cannot compute expected filenames: output_format {raw_format!r} is not one of "
+            f"{sorted(f.value for f in OutputFormat)}"
         )
     else:
+        ext = output_format.extension
         expected_filenames = [f"shard-{i:06d}{ext}" for i in range(3)]
         if filenames != expected_filenames:
             errors.append(f"expected filenames {expected_filenames}, got {filenames}")

--- a/src/synth_setter/pipeline/data/reshard.py
+++ b/src/synth_setter/pipeline/data/reshard.py
@@ -20,7 +20,7 @@ from synth_setter.pipeline.ci.validate_shard import (
     check_shards_present,
 )
 from synth_setter.pipeline.constants import INPUT_SPEC_FILENAME
-from synth_setter.pipeline.schemas.spec import DatasetSpec
+from synth_setter.pipeline.schemas.spec import DatasetSpec, OutputFormat
 from synth_setter.pipeline.spec_io import load_spec_from_uri
 
 # Output filenames, in the order ``main`` writes them.
@@ -101,10 +101,10 @@ def _load_spec(spec_uri: str | None, dataset_root: Path) -> DatasetSpec:
         # (a ValueError subclass) for malformed / stale specs both land here.
         raise click.ClickException(f"DatasetSpec at {resolved_uri} is invalid: {exc}") from exc
 
-    if spec.output_format != "hdf5":
+    if spec.output_format is not OutputFormat.HDF5:
         raise click.ClickException(
             f"reshard only supports output_format='hdf5'; spec at {resolved_uri} "
-            f"declares output_format={spec.output_format!r}."
+            f"declares output_format={spec.output_format.value!r}."
         )
     return spec
 

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import subprocess
 import sys
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -38,10 +39,9 @@ if TYPE_CHECKING:
     from omegaconf import DictConfig
 
 __all__ = [
-    "EXTENSION_TO_OUTPUT_FORMAT",
-    "OUTPUT_FORMAT_TO_EXTENSION",
     "DatasetSpec",
     "DatasetSrcConfig",
+    "OutputFormat",
     "R2Location",
     "RenderConfig",
     "ShardSpec",
@@ -58,22 +58,58 @@ _LEGACY_FLAT_R2_KEYS: dict[str, str] = {
     "r2_prefix": "prefix",
 }
 
-# Source-of-truth mapping from ``output_format`` to shard filename suffix.
-# Adding a format means adding a row here; missing entries surface as KeyError
-# at construction rather than producing a silently-wrong filename.
-OUTPUT_FORMAT_TO_EXTENSION: dict[str, str] = {"hdf5": ".h5", "wds": ".tar"}
 
-# Reverse lookup for dispatching shard writers/validators by file suffix;
-# derived from the forward map so adding a format stays a one-place edit.
-# Two formats must never share an extension — a collision would silently drop
-# an entry from the dict-comprehension (last-key-wins) and route the wrong
-# format downstream, so guard at import time.
-EXTENSION_TO_OUTPUT_FORMAT: dict[str, str] = {v: k for k, v in OUTPUT_FORMAT_TO_EXTENSION.items()}
-if len(EXTENSION_TO_OUTPUT_FORMAT) != len(OUTPUT_FORMAT_TO_EXTENSION):
+class OutputFormat(str, Enum):
+    """Shard container format; the enum value is the on-disk / JSON token.
+
+    Subclasses ``str`` (rather than 3.11's ``StrEnum``, unavailable on the
+    ``>=3.10`` floor) so a value compares equal to and serializes as its plain
+    string token across the Hydra / R2-JSON boundary.
+
+    .. attribute :: HDF5
+
+        HDF5 container; shards are written as ``.h5`` files.
+
+    .. attribute :: WDS
+
+        WebDataset container; shards are written as ``.tar`` archives.
+    """
+
+    HDF5 = "hdf5"
+    WDS = "wds"
+
+    @property
+    def extension(self) -> str:
+        """Shard filename suffix for this format, leading dot included."""
+        return _OUTPUT_FORMAT_EXTENSIONS[self]
+
+    @classmethod
+    def from_extension(cls, suffix: str) -> OutputFormat | None:
+        """Return the format whose shards carry ``suffix``, dispatching by file type.
+
+        :param suffix: Filename suffix including the leading dot (e.g. ``.h5``).
+        :returns: Matching format, or ``None`` when ``suffix`` is unregistered.
+        """
+        return _OUTPUT_FORMAT_BY_EXTENSION.get(suffix)
+
+
+# Source-of-truth suffix per format (leading dot included). A missing row
+# surfaces as KeyError at ``.extension`` rather than a silently-wrong filename.
+_OUTPUT_FORMAT_EXTENSIONS: dict[OutputFormat, str] = {
+    OutputFormat.HDF5: ".h5",
+    OutputFormat.WDS: ".tar",
+}
+
+# Reverse map for suffix dispatch, derived from the forward map. The import
+# guard below rejects a shared suffix (last-key-wins would silently misroute).
+_OUTPUT_FORMAT_BY_EXTENSION: dict[str, OutputFormat] = {
+    ext: fmt for fmt, ext in _OUTPUT_FORMAT_EXTENSIONS.items()
+}
+if len(_OUTPUT_FORMAT_BY_EXTENSION) != len(_OUTPUT_FORMAT_EXTENSIONS):
     raise RuntimeError(
-        "Duplicate extensions in OUTPUT_FORMAT_TO_EXTENSION — "
+        "Duplicate extensions in _OUTPUT_FORMAT_EXTENSIONS — "
         "two output formats map to the same suffix: "
-        f"{OUTPUT_FORMAT_TO_EXTENSION!r}"
+        f"{_OUTPUT_FORMAT_EXTENSIONS!r}"
     )
 
 
@@ -563,10 +599,13 @@ class DatasetSpec(BaseModel):
             "config-id path segment of ``r2.prefix`` (``<root>/<task_name>/<run_id>/``)."
         )
     )
-    output_format: Literal["hdf5", "wds"] = Field(
+    # strict=False so Hydra-composed dicts and R2 JSON (raw string tokens) coerce
+    # into the enum; an unknown token still raises, matching the prior Literal.
+    output_format: OutputFormat = Field(
+        strict=False,
         description=(
             "Shard container format; ``hdf5`` writes ``.h5``, ``wds`` writes WebDataset ``.tar``."
-        )
+        ),
     )
     train_val_test_sizes: tuple[int, int, int] = Field(
         description=(
@@ -872,12 +911,12 @@ class DatasetSpec(BaseModel):
     @model_validator(mode="after")
     def _shard_filenames_match_output_format(self) -> DatasetSpec:
         """Defense-in-depth: every computed shard filename ends with the format's extension."""
-        expected_ext = OUTPUT_FORMAT_TO_EXTENSION[self.output_format]
+        expected_ext = self.output_format.extension
         for shard in self.shards:
             if not shard.filename.endswith(expected_ext):
                 raise ValueError(
                     f"shard {shard.shard_id} filename {shard.filename!r} does not match "
-                    f"output_format {self.output_format!r} (expected suffix {expected_ext!r})"
+                    f"output_format {self.output_format.value!r} (expected suffix {expected_ext!r})"
                 )
         return self
 
@@ -887,7 +926,7 @@ class DatasetSpec(BaseModel):
         """Shard identities derived from total sample counts and ``samples_per_shard``."""
         sps = self.render.samples_per_shard
         total_shards = sum(self.train_val_test_sizes) // sps
-        ext = OUTPUT_FORMAT_TO_EXTENSION[self.output_format]
+        ext = self.output_format.extension
         return tuple(
             ShardSpec(
                 shard_id=i,

--- a/tests/data/vst/test_generate_vst_dataset_cli.py
+++ b/tests/data/vst/test_generate_vst_dataset_cli.py
@@ -14,7 +14,7 @@ from pydantic_settings import CliApp
 
 from synth_setter.cli.generate_dataset import build_generate_args
 from synth_setter.data.vst.generate_vst_dataset import _GenerateCliArgs
-from synth_setter.pipeline.schemas.spec import DatasetSpec, RenderConfig
+from synth_setter.pipeline.schemas.spec import DatasetSpec, OutputFormat, RenderConfig
 
 
 def test_cli_args_class_inherits_every_render_config_field() -> None:
@@ -62,7 +62,7 @@ def _smoke_spec() -> DatasetSpec:
     )
     return DatasetSpec(
         task_name="ci-smoke-test",
-        output_format="hdf5",
+        output_format=OutputFormat.HDF5,
         train_val_test_sizes=(440000, 20000, 20000),
         base_seed=42,
         r2={"bucket": "intermediate-data"},  # type: ignore[arg-type]

--- a/tests/integration/test_local_launcher_roundtrip.py
+++ b/tests/integration/test_local_launcher_roundtrip.py
@@ -52,8 +52,8 @@ from synth_setter.pipeline.ci.validate_shard import validate_all_shards_from_r2
 from synth_setter.pipeline.ci.validate_spec import validate_structure
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
 from synth_setter.pipeline.schemas.spec import (
-    EXTENSION_TO_OUTPUT_FORMAT,
     DatasetSpec,
+    OutputFormat,
 )
 from tests.helpers.subprocess_args import find_script_index
 
@@ -158,7 +158,7 @@ def _stub_renderer(spec: DatasetSpec) -> Callable[[list[str]], int]:
     """Return a subprocess.check_call side-effect that writes dummy shards.
 
     Dispatches on the renderer's output-path suffix via
-    ``EXTENSION_TO_OUTPUT_FORMAT``, so the same factory backs both the hdf5
+    ``OutputFormat.from_extension``, so the same factory backs both the hdf5
     and wds parametrizations. ``rclone`` invocations fall through to the real
     binary so the R2 upload, the skip-existing probe, and the finalize purge
     all hit real R2.
@@ -174,10 +174,10 @@ def _stub_renderer(spec: DatasetSpec) -> Callable[[list[str]], int]:
         script_idx = find_script_index(args)
         output_file = Path(args[script_idx + 1])
         output_file.parent.mkdir(parents=True, exist_ok=True)
-        fmt = EXTENSION_TO_OUTPUT_FORMAT.get(output_file.suffix)
-        if fmt == "hdf5":
+        fmt = OutputFormat.from_extension(output_file.suffix)
+        if fmt is OutputFormat.HDF5:
             _write_dummy_h5_shard(output_file, spec)
-        elif fmt == "wds":
+        elif fmt is OutputFormat.WDS:
             _write_dummy_tar_shard(output_file, spec)
         else:
             raise AssertionError(

--- a/tests/pipeline/ci_config/test_spec_uri.py
+++ b/tests/pipeline/ci_config/test_spec_uri.py
@@ -11,7 +11,7 @@ from synth_setter.pipeline.ci.spec_uri import (
     compute_spec_uri_from_hydra,
     main,
 )
-from synth_setter.pipeline.schemas.spec import DatasetSpec
+from synth_setter.pipeline.schemas.spec import DatasetSpec, OutputFormat
 
 
 def _write_spec(tmp_path: Path, bucket: str = "intermediate-data") -> Path:
@@ -23,7 +23,7 @@ def _write_spec(tmp_path: Path, bucket: str = "intermediate-data") -> Path:
     """
     spec = DatasetSpec(
         task_name="ci-task",
-        output_format="hdf5",
+        output_format=OutputFormat.HDF5,
         train_val_test_sizes=(1, 0, 0),
         base_seed=42,
         r2={"bucket": bucket},  # type: ignore[arg-type]

--- a/tests/pipeline/ci_validate/test_validate_shard.py
+++ b/tests/pipeline/ci_validate/test_validate_shard.py
@@ -20,7 +20,7 @@ from synth_setter.pipeline.ci.validate_shard import (
     validate_all_shards_from_r2,
     validate_shard,
 )
-from synth_setter.pipeline.schemas.spec import DatasetSpec
+from synth_setter.pipeline.schemas.spec import DatasetSpec, OutputFormat
 
 # ---------------------------------------------------------------------------
 # Fixtures and helpers
@@ -61,7 +61,7 @@ def real_spec(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> DatasetSpec:
 
     return DatasetSpec(
         task_name="test-dataset",
-        output_format="hdf5",
+        output_format=OutputFormat.HDF5,
         train_val_test_sizes=(10, 0, 0),
         base_seed=42,
         r2={"bucket": "intermediate-data"},  # type: ignore[arg-type]

--- a/tests/pipeline/ci_validate/test_validate_shard_inner_shapes.py
+++ b/tests/pipeline/ci_validate/test_validate_shard_inner_shapes.py
@@ -21,7 +21,7 @@ import numpy as np
 import pytest
 
 from synth_setter.pipeline.ci.validate_shard import validate_shard
-from synth_setter.pipeline.schemas.spec import DatasetSpec
+from synth_setter.pipeline.schemas.spec import DatasetSpec, OutputFormat
 
 _VALID_AUDIO_CHANNELS = 2
 _VALID_AUDIO_SAMPLES_PER_ROW = 176400
@@ -90,7 +90,7 @@ def real_spec(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> DatasetSpec:
 
     return DatasetSpec(
         task_name="test-dataset",
-        output_format="hdf5",
+        output_format=OutputFormat.HDF5,
         train_val_test_sizes=(10, 0, 0),
         base_seed=42,
         r2={"bucket": "intermediate-data"},  # type: ignore[arg-type]

--- a/tests/pipeline/ci_validate/test_validate_shard_tar.py
+++ b/tests/pipeline/ci_validate/test_validate_shard_tar.py
@@ -29,7 +29,7 @@ import numpy as np
 import pytest
 
 from synth_setter.pipeline.ci.validate_shard import validate_shard
-from synth_setter.pipeline.schemas.spec import DatasetSpec
+from synth_setter.pipeline.schemas.spec import DatasetSpec, OutputFormat
 
 _VALID_AUDIO_CHANNELS = 2
 _VALID_AUDIO_SAMPLES_PER_ROW = 176400
@@ -70,7 +70,7 @@ def real_spec(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> DatasetSpec:
 
     return DatasetSpec(
         task_name="test-dataset",
-        output_format="wds",
+        output_format=OutputFormat.WDS,
         train_val_test_sizes=(10, 0, 0),
         base_seed=42,
         r2={"bucket": "intermediate-data"},  # type: ignore[arg-type]

--- a/tests/pipeline/schemas/test_dataset_spec.py
+++ b/tests/pipeline/schemas/test_dataset_spec.py
@@ -14,6 +14,7 @@ from synth_setter.data.vst import param_specs
 from synth_setter.pipeline.schemas.spec import (
     DatasetSpec,
     DatasetSrcConfig,
+    OutputFormat,
     RenderConfig,
     ShardSpec,
 )
@@ -469,11 +470,13 @@ class TestDatasetSpecValidators:
         with pytest.raises(ValidationError, match="must sum to a positive count"):
             DatasetSpec(**_valid_spec_kwargs(train_val_test_sizes=[0, 0, 0]))
 
-    def test_invalid_output_format_literal_raises(self, patch_runtime_io: None) -> None:
-        """An output_format outside the supported Literal set is rejected.
+    def test_invalid_output_format_token_raises(self, patch_runtime_io: None) -> None:
+        """An output_format outside the ``OutputFormat`` enum is rejected.
 
-        ``parquet`` stays outside the Literal even as new formats (wds) join — pinning
+        ``parquet`` stays outside the enum even as new formats (wds) join — pinning
         the rejection here prevents a typo (``parquet`` vs. ``wds``) from sneaking in.
+
+        :param patch_runtime_io: Fixture stubbing git/clock runtime fields.
         """
         with pytest.raises(ValidationError):
             DatasetSpec(**_valid_spec_kwargs(output_format="parquet"))
@@ -482,6 +485,42 @@ class TestDatasetSpecValidators:
         """``output_format='wds'`` is accepted (unblocks the wds writer landing in PR-13)."""
         spec = DatasetSpec(**_valid_spec_kwargs(output_format="wds"))
         assert spec.output_format == "wds"
+
+    def test_string_token_coerces_into_output_format_enum(self, patch_runtime_io: None) -> None:
+        """The raw ``hdf5`` token from Hydra / R2 JSON becomes an ``OutputFormat`` member.
+
+        Pins that callers can reach ``.extension`` on a constructed spec rather than
+        re-deriving the suffix from a bare string.
+
+        :param patch_runtime_io: Fixture stubbing git/clock runtime fields.
+        """
+        spec = DatasetSpec(**_valid_spec_kwargs(output_format="hdf5"))
+        assert spec.output_format is OutputFormat.HDF5
+        assert spec.output_format.extension == ".h5"
+
+    def test_output_format_serializes_as_plain_token(self, patch_runtime_io: None) -> None:
+        """JSON serialization emits the bare token, not the enum repr (R2 / Hydra contract).
+
+        The reason ``OutputFormat`` subclasses ``str``: the materialized
+        ``input_spec.json`` on R2 must round-trip as ``"wds"``, not ``"OutputFormat.WDS"``.
+
+        :param patch_runtime_io: Fixture stubbing git/clock runtime fields.
+        """
+        spec = DatasetSpec(**_valid_spec_kwargs(output_format="wds"))
+        assert '"output_format":"wds"' in spec.model_dump_json()
+
+    def test_non_string_output_format_rejected_despite_non_strict_field(
+        self, patch_runtime_io: None
+    ) -> None:
+        """``Field(strict=False)`` still rejects a non-string scalar, not just unknown tokens.
+
+        The field opts out of strict mode only to coerce raw string tokens; an
+        ``int`` must not silently become a format.
+
+        :param patch_runtime_io: Fixture stubbing git/clock runtime fields.
+        """
+        with pytest.raises(ValidationError):
+            DatasetSpec(**_valid_spec_kwargs(output_format=1))
 
     def test_strict_mode_rejects_int_for_string_field(self, patch_runtime_io: None) -> None:
         """Strict mode rejects silent int→str coercion at the trust boundary."""

--- a/tests/pipeline/schemas/test_format_dispatch.py
+++ b/tests/pipeline/schemas/test_format_dispatch.py
@@ -1,30 +1,50 @@
-"""Tests for the forward/reverse output-format <-> extension maps in ``spec.py``."""
+"""Tests for ``OutputFormat`` — the shard-container enum and its extension dispatch."""
 
 from __future__ import annotations
 
-from synth_setter.pipeline.schemas.spec import (
-    EXTENSION_TO_OUTPUT_FORMAT,
-    OUTPUT_FORMAT_TO_EXTENSION,
-)
+import pytest
+
+from synth_setter.pipeline.schemas.spec import OutputFormat
 
 
-def test_extension_to_output_format_is_inverse_of_forward_map() -> None:
-    """``EXTENSION_TO_OUTPUT_FORMAT`` round-trips every entry in the forward map."""
-    for output_format, extension in OUTPUT_FORMAT_TO_EXTENSION.items():
-        assert EXTENSION_TO_OUTPUT_FORMAT[extension] == output_format
+def test_output_format_extension_hdf5_is_h5() -> None:
+    """``HDF5`` shards carry the ``.h5`` suffix."""
+    assert OutputFormat.HDF5.extension == ".h5"
 
 
-def test_extension_to_output_format_covers_h5_and_tar() -> None:
-    """The reverse map dispatches the two formats the pipeline writes today."""
-    assert EXTENSION_TO_OUTPUT_FORMAT[".h5"] == "hdf5"
-    assert EXTENSION_TO_OUTPUT_FORMAT[".tar"] == "wds"
+def test_output_format_extension_wds_is_tar() -> None:
+    """``WDS`` shards carry the WebDataset ``.tar`` suffix."""
+    assert OutputFormat.WDS.extension == ".tar"
 
 
-def test_reverse_map_has_no_silent_collisions() -> None:
-    """The reverse map never loses entries to last-key-wins collisions.
+def test_from_extension_h5_returns_hdf5() -> None:
+    """``.h5`` reverse-maps to the HDF5 format."""
+    assert OutputFormat.from_extension(".h5") is OutputFormat.HDF5
 
-    The forward map must use distinct extensions per format, so reversing it
-    preserves cardinality. This pins the invariant the import-time guard in
-    ``spec.py`` enforces.
+
+def test_from_extension_tar_returns_wds() -> None:
+    """``.tar`` reverse-maps to the WDS format."""
+    assert OutputFormat.from_extension(".tar") is OutputFormat.WDS
+
+
+def test_from_extension_unknown_suffix_returns_none() -> None:
+    """An unregistered suffix reverse-maps to ``None`` so callers raise their own error."""
+    assert OutputFormat.from_extension(".parquet") is None
+
+
+@pytest.mark.parametrize("fmt", list(OutputFormat))
+def test_extension_round_trips_through_from_extension(fmt: OutputFormat) -> None:
+    """Every format's ``.extension`` reverse-maps back to that same format.
+
+    Pins the no-collision invariant the import-time guard in ``spec.py``
+    enforces: if two formats shared a suffix, one would fail to round-trip.
+
+    :param fmt: The output format under test (swept over every enum member).
     """
-    assert len(EXTENSION_TO_OUTPUT_FORMAT) == len(OUTPUT_FORMAT_TO_EXTENSION)
+    assert OutputFormat.from_extension(fmt.extension) is fmt
+
+
+def test_value_is_the_lowercase_token() -> None:
+    """Enum values are the on-disk / JSON tokens used at the Hydra / R2 boundary."""
+    assert OutputFormat.HDF5 == "hdf5"
+    assert OutputFormat.WDS == "wds"


### PR DESCRIPTION
## What

Replace `DatasetSpec.output_format`'s inline `Literal["hdf5", "wds"]` — and the two parallel module-level maps `OUTPUT_FORMAT_TO_EXTENSION` / `EXTENSION_TO_OUTPUT_FORMAT` — with a single `OutputFormat(str, Enum)` domain type. The enum owns the format↔suffix mapping:

- `.extension` — the shard filename suffix (`.h5` / `.tar`)
- `.from_extension()` — reverse lookup for suffix-based writer/validator dispatch

A format and its on-disk suffix now live in one place instead of two dicts kept inverse by an import-time guard.

## Why

Primitive-obsession cleanup: the format was a bare string, its suffix lived elsewhere, and dispatch was scattered across `== "hdf5"` comparisons. Modeling it as a domain object single-sources the valid set, makes adding a format a one-row edit, and turns a missing mapping into an immediate `KeyError` rather than a silently-wrong filename.

## Notes

- Subclasses `str` (not 3.11's `StrEnum` — the project floor is 3.10), so a value compares equal to and serializes as its plain token.
- The field sets `Field(strict=False)` so raw `"hdf5"`/`"wds"` tokens from Hydra-composed configs and R2 JSON still coerce on an otherwise-`strict=True` model; unknown tokens raise exactly as the prior `Literal` did, and `model_dump_json` still emits the bare token (R2 round-trip unchanged). Both contracts are pinned by new tests.
- All consumers — finalize/reshard dispatch, the renderer-CLI suffix dispatch, and the pre-construction spec validator — dispatch on enum members or `OutputFormat.from_extension`. The one raw-`DictConfig` compare in `generate_dataset.py` stays a string compare (it reads the un-validated Hydra cfg, not the spec).
- Docs (`docs/design/data-pipeline.md` §7.10, `docs/doc-map.yaml`) updated to the new symbols.

## Testing

- `make test-fast` and the full pipeline suite green (735 passed); `make format` clean (ruff, pyright, pydoclint).
- New tests pin: string-token → enum coercion + `.extension` reachability, plain-token JSON serialization, non-string rejection under `strict=False`, and the parametrized extension↔format round-trip (subsuming the old collision invariant).

## Follow-up

`output_format` is the first instance of a broader stringly-typed-field migration; remaining candidates (e.g. `param_spec_name`, the cadence literals, parameter `encoding`) are catalogued in #1437.

Closes #1436
Refs #1437
