### PR TITLE
docs(agents): probe VST/R2 before skipping; add auto-skip hook + tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,23 @@ python3 -c "import torch; print('cuda:', torch.cuda.is_available(), 'count:', to
 Only skip if BOTH report no usable GPU. If they disagree, document it as an
 environment/setup mismatch — not "no GPU available".
 
+## VST and R2 verification
+
+This devcontainer ships `SYNTH_SETTER_PLUGIN_PATH` (Surge XT VST) and
+`RCLONE_CONFIG_R2_*` (Cloudflare R2 credentials). Before labelling a
+`@pytest.mark.requires_vst` or `@pytest.mark.integration_r2` test as
+unrunnable, probe:
+
+```bash
+ls "${SYNTH_SETTER_PLUGIN_PATH:-plugins/Surge XT.vst3}"
+rclone lsd r2:
+```
+
+Both succeed in this devcontainer. **Run — do not skip — these tests.**
+`make test-vst-cpu` covers `requires_vst`; `uv run pytest -m "integration_r2" -v`
+covers R2 e2e. In PR verification tables, list actual pass/fail results rather
+than "SKIP: requires VST / R2".
+
 ## Commands
 
 ```bash

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-"""This file prepares config fixtures for other tests."""
+"""Config fixtures and collection-time skip hooks for the test suite."""
 
 import copy
 import os
@@ -56,9 +56,8 @@ _VST_SUBPROCESS_TIMEOUT_SECONDS = 600
 
 NUM_FIXTURE_SAMPLES = 5
 
-# Probed once at module import so pytest_collection_modifyitems doesn't re-probe per item.
-# _R2_AVAILABLE uses the env var (fast, no network); AGENTS.md's `rclone lsd r2:` is
-# the interactive verification command, not the skip criterion.
+# Probed once at module import; _R2_AVAILABLE uses the env var (no network hit)
+# — AGENTS.md's `rclone lsd r2:` is for interactive verification, not the skip criterion.
 _VST_AVAILABLE = Path(_SURGE_FIXTURE_PLUGIN_PATH).exists()
 _R2_AVAILABLE = bool(os.environ.get("RCLONE_CONFIG_R2_ACCESS_KEY_ID"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,26 +56,17 @@ _VST_SUBPROCESS_TIMEOUT_SECONDS = 600
 
 NUM_FIXTURE_SAMPLES = 5
 
-# Probe results cached at collection time so pytest_collection_modifyitems
-# can skip unavailable-resource tests without re-probing per item.
+# Probed once at module import so pytest_collection_modifyitems doesn't re-probe per item.
+# _R2_AVAILABLE uses the env var (fast, no network); AGENTS.md's `rclone lsd r2:` is
+# the interactive verification command, not the skip criterion.
 _VST_AVAILABLE = Path(_SURGE_FIXTURE_PLUGIN_PATH).exists()
 _R2_AVAILABLE = bool(os.environ.get("RCLONE_CONFIG_R2_ACCESS_KEY_ID"))
 
 
-def pytest_configure(config: pytest.Config) -> None:
-    """Cache VST and R2 availability on the config object for the skip hook.
-
-    :param config: pytest config object; receives ``_vst_available`` and ``_r2_available`` attrs.
-    """
-    config._vst_available = _VST_AVAILABLE  # type: ignore[attr-defined]
-    config._r2_available = _R2_AVAILABLE  # type: ignore[attr-defined]
-
-
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     """Auto-skip requires_vst / integration_r2 tests when resources are absent.
 
-    :param config: pytest config carrying the pre-probed availability flags.
-    :param items: collected test items, mutated in-place.
+    :param items: mutated in-place to insert skip markers for missing resources.
     """
     skip_vst = pytest.mark.skip(
         reason=f"Surge XT VST not found at {_SURGE_FIXTURE_PLUGIN_PATH!r} "
@@ -86,9 +77,9 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         "run `rclone lsd r2:` to verify"
     )
     for item in items:
-        if "requires_vst" in item.keywords and not config._vst_available:  # type: ignore[attr-defined]
+        if "requires_vst" in item.keywords and not _VST_AVAILABLE:
             item.add_marker(skip_vst)
-        if "integration_r2" in item.keywords and not config._r2_available:  # type: ignore[attr-defined]
+        if "integration_r2" in item.keywords and not _R2_AVAILABLE:
             item.add_marker(skip_r2)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,41 @@ _VST_SUBPROCESS_TIMEOUT_SECONDS = 600
 
 NUM_FIXTURE_SAMPLES = 5
 
+# Probe results cached at collection time so pytest_collection_modifyitems
+# can skip unavailable-resource tests without re-probing per item.
+_VST_AVAILABLE = Path(_SURGE_FIXTURE_PLUGIN_PATH).exists()
+_R2_AVAILABLE = bool(os.environ.get("RCLONE_CONFIG_R2_ACCESS_KEY_ID"))
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Cache VST and R2 availability on the config object for the skip hook.
+
+    :param config: pytest config object; receives ``_vst_available`` and ``_r2_available`` attrs.
+    """
+    config._vst_available = _VST_AVAILABLE  # type: ignore[attr-defined]
+    config._r2_available = _R2_AVAILABLE  # type: ignore[attr-defined]
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Auto-skip requires_vst / integration_r2 tests when resources are absent.
+
+    :param config: pytest config carrying the pre-probed availability flags.
+    :param items: collected test items, mutated in-place.
+    """
+    skip_vst = pytest.mark.skip(
+        reason=f"Surge XT VST not found at {_SURGE_FIXTURE_PLUGIN_PATH!r} "
+        f"(set SYNTH_SETTER_PLUGIN_PATH or place plugin at that path)"
+    )
+    skip_r2 = pytest.mark.skip(
+        reason="R2 credentials absent (RCLONE_CONFIG_R2_ACCESS_KEY_ID not set); "
+        "run `rclone lsd r2:` to verify"
+    )
+    for item in items:
+        if "requires_vst" in item.keywords and not config._vst_available:  # type: ignore[attr-defined]
+            item.add_marker(skip_vst)
+        if "integration_r2" in item.keywords and not config._r2_available:  # type: ignore[attr-defined]
+            item.add_marker(skip_r2)
+
 
 # Bootstraps Xvfb + xsettingsd + dbus for VST3 plugin init; ships inside
 # the ``synth_setter`` package via :mod:`synth_setter.resources`. X11

--- a/tests/infra/test_conftest_skip_hooks.py
+++ b/tests/infra/test_conftest_skip_hooks.py
@@ -6,7 +6,7 @@ to verify both the skip-inserted and run-through branches for each marker.
 
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import cast
 
 import pytest
 
@@ -16,18 +16,18 @@ import tests.conftest as conftest_module
 class _FakeItem:
     """Minimal pytest item double sufficient for the skip hook."""
 
-    def __init__(self, keywords: dict[str, Any]) -> None:
+    def __init__(self, keywords: dict[str, pytest.MarkDecorator]) -> None:
         """Initialise with a keyword dict that mimics ``item.keywords``.
 
-        :param keywords: mapping from marker name to a truthy marker object.
+        :param keywords: marker-name-to-marker mapping the hook inspects.
         """
         self.keywords = keywords
-        self.added_markers: list[Any] = []
+        self.added_markers: list[pytest.MarkDecorator] = []
 
-    def add_marker(self, marker: Any) -> None:
+    def add_marker(self, marker: pytest.MarkDecorator) -> None:
         """Record the marker — mirrors ``pytest.Item.add_marker``.
 
-        :param marker: the marker passed by the hook.
+        :param marker: appended to ``added_markers`` for assertion.
         """
         self.added_markers.append(marker)
 
@@ -36,7 +36,7 @@ class _FakeItem:
 def test_requires_vst_item_skipped_when_vst_absent(monkeypatch: pytest.MonkeyPatch) -> None:
     """requires_vst item gets a skip marker with a path-specific reason when VST is absent.
 
-    :param monkeypatch: pytest fixture for patching module attributes.
+    :param monkeypatch: rebinds ``_VST_AVAILABLE`` on ``conftest_module``.
     """
     monkeypatch.setattr(conftest_module, "_VST_AVAILABLE", False)
     item = _FakeItem({"requires_vst": pytest.mark.requires_vst})
@@ -49,7 +49,7 @@ def test_requires_vst_item_skipped_when_vst_absent(monkeypatch: pytest.MonkeyPat
 def test_integration_r2_item_skipped_when_r2_absent(monkeypatch: pytest.MonkeyPatch) -> None:
     """integration_r2 item gets a skip marker with a credential hint when R2 is absent.
 
-    :param monkeypatch: pytest fixture for patching module attributes.
+    :param monkeypatch: rebinds ``_R2_AVAILABLE`` on ``conftest_module``.
     """
     monkeypatch.setattr(conftest_module, "_R2_AVAILABLE", False)
     item = _FakeItem({"integration_r2": pytest.mark.integration_r2})
@@ -62,7 +62,7 @@ def test_integration_r2_item_skipped_when_r2_absent(monkeypatch: pytest.MonkeyPa
 def test_requires_vst_item_not_skipped_when_vst_present(monkeypatch: pytest.MonkeyPatch) -> None:
     """requires_vst item receives no skip marker when VST is present.
 
-    :param monkeypatch: pytest fixture for patching module attributes.
+    :param monkeypatch: rebinds ``_VST_AVAILABLE`` on ``conftest_module``.
     """
     monkeypatch.setattr(conftest_module, "_VST_AVAILABLE", True)
     item = _FakeItem({"requires_vst": pytest.mark.requires_vst})
@@ -74,7 +74,7 @@ def test_requires_vst_item_not_skipped_when_vst_present(monkeypatch: pytest.Monk
 def test_integration_r2_item_not_skipped_when_r2_present(monkeypatch: pytest.MonkeyPatch) -> None:
     """integration_r2 item receives no skip marker when R2 credentials are present.
 
-    :param monkeypatch: pytest fixture for patching module attributes.
+    :param monkeypatch: rebinds ``_R2_AVAILABLE`` on ``conftest_module``.
     """
     monkeypatch.setattr(conftest_module, "_R2_AVAILABLE", True)
     item = _FakeItem({"integration_r2": pytest.mark.integration_r2})
@@ -86,7 +86,7 @@ def test_integration_r2_item_not_skipped_when_r2_present(monkeypatch: pytest.Mon
 def test_unmarked_item_receives_no_skip_markers(monkeypatch: pytest.MonkeyPatch) -> None:
     """An item with no VST/R2 markers is untouched regardless of resource availability.
 
-    :param monkeypatch: pytest fixture for patching module attributes.
+    :param monkeypatch: rebinds both ``_VST_AVAILABLE`` and ``_R2_AVAILABLE`` to False.
     """
     monkeypatch.setattr(conftest_module, "_VST_AVAILABLE", False)
     monkeypatch.setattr(conftest_module, "_R2_AVAILABLE", False)

--- a/tests/infra/test_conftest_skip_hooks.py
+++ b/tests/infra/test_conftest_skip_hooks.py
@@ -1,0 +1,95 @@
+"""Tests for the conftest.py auto-skip hooks for requires_vst and integration_r2.
+
+Exercises ``pytest_collection_modifyitems`` directly with a lightweight item double
+to verify both the skip-inserted and run-through branches for each marker.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+import tests.conftest as conftest_module
+
+
+class _FakeItem:
+    """Minimal pytest item double sufficient for the skip hook."""
+
+    def __init__(self, keywords: dict[str, Any]) -> None:
+        """Initialise with a keyword dict that mimics ``item.keywords``.
+
+        :param keywords: mapping from marker name to a truthy marker object.
+        """
+        self.keywords = keywords
+        self.added_markers: list[Any] = []
+
+    def add_marker(self, marker: Any) -> None:
+        """Record the marker — mirrors ``pytest.Item.add_marker``.
+
+        :param marker: the marker passed by the hook.
+        """
+        self.added_markers.append(marker)
+
+
+@pytest.mark.infra
+def test_requires_vst_item_skipped_when_vst_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """requires_vst item gets a skip marker with a path-specific reason when VST is absent.
+
+    :param monkeypatch: pytest fixture for patching module attributes.
+    """
+    monkeypatch.setattr(conftest_module, "_VST_AVAILABLE", False)
+    item = _FakeItem({"requires_vst": pytest.mark.requires_vst})
+    conftest_module.pytest_collection_modifyitems(items=cast(list[pytest.Item], [item]))
+    assert len(item.added_markers) == 1
+    assert "Surge XT VST not found" in item.added_markers[0].kwargs["reason"]
+
+
+@pytest.mark.infra
+def test_integration_r2_item_skipped_when_r2_absent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """integration_r2 item gets a skip marker with a credential hint when R2 is absent.
+
+    :param monkeypatch: pytest fixture for patching module attributes.
+    """
+    monkeypatch.setattr(conftest_module, "_R2_AVAILABLE", False)
+    item = _FakeItem({"integration_r2": pytest.mark.integration_r2})
+    conftest_module.pytest_collection_modifyitems(items=cast(list[pytest.Item], [item]))
+    assert len(item.added_markers) == 1
+    assert "RCLONE_CONFIG_R2_ACCESS_KEY_ID" in item.added_markers[0].kwargs["reason"]
+
+
+@pytest.mark.infra
+def test_requires_vst_item_not_skipped_when_vst_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """requires_vst item receives no skip marker when VST is present.
+
+    :param monkeypatch: pytest fixture for patching module attributes.
+    """
+    monkeypatch.setattr(conftest_module, "_VST_AVAILABLE", True)
+    item = _FakeItem({"requires_vst": pytest.mark.requires_vst})
+    conftest_module.pytest_collection_modifyitems(items=cast(list[pytest.Item], [item]))
+    assert item.added_markers == []
+
+
+@pytest.mark.infra
+def test_integration_r2_item_not_skipped_when_r2_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """integration_r2 item receives no skip marker when R2 credentials are present.
+
+    :param monkeypatch: pytest fixture for patching module attributes.
+    """
+    monkeypatch.setattr(conftest_module, "_R2_AVAILABLE", True)
+    item = _FakeItem({"integration_r2": pytest.mark.integration_r2})
+    conftest_module.pytest_collection_modifyitems(items=cast(list[pytest.Item], [item]))
+    assert item.added_markers == []
+
+
+@pytest.mark.infra
+def test_unmarked_item_receives_no_skip_markers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An item with no VST/R2 markers is untouched regardless of resource availability.
+
+    :param monkeypatch: pytest fixture for patching module attributes.
+    """
+    monkeypatch.setattr(conftest_module, "_VST_AVAILABLE", False)
+    monkeypatch.setattr(conftest_module, "_R2_AVAILABLE", False)
+    item = _FakeItem({"slow": pytest.mark.slow})
+    conftest_module.pytest_collection_modifyitems(items=cast(list[pytest.Item], [item]))
+    assert item.added_markers == []


### PR DESCRIPTION
## Summary

- Adds a "VST and R2 verification" section to `AGENTS.md` (mirrors the existing GPU verification pattern) that instructs agents to probe `SYNTH_SETTER_PLUGIN_PATH` and `RCLONE_CONFIG_R2_ACCESS_KEY_ID` before labelling `@pytest.mark.requires_vst` / `@pytest.mark.integration_r2` tests as unrunnable — and directs them to run `make test-vst-cpu` / `uv run pytest -m integration_r2` instead of writing "SKIP" in PR verification tables
- Adds `pytest_collection_modifyitems` to `tests/conftest.py` that auto-skips those tests when resources are genuinely absent (so pytest itself is authoritative rather than the agent guessing)
- Adds 5 `@pytest.mark.infra` tests in `tests/infra/test_conftest_skip_hooks.py` covering all skip/run branches

## Test plan

- [x] `uv run pytest tests/infra/test_conftest_skip_hooks.py -v` — 5 passed
- [x] `uv run pytest tests/infra/ -q` — 108 passed, 2 skipped
- [x] `uv run pytest tests/ -q --collect-only -m requires_vst` — 52 tests collected (not auto-skipped), confirming VST is present
- [x] `uv run pytest tests/ -q --collect-only -m integration_r2` — 14 tests collected (not auto-skipped), confirming R2 is present
- [x] `make format` — all hooks pass

Refs #1485
