### PR TITLE
feat(evaluation): shuffle pred.wav across sample dirs to probe render order

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -90,7 +90,7 @@ synth-setter/
 │   │   ├── data/           #     Dataset-shaping utilities (reshard, rewrite_to_latest, stats, r2_report, ...)
 │   │   ├── skypilot_launch.py  # SkyPilot launcher CLI
 │   │   └── constants.py    #     Shared constants (`INPUT_SPEC_FILENAME`)
-│   ├── evaluation/         #   predict_vst_audio, compute_audio_metrics (library code called by cli/eval.py)
+│   ├── evaluation/         #   predict_vst_audio, compute_audio_metrics, shuffle_pred_audio (library code called by cli/eval.py)
 │   ├── tools/              #   `python -m` utilities (surge_xt_interactive, plot_param2tok, ...)
 │   └── configs/            #   Hydra YAML configs (and SkyPilot Task templates under compute/) — #1236
 │       ├── train.yaml      #     Root training config

--- a/docs/design/eval-pipeline.md
+++ b/docs/design/eval-pipeline.md
@@ -240,14 +240,16 @@ The predict stage loads a trained model checkpoint via PyTorch Lightning's `Trai
 
 #### Predict-mode post-processing (in-process)
 
-When `cfg.mode == "predict"`, `cli/eval.py` invokes `_run_predict_postprocessing()` after `trainer.predict()`. Both phases shell out to the existing CLIs (`predict_vst_audio.py`, `compute_audio_metrics.py`) and are gated by `cfg.evaluation`:
+When `cfg.mode == "predict"`, `cli/eval.py` invokes `_run_predict_postprocessing()` after `trainer.predict()`. The render and metrics phases shell out to the existing CLIs (`predict_vst_audio.py`, `compute_audio_metrics.py`); an optional in-process shuffle (`shuffle_pred_audio.py`) runs between them. All are gated by `cfg.evaluation`:
 
-| Key                          | Default | Effect when true                                                                                                                                                                                 |
-| ---------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `evaluation.render_vst`      | `false` | Subprocess-renders `${paths.output_dir}/audio/sample_*/{pred.wav, target.wav, spec.png, params.csv}`; requires `cfg.render.{param_spec_name, preset_path}` and optional `cfg.render.plugin_path` |
-| `evaluation.compute_metrics` | `false` | Subprocess-computes `${paths.output_dir}/metrics/{metrics, aggregated_metrics}.csv` against the rendered pairs                                                                                   |
-| `evaluation.rerender_target` | `true`  | Forwards `-t` to `predict_vst_audio` so `target.wav` is re-synthesized from stored target params (comparable to the rendered `pred.wav`) instead of replayed from `target-audio-*.pt`            |
-| `evaluation.num_workers`     | `1`     | Forwarded as `-w` to `compute_audio_metrics`                                                                                                                                                     |
+| Key                             | Default | Effect when true                                                                                                                                                                                                         |
+| ------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `evaluation.render_vst`         | `false` | Subprocess-renders `${paths.output_dir}/audio/sample_*/{pred.wav, target.wav, spec.png, params.csv}`; requires `cfg.render.{param_spec_name, preset_path}` and optional `cfg.render.plugin_path`                         |
+| `evaluation.compute_metrics`    | `false` | Subprocess-computes `${paths.output_dir}/metrics/{metrics, aggregated_metrics}.csv` against the rendered pairs                                                                                                           |
+| `evaluation.rerender_target`    | `true`  | Forwards `-t` to `predict_vst_audio` so `target.wav` is re-synthesized from stored target params (comparable to the rendered `pred.wav`) instead of replayed from `target-audio-*.pt`                                    |
+| `evaluation.num_workers`        | `1`     | Forwarded as `-w` to `compute_audio_metrics`                                                                                                                                                                             |
+| `evaluation.shuffle_pred_audio` | `false` | In-process step (between render and metrics) that permutes `pred.wav` across `sample_*` dirs, gated on every dir's `params.csv` being identical; isolates render-order from parameter variation in the audio loss (#489) |
+| `evaluation.shuffle_seed`       | `0`     | Seed for the `shuffle_pred_audio` permutation; identical seeds reproduce it                                                                                                                                              |
 
 On Linux the render subprocess is prefixed with the headless wrapper materialised via `synth_setter.resources.vst_headless_wrapper()` so the VST3 plugin sees an Xvfb display before pedalboard imports it; the metrics subprocess is CPU-only and runs unwrapped. Both default-off so `mode: test` and `mode: validate` paths are unchanged.
 

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -197,6 +197,8 @@ docs:
         covers: "Audio prediction script, VST rendering, parameter-to-audio pipeline"
       - pattern: "src/synth_setter/evaluation/compute_audio_metrics.py"
         covers: "Audio metric computation, MSS/wMFCC/SOT/RMS distance metrics, parallel workers"
+      - pattern: "src/synth_setter/evaluation/shuffle_pred_audio.py"
+        covers: "Render-order probe — permutes pred.wav across sample dirs (params-uniform gate, crash-safe snapshots) between render and metrics (#489)"
       - pattern: "renderscript.sh"
         covers: "Cross-platform rendering script, Xvfb auto-detection"
       - pattern: "src/synth_setter/configs/eval.yaml"

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -92,7 +92,7 @@ Reference: `training-pipeline.md` §4–5
 
 ```
 eval.yaml + experiment config (pins model + data + checkpoint)
-  + evaluation: {render_vst, compute_metrics, rerender_target, num_workers}
+  + evaluation: {render_vst, compute_metrics, rerender_target, num_workers, shuffle_pred_audio, shuffle_seed}
   + render: {param_spec_name, preset_path, plugin_path?}   # required when render_vst=true
   → Hydra composes DictConfig → predict (→ render → metrics if mode=predict and gates on)
 ```

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -14,6 +14,7 @@ from lightning import Callback, LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.loggers import Logger
 from omegaconf import DictConfig
 
+from synth_setter.evaluation.shuffle_pred_audio import shuffle_pred_audio
 from synth_setter.pipeline import r2_io
 from synth_setter.resources import as_file, vst_headless_wrapper
 from synth_setter.utils import (
@@ -87,19 +88,22 @@ def _log_audio_metrics_to_wandb(audio_metrics: dict[str, float]) -> None:
 
 
 def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: DOC502,DOC503
-    """Render VST audio, compute audio metrics, and return their aggregated values.
+    """Render VST audio, optionally shuffle it, compute audio metrics, return them.
 
     The VST render subprocess is prefixed with the headless wrapper on Linux so
     the VST3 plugin gets an Xvfb display before pedalboard imports it; the
-    metrics subprocess is CPU-only and needs no wrapper.
+    metrics subprocess is CPU-only and needs no wrapper. The optional shuffle
+    runs between render and metrics — see #489.
 
-    :param cfg: Reads ``cfg.evaluation`` (gates + ``num_workers``), ``cfg.render``
-        (param spec, preset, optional plugin path), and ``cfg.paths.output_dir``
-        (base for ``predictions/``, ``audio/``, ``metrics/``).
+    :param cfg: Reads ``cfg.evaluation`` (gates + ``num_workers`` +
+        ``shuffle_pred_audio`` / ``shuffle_seed``), ``cfg.render`` (param spec,
+        preset, optional plugin path), and ``cfg.paths.output_dir`` (base for
+        ``predictions/``, ``audio/``, ``metrics/``).
     :returns: ``{"audio/<name>_<stat>": value}`` when ``compute_metrics`` ran;
         empty dict otherwise. Always rank-zero — the caller gates DDP duplication.
     :raises ValueError: if ``evaluation.render_vst`` is enabled but ``cfg.render`` is
-        unset, or the expected input directory for a stage is missing.
+        unset, the expected input directory for a stage is missing, or the shuffle
+        gate finds non-uniform params across sample dirs.
     :raises subprocess.CalledProcessError: propagated from a non-zero subprocess exit.
     :raises subprocess.TimeoutExpired: propagated when a subprocess exceeds
         :data:`_SUBPROCESS_TIMEOUT_SECONDS`.
@@ -147,6 +151,17 @@ def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: D
                 check=True,
                 timeout=_SUBPROCESS_TIMEOUT_SECONDS,
             )
