### PR TITLE
test(testing): replace sleep-sync and mock-only test assertions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 """This file prepares config fixtures for other tests."""
 
+import copy
 import os
 import shutil
 import subprocess
 import sys
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 import h5py
 import hdf5plugin  # noqa: F401   side-effect import: registers HDF5_PLUGIN_PATH so h5py can load Blosc2 filters in fixtures
@@ -17,6 +20,7 @@ from hydra.core.global_hydra import GlobalHydra
 from omegaconf import DictConfig, open_dict
 
 from synth_setter.data.vst import core, param_specs, preset_paths
+from synth_setter.pipeline.schemas.spec import DatasetSpec
 from synth_setter.resources import vst_headless_wrapper
 from synth_setter.utils.utils import register_resolvers
 from synth_setter.workspace import operator_workspace
@@ -741,6 +745,60 @@ def install_fake_plugin(
     monkeypatch.setattr(core, "load_plugin", lambda _path, **_kw: fake_vst3_plugin)
     monkeypatch.setattr(core, "VST3Plugin", lambda _path: fake_vst3_plugin)
     return fake_vst3_plugin
+
+
+def _base_dataset_spec_kwargs() -> dict[str, Any]:
+    """Return the skeleton shared by hand-built ``DatasetSpec`` test specs.
+
+    Carries the fields both the wandb-tracking and parallel-dispatch tests fix
+    identically (deterministic ``created_at`` / ``git_sha``, hdf5 output, the
+    Darwin-portable ``gui_toggle_cadence``); per-test fields (``task_name``,
+    ``run_id``, ``r2``, shard sizes, ``parallel``) come in as overrides.
+
+    :returns: A fresh kwargs dict safe for in-place override per call.
+    """
+    return {
+        "created_at": datetime(2026, 5, 20, 0, 0, 0, tzinfo=timezone.utc),
+        "git_sha": "0" * 40,
+        "is_repo_dirty": False,
+        "output_format": "hdf5",
+        "base_seed": 42,
+        "render": {
+            "plugin_path": "plugins/fake.vst3",
+            "preset_path": "presets/fake.vstpreset",
+            "param_spec_name": "surge_simple",
+            "renderer_version": "0.0.0-fake",
+            "sample_rate": 44100,
+            "channels": 2,
+            "velocity": 100,
+            "signal_duration_seconds": 1.0,
+            "min_loudness": -60.0,
+            # Darwin-portable (#714).
+            "gui_toggle_cadence": "never",
+        },
+    }
+
+
+@pytest.fixture()
+def dataset_spec_factory() -> Callable[..., DatasetSpec]:
+    """Build a ``DatasetSpec`` from the shared skeleton plus per-test overrides.
+
+    ``render`` overrides deep-merge into the skeleton's ``render`` block; all
+    other keyword arguments replace top-level fields. Consolidates the
+    previously duplicated ``_build_spec`` helpers in the wandb-tracking and
+    parallel-dispatch tests.
+
+    :returns: ``factory(*, render=None, **overrides) -> DatasetSpec``.
+    """
+
+    def factory(*, render: dict[str, Any] | None = None, **overrides: Any) -> DatasetSpec:
+        kwargs = copy.deepcopy(_base_dataset_spec_kwargs())
+        if render is not None:
+            kwargs["render"].update(render)
+        kwargs.update(overrides)
+        return DatasetSpec(**kwargs)  # type: ignore[arg-type]
+
+    return factory
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/data/test_ot.py
+++ b/tests/data/test_ot.py
@@ -17,7 +17,8 @@ assignment is genuinely the minimum-cost one. This catches subtle bugs the
 from __future__ import annotations
 
 import itertools
-from typing import Iterator, TypeVar
+from collections.abc import Iterator
+from typing import TypeVar
 from unittest.mock import patch
 
 import numpy as np
@@ -178,7 +179,8 @@ class TestHungarianMatchPermutation:
     """The returned ordering must be a bijection over [0, B-1]."""
 
     def test_returned_params_are_a_permutation_of_input(self) -> None:
-        """No row is duplicated or dropped — output params is a bijective row-permutation of input.
+        """No row is duplicated or dropped — output params is a bijective row-permutation of
+        input.
 
         A row-equality matrix between input and output rows must be a permutation matrix (exactly
         one True per row and per column), which rules out duplicates or drops even when input rows
@@ -475,23 +477,33 @@ class TestOtCollateTuple:
     """`_ot_collate_tuple` collates then applies :func:`_hungarian_match` to (noise, params,
     sins)."""
 
-    def test_calls_hungarian_match_with_three_aligned_tensors(self) -> None:
-        """The OT call sees noise, params, and sins — three positional args."""
+    def test_sins_co_data_follows_params_under_optimal_pairing(self) -> None:
+        """Real OT pairs noise→params optimally and moves ``sins`` in lockstep.
+
+        Patches only ``torch.randn_like`` to a fixed noise that is ``params``
+        reordered by a known non-identity permutation, so the zero-cost optimal
+        matching *is* that permutation. ``sins`` rows are bonded to their
+        ``params`` rows by index, so asserting the post-OT ``sins`` order equals
+        the permutation proves co-data alignment — not merely that OT was called.
+        """
         sin_fn = object()
-        batch = [(torch.zeros(2, 5), torch.ones(2, 3), sin_fn) for _ in range(2)]
+        # params rows are distinct unit vectors so the optimal pairing is unique.
+        params_pre = torch.eye(4, 3)
+        # Each sins row carries its params index in column 0 for provenance.
+        sins_pre = torch.zeros(4, 5)
+        sins_pre[:, 0] = torch.arange(4, dtype=torch.float32)
+        permutation = [2, 0, 3, 1]
+        fixed_noise = params_pre[permutation].clone()
 
-        with patch(
-            "synth_setter.data.ot._hungarian_match",
-            side_effect=lambda n, p, s: (n, p, s),
-        ) as patched:
-            sins, params, noise, sin_fn_out = _ot_collate_tuple(batch)
+        batch = [(sins_pre[i : i + 1], params_pre[i : i + 1], sin_fn) for i in range(4)]
 
-        patched.assert_called_once()
-        args = patched.call_args.args
-        assert len(args) == 3
-        assert args[0].shape == (4, 3)  # noise (matches params shape)
-        assert args[1].shape == (4, 3)  # params
-        assert args[2].shape == (4, 5)  # sins
+        with patch("synth_setter.data.ot.torch.randn_like", return_value=fixed_noise.clone()):
+            sins_out, params_out, noise_out, sin_fn_out = _ot_collate_tuple(batch)
+
+        # Zero-cost match: each noise row paired with the identical params row.
+        torch.testing.assert_close(noise_out, params_out)
+        # sins must be reordered by the same permutation that aligns params to noise.
+        assert sins_out[:, 0].tolist() == [float(p) for p in permutation]
         assert sin_fn_out is sin_fn
 
     def test_end_to_end_with_real_hungarian_match_returns_optimal_pairing(self) -> None:
@@ -511,9 +523,7 @@ class TestOtCollateTuple:
         fixed_noise = torch.randn(4, 3, generator=torch.Generator().manual_seed(99))
         brute_force_cost = _brute_force_optimal_cost(fixed_noise, params_pre)
 
-        with patch(
-            "synth_setter.data.ot.torch.randn_like", return_value=fixed_noise.clone()
-        ):
+        with patch("synth_setter.data.ot.torch.randn_like", return_value=fixed_noise.clone()):
             _, params_out, noise_out, _ = _ot_collate_tuple(batch)
 
         hungarian_cost = _total_pairwise_cost(noise_out, params_out)

--- a/tests/data/vst/test_core.py
+++ b/tests/data/vst/test_core.py
@@ -87,15 +87,34 @@ class TestLoadPluginNoWarmup:
 
 
 class TestWarmupPlugin:
-    """``warmup_plugin`` runs ``show_editor`` on the passed-in plugin once."""
+    """``warmup_plugin`` runs ``show_editor`` once and sets the close event so it returns."""
 
-    def test_warmup_plugin_calls_show_editor(self) -> None:
-        """``warmup_plugin`` invokes ``show_editor`` exactly once on the supplied plugin."""
-        fake_plugin = MagicMock()
+    def test_warmup_plugin_opens_editor_once_and_sets_close_event(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``warmup_plugin`` opens the editor once and signals close so the call unblocks.
 
-        warmup_plugin(fake_plugin)
+        Drives the real ``FakeVST3Plugin``, whose ``show_editor`` blocks on
+        ``close_event.wait()``. ``warmup_plugin`` returning at all proves it set
+        the event; the recorded event's ``is_set()`` pins that observable effect
+        rather than merely asserting the method was invoked.
 
-        fake_plugin.show_editor.assert_called_once()
+        :param monkeypatch: Shrinks ``_EDITOR_INIT_DELAY_SECONDS`` so the
+            production close-timer fires promptly — the delay value is not under
+            test, only that the event ends up set.
+        """
+        monkeypatch.setattr(core, "_EDITOR_INIT_DELAY_SECONDS", 0.0)
+        opened: list[threading.Event] = []
+
+        class _RecordingPlugin(FakeVST3Plugin):
+            def show_editor(self, close_event: threading.Event) -> None:
+                opened.append(close_event)
+                super().show_editor(close_event)
+
+        warmup_plugin(cast("VST3Plugin", _RecordingPlugin("plugins/Surge XT.vst3")))
+
+        assert len(opened) == 1
+        assert opened[0].is_set()
 
 
 class TestRunWithEditorHeldOpen:
@@ -218,10 +237,17 @@ class TestRunWithEditorHeldOpen:
         """
         monkeypatch.setattr(core, "_EDITOR_JOIN_TIMEOUT_SECONDS", 1.0)
         fake_plugin = MagicMock()
-        fake_plugin.show_editor.side_effect = lambda event: event.wait(timeout=5.0)
+
+        # ``body_started`` releases ``show_editor`` the instant the worker is
+        # running, so the editor returns while the body is still mid-flight —
+        # the "slow finish" race — without a wall-clock sleep. The body then
+        # raises within the join window, exercising body-exception precedence
+        # over the leak path.
+        body_started = threading.Event()
+        fake_plugin.show_editor.side_effect = lambda event: body_started.wait(timeout=5.0)
 
         def body() -> None:
-            time.sleep(0.05)
+            body_started.set()
             raise ValueError("body slow-failed")
 
         with pytest.raises(ValueError, match="body slow-failed"):

--- a/tests/data/vst/test_preset_coverage.py
+++ b/tests/data/vst/test_preset_coverage.py
@@ -15,18 +15,17 @@ Pattern compared:
 
 import os
 import sys
-import threading
-import time
 from pathlib import Path
 
 import pytest
 from pedalboard import VST3Plugin
 
+from synth_setter.data.vst.core import warmup_plugin
+
 _PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
 _PRESET_DIR = Path("presets")
 _SAMPLE_RATE = 44100.0
 _CHANNELS = 2
-_EDITOR_SLEEP_S = 0.5
 _FLUSH_DURATION_S = 32.0
 _FLUSH_BLOCK_SIZE = 2048
 
@@ -49,20 +48,6 @@ def _flush(plugin: VST3Plugin) -> None:
     """Run a silent process()+reset() to commit pending preset state."""
     plugin.process([], _FLUSH_DURATION_S, _SAMPLE_RATE, _CHANNELS, _FLUSH_BLOCK_SIZE, True)
     plugin.reset()
-
-
-def _open_editor_briefly(plugin: VST3Plugin) -> None:
-    """Open and close the plugin editor (the spotify/pedalboard#394 workaround)."""
-    stop_event = threading.Event()
-
-    def _closer() -> None:
-        time.sleep(_EDITOR_SLEEP_S)
-        stop_event.set()
-
-    t = threading.Thread(target=_closer, daemon=True)
-    t.start()
-    plugin.show_editor(stop_event)
-    t.join(timeout=1.0)
 
 
 def _read_all_params(plugin: VST3Plugin) -> dict[str, float]:
@@ -89,7 +74,9 @@ def test_flush_pattern_matches_show_editor_pattern(preset_path: str) -> None:
     no_editor_state = _read_all_params(p_no)
 
     p_we = VST3Plugin(_PLUGIN_PATH)
-    _open_editor_briefly(p_we)
+    # Production's editor warm-up (spotify/pedalboard#394): show_editor closes via
+    # the threading.Event the editor exposes, not a test-local wall-clock sleep.
+    warmup_plugin(p_we)
     p_we.load_preset(preset_path)
     _flush(p_we)
     with_editor_state = _read_all_params(p_we)

--- a/tests/integration/test_parallel_shard_dispatch.py
+++ b/tests/integration/test_parallel_shard_dispatch.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import shutil
 import sys
 import textwrap
-from datetime import datetime, timezone
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -59,45 +59,33 @@ def _write_fake_renderer(tmp_path: Path) -> Path:
     return script_path
 
 
-def _build_spec() -> DatasetSpec:
-    """Return a ``DatasetSpec`` with ``num_shards=4`` and ``parallel=True``.
+_RUN_ID = "parallel-dispatch-xplat-20260520T000000000Z"
+
+
+def _build_spec(dataset_spec_factory: Callable[..., DatasetSpec]) -> DatasetSpec:
+    """Build a 4-shard ``parallel=True`` spec from the shared factory.
 
     Pins the renderer/plugin paths to placeholders — the real check is bypassed
     by monkeypatching ``extract_renderer_version`` in the test body, so the
     paths only need to round-trip through Pydantic.
 
+    :param dataset_spec_factory: Shared ``conftest`` factory.
     :returns: Spec yielding 4 shards of ``_SAMPLES_PER_SHARD`` rows each.
     """
-    kwargs: dict[str, object] = {
-        "task_name": "parallel-dispatch-xplat",
-        "run_id": "parallel-dispatch-xplat-20260520T000000000Z",
-        "created_at": datetime(2026, 5, 20, 0, 0, 0, tzinfo=timezone.utc),
-        "git_sha": "0" * 40,
-        "is_repo_dirty": False,
-        "output_format": "hdf5",
-        "train_val_test_sizes": [_SAMPLES_PER_SHARD * _NUM_SHARDS, 0, 0],
-        "base_seed": 42,
-        "r2": {
+    return dataset_spec_factory(
+        task_name="parallel-dispatch-xplat",
+        run_id=_RUN_ID,
+        train_val_test_sizes=[_SAMPLES_PER_SHARD * _NUM_SHARDS, 0, 0],
+        r2={
             "bucket": "parallel-dispatch-bucket",
-            "prefix": "data/parallel-dispatch-xplat/parallel-dispatch-xplat-20260520T000000000Z/",
+            "prefix": f"data/parallel-dispatch-xplat/{_RUN_ID}/",
         },
-        "render": {
-            "plugin_path": "plugins/fake.vst3",
-            "preset_path": "presets/fake.vstpreset",
-            "param_spec_name": "surge_simple",
-            "renderer_version": "0.0.0-fake",
-            "sample_rate": 44100,
-            "channels": 2,
-            "velocity": 100,
-            "signal_duration_seconds": 1.0,
-            "min_loudness": -60.0,
+        render={
             "samples_per_render_batch": _SAMPLES_PER_SHARD,
             "samples_per_shard": _SAMPLES_PER_SHARD,
             "parallel": True,
-            "gui_toggle_cadence": "never",
         },
-    }
-    return DatasetSpec(**kwargs)  # type: ignore[arg-type]
+    )
 
 
 def _wire_generate_into_fake_renderer(
@@ -142,6 +130,7 @@ def test_parallel_dispatch_crosses_real_subprocess_boundary(
     fake_r2_remote: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    dataset_spec_factory: Callable[..., DatasetSpec],
 ) -> None:
     """``parallel=True`` + 4 shards uploads every shard via real subprocess + real rclone.
 
@@ -151,8 +140,9 @@ def test_parallel_dispatch_crosses_real_subprocess_boundary(
     :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
     :param tmp_path: Per-test tmp dir for the fake renderer script.
     :param monkeypatch: Used to pin pool size and swap version/probe/args.
+    :param dataset_spec_factory: Shared ``conftest`` ``DatasetSpec`` factory.
     """
-    spec = _build_spec()
+    spec = _build_spec(dataset_spec_factory)
     assert len(spec.shards) == _NUM_SHARDS
 
     monkeypatch.setenv("SYNTH_SETTER_WORKER_RANK", "0")
@@ -172,6 +162,7 @@ def test_two_ranks_render_disjoint_complete_shard_partition(
     fake_r2_remote: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    dataset_spec_factory: Callable[..., DatasetSpec],
 ) -> None:
     """Two ranks (0/2 + 1/2) over the same spec produce a disjoint, complete shard set.
 
@@ -187,8 +178,9 @@ def test_two_ranks_render_disjoint_complete_shard_partition(
     :param fake_r2_remote: Local-typed rclone remote rooted at a tmp dir.
     :param tmp_path: Per-test tmp dir for the fake renderer script.
     :param monkeypatch: Used by the shared setup helper plus per-rank env injection.
+    :param dataset_spec_factory: Shared ``conftest`` ``DatasetSpec`` factory.
     """
-    spec = _build_spec()
+    spec = _build_spec(dataset_spec_factory)
     assert len(spec.shards) == _NUM_SHARDS
 
     _wire_generate_into_fake_renderer(spec, tmp_path, monkeypatch)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,11 +1,17 @@
 """Tests for ``synth_setter.utils.callbacks._log_figure`` logger dispatch.
 
-Uses ``MagicMock(spec=...)`` so ``isinstance`` checks against the real Lightning
-logger classes pass, without instantiating any backends (no W&B auth prompt,
-no TensorBoard file writes).
+Exercises the real ``_log_figure`` routing against lightweight logger
+stand-ins that subclass the production ``WandbLogger`` / ``TensorBoardLogger``
+(so the ``isinstance`` dispatch fires) but record calls instead of touching any
+backend — no W&B auth prompt, no TensorBoard file writes. Only the leaf logger
+backends are faked; the production routing/rank-gating/argument wiring runs for
+real.
 """
 
-from unittest.mock import MagicMock
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
 
 from lightning.pytorch import Trainer
 from lightning.pytorch.loggers import CSVLogger, TensorBoardLogger, WandbLogger
@@ -14,81 +20,158 @@ from matplotlib.figure import Figure
 from synth_setter.utils.callbacks import _log_figure
 
 
-def _make_trainer(
-    loggers: list[object],
-    global_step: int = 42,
-    is_global_zero: bool = True,
-) -> MagicMock:
-    """Build a stand-in ``Trainer`` exposing ``loggers``, ``global_step``, and rank.
+class _RecordingWandbLogger(WandbLogger):
+    """``WandbLogger`` that records ``log_image`` calls without a W&B backend.
 
-    ``spec=Trainer`` confines the mock to the real ``Trainer`` interface, so a
-    typo'd attribute access in the code under test raises ``AttributeError``
-    instead of silently auto-creating a child mock.
+    Subclasses the production class so ``_log_figure``'s ``isinstance`` branch
+    selects it, but bypasses ``__init__`` so no run is started.
     """
-    trainer = MagicMock(spec=Trainer)
-    trainer.loggers = loggers
-    trainer.global_step = global_step
-    trainer.is_global_zero = is_global_zero
-    return trainer
+
+    def __init__(self) -> None:
+        self.image_calls: list[dict[str, object]] = []
+
+    def log_image(self, key: str, images: list[object], step: int) -> None:
+        """Record the keyword-routed image payload the callback dispatches.
+
+        :param key: Log key the callback routed the figure under.
+        :param images: Single-element list holding the dispatched figure.
+        :param step: Global step the callback tagged the image with.
+        """
+        self.image_calls.append({"key": key, "images": images, "step": step})
+
+
+class _RecordingTensorBoardExperiment:
+    """Stand-in for ``TensorBoardLogger.experiment`` recording ``add_figure``."""
+
+    def __init__(self) -> None:
+        self.figure_calls: list[dict[str, object]] = []
+
+    def add_figure(self, tag: str, figure: object, global_step: int) -> None:
+        """Record the positional/keyword payload the callback dispatches.
+
+        :param tag: TensorBoard tag the callback routed the figure under.
+        :param figure: The dispatched matplotlib figure.
+        :param global_step: Global step the callback tagged the figure with.
+        """
+        self.figure_calls.append({"tag": tag, "figure": figure, "global_step": global_step})
+
+
+class _RecordingTensorBoardLogger(TensorBoardLogger):
+    """``TensorBoardLogger`` exposing a recording ``experiment``, no file writes."""
+
+    def __init__(self) -> None:
+        self._recording_experiment = _RecordingTensorBoardExperiment()
+
+    @property
+    def experiment(self) -> _RecordingTensorBoardExperiment:  # type: ignore[override]
+        """Return the recorder in place of the real ``SummaryWriter``."""
+        return self._recording_experiment
+
+
+class _RecordingCSVLogger(CSVLogger):
+    """``CSVLogger`` stand-in; has no image API, so ``_log_figure`` must skip it.
+
+    Any attribute access the callback makes would raise ``AttributeError`` (no
+    ``log_image`` / ``experiment.add_figure``), proving the no-op path is taken.
+    """
+
+    def __init__(self) -> None:
+        pass
+
+
+@dataclass
+class _FakeTrainer:
+    """Minimal ``Trainer`` surface ``_log_figure`` reads: loggers, step, and rank.
+
+    .. attribute :: loggers
+
+       Loggers ``_log_figure`` iterates over for image dispatch.
+
+    .. attribute :: global_step
+
+       Step value the callback stamps onto each emitted figure.
+
+    .. attribute :: is_global_zero
+
+       Rank-0 gate; ``False`` makes ``_log_figure`` a no-op.
+    """
+
+    loggers: list[object]
+    global_step: int = 42
+    is_global_zero: bool = True
+
+
+def _trainer(
+    loggers: list[object], *, global_step: int = 42, is_global_zero: bool = True
+) -> Trainer:
+    """Build a ``_FakeTrainer`` cast to ``Trainer`` for ``_log_figure``'s signature.
+
+    :param loggers: Loggers attached to the fake trainer.
+    :param global_step: Step value the callback stamps onto figures.
+    :param is_global_zero: Rank-0 gate; ``False`` makes ``_log_figure`` a no-op.
+    :returns: The fake narrowed to ``Trainer`` for the call site's type checker.
+    """
+    return cast("Trainer", _FakeTrainer(loggers, global_step, is_global_zero))
 
 
 def test_log_figure_routes_to_wandb_logger_when_only_wandb_logger_present():
     """A lone WandbLogger receives one ``log_image`` call with the figure and step."""
-    wandb_logger = MagicMock(spec=WandbLogger)
-    trainer = _make_trainer([wandb_logger], global_step=42)
-    fig = MagicMock(spec=Figure)
+    wandb_logger = _RecordingWandbLogger()
+    trainer = _trainer([wandb_logger], global_step=42)
+    fig = Figure()
 
     _log_figure(trainer, "plot", fig)
 
-    wandb_logger.log_image.assert_called_once_with(key="plot", images=[fig], step=42)
+    assert wandb_logger.image_calls == [{"key": "plot", "images": [fig], "step": 42}]
 
 
 def test_log_figure_routes_to_tensorboard_logger_when_only_tensorboard_logger_present():
     """A lone TensorBoardLogger receives one ``experiment.add_figure`` call."""
-    tb_logger = MagicMock(spec=TensorBoardLogger)
-    trainer = _make_trainer([tb_logger], global_step=7)
-    fig = MagicMock(spec=Figure)
+    tb_logger = _RecordingTensorBoardLogger()
+    trainer = _trainer([tb_logger], global_step=7)
+    fig = Figure()
 
     _log_figure(trainer, "pos_enc_similarity", fig)
 
-    tb_logger.experiment.add_figure.assert_called_once_with(
-        "pos_enc_similarity", fig, global_step=7
-    )
+    assert tb_logger.experiment.figure_calls == [
+        {"tag": "pos_enc_similarity", "figure": fig, "global_step": 7}
+    ]
 
 
 def test_log_figure_dispatches_to_both_when_both_loggers_present():
     """When both loggers are attached, each receives exactly one call."""
-    wandb_logger = MagicMock(spec=WandbLogger)
-    tb_logger = MagicMock(spec=TensorBoardLogger)
-    trainer = _make_trainer([wandb_logger, tb_logger], global_step=3)
-    fig = MagicMock(spec=Figure)
+    wandb_logger = _RecordingWandbLogger()
+    tb_logger = _RecordingTensorBoardLogger()
+    trainer = _trainer([wandb_logger, tb_logger], global_step=3)
+    fig = Figure()
 
     _log_figure(trainer, "assignment", fig)
 
-    wandb_logger.log_image.assert_called_once_with(key="assignment", images=[fig], step=3)
-    tb_logger.experiment.add_figure.assert_called_once_with("assignment", fig, global_step=3)
+    assert wandb_logger.image_calls == [{"key": "assignment", "images": [fig], "step": 3}]
+    assert tb_logger.experiment.figure_calls == [
+        {"tag": "assignment", "figure": fig, "global_step": 3}
+    ]
 
 
 def test_log_figure_is_noop_when_no_image_capable_loggers_present():
     """CSV-only setup (the default after #612) stays silent — no calls, no errors."""
-    csv_logger = MagicMock(spec=CSVLogger)
-    trainer = _make_trainer([csv_logger], global_step=5)
-    fig = MagicMock(spec=Figure)
+    csv_logger = _RecordingCSVLogger()
+    trainer = _trainer([csv_logger], global_step=5)
+    fig = Figure()
 
+    # A non-skip would touch ``log_image`` / ``experiment`` on the CSV stand-in
+    # and raise ``AttributeError``; reaching this assertion proves the no-op path.
     _log_figure(trainer, "plot", fig)
-
-    # CSVLogger has no image API; ensure we didn't accidentally invoke anything.
-    assert not csv_logger.method_calls
 
 
 def test_log_figure_is_noop_on_non_zero_rank():
     """Under DDP, only rank 0 should emit — SummaryWriter is not rank-safe."""
-    wandb_logger = MagicMock(spec=WandbLogger)
-    tb_logger = MagicMock(spec=TensorBoardLogger)
-    trainer = _make_trainer([wandb_logger, tb_logger], is_global_zero=False)
-    fig = MagicMock(spec=Figure)
+    wandb_logger = _RecordingWandbLogger()
+    tb_logger = _RecordingTensorBoardLogger()
+    trainer = _trainer([wandb_logger, tb_logger], is_global_zero=False)
+    fig = Figure()
 
     _log_figure(trainer, "plot", fig)
 
-    wandb_logger.log_image.assert_not_called()
-    tb_logger.experiment.add_figure.assert_not_called()
+    assert wandb_logger.image_calls == []
+    assert tb_logger.experiment.figure_calls == []

--- a/tests/test_generate_dataset_wandb.py
+++ b/tests/test_generate_dataset_wandb.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import glob
 import json
 import os
-from datetime import datetime, timezone
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -22,44 +22,28 @@ from synth_setter.cli.generate_dataset import generate
 from synth_setter.pipeline.schemas.spec import DatasetSpec
 from tests.helpers.wandb_offline import read_history_rows, read_run_binary
 
+_RUN_ID = "wandb-track-test-20260520T000000000Z"
 
-def _build_spec() -> DatasetSpec:
-    """Hand-built spec with a fixed ``run_id`` and 2 shards; renderer paths are placeholders.
+
+def _build_spec(dataset_spec_factory: Callable[..., DatasetSpec]) -> DatasetSpec:
+    """Build a 2-shard wandb-tracking spec from the shared factory.
 
     ``extract_renderer_version`` is stubbed in the test so the placeholder
     ``plugin_path`` never has to resolve.
 
+    :param dataset_spec_factory: Shared ``conftest`` factory.
     :returns: Spec with ``num_shards == 2`` and a deterministic ``run_id``.
     """
-    kwargs: dict[str, object] = {
-        "task_name": "wandb-track-test",
-        "run_id": "wandb-track-test-20260520T000000000Z",
-        "created_at": datetime(2026, 5, 20, 0, 0, 0, tzinfo=timezone.utc),
-        "git_sha": "0" * 40,
-        "is_repo_dirty": False,
-        "output_format": "hdf5",
-        "train_val_test_sizes": [8, 0, 0],
-        "base_seed": 42,
-        "r2": {
+    return dataset_spec_factory(
+        task_name="wandb-track-test",
+        run_id=_RUN_ID,
+        train_val_test_sizes=[8, 0, 0],
+        r2={
             "bucket": "wandb-track-bucket",
-            "prefix": "data/wandb-track-test/wandb-track-test-20260520T000000000Z/",
+            "prefix": f"data/wandb-track-test/{_RUN_ID}/",
         },
-        "render": {
-            "plugin_path": "plugins/fake.vst3",
-            "preset_path": "presets/fake.vstpreset",
-            "param_spec_name": "surge_simple",
-            "renderer_version": "0.0.0-fake",
-            "sample_rate": 44100,
-            "channels": 2,
-            "velocity": 100,
-            "signal_duration_seconds": 1.0,
-            "min_loudness": -60.0,
-            "samples_per_render_batch": 4,
-            "samples_per_shard": 4,
-            "gui_toggle_cadence": "never",
-        },
-    }
-    return DatasetSpec(**kwargs)  # type: ignore[arg-type]
+        render={"samples_per_render_batch": 4, "samples_per_shard": 4},
+    )
 
 
 def _offline_wandb_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -85,7 +69,9 @@ def _reset_wandb_session_state() -> None:
 
 
 def test_generate_logs_spec_as_hyperparams_and_artifact_offline(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    dataset_spec_factory: Callable[..., DatasetSpec],
 ) -> None:
     """``generate`` pushes the spec as hyperparams + uploads a spec artifact.
 
@@ -96,10 +82,11 @@ def test_generate_logs_spec_as_hyperparams_and_artifact_offline(
         ``tmp_path/wandb/offline-run-*-<run_id>``.
     :param monkeypatch: Used to pin a hermetic offline ``WANDB_*`` env and stub
         ``object_size`` + ``extract_renderer_version``.
+    :param dataset_spec_factory: Shared ``conftest`` ``DatasetSpec`` factory.
     """
     _offline_wandb_env(monkeypatch, tmp_path)
 
-    spec = _build_spec()
+    spec = _build_spec(dataset_spec_factory)
 
     monkeypatch.setattr(
         "synth_setter.cli.generate_dataset.extract_renderer_version",
@@ -145,7 +132,9 @@ def test_generate_logs_spec_as_hyperparams_and_artifact_offline(
 
 
 def test_generate_logs_per_shard_and_summary_metrics_offline(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    dataset_spec_factory: Callable[..., DatasetSpec],
 ) -> None:
     """``generate`` emits one history row per shard plus a terminal summary row.
 
@@ -159,10 +148,11 @@ def test_generate_logs_per_shard_and_summary_metrics_offline(
         ``tmp_path/wandb/offline-run-*-<run_id>``.
     :param monkeypatch: Used to pin a hermetic offline ``WANDB_*`` env and stub
         ``object_size`` + ``extract_renderer_version``.
+    :param dataset_spec_factory: Shared ``conftest`` ``DatasetSpec`` factory.
     """
     _offline_wandb_env(monkeypatch, tmp_path)
 
-    spec = _build_spec()
+    spec = _build_spec(dataset_spec_factory)
 
     monkeypatch.setattr(
         "synth_setter.cli.generate_dataset.extract_renderer_version",


### PR DESCRIPTION
## What

Test-only cleanup of six test smells (Batch E) — replaces wall-clock sleeps used as thread synchronization and mock-only assertions that never exercised production routing.

## Changes

- **`tests/data/vst/test_preset_coverage.py`** — drop the `time.sleep`-then-set daemon thread in `_open_editor_briefly`; drive the editor warm-up through production `warmup_plugin`, which closes `show_editor` via the `threading.Event` the editor exposes.
- **`tests/data/vst/test_core.py`** (slow-finish test) — gate `show_editor` release on a `body_started` Event instead of `time.sleep(0.05)`, keeping the body-exception-precedence-over-leak race deterministic.
- **`tests/test_callbacks.py`** — exercise the real `_log_figure` dispatch against lightweight logger stand-ins that subclass `WandbLogger`/`TensorBoardLogger` and record calls, so `isinstance` routing, rank-gating, and key/step wiring run for real; mocks are no longer used (backends are faked by the recording subclasses).
- **`tests/data/vst/test_core.py`** (warmup test) — assert the observable effect (editor opened once, close event `is_set()`) via a recording `FakeVST3Plugin` subclass rather than a bare `MagicMock.assert_called_once()`.
- **`tests/data/test_ot.py`** — replace the pass-through `_hungarian_match` patch + `assert_called_once()` with a known-answer optimal-transport check: a fixed non-identity permutation makes the optimal pairing provable, and the test asserts `sins` co-data follows `params` under that permutation.
- **`tests/conftest.py` / `tests/test_generate_dataset_wandb.py` / `tests/integration/test_parallel_shard_dispatch.py`** — promote the shared `_build_spec` skeleton to a `dataset_spec_factory` fixture in the nearest common conftest; both modules consume it with per-test overrides (the two specs were not byte-identical, so distinct fields stay explicit).

## Verification

- Affected non-gated modules: 62 passed.
- `make test-fast`: green for all changed code (two unrelated `tests/test_eval.py` failures are pre-existing xdist worker crashes under memory pressure — both pass in isolation; eval code is untouched).
- `test_preset_coverage` runs the real Surge VST3 under X11, so on this headless box it only collects cleanly; runtime verification needs the plugin/Xvfb env.
- `make format` clean; pyright/pydoclint/ruff pass on all changed files.

Refs #1475
