### PR TITLE
refactor(testing): spec the Trainer stand-in in callbacks tests

### DIFF
--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -7,6 +7,7 @@ no TensorBoard file writes).
 
 from unittest.mock import MagicMock
 
+from lightning.pytorch import Trainer
 from lightning.pytorch.loggers import CSVLogger, TensorBoardLogger, WandbLogger
 from matplotlib.figure import Figure
 
@@ -18,8 +19,13 @@ def _make_trainer(
     global_step: int = 42,
     is_global_zero: bool = True,
 ) -> MagicMock:
-    """Build a stand-in ``Trainer`` exposing ``loggers``, ``global_step``, and rank."""
-    trainer = MagicMock()
+    """Build a stand-in ``Trainer`` exposing ``loggers``, ``global_step``, and rank.
+
+    ``spec=Trainer`` confines the mock to the real ``Trainer`` interface, so a
+    typo'd attribute access in the code under test raises ``AttributeError``
+    instead of silently auto-creating a child mock.
+    """
+    trainer = MagicMock(spec=Trainer)
     trainer.loggers = loggers
     trainer.global_step = global_step
     trainer.is_global_zero = is_global_zero


### PR DESCRIPTION
## What

The `_make_trainer` helper in `tests/test_callbacks.py` used a bare
`MagicMock()` as the Lightning `Trainer` stand-in. The logger mocks in the
same helper correctly pin `spec=` to their real classes, but the bare trainer
mock auto-creates any attribute on access. `_log_figure` reads only `loggers`,
`global_step`, and `is_global_zero`, so a typo'd attribute read in the code
under test would silently pass instead of failing the test.

## Change

Pin `spec=Trainer` (`from lightning.pytorch import Trainer`) on the stand-in so
the mock is confined to the real `Trainer` interface and a typo'd attribute
access raises `AttributeError`. The existing value-setup (`loggers`,
`global_step`, `is_global_zero`) and the logger-mock `log_image` / `add_figure`
call introspection — the function's only observable effects — are unchanged.

`spec=Trainer` was chosen over a `SimpleNamespace` fake: the helper's return
type is annotated `MagicMock`, and a `SimpleNamespace` return failed pyright
(not assignable to the `Trainer` parameter), whereas `MagicMock(spec=Trainer)`
keeps strict typing green and still rejects typos.

## Verification

- `uv run pytest tests/test_callbacks.py -q` — 5 passed.
- Confirmed a typo'd attribute (`is_globl_zero`) on the stand-in now raises
  `AttributeError`.
- `make format` — all hooks pass.

Refs #1445