+
+    if cfg.evaluation.get("shuffle_pred_audio"):
+        if not audio_dir.is_dir():
+            raise ValueError(
+                f"evaluation.shuffle_pred_audio=true expects rendered audio at {audio_dir} "
+                "— enable evaluation.render_vst or point cfg.paths.output_dir at a "
+                "directory containing an `audio/` subdirectory."
+            )
+        seed = cfg.evaluation.get("shuffle_seed", 0)
+        permutation = shuffle_pred_audio(audio_dir, seed)
+        log.info(f"Shuffled pred audio across {len(permutation)} sample dirs (seed={seed}).")
 
     if cfg.evaluation.compute_metrics:
         if not audio_dir.is_dir():

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -161,7 +161,12 @@ def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: D
             )
         seed = cfg.evaluation.get("shuffle_seed", 0)
         permutation = shuffle_pred_audio(audio_dir, seed)
-        log.info(f"Shuffled pred audio across {len(permutation)} sample dirs (seed={seed}).")
+        if len(permutation) < 2:
+            log.info(
+                f"Shuffle skipped: {len(permutation)} sample dir(s) in {audio_dir} (need >=2)."
+            )
+        else:
+            log.info(f"Shuffled pred audio across {len(permutation)} sample dirs (seed={seed}).")
 
     if cfg.evaluation.compute_metrics:
         if not audio_dir.is_dir():

--- a/src/synth_setter/configs/eval.yaml
+++ b/src/synth_setter/configs/eval.yaml
@@ -24,6 +24,11 @@ evaluation:
   compute_metrics: false
   rerender_target: true
   num_workers: 1
+  # Opt-in render-order probe: permute pred.wav across sample dirs (gated on
+  # uniform params) between render and metrics, isolating render-order from
+  # parameter variation in the audio loss (#489).
+  shuffle_pred_audio: false
+  shuffle_seed: 0
   # Opt-in: an `r2://bucket/prefix` mirror of the whole run dir, copied after eval.
   upload_output_dir_uri: null
 

--- a/src/synth_setter/evaluation/shuffle_pred_audio.py
+++ b/src/synth_setter/evaluation/shuffle_pred_audio.py
@@ -1,0 +1,114 @@
+"""Permute rendered ``pred.wav`` across sample dirs to probe render-order effects.
+
+Reassigns each ``sample_*/pred.wav`` to a different sample dir while leaving
+``target.wav`` and ``params.csv`` in place, so recomputed metrics score each
+target against a pred rendered from identical params but a different render-order
+position. Only meaningful when every sample dir renders identical params, so the
+shuffle is gated on that invariant — see #489.
+"""
+
+import shutil
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+_PRED_FILENAME = "pred.wav"
+_PARAMS_FILENAME = "params.csv"
+_SNAPSHOT_SUFFIX = ".shuffle-src"
+
+
+def _sample_dirs(audio_dir: Path) -> list[Path]:
+    """Find the sample dirs holding both a ``pred.wav`` and a ``params.csv``.
+
+    :param audio_dir: Directory whose ``sample_*`` children are candidates.
+    :returns: Matches sorted by path, so the permutation is stable across filesystems.
+    """
+    return sorted(
+        d
+        for d in audio_dir.glob("*")
+        if d.is_dir() and (d / _PRED_FILENAME).is_file() and (d / _PARAMS_FILENAME).is_file()
+    )
+
+
+def _assert_uniform_params(sample_dirs: list[Path]) -> None:
+    """Raise unless every sample dir's ``params.csv`` equals the first dir's.
+
+    One writer (``predict_vst_audio.params_to_csv``) emits every CSV, so exact
+    ``DataFrame.equals`` comparison is safe.
+
+    :param sample_dirs: Dirs to compare against ``sample_dirs[0]``.
+    :raises ValueError: when any ``params.csv`` differs, naming the offending dir.
+    """
+    reference = pd.read_csv(sample_dirs[0] / _PARAMS_FILENAME, index_col=0)
+    for sample_dir in sample_dirs[1:]:
+        other = pd.read_csv(sample_dir / _PARAMS_FILENAME, index_col=0)
+        if not reference.equals(other):
+            raise ValueError(
+                "shuffle_pred_audio requires identical params across all sample dirs; "
+                f"{sample_dir.name}/{_PARAMS_FILENAME} differs from "
+                f"{sample_dirs[0].name}/{_PARAMS_FILENAME}."
+            )
+
+
+def _draw_non_identity_permutation(n: int, seed: int) -> list[int]:
+    """Draw a seeded permutation of ``range(n)`` that is never the identity.
+
+    The identity would silently reproduce the unshuffled baseline, making the
+    render-order probe a no-op; redraw on the same RNG until ``pred.wav`` moves.
+    Expected redraws are O(1) — the identity has probability ``1 / n!``.
+
+    :param n: Number of elements; the caller guarantees ``n >= 2``.
+    :param seed: Seed for the RNG; identical seeds yield identical permutations.
+    :returns: A permutation of ``range(n)`` that differs from ``list(range(n))``.
+    """
+    identity = list(range(n))
+    rng = np.random.default_rng(seed)
+    permutation = identity
+    while permutation == identity:
+        permutation = rng.permutation(n).tolist()
+    return permutation
+
+
+def shuffle_pred_audio(audio_dir: Path, seed: int) -> list[int]:  # noqa: DOC502
+    """Permute ``pred.wav`` across the sample dirs in ``audio_dir`` in place.
+
+    Fewer than two sample dirs cannot be shuffled, so the identity permutation is
+    returned and no file is touched. Otherwise the params gate runs before any
+    write, so a rejection leaves the tree untouched. The permutation is applied
+    from per-dir ``.shuffle-src`` snapshots, so the unshuffled baseline survives a
+    crash and the next run restores each ``pred.wav`` from its snapshot first.
+
+    :param audio_dir: ``audio/`` dir of ``sample_*`` subdirs, each with a
+        ``pred.wav`` and a ``params.csv``.
+    :param seed: Seed for the permutation; identical seeds reproduce it.
+    :returns: The permutation as ``dest_idx -> src_idx`` over the sorted sample
+        dirs — sample dir ``i`` ends up holding the pred.wav of dir ``perm[i]``.
+    :raises ValueError: when the params gate finds a non-uniform ``params.csv``.
+    """
+    sample_dirs = _sample_dirs(audio_dir)
+    if len(sample_dirs) < 2:
+        return list(range(len(sample_dirs)))
+
+    _assert_uniform_params(sample_dirs)
+
+    snapshots = [d / (_PRED_FILENAME + _SNAPSHOT_SUFFIX) for d in sample_dirs]
+    # A snapshot left by an interrupted run holds that dir's pre-shuffle pred.wav;
+    # restore it so a retry starts from the baseline rather than a half-shuffled tree.
+    for sample_dir, snapshot in zip(sample_dirs, snapshots):
+        if snapshot.exists():
+            shutil.copyfile(snapshot, sample_dir / _PRED_FILENAME)
+
+    # Snapshot every pred.wav before overwriting any, so a permuted source is read
+    # from an immutable copy and the baseline is never destroyed mid-operation.
+    for sample_dir, snapshot in zip(sample_dirs, snapshots):
+        shutil.copyfile(sample_dir / _PRED_FILENAME, snapshot)
+
+    permutation = _draw_non_identity_permutation(len(sample_dirs), seed)
+    for dest_idx, src_idx in enumerate(permutation):
+        shutil.copyfile(snapshots[src_idx], sample_dirs[dest_idx] / _PRED_FILENAME)
+
+    for snapshot in snapshots:
+        snapshot.unlink()
+
+    return permutation

