### PR TITLE
automation: link worktree thoughts/ to the primary central copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,8 +170,9 @@ checkpoints/
 # Advisory reports written by .claude/hooks/doc-drift.sh and pr-review-resolver.sh
 .agent-reviews/
 
-# Local working notes written by qrspi skills and research/plan tooling
-thoughts/
+# Local working notes from qrspi skills. No trailing slash: `make link-thoughts`
+# swaps this for a symlink, which a dir-only `thoughts/` pattern would miss.
+thoughts
 
 # Git worktrees
 .worktrees/

--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,40 @@ link-plugins: ## Mirror the primary checkout's plugins/ into the current worktre
 		echo "linked plugins/$$name -> $$entry"; \
 	done
 
+# Symlink this worktree's gitignored thoughts/ to the primary's central thoughts/
+# so qrspi docs from every worktree converge; migrates pre-existing files first.
+link-thoughts: ## Symlink this worktree's thoughts/ to the primary checkout's central thoughts/ (no-op in primary)
+	@set -e; \
+	primary="$$(cd "$$(dirname "$$(git rev-parse --git-common-dir)")" && pwd)"; \
+	here="$$(git rev-parse --show-toplevel)"; \
+	if [ "$$primary" = "$$here" ]; then \
+		echo "In primary checkout — thoughts/ is already central."; exit 0; \
+	fi; \
+	central="$$primary/thoughts"; \
+	mkdir -p "$$central"; \
+	if [ -L "$$here/thoughts" ]; then \
+		echo "thoughts/ already linked -> $$(readlink "$$here/thoughts")"; exit 0; \
+	fi; \
+	if [ -d "$$here/thoughts" ]; then \
+		find "$$here/thoughts" -type f | while read -r f; do \
+			rel="$${f#"$$here/thoughts/"}"; \
+			if [ -e "$$central/$$rel" ]; then \
+				if ! cmp -s "$$f" "$$central/$$rel"; then \
+					alt="$$rel.from-$$(basename "$$here")"; \
+					cp "$$f" "$$central/$$alt" || exit 1; \
+					echo "collision: kept central/$$rel; saved worktree copy as $$alt"; \
+				fi; \
+			else \
+				mkdir -p "$$central/$$(dirname "$$rel")" || exit 1; \
+				cp "$$f" "$$central/$$rel" || exit 1; \
+				echo "migrated $$rel"; \
+			fi; \
+		done; \
+		rm -rf "$$here/thoughts"; \
+	fi; \
+	ln -sfn "$$central" "$$here/thoughts"; \
+	echo "linked thoughts/ -> $$central"
+
 # Mirrors the --cov flags used by .github/workflows/test.yml so local
 # coverage runs reproduce CI output (xml report feeds Codecov; html is for
 # local browsing).

--- a/Makefile
+++ b/Makefile
@@ -203,10 +203,13 @@ link-thoughts: ## Symlink this worktree's thoughts/ to the primary checkout's ce
 	central="$$primary/thoughts"; \
 	mkdir -p "$$central"; \
 	if [ -L "$$here/thoughts" ]; then \
-		echo "thoughts/ already linked -> $$(readlink "$$here/thoughts")"; exit 0; \
+		if [ "$$(readlink "$$here/thoughts")" = "$$central" ]; then \
+			echo "thoughts/ already linked -> $$central"; exit 0; \
+		fi; \
+		rm -f "$$here/thoughts"; \
 	fi; \
 	if [ -d "$$here/thoughts" ]; then \
-		find "$$here/thoughts" -type f | while read -r f; do \
+		find "$$here/thoughts" -type f | while IFS= read -r f; do \
 			rel="$${f#"$$here/thoughts/"}"; \
 			if [ -e "$$central/$$rel" ]; then \
 				if ! cmp -s "$$f" "$$central/$$rel"; then \

--- a/Makefile
+++ b/Makefile
@@ -209,7 +209,9 @@ link-thoughts: ## Symlink this worktree's thoughts/ to the primary checkout's ce
 		rm -f "$$here/thoughts"; \
 	fi; \
 	if [ -d "$$here/thoughts" ]; then \
