### PR TITLE
refactor(testing): patch a _utcnow seam in prefix default-time test

### DIFF
--- a/src/synth_setter/pipeline/schemas/prefix.py
+++ b/src/synth_setter/pipeline/schemas/prefix.py
@@ -12,6 +12,14 @@ R2Prefix = NewType("R2Prefix", str)
 DEFAULT_R2_PREFIX_ROOT = "data"
 
 
+def _utcnow() -> datetime:
+    """Return the current UTC time as a seam tests can patch.
+
+    :returns: A timezone-aware ``datetime`` in UTC.
+    """
+    return datetime.now(timezone.utc)
+
+
 def make_dataset_wandb_run_id(
     dataset_config_id: DatasetConfigId | str,
     timestamp: datetime | None = None,
@@ -24,7 +32,7 @@ def make_dataset_wandb_run_id(
         a zero-padded 3-digit millisecond field.
     """
     if timestamp is None:
-        timestamp = datetime.now(timezone.utc)
+        timestamp = _utcnow()
     if timestamp.tzinfo is None:
         raise ValueError("timestamp must be timezone-aware (got naive datetime)")
     offset = timestamp.utcoffset()

--- a/src/synth_setter/pipeline/schemas/prefix.py
+++ b/src/synth_setter/pipeline/schemas/prefix.py
@@ -12,8 +12,8 @@ R2Prefix = NewType("R2Prefix", str)
 DEFAULT_R2_PREFIX_ROOT = "data"
 
 
-def _utcnow() -> datetime:
-    """Return the current UTC time as a seam tests can patch.
+def _utc_now() -> datetime:
+    """Return the current time as a timezone-aware UTC datetime.
 
     :returns: A timezone-aware ``datetime`` in UTC.
     """
@@ -32,7 +32,7 @@ def make_dataset_wandb_run_id(
         a zero-padded 3-digit millisecond field.
     """
     if timestamp is None:
-        timestamp = _utcnow()
+        timestamp = _utc_now()
     if timestamp.tzinfo is None:
         raise ValueError("timestamp must be timezone-aware (got naive datetime)")
     offset = timestamp.utcoffset()

--- a/tests/pipeline/schemas/test_prefix.py
+++ b/tests/pipeline/schemas/test_prefix.py
@@ -38,14 +38,14 @@ class TestMakeDatasetWandbRunId:
         id2 = make_dataset_wandb_run_id(DatasetConfigId("cfg"), timestamp=ts2)
         assert id1 != id2
 
-    @patch("synth_setter.pipeline.schemas.prefix._utcnow", return_value=FIXED_NOW)
-    def test_make_run_id_default_timestamp_is_utc(self, mock_utcnow):
+    @patch("synth_setter.pipeline.schemas.prefix._utc_now", return_value=FIXED_NOW)
+    def test_make_run_id_default_timestamp_is_utc(self, mock_utc_now):
         """Default (no timestamp) stamps the current UTC time and produces the expected ID.
 
-        :param mock_utcnow: Patched ``prefix._utcnow`` returning ``FIXED_NOW``.
+        :param mock_utc_now: Patched ``prefix._utc_now`` returning ``FIXED_NOW``.
         """
         result = make_dataset_wandb_run_id(DatasetConfigId("test-config"))
-        mock_utcnow.assert_called_once_with()
+        mock_utc_now.assert_called_once_with()
         assert result == "test-config-20260615T123045000Z"
 
     def test_make_run_id_rejects_naive_timestamp(self):

--- a/tests/pipeline/schemas/test_prefix.py
+++ b/tests/pipeline/schemas/test_prefix.py
@@ -38,13 +38,14 @@ class TestMakeDatasetWandbRunId:
         id2 = make_dataset_wandb_run_id(DatasetConfigId("cfg"), timestamp=ts2)
         assert id1 != id2
 
-    @patch("synth_setter.pipeline.schemas.prefix.datetime")
-    def test_make_run_id_default_timestamp_is_utc(self, mock_datetime):
-        """Default (no timestamp) uses datetime.now(UTC) and produces the expected ID."""
-        mock_datetime.now.return_value = FIXED_NOW
-        mock_datetime.side_effect = lambda *a, **kw: datetime(*a, **kw)
+    @patch("synth_setter.pipeline.schemas.prefix._utcnow", return_value=FIXED_NOW)
+    def test_make_run_id_default_timestamp_is_utc(self, mock_utcnow):
+        """Default (no timestamp) stamps the current UTC time and produces the expected ID.
+
+        :param mock_utcnow: Patched ``prefix._utcnow`` returning ``FIXED_NOW``.
+        """
         result = make_dataset_wandb_run_id(DatasetConfigId("test-config"))
-        mock_datetime.now.assert_called_once_with(timezone.utc)
+        mock_utcnow.assert_called_once_with()
         assert result == "test-config-20260615T123045000Z"
 
     def test_make_run_id_rejects_naive_timestamp(self):


### PR DESCRIPTION
## What

Replace a fragile whole-`datetime`-class patch in the default-timestamp test for
`make_dataset_wandb_run_id` with a patch of a narrow `_utcnow()` seam.

The old test patched `synth_setter.pipeline.schemas.prefix.datetime` and then
reimplemented the stdlib constructor so ordinary `datetime(...)` construction
still worked while `now()` was stubbed:

```python
mock_datetime.now.return_value = FIXED_NOW
mock_datetime.side_effect = lambda *a, **kw: datetime(*a, **kw)
```

Reimplementing a stdlib type in a test is brittle. This test uniquely exists to
prove the **default** path stamps `now(timezone.utc)` — the other tests inject
`timestamp=` directly.

## Approach (option chosen)

Of the considered options:

1. Patch an existing narrow seam — none existed; the default path called
   `datetime.now(timezone.utc)` inline.
2. Use `freezegun` — not a dev dependency in this repo.
3. **Introduce a minimal `_utcnow()` indirection** that the default path calls,
   then patch `prefix._utcnow` in the test. Chosen.

Option 3 is the least-invasive available. The production change is a one-line,
behavior-preserving helper:

```python
def _utcnow() -> datetime:
    return datetime.now(timezone.utc)
```

The test now patches that seam and asserts on the real produced run-ID string
through the public function, so it exercises the real default code path instead
of reimplementing `datetime`.

## Validation

- `uv run pytest tests/pipeline/schemas/test_prefix.py -q` — 13 passed.
- `uv run pytest tests/pipeline/schemas/ -q` — 266 passed (no other code patched
  `prefix.datetime`).
- `make format` — all hooks pass (ruff, pyright, pydoclint, etc.).

Refs #1445