--- a/src/synth_setter/evaluation/shuffle_pred_audio.py
+++ b/src/synth_setter/evaluation/shuffle_pred_audio.py
@@ -26,7 +26,7 @@ def _sample_dirs(audio_dir: Path) -> list[Path]:
     """
     return sorted(
         d
-        for d in audio_dir.glob("*")
+        for d in audio_dir.glob("sample_*")
         if d.is_dir() and (d / _PRED_FILENAME).is_file() and (d / _PARAMS_FILENAME).is_file()
     )
 
@@ -84,7 +84,8 @@ def shuffle_pred_audio(audio_dir: Path, seed: int) -> list[int]:  # noqa: DOC502
     :param seed: Seed for the permutation; identical seeds reproduce it.
     :returns: The permutation as ``dest_idx -> src_idx`` over the sorted sample
         dirs — sample dir ``i`` ends up holding the pred.wav of dir ``perm[i]``.
-    :raises ValueError: when the params gate finds a non-uniform ``params.csv``.
+    :raises ValueError: when the params gate finds a non-uniform ``params.csv``,
+        or a partial set of ``.shuffle-src`` snapshots makes the tree ambiguous.
     """
     sample_dirs = _sample_dirs(audio_dir)
     if len(sample_dirs) < 2:
@@ -93,8 +94,15 @@ def shuffle_pred_audio(audio_dir: Path, seed: int) -> list[int]:  # noqa: DOC502
     _assert_uniform_params(sample_dirs)
 
     snapshots = [d / (_PRED_FILENAME + _SNAPSHOT_SUFFIX) for d in sample_dirs]
-    # A snapshot left by an interrupted run holds that dir's pre-shuffle pred.wav;
-    # restore it so a retry starts from the baseline rather than a half-shuffled tree.
+    present = [s for s in snapshots if s.exists()]
+    if present and len(present) != len(snapshots):
+        raise ValueError(
+            f"shuffle_pred_audio found {len(present)} of {len(snapshots)} .shuffle-src "
+            f"snapshots (e.g. {present[0]}) — an interrupted shuffle left an ambiguous "
+            "tree. Restore each pred.wav from its snapshot or delete the snapshots before retrying."
+        )
+    # A full set of snapshots is left by an interrupted run and holds the pre-shuffle
+    # pred.wav; restore from them so a retry starts from the baseline, not a half-shuffled tree.
     for sample_dir, snapshot in zip(sample_dirs, snapshots):
         if snapshot.exists():
             shutil.copyfile(snapshot, sample_dir / _PRED_FILENAME)
@@ -108,7 +116,8 @@ def shuffle_pred_audio(audio_dir: Path, seed: int) -> list[int]:  # noqa: DOC502
     for dest_idx, src_idx in enumerate(permutation):
         shutil.copyfile(snapshots[src_idx], sample_dirs[dest_idx] / _PRED_FILENAME)
 
+    # missing_ok: a successful shuffle must not raise if a snapshot is already gone.
     for snapshot in snapshots:
-        snapshot.unlink()
+        snapshot.unlink(missing_ok=True)
 
     return permutation

--- a/src/synth_setter/evaluation/shuffle_pred_audio.py
+++ b/src/synth_setter/evaluation/shuffle_pred_audio.py
@@ -77,7 +77,8 @@ def shuffle_pred_audio(audio_dir: Path, seed: int) -> list[int]:  # noqa: DOC502
     returned and no file is touched. Otherwise the params gate runs before any
     write, so a rejection leaves the tree untouched. The permutation is applied
     from per-dir ``.shuffle-src`` snapshots, so the unshuffled baseline survives a
-    crash and the next run restores each ``pred.wav`` from its snapshot first.
+    crash: when a full snapshot set is present the next run restores each
+    ``pred.wav`` from its snapshot first, while a partial set raises (see below).
 
     :param audio_dir: ``audio/`` dir of ``sample_*`` subdirs, each with a
         ``pred.wav`` and a ``params.csv``.

--- a/tests/evaluation/test_shuffle_pred_audio.py
+++ b/tests/evaluation/test_shuffle_pred_audio.py
@@ -107,14 +107,14 @@ def test_shuffle_pred_audio_never_returns_identity_for_two_dirs(tmp_path: Path) 
     assert permutation == [1, 0]
 
 
-def test_shuffle_pred_audio_recovers_baseline_from_stale_snapshot(tmp_path: Path) -> None:
-    """A leftover ``.shuffle-src`` snapshot restores the baseline before re-shuffling.
+def test_shuffle_pred_audio_recovers_baseline_from_full_snapshot_set(tmp_path: Path) -> None:
+    """A full set of ``.shuffle-src`` snapshots restores the baseline before re-shuffling.
 
     Simulates an interrupted run: each pred.wav holds half-overwritten junk while
     its snapshot holds the true baseline. The retry must discard the junk, recover
     the baseline from the snapshots, and permute that — yielding the clean result.
 
-    :param tmp_path: Holds the ``audio/`` tree seeded with stale snapshots.
+    :param tmp_path: Holds the ``audio/`` tree seeded with a full snapshot set.
     """
     audio_dir = _build_audio_dir(tmp_path, 2)
     for i in range(2):
@@ -125,6 +125,22 @@ def test_shuffle_pred_audio_recovers_baseline_from_stale_snapshot(tmp_path: Path
 
     assert (audio_dir / "sample_0" / "pred.wav").read_bytes() == b"pred-1"
     assert (audio_dir / "sample_1" / "pred.wav").read_bytes() == b"pred-0"
+
+
+def test_shuffle_pred_audio_raises_on_partial_snapshot_set(tmp_path: Path) -> None:
+    """A partial ``.shuffle-src`` set is ambiguous, so the shuffle refuses to run.
+
+    :param tmp_path: Holds the ``audio/`` tree with a snapshot in only one of three dirs.
+    """
+    audio_dir = _build_audio_dir(tmp_path, 3)
+    (audio_dir / "sample_1" / "pred.wav.shuffle-src").write_bytes(b"orphan")
+    before = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(3)]
+
+    with pytest.raises(ValueError, match="ambiguous"):
+        shuffle_pred_audio(audio_dir, seed=1)
+
+    after = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(3)]
+    assert after == before
 
 
 def test_shuffle_pred_audio_removes_snapshots_after_run(tmp_path: Path) -> None:
@@ -218,16 +234,19 @@ def test_shuffle_pred_audio_no_samples_returns_empty(tmp_path: Path) -> None:
     assert shuffle_pred_audio(audio_dir, seed=1) == []
 
 
-def test_shuffle_pred_audio_ignores_dirs_without_pred(tmp_path: Path) -> None:
-    """Stray dirs lacking a pred.wav are not counted as sample dirs.
+def test_shuffle_pred_audio_ignores_non_sample_dirs(tmp_path: Path) -> None:
+    """Only ``sample_*`` dirs count, even when a stray dir holds both files.
 
-    :param tmp_path: Holds an ``audio/`` tree with two samples plus a stray dir.
+    :param tmp_path: Holds an ``audio/`` tree with two samples plus a non-sample dir
+        that has a pred.wav + params.csv (must still be excluded by the glob).
     """
     audio_dir = _build_audio_dir(tmp_path, 2)
     stray = audio_dir / "metrics_scratch"
     stray.mkdir()
+    (stray / "pred.wav").write_bytes(b"stray")
     (stray / "params.csv").write_text(_UNIFORM_PARAMS_CSV)
 
     permutation = shuffle_pred_audio(audio_dir, seed=3)
 
     assert len(permutation) == 2
+    assert (stray / "pred.wav").read_bytes() == b"stray"

