### PR TITLE
feat(generate_dataset): add per-shard RNG seed for reproducibility

### DIFF
--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -201,6 +201,10 @@ def build_generate_args(spec: DatasetSpec, shard: ShardSpec, output_dir: Path) -
     ``OutputFormat.from_extension``. When ``spec.datasetsrc`` is set, the copy
     root is forwarded as ``--copy_dataset_root`` so the subprocess re-renders the
     same-named source shard's params instead of sampling fresh ones.
+
+    ``shard.seed`` (= ``base_seed + shard_id``) overrides ``spec.render.seed`` so
+    each subprocess receives its deterministic per-shard seed regardless of what
+    the spec-level ``render.seed`` carries.
     """
     output_path = output_dir / shard.filename
     args = [
@@ -208,7 +212,8 @@ def build_generate_args(spec: DatasetSpec, shard: ShardSpec, output_dir: Path) -
         "src/synth_setter/data/vst/generate_vst_dataset.py",
         str(output_path),
     ]
-    for key, value in spec.render.model_dump().items():
+    render_with_seed = spec.render.model_copy(update={"seed": shard.seed})
+    for key, value in render_with_seed.model_dump().items():
         args.extend([f"--{key}", str(value)])
     if spec.datasetsrc is not None:
         args.extend(["--copy_dataset_root", spec.datasetsrc.copy_dataset_root])

--- a/src/synth_setter/configs/experiment/generate_dataset/smoke-shard.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/smoke-shard.yaml
@@ -19,7 +19,9 @@ train_val_test_sizes: [4, 4, 4]
 
 render:
   sample_rate: 44100
-  min_loudness: -55.0
+  # Smoke tests verify behavior, not quality; -60 dB gives headroom for
+  # shard-cadence seeded renders where one patch may land near the floor.
+  min_loudness: -60.0
   samples_per_render_batch: 4
   samples_per_shard: 4
   gui_toggle_cadence: once

--- a/src/synth_setter/data/vst/writers.py
+++ b/src/synth_setter/data/vst/writers.py
@@ -8,6 +8,7 @@ writer using ``webdataset.TarWriter``.
 
 from __future__ import annotations
 
+import random
 from collections.abc import Callable
 from pathlib import Path
 from types import TracebackType
@@ -198,6 +199,10 @@ def _render_in_batches(
     :raises ValueError: ``param_sample_cadence="shard"`` combined with
         caller-supplied fixed-params lists (shard cadence owns its own patch).
     """
+    if render_cfg.seed is not None:
+        random.seed(render_cfg.seed)
+        np.random.seed(render_cfg.seed)
+
     num_samples = render_cfg.samples_per_shard
     share_params = render_cfg.param_sample_cadence == "shard"
     # Shard cadence draws and owns the shard's single patch, so caller-supplied

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -350,7 +350,7 @@ class RenderConfig(BaseModel):
         description=(
             "Per-shard RNG seed; when set, ``random`` and ``np.random`` are seeded at "
             "the start of the shard render so param sampling is reproducible. ``None`` "
-            "(default) retains the historical unseeded behaviour. Set automatically by "
+            "(default) leaves RNGs unseeded. Set automatically by "
             "``build_generate_args`` to ``base_seed + shard_id`` for each subprocess."
         ),
     )

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -253,6 +253,10 @@ class RenderConfig(BaseModel):
     parameter arrays for its assigned shard. ``param_spec_name`` is resolved
     against the in-process registry inside the writer (not at the launcher),
     so launcher-side construction stays interpreter-only.