-		find "$$here/thoughts" -type f | while IFS= read -r f; do \
+		list="$$(mktemp)"; \
+		find "$$here/thoughts" -type f > "$$list" || { rm -f "$$list"; exit 1; }; \
+		while IFS= read -r f; do \
 			rel="$${f#"$$here/thoughts/"}"; \
 			if [ -e "$$central/$$rel" ]; then \
 				if ! cmp -s "$$f" "$$central/$$rel"; then \
@@ -222,7 +224,8 @@ link-thoughts: ## Symlink this worktree's thoughts/ to the primary checkout's ce
 				cp "$$f" "$$central/$$rel" || exit 1; \
 				echo "migrated $$rel"; \
 			fi; \
-		done; \
+		done < "$$list"; \
+		rm -f "$$list"; \
 		rm -rf "$$here/thoughts"; \
 	fi; \
 	ln -sfn "$$central" "$$here/thoughts"; \

--- a/agent/hooks/session-start-cwd-banner.sh
+++ b/agent/hooks/session-start-cwd-banner.sh
@@ -49,8 +49,9 @@ main() {
     printf 'Spawn a worktree before editing:\n'
     # Anchor to $primary_root so the command works even when the session started in a subdir.
     # `uv sync` builds the worktree's own .venv; `make link-plugins` backfills the
-    # gitignored plugins/ symlink. Single-quote the paths so the command survives spaces.
-    printf "  git worktree add --detach '%s/.claude/worktrees/%s' && cd '%s/.claude/worktrees/%s' && uv sync && make link-plugins\n" \
+    # gitignored plugins/ symlink; `make link-thoughts` points thoughts/ at the
+    # central primary copy. Single-quote the paths so the command survives spaces.
+    printf "  git worktree add --detach '%s/.claude/worktrees/%s' && cd '%s/.claude/worktrees/%s' && uv sync && make link-plugins && make link-thoughts\n" \
       "$primary_root" "$slug" "$primary_root" "$slug"
   else
     printf '  status   : isolated worktree (OK)\n'

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -1226,6 +1226,7 @@ T_worktree_guard_warns_in_primary() {
   grep -q "WARNING" "$stderr_file" || { echo "stderr should contain WARNING; got: $(cat "$stderr_file")"; return 1; }
   grep -q "git worktree add" "$stderr_file" || { echo "stderr should suggest 'git worktree add'"; return 1; }
   grep -q "make link-plugins" "$stderr_file" || { echo "remediation should chain 'make link-plugins' so the new worktree gets the VST symlink; got: $(cat "$stderr_file")"; return 1; }
+  grep -q "make link-thoughts" "$stderr_file" || { echo "remediation should chain 'make link-thoughts' so the new worktree shares central thoughts/; got: $(cat "$stderr_file")"; return 1; }
 }
 it "worktree-guard: edit in primary (warn mode default) → exit 0 with WARNING + remediation on stderr" T_worktree_guard_warns_in_primary
 
@@ -1366,6 +1367,7 @@ T_session_start_banner_in_primary() {
   [[ "$out" == *"PRIMARY CHECKOUT"* ]] || { echo "banner should flag PRIMARY CHECKOUT; got: $out"; return 1; }
   [[ "$out" == *"git worktree add"* ]] || { echo "banner should suggest 'git worktree add'; got: $out"; return 1; }
   [[ "$out" == *"make link-plugins"* ]] || { echo "spawn command should chain 'make link-plugins' so the new worktree gets the VST symlink; got: $out"; return 1; }
+  [[ "$out" == *"make link-thoughts"* ]] || { echo "spawn command should chain 'make link-thoughts' so the new worktree shares central thoughts/; got: $out"; return 1; }
 }
 it "session-start-banner: in primary → stdout flags PRIMARY CHECKOUT and shows remediation" T_session_start_banner_in_primary
 

--- a/agent/hooks/worktree-guard.sh
+++ b/agent/hooks/worktree-guard.sh
@@ -85,7 +85,7 @@ isolated worktree before editing.
 
 Recommended (current HEAD: ${branch_label}):
   git worktree add --detach '${primary_root}/.claude/worktrees/${slug}'
-  cd '${primary_root}/.claude/worktrees/${slug}' && uv sync && make link-plugins
+  cd '${primary_root}/.claude/worktrees/${slug}' && uv sync && make link-plugins && make link-thoughts
 
 ${override_hint}
 EOF

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -223,7 +223,7 @@ docs:
     description: Onboarding — local dev, Codespaces, and dev container flows
     sources:
       - pattern: "Makefile"
-        covers: "Local dev targets — install (uv + .venv + deps + pre-commit), install-surge-xt (download + md5 verify + extract Surge XT VST3), link-plugins (mirror primary's plugins/ into a worktree), SURGE_XT_VERSION + related vars"
+        covers: "Local dev targets — install (uv + .venv + deps + pre-commit), install-surge-xt (download + md5 verify + extract Surge XT VST3), link-plugins (mirror primary's plugins/ into a worktree), link-thoughts (symlink a worktree's thoughts/ to the primary's central copy; no-op in primary), SURGE_XT_VERSION + related vars"
         scope: "local-dev"
       - pattern: ".devcontainer/cpu/devcontainer.json"
         covers: "CPU dev container config — remoteUser, mounts (bash-history named volume + per-user tmux-resurrect and zellij-cache named volumes for dev and root + plugins/ anonymous overlay), --env-file .env, initializeCommand, postCreateCommand, VS Code terminal profile defaulting to zellij (tmux still selectable)"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -760,7 +760,7 @@ devcontainer up --workspace-folder .
 ```bash
 # Inside the container, starting from the workspace root on main:
 git worktree add .claude/worktrees/my-feature -b feat/my-feature
-cd .claude/worktrees/my-feature && make link-plugins
+cd .claude/worktrees/my-feature && make link-plugins && make link-thoughts
 ```
 
 This is the supported local pattern. Mounting a worktree directly from the
@@ -788,6 +788,13 @@ the failure surfaces immediately rather than partway through `post-create`.
   `git worktree add` doesn't copy it). `make link-plugins` mirrors the
   primary checkout's `plugins/` entries into the worktree (no-op in the
   primary) — that's why the spawn command above chains it.