--- a/tests/evaluation/test_shuffle_pred_audio.py
+++ b/tests/evaluation/test_shuffle_pred_audio.py
@@ -11,6 +11,15 @@ import pytest
 from synth_setter.evaluation.shuffle_pred_audio import shuffle_pred_audio
 
 _UNIFORM_PARAMS_CSV = ",pred,target\ncutoff,0.5,0.5\nresonance,0.2,0.2\n"
+# A params.csv differing from _UNIFORM_PARAMS_CSV, used to trip the uniform-params gate.
+_DIFFERENT_PARAMS_CSV = ",pred,target\ncutoff,0.9,0.9\n"
+
+# Default sample-dir count and seed shared by the behaviour tests. Individual
+# tests override only for a boundary cardinality (a pair, a single dir, or none),
+# which is the behaviour under test rather than an arbitrary value.
+_SAMPLE_COUNT = 6
+_PAIR = 2
+_SEED = 42
 
 
 def _make_sample_dir(
@@ -35,7 +44,7 @@ def _make_sample_dir(
     return sample_dir
 
 
-def _build_audio_dir(base: Path, n: int) -> Path:
+def _build_audio_dir(base: Path, n: int = _SAMPLE_COUNT) -> Path:
     """Create ``base/audio`` with ``n`` uniform-params sample dirs.
 
     :param base: Directory under which ``audio/`` is created.
@@ -54,10 +63,12 @@ def test_shuffle_pred_audio_reassigns_pred_to_permuted_source(tmp_path: Path) ->
 
     :param tmp_path: Holds the ``audio/`` tree the shuffle rewrites.
     """
-    audio_dir = _build_audio_dir(tmp_path, 6)
-    original = {i: (audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(6)}
+    audio_dir = _build_audio_dir(tmp_path)
+    original = {
+        i: (audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(_SAMPLE_COUNT)
+    }
 
-    permutation = shuffle_pred_audio(audio_dir, seed=42)
+    permutation = shuffle_pred_audio(audio_dir, seed=_SEED)
 
     for dest_idx, src_idx in enumerate(permutation):
         assert (audio_dir / f"sample_{dest_idx}" / "pred.wav").read_bytes() == original[src_idx]
@@ -68,12 +79,16 @@ def test_shuffle_pred_audio_preserves_every_pred_file(tmp_path: Path) -> None:
 
     :param tmp_path: Holds the ``audio/`` tree the shuffle rewrites.
     """
-    audio_dir = _build_audio_dir(tmp_path, 6)
-    before = sorted((audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(6))
+    audio_dir = _build_audio_dir(tmp_path)
+    before = sorted(
+        (audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(_SAMPLE_COUNT)
+    )
 
-    shuffle_pred_audio(audio_dir, seed=42)
+    shuffle_pred_audio(audio_dir, seed=_SEED)
 
-    after = sorted((audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(6))
+    after = sorted(
+        (audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(_SAMPLE_COUNT)
+    )
     assert after == before
 
 
@@ -82,14 +97,14 @@ def test_shuffle_pred_audio_changes_pred_arrangement(tmp_path: Path) -> None:
 
     :param tmp_path: Holds the ``audio/`` tree the shuffle rewrites.
     """
-    audio_dir = _build_audio_dir(tmp_path, 8)
-    before = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(8)]
+    audio_dir = _build_audio_dir(tmp_path)
+    before = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(_SAMPLE_COUNT)]
 
-    permutation = shuffle_pred_audio(audio_dir, seed=42)
+    permutation = shuffle_pred_audio(audio_dir, seed=_SEED)
 
-    after = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(8)]
+    after = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(_SAMPLE_COUNT)]
     assert after != before
-    assert permutation != list(range(8))
+    assert permutation != list(range(_SAMPLE_COUNT))
 
 
 def test_shuffle_pred_audio_never_returns_identity_for_two_dirs(tmp_path: Path) -> None:
@@ -100,9 +115,9 @@ def test_shuffle_pred_audio_never_returns_identity_for_two_dirs(tmp_path: Path) 
 
     :param tmp_path: Holds the two-dir ``audio/`` tree the shuffle rewrites.
     """
-    audio_dir = _build_audio_dir(tmp_path, 2)
+    audio_dir = _build_audio_dir(tmp_path, _PAIR)
 
-    permutation = shuffle_pred_audio(audio_dir, seed=0)
+    permutation = shuffle_pred_audio(audio_dir, seed=_SEED)
 
     assert permutation == [1, 0]
 
@@ -116,12 +131,12 @@ def test_shuffle_pred_audio_recovers_baseline_from_full_snapshot_set(tmp_path: P
 
     :param tmp_path: Holds the ``audio/`` tree seeded with a full snapshot set.
     """
-    audio_dir = _build_audio_dir(tmp_path, 2)
-    for i in range(2):
+    audio_dir = _build_audio_dir(tmp_path, _PAIR)
+    for i in range(_PAIR):
         (audio_dir / f"sample_{i}" / "pred.wav").write_bytes(f"junk-{i}".encode())
         (audio_dir / f"sample_{i}" / "pred.wav.shuffle-src").write_bytes(f"pred-{i}".encode())
 
-    shuffle_pred_audio(audio_dir, seed=0)
+    shuffle_pred_audio(audio_dir, seed=_SEED)
 
     assert (audio_dir / "sample_0" / "pred.wav").read_bytes() == b"pred-1"
     assert (audio_dir / "sample_1" / "pred.wav").read_bytes() == b"pred-0"
@@ -130,16 +145,16 @@ def test_shuffle_pred_audio_recovers_baseline_from_full_snapshot_set(tmp_path: P
 def test_shuffle_pred_audio_raises_on_partial_snapshot_set(tmp_path: Path) -> None:
     """A partial ``.shuffle-src`` set is ambiguous, so the shuffle refuses to run.
 
-    :param tmp_path: Holds the ``audio/`` tree with a snapshot in only one of three dirs.
+    :param tmp_path: Holds the ``audio/`` tree with a snapshot in only one dir.
     """
-    audio_dir = _build_audio_dir(tmp_path, 3)
+    audio_dir = _build_audio_dir(tmp_path)
     (audio_dir / "sample_1" / "pred.wav.shuffle-src").write_bytes(b"orphan")
-    before = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(3)]
+    before = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(_SAMPLE_COUNT)]
 
     with pytest.raises(ValueError, match="ambiguous"):
-        shuffle_pred_audio(audio_dir, seed=1)
+        shuffle_pred_audio(audio_dir, seed=_SEED)
 
-    after = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(3)]
+    after = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(_SAMPLE_COUNT)]
     assert after == before
 
 
@@ -148,9 +163,9 @@ def test_shuffle_pred_audio_removes_snapshots_after_run(tmp_path: Path) -> None:
 
     :param tmp_path: Holds the ``audio/`` tree the shuffle rewrites.
     """
-    audio_dir = _build_audio_dir(tmp_path, 4)
+    audio_dir = _build_audio_dir(tmp_path)
 
-    shuffle_pred_audio(audio_dir, seed=1)
+    shuffle_pred_audio(audio_dir, seed=_SEED)
 
     assert list(audio_dir.glob("*/pred.wav.shuffle-src")) == []
 
@@ -160,11 +175,11 @@ def test_shuffle_pred_audio_same_seed_yields_same_permutation(tmp_path: Path) ->
 
     :param tmp_path: Parents two independent ``audio/`` trees shuffled with one seed.
     """
-    audio_dir_a = _build_audio_dir(tmp_path / "a", 6)
-    audio_dir_b = _build_audio_dir(tmp_path / "b", 6)
+    audio_dir_a = _build_audio_dir(tmp_path / "a")
+    audio_dir_b = _build_audio_dir(tmp_path / "b")
 
