### PR TITLE
chore(logging): replace stray print() with structured logging

### DIFF
--- a/src/synth_setter/pipeline/data/stats.py
+++ b/src/synth_setter/pipeline/data/stats.py
@@ -162,34 +162,32 @@ def get_stats_hdf5(filename: str, mask_degenerate: bool = False) -> None:
     dataset_name = "mel_spec"
     num_workers = 4
 
-    print("Starting client...")
+    logger.info("Starting Dask client (n_workers=%d)", num_workers)
     with Client(n_workers=num_workers, threads_per_worker=8) as client:
         # ``da.from_array`` reads lazily; the h5py.File must stay open through
         # the final ``.compute()`` so workers can pull chunks on demand.
         with h5py.File(filename, "r") as h5_file:
-            print("Creating dask array...")
+            logger.info("Creating Dask array from dataset %r", dataset_name)
             darray = da.from_array(h5_file[dataset_name], chunks="auto")
 
-            print("Computing mean and std...")
+            logger.info("Building mean/std reduction tasks")
             mean_task = darray.mean(axis=0)
             std_task = darray.std(axis=0)
 
-            print("Persisting tasks...")
+            logger.info("Persisting reduction tasks")
             futures = [mean_task.persist(), std_task.persist()]
 
-            print("Displaying progress...")
+            logger.info("Displaying compute progress")
             progress(futures)
 
-            print("Gathering results...")
+            logger.info("Gathering results")
             mean_val, std_val = client.gather(futures)
-
-            print("Mean:", mean_val)
-            print("std:", std_val)
 
             mean = mean_val.compute()
             std = std_val.compute()
+            logger.info("Computed mean and std (shapes %s, %s)", mean.shape, std.shape)
 
-    print("Saving to file...")
+    logger.info("Saving stats to file")
     out_file = SurgeXTDataset.get_stats_file_path(filename)
     if mask_degenerate:
         std = _fix_degenerate_bins(std)

--- a/src/synth_setter/utils/callbacks.py
+++ b/src/synth_setter/utils/callbacks.py
@@ -313,7 +313,6 @@ class PlotLearntProjection(Callback):
         #     print("wrong projection")
         #     return
 
-        print("plotting")
         fig_ass = self._plot_assignments(pl_module)
         fig_value = self._plot_projections(pl_module)
         self._log_plots(fig_ass, fig_value, trainer)


### PR DESCRIPTION
## What

Replace stray `print()` calls with the modules' loggers in two production code paths.

- **`src/synth_setter/pipeline/data/stats.py`** — convert the nine `print()` calls in `get_stats_hdf5` to the module's existing stdlib `logging` logger (the file already standardizes on `logging.getLogger(__name__)`, used at five other call sites). Messages use lazy `%`-formatting and snake_case-style event text. The two full-array `print("Mean:", ...)` / `print("std:", ...)` dumps collapse into a single shape-logging line so a real mel spec doesn't flood INFO logs with megabyte-scale array text.
- **`src/synth_setter/utils/callbacks.py`** — delete the stray `print("plotting")` debug breadcrumb in `PlotLearntProjection._do_plotting`. It sat directly below commented-out debug `print(...)` lines and the callback emits no other logging, so it was leftover noise rather than an intentional log line. `utils/` is non-pipeline code; per CLAUDE.md it would use stdlib `logging` if a log line were warranted, but there is no signal to keep here.

## Why

`print()` in production code bypasses log levels, handlers, and structured fields, and the array dumps were a real noise hazard on production-sized data. No active `print()` remains in either file (the two commented-out prints in `callbacks.py` are pre-existing unrelated dead code, left untouched to keep the diff focused).

## Testing

- `uv run pytest tests/pipeline/data/test_stats.py tests/test_callbacks.py -q` -> 40 passed.
- `make test-fast` -> 1752 passed, 6 skipped.
- `make format` (ruff, ruff-format, pydoclint, prettier, mdformat, gitlint) clean on the two changed files; `pyright` clean.

No test asserted on the removed `print()` output, so no test changes were needed.

Refs #1475