### PR TITLE
fix(monitoring): capture wandb console at fd level for non-empty logs

### DIFF
--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -21,15 +21,16 @@ ______________________________________________________________________
 
 ## 1. Initialization
 
-| Concern           | How it works                                                                                             | File                                                |
-| ----------------- | -------------------------------------------------------------------------------------------------------- | --------------------------------------------------- |
-| W&B run creation  | `WandbLogger` instantiated by Hydra — included in the default `many_loggers` compose (W&B + CSV + TB)    | `src/synth_setter/configs/logger/wandb.yaml`        |
-| Entity / project  | Env-var driven: `entity: ${oc.env:WANDB_ENTITY,null}`, `project: "${oc.env:WANDB_PROJECT,synth-setter}"` | `src/synth_setter/configs/logger/wandb.yaml:10,13`  |
-| Default compose   | `many_loggers` composes `csv + tensorboard + wandb` (W&B enabled by default)                             | `src/synth_setter/configs/logger/many_loggers.yaml` |
-| Run ID            | `null` (W&B auto-generates)                                                                              | `src/synth_setter/configs/logger/wandb.yaml:8`      |
-| Checkpoint upload | `log_model: "all"`                                                                                       | `src/synth_setter/configs/logger/wandb.yaml:11`     |
-| Code saving       | `wandb.Settings(code_dir=".")`                                                                           | `src/synth_setter/configs/logger/wandb.yaml:17-19`  |
-| Run teardown      | `wandb.finish()` in `task_wrapper` finally block                                                         | `src/synth_setter/utils/utils.py:101-106`           |
+| Concern           | How it works                                                                                                                      | File                                                            |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| W&B run creation  | `WandbLogger` instantiated by Hydra — included in the default `many_loggers` compose (W&B + CSV + TB)                             | `src/synth_setter/configs/logger/wandb.yaml`                    |
+| Entity / project  | Env-var driven: `entity: ${oc.env:WANDB_ENTITY,null}`, `project: "${oc.env:WANDB_PROJECT,synth-setter}"`                          | `src/synth_setter/configs/logger/wandb.yaml:10,13`              |
+| Default compose   | `many_loggers` composes `csv + tensorboard + wandb` (W&B enabled by default)                                                      | `src/synth_setter/configs/logger/many_loggers.yaml`             |
+| Run ID            | `null` (W&B auto-generates)                                                                                                       | `src/synth_setter/configs/logger/wandb.yaml:8`                  |
+| Checkpoint upload | `log_model: "all"`                                                                                                                | `src/synth_setter/configs/logger/wandb.yaml:11`                 |
+| Code saving       | `wandb.Settings(code_dir=".")`                                                                                                    | `src/synth_setter/configs/logger/wandb.yaml` § `wandb.settings` |
+| Console capture   | `wandb.Settings(console="redirect")` — fd-level redirect so non-TTY worker logs (loguru stderr + subprocess output) reach the run | `src/synth_setter/configs/logger/wandb.yaml` § `wandb.settings` |
+| Run teardown      | `wandb.finish()` in `task_wrapper` finally block                                                                                  | `src/synth_setter/utils/utils.py:101-106`                       |
 
 **No direct `wandb.init()` calls exist in runtime code.** One `wandb.config.update()` call exists: `log_wandb_provenance()` in `src/synth_setter/utils/logging_utils.py:91` writes provenance metadata (see [2g](#2g-provenance-metadata-logged-once-at-run-start)).
 

--- a/src/synth_setter/configs/logger/wandb.yaml
+++ b/src/synth_setter/configs/logger/wandb.yaml
@@ -17,3 +17,6 @@ wandb:
   settings:
     _target_: wandb.Settings
     code_dir: .
+    # fd-level capture, needed because ``auto`` picks ``wrap`` on non-TTY workers
+    # — ``wrap`` misses loguru's import-time stderr and subprocess output entirely.
+    console: redirect

--- a/tests/schemas/test_logger_config.py
+++ b/tests/schemas/test_logger_config.py
@@ -48,6 +48,21 @@ class TestLoggerConfigAcceptsEveryComposition:
         assert len(parsed.root) > 1
 
 
+class TestWandbConsoleCapture:
+    """The wandb logger must capture console output at the file-descriptor level."""
+
+    def test_wandb_settings_console_is_redirect(self) -> None:
+        """The composed ``wandb.settings.console`` pins ``redirect`` (not the ``auto`` default).
+
+        Config-pin guard: asserts the value, not the runtime capture. ``redirect`` is required
+        because ``auto`` resolves to ``wrap`` on non-TTY workers, which patches ``sys.stdout``
+        only and so misses loguru's import-time ``sys.stderr`` binding and subprocess output —
+        leaving the run's log stream empty.
+        """
+        logger_subtree = compose_subtree("logger", "wandb")
+        assert logger_subtree["wandb"]["settings"]["console"] == "redirect"
+
+
 _VALID_LOGGER = {
     "_target_": "lightning.pytorch.loggers.csv_logs.CSVLogger",
     "save_dir": "/tmp/csv",  # noqa: S108

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.18.1"
+version = "8.18.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Problem

Dataset-generation runs appear in wandb but their **Logs** stream is empty — no loguru output and none of the per-shard render-subprocess output is captured.

## Root cause

`configs/logger/wandb.yaml` left console capture at the wandb default `console=auto`, which resolves to `wrap` on non-TTY workers. `wrap` only patches the parent's `sys.stdout`, so it captures:

- **Neither** generate_dataset's loguru output — loguru's default handler binds a reference to `sys.stderr` at import time (`from loguru import logger`), before `wandb.init` runs inside `generate()`, so the wrapper never sees it;
- **Nor** the render-subprocess output — `wrap` is Python-level only and cannot capture a child process's fds.

Only fd-level `console=redirect` captures both (it dups fds 1/2, surviving loguru's early binding and inherited by subprocesses).

## Change

- Pin `console: redirect` in the wandb logger `settings` block.
- Add a config-composition test (`TestWandbConsoleCapture`) asserting the composed `wandb.settings.console == "redirect"` through real Hydra composition.

Shared with `train`/`eval` (wandb-recommended default; coexists with tqdm progress bars).

## Verification

- `tests/schemas/test_logger_config.py` — green (config-pin via real Hydra composition).
- Confirmed `wandb.Settings(console="redirect")` is accepted by the installed wandb 0.26.1.
- [ ] **Manual e2e (needs a wandb-authenticated run):** run a `generate_dataset` smoke shard that fails mid-render and confirm the wandb run's log stream contains the loguru lines **and** the `generate_vst_dataset.py` subprocess output. The committed test pins the config value but does not exercise runtime capture.

## Scope notes

- `@task_wrapper` was evaluated and **rejected**: its only effect is `wandb.finish()` on exception, which `generate()`'s existing `_close_loggers` already does (and more carefully — it marks `finalize("failed")` and guards against finishing a foreign `wandb.run`). It also does not affect console capture, so it would not fix this bug.
- Entrypoint parity (`extras(cfg)` + `log_wandb_provenance()`, plus adding a `tags` field to the dataset config) is tracked separately in #1464.

Fixes #1465