-    perm_a = shuffle_pred_audio(audio_dir_a, seed=7)
-    perm_b = shuffle_pred_audio(audio_dir_b, seed=7)
+    perm_a = shuffle_pred_audio(audio_dir_a, seed=_SEED)
+    perm_b = shuffle_pred_audio(audio_dir_b, seed=_SEED)
 
     assert perm_a == perm_b
 
@@ -174,11 +189,11 @@ def test_shuffle_pred_audio_leaves_target_wav_in_place(tmp_path: Path) -> None:
 
     :param tmp_path: Holds the ``audio/`` tree the shuffle rewrites.
     """
-    audio_dir = _build_audio_dir(tmp_path, 4)
+    audio_dir = _build_audio_dir(tmp_path)
 
-    shuffle_pred_audio(audio_dir, seed=1)
+    shuffle_pred_audio(audio_dir, seed=_SEED)
 
-    for i in range(4):
+    for i in range(_SAMPLE_COUNT):
         assert (audio_dir / f"sample_{i}" / "target.wav").read_bytes() == f"target-{i}".encode()
 
 
@@ -187,11 +202,11 @@ def test_shuffle_pred_audio_raises_when_params_differ(tmp_path: Path) -> None:
 
     :param tmp_path: Holds the ``audio/`` tree with one mismatched params.csv.
     """
-    audio_dir = _build_audio_dir(tmp_path, 3)
-    (audio_dir / "sample_2" / "params.csv").write_text(",pred,target\ncutoff,0.9,0.9\n")
+    audio_dir = _build_audio_dir(tmp_path)
+    (audio_dir / "sample_2" / "params.csv").write_text(_DIFFERENT_PARAMS_CSV)
 
     with pytest.raises(ValueError, match="identical params"):
-        shuffle_pred_audio(audio_dir, seed=1)
+        shuffle_pred_audio(audio_dir, seed=_SEED)
 
 
 def test_shuffle_pred_audio_does_not_move_files_when_params_differ(tmp_path: Path) -> None:
