### PR TITLE
refactor(testing): bind writer param_spec mock to ParamSpec interface

### DIFF
--- a/tests/data/vst/test_writers.py
+++ b/tests/data/vst/test_writers.py
@@ -900,7 +900,7 @@ def _install_writer_level_fakes(
         {"a_amp_eg_attack": 0.5},
         {"pitch": 64, "note_start_and_end": (0.1, 0.9)},
     )
-    fake_spec = MagicMock(spec=ParamSpec, name="param_spec")
+    fake_spec = MagicMock(spec_set=ParamSpec, name="param_spec")
     fake_spec.sample.return_value = fake_spec_payload
     fake_spec.encode.return_value = np.zeros((4,), dtype=np.float32)
 

--- a/tests/data/vst/test_writers.py
+++ b/tests/data/vst/test_writers.py
@@ -17,6 +17,7 @@ import pytest
 
 from synth_setter.data.vst import writers
 from synth_setter.data.vst.generate_vst_dataset import VSTDataSample
+from synth_setter.data.vst.param_spec import ParamSpec
 from synth_setter.data.vst.writers import _render_in_batches, _shard_metadata_from_render
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
 from synth_setter.pipeline.schemas.spec import RenderConfig
@@ -899,7 +900,7 @@ def _install_writer_level_fakes(
         {"a_amp_eg_attack": 0.5},
         {"pitch": 64, "note_start_and_end": (0.1, 0.9)},
     )
-    fake_spec = MagicMock(name="param_spec")
+    fake_spec = MagicMock(spec=ParamSpec, name="param_spec")
     fake_spec.sample.return_value = fake_spec_payload
     fake_spec.encode.return_value = np.zeros((4,), dtype=np.float32)
 


### PR DESCRIPTION
## What

Bind the writer-level `param_spec` test double in
`tests/data/vst/test_writers.py` to the real `ParamSpec` interface.

`_install_writer_level_fakes` configured a bare `MagicMock(name="param_spec")`
with `.sample`/`.encode` return values to stand in for the real `ParamSpec`
collaborator. A bare `MagicMock` silently accepts a renamed or removed method,
so production interface drift would pass the test undetected.

## Change

```python
-    fake_spec = MagicMock(name="param_spec")
+    fake_spec = MagicMock(spec_set=ParamSpec, name="param_spec")
```

`spec_set=ParamSpec` makes the mock reject attributes the real class does not
have — both *reading* and *setting* — catching interface drift, while
preserving the configured `.sample`/`.encode` returns. Both `sample` and
`encode` are real methods of `ParamSpec`
(`src/synth_setter/data/vst/param_spec.py`), so the existing return-value
wiring is unaffected. Verified empirically: `.sample()`/`.encode()` still
return their configured values, and an unknown attribute now raises
`AttributeError` on both access and assignment.

Test-only; no production code changed. The other opaque
`param_spec=MagicMock(...)` sites that pass the mock purely as an unused token
are intentionally left untouched.

## Verification

- `uv run pytest tests/data/vst/test_writers.py -q` — 26 passed.
- `make format` — all pre-commit hooks pass.

Refs #1445
