### PR TITLE
feat(generate_dataset): run inline oracle eval once per split

### DIFF
--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -259,7 +259,7 @@ Each trial subprocess opens its own wandb run with `id = spec.run_id`; the
 ### 5f. Inline oracle eval (`oracle_eval_inline=true`)
 
 When `oracle_eval_inline=true`, the local-run path shells out to
-`synth_setter.cli.eval` after `generate(...)` has closed its run.
+`synth_setter.cli.eval` **once per split (train, val, test)** after `generate(...)` has closed its run.
 `_run_oracle_eval_subprocess` (`src/synth_setter/cli/generate_dataset.py`)
 re-opens the same run via `logger.wandb.id=<spec.run_id> +logger.wandb.resume=must`, runs `mode=predict` with `render=surge_simple` to
 re-render the predicted params, and deposits `audio/*` audio-similarity

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -878,7 +878,6 @@ def main(cfg: DictConfig) -> None:
             # generate + finalize already wrote the shards, VDS splits, and
             # stats.npz into output_dir; the splits reference the shards by
             # basename, so read them in place — no R2 round-trip.
-            # Run once per split.
             output_dir = Path(cfg.paths.output_dir)
             for split in ("train", "val", "test"):
                 _run_oracle_eval_subprocess(

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -106,6 +106,7 @@ def _run_oracle_eval_subprocess(
     :raises FileNotFoundError: ``dataset_root`` is missing any finalized split
         or ``stats.npz`` — e.g. a resume where ``finalize_from_spec``
         short-circuited on an existing R2 marker without repopulating it.
+        Also raised when ``predict_file`` itself does not exist.
     """
     missing = [n for n in _ORACLE_EVAL_REQUIRED_ARTIFACTS if not (dataset_root / n).is_file()]
     if missing:
@@ -114,6 +115,11 @@ def _run_oracle_eval_subprocess(
             f"but {missing} are absent. finalize_from_spec short-circuits when R2 already "
             f"holds the dataset.complete marker, leaving output_dir unpopulated on a resume; "
             f"rerun with a fresh paths.output_dir."
+        )
+    if not predict_file.is_file():
+        raise FileNotFoundError(
+            f"predict_file {predict_file} not found; "
+            f"ensure the split HDF5 exists in {dataset_root} before shelling out."
         )
     argv = [
         sys.executable,

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -102,8 +102,7 @@ def _run_oracle_eval_subprocess(
         workers pickle the dataset, but ``SurgeXTDataset`` holds an open h5py
         handle that cannot be pickled.
     :param predict_file: HDF5 split file for the datamodule's predict dataloader
-        (e.g. ``dataset_root / "train.h5"``). Callers loop over all three splits
-        so each is evaluated independently.
+        (e.g. ``dataset_root / "train.h5"``).
     :raises FileNotFoundError: ``dataset_root`` is missing any finalized split
         or ``stats.npz`` — e.g. a resume where ``finalize_from_spec``
         short-circuited on an existing R2 marker without repopulating it.
@@ -879,7 +878,7 @@ def main(cfg: DictConfig) -> None:
             # generate + finalize already wrote the shards, VDS splits, and
             # stats.npz into output_dir; the splits reference the shards by
             # basename, so read them in place — no R2 round-trip.
-            # Run once per split so train/val/test are each evaluated independently.
+            # Run once per split.
             output_dir = Path(cfg.paths.output_dir)
             for split in ("train", "val", "test"):
                 _run_oracle_eval_subprocess(

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -22,13 +22,13 @@ from pathlib import Path
 from typing import Any
 
 import hydra
+import wandb
 from hydra.core.hydra_config import HydraConfig
 from lightning.pytorch.loggers import Logger
 from lightning.pytorch.loggers.wandb import WandbLogger
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
-import wandb
 from synth_setter.cli.finalize_dataset import finalize_from_spec
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.pipeline import r2_io
@@ -75,8 +75,9 @@ def _run_oracle_eval_subprocess(
     *,
     render: RenderConfig,
     num_workers: int,
+    predict_file: Path,
 ) -> None:
-    """Run the fake-oracle eval over ``dataset_root`` to verify the param-array round-trip.
+    """Run the fake-oracle eval over one split of ``dataset_root``.
 
     ``check=True`` so a non-zero eval exit (or wall-clock timeout) propagates
     to the caller.
@@ -100,6 +101,9 @@ def _run_oracle_eval_subprocess(
         spawn-start-method platforms (Darwin) the caller must configure ``0``:
         workers pickle the dataset, but ``SurgeXTDataset`` holds an open h5py
         handle that cannot be pickled.
+    :param predict_file: HDF5 split file for the datamodule's predict dataloader
+        (e.g. ``dataset_root / "train.h5"``). Callers loop over all three splits
+        so each is evaluated independently.
     :raises FileNotFoundError: ``dataset_root`` is missing any finalized split
         or ``stats.npz`` — e.g. a resume where ``finalize_from_spec``
         short-circuited on an existing R2 marker without repopulating it.
@@ -144,6 +148,9 @@ def _run_oracle_eval_subprocess(
         # Forwarded from the generate run so the eval honours the same worker
         # count; pass 0 on Darwin where the open-h5py dataset can't be pickled.
         f"datamodule.num_workers={num_workers}",
+        # Override the datamodule's default predict_file (test.h5) so the caller
+        # can route each invocation to a specific split independently.
+        f"datamodule.predict_file={predict_file}",
         "mode=predict",
     ]
     logger.info(f"oracle_eval_inline subprocess: {argv}")
@@ -872,15 +879,17 @@ def main(cfg: DictConfig) -> None:
             # generate + finalize already wrote the shards, VDS splits, and
             # stats.npz into output_dir; the splits reference the shards by
             # basename, so read them in place — no R2 round-trip.
+            # Run once per split so train/val/test are each evaluated independently.
             output_dir = Path(cfg.paths.output_dir)
-            eval_run_dir = output_dir / "oracle_eval" / spec.run_id
-            _run_oracle_eval_subprocess(
-                output_dir,
-                eval_run_dir,
-                spec.run_id,
-                render=spec.render,
-                num_workers=cfg.datamodule.num_workers,
-            )
+            for split in ("train", "val", "test"):
+                _run_oracle_eval_subprocess(
+                    output_dir,
+                    output_dir / "oracle_eval" / split / spec.run_id,
+                    spec.run_id,
+                    render=spec.render,
+                    num_workers=cfg.datamodule.num_workers,
+                    predict_file=output_dir / f"{split}.h5",
+                )
         return
 
     if cfg.finalize_inline or cfg.oracle_eval_inline:

--- a/tests/integration/test_generate_dataset_cli_wandb_e2e.py
+++ b/tests/integration/test_generate_dataset_cli_wandb_e2e.py
@@ -405,9 +405,8 @@ def test_oracle_eval_inline_resumes_generate_wandb_run(
     generate_run_dir = _find_offline_run_dir(hydra_run_dir)
     generate_run_id = generate_run_dir.name.split("-", 3)[-1]
 
-    # main() writes oracle_eval/<run_id>/ under cfg.paths.output_dir
-    # (= ${hydra:runtime.output_dir}), which the fixture pins to hydra_run_dir.
-    eval_output_dir = hydra_run_dir / "oracle_eval" / generate_run_id
+    # main() writes oracle_eval/<split>/<run_id>/ for each split; check the test split.
+    eval_output_dir = hydra_run_dir / "oracle_eval" / "test" / generate_run_id
     assert eval_output_dir.is_dir(), (
         f"expected eval output dir at {eval_output_dir}; "
         f"main()'s oracle_eval_inline branch did not run with the launcher's run_id"

--- a/tests/integration/test_generate_dataset_cli_wandb_e2e.py
+++ b/tests/integration/test_generate_dataset_cli_wandb_e2e.py
@@ -376,9 +376,9 @@ def test_oracle_eval_inline_resumes_generate_wandb_run(
     One CLI invocation with ``oracle_eval_inline=true`` +
     ``finalize_inline=true`` under ``WANDB_MODE=offline``. After the CLI
     exits, the launcher's hydra dir holds generate's
-    ``offline-run-*-<run_id>``, and its ``oracle_eval/<run_id>/`` subdir
-    holds the eval's; the two ``<run_id>`` slugs must match (the eval
-    child resumed the same wandb run). Generate's dir must carry shard +
+    ``offline-run-*-<run_id>``, and its ``oracle_eval/<split>/<run_id>/``
+    subdir holds the eval's; the two ``<run_id>`` slugs must match (the
+    eval child resumed the same wandb run). Generate's dir must carry shard +
     summary history rows; eval's dir must carry at least one ``audio/*``
     row from the predict-mode oracle eval's audio metrics.
 
@@ -405,7 +405,12 @@ def test_oracle_eval_inline_resumes_generate_wandb_run(
     generate_run_dir = _find_offline_run_dir(hydra_run_dir)
     generate_run_id = generate_run_dir.name.split("-", 3)[-1]
 
-    # main() writes oracle_eval/<split>/<run_id>/ for each split; check the test split.
+    # main() writes oracle_eval/<split>/<run_id>/ for each split.
+    for _split in ("train", "val"):
+        assert (hydra_run_dir / "oracle_eval" / _split / generate_run_id).is_dir(), (
+            f"expected eval output dir for {_split!r} split; "
+            f"oracle_eval_inline subprocess call may have been silently dropped"
+        )
     eval_output_dir = hydra_run_dir / "oracle_eval" / "test" / generate_run_id
     assert eval_output_dir.is_dir(), (
         f"expected eval output dir at {eval_output_dir}; "

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -1705,9 +1705,8 @@ class TestMainDispatchBranches:
         """oracle_eval_inline=true fires the eval subprocess once per split.
 
         Asserts the eval helper fires once per split, reading data **in place**
-        from ``cfg.paths.output_dir`` (no
-        download), with each Hydra run dir isolated under
-        ``output_dir/oracle_eval/<split>/<run_id>/``.
+        from ``cfg.paths.output_dir`` (no download), with each Hydra run dir
+        isolated under ``output_dir/oracle_eval/<split>/<run_id>/``.
 
         :param monkeypatch: Patches argv + the three module-level seams.
         """
@@ -1743,7 +1742,7 @@ class TestMainDispatchBranches:
 
         gd.main()
 
-        # One invocation per split: train, val, test.
+        # One invocation per split.
         assert oracle_mock.call_count == 3
         output_dir = observed["output_dir"]
         assert isinstance(output_dir, Path)
@@ -1781,7 +1780,7 @@ class TestMainDispatchBranches:
         tmp_path: Path,
         spec: DatasetSpec,
     ) -> None:
-        """Helper subprocesses ``synth_setter.cli.eval`` with the contract argv.
+        """Calls ``synth_setter.cli.eval`` as a subprocess and pins the contract argv.
 
         Pins the load-bearing overrides (``experiment=surge/fake_oracle``,
         ``datamodule.dataset_root``, ``ckpt_path=null``, ``mode=predict``), the

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -1704,8 +1704,8 @@ class TestMainDispatchBranches:
     ) -> None:
         """oracle_eval_inline=true fires the eval subprocess once per split.
 
-        Asserts the eval helper fires three times — once each for train, val,
-        and test — reading data **in place** from ``cfg.paths.output_dir`` (no
+        Asserts the eval helper fires once per split, reading data **in place**
+        from ``cfg.paths.output_dir`` (no
         download), with each Hydra run dir isolated under
         ``output_dir/oracle_eval/<split>/<run_id>/``.
 
@@ -1748,7 +1748,8 @@ class TestMainDispatchBranches:
         output_dir = observed["output_dir"]
         assert isinstance(output_dir, Path)
         splits = ("train", "val", "test")
-        for call, split in zip(oracle_mock.call_args_list, splits):
+        split_h5s = ("train.h5", "val.h5", "test.h5")
+        for call, split, split_h5 in zip(oracle_mock.call_args_list, splits, split_h5s):
             dataset_root, run_dir, _run_id = call[0]
             # The whole generation RenderConfig flows through (keyword-only) so
             # the eval re-renders through the same spec; smoke-shard is surge_simple.
@@ -1765,7 +1766,7 @@ class TestMainDispatchBranches:
             # VDS splits already live — not a downloaded copy under oracle_eval/.
             assert dataset_root == output_dir
             # predict_file targets this split's HDF5.
-            assert call.kwargs["predict_file"] == output_dir / f"{split}.h5"
+            assert call.kwargs["predict_file"] == output_dir / split_h5
             # Run dir: oracle_eval/<split>/<run_id>
             assert run_dir.parent.parent.name == "oracle_eval", (
                 f"eval run dir should land under "

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -1702,11 +1702,12 @@ class TestMainDispatchBranches:
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """oracle_eval_inline=true on the local-run branch shells out to synth-setter-eval.
+        """oracle_eval_inline=true fires the eval subprocess once per split.
 
-        Asserts the eval helper fires once reading the data **in place** from
-        ``cfg.paths.output_dir`` (no download), with its Hydra run dir isolated
-        under ``output_dir/oracle_eval/<run_id>/``.
+        Asserts the eval helper fires three times — once each for train, val,
+        and test — reading data **in place** from ``cfg.paths.output_dir`` (no
+        download), with each Hydra run dir isolated under
+        ``output_dir/oracle_eval/<split>/<run_id>/``.
 
         :param monkeypatch: Patches argv + the three module-level seams.
         """
@@ -1742,27 +1743,36 @@ class TestMainDispatchBranches:
 
         gd.main()
 
-        oracle_mock.assert_called_once()
-        dataset_root, run_dir, _run_id = oracle_mock.call_args[0]
-        assert isinstance(dataset_root, Path)
-        # The whole generation RenderConfig flows through (keyword-only) so the eval
-        # re-renders through the same spec; smoke-shard is surge_simple.
-        render_arg = oracle_mock.call_args.kwargs["render"]
-        assert render_arg.param_spec_name == "surge_simple"
-        # The eval inherits the generate run's datamodule worker count verbatim,
-        # so a Darwin override (num_workers=0) reaches the predict DataLoader.
-        assert oracle_mock.call_args.kwargs["num_workers"] == observed["num_workers"]
-        assert render_arg.preset_path == "presets/surge-simple.vstpreset"
-        # plugin_path is the TEST_PLUGIN_VST3 this test overrode at generation —
-        # proving a non-default plugin flows through to the eval re-render.
-        assert render_arg.plugin_path == str(TEST_PLUGIN_VST3)
-        # The eval reads in place from the Hydra output_dir where the shards and
-        # VDS splits already live — not a downloaded copy under oracle_eval/.
-        assert dataset_root == observed["output_dir"]
-        assert run_dir.parent.name == "oracle_eval", (
-            f"eval run dir should land under <output_dir>/oracle_eval/<run_id>/; got {run_dir!r}"
-        )
-        assert run_dir.parent.parent == dataset_root
+        # One invocation per split: train, val, test.
+        assert oracle_mock.call_count == 3
+        output_dir = observed["output_dir"]
+        assert isinstance(output_dir, Path)
+        splits = ("train", "val", "test")
+        for call, split in zip(oracle_mock.call_args_list, splits):
+            dataset_root, run_dir, _run_id = call[0]
+            # The whole generation RenderConfig flows through (keyword-only) so
+            # the eval re-renders through the same spec; smoke-shard is surge_simple.
+            render_arg = call.kwargs["render"]
+            assert render_arg.param_spec_name == "surge_simple"
+            # The eval inherits the generate run's datamodule worker count verbatim,
+            # so a Darwin override (num_workers=0) reaches the predict DataLoader.
+            assert call.kwargs["num_workers"] == observed["num_workers"]
+            assert render_arg.preset_path == "presets/surge-simple.vstpreset"
+            # plugin_path is the TEST_PLUGIN_VST3 this test overrode at generation —
+            # proving a non-default plugin flows through to the eval re-render.
+            assert render_arg.plugin_path == str(TEST_PLUGIN_VST3)
+            # The eval reads in place from the Hydra output_dir where the shards and
+            # VDS splits already live — not a downloaded copy under oracle_eval/.
+            assert dataset_root == output_dir
+            # predict_file targets this split's HDF5.
+            assert call.kwargs["predict_file"] == output_dir / f"{split}.h5"
+            # Run dir: oracle_eval/<split>/<run_id>
+            assert run_dir.parent.parent.name == "oracle_eval", (
+                f"eval run dir should land under "
+                f"<output_dir>/oracle_eval/<split>/<run_id>/; got {run_dir!r}"
+            )
+            assert run_dir.parent.name == split
+            assert run_dir.parent.parent.parent == dataset_root
 
     def test_run_oracle_eval_subprocess_builds_expected_argv(
         self,
@@ -1800,8 +1810,14 @@ class TestMainDispatchBranches:
                 "plugin_path": "plugins/Surge XT.vst3",
             }
         )
+        predict_file = dataset_root / "test.h5"
         gd._run_oracle_eval_subprocess(
-            dataset_root, run_dir, "some-run-id", render=render, num_workers=7
+            dataset_root,
+            run_dir,
+            "some-run-id",
+            render=render,
+            num_workers=7,
+            predict_file=predict_file,
         )
 
         run_mock.assert_called_once()
@@ -1812,7 +1828,7 @@ class TestMainDispatchBranches:
         # Data dir and the eval's Hydra run dir are DISTINCT: the split virtual
         # datasets are read in place beside their shards, while eval outputs
         # (incl. metrics/metrics.json the workflow globs) land under the
-        # oracle_eval/<run_id> run dir.
+        # oracle_eval/<split>/<run_id> run dir.
         assert f"datamodule.dataset_root={dataset_root}" in called_argv
         assert f"hydra.run.dir={run_dir}" in called_argv
         assert dataset_root != run_dir
@@ -1840,6 +1856,8 @@ class TestMainDispatchBranches:
         # Sentinel 7 (no config default) proves the value is forwarded, not hardcoded.
         assert "datamodule.num_workers=7" in called_argv
         assert "mode=predict" in called_argv
+        # predict_file routes the datamodule to this split's HDF5.
+        assert f"datamodule.predict_file={predict_file}" in called_argv
 
     def test_run_oracle_eval_subprocess_missing_local_artifacts_raises(
         self,
@@ -1866,10 +1884,11 @@ class TestMainDispatchBranches:
         with pytest.raises(FileNotFoundError, match=r"test\.h5"):
             gd._run_oracle_eval_subprocess(
                 tmp_path,
-                tmp_path / "oracle_eval" / "rid",
+                tmp_path / "oracle_eval" / "test" / "rid",
                 "rid",
                 render=spec.render,
                 num_workers=0,
+                predict_file=tmp_path / "test.h5",
             )
 
         run_mock.assert_not_called()

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -1825,10 +1825,8 @@ class TestMainDispatchBranches:
         assert "-m" in called_argv
         assert "synth_setter.cli.eval" in called_argv
         assert "experiment=surge/fake_oracle" in called_argv
-        # Data dir and the eval's Hydra run dir are DISTINCT: the split virtual
-        # datasets are read in place beside their shards, while eval outputs
-        # (incl. metrics/metrics.json the workflow globs) land under the
-        # oracle_eval/<split>/<run_id> run dir.
+        # dataset_root and run_dir are distinct: split virtual datasets are
+        # read in place beside their shards; eval outputs land in run_dir.
         assert f"datamodule.dataset_root={dataset_root}" in called_argv
         assert f"hydra.run.dir={run_dir}" in called_argv
         assert dataset_root != run_dir
@@ -1889,6 +1887,44 @@ class TestMainDispatchBranches:
                 render=spec.render,
                 num_workers=0,
                 predict_file=tmp_path / "test.h5",
+            )
+
+        run_mock.assert_not_called()
+
+    def test_run_oracle_eval_subprocess_missing_predict_file_raises(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        spec: DatasetSpec,
+    ) -> None:
+        """Non-existent ``predict_file`` ⇒ ``FileNotFoundError`` before subprocess.
+
+        All required artifacts are present in ``dataset_root`` so the existing
+        preflight passes; the ``predict_file``-specific check then catches the
+        absent path before shelling out.
+
+        :param monkeypatch: Patches ``subprocess.run`` to assert it never fires.
+        :param tmp_path: Roots the dataset dir and a missing predict path.
+        :param spec: Source of a valid ``RenderConfig`` for the call signature.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        run_mock = MagicMock()
+        monkeypatch.setattr(gd.subprocess, "run", run_mock)
+
+        dataset_root = tmp_path / "data"
+        dataset_root.mkdir()
+        for name in ("train.h5", "val.h5", "test.h5", "stats.npz"):
+            (dataset_root / name).touch()
+
+        with pytest.raises(FileNotFoundError, match=r"predict_file"):
+            gd._run_oracle_eval_subprocess(
+                dataset_root,
+                tmp_path / "oracle_eval" / "test" / "rid",
+                "rid",
+                render=spec.render,
+                num_workers=0,
+                predict_file=tmp_path / "nonexistent_split.h5",
             )
 
         run_mock.assert_not_called()

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -379,7 +379,7 @@ def test_oracle_eval_inline_writes_bounded_audio_metrics(
             f"--- STDERR (tail) ---\n{result.stderr[-2000:]}"
         )
 
-        # One metrics.json per split (train/val/test): oracle_eval/<split>/<run_id>/.
+        # One metrics.json per split: oracle_eval/<split>/<run_id>/.
         metrics_files = list(run_dir.glob("oracle_eval/*/*/metrics/metrics.json"))
         assert len(metrics_files) == 3, (
             f"expected three oracle-eval metrics.json files (one per split) under "

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -379,28 +379,42 @@ def test_oracle_eval_inline_writes_bounded_audio_metrics(
             f"--- STDERR (tail) ---\n{result.stderr[-2000:]}"
         )
 
-        metrics_files = list(run_dir.glob("oracle_eval/*/metrics/metrics.json"))
-        assert len(metrics_files) == 1, (
-            f"expected one oracle-eval metrics.json under {run_dir}/oracle_eval/; "
-            f"got {metrics_files}"
+        # One metrics.json per split (train/val/test): oracle_eval/<split>/<run_id>/.
+        metrics_files = list(run_dir.glob("oracle_eval/*/*/metrics/metrics.json"))
+        assert len(metrics_files) == 3, (
+            f"expected three oracle-eval metrics.json files (one per split) under "
+            f"{run_dir}/oracle_eval/; got {metrics_files}"
         )
-        metrics = json.loads(metrics_files[0].read_text())
-
-        for name in _ORACLE_AUDIO_METRICS:
-            for stat in ("mean", "std"):
-                key = f"audio/{name}_{stat}"
-                value = metrics.get(key)
-                assert isinstance(value, float) and math.isfinite(value), (
-                    f"{key} is not a finite float: {value!r} (metrics={metrics})"
-                )
-
-        # fake_oracle returns params verbatim, so the re-rendered audio matches
-        # the target up to Surge XT render jitter: mean distances stay under the
-        # canonical envelope and the rms cosine stays above its floor.
         bounds = ORACLE_AUDIO_METRIC_BOUNDS
-        assert metrics["audio/mss_mean"] < bounds.mss_max, metrics
-        assert metrics["audio/wmfcc_mean"] < bounds.wmfcc_max, metrics
-        assert metrics["audio/sot_mean"] < bounds.sot_max, metrics
-        assert metrics["audio/rms_mean"] > bounds.rms_min, metrics
+        for mf in metrics_files:
+            metrics = json.loads(mf.read_text())
+            for name in _ORACLE_AUDIO_METRICS:
+                for stat in ("mean", "std"):
+                    key = f"audio/{name}_{stat}"
+                    value = metrics.get(key)
+                    assert isinstance(value, float) and math.isfinite(value), (
+                        f"{key} is not a finite float: {value!r} (split={mf.parent.parent.parent.name}, "
+                        f"metrics={metrics})"
+                    )
+
+            # fake_oracle returns params verbatim, so the re-rendered audio matches
+            # the target up to Surge XT render jitter: mean distances stay under the
+            # canonical envelope and the rms cosine stays above its floor.
+            assert metrics["audio/mss_mean"] < bounds.mss_max, (
+                mf.parent.parent.parent.name,
+                metrics,
+            )
+            assert metrics["audio/wmfcc_mean"] < bounds.wmfcc_max, (
+                mf.parent.parent.parent.name,
+                metrics,
+            )
+            assert metrics["audio/sot_mean"] < bounds.sot_max, (
+                mf.parent.parent.parent.name,
+                metrics,
+            )
+            assert metrics["audio/rms_mean"] > bounds.rms_min, (
+                mf.parent.parent.parent.name,
+                metrics,
+            )
     finally:
         r2_io.purge_prefix(cfg_dataset.r2.bucket, prefix)


### PR DESCRIPTION
## Summary

- `_run_oracle_eval_subprocess` gains a `predict_file: Path` keyword-only parameter that routes the datamodule's predict DataLoader to a specific split HDF5.
- `main()` now loops over `("train", "val", "test")` and invokes `_run_oracle_eval_subprocess` once per split, writing run dirs under `oracle_eval/<split>/<run_id>/` instead of the single `oracle_eval/<run_id>/`.
- Test coverage updated across unit, integration-r2, and wandb-e2e layers to assert 3 subprocess calls and verify per-split `predict_file` routing.

## Test plan

- [ ] `make test-fast` passes (unit tests for the new 3-call loop, per-call `predict_file` kwarg, and `oracle_eval/<split>/<run_id>/` path structure)
- [ ] `test_run_oracle_eval_subprocess_builds_expected_argv` asserts `datamodule.predict_file=` in subprocess argv
- [ ] `test_oracle_eval_inline_writes_bounded_audio_metrics` (integration_r2 + slow): 3 metrics files under `oracle_eval/*/*/metrics/metrics.json`, bounds checked per split
- [ ] `test_oracle_eval_inline_resumes_generate_wandb_run` (e2e wandb): train/val/test `oracle_eval/<split>/<run_id>/` dirs all present

Fixes #1484