### PR TITLE
refactor(eval): type decode + predict_vst_audio notes with NoteParams

### DIFF
--- a/.pydoclint-baseline.txt
+++ b/.pydoclint-baseline.txt
@@ -85,7 +85,7 @@ src/synth_setter/evaluation/compute_audio_metrics.py
 --------------------
 src/synth_setter/evaluation/predict_vst_audio.py
     DOC101: Function `params_to_csv`: Docstring contains fewer arguments than in function signature.
-    DOC103: Function `params_to_csv`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [param_spec: ParamSpec, pred_note_params: dict[str, float], pred_synth_params: dict[str, float], save_path: str, target_note_params: dict[str, float], target_synth_params: dict[str, float]].
+    DOC103: Function `params_to_csv`: Docstring arguments are different from function arguments. (Or could be other formatting issues: https://jsh9.github.io/pydoclint/violation_codes.html#notes-on-doc103 ). Arguments in the function signature but not in the docstring: [param_spec: ParamSpec, pred_note_params: NoteParams, pred_synth_params: dict[str, float], save_path: str, target_note_params: NoteParams | None, target_synth_params: dict[str, float] | None].
 --------------------
 src/synth_setter/metrics.py
     DOC101: Method `LogSpectralDistance.__init__`: Docstring contains fewer arguments than in function signature.

--- a/src/synth_setter/data/vst/generate_vst_dataset.py
+++ b/src/synth_setter/data/vst/generate_vst_dataset.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 import h5py
 import hdf5plugin
@@ -279,9 +279,7 @@ def fixed_params_from_dataset(
     for row in param_array:
         synth_params, note_params = param_spec.decode(row)
         synth_params_list.append(synth_params)
-        # decode is annotated dict[str, float]; pitch is int and note_start_and_end
-        # a tuple at runtime, matching NoteParams' closed shape.
-        note_params_list.append(cast(NoteParams, note_params))
+        note_params_list.append(note_params)
     return synth_params_list, note_params_list
 
 

--- a/src/synth_setter/data/vst/param_spec.py
+++ b/src/synth_setter/data/vst/param_spec.py
@@ -269,7 +269,7 @@ class ParamSpec:
 
         return np.concatenate((synth_params, note_params))
 
-    def decode(self, params: np.ndarray) -> tuple[dict[str, float], dict[str, float]]:
+    def decode(self, params: np.ndarray) -> tuple[dict[str, float], NoteParams]:
         synth_params_to_process = [(p, len(p)) for p in self.synth_params]
         note_params_to_process = [(p, len(p)) for p in self.note_params]
 
@@ -287,7 +287,9 @@ class ParamSpec:
             note_params[param.name] = param_value
             pointer += length
 
-        return synth_params, note_params
+        # Keys come from runtime ``Parameter.name`` values, so the checker can't
+        # prove the NoteParams key->type mapping; assert it at this one source.
+        return synth_params, cast(NoteParams, note_params)
 
     @property
     def synth_param_names(self) -> list[str]:

--- a/src/synth_setter/data/vst/param_spec.py
+++ b/src/synth_setter/data/vst/param_spec.py
@@ -223,7 +223,7 @@ class NoteDurationParameter(Parameter):
 class NoteParams(TypedDict):  # noqa: DOC601, DOC603
     """Note-conditioning params consumed by ``render_params``.
 
-    Closed and total: ``ParamSpec.sample`` emits exactly these two keys.
+    Closed and total: ``ParamSpec.sample`` and ``ParamSpec.decode`` emit exactly these two keys.
     """
 
     pitch: int
@@ -287,8 +287,8 @@ class ParamSpec:
             note_params[param.name] = param_value
             pointer += length
 
-        # Keys come from runtime ``Parameter.name`` values, so the checker can't
-        # prove the NoteParams key->type mapping; assert it at this one source.
+        # Same cast as sample(): keys come from runtime ``Parameter.name`` values,
+        # so the checker can't prove the NoteParams key->type mapping.
         return synth_params, cast(NoteParams, note_params)
 
     @property

--- a/src/synth_setter/evaluation/predict_vst_audio.py
+++ b/src/synth_setter/evaluation/predict_vst_audio.py
@@ -14,7 +14,7 @@ from tqdm import tqdm, trange
 
 from synth_setter.data.vst import param_specs
 from synth_setter.data.vst.core import render_params
-from synth_setter.data.vst.param_spec import ParamSpec
+from synth_setter.data.vst.param_spec import NoteParams, ParamSpec
 
 
 def make_spectrogram(audio: np.ndarray, sample_rate: float) -> np.ndarray:
@@ -81,10 +81,10 @@ def write_spectrograms(
 
 
 def params_to_csv(
-    target_synth_params: dict[str, float],
-    target_note_params: dict[str, float],
+    target_synth_params: dict[str, float] | None,
+    target_note_params: NoteParams | None,
     pred_synth_params: dict[str, float],
-    pred_note_params: dict[str, float],
+    pred_note_params: NoteParams,
     save_path: str,
     param_spec: ParamSpec,
 ) -> None:
@@ -125,7 +125,7 @@ def main(
     no_params: bool = False,
     skip_spectrogram: bool = False,
 ):
-    param_spec = param_specs[param_spec]
+    spec = param_specs[param_spec]
     os.makedirs(output_dir, exist_ok=True)
 
     # render_params loads the plugin (and applies preset_path) on every call,
@@ -133,15 +133,15 @@ def main(
 
     # list the .pt files with accompanying indices (each file has name
     # pred-{index}.pt, and we want to sort by index)
-    pred_dir = Path(pred_dir)
-    pred_files = [f for f in pred_dir.glob("pred-*.pt") if f.is_file()]
+    pred_path = Path(pred_dir)
+    pred_files = [f for f in pred_path.glob("pred-*.pt") if f.is_file()]
     indices = [int(f.stem.split("-")[1]) for f in pred_files]
-    target_audio_files = [pred_dir / f"target-audio-{i}.pt" for i in indices]
+    target_audio_files = [pred_path / f"target-audio-{i}.pt" for i in indices]
 
     if no_params:
         target_param_files = [None] * len(pred_files)
     else:
-        target_param_files = [pred_dir / f"target-params-{i}.pt" for i in indices]
+        target_param_files = [pred_path / f"target-params-{i}.pt" for i in indices]
 
     # 4. foreach .pt file
     current_offset = 0
@@ -165,7 +165,7 @@ def main(
             row_params = pred_params[j].float().numpy()
             row_params_scaled = (row_params + 1) / 2
             row_params_scaled = np.clip(row_params_scaled, 0, 1)
-            synth_params, note_params = param_spec.decode(row_params_scaled)
+            synth_params, note_params = spec.decode(row_params_scaled)
 
             pred_audio = render_params(
                 plugin_path,
@@ -180,14 +180,14 @@ def main(
             )
 
             target_synth_params: dict[str, float] | None = None
-            target_note_params: dict[str, float] | None = None
+            target_note_params: NoteParams | None = None
 
             out_target = os.path.join(sample_dir, "target.wav")
             if rerender_target and target_params is not None:
                 target_params_ = target_params[j].numpy()
                 target_params_ = (target_params_ + 1) / 2
                 target_params_ = np.clip(target_params_, 0, 1)
-                target_synth_params, target_note_params = param_spec.decode(target_params_)
+                target_synth_params, target_note_params = spec.decode(target_params_)
 
                 new_target = render_params(
                     plugin_path,
@@ -225,7 +225,7 @@ def main(
                 synth_params,
                 note_params,
                 os.path.join(sample_dir, "params.csv"),
-                param_spec,
+                spec,
             )
 
         current_offset += pred_params.shape[0]

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -890,10 +890,7 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
     for i in range(_NUM_SAMPLES):
         decoded_synth_params, decoded_note_params = spec.decode(expected_params[i])
         synth_patches.append(decoded_synth_params)
-        # ParamSpec.decode is annotated dict[str, float] on main but actually returns
-        # dict[str, int | tuple[float, float]] at runtime (pitch is int, note_start_and_end
-        # is a tuple). Annotation gets corrected in a sibling PR.
-        note_patches.append(decoded_note_params)  # pyright: ignore[reportArgumentType]
+        note_patches.append(decoded_note_params)
     log.info("synth_patches: %s", synth_patches)
     log.info("note_patches: %s", note_patches)
 
@@ -1767,9 +1764,7 @@ def test_make_hdf5_resume_indexes_fixed_params_by_absolute_row(
         for i in range(start_idx):
             audio[i] = 1.0
             mel[i] = 1.0
-            # encode is annotated dict[str, float]; _HARDCODED_NOTE_PARAMS carries
-            # the runtime int/tuple note shape.
-            params[i] = spec.encode(synth_rows[i], note_rows[i])  # pyright: ignore[reportArgumentType]
+            params[i] = spec.encode(synth_rows[i], note_rows[i])
 
     seen_synth: list[dict[str, float]] = []
 

--- a/tests/evaluation/test_predict_vst_audio.py
+++ b/tests/evaluation/test_predict_vst_audio.py
@@ -23,6 +23,7 @@ import torch  # noqa: E402
 from click.testing import CliRunner, Result  # noqa: E402
 
 from synth_setter.data.vst import param_specs  # noqa: E402
+from synth_setter.data.vst.param_spec import NoteParams  # noqa: E402
 from synth_setter.evaluation import predict_vst_audio  # noqa: E402
 from synth_setter.evaluation.predict_vst_audio import (  # noqa: E402
     main,
@@ -114,11 +115,11 @@ def test_write_spectrograms_closes_figure_to_avoid_leaks(tmp_path: Path) -> None
 # ---------- params_to_csv ----------
 
 
-def _sample_param_dicts(seed: int = 0) -> tuple[dict[str, float], dict[str, float]]:
+def _sample_param_dicts(seed: int = 0) -> tuple[dict[str, float], NoteParams]:
     """Deterministic ``(synth_params, note_params)`` pair via ``_PARAM_SPEC.decode``.
 
     :param seed: Seed for the per-call RNG.
-    :return: ``(synth_params, note_params)`` dict pair decoded from a random encoding.
+    :return: ``(synth_params, note_params)`` pair decoded from a random encoding.
     """
     rng = np.random.default_rng(seed)
     encoded = rng.random(len(_PARAM_SPEC)).astype(np.float32)
@@ -144,14 +145,14 @@ def test_params_to_csv_writes_pred_and_target_columns(tmp_path: Path) -> None:
 
 
 def test_params_to_csv_none_target_leaves_target_column_nan(tmp_path: Path) -> None:
-    """The CLI's ``--no-params`` path passes ``None`` past the source's stricter annotation.
+    """``None`` target params (the CLI's ``--no-params`` path) leave an all-NaN target column.
 
     :param tmp_path: Pytest fixture providing a fresh test directory.
     """
     pred_s, pred_n = _sample_param_dicts()
     out = tmp_path / "params.csv"
 
-    params_to_csv(None, None, pred_s, pred_n, str(out), _PARAM_SPEC)  # type: ignore[arg-type]
+    params_to_csv(None, None, pred_s, pred_n, str(out), _PARAM_SPEC)
 
     df = pd.read_csv(out, index_col=0)
     assert bool(df["pred"].notna().all())


### PR DESCRIPTION
## What

Follow-up to #1427, which threaded the `NoteParams` TypedDict through the VST *generate* path but deliberately left the *decode* side returning `tuple[dict[str, float], dict[str, float]]` — imprecise because the note half's `note_start_and_end` is a tuple, not a float. That side was scoped out of #1427 because correcting it required also untangling `predict_vst_audio.py`'s unrelated pre-existing type errors.

This PR closes that gap. **Type-only — no runtime behavior change** (`cast` is a no-op at runtime; the local renames are mechanical).

## Changes

- **`param_spec.py`**: `ParamSpec.decode` now returns `tuple[dict[str, float], NoteParams]`, asserted via a single `cast(NoteParams, …)` at the dynamic-construction source — mirroring the existing `sample()` (keys come from runtime `Parameter.name`, so the checker can't prove the mapping).
- **`predict_vst_audio.py`**: untangle the pre-existing errors that blocked this in #1427 —
  - `param_spec`/`pred_dir` are no longer reassigned across `str`/`ParamSpec`/`Path` (new `spec`/`pred_path` locals), removing a real shadowing hazard;
  - `params_to_csv`'s `target_*` params widen to optionals because the `--no-params` path genuinely passes `None`;
  - note params adopt `NoteParams`, and the `:195`/`:197` None-subscript errors fall out of the now-narrowed `decode` return type.
- **tests**: drop the now-stale `reportArgumentType` ignores (decode- and encode-fed) in `test_generate_vst_dataset.py` and the `params_to_csv(None, …)` `# type: ignore[arg-type]` in `test_predict_vst_audio.py`; `_sample_param_dicts` returns `NoteParams`. The stale explanatory comments referencing "a sibling PR" go with them.
- **`.pydoclint-baseline.txt`**: `params_to_csv`'s existing DOC103 row updated in place for the new annotations (no new rows — append-freeze respected, matching #1427's precedent).

## Scope

`make_spectrogram` / `write_spectrograms` return-type errors (`:36`/`:44`) are unrelated to note params and left untouched. Both `param_spec.py` and `predict_vst_audio.py` remain pyright-excluded; graduating either from the exclude list is a separate `/lint-cleanup` task. The type-checking value here lands in the non-excluded test files, which now drive `decode`/`params_to_csv` with the real `NoteParams` shape.

## Verification

- Full-repo pyright: **0 errors** (matches pre-change state).
- `predict_vst_audio` suite green (15 passed serially); non-slow VST data tests green (99 passed).
- `make format` / pre-commit clean (ruff, pyright, pydoclint, …).
- Pre-PR gate: `/repo-review-full-no-comments` → 0 BLOCK across 7 skills.

Fixes #1428