+- `thoughts/` is gitignored too, so each worktree would otherwise grow its
+  own copy and scatter qrspi docs (research/structure/plan/design) across
+  worktrees. `make link-thoughts` replaces the worktree's `thoughts/` with a
+  symlink to the primary checkout's central `thoughts/` (migrating any
+  pre-existing worktree files, preserving collisions as `<name>.from-<worktree>`),
+  so every worktree's qrspi output lands in one place — that's why the spawn
+  command chains it after `make link-plugins`.
 
 ### B.3. macOS VM (Tart)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -760,7 +760,7 @@ devcontainer up --workspace-folder .
 ```bash
 # Inside the container, starting from the workspace root on main:
 git worktree add .claude/worktrees/my-feature -b feat/my-feature
-cd .claude/worktrees/my-feature && make link-plugins && make link-thoughts
+cd .claude/worktrees/my-feature && make link-plugins
 ```
 
 This is the supported local pattern. Mounting a worktree directly from the
@@ -788,13 +788,6 @@ the failure surfaces immediately rather than partway through `post-create`.
   `git worktree add` doesn't copy it). `make link-plugins` mirrors the
   primary checkout's `plugins/` entries into the worktree (no-op in the
   primary) — that's why the spawn command above chains it.
-- `thoughts/` is gitignored too, so each worktree would otherwise grow its
-  own copy and scatter qrspi docs (research/structure/plan/design) across
-  worktrees. `make link-thoughts` replaces the worktree's `thoughts/` with a
-  symlink to the primary checkout's central `thoughts/` (migrating any
-  pre-existing worktree files, preserving collisions as `<name>.from-<worktree>`),
-  so every worktree's qrspi output lands in one place — that's why the spawn
-  command chains it after `make link-plugins`.
 
 ### B.3. macOS VM (Tart)
 

