### PR TITLE
build(docker): set diagnostic and allocator env defaults

### DIFF
--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -260,15 +260,15 @@ RUN python3 --version && \
     python3 -c "import sys; exit(0) if sys.version_info[:2] == (3,10) else exit(1)"
 COPY --from=ghcr.io/astral-sh/uv:0.11.2 /uv /uvx /usr/local/bin/
 ENV VIRTUAL_ENV=/venv/main
-# PYTHONDONTWRITEBYTECODE=1 — no .pyc files written in the image
-# PYTHONUNBUFFERED=1 — real-time stdout/stderr under Docker/SLURM log capture
-# PYTHONFAULTHANDLER=1 — C/CUDA segfault traceback (pairs with HYDRA_FULL_ERROR)
 # HYDRA_FULL_ERROR=1 — full Python traceback instead of Hydra's trimmed output
-# PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True — reduces allocator fragmentation
-ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1 \
+# PYTHONDONTWRITEBYTECODE=1 — no .pyc files written in the image
+# PYTHONFAULTHANDLER=1 — C/CUDA segfault traceback (pairs with HYDRA_FULL_ERROR)
+# PYTHONUNBUFFERED=1 — real-time stdout/stderr under Docker/SLURM log capture
+# PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True — reduces CUDA allocator fragmentation (no-op on CPU)
+ENV HYDRA_FULL_ERROR=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
     PYTHONFAULTHANDLER=1 \
-    HYDRA_FULL_ERROR=1 \
+    PYTHONUNBUFFERED=1 \
     PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -261,9 +261,15 @@ RUN python3 --version && \
 COPY --from=ghcr.io/astral-sh/uv:0.11.2 /uv /uvx /usr/local/bin/
 ENV VIRTUAL_ENV=/venv/main
 # PYTHONDONTWRITEBYTECODE=1 — no .pyc files written in the image
-# PYTHONUNBUFFERED=1 — stdout/stderr stream immediately (important for logs)
+# PYTHONUNBUFFERED=1 — real-time stdout/stderr under Docker/SLURM log capture
+# PYTHONFAULTHANDLER=1 — C/CUDA segfault traceback (pairs with HYDRA_FULL_ERROR)
+# HYDRA_FULL_ERROR=1 — full Python traceback instead of Hydra's trimmed output
+# PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True — reduces allocator fragmentation
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    PYTHONFAULTHANDLER=1 \
+    HYDRA_FULL_ERROR=1 \
+    PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 RUN uv venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 RUN python --version && \


### PR DESCRIPTION
## Summary

- Adds `PYTHONFAULTHANDLER=1` — dumps a Python traceback on segfaults/aborts, catching silent C/CUDA layer failures
- Adds `HYDRA_FULL_ERROR=1` — surfaces the full Python traceback instead of Hydra's trimmed one-liner
- Adds `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` — reduces CUDA allocator fragmentation under long training runs (no-op on CPU-only images)
- `PYTHONUNBUFFERED=1` was already set; comment tightened to name the concrete contexts where it matters

All three are permanent defaults: zero runtime cost on the normal path, high diagnostic value on the failure path. Placed in the `python-base` stage so they propagate to every downstream stage (`dev-base`, `devcontainer-tools`, `dev-snapshot`).

## Test plan

- [ ] Docker build passes (`make docker-build` or CI docker-build-validation workflow)
- [ ] Confirm `docker run --rm <image> env | grep -E 'HYDRA|PYTHONFAULTHANDLER|PYTORCH_CUDA_ALLOC_CONF'` shows all three vars

Refs #489