### PR TITLE
feat(data-pipeline): generate_dataset extras + wandb provenance parity

### DIFF
--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -124,8 +124,10 @@ Source: `src/synth_setter/utils/utils.py:137-148`, called from `src/synth_setter
 
 ### 2g. Provenance metadata (logged once at run start)
 
-`log_wandb_provenance()` (`src/synth_setter/utils/logging_utils.py:64-98`) is called in both
-`src/synth_setter/cli/train.py:89` and `src/synth_setter/cli/eval.py:82`, after `log_hyperparameters()`.
+`log_wandb_provenance()` (`src/synth_setter/utils/logging_utils.py:64-98`) is called on all three
+entrypoints: `src/synth_setter/cli/train.py` and `src/synth_setter/cli/eval.py` after
+`log_hyperparameters()`, and `src/synth_setter/cli/generate_dataset.py` inside `generate()` right
+after `_log_hyperparams()` (covering both the local `main` and worker `from_hydra` paths).
 
 | Key          | Source               | Example                                                 |
 | ------------ | -------------------- | ------------------------------------------------------- |
@@ -175,11 +177,11 @@ ______________________________________________________________________
 
 ## 4. Entry Points
 
-| Entry point                                | W&B usage                                                                                                                                                                            | File                                       |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
-| `src/synth_setter/cli/train.py`            | Full: logger init → hparams → provenance → train metrics → test metrics → teardown                                                                                                   | `src/synth_setter/cli/train.py`            |
-| `src/synth_setter/cli/eval.py`             | Full: logger init → hparams → provenance → test/val metrics (+ optional predictions) → predict-mode `audio/<metric>_{mean,std}` keys from `_log_audio_metrics_to_wandb` → teardown   | `src/synth_setter/cli/eval.py`             |
-| `src/synth_setter/cli/generate_dataset.py` | Dataset-generation: logger init pinned to `spec.run_id` → spec hparams → `<task_name>-input-spec` artifact → per-shard metrics → run summary → `finalize(status)` + `wandb.finish()` | `src/synth_setter/cli/generate_dataset.py` |
+| Entry point                                | W&B usage                                                                                                                                                                                         | File                                       |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `src/synth_setter/cli/train.py`            | Full: logger init → hparams → provenance → train metrics → test metrics → teardown                                                                                                                | `src/synth_setter/cli/train.py`            |
+| `src/synth_setter/cli/eval.py`             | Full: logger init → hparams → provenance → test/val metrics (+ optional predictions) → predict-mode `audio/<metric>_{mean,std}` keys from `_log_audio_metrics_to_wandb` → teardown                | `src/synth_setter/cli/eval.py`             |
+| `src/synth_setter/cli/generate_dataset.py` | Dataset-generation: logger init pinned to `spec.run_id` → spec hparams → provenance → `<task_name>-input-spec` artifact → per-shard metrics → run summary → `finalize(status)` + `wandb.finish()` | `src/synth_setter/cli/generate_dataset.py` |
 
 Both training and eval use `@task_wrapper` which ensures `wandb.finish()` runs even on exception.
 `generate_dataset` brackets `generate(...)` in its own `try/finally` that calls `_close_loggers` — see §5 for the metric / run-id contract.

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -22,13 +22,13 @@ from pathlib import Path
 from typing import Any
 
 import hydra
+import wandb
 from hydra.core.hydra_config import HydraConfig
 from lightning.pytorch.loggers import Logger
 from lightning.pytorch.loggers.wandb import WandbLogger
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
-import wandb
 from synth_setter.cli.finalize_dataset import finalize_from_spec
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.pipeline import r2_io
@@ -50,12 +50,17 @@ from synth_setter.pipeline.spec_io import (
     write_spec_locally,
 )
 from synth_setter.resources import as_file, vst_headless_wrapper
+from synth_setter.utils import extras, log_wandb_provenance, register_resolvers
 from synth_setter.utils.instantiators import instantiate_loggers
 from synth_setter.workspace import operator_workspace
 
 # Side effect only: publish ``PROJECT_ROOT`` so ``${oc.env:PROJECT_ROOT}``
 # in ``configs/paths/default.yaml`` resolves under @hydra.main compose.
 operator_workspace()
+
+# Defensive parity with train.py/eval.py. The dataset compose path uses no
+# ``${mul:}``/``${div:}`` resolvers today, so this is parity-only, not required.
+register_resolvers()
 
 # Worker-side checkout path — baked WORKDIR of the dev-snapshot image, not the
 # launcher's workspace (which may not exist on the worker filesystem).
@@ -296,6 +301,7 @@ def generate(spec: DatasetSpec, work_dir: Path, loggers: list[Logger]) -> None: 
         # ``wandb.finish()`` in the ``finally`` — otherwise the wandb run
         # leaks un-closed on the helper's exception path.
         _log_hyperparams(loggers, spec)
+        log_wandb_provenance()
         _log_spec_artifact(loggers, spec)
         # Fail a misconfigured dataset-copy at launch, before the first render.
         _validate_copy_source(spec)
@@ -793,6 +799,7 @@ def from_hydra(cfg: DictConfig) -> None:
     :param cfg: Composed Hydra dataset cfg supplied by ``@hydra.main`` from
         the worker's argv overrides.
     """
+    extras(cfg)
     spec = spec_from_cfg(cfg)
     loggers = _loggers_pinned_to_spec(cfg, spec)
     generate(spec, Path(cfg.paths.output_dir), loggers)
@@ -817,6 +824,7 @@ def main(cfg: DictConfig) -> None:
         a zero-size train / val / test split (the eval datamodule opens
         all three split files unconditionally).
     """
+    extras(cfg)
     render_cfg = cfg.get("render")
     skip_reason = None if render_cfg is None else _unsupported_cadence_reason(render_cfg)
     if skip_reason is not None:

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -301,7 +301,11 @@ def generate(spec: DatasetSpec, work_dir: Path, loggers: list[Logger]) -> None: 
         # ``wandb.finish()`` in the ``finally`` — otherwise the wandb run
         # leaks un-closed on the helper's exception path.
         _log_hyperparams(loggers, spec)
-        log_wandb_provenance()
+        # Provenance mutates the process-global ``wandb.run``; only stamp it when
+        # a ``WandbLogger`` here owns the run, mirroring ``_close_loggers`` — else
+        # an empty-logger run would stamp a foreign run started elsewhere.
+        if any(isinstance(lg, WandbLogger) for lg in loggers):
+            log_wandb_provenance()
         _log_spec_artifact(loggers, spec)
         # Fail a misconfigured dataset-copy at launch, before the first render.
         _validate_copy_source(spec)

--- a/src/synth_setter/configs/dataset.yaml
+++ b/src/synth_setter/configs/dataset.yaml
@@ -14,6 +14,7 @@ defaults:
   - skypilot_launch: default
   - experiment: ???
   - logger: wandb
+  - extras: default
 
 task_name: ???
 # ``configs/hydra/default.yaml`` interpolates ``${run_name}`` into ``hydra.run.dir``;
@@ -24,6 +25,11 @@ task_name: ???
 run_name: ${task_name}
 output_format: hdf5
 base_seed: 42
+
+# Wandb run tags; parity with train.yaml/eval.yaml. ``extras: default`` sets
+# ``enforce_tags: True`` — a non-empty default keeps that path from prompting/raising.
+# Masked out of ``DatasetSpec`` by ``from_hydra_cfg`` (not a spec field).
+tags: ["dev", "generate_dataset"]
 
 # Optional dataset-copy source. ``null`` samples fresh params (the default).
 # Set ``datasetsrc.copy_dataset_root`` to a directory of source shards to

--- a/tests/helpers/wandb_offline.py
+++ b/tests/helpers/wandb_offline.py
@@ -147,3 +147,53 @@ def _scan_history_rows(wandb_binary: Path) -> list[dict[str, str]]:
         return rows
     finally:
         ds.close()
+
+
+def read_run_config(
+    wandb_binary: Path,
+    *,
+    until: Callable[[dict[str, str]], bool] | None = None,
+    timeout_s: float = _FLUSH_TIMEOUT_S,
+) -> dict[str, str]:
+    """Merge every ``wandb.config`` update in a wandb offline ``run-*.wandb`` binary, last-wins.
+
+    Config records are surfaced separately from history; use this to assert on
+    provenance keys (``github_sha``, ``image_tag``, ``command``) that land in
+    config, not history.
+
+    :param wandb_binary: The offline ``run-*.wandb`` file to decode.
+    :param until: Re-scan until this predicate over the merged config holds; when
+        ``None``, scan exactly once. See ``_poll_until`` for the flush-race and
+        on-timeout semantics.
+    :param timeout_s: Polling upper bound; unused when ``until`` is ``None``.
+    :returns: Merged config; values are JSON-encoded strings as the datastore stores them.
+    """
+    return _poll_until(lambda: _scan_run_config(wandb_binary), until, timeout_s)
+
+
+def _scan_run_config(wandb_binary: Path) -> dict[str, str]:
+    """Single-pass decode of the datastore binary's config records, merged.
+
+    :param wandb_binary: Path to the offline ``run-*.wandb`` file.
+    :returns: Merged config mapping over every config update in this scan.
+    """
+    ds = wandb_datastore.DataStore()
+    ds.open_for_scan(str(wandb_binary))
+    # ``open_for_scan`` opens a file handle; close it each pass so the polling
+    # loop in ``read_run_config`` can't leak one handle per re-scan.
+    try:
+        config: dict[str, str] = {}
+        while True:
+            data = ds.scan_data()
+            if data is None:
+                break
+            rec = wandb_pb.Record()  # pyright: ignore[reportAttributeAccessIssue]
+            rec.ParseFromString(data)
+            if not rec.HasField("config"):
+                continue
+            for item in rec.config.update:
+                key = item.key if item.key else "/".join(item.nested_key)
+                config[key] = item.value_json
+        return config
+    finally:
+        ds.close()

--- a/tests/pipeline/configs/test_dataset_extras_tags.py
+++ b/tests/pipeline/configs/test_dataset_extras_tags.py
@@ -1,0 +1,49 @@
+"""Pin ``dataset.yaml``'s ``extras`` + ``tags`` parity with ``train.yaml`` / ``eval.yaml``.
+
+Composing ``dataset.yaml`` must surface the ``extras: default`` group (so the
+entrypoints' ``extras(cfg)`` call has a config to act on) and a non-empty
+top-level ``tags`` (so ``enforce_tags`` never prompts/raises on the default
+compose). ``tags`` is not a ``DatasetSpec`` field, so the spec round-trip must
+still succeed with it masked out.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from hydra import compose, initialize_config_module
+
+from synth_setter.pipeline.schemas.spec import DatasetSpec
+
+# Local checkout root — pins ``cfg.paths.*`` so the composed
+# ``${oc.env:PROJECT_ROOT}`` / ``${hydra:runtime.output_dir}`` interpolations
+# resolve to a real on-disk path during unit tests (mirrors test_experiment_yamls).
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_dataset_compose_enforce_tags_true_and_default_tags() -> None:
+    """Composing ``dataset.yaml`` carries ``extras.enforce_tags`` and the default ``tags``.
+
+    Parity with ``train.yaml`` / ``eval.yaml``: ``extras: default`` sets
+    ``enforce_tags: True`` and a non-empty ``tags`` keeps that path from
+    prompting/raising on a default compose.
+    """
+    with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
+        cfg = compose(config_name="dataset", overrides=["experiment=generate_dataset/smoke-shard"])
+
+    assert cfg.extras.enforce_tags is True
+    assert cfg.tags == ["dev", "generate_dataset"]
+
+
+def test_dataset_compose_with_tags_still_builds_dataset_spec() -> None:
+    """``from_hydra_cfg`` masks ``tags`` out so the spec still builds with it present."""
+    with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
+        cfg = compose(config_name="dataset", overrides=["experiment=generate_dataset/smoke-shard"])
+    cfg.paths.root_dir = str(REPO_ROOT)
+    cfg.paths.output_dir = str(REPO_ROOT)
+    cfg.paths.work_dir = str(REPO_ROOT)
+
+    spec = DatasetSpec.from_hydra_cfg(cfg)
+
+    assert isinstance(spec, DatasetSpec)
+    assert not hasattr(spec, "tags")

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -1182,6 +1182,32 @@ class TestRun:
         assert captured["src"] == tmp_path / spec.shards[0].filename
         assert captured["existed_at_upload"] is True
 
+    def test_provenance_not_stamped_when_no_wandb_logger(
+        self,
+        patched_subprocess: MagicMock,  # noqa: ARG002
+        spec: DatasetSpec,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``log_wandb_provenance`` is skipped when ``loggers`` owns no ``WandbLogger``.
+
+        Provenance mutates the process-global ``wandb.run``; gating the call on a
+        locally-owned ``WandbLogger`` keeps an empty-logger run from stamping a
+        foreign in-process run, mirroring the ``_close_loggers`` ownership guard.
+
+        :param patched_subprocess: Fixture-activation only; the renderer
+            materializes the shard so the run reaches its summary.
+        :param spec: Fixture-provided single-shard ``DatasetSpec``.
+        :param tmp_path: Caller-supplied work_dir for ``generate()``.
+        :param monkeypatch: Installs the ``log_wandb_provenance`` spy.
+        """
+        provenance = MagicMock()
+        monkeypatch.setattr("synth_setter.cli.generate_dataset.log_wandb_provenance", provenance)
+
+        generate(spec, tmp_path, [])
+
+        provenance.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # build_generate_args — arg construction from spec + shard

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -1483,6 +1483,44 @@ class TestMainDispatchBranches:
         assert isinstance(spec, DatasetSpec)
         assert spec.render.plugin_path == str(TEST_PLUGIN_VST3)
 
+    def test_local_run_applies_extras_writing_tags_and_config_tree(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``main()`` runs ``extras(cfg)`` before generating, materializing its artifacts.
+
+        ``dataset.yaml`` composes ``extras: default`` (``enforce_tags`` +
+        ``print_config`` true) and a non-empty ``tags``, so ``extras(cfg)``
+        exports ``tags.log`` and ``config_tree.log`` to ``cfg.paths.output_dir``.
+        Asserting those files exist verifies the entrypoint applied extras via
+        its observable side effects rather than mocking the call.
+
+        :param monkeypatch: Pytest fixture used to patch argv + ``generate``.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        argv = [
+            "synth-setter-generate-dataset",
+            "experiment=generate_dataset/smoke-shard",
+            f"render.plugin_path={TEST_PLUGIN_VST3}",
+        ]
+        monkeypatch.setattr("sys.argv", argv)
+
+        recorded: dict[str, Path] = {}
+
+        def _fake_run(_spec: object, work_dir: Path, _loggers: object) -> None:
+            recorded["work_dir"] = work_dir
+
+        monkeypatch.setattr(gd, "generate", _fake_run)
+
+        gd.main()
+
+        output_dir = recorded["work_dir"]
+        for artifact in ("tags.log", "config_tree.log"):
+            path = output_dir / artifact
+            assert path.is_file(), f"extras did not write {artifact}"
+            assert path.stat().st_size > 0, f"{artifact} is empty"
+
     def test_compute_template_set_calls_dispatch_via_skypilot(
         self,
         monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -195,6 +195,38 @@ def test_from_hydra_renders_every_shard_to_fake_r2_then_resume_skips(
     )
 
 
+def test_from_hydra_applies_extras_writing_tags_and_config_tree(
+    cfg_dataset: DictConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``from_hydra`` runs ``extras(cfg)`` before rendering, materializing its artifacts.
+
+    Drives the worker entrypoint end-to-end with ``generate`` stubbed so no VST/R2
+    is needed. ``dataset.yaml`` composes ``extras: default`` (``enforce_tags`` +
+    ``print_config`` true) and a non-empty ``tags``, so ``extras`` exports
+    ``tags.log`` and ``config_tree.log`` to ``cfg.paths.output_dir``. Asserting both
+    files exist and are non-empty verifies the entrypoint applied extras via its
+    observable side effects rather than mocking the call.
+
+    :param cfg_dataset: Composed dataset cfg; ``logger`` is nulled so stubbing
+        ``generate`` does not leave a wandb run to instantiate.
+    :param monkeypatch: Stubs ``generate`` to a no-op so only the ``extras`` side
+        effects are exercised.
+    """
+    with open_dict(cfg_dataset):
+        cfg_dataset.logger = None
+    output_dir = Path(cfg_dataset.paths.output_dir)
+
+    monkeypatch.setattr("synth_setter.cli.generate_dataset.generate", lambda *_a, **_k: None)
+
+    from_hydra(cfg_dataset)
+
+    for artifact in ("tags.log", "config_tree.log"):
+        path = output_dir / artifact
+        assert path.is_file(), f"extras did not write {artifact}"
+        assert path.stat().st_size > 0, f"{artifact} is empty"
+
+
 @pytest.mark.slow
 def test_main_skips_schema_invalid_cadence_cell_without_failing(
     tmp_path: Path,

--- a/tests/test_generate_dataset_wandb.py
+++ b/tests/test_generate_dataset_wandb.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import glob
 import json
 import os
+import re
 from collections.abc import Callable
 from pathlib import Path
 
@@ -20,7 +21,7 @@ from lightning.pytorch.loggers.wandb import WandbLogger
 
 from synth_setter.cli.generate_dataset import generate
 from synth_setter.pipeline.schemas.spec import DatasetSpec
-from tests.helpers.wandb_offline import read_history_rows, read_run_binary
+from tests.helpers.wandb_offline import read_history_rows, read_run_binary, read_run_config
 
 _RUN_ID = "wandb-track-test-20260520T000000000Z"
 
@@ -207,3 +208,60 @@ def test_generate_logs_per_shard_and_summary_metrics_offline(
         assert key in summary, (key, summary)
     assert json.loads(summary["generation/samples"]) == 0, summary
     assert json.loads(summary["generation/samples_per_second"]) == 0.0, summary
+
+
+def test_generate_stamps_wandb_provenance_into_run_config_offline(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    dataset_spec_factory: Callable[..., DatasetSpec],
+) -> None:
+    """``generate`` stamps ``github_sha``/``image_tag``/``command`` into the run config.
+
+    Parity with train.py/eval.py: provenance lands in ``wandb.config`` (not
+    history). ``image_tag`` is pinned via ``IMAGE_TAG`` and ``command``/argv via a
+    stubbed ``sys.argv`` so the stamped values — not just the keys — are asserted;
+    ``github_sha`` is a 40-char hex SHA or the ``"unknown"`` git-unavailable
+    sentinel. The run is still closed on return (``wandb.run is None``).
+
+    :param tmp_path: Per-test tmp dir; the offline run lands at
+        ``tmp_path/wandb/offline-run-*-<run_id>``.
+    :param monkeypatch: Used to pin a hermetic offline ``WANDB_*`` env, ``IMAGE_TAG``,
+        ``sys.argv``, and stub ``object_size`` + ``extract_renderer_version``.
+    :param dataset_spec_factory: Shared ``conftest`` ``DatasetSpec`` factory.
+    """
+    _offline_wandb_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("IMAGE_TAG", "test-image:abc123")
+    pinned_argv = ["synth-setter-generate-dataset", "experiment=smoke-shard"]
+    monkeypatch.setattr("sys.argv", pinned_argv)
+
+    spec = _build_spec(dataset_spec_factory)
+
+    monkeypatch.setattr(
+        "synth_setter.cli.generate_dataset.extract_renderer_version",
+        lambda _path: spec.render.renderer_version,
+    )
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.object_size", lambda *_a, **_k: 1_024)
+
+    wandb_logger = WandbLogger(
+        offline=True,
+        save_dir=str(tmp_path),
+        id=spec.run_id,
+        project="wandb-track-test-project",
+    )
+
+    generate(spec, tmp_path, [wandb_logger])
+    assert wandb.run is None, "generate() did not close the wandb run on return"
+
+    binary_files = glob.glob(
+        str(tmp_path / "wandb" / f"offline-run-*-{spec.run_id}" / "run-*.wandb")
+    )
+    assert len(binary_files) == 1, f"expected exactly one .wandb binary, found {binary_files}"
+
+    config = read_run_config(
+        Path(binary_files[0]),
+        until=lambda c: {"github_sha", "image_tag", "command"} <= c.keys(),
+    )
+    assert json.loads(config["command"]) == " ".join(pinned_argv), config
+    assert json.loads(config["image_tag"]) == "test-image:abc123", config
+    sha = json.loads(config["github_sha"])
+    assert sha == "unknown" or re.fullmatch(r"[0-9a-f]{40}", sha), config

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.18.3"
+version = "8.18.4"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What

Brings the `generate_dataset` Hydra entrypoint to the same entrypoint hygiene `train.py` and `eval.py` already apply:

- **`extras(cfg)`** — wires `- extras: default` into `dataset.yaml` and calls `extras(cfg)` at the top of both `@hydra.main` entrypoints (`from_hydra`, `main`).
- **`tags`** — adds a non-empty `tags: ["dev", "generate_dataset"]` default so the stock `enforce_tags: True` path runs as designed instead of prompting/raising. `tags` is config-layer only; `DatasetSpec.from_hydra_cfg` masks it out (no schema change).
- **`log_wandb_provenance()`** — stamps `github_sha` / `image_tag` (`$IMAGE_TAG`) / `command` into the live wandb run inside `generate()`, right after `_log_hyperparams`, covering both the local `main` and worker `from_hydra` paths with one call.
- **`register_resolvers()`** — registered at import for defensive parity with train/eval (documented as parity-only; the dataset compose path uses no `${mul:}`/`${div:}` resolvers today).

## Why

Surfaced while diagnosing the wandb empty-log bug; orthogonal to that fix. Provenance matters more for dataset generation than training — the pipeline already pins `renderer_version` and cross-checks the plugin, so recording which image/SHA rendered a dataset completes that lineage.

## Decisions

- `tags` default is `["dev", "generate_dataset"]` (keeps the `dev` parity marker, adds a self-documenting dataset tag).
- The cadence sweeps (`sweeps/generate_dataset_cadence*.yaml`) are **wandb sweeps**, not Hydra `--multirun`, so the `enforce_tags` multirun hard-raise never fires from them; a non-empty default makes it safe regardless. No sweep edits.
- `@task_wrapper` deliberately not added — `generate()`'s `_close_loggers` finally already handles `wandb.finish()` more carefully. (Out of scope per the issue.)

## Tests

- `tests/pipeline/configs/test_dataset_extras_tags.py` — composition asserts `extras.enforce_tags` + `tags`; spec round-trips with `tags` masked.
- `tests/test_generate_dataset.py::test_from_hydra_applies_extras_writing_tags_and_config_tree` — drives `from_hydra` end-to-end (generate stubbed), asserts `extras` materializes non-empty `tags.log`/`config_tree.log`.
- `tests/pipeline/entrypoints/test_generate_dataset_unit.py` — `main()` applies extras (non-empty artifacts).
- `tests/test_generate_dataset_wandb.py::test_generate_stamps_wandb_provenance_into_run_config_offline` — offline wandb round-trip asserts the stamped `github_sha`/`image_tag`/`command` values.

## Notes

- Regenerates `uv.lock` to 8.18.2 — the 8.18.2 release commit used `[skip ci]` and left the lock at 8.18.1, which the `uv-lock` hook would otherwise flag.
- Deferred: a dataset-tailored `print_order` to silence the train-only `print_config_tree` warnings — tracked in #1480.

Fixes #1464