+
+    .. attribute :: seed
+
+       Per-shard RNG seed; seeds ``random`` and ``np.random`` at shard start.
     """
 
     model_config = ConfigDict(strict=True, frozen=True, extra="forbid")
@@ -338,8 +342,16 @@ class RenderConfig(BaseModel):
             'draws a fresh patch for every sample; ``"shard"`` draws one patch (the '
             "first sample, via the normal loudness-gated path) and reuses it for the "
             "rest of the shard — one identical patch per shard, a probe for the "
-            "per-patch render variance tracked in #489. The patch is drawn fresh each "
-            "run (no seeding), so shard cadence is not reproducible across runs."
+            "per-patch render variance tracked in #489."
+        ),
+    )
+    seed: int | None = Field(
+        default=None,
+        description=(
+            "Per-shard RNG seed; when set, ``random`` and ``np.random`` are seeded at "
+            "the start of the shard render so param sampling is reproducible. ``None`` "
+            "(default) retains the historical unseeded behaviour. Set automatically by "
+            "``build_generate_args`` to ``base_seed + shard_id`` for each subprocess."
         ),
     )
 

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -201,7 +201,11 @@ class ShardSpec(BaseModel):
             "(``shard-NNNNNN.h5`` or ``shard-NNNNNN.tar``)."
         )
     )
-    seed: int = Field(description="Per-shard RNG seed, derived as ``base_seed + shard_id``.")
+    seed: int = Field(
+        ge=0,
+        le=2**32 - 1,
+        description="Per-shard RNG seed, derived as ``base_seed + shard_id``.",
+    )
 
 
 class DatasetSrcConfig(BaseModel):
@@ -374,6 +378,10 @@ class RenderConfig(BaseModel):
             raise ValueError("param_spec_name must not be blank")
         if not self.renderer_version.strip():
             raise ValueError("renderer_version must not be blank")
+        if self.seed is not None and not (0 <= self.seed <= 2**32 - 1):
+            raise ValueError(
+                f"seed must be in [0, 2**32-1] for np.random compatibility; got {self.seed}"
+            )
         return self
 
     @model_validator(mode="after")

--- a/tests/data/vst/test_fake_plugin_e2e.py
+++ b/tests/data/vst/test_fake_plugin_e2e.py
@@ -96,3 +96,89 @@ def test_make_hdf5_dataset_writes_valid_shard_under_fake_plugin(
     assert fake_logger.exception.call_count == 0, (
         f"unexpected logger.exception calls: {fake_logger.exception.call_args_list}"
     )
+
+
+@pytest.mark.fake_vst
+def test_same_seed_produces_identical_param_arrays(
+    tmp_path: Path,
+    install_fake_plugin: FakeVST3Plugin,
+) -> None:
+    """Two ``make_hdf5_dataset`` runs with the same seed write identical ``param_array`` datasets.
+
+    Exercises the full shard-render stack — RNG seeding → ``param_spec.sample()``
+    → HDF5 write — so the per-shard reproducibility guarantee is validated
+    end-to-end.
+
+    :param tmp_path: Destination directory for the two output shards.
+    :param install_fake_plugin: Swaps the real loader for the fake so no VST binary is needed.
+    """
+    num_samples = 4
+    render_cfg = _render_cfg(
+        num_samples=num_samples,
+        samples_per_render_batch=2,
+        plugin_reload_cadence="once",
+        gui_toggle_cadence="never",
+    ).model_copy(
+        update={
+            "plugin_path": _PLUGIN_PATH,
+            "preset_path": _PRESET_PATH,
+            "renderer_version": _RENDERER_VERSION,
+            "seed": 77,
+        }
+    )
+
+    out_a = tmp_path / "shard_a.h5"
+    out_b = tmp_path / "shard_b.h5"
+    make_hdf5_dataset(hdf5_file=out_a, render_cfg=render_cfg)
+    make_hdf5_dataset(hdf5_file=out_b, render_cfg=render_cfg)
+
+    with h5py.File(out_a, "r") as fa, h5py.File(out_b, "r") as fb:
+        params_a = np.asarray(fa["param_array"])
+        params_b = np.asarray(fb["param_array"])
+
+    np.testing.assert_array_equal(params_a, params_b)
+
+
+@pytest.mark.fake_vst
+def test_different_seeds_produce_different_param_arrays(
+    tmp_path: Path,
+    install_fake_plugin: FakeVST3Plugin,
+) -> None:
+    """Two ``make_hdf5_dataset`` runs with different seeds write different ``param_array``
+    datasets.
+
+    Confirms the seed actually changes sampled params — a no-op seeding would make reproducibility
+    meaningless.
+
+    :param tmp_path: Destination directory for the two output shards.
+    :param install_fake_plugin: Swaps the real loader for the fake so no VST binary is needed.
+    """
+    num_samples = 4
+
+    def _cfg(seed: int):
+        return _render_cfg(
+            num_samples=num_samples,
+            samples_per_render_batch=2,
+            plugin_reload_cadence="once",
+            gui_toggle_cadence="never",
+        ).model_copy(
+            update={
+                "plugin_path": _PLUGIN_PATH,
+                "preset_path": _PRESET_PATH,
+                "renderer_version": _RENDERER_VERSION,
+                "seed": seed,
+            }
+        )
+
+    out_1 = tmp_path / "shard_seed1.h5"
+    out_2 = tmp_path / "shard_seed2.h5"
+    make_hdf5_dataset(hdf5_file=out_1, render_cfg=_cfg(seed=1))
+    make_hdf5_dataset(hdf5_file=out_2, render_cfg=_cfg(seed=2))
+
+    with h5py.File(out_1, "r") as f1, h5py.File(out_2, "r") as f2:
+        params_1 = np.asarray(f1["param_array"])
+        params_2 = np.asarray(f2["param_array"])
+
+    assert not np.array_equal(params_1, params_2), (
+        "Different seeds must produce different param arrays"
+    )

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -1675,7 +1675,8 @@ def test_main_copy_dataset_root_feeds_decoded_params_to_writer(
     out = tmp_path / "shard-000000.h5"
     argv = ["generate_vst_dataset", str(out)]
     for key, value in _render_cfg(num_rows).model_dump().items():
-        argv += [f"--{key}", str(value)]
+        if value is not None:
+            argv += [f"--{key}", str(value)]
     argv += ["--copy_dataset_root", str(source_dir)]
     monkeypatch.setattr(sys, "argv", argv)
 
@@ -1699,7 +1700,8 @@ def test_main_copy_dataset_root_rejects_wds_output(
     out = tmp_path / "shard-000000.tar"
     argv = ["generate_vst_dataset", str(out)]
     for key, value in _render_cfg(2).model_dump().items():
-        argv += [f"--{key}", str(value)]
+        if value is not None:
+            argv += [f"--{key}", str(value)]
     argv += ["--copy_dataset_root", str(tmp_path)]
     monkeypatch.setattr(sys, "argv", argv)
 
@@ -1727,7 +1729,8 @@ def test_main_copy_dataset_root_propagates_source_validation_error(
     out = tmp_path / "shard-000000.h5"
     argv = ["generate_vst_dataset", str(out)]
     for key, value in _render_cfg(3).model_dump().items():
-        argv += [f"--{key}", str(value)]
+        if value is not None:
+            argv += [f"--{key}", str(value)]
     argv += ["--copy_dataset_root", str(source_dir)]
     monkeypatch.setattr(sys, "argv", argv)
 

--- a/tests/data/vst/test_generate_vst_dataset_cli.py
+++ b/tests/data/vst/test_generate_vst_dataset_cli.py
@@ -35,6 +35,7 @@ def test_cli_args_class_adds_only_data_file_and_copy_dataset_root_beyond_render_
 
     Guards against accidental CLI bloat — adding a flag here should be a deliberate decision,
     not silent drift. ``copy_dataset_root`` is the deliberate dataset-copy opt-in.
+    ``seed`` lives on ``RenderConfig`` so it is NOT counted as an extra here.
     """
     cli_fields = set(_GenerateCliArgs.model_fields.keys())
     render_fields = set(RenderConfig.model_fields.keys())