@@ -199,14 +214,14 @@ def test_shuffle_pred_audio_does_not_move_files_when_params_differ(tmp_path: Pat
 
     :param tmp_path: Holds the ``audio/`` tree with one mismatched params.csv.
     """
-    audio_dir = _build_audio_dir(tmp_path, 3)
-    (audio_dir / "sample_2" / "params.csv").write_text(",pred,target\ncutoff,0.9,0.9\n")
-    before = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(3)]
+    audio_dir = _build_audio_dir(tmp_path)
+    (audio_dir / "sample_2" / "params.csv").write_text(_DIFFERENT_PARAMS_CSV)
+    before = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(_SAMPLE_COUNT)]
 
     with pytest.raises(ValueError):
-        shuffle_pred_audio(audio_dir, seed=1)
+        shuffle_pred_audio(audio_dir, seed=_SEED)
 
-    after = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(3)]
+    after = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(_SAMPLE_COUNT)]
     assert after == before
 
 
@@ -217,7 +232,7 @@ def test_shuffle_pred_audio_single_dir_is_noop(tmp_path: Path) -> None:
     """
     audio_dir = _build_audio_dir(tmp_path, 1)
 
-    permutation = shuffle_pred_audio(audio_dir, seed=1)
+    permutation = shuffle_pred_audio(audio_dir, seed=_SEED)
 
     assert permutation == [0]
     assert (audio_dir / "sample_0" / "pred.wav").read_bytes() == b"pred-0"
@@ -231,22 +246,22 @@ def test_shuffle_pred_audio_no_samples_returns_empty(tmp_path: Path) -> None:
     audio_dir = tmp_path / "audio"
     audio_dir.mkdir()
 
-    assert shuffle_pred_audio(audio_dir, seed=1) == []
+    assert shuffle_pred_audio(audio_dir, seed=_SEED) == []
 
 
 def test_shuffle_pred_audio_ignores_non_sample_dirs(tmp_path: Path) -> None:
     """Only ``sample_*`` dirs count, even when a stray dir holds both files.
 
-    :param tmp_path: Holds an ``audio/`` tree with two samples plus a non-sample dir
-        that has a pred.wav + params.csv (must still be excluded by the glob).
+    :param tmp_path: Holds an ``audio/`` tree with the default samples plus a
+        non-sample dir that has a pred.wav + params.csv (must still be excluded).
     """
-    audio_dir = _build_audio_dir(tmp_path, 2)
+    audio_dir = _build_audio_dir(tmp_path)
     stray = audio_dir / "metrics_scratch"
     stray.mkdir()
     (stray / "pred.wav").write_bytes(b"stray")
     (stray / "params.csv").write_text(_UNIFORM_PARAMS_CSV)
 
-    permutation = shuffle_pred_audio(audio_dir, seed=3)
+    permutation = shuffle_pred_audio(audio_dir, seed=_SEED)
 
-    assert len(permutation) == 2
+    assert len(permutation) == _SAMPLE_COUNT
     assert (stray / "pred.wav").read_bytes() == b"stray"

--- a/tests/evaluation/test_shuffle_pred_audio.py
+++ b/tests/evaluation/test_shuffle_pred_audio.py
@@ -1,0 +1,233 @@
+"""Behavior tests for ``synth_setter.evaluation.shuffle_pred_audio``.
+
+Drive the real function against real files in ``tmp_path`` — no mocks — and
+assert on the observable filesystem state and the returned permutation.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from synth_setter.evaluation.shuffle_pred_audio import shuffle_pred_audio
+
+_UNIFORM_PARAMS_CSV = ",pred,target\ncutoff,0.5,0.5\nresonance,0.2,0.2\n"
+
+
+def _make_sample_dir(
+    audio_dir: Path,
+    index: int,
+    *,
+    params_csv: str = _UNIFORM_PARAMS_CSV,
+) -> Path:
+    """Create ``audio_dir/sample_<index>`` with a uniquely-tagged pred.wav.
+
+    :param audio_dir: Parent ``audio/`` directory.
+    :param index: Sample index; ``pred.wav`` is tagged ``pred-<index>`` so a
+        permutation is observable by reading bytes back.
+    :param params_csv: Body written to ``params.csv``; vary it to break the gate.
+    :returns: The created sample directory.
+    """
+    sample_dir = audio_dir / f"sample_{index}"
+    sample_dir.mkdir(parents=True)
+    (sample_dir / "pred.wav").write_bytes(f"pred-{index}".encode())
+    (sample_dir / "target.wav").write_bytes(f"target-{index}".encode())
+    (sample_dir / "params.csv").write_text(params_csv)
+    return sample_dir
+
+
+def _build_audio_dir(base: Path, n: int) -> Path:
+    """Create ``base/audio`` with ``n`` uniform-params sample dirs.
+
+    :param base: Directory under which ``audio/`` is created.
+    :param n: Number of ``sample_<i>`` dirs to create.
+    :returns: The created ``audio/`` directory.
+    """
+    audio_dir = base / "audio"
+    audio_dir.mkdir(parents=True)
+    for i in range(n):
+        _make_sample_dir(audio_dir, i)
+    return audio_dir
+
+
+def test_shuffle_pred_audio_reassigns_pred_to_permuted_source(tmp_path: Path) -> None:
+    """Each sample dir ends up holding the pred.wav of its permuted source dir.
+
+    :param tmp_path: Holds the ``audio/`` tree the shuffle rewrites.
+    """
+    audio_dir = _build_audio_dir(tmp_path, 6)
+    original = {i: (audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(6)}
+
+    permutation = shuffle_pred_audio(audio_dir, seed=42)
+
+    for dest_idx, src_idx in enumerate(permutation):
+        assert (audio_dir / f"sample_{dest_idx}" / "pred.wav").read_bytes() == original[src_idx]
+
+
+def test_shuffle_pred_audio_preserves_every_pred_file(tmp_path: Path) -> None:
+    """No pred.wav is lost or duplicated — the multiset of contents is preserved.
+
+    :param tmp_path: Holds the ``audio/`` tree the shuffle rewrites.
+    """
+    audio_dir = _build_audio_dir(tmp_path, 6)
+    before = sorted((audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(6))
+
+    shuffle_pred_audio(audio_dir, seed=42)
+
+    after = sorted((audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(6))
+    assert after == before
+
+
+def test_shuffle_pred_audio_changes_pred_arrangement(tmp_path: Path) -> None:
+    """A non-trivial seed actually reorders the pred.wav files across dirs.
+
+    :param tmp_path: Holds the ``audio/`` tree the shuffle rewrites.
+    """
+    audio_dir = _build_audio_dir(tmp_path, 8)
+    before = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(8)]
+
+    permutation = shuffle_pred_audio(audio_dir, seed=42)
+
+    after = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(8)]
+    assert after != before
+    assert permutation != list(range(8))
+
+
+def test_shuffle_pred_audio_never_returns_identity_for_two_dirs(tmp_path: Path) -> None:
+    """With two dirs the only non-identity permutation is forced, regardless of seed.
+
+    Guards the render-order probe against silently degenerating into the
+    unshuffled baseline when a seed would otherwise draw the identity.
+
+    :param tmp_path: Holds the two-dir ``audio/`` tree the shuffle rewrites.
+    """
+    audio_dir = _build_audio_dir(tmp_path, 2)
+
+    permutation = shuffle_pred_audio(audio_dir, seed=0)
+
+    assert permutation == [1, 0]
+
+
+def test_shuffle_pred_audio_recovers_baseline_from_stale_snapshot(tmp_path: Path) -> None:
+    """A leftover ``.shuffle-src`` snapshot restores the baseline before re-shuffling.
+
+    Simulates an interrupted run: each pred.wav holds half-overwritten junk while
+    its snapshot holds the true baseline. The retry must discard the junk, recover
+    the baseline from the snapshots, and permute that — yielding the clean result.
+
+    :param tmp_path: Holds the ``audio/`` tree seeded with stale snapshots.
+    """
+    audio_dir = _build_audio_dir(tmp_path, 2)
+    for i in range(2):
+        (audio_dir / f"sample_{i}" / "pred.wav").write_bytes(f"junk-{i}".encode())
+        (audio_dir / f"sample_{i}" / "pred.wav.shuffle-src").write_bytes(f"pred-{i}".encode())
+
+    shuffle_pred_audio(audio_dir, seed=0)
+
+    assert (audio_dir / "sample_0" / "pred.wav").read_bytes() == b"pred-1"
+    assert (audio_dir / "sample_1" / "pred.wav").read_bytes() == b"pred-0"
+
+
+def test_shuffle_pred_audio_removes_snapshots_after_run(tmp_path: Path) -> None:
+    """A completed shuffle leaves no ``.shuffle-src`` snapshot files behind.
+
+    :param tmp_path: Holds the ``audio/`` tree the shuffle rewrites.
+    """
+    audio_dir = _build_audio_dir(tmp_path, 4)
+
+    shuffle_pred_audio(audio_dir, seed=1)
+
+    assert list(audio_dir.glob("*/pred.wav.shuffle-src")) == []
+
+
+def test_shuffle_pred_audio_same_seed_yields_same_permutation(tmp_path: Path) -> None:
+    """The permutation is deterministic for a fixed seed.
+
+    :param tmp_path: Parents two independent ``audio/`` trees shuffled with one seed.
+    """
+    audio_dir_a = _build_audio_dir(tmp_path / "a", 6)
+    audio_dir_b = _build_audio_dir(tmp_path / "b", 6)
+
+    perm_a = shuffle_pred_audio(audio_dir_a, seed=7)
+    perm_b = shuffle_pred_audio(audio_dir_b, seed=7)
+
+    assert perm_a == perm_b
+
+
+def test_shuffle_pred_audio_leaves_target_wav_in_place(tmp_path: Path) -> None:
+    """Only pred.wav moves; each target.wav stays in its own dir.
+
+    :param tmp_path: Holds the ``audio/`` tree the shuffle rewrites.
+    """
+    audio_dir = _build_audio_dir(tmp_path, 4)
+
+    shuffle_pred_audio(audio_dir, seed=1)
+
+    for i in range(4):
+        assert (audio_dir / f"sample_{i}" / "target.wav").read_bytes() == f"target-{i}".encode()
+
+
+def test_shuffle_pred_audio_raises_when_params_differ(tmp_path: Path) -> None:
+    """The gate refuses to shuffle when a sample dir's params.csv differs.
+
+    :param tmp_path: Holds the ``audio/`` tree with one mismatched params.csv.
+    """
+    audio_dir = _build_audio_dir(tmp_path, 3)
+    (audio_dir / "sample_2" / "params.csv").write_text(",pred,target\ncutoff,0.9,0.9\n")
+
+    with pytest.raises(ValueError, match="identical params"):
+        shuffle_pred_audio(audio_dir, seed=1)
+
+
+def test_shuffle_pred_audio_does_not_move_files_when_params_differ(tmp_path: Path) -> None:
+    """A gate rejection leaves every pred.wav untouched (validate before moving).
+
+    :param tmp_path: Holds the ``audio/`` tree with one mismatched params.csv.
+    """
+    audio_dir = _build_audio_dir(tmp_path, 3)
+    (audio_dir / "sample_2" / "params.csv").write_text(",pred,target\ncutoff,0.9,0.9\n")
+    before = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(3)]
+
+    with pytest.raises(ValueError):
+        shuffle_pred_audio(audio_dir, seed=1)
+
+    after = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(3)]
+    assert after == before
+
+
+def test_shuffle_pred_audio_single_dir_is_noop(tmp_path: Path) -> None:
+    """One sample dir cannot be shuffled — return identity, leave the file in place.
+
+    :param tmp_path: Holds the single-dir ``audio/`` tree.
+    """
+    audio_dir = _build_audio_dir(tmp_path, 1)
+
+    permutation = shuffle_pred_audio(audio_dir, seed=1)
+
+    assert permutation == [0]
+    assert (audio_dir / "sample_0" / "pred.wav").read_bytes() == b"pred-0"
+
+
+def test_shuffle_pred_audio_no_samples_returns_empty(tmp_path: Path) -> None:
+    """An audio dir with no sample dirs yields an empty permutation.
+
+    :param tmp_path: Parents an empty ``audio/`` directory.
+    """
+    audio_dir = tmp_path / "audio"
+    audio_dir.mkdir()
+
+    assert shuffle_pred_audio(audio_dir, seed=1) == []
+
+
+def test_shuffle_pred_audio_ignores_dirs_without_pred(tmp_path: Path) -> None:
+    """Stray dirs lacking a pred.wav are not counted as sample dirs.
+
+    :param tmp_path: Holds an ``audio/`` tree with two samples plus a stray dir.
+    """
+    audio_dir = _build_audio_dir(tmp_path, 2)
+    stray = audio_dir / "metrics_scratch"
+    stray.mkdir()
+    (stray / "params.csv").write_text(_UNIFORM_PARAMS_CSV)
+
+    permutation = shuffle_pred_audio(audio_dir, seed=3)
+
+    assert len(permutation) == 2

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -23,7 +23,6 @@ from synth_setter.cli.eval import evaluate
 from synth_setter.cli.train import train
 from synth_setter.data.vst import param_specs
 from synth_setter.workspace import operator_workspace
-from tests.conftest import NUM_FIXTURE_SAMPLES
 from tests.helpers.run_if import RunIf
 
 
@@ -82,23 +81,24 @@ def test_evaluate_runs_oracle_with_null_ckpt_path(
 
 @pytest.mark.requires_vst
 @pytest.mark.slow
-def test_evaluate_predict_shuffle_pred_audio_reaches_metrics(
-    tmp_path: Path,
+def test_evaluate_predict_shuffle_pred_audio_rejects_nonuniform_params(
     cfg_surge_xt: DictConfig,
     cfg_surge_xt_eval: DictConfig,
 ) -> None:
-    """``evaluate()`` predict mode with the shuffle on still lands finite audio metrics.
+    """``evaluate()`` predict mode with the shuffle on raises the directed gate error.
 
     Drives the real train->eval roundtrip end-to-end with ``shuffle_pred_audio``
     enabled, exercising the ``evaluate()`` -> ``_run_predict_postprocessing`` ->
-    shuffle wiring (rank-zero gate, cfg default, render->shuffle->metrics order).
-    Asserts the metrics still aggregate and every pred.wav survives the permutation
-    (#489); the shuffle deliberately mismatches pred to target, so metric magnitudes
-    are not asserted — only that they are present and finite.
+    shuffle wiring. The smoke dataset renders distinct params per sample, so the
+    uniform-params gate must reject it (after render, before metrics) — confirming
+    the gate is wired through the real entrypoint (#489). The successful-permutation
+    path needs a uniform-params tree (only meaningful for the render-order probe)
+    and is covered by ``tests/evaluation/test_shuffle_pred_audio.py`` and the
+    ``_run_predict_postprocessing`` integration test in ``test_eval_postprocessing``.
 
-    :param tmp_path: Shared output dir for the train run and the eval run.
     :param cfg_surge_xt: Surge XT smoke-test training config.
-    :param cfg_surge_xt_eval: Matching predict-mode eval config (render + metrics on).
+    :param cfg_surge_xt_eval: Matching predict-mode eval config (render + metrics on),
+        sharing ``tmp_path`` so eval reads the checkpoint training writes.
     """
     HydraConfig().set_config(cfg_surge_xt)
     train(cfg_surge_xt)
@@ -106,20 +106,10 @@ def test_evaluate_predict_shuffle_pred_audio_reaches_metrics(
 
     with open_dict(cfg_surge_xt_eval):
         cfg_surge_xt_eval.evaluation.shuffle_pred_audio = True
-        cfg_surge_xt_eval.evaluation.shuffle_seed = 42
 
     HydraConfig().set_config(cfg_surge_xt_eval)
-    metric_dict, _ = evaluate(cfg_surge_xt_eval)
-
-    audio_metric_keys = [key for key in metric_dict if key.startswith("audio/")]
-    assert audio_metric_keys, f"expected audio/* metrics; got {sorted(metric_dict)}"
-    for key in audio_metric_keys:
-        assert math.isfinite(float(metric_dict[key])), f"{key} not finite: {metric_dict[key]!r}"
-
-    sample_dirs = sorted(d for d in (tmp_path / "audio").iterdir() if d.is_dir())
-    assert len(sample_dirs) == NUM_FIXTURE_SAMPLES
-    for sample_dir in sample_dirs:
-        assert (sample_dir / "pred.wav").is_file()
+    with pytest.raises(ValueError, match="identical params"):
+        evaluate(cfg_surge_xt_eval)
 
 
 @pytest.mark.gpu

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -23,6 +23,7 @@ from synth_setter.cli.eval import evaluate
 from synth_setter.cli.train import train
 from synth_setter.data.vst import param_specs
 from synth_setter.workspace import operator_workspace
+from tests.conftest import NUM_FIXTURE_SAMPLES
 from tests.helpers.run_if import RunIf
 
 
@@ -77,6 +78,48 @@ def test_evaluate_runs_oracle_with_null_ckpt_path(
     assert param_mse.dtype.is_floating_point
     assert torch.isfinite(param_mse), f"oracle test/param_mse must be finite; got {param_mse!r}"
     assert param_mse.item() == 0.0
+
+
+@pytest.mark.requires_vst
+@pytest.mark.slow
+def test_evaluate_predict_shuffle_pred_audio_reaches_metrics(
+    tmp_path: Path,
+    cfg_surge_xt: DictConfig,
+    cfg_surge_xt_eval: DictConfig,
+) -> None:
+    """``evaluate()`` predict mode with the shuffle on still lands finite audio metrics.
+
+    Drives the real train->eval roundtrip end-to-end with ``shuffle_pred_audio``
+    enabled, exercising the ``evaluate()`` -> ``_run_predict_postprocessing`` ->
+    shuffle wiring (rank-zero gate, cfg default, render->shuffle->metrics order).
+    Asserts the metrics still aggregate and every pred.wav survives the permutation
+    (#489); the shuffle deliberately mismatches pred to target, so metric magnitudes
+    are not asserted — only that they are present and finite.
+
+    :param tmp_path: Shared output dir for the train run and the eval run.
+    :param cfg_surge_xt: Surge XT smoke-test training config.
+    :param cfg_surge_xt_eval: Matching predict-mode eval config (render + metrics on).
+    """
+    HydraConfig().set_config(cfg_surge_xt)
+    train(cfg_surge_xt)
+    assert Path(cfg_surge_xt_eval.ckpt_path).exists()
+
+    with open_dict(cfg_surge_xt_eval):
+        cfg_surge_xt_eval.evaluation.shuffle_pred_audio = True
+        cfg_surge_xt_eval.evaluation.shuffle_seed = 42
+
+    HydraConfig().set_config(cfg_surge_xt_eval)
+    metric_dict, _ = evaluate(cfg_surge_xt_eval)
+
+    audio_metric_keys = [key for key in metric_dict if key.startswith("audio/")]
+    assert audio_metric_keys, f"expected audio/* metrics; got {sorted(metric_dict)}"
+    for key in audio_metric_keys:
+        assert math.isfinite(float(metric_dict[key])), f"{key} not finite: {metric_dict[key]!r}"
+
+    sample_dirs = sorted(d for d in (tmp_path / "audio").iterdir() if d.is_dir())
+    assert len(sample_dirs) == NUM_FIXTURE_SAMPLES
+    for sample_dir in sample_dirs:
+        assert (sample_dir / "pred.wav").is_file()
 
 
 @pytest.mark.gpu

--- a/tests/test_eval_postprocessing.py
+++ b/tests/test_eval_postprocessing.py
@@ -39,6 +39,8 @@ def _build_postprocess_cfg(
     compute_metrics: bool = True,
     rerender_target: bool = True,
     num_workers: int = 1,
+    shuffle_pred_audio: bool = False,
+    shuffle_seed: int = 0,
     render: dict[str, Any] | None = None,
 ) -> DictConfig:
     """Build a minimal cfg accepted by ``_run_predict_postprocessing``.
@@ -49,6 +51,8 @@ def _build_postprocess_cfg(
     :param compute_metrics: Drives ``cfg.evaluation.compute_metrics``.
     :param rerender_target: Drives ``cfg.evaluation.rerender_target``.
     :param num_workers: Drives ``cfg.evaluation.num_workers``.
+    :param shuffle_pred_audio: Drives ``cfg.evaluation.shuffle_pred_audio``.
+    :param shuffle_seed: Drives ``cfg.evaluation.shuffle_seed``.
     :param render: Drives ``cfg.render``; pass ``None`` to test the unset-render branch.
     :returns: Minimal :class:`DictConfig` shaped the way the helper reads it.
     """
@@ -60,6 +64,8 @@ def _build_postprocess_cfg(
                 "compute_metrics": compute_metrics,
                 "rerender_target": rerender_target,
                 "num_workers": num_workers,
+                "shuffle_pred_audio": shuffle_pred_audio,
+                "shuffle_seed": shuffle_seed,
             },
             "render": render,
         }
@@ -463,3 +469,126 @@ def test_postprocessing_skips_wandb_when_no_run(
     result = _run_predict_postprocessing(cfg)
 
     assert result == _EXPECTED_AUDIO_METRICS
+
+
+def _populate_audio_samples(audio_dir: Path, n: int) -> None:
+    """Fill ``audio_dir`` with ``n`` uniform-params sample dirs holding tagged pred.wav.
+
+    :param audio_dir: Pre-existing ``audio/`` dir to populate.
+    :param n: Number of ``sample_<i>`` dirs to create; each pred.wav is tagged
+        ``pred-<i>`` so a shuffle is observable by reading bytes back.
+    """
+    params_csv = ",pred,target\ncutoff,0.5,0.5\n"
+    for i in range(n):
+        sample_dir = audio_dir / f"sample_{i}"
+        sample_dir.mkdir()
+        (sample_dir / "pred.wav").write_bytes(f"pred-{i}".encode())
+        (sample_dir / "target.wav").write_bytes(b"target")
+        (sample_dir / "params.csv").write_text(params_csv)
+
+
+def test_postprocessing_shuffles_pred_audio_when_enabled(
+    predictions_tree: Path,
+    captured_argv: list[list[str]],
+) -> None:
+    """``shuffle_pred_audio=true`` permutes pred.wav across sample dirs, no subprocess.
+
+    :param predictions_tree: ``tmp_path`` with ``predictions/`` + ``audio/`` pre-created.
+    :param captured_argv: Captured argv list — asserted empty since shuffle is in-process.
+    """
+    audio_dir = predictions_tree / "audio"
+    _populate_audio_samples(audio_dir, 8)
+    before = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(8)]
+    cfg = _build_postprocess_cfg(
+        predictions_tree,
+        render_vst=False,
+        compute_metrics=False,
+        shuffle_pred_audio=True,
+        shuffle_seed=42,
+    )
+
+    _run_predict_postprocessing(cfg)
+
+    after = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(8)]
+    assert after != before
+    assert set(after) == set(before)
+    assert captured_argv == []
+
+
+def test_postprocessing_does_not_shuffle_when_disabled(predictions_tree: Path) -> None:
+    """``shuffle_pred_audio`` defaulting off leaves each pred.wav in its own dir.
+
+    :param predictions_tree: ``tmp_path`` with ``predictions/`` + ``audio/`` pre-created.
+    """
+    audio_dir = predictions_tree / "audio"
+    _populate_audio_samples(audio_dir, 4)
+    cfg = _build_postprocess_cfg(predictions_tree, render_vst=False, compute_metrics=False)
+
+    _run_predict_postprocessing(cfg)
+
+    for i in range(4):
+        assert (audio_dir / f"sample_{i}" / "pred.wav").read_bytes() == f"pred-{i}".encode()
+
+
+def test_postprocessing_shuffle_requires_audio_dir(
+    tmp_path: Path,
+    captured_argv: list[list[str]],
+) -> None:
+    """``shuffle_pred_audio=true`` with no ``audio/`` dir surfaces a directed ``ValueError``.
+
+    :param tmp_path: Pytest temp dir used as ``output_dir`` without pre-creating subtrees.
+    :param captured_argv: Captured argv list — asserted empty (helper fails before dispatch).
+    """
+    cfg = _build_postprocess_cfg(
+        tmp_path,
+        render_vst=False,
+        compute_metrics=False,
+        shuffle_pred_audio=True,
+    )
+
+    with pytest.raises(ValueError, match="shuffle_pred_audio"):
+        _run_predict_postprocessing(cfg)
+    assert captured_argv == []
+
+
+def test_postprocessing_shuffle_runs_before_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+    predictions_tree: Path,
+) -> None:
+    """The metrics subprocess sees the post-shuffle pred arrangement, pinning the ordering.
+
+    :param monkeypatch: Stubs ``subprocess.run`` with a fake that snapshots pred.wav
+        bytes when the metrics module is dispatched, and pins ``wandb.run`` to ``None``.
+    :param predictions_tree: ``tmp_path`` with ``predictions/`` + ``audio/`` pre-created.
+    """
+    audio_dir = predictions_tree / "audio"
+    _populate_audio_samples(audio_dir, 8)
+    before = [(audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(8)]
+
+    seen_by_metrics: list[bytes] = []
+
+    def _snapshot_then_write(args: list[str], **_kwargs: Any) -> None:
+        if _COMPUTE_AUDIO_METRICS_MODULE not in args:
+            return
+        seen_by_metrics.extend(
+            (audio_dir / f"sample_{i}" / "pred.wav").read_bytes() for i in range(8)
+        )
+        metrics_dir = Path(args[args.index(_COMPUTE_AUDIO_METRICS_MODULE) + 2])
+        metrics_dir.mkdir(parents=True, exist_ok=True)
+        (metrics_dir / "aggregated_metrics.csv").write_text(_AGGREGATED_METRICS_CSV)
+
+    monkeypatch.setattr(eval_mod.subprocess, "run", _snapshot_then_write)
+    monkeypatch.setattr(eval_mod.wandb, "run", None)
+
+    cfg = _build_postprocess_cfg(
+        predictions_tree,
+        render_vst=False,
+        compute_metrics=True,
+        shuffle_pred_audio=True,
+        shuffle_seed=42,
+    )
+
+    _run_predict_postprocessing(cfg)
+
+    assert seen_by_metrics != before
+    assert sorted(seen_by_metrics) == sorted(before)


### PR DESCRIPTION
## What

Adds `shuffle_pred_audio`, an opt-in eval post-processing step that permutes each `sample_*/pred.wav` across the rendered `audio/` dir between the render and metrics stages, leaving `target.wav` / `params.csv` in place. Recomputing audio metrics after the shuffle scores each target against a `pred` rendered from the **same params** but in a **different render-order position** — isolating render-order variation from parameter variation.

This is investigation tooling for #489 (pedalboard + full param set produces unexplained variance with identical patches): it directly measures whether render order moves the audio loss when the patch is held fixed.

## How

- New module `src/synth_setter/evaluation/shuffle_pred_audio.py`:
  - **Gated** on every sample dir's `params.csv` being identical (`_assert_uniform_params`) — a permutation is only meaningful when each pred renders the same params, so a non-uniform dir raises before any file is touched.
  - **Non-identity guarantee**: the permutation is redrawn until it differs from the identity, so the probe can't silently degenerate into the unshuffled baseline.
  - **Crash-safe copy-snapshot apply**: each `pred.wav` is copied to a sibling `.shuffle-src` before any `pred.wav` is overwritten, permuted preds are written from the immutable snapshots, and snapshots are deleted only after all writes succeed. An interrupted run is recovered on the next run by restoring each `pred.wav` from its surviving snapshot — no original is ever destroyed mid-operation.
- Wired into `_run_predict_postprocessing` (`cli/eval.py`) behind `evaluation.shuffle_pred_audio` (default `false`) with `evaluation.shuffle_seed` for reproducibility; runs render -> shuffle -> metrics, rank-zero gated like the rest of predict post-processing. Defaults keep `mode: test` / `validate` unchanged.

## Configuration (Hydra)

```yaml
evaluation:
  shuffle_pred_audio: false  # opt-in render-order probe
  shuffle_seed: 0
```

## Tests

- `tests/evaluation/test_shuffle_pred_audio.py` — behavior tests against real files (no mocks): permutation->source mapping, multiset preservation, target-left-in-place, params gate (raise + no-move-on-reject), non-identity-for-two-dirs, deterministic seed, stale-snapshot recovery, snapshot cleanup, single/empty/stray-dir edges.
- `tests/test_eval_postprocessing.py` — CLI wiring: shuffle enabled/disabled, missing-`audio/` gate, and an ordering test proving the metrics stage sees the post-shuffle arrangement.
- `tests/test_eval.py` — a `requires_vst` + `slow` end-to-end test driving the real `evaluate()` predict roundtrip with the shuffle on (satisfies the eval-entrypoint e2e standard).

Refs #489
