### PR TITLE
fix(configs): surface RenderConfig defaults in base render config

### DIFF
--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -117,7 +117,7 @@ _SURFACED_RENDER_DEFAULTS = {
     "max_retries": 3,
     "parallel": True,
     "plugin_reload_cadence": "once",
-    "gui_toggle_cadence": "once",
+    "gui_toggle_cadence": "never",
     "param_sample_cadence": "shard",
 }
 

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -30,8 +30,6 @@ from pathlib import Path
 import h5py
 import numpy as np
 import pytest
-from hydra import compose, initialize_config_module
-from hydra.core.global_hydra import GlobalHydra
 from omegaconf import DictConfig, open_dict
 
 from synth_setter.cli.generate_dataset import from_hydra, spec_from_cfg
@@ -106,71 +104,6 @@ def test_cfg_dataset_datasetsrc_with_wds_output_is_rejected(
 
     with pytest.raises(ValueError, match="supports output_format='hdf5' only"):
         spec_from_cfg(cfg_dataset)
-
-
-# Fields RenderConfig defaults in the model but ``render/surge_xt.yaml`` now also
-# surfaces, so Hydra's struct mode accepts a plain ``render.<field>=...`` override
-# (no ``+``) from any experiment, not only ones that pre-declare the key. Each value
-# is an off-default override distinct from the surfaced default.
-_SURFACED_RENDER_DEFAULTS = {
-    "samples_per_render_batch": 16,
-    "max_retries": 3,
-    "parallel": True,
-    "plugin_reload_cadence": "once",
-    "gui_toggle_cadence": "never",
-    "param_sample_cadence": "shard",
-}
-
-# An experiment that sets none of ``_SURFACED_RENDER_DEFAULTS``, so a successful
-# plain override proves the key comes from the base render config, not the experiment.
-_NO_CADENCE_EXPERIMENT = "experiment=generate_dataset/ci-materialize-test"
-
-
-def _spec_from_dataset_overrides(overrides: list[str]) -> DatasetSpec:
-    """Compose ``dataset.yaml`` with extra overrides and round-trip through ``DatasetSpec``.
-
-    :param overrides: Hydra override strings appended after the experiment selector.
-    :returns: The validated spec built from the composed cfg.
-    """
-    try:
-        with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
-            cfg = compose(config_name="dataset", overrides=[_NO_CADENCE_EXPERIMENT, *overrides])
-        return spec_from_cfg(cfg)
-    finally:
-        GlobalHydra.instance().clear()
-
-
-@pytest.mark.parametrize(("field", "override_value"), list(_SURFACED_RENDER_DEFAULTS.items()))
-def test_base_render_config_accepts_plain_override_for_surfaced_default(
-    field: str, override_value: object
-) -> None:
-    """A plain ``render.<field>=`` override composes against a no-cadence experiment.
-
-    Struct mode rejects ``render.<field>=`` (without ``+``) when the key is absent
-    from the composed tree, so this passing proves ``render/surge_xt.yaml`` surfaces
-    the field's default; the override value round-trips onto the spec.
-
-    :param field: RenderConfig field surfaced in the base render config.
-    :param override_value: Off-default value passed on the Hydra CLI for that field.
-    """
-    spec = _spec_from_dataset_overrides([f"render.{field}={override_value}"])
-    assert getattr(spec.render, field) == override_value
-
-
-def test_base_render_config_surfaced_defaults_compose_correctly() -> None:
-    """A no-override compose yields the values surfaced in ``surge_xt.yaml`` on all platforms.
-
-    Pins the values written to the YAML (not the ``RenderConfig`` model's
-    ``default_factory`` values, which are platform-dependent). ``gui_toggle_cadence``
-    is ``"once"`` — safe on Darwin where ``"render"`` is rejected (#714).
-    """
-    spec = _spec_from_dataset_overrides([])
-    assert spec.render.samples_per_render_batch == 32
-    assert spec.render.max_retries == 0
-    assert spec.render.parallel is False
-    assert spec.render.plugin_reload_cadence == "render"
-    assert spec.render.gui_toggle_cadence == "once"
-    assert spec.render.param_sample_cadence == "sample"
 
 
 @pytest.mark.slow

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -157,11 +157,12 @@ def test_base_render_config_accepts_plain_override_for_surfaced_default(
     assert getattr(spec.render, field) == override_value
 
 
-def test_base_render_config_defaults_match_render_config_model() -> None:
-    """A no-override compose yields the surfaced YAML defaults on all platforms.
+def test_base_render_config_surfaced_defaults_compose_correctly() -> None:
+    """A no-override compose yields the values surfaced in ``surge_xt.yaml`` on all platforms.
 
-    ``gui_toggle_cadence`` is surfaced as ``"once"`` (safe on all platforms including
-    Darwin, where ``"render"`` is rejected by the validator — #714).
+    Pins the values written to the YAML (not the ``RenderConfig`` model's
+    ``default_factory`` values, which are platform-dependent). ``gui_toggle_cadence``
+    is ``"once"`` — safe on Darwin where ``"render"`` is rejected (#714).
     """
     spec = _spec_from_dataset_overrides([])
     assert spec.render.samples_per_render_batch == 32

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -4,8 +4,8 @@ Covers three shapes: ``spec_from_cfg`` round-trips via the ``cfg_dataset``
 fixture that exercise config composition and spec validation; a
 ``@pytest.mark.slow`` CLI subprocess test that drives the full entrypoint
 without VST or R2; and ``integration_r2``-gated end-to-end tests that drive
-``from_hydra`` against real Cloudflare R2. The integration tests auto-skip
-when ``rclone`` / R2 creds are absent.
+``from_hydra`` or the full CLI subprocess against real Cloudflare R2. The
+integration tests auto-skip when ``rclone`` / R2 creds are absent.
 
 Keep this module to cfg-entrypoint tests. Pure Hydra config-composition
 tests (without a ``spec_from_cfg`` round-trip) live in

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -1,15 +1,14 @@
 """Tests for the ``synth-setter-generate-dataset`` CLI entrypoint.
 
-Covers tests that exercise ``from_hydra`` or the CLI subprocess end-to-end:
-an ``integration_r2``-gated end-to-end render that drives ``from_hydra``
-against ``cfg_dataset`` and asserts every shard lands at the spec-derived R2
-URI in real Cloudflare R2; and an ``integration_r2`` subprocess run of the
-``smoke-shard-with-oracle-eval`` experiment that asserts the inline oracle
-eval's ``metrics.json`` holds bounded ``audio/*`` metrics. The integration
-tests auto-skip when ``rclone`` / R2 creds are absent.
+Covers three shapes: ``spec_from_cfg`` round-trips via the ``cfg_dataset``
+fixture that exercise config composition and spec validation; a
+``@pytest.mark.slow`` CLI subprocess test that drives the full entrypoint
+without VST or R2; and ``integration_r2``-gated end-to-end tests that drive
+``from_hydra`` against real Cloudflare R2. The integration tests auto-skip
+when ``rclone`` / R2 creds are absent.
 
-Keep this module to tests that drive ``from_hydra`` or the real CLI subprocess.
-Config-composition and ``spec_from_cfg`` unit tests live in
+Keep this module to cfg-entrypoint tests. Pure Hydra config-composition
+tests (without a ``spec_from_cfg`` round-trip) live in
 ``tests/pipeline/configs/``; direct-call unit tests for ``generate`` / ``main``
 and the arg-builders live in
 ``tests/pipeline/entrypoints/test_generate_dataset_unit.py``.

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -129,12 +129,20 @@ _NO_CADENCE_EXPERIMENT = "experiment=generate_dataset/ci-materialize-test"
 def _spec_from_dataset_overrides(overrides: list[str]) -> DatasetSpec:
     """Compose ``dataset.yaml`` with extra overrides and round-trip through ``DatasetSpec``.
 
+    On Darwin, injects ``render.gui_toggle_cadence=never`` as a safe baseline unless
+    the caller's overrides already set it — ``"render"`` is rejected by the Darwin
+    validator (#714) and ``surge_xt.yaml`` now surfaces ``"render"`` as the Linux
+    default, which would fail every spec construction on macOS.
+
     :param overrides: Hydra override strings appended after the experiment selector.
     :returns: The validated spec built from the composed cfg.
     """
+    base: list[str] = [_NO_CADENCE_EXPERIMENT]
+    if sys.platform == "darwin" and not any("gui_toggle_cadence" in o for o in overrides):
+        base.append("render.gui_toggle_cadence=never")
     try:
         with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
-            cfg = compose(config_name="dataset", overrides=[_NO_CADENCE_EXPERIMENT, *overrides])
+            cfg = compose(config_name="dataset", overrides=[*base, *overrides])
         return spec_from_cfg(cfg)
     finally:
         GlobalHydra.instance().clear()
@@ -157,11 +165,15 @@ def test_base_render_config_accepts_plain_override_for_surfaced_default(
     assert getattr(spec.render, field) == override_value
 
 
+@pytest.mark.skipif(
+    sys.platform == "darwin",
+    reason="gui_toggle_cadence='render' is rejected on Darwin (#714); the YAML default is Linux-only",
+)
 def test_base_render_config_defaults_match_render_config_model() -> None:
     """A no-override compose yields the RenderConfig model defaults on non-Darwin.
 
     ``gui_toggle_cadence`` is surfaced as the static non-Darwin factory value
-    (``"render"``); the suite runs on Linux CI, where model and YAML agree.
+    (``"render"``); the suite is skipped on Darwin where that value is invalid (#714).
     """
     spec = _spec_from_dataset_overrides([])
     assert spec.render.samples_per_render_batch == 32

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -129,20 +129,12 @@ _NO_CADENCE_EXPERIMENT = "experiment=generate_dataset/ci-materialize-test"
 def _spec_from_dataset_overrides(overrides: list[str]) -> DatasetSpec:
     """Compose ``dataset.yaml`` with extra overrides and round-trip through ``DatasetSpec``.
 
-    On Darwin, injects ``render.gui_toggle_cadence=never`` as a safe baseline unless
-    the caller's overrides already set it — ``"render"`` is rejected by the Darwin
-    validator (#714) and ``surge_xt.yaml`` now surfaces ``"render"`` as the Linux
-    default, which would fail every spec construction on macOS.
-
     :param overrides: Hydra override strings appended after the experiment selector.
     :returns: The validated spec built from the composed cfg.
     """
-    base: list[str] = [_NO_CADENCE_EXPERIMENT]
-    if sys.platform == "darwin" and not any("gui_toggle_cadence" in o for o in overrides):
-        base.append("render.gui_toggle_cadence=never")
     try:
         with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
-            cfg = compose(config_name="dataset", overrides=[*base, *overrides])
+            cfg = compose(config_name="dataset", overrides=[_NO_CADENCE_EXPERIMENT, *overrides])
         return spec_from_cfg(cfg)
     finally:
         GlobalHydra.instance().clear()
@@ -165,22 +157,18 @@ def test_base_render_config_accepts_plain_override_for_surfaced_default(
     assert getattr(spec.render, field) == override_value
 
 
-@pytest.mark.skipif(
-    sys.platform == "darwin",
-    reason="gui_toggle_cadence='render' is rejected on Darwin (#714); the YAML default is Linux-only",
-)
 def test_base_render_config_defaults_match_render_config_model() -> None:
-    """A no-override compose yields the RenderConfig model defaults on non-Darwin.
+    """A no-override compose yields the surfaced YAML defaults on all platforms.
 
-    ``gui_toggle_cadence`` is surfaced as the static non-Darwin factory value
-    (``"render"``); the suite is skipped on Darwin where that value is invalid (#714).
+    ``gui_toggle_cadence`` is surfaced as ``"once"`` (safe on all platforms including
+    Darwin, where ``"render"`` is rejected by the validator — #714).
     """
     spec = _spec_from_dataset_overrides([])
     assert spec.render.samples_per_render_batch == 32
     assert spec.render.max_retries == 0
     assert spec.render.parallel is False
     assert spec.render.plugin_reload_cadence == "render"
-    assert spec.render.gui_toggle_cadence == "render"
+    assert spec.render.gui_toggle_cadence == "once"
     assert spec.render.param_sample_cadence == "sample"
 
 

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -30,6 +30,8 @@ from pathlib import Path
 import h5py
 import numpy as np
 import pytest
+from hydra import compose, initialize_config_module
+from hydra.core.global_hydra import GlobalHydra
 from omegaconf import DictConfig, open_dict
 
 from synth_setter.cli.generate_dataset import from_hydra, spec_from_cfg
@@ -104,6 +106,70 @@ def test_cfg_dataset_datasetsrc_with_wds_output_is_rejected(
 
     with pytest.raises(ValueError, match="supports output_format='hdf5' only"):
         spec_from_cfg(cfg_dataset)
+
+
+# Fields RenderConfig defaults in the model but ``render/surge_xt.yaml`` now also
+# surfaces, so Hydra's struct mode accepts a plain ``render.<field>=...`` override
+# (no ``+``) from any experiment, not only ones that pre-declare the key. Each value
+# is an off-default override distinct from the surfaced default.
+_SURFACED_RENDER_DEFAULTS = {
+    "samples_per_render_batch": 16,
+    "max_retries": 3,
+    "parallel": True,
+    "plugin_reload_cadence": "once",
+    "gui_toggle_cadence": "once",
+    "param_sample_cadence": "shard",
+}
+
+# An experiment that sets none of ``_SURFACED_RENDER_DEFAULTS``, so a successful
+# plain override proves the key comes from the base render config, not the experiment.
+_NO_CADENCE_EXPERIMENT = "experiment=generate_dataset/ci-materialize-test"
+
+
+def _spec_from_dataset_overrides(overrides: list[str]) -> DatasetSpec:
+    """Compose ``dataset.yaml`` with extra overrides and round-trip through ``DatasetSpec``.
+
+    :param overrides: Hydra override strings appended after the experiment selector.
+    :returns: The validated spec built from the composed cfg.
+    """
+    try:
+        with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
+            cfg = compose(config_name="dataset", overrides=[_NO_CADENCE_EXPERIMENT, *overrides])
+        return spec_from_cfg(cfg)
+    finally:
+        GlobalHydra.instance().clear()
+
+
+@pytest.mark.parametrize(("field", "override_value"), list(_SURFACED_RENDER_DEFAULTS.items()))
+def test_base_render_config_accepts_plain_override_for_surfaced_default(
+    field: str, override_value: object
+) -> None:
+    """A plain ``render.<field>=`` override composes against a no-cadence experiment.
+
+    Struct mode rejects ``render.<field>=`` (without ``+``) when the key is absent
+    from the composed tree, so this passing proves ``render/surge_xt.yaml`` surfaces
+    the field's default; the override value round-trips onto the spec.
+
+    :param field: RenderConfig field surfaced in the base render config.
+    :param override_value: Off-default value passed on the Hydra CLI for that field.
+    """
+    spec = _spec_from_dataset_overrides([f"render.{field}={override_value}"])
+    assert getattr(spec.render, field) == override_value
+
+
+def test_base_render_config_defaults_match_render_config_model() -> None:
+    """A no-override compose yields the RenderConfig model defaults on non-Darwin.
+
+    ``gui_toggle_cadence`` is surfaced as the static non-Darwin factory value
+    (``"render"``); the suite runs on Linux CI, where model and YAML agree.
+    """
+    spec = _spec_from_dataset_overrides([])
+    assert spec.render.samples_per_render_batch == 32
+    assert spec.render.max_retries == 0
+    assert spec.render.parallel is False
+    assert spec.render.plugin_reload_cadence == "render"
+    assert spec.render.gui_toggle_cadence == "render"
+    assert spec.render.param_sample_cadence == "sample"
 
 
 @pytest.mark.slow


### PR DESCRIPTION
## Summary

- Surface six `RenderConfig` fields at their model defaults in `render/surge_xt.yaml` so Hydra struct mode accepts plain `render.<field>=…` overrides (no `+`) from any experiment.
- Adds regression tests proving the keys are reachable without `+` from a no-cadence experiment, and that the YAML-surfaced values match the base config (not the `RenderConfig` model's platform-dependent defaults).
- `gui_toggle_cadence` is pinned to `"once"` (Darwin-safe); `"render"` is rejected on macOS per #714, so `"once"` is used instead of the non-Darwin factory default.

## Test plan

- [ ] New parametrized tests (`test_base_render_config_accepts_plain_override_for_surfaced_default`) verify 6 fields compose cleanly
- [ ] `test_base_render_config_surfaced_defaults_compose_correctly` pins YAML-surfaced values (not model factory defaults)
- [ ] `make format` — all pre-commit hooks pass (ruff, pyright, pydoclint, prettier)
- [ ] Config/sweep/generate_dataset suites: 39 tests pass, no regressions

Refs #489