### PR TITLE
refactor(testing): autospec sky Resources/Task in launcher tests

### DIFF
--- a/tests/pipeline/entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/entrypoints/test_skypilot_launch.py
@@ -14,10 +14,11 @@ import os
 import re
 from pathlib import Path
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
 import click
 import pytest
+import sky
 import yaml
 
 from synth_setter.pipeline.constants import WORKER_SPEC_URI_ENV
@@ -371,16 +372,19 @@ class TestOverrideImageId:
     """
 
     @staticmethod
-    def _make_resource(cloud: object) -> MagicMock:
-        """Fake ``sky.Resources`` with a ``.cloud`` attr and a ``.copy()`` that records image_id.
+    def _make_resource(cloud: object) -> Any:
+        """Autospec ``sky.Resources`` with a ``.cloud`` attr and a ``.copy()`` recording image_id.
 
-        :param cloud: Pytest fixture.
+        ``create_autospec`` binds the mock surface to the real SDK class, so a renamed or
+        removed attribute fails the test instead of silently passing a stale hand-listed spec.
+
+        :param cloud: Cloud object assigned to ``.cloud`` (a real OCI instance or a sentinel).
         """
-        res = MagicMock(spec=["cloud", "copy"])
+        res = create_autospec(sky.Resources, instance=True)
         res.cloud = cloud
 
-        def _copy(**kwargs: Any) -> MagicMock:
-            new = MagicMock(spec=["cloud", "image_id"])
+        def _copy(**kwargs: Any) -> Any:
+            new = create_autospec(sky.Resources, instance=True)
             new.cloud = cloud
             new.image_id = kwargs.get("image_id")
             return new
@@ -389,12 +393,12 @@ class TestOverrideImageId:
         return res
 
     @staticmethod
-    def _make_task(resources: list[Any]) -> MagicMock:
-        """Fake ``sky.Task`` carrying ``resources`` (as a list, so ``type(...)`` is ``list``).
+    def _make_task(resources: list[Any]) -> Any:
+        """Autospec ``sky.Task`` carrying ``resources`` (as a list, so ``type(...)`` is ``list``).
 
-        :param resources: Pytest fixture.
+        :param resources: Resources entries assigned to ``task.resources``.
         """
-        task = MagicMock(spec=["resources", "set_resources"])
+        task = create_autospec(sky.Task, instance=True)
         task.resources = list(resources)
         return task
 


### PR DESCRIPTION
## What

Replace the hand-maintained `MagicMock(spec=[...])` attribute lists for `sky.Resources` and `sky.Task` in `TestOverrideImageId` with `unittest.mock.create_autospec` against the real SkyPilot SDK classes.

## Why

The hand-listed specs (`spec=["cloud", "copy"]`, `spec=["resources", "set_resources"]`, etc.) can silently drift from the real SDK surface: if SkyPilot renames or removes `copy` / `set_resources` / `cloud` / `image_id`, the old fakes keep passing while production breaks. `create_autospec` binds the mock surface to the installed `sky` classes, so a renamed/removed attribute now fails the test instead of passing a stale spec.

## Feasibility check

`sky` is a real, importable dependency (version 0.12.0) in this environment, so autospec against the real classes is viable. Verified:

- `sky.Resources` exposes `cloud`, `copy`, `image_id`; `sky.Task` exposes `resources`, `set_resources` — all settable on the autospec instances (no read-only `@property` blocks the `.resources` / `.image_id` assignments the tests rely on).
- `create_autospec(...).copy.side_effect` still accepts the custom `_copy` callable.
- `create_autospec` rejects a nonexistent attribute (`r.copyy(...)` raises `AttributeError`), confirming the drift guard is live.

## Scope

Test-only change. No production code touched. The `MagicMock(spec=[...])` → `create_autospec` swap is confined to the two `TestOverrideImageId` helper factories. Docstrings updated (the old `:param cloud: Pytest fixture.` was inaccurate — `cloud` is a cloud object, not a fixture).

## Verification

`uv run pytest tests/pipeline/entrypoints/test_skypilot_launch.py -q` → 79 passed, asserting identical behavior. `make format` clean (ruff, ruff-format, pyright, pydoclint, prettier all pass).

Refs #1445