@@ -71,19 +72,26 @@ def _smoke_spec() -> DatasetSpec:
 
 
 def test_build_generate_args_roundtrips_through_cli_parser() -> None:
-    """Args emitted by ``build_generate_args`` parse back into the same ``RenderConfig``.
+    """Args emitted by ``build_generate_args`` parse back as a ``RenderConfig`` with shard seed.
+
+    ``build_generate_args`` overrides ``spec.render.seed`` with the shard's
+    deterministic seed (``base_seed + shard_id``).  The round-trip therefore
+    reconstructs a ``RenderConfig`` whose ``seed`` equals ``spec.shards[0].seed``
+    rather than ``spec.render.seed`` (which is ``None`` by default).
 
     Pins the full producer↔consumer contract: a divergence in flag spelling (kebab vs.
     underscore), value coercion (int vs. float), or ``extra="forbid"`` rejection would
     break this round-trip even when the field-set parity tests still pass.
     """
     spec = _smoke_spec()
-    args = build_generate_args(spec, spec.shards[0], Path("/tmp"))
+    shard = spec.shards[0]
+    args = build_generate_args(spec, shard, Path("/tmp"))
 
     parsed = CliApp.run(_GenerateCliArgs, cli_args=args[2:])
     reconstructed = RenderConfig(**parsed.model_dump(exclude={"data_file", "copy_dataset_root"}))
 
-    assert reconstructed == spec.render
+    # The shard's seed overrides spec.render.seed (None → base_seed+shard_id).
+    assert reconstructed == spec.render.model_copy(update={"seed": shard.seed})
     assert parsed.data_file == "/tmp/shard-000000.h5"
     # No copy source on this spec, so the CLI flag is absent and parses to None.
     assert parsed.copy_dataset_root is None

--- a/tests/data/vst/test_generate_vst_dataset_cli.py
+++ b/tests/data/vst/test_generate_vst_dataset_cli.py
@@ -90,7 +90,6 @@ def test_build_generate_args_roundtrips_through_cli_parser() -> None:
     parsed = CliApp.run(_GenerateCliArgs, cli_args=args[2:])
     reconstructed = RenderConfig(**parsed.model_dump(exclude={"data_file", "copy_dataset_root"}))
 
-    # The shard's seed overrides spec.render.seed (None → base_seed+shard_id).
     assert reconstructed == spec.render.model_copy(update={"seed": shard.seed})
     assert parsed.data_file == "/tmp/shard-000000.h5"
     # No copy source on this spec, so the CLI flag is absent and parses to None.

--- a/tests/data/vst/test_writers.py
+++ b/tests/data/vst/test_writers.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 
 from synth_setter.data.vst import writers
@@ -814,7 +815,6 @@ def _silent_render() -> object:
 
     :return: Zero-filled stereo audio array shaped like a real render.
     """
