### PR TITLE
test(generate_dataset): add resume-correctness tests for h5

### DIFF
--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -1862,7 +1862,7 @@ def _prewrite_resumable_head(
     param rows take the caller-supplied encodings so the head's stored params are
     known and can be asserted intact after the resume.
 
-    :param out: Destination shard path, opened in append mode.
+    :param out: Destination shard path; this helper opens it in append mode.
     :param spec: Param spec fixing the ``param_array`` column count.
     :param num_samples: Total shard rows (dataset length).
     :param head_rows: Number of leading rows to mark as already written.

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -9,7 +9,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Literal, NoReturn
 from unittest.mock import MagicMock, patch
 
 import h5py
@@ -1837,3 +1837,344 @@ def test_copy_dataset_reproduces_source_param_array(tmp_path: Path) -> None:
         atol=_ABSOLUTE_TOLERANCE,
         err_msg="copied dataset param_array does not match source",
     )
+
+
+# HDF5 resume correctness: output row i renders fixed_*_params_list[i] by absolute
+# index, for both the copy (fixed params) and plain (sampled) paths — see #1430.
+# render_params is stubbed, so no plugin is needed and the stored param_array is a
+# deterministic param_spec.encode of the per-row fixed params.
+
+
+def _prewrite_resumable_head(
+    out: Path,
+    spec: ParamSpec,
+    num_samples: int,
+    head_rows: int,
+    param_rows: list[np.ndarray],
+    *,
+    audio_fill: float = 1.0,
+    mel_fill: float = 1.0,
+) -> None:
+    """Pre-write rows ``[0, head_rows)`` so a resume reports ``start_idx == head_rows``.
+
+    All three datasets are filled non-zero across the head so the writer's
+    min-across-datasets ``get_first_unwritten_idx`` lands at ``head_rows``; the
+    param rows take the caller-supplied encodings so the head's stored params are
+    known and can be asserted intact after the resume.
+
+    :param out: Destination shard path, opened in append mode.
+    :param spec: Param spec fixing the ``param_array`` column count.
+    :param num_samples: Total shard rows (dataset length).
+    :param head_rows: Number of leading rows to mark as already written.
+    :param param_rows: Per-head-row encoded param arrays; length must be ``head_rows``.
+    :param audio_fill: Sentinel written to every head audio cell (non-zero).
+    :param mel_fill: Sentinel written to every head mel cell (non-zero).
+    """
+    from synth_setter.data.vst.generate_vst_dataset import create_datasets_and_get_start_idx
+
+    with h5py.File(out, "a") as h5:
+        audio, mel, params, _ = create_datasets_and_get_start_idx(
+            h5, num_samples, _CHANNELS, _SAMPLE_RATE, _DURATION, len(spec)
+        )
+        for i in range(head_rows):
+            audio[i] = audio_fill
+            mel[i] = mel_fill
+            params[i] = param_rows[i]
+
+
+def _read_dataset(h5: h5py.File, name: str) -> np.ndarray:
+    """Read a full HDF5 dataset as a numpy array, narrowing the ``h5[name]`` union.
+
+    ``h5py.File.__getitem__`` is typed ``Group | Dataset | Datatype``; the
+    ``isinstance`` assert narrows it to ``Dataset`` so the slice type-checks.
+
+    :param h5: Open HDF5 file handle.
+    :param name: Dataset key to read.
+    :returns: The whole dataset materialized as a numpy array.
+    """
+    dataset = h5[name]
+    assert isinstance(dataset, h5py.Dataset)
+    return dataset[...]
+
+
+def _distinct_note_rows(num_rows: int) -> list[dict[str, int | tuple[float, float]]]:
+    """Build note params with a distinct pitch per row.
+
+    Distinct per-row values are what let a resume test tell absolute indexing
+    apart from a tail offset: identical rows would render the same regardless.
+
+    :param num_rows: Number of note-param dicts to build.
+    :returns: ``num_rows`` note-param dicts, each with a unique pitch.
+    """
+    return [{"pitch": 40 + 2 * i, "note_start_and_end": (0.5, 2.0)} for i in range(num_rows)]
+
+
+def _encode_rows(
+    spec: ParamSpec,
+    synth_rows: list[dict[str, float]],
+    note_rows: list[dict[str, int | tuple[float, float]]],
+) -> list[np.ndarray]:
+    """Encode each ``(synth, note)`` row pair into its ``param_array`` row.
+
+    :param spec: Param spec doing the encode.
+    :param synth_rows: Per-row synth params.
+    :param note_rows: Per-row note params, aligned with ``synth_rows``.
+    :returns: One encoded ``param_array`` row per input pair.
+    """
+    return [
+        spec.encode(synth_rows[i], note_rows[i])  # pyright: ignore[reportArgumentType]
+        for i in range(len(synth_rows))
+    ]
+
+
+def test_make_hdf5_resume_indexes_note_params_by_absolute_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On resume, output row i re-renders ``fixed_note_params_list[i]`` by absolute index.
+
+    Complements the synth-params regression pin: that test holds note params
+    constant across rows, so it cannot tell absolute from tail indexing for the
+    note list. Here each row carries a distinct pitch, so a tail-offset bug would
+    surface as the wrong pitch reaching the renderer.
+
+    :param tmp_path: Pytest temp dir holding the partially-written shard.
+    :param monkeypatch: Stubs ``render_params`` so the test runs without a plugin.
+    """
+    from synth_setter.data.vst import generate_vst_dataset
+
+    spec = param_specs[_SPEC_NAME]
+    num_samples = 4
+    start_idx = 2
+    synth_rows = [spec.sample()[0] for _ in range(num_samples)]
+    note_rows = _distinct_note_rows(num_samples)
+    head_params = _encode_rows(spec, synth_rows[:start_idx], note_rows[:start_idx])
+
+    out = tmp_path / "resume.h5"
+    _prewrite_resumable_head(out, spec, num_samples, start_idx, head_params)
+
+    seen_pitch: list[int] = []
+
+    # pitch is the third positional arg generate_sample passes to render_params.
+    def _capture_render(
+        plugin_path: str, synth_params: dict[str, float], pitch: int, *a: object, **kw: object
+    ) -> np.ndarray:
+        seen_pitch.append(pitch)
+        return _loud_audio()
+
+    monkeypatch.setattr(generate_vst_dataset, "render_params", _capture_render)
+
+    make_hdf5_dataset(
+        hdf5_file=out,
+        render_cfg=_render_cfg(num_samples),
+        fixed_synth_params_list=synth_rows,
+        fixed_note_params_list=note_rows,
+    )
+
+    assert seen_pitch == [note_rows[i]["pitch"] for i in range(start_idx, num_samples)]
+
+
+def test_make_hdf5_resume_preserves_already_written_rows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A plain (sampled-params) resume re-renders only the tail and leaves the head intact.
+
+    Guards the non-copy resume path the indexing change also touched: rows
+    ``[0, start_idx)`` written by an earlier run keep their exact bytes, while
+    only ``[start_idx, num_samples)`` are overwritten by the resumed render.
+
+    :param tmp_path: Pytest temp dir holding the partially-written shard.
+    :param monkeypatch: Stubs ``render_params`` so the test runs without a plugin.
+    """
+    from synth_setter.data.vst import generate_vst_dataset
+
+    spec = param_specs[_SPEC_NAME]
+    num_samples = 4
+    start_idx = 2
+    head_audio_fill = 0.123
+    head_mel_fill = 0.456
+    head_params = _encode_rows(
+        spec, [_HARDCODED_SYNTH_PARAMS] * start_idx, [_HARDCODED_NOTE_PARAMS] * start_idx
+    )
+
+    out = tmp_path / "resume.h5"
+    _prewrite_resumable_head(
+        out,
+        spec,
+        num_samples,
+        start_idx,
+        head_params,
+        audio_fill=head_audio_fill,
+        mel_fill=head_mel_fill,
+    )
+
+    monkeypatch.setattr(generate_vst_dataset, "render_params", lambda *a, **kw: _loud_audio())
+
+    make_hdf5_dataset(hdf5_file=out, render_cfg=_render_cfg(num_samples))
+
+    with h5py.File(out, "r") as h5:
+        audio = _read_dataset(h5, "audio").astype(np.float32)
+        mel = _read_dataset(h5, "mel_spec")
+        params = _read_dataset(h5, "param_array")
+
+    # audio is stored as float16, so compare against the round-tripped fill.
+    head_audio = np.float32(np.float16(head_audio_fill))
+    for i in range(start_idx):
+        assert np.all(audio[i] == head_audio), f"head audio row {i} overwritten"
+        assert np.all(mel[i] == np.float32(head_mel_fill)), f"head mel row {i} overwritten"
+        np.testing.assert_array_equal(params[i], head_params[i])
+    for i in range(start_idx, num_samples):
+        assert not np.all(audio[i] == head_audio), f"tail row {i} not rendered"
+
+
+def test_make_hdf5_crash_then_resume_copy_reproduces_single_shot_param_array(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A crashed-then-resumed copy run reconstructs the param_array of a single-shot copy.
+
+    The headline resume-correctness property for the dataset-copy path: render
+    crashes mid-shard, the worker re-runs, and the absolute-row indexing makes the
+    resumed tail read the same source rows it would have on an uninterrupted run.
+    Per-row batching makes the crash drop exactly ``start_idx`` written rows.
+
+    :param tmp_path: Pytest temp dir holding the single-shot and resumed shards.
+    :param monkeypatch: Stubs ``render_params`` (one crashing, one healthy).
+    """
+    from synth_setter.data.vst import generate_vst_dataset
+
+    spec = param_specs[_SPEC_NAME]
+    num_samples = 4
+    start_idx = 2
+    synth_rows = [spec.sample()[0] for _ in range(num_samples)]
+    note_rows = _distinct_note_rows(num_samples)
+    expected_params = _encode_rows(spec, synth_rows, note_rows)
+    render_cfg = _render_cfg(num_samples, samples_per_render_batch=1)
+
+    single_shot = tmp_path / "single_shot.h5"
+    monkeypatch.setattr(generate_vst_dataset, "render_params", lambda *a, **kw: _loud_audio())
+    make_hdf5_dataset(
+        hdf5_file=single_shot,
+        render_cfg=render_cfg,
+        fixed_synth_params_list=synth_rows,
+        fixed_note_params_list=note_rows,
+    )
+    with h5py.File(single_shot, "r") as h5:
+        single_shot_params = _read_dataset(h5, "param_array")
+
+    rendered = {"count": 0}
+
+    def _crash_after_start_idx(*a: object, **kw: object) -> np.ndarray:
+        if rendered["count"] >= start_idx:
+            raise RuntimeError("simulated renderer crash")
+        rendered["count"] += 1
+        return _loud_audio()
+
+    resumed = tmp_path / "resumed.h5"
+    monkeypatch.setattr(generate_vst_dataset, "render_params", _crash_after_start_idx)
+    with pytest.raises(RuntimeError, match="simulated renderer crash"):
+        make_hdf5_dataset(
+            hdf5_file=resumed,
+            render_cfg=render_cfg,
+            fixed_synth_params_list=synth_rows,
+            fixed_note_params_list=note_rows,
+        )
+
+    # The crash must leave exactly start_idx rows persisted, so resume picks up there.
+    with h5py.File(resumed, "r") as h5:
+        crashed_param_ds = h5["param_array"]
+        assert isinstance(crashed_param_ds, h5py.Dataset)
+        assert generate_vst_dataset.get_first_unwritten_idx(crashed_param_ds) == start_idx
+
+    monkeypatch.setattr(generate_vst_dataset, "render_params", lambda *a, **kw: _loud_audio())
+    make_hdf5_dataset(
+        hdf5_file=resumed,
+        render_cfg=render_cfg,
+        fixed_synth_params_list=synth_rows,
+        fixed_note_params_list=note_rows,
+    )
+    with h5py.File(resumed, "r") as h5:
+        resumed_params = _read_dataset(h5, "param_array")
+
+    np.testing.assert_array_equal(resumed_params, single_shot_params)
+    for i in range(num_samples):
+        np.testing.assert_array_equal(resumed_params[i], expected_params[i])
+
+
+def test_make_hdf5_rerun_on_complete_shard_renders_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Re-running on a fully-written shard renders no rows and leaves the data untouched.
+
+    The ``start_idx == num_samples`` resume boundary: a complete shard re-run is a
+    no-op even when full-length fixed lists are supplied (the length check passes,
+    nothing is rendered).
+
+    :param tmp_path: Pytest temp dir holding the complete shard.
+    :param monkeypatch: Stubs ``render_params`` to assert it is never invoked.
+    """
+    from synth_setter.data.vst import generate_vst_dataset
+
+    spec = param_specs[_SPEC_NAME]
+    num_samples = 3
+    synth_rows = [spec.sample()[0] for _ in range(num_samples)]
+    note_rows = _distinct_note_rows(num_samples)
+    full_params = _encode_rows(spec, synth_rows, note_rows)
+
+    out = tmp_path / "complete.h5"
+    _prewrite_resumable_head(out, spec, num_samples, num_samples, full_params)
+
+    def _fail_if_called(*a: object, **kw: object) -> NoReturn:
+        raise AssertionError("render_params called on a complete shard")
+
+    monkeypatch.setattr(generate_vst_dataset, "render_params", _fail_if_called)
+
+    make_hdf5_dataset(
+        hdf5_file=out,
+        render_cfg=_render_cfg(num_samples),
+        fixed_synth_params_list=synth_rows,
+        fixed_note_params_list=note_rows,
+    )
+
+    with h5py.File(out, "r") as h5:
+        params = _read_dataset(h5, "param_array")
+    for i in range(num_samples):
+        np.testing.assert_array_equal(params[i], full_params[i])
+
+
+def test_make_hdf5_resume_across_batch_boundary_indexes_by_absolute_row(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A resume starting mid-batch writes each tail row at its absolute index with ``fixed[i]``.
+
+    Pins the batch-flush offset and absolute fixed-params indexing jointly: with
+    ``samples_per_render_batch`` smaller than the shard and ``start_idx`` not on a
+    batch edge, every row's stored params must still equal ``encode(fixed[i])`` —
+    a tail-offset or mis-aligned flush would land the wrong params at the wrong row.
+
+    :param tmp_path: Pytest temp dir holding the partially-written shard.
+    :param monkeypatch: Stubs ``render_params`` so the test runs without a plugin.
+    """
+    from synth_setter.data.vst import generate_vst_dataset
+
+    spec = param_specs[_SPEC_NAME]
+    num_samples = 6
+    start_idx = 3
+    synth_rows = [spec.sample()[0] for _ in range(num_samples)]
+    note_rows = _distinct_note_rows(num_samples)
+    full_params = _encode_rows(spec, synth_rows, note_rows)
+
+    out = tmp_path / "resume_batched.h5"
+    _prewrite_resumable_head(out, spec, num_samples, start_idx, full_params[:start_idx])
+
+    monkeypatch.setattr(generate_vst_dataset, "render_params", lambda *a, **kw: _loud_audio())
+
+    make_hdf5_dataset(
+        hdf5_file=out,
+        render_cfg=_render_cfg(num_samples, samples_per_render_batch=2),
+        fixed_synth_params_list=synth_rows,
+        fixed_note_params_list=note_rows,
+    )
+
+    with h5py.File(out, "r") as h5:
+        params = _read_dataset(h5, "param_array")
+    for i in range(num_samples):
+        np.testing.assert_array_equal(params[i], full_params[i])


### PR DESCRIPTION
## Summary

Adds a CPU-only regression test suite pinning that the **HDF5 dataset resume**
functionality stays correct under the fixed-params indexing contract introduced
by #1430 (merged). That PR changed how the writer indexes pre-set params — from
tail-aligned `fixed_list[i - start_idx]` (list length `num_samples - start_idx`)
to absolute row `fixed_list[i]` (list length `num_samples`). These tests lock in
that resume still reconstructs the exact dataset a single uninterrupted run would.

This PR is purely additive (one test file, no production changes) and does not
touch #1430's merged code in any way.

## What changed

`tests/data/vst/test_generate_vst_dataset.py` gains 4 small helpers
(`_prewrite_resumable_head`, `_read_dataset`, `_distinct_note_rows`,
`_encode_rows`) and 5 tests. All stub `render_params`, so they run without a VST
plugin; the stored `param_array` is a deterministic `param_spec.encode` of the
per-row fixed params, which makes the assertions exact.

- **`test_make_hdf5_resume_indexes_note_params_by_absolute_row`** — note params
  are absolute-indexed on resume. The existing pin only varies *synth* params
  (note params are identical across rows there), so it cannot distinguish
  absolute from tail indexing for the note list; this uses a distinct pitch per
  row to do so.
- **`test_make_hdf5_resume_preserves_already_written_rows`** — a plain
  (sampled-params) resume re-renders only the tail and leaves already-written
  head rows byte-identical. Guards the non-copy resume path the signature change
  also touched.
- **`test_make_hdf5_crash_then_resume_copy_reproduces_single_shot_param_array`**
  — the headline property: a render crash mid-shard followed by a resume
  reproduces the `param_array` of a single uninterrupted copy run. Also asserts
  the crash persisted exactly `start_idx` rows (`get_first_unwritten_idx`).
- **`test_make_hdf5_rerun_on_complete_shard_renders_nothing`** — the
  `start_idx == num_samples` boundary: re-running a complete shard renders
  nothing and leaves the data untouched.
- **`test_make_hdf5_resume_across_batch_boundary_indexes_by_absolute_row`** — a
  resume starting mid-batch lands each tail row at its absolute index with
  `fixed[i]` (pins batch-flush offset and absolute indexing jointly).

## Validation

- `make format` clean (ruff, ruff-format, pyright, pydoclint, docformatter,
  interrogate, …).
- New tests green; the full non-slow `test_generate_vst_dataset.py` suite passes
  (29 passed).
- **Teeth verified:** temporarily reverting the writer to the old
  `i - start_idx` indexing makes 3 of the 5 new tests fail (note-params,
  crash-then-resume, batch-boundary); the other 2 pin orthogonal resume
  properties (head preservation, complete-shard no-op) that the indexing change
  does not affect. See the verification comment on this PR.
- Went through `/repo-review-full-no-comments` (0 BLOCK; remaining items are
  accepted advisory WARNs).

Refs #1429
