### PR TITLE
internal-feat(dev): add export/unset-debug-envars make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -249,20 +249,20 @@ train: ## Train the model
 # All vars are expensive — enable only while actively reproducing a crash.
 # CUDA_LAUNCH_BLOCKING serialises kernel launches so tracebacks name the offending kernel.
 export-debug-envars: ## Print CUDA/PyTorch debug export commands (eval $(make export-debug-envars))
-	@echo "export CUDA_LAUNCH_BLOCKING=1"
-	@echo "export TORCH_SHOW_CPP_STACKTRACES=1"
-	@echo "export TORCH_DISTRIBUTED_DEBUG=DETAIL"
-	@echo "export NCCL_DEBUG=INFO"
-	@echo "export TORCH_LOGS=all"
-	@echo "export TORCHDYNAMO_VERBOSE=1"
+	@echo "export CUDA_LAUNCH_BLOCKING=1;"
+	@echo "export TORCH_SHOW_CPP_STACKTRACES=1;"
+	@echo "export TORCH_DISTRIBUTED_DEBUG=DETAIL;"
+	@echo "export NCCL_DEBUG=INFO;"
+	@echo "export TORCH_LOGS=all;"
+	@echo "export TORCHDYNAMO_VERBOSE=1;"
 
 unset-debug-envars: ## Print unset commands to clear CUDA/PyTorch debug variables (eval $(make unset-debug-envars))
-	@echo "unset CUDA_LAUNCH_BLOCKING"
-	@echo "unset TORCH_SHOW_CPP_STACKTRACES"
-	@echo "unset TORCH_DISTRIBUTED_DEBUG"
-	@echo "unset NCCL_DEBUG"
-	@echo "unset TORCH_LOGS"
-	@echo "unset TORCHDYNAMO_VERBOSE"
+	@echo "unset CUDA_LAUNCH_BLOCKING;"
+	@echo "unset TORCH_SHOW_CPP_STACKTRACES;"
+	@echo "unset TORCH_DISTRIBUTED_DEBUG;"
+	@echo "unset NCCL_DEBUG;"
+	@echo "unset TORCH_LOGS;"
+	@echo "unset TORCHDYNAMO_VERBOSE;"
 
 # =====================================================================
 # Docker targets

--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,26 @@ mutmut: ## Run mutation testing
 train: ## Train the model
 	python src/train.py
 
+# Debug env vars — use with eval: eval $(make export-debug-envars)
+# CUDA_LAUNCH_BLOCKING serialises kernel launches so tracebacks point at
+# the offending kernel; the rest add C++ traces, DDP/NCCL verbosity, and
+# torch.compile diagnostics. All are expensive — set only while reproducing.
+export-debug-envars: ## Print CUDA/PyTorch debug export commands (eval $(make export-debug-envars))
+	@echo "export CUDA_LAUNCH_BLOCKING=1"
+	@echo "export TORCH_SHOW_CPP_STACKTRACES=1"
+	@echo "export TORCH_DISTRIBUTED_DEBUG=DETAIL"
+	@echo "export NCCL_DEBUG=INFO"
+	@echo "export TORCH_LOGS=all"
+	@echo "export TORCHDYNAMO_VERBOSE=1"
+
+unset-debug-envars: ## Print unset commands to clear CUDA/PyTorch debug variables (eval $(make unset-debug-envars))
+	@echo "unset CUDA_LAUNCH_BLOCKING"
+	@echo "unset TORCH_SHOW_CPP_STACKTRACES"
+	@echo "unset TORCH_DISTRIBUTED_DEBUG"
+	@echo "unset NCCL_DEBUG"
+	@echo "unset TORCH_LOGS"
+	@echo "unset TORCHDYNAMO_VERBOSE"
+
 # =====================================================================
 # Docker targets
 # =====================================================================

--- a/Makefile
+++ b/Makefile
@@ -246,10 +246,8 @@ mutmut: ## Run mutation testing
 train: ## Train the model
 	python src/train.py
 
-# Debug env vars — use with eval: eval $(make export-debug-envars)
-# CUDA_LAUNCH_BLOCKING serialises kernel launches so tracebacks point at
-# the offending kernel; the rest add C++ traces, DDP/NCCL verbosity, and
-# torch.compile diagnostics. All are expensive — set only while reproducing.
+# All vars are expensive — enable only while actively reproducing a crash.
+# CUDA_LAUNCH_BLOCKING serialises kernel launches so tracebacks name the offending kernel.
 export-debug-envars: ## Print CUDA/PyTorch debug export commands (eval $(make export-debug-envars))
 	@echo "export CUDA_LAUNCH_BLOCKING=1"
 	@echo "export TORCH_SHOW_CPP_STACKTRACES=1"

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -22,13 +22,13 @@ from pathlib import Path
 from typing import Any
 
 import hydra
+import wandb
 from hydra.core.hydra_config import HydraConfig
 from lightning.pytorch.loggers import Logger
 from lightning.pytorch.loggers.wandb import WandbLogger
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
-import wandb
 from synth_setter.cli.finalize_dataset import finalize_from_spec
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.pipeline import r2_io

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.18.3"
+version = "8.18.4"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Adds `export-debug-envars` and `unset-debug-envars` Make targets for toggling the standard CUDA/PyTorch debug variable set
- Use with `eval $(make export-debug-envars)` / `eval $(make unset-debug-envars)`
- Variables covered: `CUDA_LAUNCH_BLOCKING=1`, `TORCH_SHOW_CPP_STACKTRACES=1`, `TORCH_DISTRIBUTED_DEBUG=DETAIL`, `NCCL_DEBUG=INFO`, `TORCH_LOGS=all`, `TORCHDYNAMO_VERBOSE=1`
- Also includes two incidental `make format` fixes: ruff import-order reorder in `generate_dataset.py` and `uv.lock` sync to v8.18.4 (stale after the `[skip ci]` release commit)

Refs #938

## Test plan

- [ ] `make export-debug-envars` prints six `export VAR=value` lines
- [ ] `make unset-debug-envars` prints six `unset VAR` lines
- [ ] `eval $(make export-debug-envars)` sets the vars in the current shell (`echo $CUDA_LAUNCH_BLOCKING` → `1`)
- [ ] `eval $(make unset-debug-envars)` clears them (`echo $CUDA_LAUNCH_BLOCKING` → empty)
- [ ] Both targets appear in `make help` output with their descriptions