-    import numpy as np
 
     return np.zeros(_RENDERER_FAKE_AUDIO_SHAPE, dtype=np.float32)
 
@@ -826,7 +826,6 @@ def _loud_render() -> object:
 
     :return: 440 Hz sine wave stereo audio array shaped like a real render.
     """
-    import numpy as np
 
     n = _RENDERER_FAKE_AUDIO_SHAPE[1]
     t = np.arange(n) / 44100.0
@@ -858,7 +857,6 @@ def _install_writer_level_fakes(
         ``generate_sample`` call.
     :returns: ``(warmup_mock, fake_spec)``.
     """
-    import numpy as np
 
     from synth_setter.data.vst import generate_vst_dataset
 
@@ -1036,3 +1034,128 @@ def test_render_in_batches_sample_cadence_draws_param_spec_per_sample(
     )
 
     assert fake_spec.sample.call_count == n
+
+
+# ---------------------------------------------------------------------------
+# Seeding behaviour — _render_in_batches seeds global RNGs from render_cfg.seed
+# ---------------------------------------------------------------------------
+
+
+def _fake_generate_sample_using_real_spec(
+    plugin_path: str,
+    *,
+    param_spec: object,
+    velocity: int,
+    signal_duration_seconds: float,
+    sample_rate: int,
+    channels: int,
+    **_kw: object,
+) -> VSTDataSample:
+    """Stand-in for ``generate_sample`` that does real param sampling but skips the plugin.
+
+    Calls ``param_spec.sample()`` so ``_render_in_batches``'s RNG seeding is
+    observable through the returned ``VSTDataSample.param_array``.  Audio is a
+    trivially non-silent constant array (loudness gate is bypassed by skipping
+    the meter).
+
+    :param plugin_path: Ignored; accepted so the signature matches ``generate_sample``.
+    :param param_spec: The ``ParamSpec`` used to draw synth and note parameters.
+    :param velocity: MIDI velocity forwarded to ``VSTDataSample``.
+    :param signal_duration_seconds: Audio duration; used to size the dummy audio array.
+    :param sample_rate: Sample rate forwarded to ``VSTDataSample``.
+    :param channels: Channel count forwarded to ``VSTDataSample``.
+    :param **_kw: Extra keyword arguments; silently ignored.
+    :returns: A ``VSTDataSample`` with real param draws and constant dummy audio.
+    """
+    from synth_setter.data.vst.param_spec import ParamSpec
+
+    assert isinstance(param_spec, ParamSpec)
+    synth, note = param_spec.sample()
+    n_audio = int(sample_rate * signal_duration_seconds)
+    audio = np.ones((channels, n_audio), dtype=np.float32)
+    mel_spec = np.zeros((channels, 128, 401), dtype=np.float32)
+    return VSTDataSample(
+        synth_params=synth,
+        note_params=note,
+        audio=audio,
+        mel_spec=mel_spec,
+        sample_rate=float(sample_rate),
+        channels=channels,
+        param_spec=param_spec,
+    )
+
+
+def test_render_in_batches_same_seed_produces_identical_param_arrays(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two ``_render_in_batches`` calls with the same seed produce the same param arrays.
+
+    Uses real ``param_spec.sample()`` (via the stand-in) so the seeded RNGs
+    drive actual param draws.  Both runs produce identical ``param_array``
+    values — the behavioural invariant of per-shard reproducibility.
+
+    :param monkeypatch: Patches ``generate_sample`` to the stand-in that does
+        real sampling without needing a VST plugin.
+    """
+    from synth_setter.data.vst.param_spec_registry import param_specs
+
+    monkeypatch.setattr(writers, "generate_sample", _fake_generate_sample_using_real_spec)
+    spec = param_specs["surge_simple"]
+    render_cfg = _smoke_render_cfg(seed=42, samples_per_shard=4, samples_per_render_batch=4)
+
+    def _collect(render_cfg: RenderConfig) -> list[np.ndarray]:
+        arrays: list[np.ndarray] = []
+        _render_in_batches(
+            render_cfg=render_cfg,
+            param_spec=spec,
+            start_idx=0,
+            fixed_synth_params_list=None,
+            fixed_note_params_list=None,
+            flush_batch=lambda batch, _start: arrays.extend(s.param_array for s in batch),
+        )
+        return arrays
+
+    run_a = _collect(render_cfg)
+    run_b = _collect(render_cfg)
+
+    assert len(run_a) == len(run_b) == 4
+    for arr_a, arr_b in zip(run_a, run_b):
+        np.testing.assert_array_equal(arr_a, arr_b)
+
+
+def test_render_in_batches_different_seeds_produce_different_param_arrays(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two ``_render_in_batches`` calls with different seeds produce different param arrays.
+
+    Confirms that seed differentiation actually changes the sampled params —
+    a seed that is a no-op would make reproducibility meaningless.
+
+    :param monkeypatch: Patches ``generate_sample`` to the stand-in.
+    """
+    from synth_setter.data.vst.param_spec_registry import param_specs
+
+    monkeypatch.setattr(writers, "generate_sample", _fake_generate_sample_using_real_spec)
+    spec = param_specs["surge_simple"]
+
+    def _collect(seed: int) -> list[np.ndarray]:
+        arrays: list[np.ndarray] = []
+        cfg = _smoke_render_cfg(seed=seed, samples_per_shard=4, samples_per_render_batch=4)
+        _render_in_batches(
+            render_cfg=cfg,
+            param_spec=spec,
+            start_idx=0,
+            fixed_synth_params_list=None,
+            fixed_note_params_list=None,
+            flush_batch=lambda batch, _start: arrays.extend(s.param_array for s in batch),
+        )
+        return arrays
+
+    run_seed1 = _collect(seed=1)
+    run_seed2 = _collect(seed=2)
+
+    stacked_1 = np.stack(run_seed1)
+    stacked_2 = np.stack(run_seed2)
+    assert not np.array_equal(stacked_1, stacked_2), (
+        "Different seeds must produce different param arrays"
+    )

--- a/tests/data/vst/test_writers.py
+++ b/tests/data/vst/test_writers.py
@@ -1036,9 +1036,7 @@ def test_render_in_batches_sample_cadence_draws_param_spec_per_sample(
     assert fake_spec.sample.call_count == n
 
 
-# ---------------------------------------------------------------------------
 # Seeding behaviour — _render_in_batches seeds global RNGs from render_cfg.seed
-# ---------------------------------------------------------------------------
 
 
 def _fake_generate_sample_using_real_spec(

--- a/tests/pipeline/ci_validate/test_validate_spec.py
+++ b/tests/pipeline/ci_validate/test_validate_spec.py
@@ -50,6 +50,7 @@ def _make_valid_spec(*, output_format: str = "hdf5", **overrides: object) -> dic
             "plugin_reload_cadence": "render",
             "gui_toggle_cadence": "never",
             "param_sample_cadence": "sample",
+            "seed": None,
         },
         "shards": [
             {"shard_id": i, "filename": f"shard-{i:06d}{ext}", "seed": 42 + i} for i in range(3)

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -1201,6 +1201,41 @@ class TestBuildGenerateArgs:
         flag_idx = args.index("--copy_dataset_root")
         assert args[flag_idx + 1] == "/data/source"
 
+    def test_shard_seed_forwarded_as_seed_flag(self, tmp_path: Path) -> None:
+        """``--seed`` flag carries the shard's deterministic seed (base_seed + shard_id).
+
+        ``ShardSpec.seed == base_seed + shard_id``, so shard 0 with base_seed=7 must
+        produce ``--seed 7`` in the generated argv.
+
+        :param tmp_path: Pytest tmp dir for the plugin path.
+        """
+        spec = DatasetSpec(**_base_spec_kwargs(tmp_path, base_seed=7))  # type: ignore[arg-type]
+
+        args = build_generate_args(spec, spec.shards[0], Path("out"))
+
+        flag_idx = args.index("--seed")
+        assert args[flag_idx + 1] == "7"
+
+    def test_seed_increments_per_shard(self, tmp_path: Path) -> None:
+        """Each shard's ``--seed`` value is one greater than the previous shard's.
+
+        Verifies the ``base_seed + shard_id`` derivation propagates through
+        ``build_generate_args`` for both shard 0 and shard 1.
+
+        :param tmp_path: Pytest tmp dir for the plugin path.
+        """
+        spec = DatasetSpec(
+            **_base_spec_kwargs(tmp_path, base_seed=7, train_val_test_sizes=[20000, 0, 0])  # type: ignore[arg-type]
+        )
+
+        args0 = build_generate_args(spec, spec.shards[0], Path("out"))
+        args1 = build_generate_args(spec, spec.shards[1], Path("out"))
+
+        seed0 = args0[args0.index("--seed") + 1]
+        seed1 = args1[args1.index("--seed") + 1]
+        assert seed0 == "7"
+        assert seed1 == "8"
+
 
 # ---------------------------------------------------------------------------
 # spec_from_cfg — Hydra-composed cfg → DatasetSpec

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -1236,6 +1236,56 @@ class TestBuildGenerateArgs:
         assert seed0 == "7"
         assert seed1 == "8"
 
+    def test_render_config_seed_negative_raises_validation_error(self) -> None:
+        """``RenderConfig`` rejects a negative seed — ``np.random.seed`` requires uint32.
+
+        Constructs a complete ``RenderConfig`` so the seed check in
+        ``_ranges_must_be_sane`` is the only validation that can fail.
+        """
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="np.random compatibility"):
+            RenderConfig(
+                plugin_path="plugins/Surge XT.vst3",
+                preset_path="presets/surge-base.vstpreset",
+                param_spec_name="surge_simple",
+                renderer_version="1.3.4",
+                sample_rate=44100,
+                channels=2,
+                velocity=100,
+                signal_duration_seconds=4.0,
+                min_loudness=-55.0,
+                samples_per_render_batch=32,
+                samples_per_shard=1000,
+                gui_toggle_cadence="never",
+                seed=-1,
+            )
+
+    def test_render_config_seed_above_uint32_max_raises_validation_error(self) -> None:
+        """``RenderConfig`` rejects seeds above 2^32-1 — ``np.random.seed`` requires uint32.
+
+        Constructs a complete ``RenderConfig`` so the seed check in
+        ``_ranges_must_be_sane`` is the only validation that can fail.
+        """
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="np.random compatibility"):
+            RenderConfig(
+                plugin_path="plugins/Surge XT.vst3",
+                preset_path="presets/surge-base.vstpreset",
+                param_spec_name="surge_simple",
+                renderer_version="1.3.4",
+                sample_rate=44100,
+                channels=2,
+                velocity=100,
+                signal_duration_seconds=4.0,
+                min_loudness=-55.0,
+                samples_per_render_batch=32,
+                samples_per_shard=1000,
+                gui_toggle_cadence="never",
+                seed=2**32,
+            )
+
 
 # ---------------------------------------------------------------------------
 # spec_from_cfg — Hydra-composed cfg → DatasetSpec

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -85,6 +85,24 @@ def test_cfg_dataset_with_datasetsrc_composes_copy_source_into_spec(
     assert spec.datasetsrc.copy_dataset_root == "/data/source-dataset"
 
 
+def test_cfg_dataset_shard_seeds_derive_from_base_seed(
+    cfg_dataset: DictConfig,
+) -> None:
+    """Each ``ShardSpec.seed`` equals ``base_seed + shard_id`` after Hydra compose.
+
+    Pins the full path: Hydra ``base_seed`` → ``spec_from_cfg`` → ``DatasetSpec.shards``.
+    ``render.seed`` remains ``None`` (unseeded default) — only the per-shard value
+    carries a concrete integer.
+
+    :param cfg_dataset: Function-scoped fixture composing ``dataset.yaml`` with the
+        ``generate_dataset/smoke-shard`` experiment and ``tmp_path``-pinned paths.
+    """
+    spec = spec_from_cfg(cfg_dataset)
+    assert spec.render.seed is None
+    for shard in spec.shards:
+        assert shard.seed == spec.base_seed + shard.shard_id
+
+
 def test_cfg_dataset_datasetsrc_with_wds_output_is_rejected(
     cfg_dataset: DictConfig,
 ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -6022,7 +6022,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.17.0"
+version = "8.18.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Add `seed: int | None = None` field to `RenderConfig`; `None` retains the historical unseeded behaviour
- `build_generate_args` injects `--seed <base_seed + shard_id>` per subprocess via `model_copy(update={"seed": shard.seed})`
- `_render_in_batches` seeds `random` and `np.random` at shard start when `seed` is not `None`
- `ShardSpec.seed` (= `base_seed + shard_id`) was already computed; this PR wires it through to the render subprocess

## Test plan

- [ ] `tests/pipeline/entrypoints/test_generate_dataset_unit.py` — `test_shard_seed_forwarded_as_seed_flag`, `test_seed_increments_per_shard` (CLI argv contract)
- [ ] `tests/data/vst/test_writers.py` — `test_render_in_batches_same_seed_produces_identical_param_arrays`, `test_render_in_batches_different_seeds_produce_different_param_arrays` (behavioral, real `param_spec.sample()`)
- [ ] `tests/data/vst/test_fake_plugin_e2e.py` — `test_same_seed_produces_identical_param_arrays`, `test_different_seeds_produce_different_param_arrays` (e2e, FakeVST3Plugin, asserts on HDF5 `param_array`)
- [ ] `tests/test_generate_dataset.py` — `test_cfg_dataset_shard_seeds_derive_from_base_seed` (Hydra compose → `spec_from_cfg` → shard seeds)
- [ ] `make test-fast` — 1735 passed, 3 skipped

### Known advisory (intentional)

The `.. attribute :: seed` block in `RenderConfig` is flagged as a comment-hygiene warn (duplicates `Field(description=…)`). It is required by pydoclint's REST attribute parser to prevent the `seed` field from appearing in the DOC603 "not in docstring" list; removing it would reintroduce a pydoclint violation. Tracked as a lint-cleanup follow-up.

Closes #364
Refs #100
Refs #884
