### PR TITLE
chore(r2): preserve exception cause on generate_dataset failure path

### DIFF
--- a/src/synth_setter/pipeline/r2_io.py
+++ b/src/synth_setter/pipeline/r2_io.py
@@ -333,6 +333,9 @@ def object_size(r2_uri: str) -> int | None:
 
     A zero-size object exists and returns ``0``. Callers that want to treat zero-size as absent
     (e.g. defending against half-uploaded objects) test ``size and size > 0`` themselves.
+
+    :raises RuntimeError: stdout is non-empty but not an integer; chained to the
+        underlying ``ValueError`` so the probed URI survives the failure path.
     """
     args = [  # noqa: S607 — rclone resolved by image's PATH
         "rclone",
@@ -344,7 +347,16 @@ def object_size(r2_uri: str) -> int | None:
         args, check=True, capture_output=True, text=True
     )
     out = result.stdout.strip()
-    return int(out) if out else None
+    if not out:
+        return None
+    try:
+        return int(out)
+    except ValueError as exc:
+        # Chain the parse failure so the probed URI and rclone payload survive
+        # the generate failure path instead of a bare ``invalid literal``.
+        raise RuntimeError(
+            f"rclone lsf --format=s returned unparsable size {out!r} for {r2_uri}"
+        ) from exc
 
 
 def purge_prefix(bucket: str, prefix: str) -> None:

--- a/tests/pipeline/test_r2_io.py
+++ b/tests/pipeline/test_r2_io.py
@@ -565,6 +565,19 @@ class TestObjectSize:
             with pytest.raises(subprocess.CalledProcessError):
                 r2_io.object_size("r2://bucket/key.h5")
 
+    def test_non_integer_stdout_raises_with_original_cause(self) -> None:
+        """Unparsable rclone stdout raises a contextual error chained to the ValueError.
+
+        Guards the generate failure path: ``int(out)`` on garbage stdout would
+        otherwise surface a bare ``invalid literal for int()`` with no probed
+        URI, losing the rclone-listing context. The re-raise must keep the
+        original ``ValueError`` as ``__cause__``.
+        """
+        with patch.object(r2_io.subprocess, "run", return_value=self._mock_run("not-a-number")):
+            with pytest.raises(RuntimeError, match="r2://bucket/key.h5") as excinfo:
+                r2_io.object_size("r2://bucket/key.h5")
+        assert isinstance(excinfo.value.__cause__, ValueError)
+
     def test_invokes_rclone_lsf_format_s(self) -> None:
         """Probe argv shape: rclone lsf --format=s <translated path>.
 


### PR DESCRIPTION
## What

On the `generate` dataset failure path, `r2_io.object_size` parsed `rclone lsf --format=s` stdout with a bare `int(out)`. Non-integer stdout (an unexpected listing, garbage, a protocol change) raised a context-free `ValueError: invalid literal for int()` that named neither the probed URI nor the rclone payload. As that error propagated up through `generate()`'s `except BaseException` / `finally`, the cause was effectively lost — the operator saw only the literal-parse failure with no provenance.

The anchored line (`generate_dataset.py:348`) is a bare `raise` that already preserves context; the genuine cause-loss reachable on that failure path is this implicit `int()` parse in the R2 probe each shard calls via `_render_one_owned_shard`.

## Change

- Guard the `int(out)` parse in `object_size`; on `ValueError`, re-raise a contextual `RuntimeError` (naming the probed URI and the offending payload) chained via `from exc`, preserving the original `ValueError` as `__cause__`.
- Keep the empty-stdout → `None` and zero-size → `0` semantics unchanged.
- Document the new `:raises RuntimeError:` contract.

## Test

`test_non_integer_stdout_raises_with_original_cause` (added first, Red→Green) asserts the contextual message includes the probed URI and that `excinfo.value.__cause__` is the original `ValueError`.

Refs #1475
