### PR TITLE
fix(eval): forward num_workers to inline oracle-eval predict DataLoader

### DIFF
--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -22,13 +22,13 @@ from pathlib import Path
 from typing import Any
 
 import hydra
-import wandb
 from hydra.core.hydra_config import HydraConfig
 from lightning.pytorch.loggers import Logger
 from lightning.pytorch.loggers.wandb import WandbLogger
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
+import wandb
 from synth_setter.cli.finalize_dataset import finalize_from_spec
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.pipeline import r2_io
@@ -69,6 +69,7 @@ def _run_oracle_eval_subprocess(
     run_id: str,
     *,
     render: RenderConfig,
+    num_workers: int,
 ) -> None:
     """Run the fake-oracle eval over ``dataset_root`` to verify the param-array round-trip.
 
@@ -89,6 +90,11 @@ def _run_oracle_eval_subprocess(
         (param spec, preset, plugin, sample rate, channels, velocity, signal
         duration) is overridden from this so the re-render matches generation
         exactly rather than falling back to the render group / CLI defaults.
+    :param num_workers: Predict DataLoader worker count, forwarded verbatim from
+        the generate run's ``datamodule`` config — no platform guard. On
+        spawn-start-method platforms (Darwin) the caller must configure ``0``:
+        workers pickle the dataset, but ``SurgeXTDataset`` holds an open h5py
+        handle that cannot be pickled.
     :raises FileNotFoundError: ``dataset_root`` is missing any finalized split
         or ``stats.npz`` — e.g. a resume where ``finalize_from_spec``
         short-circuited on an existing R2 marker without repopulating it.
@@ -130,6 +136,9 @@ def _run_oracle_eval_subprocess(
         # would yield zero batches on the smoke-sized test split (4 samples),
         # so predict_step never runs and no audio/* metric is logged — see #1331.
         "datamodule.batch_size=1",
+        # Forwarded from the generate run so the eval honours the same worker
+        # count; pass 0 on Darwin where the open-h5py dataset can't be pickled.
+        f"datamodule.num_workers={num_workers}",
         "mode=predict",
     ]
     logger.info(f"oracle_eval_inline subprocess: {argv}")
@@ -836,6 +845,7 @@ def main(cfg: DictConfig) -> None:
                 eval_run_dir,
                 spec.run_id,
                 render=spec.render,
+                num_workers=cfg.datamodule.num_workers,
             )
         return
 

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -1678,11 +1678,12 @@ class TestMainDispatchBranches:
 
         # Capture the resolved output_dir so the eval's dataset_root can be
         # pinned to the exact dir generate+finalize wrote the shards into.
-        observed: dict[str, Path] = {}
+        observed: dict[str, object] = {}
         real_spec_from_cfg = gd.spec_from_cfg
 
         def _capture_output_dir(cfg: object) -> DatasetSpec:
             observed["output_dir"] = Path(cfg.paths.output_dir)  # type: ignore[attr-defined]
+            observed["num_workers"] = cfg.datamodule.num_workers  # type: ignore[attr-defined]
             return real_spec_from_cfg(cfg)  # type: ignore[arg-type]
 
         monkeypatch.setattr(gd, "spec_from_cfg", _capture_output_dir)
@@ -1696,6 +1697,9 @@ class TestMainDispatchBranches:
         # re-renders through the same spec; smoke-shard is surge_simple.
         render_arg = oracle_mock.call_args.kwargs["render"]
         assert render_arg.param_spec_name == "surge_simple"
+        # The eval inherits the generate run's datamodule worker count verbatim,
+        # so a Darwin override (num_workers=0) reaches the predict DataLoader.
+        assert oracle_mock.call_args.kwargs["num_workers"] == observed["num_workers"]
         assert render_arg.preset_path == "presets/surge-simple.vstpreset"
         # plugin_path is the TEST_PLUGIN_VST3 this test overrode at generation —
         # proving a non-default plugin flows through to the eval re-render.
@@ -1744,7 +1748,9 @@ class TestMainDispatchBranches:
                 "plugin_path": "plugins/Surge XT.vst3",
             }
         )
-        gd._run_oracle_eval_subprocess(dataset_root, run_dir, "some-run-id", render=render)
+        gd._run_oracle_eval_subprocess(
+            dataset_root, run_dir, "some-run-id", render=render, num_workers=7
+        )
 
         run_mock.assert_called_once()
         called_argv = run_mock.call_args[0][0]
@@ -1779,6 +1785,8 @@ class TestMainDispatchBranches:
         # batch_size=1 keeps the smoke-sized test split (4 samples) from
         # flooring to zero batches under the 128 default — see #1331.
         assert "datamodule.batch_size=1" in called_argv
+        # Sentinel 7 (no config default) proves the value is forwarded, not hardcoded.
+        assert "datamodule.num_workers=7" in called_argv
         assert "mode=predict" in called_argv
 
     def test_run_oracle_eval_subprocess_missing_local_artifacts_raises(
@@ -1809,6 +1817,7 @@ class TestMainDispatchBranches:
                 tmp_path / "oracle_eval" / "rid",
                 "rid",
                 render=spec.render,
+                num_workers=0,
             )
 
         run_mock.assert_not_called()

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.18.0"
+version = "8.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What

The inline oracle-eval subprocess (`generate_dataset.py`, run when `oracle_eval_inline=true`) built its argv with a fixed worker count — the eval's `surge` datamodule default of `num_workers=11` — and never forwarded the generate run's `datamodule.num_workers`. On macOS the multiprocessing start method is **spawn**, which pickles the dataset to each predict-DataLoader worker; `SurgeXTDataset` holds an open `h5py.File` handle that cannot be pickled, so every `oracle_eval_inline` run crashed with `TypeError: h5py objects cannot be pickled`. A `datamodule.num_workers=0` override on the generate command had no effect, because the argv never carried it through.

On the Linux pipeline this never fired (`fork` doesn't pickle), so it was a macOS-only blocker.

## Change

Forward the generate run's `cfg.datamodule.num_workers` into the eval subprocess argv as `datamodule.num_workers=<value>`, so the eval honours the configured worker count. Callers set `num_workers=0` on macOS (e.g. in the cadence sweep command); Linux keeps its default. The open-h5py dataset is unchanged — a lazy-open refactor of `SurgeXTDataset` is deliberately out of scope.

## Test

- `test_run_oracle_eval_subprocess_builds_expected_argv` forwards a sentinel `num_workers=7` and asserts `datamodule.num_workers=7` lands in the argv — proving the value is forwarded, not hardcoded (7 is no config default).
- `test_main_oracle_eval_inline_true_invokes_subprocess` now pins the call site: the forwarded `num_workers` kwarg equals the resolved `cfg.datamodule.num_workers`.
- Full `tests/pipeline/entrypoints/test_generate_dataset_unit.py` green (71 tests); pre-commit (ruff, pyright, pydoclint, …) clean.

## Note

The fix forwards verbatim rather than clamping to `0` on Darwin, so a zero-config macOS run still crashes — the caller's config is responsible for setting `0` there (the docstring says so). A `sys.platform == "darwin"` clamp is a possible follow-up if a zero-config guard is wanted.

Fixes #1462
