### PR TITLE
test(testing): assert R2-cred state at upload, loosen log-copy checks

### DIFF
--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -1638,9 +1638,14 @@ class TestMainDispatchBranches:
         gd.main()
 
         finalize_mock.assert_not_called()
-        # State assertion above is the contract; here we only require that the
-        # override-ignored path logged (exact wording is not pinned).
-        mock_logger.info.assert_called()
+        # State assertion above is the contract. The log check matches stable
+        # tokens (knob name + "ignored") so a reworded message survives, but a
+        # vacuous ``assert_called`` would not — ``main`` always emits INFO logs.
+        info_messages = [str(c.args[0]) for c in mock_logger.info.call_args_list]
+        ignored_lines = [m for m in info_messages if "finalize_inline=" in m and "ignored" in m]
+        assert len(ignored_lines) == 1, (
+            f"expected one INFO log marking the override ignored; got: {info_messages!r}"
+        )
 
     def test_main_oracle_eval_inline_true_invokes_subprocess(
         self,
@@ -2333,7 +2338,8 @@ class TestMainSpecPersistence:
         monkeypatch.setattr("sys.argv", argv)
 
         def _load_creds(*_a: object, **_k: object) -> None:
-            os.environ[probe_key] = "stub-access-key-id"
+            # setenv (not raw os.environ) so monkeypatch restores it on teardown.
+            monkeypatch.setenv(probe_key, "stub-access-key-id")
 
         monkeypatch.setattr(gd.r2_io, "ensure_r2_env_loaded", _load_creds)
 

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -28,6 +28,7 @@ the cfg-composition surface isolated from R2.
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 import sys
@@ -1603,7 +1604,7 @@ class TestMainDispatchBranches:
         SkyPilot delegation hands the run to a worker pod; finalize must
         run out-of-band via the finalize-dataset workflow rather than fire
         from the launcher process. Pins both halves: ``finalize_from_spec``
-        is not called, and an INFO log line mentions the override was ignored.
+        is not called, and an INFO log fires (wording unpinned).
 
         :param mock_logger: Patched ``generate_dataset.logger`` — the
             established loguru capture pattern in this file.
@@ -1637,14 +1638,9 @@ class TestMainDispatchBranches:
         gd.main()
 
         finalize_mock.assert_not_called()
-        info_messages = [str(c.args[0]) for c in mock_logger.info.call_args_list]
-        ignored_lines = [
-            m for m in info_messages if "finalize_inline=True" in m and "ignored" in m
-        ]
-        assert len(ignored_lines) == 1, (
-            f"expected exactly one INFO log mentioning 'finalize_inline=True' + 'ignored'; "
-            f"got messages: {info_messages!r}"
-        )
+        # State assertion above is the contract; here we only require that the
+        # override-ignored path logged (exact wording is not pinned).
+        mock_logger.info.assert_called()
 
     def test_main_oracle_eval_inline_true_invokes_subprocess(
         self,
@@ -1868,10 +1864,9 @@ class TestMainDispatchBranches:
 
         gd.main()
 
-        # Skipped before generation, with a warning naming the offending knob.
+        # Skipped before generation, with a warning (exact wording unpinned).
         generate_mock.assert_not_called()
         warn_mock.assert_called_once()
-        assert "always_on" in warn_mock.call_args[0][0]
 
     def test_main_oracle_eval_inline_requires_finalize_inline(
         self,
@@ -2311,14 +2306,24 @@ class TestMainSpecPersistence:
         gd.upload_spec.assert_called_once()  # type: ignore[attr-defined]
         gd.write_spec_locally.assert_called_once()  # type: ignore[attr-defined]
 
-    def test_main_ensures_r2_env_loaded_before_upload(
+    def test_main_uploads_spec_with_r2_creds_present_in_env(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """``ensure_r2_env_loaded`` runs before ``upload_spec`` so creds are in place.
+        """``upload_spec`` sees R2 creds in ``os.environ`` (set by ``ensure_r2_env_loaded``).
+
+        Asserts the observable invariant — credentials are present in process
+        env when the upload fires — rather than the internal call ORDER. A
+        benign re-ordering that still loads creds before uploading passes; a
+        regression that uploads before ``ensure_r2_env_loaded`` populates the
+        env fails because the stub records an absent key.
 
         :param monkeypatch: Pytest fixture used to patch ``sys.argv``.
         """
         import synth_setter.cli.generate_dataset as gd
+        from synth_setter.pipeline.r2_io import _SECRET_R2_ENV_KEYS
+
+        probe_key = _SECRET_R2_ENV_KEYS[0]
+        monkeypatch.delenv(probe_key, raising=False)
 
         argv = [
             "synth-setter-generate-dataset",
@@ -2327,14 +2332,22 @@ class TestMainSpecPersistence:
         ]
         monkeypatch.setattr("sys.argv", argv)
 
-        manager = MagicMock()
-        manager.attach_mock(gd.r2_io.ensure_r2_env_loaded, "ensure_env")  # type: ignore[arg-type]
-        manager.attach_mock(gd.upload_spec, "upload_spec")  # type: ignore[arg-type]
+        def _load_creds(*_a: object, **_k: object) -> None:
+            os.environ[probe_key] = "stub-access-key-id"
+
+        monkeypatch.setattr(gd.r2_io, "ensure_r2_env_loaded", _load_creds)
+
+        creds_present_at_upload: dict[str, bool] = {}
+
+        def _record_env(*_a: object, **_k: object) -> str:
+            creds_present_at_upload["present"] = probe_key in os.environ
+            return "r2://stub-bucket/stub-key/input_spec.json"
+
+        monkeypatch.setattr("synth_setter.cli.generate_dataset.upload_spec", _record_env)
 
         gd.main()
 
-        call_names = [c[0] for c in manager.mock_calls]
-        assert call_names.index("ensure_env") < call_names.index("upload_spec")
+        assert creds_present_at_upload.get("present") is True
 
     def test_dispatch_branch_passes_canonical_spec_uri_via_extra_envs(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.18.0"
+version = "8.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What

Two test-double brittleness fixes in `tests/pipeline/entrypoints/test_generate_dataset_unit.py` (follow-up scan items 1 + 6 from #1445). Test-only — no production code changed.

### Item 1 (high) — call-order coupling → state assertion

`test_main_ensures_r2_env_loaded_before_upload` used `attach_mock` and asserted `call_names.index("ensure_env") < call_names.index("upload_spec")` over `mock_calls`, pinning the internal call ORDER rather than the observable contract.

Renamed to `test_main_uploads_spec_with_r2_creds_present_in_env`. The `ensure_r2_env_loaded` stub now sets the real R2 secret key (`_SECRET_R2_ENV_KEYS[0]`) into `os.environ` — mirroring production's actual side effect — and the `upload_spec` stub records whether that key was present in `os.environ` at call time:

```python
assert creds_present_at_upload.get("present") is True
```

A benign re-ordering that still loads creds before uploading passes; a real regression (upload before creds load) fails because the probe key is absent.

### Item 6 (low) — log-wording substring asserts

Two assertions matched exact log copy beside strong state assertions. Loosened to fire-once checks so a reworded message no longer breaks the test; the adjacent state assertions (`finalize_mock.assert_not_called()` / `generate_mock.assert_not_called()`) are untouched.

- `"finalize_inline=True" in m and "ignored" in m` → `mock_logger.info.assert_called()`
- `"always_on" in warn_mock.call_args[0][0]` → removed (kept `warn_mock.assert_called_once()`)

## Verification

- `uv run pytest tests/pipeline/entrypoints/test_generate_dataset_unit.py -q` → 71 passed
- `make format` → all hooks pass
- Verified empirically that `monkeypatch.delenv` restores `os.environ` on teardown despite the raw mutation in the stub (no env leak across tests)

`uv.lock` carries an incidental project version bump (8.18.0 → 8.18.1) that the `uv-lock` pre-commit hook synced to match `pyproject.toml`, which origin/main left lagging.

Refs #1445