--- a/tests/infra/test_worktree_thoughts_links.py
+++ b/tests/infra/test_worktree_thoughts_links.py
@@ -185,6 +185,43 @@ def test_link_thoughts_skips_identical_collision_quietly(tmp_path: Path) -> None
     assert not list((primary / "thoughts" / "shared" / "plans").glob("*.from-*"))
 
 
+def test_link_thoughts_relinks_a_symlink_pointing_elsewhere(tmp_path: Path) -> None:
+    """A thoughts symlink aimed off-central is repointed to central, not treated as a no-op.
+
+    :param tmp_path: holds the primary checkout, the worktree, and a stray link target.
+    """
+    primary = tmp_path / "primary"
+    _init_primary_repo(primary)
+    worktree = tmp_path / "wt"
+    _git(primary, "worktree", "add", "--detach", "-q", str(worktree))
+    stray = tmp_path / "stray"
+    stray.mkdir()
+    (worktree / "thoughts").symlink_to(stray)
+
+    stdout = _make_link_thoughts(worktree)
+
+    assert "already linked" not in stdout
+    assert (worktree / "thoughts").resolve() == (primary / "thoughts").resolve()
+
+
+def test_link_thoughts_migrates_a_path_with_spaces(tmp_path: Path) -> None:
+    """A worktree file whose path contains spaces migrates to the matching central path intact.
+
+    :param tmp_path: holds the primary checkout and the worktree with a spaced doc path.
+    """
+    primary = tmp_path / "primary"
+    _init_primary_repo(primary)
+    worktree = tmp_path / "wt"
+    _git(primary, "worktree", "add", "--detach", "-q", str(worktree))
+    doc = worktree / "thoughts" / "shared" / "my notes" / "a doc.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("spaced")
+
+    _make_link_thoughts(worktree)
+
+    assert (primary / "thoughts" / "shared" / "my notes" / "a doc.md").read_text() == "spaced"
+
+
 def test_link_thoughts_symlink_is_gitignored(tmp_path: Path) -> None:
     """After linking, the worktree's thoughts symlink is gitignored, not a dirty untracked entry.
 

--- a/tests/infra/test_worktree_thoughts_links.py
+++ b/tests/infra/test_worktree_thoughts_links.py
@@ -1,0 +1,214 @@
+"""`make link-thoughts` links a worktree's gitignored thoughts/ to the primary's central one.
+
+`thoughts/` is gitignored, so each `git worktree add` grows its own copy and scatters qrspi docs
+(research/structure/plan/design) across worktrees. The target replaces the worktree's thoughts/ with
+a symlink to the primary's central thoughts/, migrating any pre-existing files first and preserving a
+divergent collision as ``<name>.from-<worktree>`` rather than dropping it. The spawn command printed
+by the SessionStart banner and worktree-guard chains it on so the link appears naturally.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+pytestmark = pytest.mark.infra
+
+# Bound subprocess calls so a hung git/make can't wedge the suite.
+_TIMEOUT_S = 60
+
+for _tool in ("git", "make"):
+    if shutil.which(_tool) is None:
+        pytest.skip(f"{_tool} not on PATH", allow_module_level=True)
+
+
+def _git(repo: Path, *args: str) -> None:
+    """Run a git subcommand in ``repo``, raising on non-zero exit.
+
+    :param repo: checkout the subcommand runs against (``git -C``).
+    :param *args: subcommand and its arguments.
+    """
+    subprocess.run(  # noqa: S603 — fixed argv, no shell
+        ["git", "-C", str(repo), *args],  # noqa: S607 — git on PATH
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT_S,
+    )
+
+
+def _make_link_thoughts(cwd: Path) -> str:
+    """Run ``make link-thoughts`` in ``cwd``, returning its stdout.
+
+    :param cwd: directory to run the target from (a primary checkout or worktree).
+    :returns: the target's stdout (the linked/migrated/no-op message lines).
+    """
+    return subprocess.run(  # noqa: S603 — fixed argv, no shell
+        ["make", "link-thoughts"],  # noqa: S607 — make on PATH
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT_S,
+    ).stdout
+
+
+def _init_primary_repo(path: Path) -> None:
+    """Init a committed git checkout at ``path`` with the project Makefile.
+
+    :param path: empty directory to turn into the primary checkout.
+    """
+    path.mkdir()
+    _git(path, "init", "-q")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "test")
+    shutil.copy(PROJECT_ROOT / "Makefile", path / "Makefile")
+    _git(path, "add", "Makefile")
+    _git(path, "commit", "-qm", "init")
+
+
+def test_link_thoughts_symlinks_fresh_worktree_to_central(tmp_path: Path) -> None:
+    """`make link-thoughts` links a fresh worktree's thoughts/ to central, idempotently.
+
+    :param tmp_path: holds the primary checkout and the worktree added off it.
+    """
+    primary = tmp_path / "primary"
+    _init_primary_repo(primary)
+    worktree = tmp_path / "wt"
+    _git(primary, "worktree", "add", "--detach", "-q", str(worktree))
+    assert not (worktree / "thoughts").exists(), (
+        "precondition: gitignored thoughts/ absent in fresh worktree"
+    )
+
+    _make_link_thoughts(worktree)
+    link = worktree / "thoughts"
+    assert link.is_symlink()
+    assert link.resolve() == (primary / "thoughts").resolve()
+
+    # Re-running must report the existing link, not nest a symlink inside it.
+    stdout = _make_link_thoughts(worktree)
+    assert "already linked" in stdout
+    assert link.is_symlink()
+    assert link.resolve() == (primary / "thoughts").resolve()
+
+
+def test_link_thoughts_is_noop_in_primary(tmp_path: Path) -> None:
+    """`make link-thoughts` leaves the primary alone — its thoughts/ is already central.
+
+    :param tmp_path: holds the primary checkout.
+    """
+    primary = tmp_path / "primary"
+    _init_primary_repo(primary)
+
+    stdout = _make_link_thoughts(primary)
+
+    assert "already central" in stdout
+    assert not (primary / "thoughts").is_symlink()
+
+
+def test_link_thoughts_migrates_worktree_files_into_central(tmp_path: Path) -> None:
+    """`make link-thoughts` migrates a pre-existing worktree file into central before linking.
+
+    :param tmp_path: holds the primary checkout and the worktree with local thoughts/.
+    """
+    primary = tmp_path / "primary"
+    _init_primary_repo(primary)
+    worktree = tmp_path / "wt"
+    _git(primary, "worktree", "add", "--detach", "-q", str(worktree))
+    doc = worktree / "thoughts" / "shared" / "research" / "doc.md"
+    doc.parent.mkdir(parents=True)
+    doc.write_text("worktree-only")
+
+    _make_link_thoughts(worktree)
+
+    central_doc = primary / "thoughts" / "shared" / "research" / "doc.md"
+    assert central_doc.read_text() == "worktree-only"
+    assert (worktree / "thoughts").is_symlink()
+    # The migrated file is now reachable through the symlink, not a separate copy.
+    assert (
+        worktree / "thoughts" / "shared" / "research" / "doc.md"
+    ).read_text() == "worktree-only"
+
+
+def test_link_thoughts_preserves_divergent_collision(tmp_path: Path) -> None:
+    """A divergent worktree file survives as ``<name>.from-<worktree>``, never dropped.
+
+    :param tmp_path: holds the primary checkout and the worktree with a colliding doc.
+    """
+    primary = tmp_path / "primary"
+    _init_primary_repo(primary)
+    worktree = tmp_path / "wt"
+    _git(primary, "worktree", "add", "--detach", "-q", str(worktree))
+
+    rel = Path("shared") / "design" / "doc.md"
+    central_doc = primary / "thoughts" / rel
+    central_doc.parent.mkdir(parents=True)
+    central_doc.write_text("central-version")
+    wt_doc = worktree / "thoughts" / rel
+    wt_doc.parent.mkdir(parents=True)
+    wt_doc.write_text("worktree-version")
+
+    stdout = _make_link_thoughts(worktree)
+
+    assert "collision" in stdout
+    assert central_doc.read_text() == "central-version", (
+        "central copy is authoritative on collision"
+    )
+    preserved = primary / "thoughts" / "shared" / "design" / f"doc.md.from-{worktree.name}"
+    assert preserved.read_text() == "worktree-version", "divergent worktree copy is preserved"
+
+
+def test_link_thoughts_skips_identical_collision_quietly(tmp_path: Path) -> None:
+    """A worktree file identical to central produces no ``.from-`` copy and no collision notice.
+
+    :param tmp_path: holds the primary checkout and the worktree with an identical doc.
+    """
+    primary = tmp_path / "primary"
+    _init_primary_repo(primary)
+    worktree = tmp_path / "wt"
+    _git(primary, "worktree", "add", "--detach", "-q", str(worktree))
+
+    rel = Path("shared") / "plans" / "doc.md"
+    (primary / "thoughts" / rel).parent.mkdir(parents=True)
+    (primary / "thoughts" / rel).write_text("same")
+    (worktree / "thoughts" / rel).parent.mkdir(parents=True)
+    (worktree / "thoughts" / rel).write_text("same")
+
+    stdout = _make_link_thoughts(worktree)
+
+    assert "collision" not in stdout
+    assert not list((primary / "thoughts" / "shared" / "plans").glob("*.from-*"))
+
+
+def test_link_thoughts_symlink_is_gitignored(tmp_path: Path) -> None:
+    """After linking, the worktree's thoughts symlink is gitignored, not a dirty untracked entry.
+
+    The project ignores ``thoughts`` without a trailing slash precisely so this symlink is caught;
+    a dir-only ``thoughts/`` pattern misses it, leaving the link untracked and committable.
+
+    :param tmp_path: holds the primary checkout (with .gitignore) and its worktree.
+    """
+    primary = tmp_path / "primary"
+    _init_primary_repo(primary)
+    shutil.copy(PROJECT_ROOT / ".gitignore", primary / ".gitignore")
+    _git(primary, "add", ".gitignore")
+    _git(primary, "commit", "-qm", "gitignore")
+    worktree = tmp_path / "wt"
+    _git(primary, "worktree", "add", "--detach", "-q", str(worktree))
+
+    _make_link_thoughts(worktree)
+
+    status = subprocess.run(  # noqa: S603 — fixed argv, no shell
+        ["git", "-C", str(worktree), "status", "--porcelain"],  # noqa: S607 — git on PATH
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT_S,
+    ).stdout
+    assert (worktree / "thoughts").is_symlink()
+    assert "thoughts" not in status, f"symlink should be gitignored; git status: {status!r}"


