### PR TITLE
refactor(testing): share VST no-logger-exceptions crash-gate helper

### DIFF
--- a/tests/data/vst/test_always_on_integration.py
+++ b/tests/data/vst/test_always_on_integration.py
@@ -16,7 +16,6 @@ issue noted in the Wave 3 PR body.
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import h5py
 import hdf5plugin  # noqa: F401  side-effect: registers Blosc2 filter for h5py reads
@@ -38,6 +37,7 @@ from tests.data.vst.test_generate_vst_dataset import (  # noqa: E402  pinned can
     _PLUGIN_PATH,
     _render_cfg,
 )
+from tests.helpers.logger_assertions import assert_no_logger_exceptions  # noqa: E402
 
 skip_no_vst = pytest.mark.skipif(
     not Path(_PLUGIN_PATH).exists(),
@@ -76,15 +76,14 @@ def test_always_on_renders_small_shard_end_to_end(
     out = tmp_path / "shard-000000.h5"
     fixed_synth = [_HARDCODED_SYNTH_PARAMS] * num_samples
     fixed_note = [_HARDCODED_NOTE_PARAMS] * num_samples
-    fake_logger = MagicMock(wraps=core.logger)
-    monkeypatch.setattr(core, "logger", fake_logger)
 
-    make_hdf5_dataset(
-        hdf5_file=out,
-        render_cfg=render_cfg,
-        fixed_synth_params_list=fixed_synth,
-        fixed_note_params_list=fixed_note,
-    )
+    with assert_no_logger_exceptions(monkeypatch, core):
+        make_hdf5_dataset(
+            hdf5_file=out,
+            render_cfg=render_cfg,
+            fixed_synth_params_list=fixed_synth,
+            fixed_note_params_list=fixed_note,
+        )
 
     assert out.exists()
     with h5py.File(out, "r") as f:
@@ -96,7 +95,3 @@ def test_always_on_renders_small_shard_end_to_end(
         audio = audio_ds[...]
     assert np.isfinite(audio).all(), "rendered audio contains NaN/Inf"
     assert (np.abs(audio) <= 1.0).all(), "rendered audio exceeds [-1, 1] bounds"
-
-    assert fake_logger.exception.call_count == 0, (
-        f"unexpected logger.exception calls: {fake_logger.exception.call_args_list}"
-    )

--- a/tests/data/vst/test_fake_plugin_e2e.py
+++ b/tests/data/vst/test_fake_plugin_e2e.py
@@ -11,7 +11,6 @@ work" gate; this is the "does our pipeline still work" gate.
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import h5py
 import hdf5plugin  # noqa: F401  side-effect: registers Blosc2 filter for h5py reads
@@ -29,6 +28,7 @@ from tests.data.vst.test_generate_vst_dataset import (  # noqa: E402  pinned can
     _HARDCODED_SYNTH_PARAMS,
     _render_cfg,
 )
+from tests.helpers.logger_assertions import assert_no_logger_exceptions  # noqa: E402
 
 _PLUGIN_PATH = "plugins/fake.vst3"  # never touched on disk — load_plugin is patched
 _PRESET_PATH = "presets/fake.vstpreset"
@@ -72,15 +72,14 @@ def test_make_hdf5_dataset_writes_valid_shard_under_fake_plugin(
     out = tmp_path / "shard-000000.h5"
     fixed_synth = [_HARDCODED_SYNTH_PARAMS] * num_samples
     fixed_note = [_HARDCODED_NOTE_PARAMS] * num_samples
-    fake_logger = MagicMock(wraps=core.logger)
-    monkeypatch.setattr(core, "logger", fake_logger)
 
-    make_hdf5_dataset(
-        hdf5_file=out,
-        render_cfg=render_cfg,
-        fixed_synth_params_list=fixed_synth,
-        fixed_note_params_list=fixed_note,
-    )
+    with assert_no_logger_exceptions(monkeypatch, core):
+        make_hdf5_dataset(
+            hdf5_file=out,
+            render_cfg=render_cfg,
+            fixed_synth_params_list=fixed_synth,
+            fixed_note_params_list=fixed_note,
+        )
 
     assert out.exists()
     with h5py.File(out, "r") as f:
@@ -92,7 +91,3 @@ def test_make_hdf5_dataset_writes_valid_shard_under_fake_plugin(
         audio = audio_ds[...]
     assert np.isfinite(audio).all(), "rendered audio contains NaN/Inf"
     assert (np.abs(audio) <= 1.0).all(), "rendered audio exceeds [-1, 1] bounds"
-
-    assert fake_logger.exception.call_count == 0, (
-        f"unexpected logger.exception calls: {fake_logger.exception.call_args_list}"
-    )

--- a/tests/helpers/logger_assertions.py
+++ b/tests/helpers/logger_assertions.py
@@ -25,20 +25,24 @@ def assert_no_logger_exceptions(
     """Patch ``module.logger`` with a recording mock and assert no ``.exception`` fired.
 
     The mock wraps the real logger, so log lines still emit while their calls
-    are recorded. On clean exit the body must not have triggered
-    ``logger.exception`` — the structural crash gate that ``caplog`` cannot
-    observe for loguru. Only ``.exception`` is gated, matching what the call
-    sites assert; the yielded mock exposes the rest for finer checks.
+    are recorded. The patch is reverted on context exit — including when the
+    body raises — via a nested ``monkeypatch.context()``. On clean exit the
+    body must not have triggered ``logger.exception``, the structural crash
+    gate that ``caplog`` cannot observe for loguru; that assertion is skipped
+    when the body raises so the original error propagates unmasked. Only
+    ``.exception`` is gated, matching what the call sites assert; the yielded
+    mock exposes the rest for finer checks.
 
-    :param monkeypatch: Active pytest monkeypatch fixture; the patch is reverted
-        when it tears down.
+    :param monkeypatch: Active pytest monkeypatch fixture; a nested context
+        reverts the patch on exit.
     :param module: Module whose ``logger`` attribute is stubbed for the body.
     :yields: The recording mock, so callers may assert on other logger calls.
     :ytype: MagicMock
     """
     fake_logger = MagicMock(wraps=module.logger)
-    monkeypatch.setattr(module, "logger", fake_logger)
-    yield fake_logger
+    with monkeypatch.context() as patch:
+        patch.setattr(module, "logger", fake_logger)
+        yield fake_logger
     assert fake_logger.exception.call_count == 0, (
         f"unexpected logger.exception calls: {fake_logger.exception.call_args_list}"
     )

--- a/tests/helpers/logger_assertions.py
+++ b/tests/helpers/logger_assertions.py
@@ -1,0 +1,44 @@
+"""Crash-gate assertion over a loguru ``logger`` patched onto a module.
+
+loguru output does not propagate to pytest's ``caplog``, so a test that wants
+to prove a render worker never logged a crash has to stub the module's
+``logger`` with a recording mock and inspect its calls. Two VST end-to-end
+tests (``tests/data/vst/test_fake_plugin_e2e.py`` and
+``tests/data/vst/test_always_on_integration.py``) share this idiom; this
+module is its single owner.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@contextmanager
+def assert_no_logger_exceptions(
+    monkeypatch: pytest.MonkeyPatch, module: ModuleType
+) -> Iterator[MagicMock]:
+    """Patch ``module.logger`` with a recording mock and assert no ``.exception`` fired.
+
+    The mock wraps the real logger, so log lines still emit while their calls
+    are recorded. On clean exit the body must not have triggered
+    ``logger.exception`` — the structural crash gate that ``caplog`` cannot
+    observe for loguru. Only ``.exception`` is gated, matching what the call
+    sites assert; the yielded mock exposes the rest for finer checks.
+
+    :param monkeypatch: Active pytest monkeypatch fixture; the patch is reverted
+        when it tears down.
+    :param module: Module whose ``logger`` attribute is stubbed for the body.
+    :yields: The recording mock, so callers may assert on other logger calls.
+    :ytype: MagicMock
+    """
+    fake_logger = MagicMock(wraps=module.logger)
+    monkeypatch.setattr(module, "logger", fake_logger)
+    yield fake_logger
+    assert fake_logger.exception.call_count == 0, (
+        f"unexpected logger.exception calls: {fake_logger.exception.call_args_list}"
+    )

--- a/tests/helpers/test_logger_assertions.py
+++ b/tests/helpers/test_logger_assertions.py
@@ -1,0 +1,61 @@
+"""Unit tests for the ``assert_no_logger_exceptions`` crash-gate helper."""
+
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+from typing import cast
+
+import pytest
+
+from tests.helpers.logger_assertions import assert_no_logger_exceptions
+
+
+def _module_with_logger() -> ModuleType:
+    """Build a stand-in module exposing a no-op ``logger`` with loguru-like methods.
+
+    :returns: An object usable where ``assert_no_logger_exceptions`` expects a
+        module with a ``logger`` attribute.
+    """
+    logger = SimpleNamespace(exception=lambda *a, **k: None, error=lambda *a, **k: None)
+    return cast(ModuleType, SimpleNamespace(logger=logger))
+
+
+def test_assert_no_logger_exceptions_no_calls_passes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A body that never calls ``logger.exception`` exits cleanly.
+
+    :param monkeypatch: Pytest monkeypatch fixture passed to the helper.
+    """
+    module = _module_with_logger()
+    with assert_no_logger_exceptions(monkeypatch, module) as fake_logger:
+        module.logger.error("non-fatal")
+    assert fake_logger.error.call_count == 1
+
+
+def test_assert_no_logger_exceptions_on_exception_call_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A body that calls ``logger.exception`` trips the crash gate on exit.
+
+    :param monkeypatch: Pytest monkeypatch fixture passed to the helper.
+    """
+    module = _module_with_logger()
+    with pytest.raises(AssertionError, match="logger.exception"):
+        with assert_no_logger_exceptions(monkeypatch, module):
+            module.logger.exception("boom")
+
+
+def test_assert_no_logger_exceptions_restores_logger(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The patched ``logger`` is reverted once monkeypatch tears down.
+
+    :param monkeypatch: Pytest monkeypatch fixture passed to the helper.
+    """
+    module = _module_with_logger()
+    original = module.logger
+    with assert_no_logger_exceptions(monkeypatch, module):
+        assert module.logger is not original
+    monkeypatch.undo()
+    assert module.logger is original

--- a/tests/helpers/test_logger_assertions.py
+++ b/tests/helpers/test_logger_assertions.py
@@ -20,6 +20,14 @@ def _module_with_logger() -> ModuleType:
     return cast(ModuleType, SimpleNamespace(logger=logger))
 
 
+def _raise_boom() -> None:
+    """Raise ``RuntimeError`` to drive the helper's body-error restore path.
+
+    :raises RuntimeError: Always, with message ``boom``.
+    """
+    raise RuntimeError("boom")
+
+
 def test_assert_no_logger_exceptions_no_calls_passes(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -46,10 +54,10 @@ def test_assert_no_logger_exceptions_on_exception_call_raises(
             module.logger.exception("boom")
 
 
-def test_assert_no_logger_exceptions_restores_logger(
+def test_assert_no_logger_exceptions_restores_logger_on_exit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The patched ``logger`` is reverted once monkeypatch tears down.
+    """The patched ``logger`` is restored when the context exits, not at teardown.
 
     :param monkeypatch: Pytest monkeypatch fixture passed to the helper.
     """
@@ -57,5 +65,19 @@ def test_assert_no_logger_exceptions_restores_logger(
     original = module.logger
     with assert_no_logger_exceptions(monkeypatch, module):
         assert module.logger is not original
-    monkeypatch.undo()
+    assert module.logger is original
+
+
+def test_assert_no_logger_exceptions_restores_logger_on_body_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A body that raises still restores the original ``logger`` on exit.
+
+    :param monkeypatch: Pytest monkeypatch fixture passed to the helper.
+    """
+    module = _module_with_logger()
+    original = module.logger
+    with pytest.raises(RuntimeError, match="boom"):
+        with assert_no_logger_exceptions(monkeypatch, module):
+            _raise_boom()
     assert module.logger is original


### PR DESCRIPTION
## What

Promotes the duplicated loguru crash-gate idiom shared by two VST end-to-end
tests into a single reusable helper.

`tests/data/vst/test_fake_plugin_e2e.py` and
`tests/data/vst/test_always_on_integration.py` each carried an identical inline
block that wrapped `core.logger` with `MagicMock(wraps=...)` (loguru output is
invisible to `caplog`) and later asserted `logger.exception.call_count == 0`.
The pattern is justified, but the duplication should live in one place.

## Changes

- Add `tests/helpers/logger_assertions.py` with `assert_no_logger_exceptions`,
  a context manager that stubs `module.logger` with a recording mock, yields it,
  and on exit asserts no `.exception` calls fired — the single owner of the idiom.
- Add `tests/helpers/test_logger_assertions.py` covering the pass, fail-on-exception,
  and logger-restoration behaviours.
- Refactor both VST tests to use the helper, removing the inline blocks.

Test-only change; behaviour and coverage are unchanged. Only `.exception` is
gated, matching what both call sites assert.

## Verification

- `uv run pytest tests/helpers/test_logger_assertions.py tests/data/vst/test_fake_plugin_e2e.py tests/data/vst/test_always_on_integration.py` — 5 passed (the real-VST `test_always_on` ran against the installed Surge XT, not skipped).
- `make format` clean (ruff, ruff-format, pyright, pydoclint, interrogate, prettier all pass).

Refs #1445
