### PR TITLE
automation(dev): auto-link plugins and thoughts after worktree add

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -133,6 +133,18 @@
       },
       {
         "matcher": "Bash",
+        "description": "Worktree post-setup: after `git worktree add`, automatically runs `make link-plugins && make link-thoughts` in the new worktree so the plugins/ symlink and thoughts/ symlink are present without a manual follow-up. Parses the worktree path from the captured command; exits 0 on any failure (fail-safe, never blocks). Closes #1343.",
+        "hooks": [
+          {
+            "type": "command",
+            "if": "Bash(git worktree add *)",
+            "statusMessage": "Linking plugins and thoughts in new worktree...",
+            "command": "bash agent/hooks/worktree-post-setup.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
         "description": "Taxonomy verification: validates GitHub metadata after gh issue create, gh pr create, and addSubIssue mutations. Checks issue type, domain label, milestone, project board, and hierarchy. Goal: enforce the project's GitHub taxonomy conventions (docs/design/github-taxonomy.md) before metadata gaps compound.",
         "hooks": [
           {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -133,7 +133,7 @@
       },
       {
         "matcher": "Bash",
-        "description": "Worktree post-setup: after `git worktree add`, automatically runs `make link-plugins && make link-thoughts` in the new worktree so the plugins/ symlink and thoughts/ symlink are present without a manual follow-up. Parses the worktree path from the captured command; exits 0 on any failure (fail-safe, never blocks). Closes #1343.",
+        "description": "Worktree post-setup: after `git worktree add`, automatically runs `make link-plugins && make link-thoughts` in the new worktree so the plugins/ symlink and thoughts/ symlink are present without a manual follow-up. Parses the worktree path from the captured command; exits 0 on any failure (fail-safe, never blocks).",
         "hooks": [
           {
             "type": "command",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,10 @@ Architecture: [docs/architecture.md](docs/architecture.md).
   (`agent/hooks/session-start-cwd-banner.sh`) prints a primary-vs-worktree
   banner on startup/resume/clear/compact; a `PreToolUse` hook
   (`agent/hooks/worktree-guard.sh`) warns on Edit/Write inside the primary
-  checkout (`WORKTREE_GUARD_MODE`: `warn` default / `block` / `off`).
+  checkout (`WORKTREE_GUARD_MODE`: `warn` default / `block` / `off`); a
+  `PostToolUse` hook (`agent/hooks/worktree-post-setup.sh`) automatically
+  runs `make link-plugins && make link-thoughts` in every new worktree after
+  `git worktree add` (fail-safe, exits 0 on any error — see #1343).
 - **Each worktree gets its own `.venv`.** The spawn command runs `uv sync`;
   `~/.bashrc` (installed by `.devcontainer/post-create.sh`) then activates
   `./.venv` per directory, overriding the image's shared `/venv/main`. For

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -1817,6 +1817,28 @@ MAKE_STUB
 }
 it "worktree-post-setup: compound command (cd && git worktree add) — path extracted correctly" T_wt_post_setup_parse_compound_command
 
+T_wt_post_setup_quoted_substring_not_matched() {
+  local out make_log
+  reset_sandbox
+  make_log="$TEST_DIR/make-quoted-$$.txt"
+  cat > "$STUBS/make" <<MAKE_STUB
+#!/usr/bin/env bash
+echo "CALLED" >> "$make_log"
+MAKE_STUB
+  chmod +x "$STUBS/make"
+  # `echo "git worktree add /path"` contains the substring but is NOT an invocation.
+  # The boundary-aware guard must reject it and exit 0 without running make.
+  out=$(cd "$SANDBOX" && \
+    echo '{"tool_name":"Bash","tool_input":{"command":"echo \"git worktree add /some/path\""}}' | \
+    bash "$SANDBOX/agent/hooks/worktree-post-setup.sh" 2>&1; echo "EXIT:$?")
+  rm -f "$STUBS/make"
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected exit 0, got: $out"; return 1; }
+  [[ ! -f "$make_log" ]] || {
+    echo "make should not have run for quoted substring; log: $(cat "$make_log")"; return 1
+  }
+}
+it "worktree-post-setup: echo with quoted 'git worktree add' — boundary guard rejects, make not called" T_wt_post_setup_quoted_substring_not_matched
+
 # ===========================================================================
 # Run
 # ===========================================================================

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -1768,6 +1768,30 @@ MAKE_STUB
 }
 it "worktree-post-setup: quoted path with spaces parsed correctly via shlex" T_wt_post_setup_parse_quoted_path_with_spaces
 
+T_wt_post_setup_parse_end_of_options_marker() {
+  local out target make_log
+  reset_sandbox
+  target="$TEST_DIR/wt-eoo-$$"
+  mkdir -p "$target"
+  make_log="$TEST_DIR/make-eoo-$$.txt"
+  cat > "$STUBS/make" <<MAKE_STUB
+#!/usr/bin/env bash
+echo "CWD=\$(pwd)" >> "$make_log"
+MAKE_STUB
+  chmod +x "$STUBS/make"
+  # -- signals end-of-options; path token follows even if it starts with dashes.
+  out=$(cd "$SANDBOX" && \
+    printf '{"tool_name":"Bash","tool_input":{"command":"git worktree add -- %s"}}' "$target" | \
+    bash "$SANDBOX/agent/hooks/worktree-post-setup.sh" 2>&1; echo "EXIT:$?")
+  rm -f "$STUBS/make"
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected exit 0, got: $out"; return 1; }
+  grep -q "CWD=$target" "$make_log" 2>/dev/null || {
+    echo "-- marker: make ran in wrong dir (token after -- not used as path?); log: $(cat "$make_log" 2>/dev/null)"
+    return 1
+  }
+}
+it "worktree-post-setup: -- end-of-options marker — path after -- is used even when it starts with dashes" T_wt_post_setup_parse_end_of_options_marker
+
 # ===========================================================================
 # Run
 # ===========================================================================

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -1792,6 +1792,31 @@ MAKE_STUB
 }
 it "worktree-post-setup: -- end-of-options marker — path after -- is used even when it starts with dashes" T_wt_post_setup_parse_end_of_options_marker
 
+T_wt_post_setup_parse_compound_command() {
+  local out target make_log
+  reset_sandbox
+  target="$TEST_DIR/wt-compound-$$"
+  mkdir -p "$target"
+  make_log="$TEST_DIR/make-compound-$$.txt"
+  cat > "$STUBS/make" <<MAKE_STUB
+#!/usr/bin/env bash
+echo "CWD=\$(pwd)" >> "$make_log"
+MAKE_STUB
+  chmod +x "$STUBS/make"
+  # Compound command: cd ... && git worktree add <path> — the parser must find
+  # the git-worktree-add subsequence rather than assuming it starts the tokens.
+  out=$(cd "$SANDBOX" && \
+    printf '{"tool_name":"Bash","tool_input":{"command":"cd /some/dir && git worktree add %s"}}' "$target" | \
+    bash "$SANDBOX/agent/hooks/worktree-post-setup.sh" 2>&1; echo "EXIT:$?")
+  rm -f "$STUBS/make"
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected exit 0, got: $out"; return 1; }
+  grep -q "CWD=$target" "$make_log" 2>/dev/null || {
+    echo "compound command: make ran in wrong dir or not called; log: $(cat "$make_log" 2>/dev/null)"
+    return 1
+  }
+}
+it "worktree-post-setup: compound command (cd && git worktree add) — path extracted correctly" T_wt_post_setup_parse_compound_command
+
 # ===========================================================================
 # Run
 # ===========================================================================

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -32,6 +32,7 @@ cp agent/hooks/_lib.sh \
    agent/hooks/worktree-guard.sh \
    agent/hooks/session-start-cwd-banner.sh \
    agent/hooks/pr-readiness-stop.sh \
+   agent/hooks/worktree-post-setup.sh \
    "$SANDBOX/agent/hooks/"
 cp agent/_shared/review_sentinel.py "$SANDBOX/agent/_shared/"
 cd "$SANDBOX"
@@ -1627,6 +1628,145 @@ T_readiness_drains_large_stdin() {
   [[ "$exit_code" == "0" ]] || { echo "off-mode pipeline exit was $exit_code (likely SIGPIPE)"; return 1; }
 }
 it "pr-readiness-stop: off mode drains stdin before exiting (no SIGPIPE risk)" T_readiness_drains_large_stdin
+
+# ===========================================================================
+# worktree-post-setup
+# ===========================================================================
+
+T_wt_post_setup_runs_make_in_new_worktree() {
+  local out target make_log
+  reset_sandbox
+  target="$TEST_DIR/wt-target-$$"
+  mkdir -p "$target"
+  make_log="$TEST_DIR/make-calls-$$.txt"
+  # Stub make records cwd + args so we can assert link-plugins + link-thoughts ran.
+  cat > "$STUBS/make" <<MAKE_STUB
+#!/usr/bin/env bash
+echo "CWD=\$(pwd)" >> "$make_log"
+echo "ARGS=\$*" >> "$make_log"
+MAKE_STUB
+  chmod +x "$STUBS/make"
+  out=$(cd "$SANDBOX" && \
+    printf '{"tool_name":"Bash","tool_input":{"command":"git worktree add --detach %s"}}' "$target" | \
+    bash "$SANDBOX/agent/hooks/worktree-post-setup.sh" 2>&1; echo "EXIT:$?")
+  rm -f "$STUBS/make"
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || {
+    echo "expected exit 0, got: $out"; return 1
+  }
+  grep -q "CWD=$target" "$make_log" 2>/dev/null || {
+    echo "make not called in expected directory $target; log: $(cat "$make_log" 2>/dev/null)"; return 1
+  }
+  grep -q "ARGS=link-plugins" "$make_log" 2>/dev/null || {
+    echo "make link-plugins not called; log: $(cat "$make_log" 2>/dev/null)"; return 1
+  }
+  grep -q "ARGS=link-thoughts" "$make_log" 2>/dev/null || {
+    echo "make link-thoughts not called; log: $(cat "$make_log" 2>/dev/null)"; return 1
+  }
+}
+it "worktree-post-setup: valid path → make link-plugins + link-thoughts run in that directory" T_wt_post_setup_runs_make_in_new_worktree
+
+T_wt_post_setup_exits_0_on_missing_path() {
+  local out
+  reset_sandbox
+  out=$(cd "$SANDBOX" && \
+    echo '{"tool_name":"Bash","tool_input":{"command":"git worktree add --detach /tmp/absent-wt-path-99999"}}' | \
+    bash "$SANDBOX/agent/hooks/worktree-post-setup.sh" 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || {
+    echo "expected exit 0 for missing path, got: $out"; return 1
+  }
+}
+it "worktree-post-setup: non-existent path → exits 0 (fail-safe)" T_wt_post_setup_exits_0_on_missing_path
+
+T_wt_post_setup_exits_0_on_malformed_json() {
+  local out
+  reset_sandbox
+  out=$(cd "$SANDBOX" && echo 'not-valid-json' | \
+    bash "$SANDBOX/agent/hooks/worktree-post-setup.sh" 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || {
+    echo "expected exit 0 for malformed JSON, got: $out"; return 1
+  }
+}
+it "worktree-post-setup: malformed JSON → exits 0 (fail-safe)" T_wt_post_setup_exits_0_on_malformed_json
+
+T_wt_post_setup_exits_0_on_unrelated_command() {
+  local out
+  reset_sandbox
+  out=$(cd "$SANDBOX" && \
+    echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' | \
+    bash "$SANDBOX/agent/hooks/worktree-post-setup.sh" 2>&1; echo "EXIT:$?")
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || {
+    echo "expected exit 0 for unrelated command, got: $out"; return 1
+  }
+}
+it "worktree-post-setup: unrelated Bash command → exits 0 without running make" T_wt_post_setup_exits_0_on_unrelated_command
+
+T_wt_post_setup_parse_dash_b() {
+  local out target make_log
+  reset_sandbox
+  target="$TEST_DIR/wt-dash-b-$$"
+  mkdir -p "$target"
+  make_log="$TEST_DIR/make-dash-b-$$.txt"
+  cat > "$STUBS/make" <<MAKE_STUB
+#!/usr/bin/env bash
+echo "CWD=\$(pwd)" >> "$make_log"
+MAKE_STUB
+  chmod +x "$STUBS/make"
+  out=$(cd "$SANDBOX" && \
+    printf '{"tool_name":"Bash","tool_input":{"command":"git worktree add -b feat/foo %s"}}' "$target" | \
+    bash "$SANDBOX/agent/hooks/worktree-post-setup.sh" 2>&1; echo "EXIT:$?")
+  rm -f "$STUBS/make"
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected exit 0, got: $out"; return 1; }
+  grep -q "CWD=$target" "$make_log" 2>/dev/null || {
+    echo "-b flag: make ran in wrong dir; log: $(cat "$make_log" 2>/dev/null)"; return 1
+  }
+}
+it "worktree-post-setup: -b <branch> <path> — path after branch name is found" T_wt_post_setup_parse_dash_b
+
+T_wt_post_setup_parse_orphan_consumes_arg() {
+  local out target make_log
+  reset_sandbox
+  target="$TEST_DIR/wt-orphan-$$"
+  mkdir -p "$target"
+  make_log="$TEST_DIR/make-orphan-$$.txt"
+  cat > "$STUBS/make" <<MAKE_STUB
+#!/usr/bin/env bash
+echo "CWD=\$(pwd)" >> "$make_log"
+MAKE_STUB
+  chmod +x "$STUBS/make"
+  # --orphan takes <new-branch> in git 2.42+; path is the next token after the branch name
+  out=$(cd "$SANDBOX" && \
+    printf '{"tool_name":"Bash","tool_input":{"command":"git worktree add --orphan new-branch %s"}}' "$target" | \
+    bash "$SANDBOX/agent/hooks/worktree-post-setup.sh" 2>&1; echo "EXIT:$?")
+  rm -f "$STUBS/make"
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected exit 0, got: $out"; return 1; }
+  grep -q "CWD=$target" "$make_log" 2>/dev/null || {
+    echo "--orphan: make ran in wrong dir (branch name mis-parsed as path?); log: $(cat "$make_log" 2>/dev/null)"
+    return 1
+  }
+}
+it "worktree-post-setup: --orphan <branch> <path> — branch consumed, path found correctly" T_wt_post_setup_parse_orphan_consumes_arg
+
+T_wt_post_setup_parse_quoted_path_with_spaces() {
+  local out target make_log
+  reset_sandbox
+  target="$TEST_DIR/wt path with spaces $$"
+  mkdir -p "$target"
+  make_log="$TEST_DIR/make-spaces-$$.txt"
+  cat > "$STUBS/make" <<MAKE_STUB
+#!/usr/bin/env bash
+echo "CWD=\$(pwd)" >> "$make_log"
+MAKE_STUB
+  chmod +x "$STUBS/make"
+  out=$(cd "$SANDBOX" && \
+    python3 -c "import json,sys; sys.stdout.write(json.dumps({'tool_name':'Bash','tool_input':{'command':'git worktree add --detach \"$target\"'}}))" | \
+    bash "$SANDBOX/agent/hooks/worktree-post-setup.sh" 2>&1; echo "EXIT:$?")
+  rm -f "$STUBS/make"
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected exit 0, got: $out"; return 1; }
+  grep -qF "CWD=$target" "$make_log" 2>/dev/null || {
+    echo "quoted path with spaces: make ran in wrong dir; log: $(cat "$make_log" 2>/dev/null)"; return 1
+  }
+}
+it "worktree-post-setup: quoted path with spaces parsed correctly via shlex" T_wt_post_setup_parse_quoted_path_with_spaces
 
 # ===========================================================================
 # Run

--- a/agent/hooks/worktree-post-setup.sh
+++ b/agent/hooks/worktree-post-setup.sh
@@ -1,12 +1,6 @@
 #!/usr/bin/env bash
-# worktree-post-setup.sh — PostToolUse hook that auto-runs
-# `make link-plugins && make link-thoughts` whenever the agent calls
-# `git worktree add`. Parses the worktree path from the captured command,
-# then runs both targets from that directory so the new worktree is
-# immediately usable without a manual follow-up.
-#
-# Fail-safe: any parse/execution failure logs and exits 0 so the hook
-# never blocks after a completed worktree-add.
+# PostToolUse hook: runs make link-plugins && make link-thoughts in every
+# new worktree after `git worktree add`. Fail-safe: exits 0 on any error — see #1343.
 set -euo pipefail
 
 # shellcheck disable=SC2034  # read by log() in _lib.sh via ${HOOK_NAME:-unknown}
@@ -20,12 +14,13 @@ readonly SCRIPT_DIR
   source "${SCRIPT_DIR}/_lib.sh"
 }
 
-# Parse the worktree path from a `git worktree add [flags] <path> [<commit-ish>]`
-# command string. Flags consuming an extra token: -b, -B, --orphan, --reason.
-# Prints the path and returns 0, or returns 1 when no path is found.
+# Parse worktree path from `git worktree add [flags] <path> [<commit-ish>]`.
+# Prints the path and exits 0; exits 1 when no path is found.
 _parse_worktree_path() {
   WT_CMD="$1" python3 - <<'PYEOF'
-import os, sys, shlex
+import os
+import shlex
+import sys
 
 try:
     tokens = shlex.split(os.environ["WT_CMD"])
@@ -36,7 +31,8 @@ i = 0
 while i < len(tokens) and tokens[i] in ("git", "worktree", "add"):
     i += 1
 
-flags_with_args = {"-b", "-B", "--orphan", "--reason"}
+# --orphan is a boolean flag; only -b/-B/--reason consume the next token.
+flags_with_args = {"-b", "-B", "--reason"}
 path = None
 while i < len(tokens):
     tok = tokens[i]
@@ -58,11 +54,7 @@ main() {
   input=$(cat)
 
   # PostToolUse for Bash delivers tool_input.command in the JSON payload.
-  cmd=$(python3 -c "
-import json, sys
-d = json.loads(sys.stdin.read())
-print(d.get('tool_input', {}).get('command', ''))
-" <<< "$input" 2>/dev/null) || { log "could not parse tool_input.command; skipping"; exit 0; }
+  cmd=$(jq -r '.tool_input.command // empty' <<< "$input" 2>/dev/null) || { log "could not parse tool_input.command; skipping"; exit 0; }
 
   # The settings.json `if` matcher already scopes this to `git worktree add *`,
   # but re-validate for safety.

--- a/agent/hooks/worktree-post-setup.sh
+++ b/agent/hooks/worktree-post-setup.sh
@@ -32,8 +32,13 @@ except Exception:
     sys.exit(1)
 
 i = 0
-while i < len(tokens) and tokens[i] in ("git", "worktree", "add"):
+while i < len(tokens) - 2:
+    if tokens[i] == "git" and tokens[i + 1] == "worktree" and tokens[i + 2] == "add":
+        i += 3
+        break
     i += 1
+else:
+    sys.exit(1)
 
 # --orphan takes <new-branch> in git 2.42+ (same positional role as -b).
 flags_with_args = {"-b", "-B", "--orphan", "--reason"}
@@ -65,12 +70,11 @@ main() {
   # PostToolUse for Bash delivers tool_input.command in the JSON payload.
   cmd=$(jq -r '.tool_input.command // empty' <<< "$input" 2>/dev/null) || { log "could not parse tool_input.command; skipping"; exit 0; }
 
-  # The settings.json `if` matcher already scopes this to `git worktree add *`,
-  # but re-validate for safety.
-  case "$cmd" in
-    *"git worktree add"*) ;;
-    *) exit 0 ;;
-  esac
+  # Boundary-aware check: matches invocations at start of command or after a
+  # separator (&&, ;, |, backtick) — avoids false positives from echo/quoted strings.
+  if ! echo "$cmd" | grep -qE '(^|[;|&`(][[:space:]]*)git[[:space:]]+worktree[[:space:]]+add([[:space:]]|$)'; then
+    exit 0
+  fi
 
   wt_path=$(_parse_worktree_path "$cmd" 2>/dev/null) || {
     log "could not parse worktree path from: $cmd"; exit 0

--- a/agent/hooks/worktree-post-setup.sh
+++ b/agent/hooks/worktree-post-setup.sh
@@ -40,7 +40,12 @@ flags_with_args = {"-b", "-B", "--orphan", "--reason"}
 path = None
 while i < len(tokens):
     tok = tokens[i]
-    if tok.startswith("-"):
+    if tok == "--":
+        # End-of-options: next token is the path even if it looks like a flag.
+        if i + 1 < len(tokens):
+            path = tokens[i + 1]
+        break
+    elif tok.startswith("-"):
         i += 2 if tok in flags_with_args else 1
     else:
         path = tok

--- a/agent/hooks/worktree-post-setup.sh
+++ b/agent/hooks/worktree-post-setup.sh
@@ -13,6 +13,10 @@ readonly SCRIPT_DIR
   # shellcheck disable=SC1091
   source "${SCRIPT_DIR}/_lib.sh"
 }
+# No-op fallback keeps fail-safe `|| { log ...; exit 0; }` branches safe
+# when _lib.sh is absent — without it, `command -v log` on macOS resolves
+# to /usr/bin/log and set -e would turn an undefined-function call fatal.
+declare -F log >/dev/null 2>&1 || log() { :; }
 
 # Parse worktree path from `git worktree add [flags] <path> [<commit-ish>]`.
 # Prints the path and exits 0; exits 1 when no path is found.
@@ -31,8 +35,8 @@ i = 0
 while i < len(tokens) and tokens[i] in ("git", "worktree", "add"):
     i += 1
 
-# --orphan is a boolean flag; only -b/-B/--reason consume the next token.
-flags_with_args = {"-b", "-B", "--reason"}
+# --orphan takes <new-branch> in git 2.42+ (same positional role as -b).
+flags_with_args = {"-b", "-B", "--orphan", "--reason"}
 path = None
 while i < len(tokens):
     tok = tokens[i]

--- a/agent/hooks/worktree-post-setup.sh
+++ b/agent/hooks/worktree-post-setup.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# worktree-post-setup.sh — PostToolUse hook that auto-runs
+# `make link-plugins && make link-thoughts` whenever the agent calls
+# `git worktree add`. Parses the worktree path from the captured command,
+# then runs both targets from that directory so the new worktree is
+# immediately usable without a manual follow-up.
+#
+# Fail-safe: any parse/execution failure logs and exits 0 so the hook
+# never blocks after a completed worktree-add.
+set -euo pipefail
+
+# shellcheck disable=SC2034  # read by log() in _lib.sh via ${HOOK_NAME:-unknown}
+readonly HOOK_NAME="worktree-post-setup"
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+readonly SCRIPT_DIR
+
+[[ -f "${SCRIPT_DIR}/_lib.sh" ]] && {
+  # shellcheck source=agent/hooks/_lib.sh
+  # shellcheck disable=SC1091
+  source "${SCRIPT_DIR}/_lib.sh"
+}
+
+# Parse the worktree path from a `git worktree add [flags] <path> [<commit-ish>]`
+# command string. Flags consuming an extra token: -b, -B, --orphan, --reason.
+# Prints the path and returns 0, or returns 1 when no path is found.
+_parse_worktree_path() {
+  WT_CMD="$1" python3 - <<'PYEOF'
+import os, sys, shlex
+
+try:
+    tokens = shlex.split(os.environ["WT_CMD"])
+except Exception:
+    sys.exit(1)
+
+i = 0
+while i < len(tokens) and tokens[i] in ("git", "worktree", "add"):
+    i += 1
+
+flags_with_args = {"-b", "-B", "--orphan", "--reason"}
+path = None
+while i < len(tokens):
+    tok = tokens[i]
+    if tok.startswith("-"):
+        i += 2 if tok in flags_with_args else 1
+    else:
+        path = tok
+        break
+
+if not path:
+    sys.exit(1)
+print(path)
+PYEOF
+}
+
+main() {
+  local input cmd wt_path
+
+  input=$(cat)
+
+  # PostToolUse for Bash delivers tool_input.command in the JSON payload.
+  cmd=$(python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read())
+print(d.get('tool_input', {}).get('command', ''))
+" <<< "$input" 2>/dev/null) || { log "could not parse tool_input.command; skipping"; exit 0; }
+
+  # The settings.json `if` matcher already scopes this to `git worktree add *`,
+  # but re-validate for safety.
+  case "$cmd" in
+    *"git worktree add"*) ;;
+    *) exit 0 ;;
+  esac
+
+  wt_path=$(_parse_worktree_path "$cmd" 2>/dev/null) || {
+    log "could not parse worktree path from: $cmd"; exit 0
+  }
+
+  if [[ ! -d "$wt_path" ]]; then
+    log "worktree path $wt_path does not exist; skipping"
+    exit 0
+  fi
+
+  log "running make link-plugins && make link-thoughts in $wt_path"
+  (
+    cd "$wt_path"
+    make link-plugins && make link-thoughts
+  ) || {
+    log "make link-plugins/link-thoughts failed in $wt_path (non-fatal)"
+  }
+}
+
+main "$@"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -760,7 +760,9 @@ devcontainer up --workspace-folder .
 ```bash
 # Inside the container, starting from the workspace root on main:
 git worktree add .claude/worktrees/my-feature -b feat/my-feature
-cd .claude/worktrees/my-feature && make link-plugins
+# Claude Code: link-plugins and link-thoughts run automatically via the PostToolUse hook.
+# Plain terminal (outside Claude Code): chain them manually:
+cd .claude/worktrees/my-feature && make link-plugins && make link-thoughts
 ```
 
 This is the supported local pattern. Mounting a worktree directly from the
@@ -784,10 +786,13 @@ the failure surfaces immediately rather than partway through `post-create`.
   VST-dependent tests. Host edits under `plugins/` are not visible
   inside the container; container edits under `plugins/` are not
   visible on the host.
-- A fresh worktree starts without `plugins/` (it's gitignored, so
-  `git worktree add` doesn't copy it). `make link-plugins` mirrors the
-  primary checkout's `plugins/` entries into the worktree (no-op in the
-  primary) — that's why the spawn command above chains it.
+- A fresh worktree starts without `plugins/` or `thoughts/` (both are
+  gitignored, so `git worktree add` doesn't copy them). `make link-plugins`
+  mirrors the primary checkout's `plugins/` entries into the worktree;
+  `make link-thoughts` symlinks `thoughts/` to the primary's central copy.
+  Claude Code runs both automatically via `agent/hooks/worktree-post-setup.sh`
+  after every `git worktree add`; in a plain terminal, chain them onto the
+  spawn command manually.
 
 ### B.3. macOS VM (Tart)
 

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -22,13 +22,13 @@ from pathlib import Path
 from typing import Any
 
 import hydra
+import wandb
 from hydra.core.hydra_config import HydraConfig
 from lightning.pytorch.loggers import Logger
 from lightning.pytorch.loggers.wandb import WandbLogger
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
-import wandb
 from synth_setter.cli.finalize_dataset import finalize_from_spec
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.pipeline import r2_io

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.18.4"
+version = "8.20.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.18.3"
+version = "8.18.4"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

- Adds `agent/hooks/worktree-post-setup.sh`: a `PostToolUse` hook that fires after every `git worktree add` and automatically runs `make link-plugins && make link-thoughts` in the new worktree
- Registers the hook in `.claude/settings.json` with an `if: "Bash(git worktree add *)"` guard so it is scoped precisely to worktree creation
- Eliminates the manual follow-up step that caused "VST not found" errors in fresh worktrees; closes the gap that issue #1343 tracked

## How it works

On every `git worktree add` the hook:
1. Reads the captured Bash command via `jq` from the `PostToolUse` JSON payload
2. Parses the worktree path using `shlex.split` via an embedded Python heredoc (handles quoted paths, `-b`/`-B`/`--reason` flags, `--detach`)
3. `cd`s into the new worktree and runs `make link-plugins && make link-thoughts`
4. Exits 0 on any failure (fail-safe — never blocks after a completed `git worktree add`)

## Test plan

- [x] `make format` — all pre-commit checks pass
- [x] End-to-end: `echo '{"tool_name":"Bash","tool_input":{"command":"git worktree add --detach /path"}}' | bash agent/hooks/worktree-post-setup.sh` runs both make targets and exits 0
- [x] Fail-safe: missing/non-existent path exits 0 with a log entry, never blocks

Fixes #1343