### PR DESCRIPTION
## Problem

qrspi skills (`qrspi-research`/`-structure`/`-plan`/`-design`/`-questions`) write to a **relative** `thoughts/shared/...` path. Each qrspi stage runs in its own git worktree, and `thoughts/` is gitignored, so `git worktree add` gives every worktree its own isolated `thoughts/`. The R→S→P→I chain therefore can't see prior stages' docs unless they happen to share a worktree, and qrspi output scatters across worktrees.

## Fix

Add a `make link-thoughts` target (sibling of `make link-plugins`, #1343) that replaces a worktree's `thoughts/` with a symlink to the primary checkout's central `thoughts/`. Because the qrspi commands use a *relative* path, both writes **and** reads (the `thoughts-locator`/`thoughts-analyzer` agents) transparently resolve to the central dir — **no qrspi command files change**. The SessionStart banner and worktree-guard spawn command chain it on so new worktrees get it automatically.

Pre-existing worktree files migrate into central on first link; `mkdir`/`cp` are guarded so a failed migration aborts before the destructive `rm -rf`. A file that differs in central is preserved as `<name>.from-<worktree>`, never silently dropped.

The `.gitignore` entry drops its trailing slash (`thoughts/` → `thoughts`) so the symlink itself is ignored — a dir-only pattern misses it, which would leave the link as a committable untracked entry.

## Tests

- `tests/infra/test_worktree_thoughts_links.py` — fresh-link + idempotency, no-op in primary, migration into central, divergent-collision preservation, identical-collision quiet skip, and the gitignore-catches-the-symlink safety case.
- `agent/hooks/test.sh` — asserts both the SessionStart banner and worktree-guard remediation chain `make link-thoughts`.

Closes #1468