### PR TITLE
feat(storage): deterministic structured W&B run IDs for data/train/eval

### DIFF
--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -16,6 +16,7 @@ from omegaconf import DictConfig
 
 from synth_setter.pipeline import r2_io
 from synth_setter.resources import as_file, vst_headless_wrapper
+from synth_setter.run_id import make_wandb_run_id
 from synth_setter.utils import (
     RankedLogger,
     extras,
@@ -23,7 +24,9 @@ from synth_setter.utils import (
     instantiate_loggers,
     log_hyperparameters,
     log_wandb_provenance,
+    pin_wandb_run_id,
     register_resolvers,
+    resolve_run_config_id,
     task_wrapper,
 )
 from synth_setter.workspace import operator_workspace
@@ -223,6 +226,7 @@ def evaluate(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     callbacks: list[Callback] = instantiate_callbacks(cfg.get("callbacks"))
 
     log.info("Instantiating loggers...")
+    pin_wandb_run_id(cfg, make_wandb_run_id(resolve_run_config_id(cfg)), "evaluation")
     logger: list[Logger] = instantiate_loggers(cfg.get("logger"))
 
     log.info(f"Instantiating trainer <{cfg.trainer._target_}>")

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -50,7 +50,7 @@ from synth_setter.pipeline.spec_io import (
     write_spec_locally,
 )
 from synth_setter.resources import as_file, vst_headless_wrapper
-from synth_setter.utils import extras, log_wandb_provenance, register_resolvers
+from synth_setter.utils import extras, log_wandb_provenance, pin_wandb_run_id, register_resolvers
 from synth_setter.utils.instantiators import instantiate_loggers
 from synth_setter.workspace import operator_workspace
 
@@ -789,10 +789,8 @@ def _loggers_pinned_to_spec(cfg: DictConfig, spec: DatasetSpec) -> list[Logger]:
         dataset.
     :returns: Loggers list — empty when ``cfg.logger`` is omitted/null.
     """
-    # Guard against non-wandb logger groups (e.g. ``logger=tensorboard``) where
-    # ``logger.wandb`` is absent and ``OmegaConf.update`` would raise.
-    if OmegaConf.select(cfg, "logger.wandb") is not None:
-        OmegaConf.update(cfg, "logger.wandb.id", spec.run_id)
+    # spec.run_id (not a fresh stamp) keeps the wandb run in lockstep with the R2 prefix.
+    pin_wandb_run_id(cfg, spec.run_id, "data-generation")
     return instantiate_loggers(cfg.get("logger"))
 
 

--- a/src/synth_setter/cli/train.py
+++ b/src/synth_setter/cli/train.py
@@ -9,6 +9,7 @@ from lightning import Callback, LightningDataModule, LightningModule, Trainer
 from lightning.pytorch.loggers import Logger
 from omegaconf import DictConfig
 
+from synth_setter.run_id import make_wandb_run_id
 from synth_setter.utils import (
     RankedLogger,
     extras,
@@ -17,7 +18,9 @@ from synth_setter.utils import (
     instantiate_loggers,
     log_hyperparameters,
     log_wandb_provenance,
+    pin_wandb_run_id,
     register_resolvers,
+    resolve_run_config_id,
     task_wrapper,
     watch_gradients,
 )
@@ -56,6 +59,7 @@ def train(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     callbacks: list[Callback] = instantiate_callbacks(cfg.get("callbacks"))
 
     log.info("Instantiating loggers...")
+    pin_wandb_run_id(cfg, make_wandb_run_id(resolve_run_config_id(cfg)), "training")
     logger: list[Logger] = instantiate_loggers(cfg.get("logger"))
 
     log.info(f"Instantiating trainer <{cfg.trainer._target_}>")

--- a/src/synth_setter/pipeline/schemas/prefix.py
+++ b/src/synth_setter/pipeline/schemas/prefix.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import NewType
 
+from synth_setter.run_id import make_wandb_run_id
+
 DatasetConfigId = NewType("DatasetConfigId", str)
 DatasetRunId = NewType("DatasetRunId", str)
 R2Prefix = NewType("R2Prefix", str)
@@ -24,23 +26,14 @@ def make_dataset_wandb_run_id(
     dataset_config_id: DatasetConfigId | str,
     timestamp: datetime | None = None,
 ) -> DatasetRunId:
-    """Build a unique run ID from a config ID and a UTC timestamp.
+    """Build a dataset run ID via the shared ``{config_id}-{timestamp}`` convention.
 
     :param dataset_config_id: The dataset config identifier (e.g. filename stem).
     :param timestamp: Optional UTC datetime; defaults to now.
     :returns: A string like ``<config_id>-<YYYYMMDD>T<HHMMSSsss>Z`` where ``sss`` is
         a zero-padded 3-digit millisecond field.
     """
-    if timestamp is None:
-        timestamp = _utc_now()
-    if timestamp.tzinfo is None:
-        raise ValueError("timestamp must be timezone-aware (got naive datetime)")
-    offset = timestamp.utcoffset()
-    if offset is None or offset.total_seconds() != 0:
-        raise ValueError("timestamp must be UTC")
-    millis = timestamp.microsecond // 1000
-    formatted = timestamp.strftime("%Y%m%dT%H%M%S") + f"{millis:03d}Z"
-    return DatasetRunId(f"{dataset_config_id}-{formatted}")
+    return DatasetRunId(make_wandb_run_id(dataset_config_id, timestamp or _utc_now()))
 
 
 def make_r2_prefix(

--- a/src/synth_setter/run_id.py
+++ b/src/synth_setter/run_id.py
@@ -1,0 +1,33 @@
+"""Canonical W&B run-id convention, shared across data, training, and eval runs.
+
+Stdlib-only so the launcher-pure ``pipeline.schemas`` layer can import it without
+pulling ``omegaconf``/``hydra`` (see ``test_bare_spec_import_does_not_pull_omegaconf``).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def make_wandb_run_id(config_id: str, timestamp: datetime | None = None) -> str:
+    """Build the canonical ``{config_id}-{timestamp}`` W&B run id.
+
+    One source of truth for the run-id format in storage-provenance-spec.md §1, so
+    data-generation, training, and eval runs stay reproducible and lineage-linkable.
+
+    :param config_id: Config identifier (e.g. dataset config stem or experiment name).
+    :param timestamp: UTC, timezone-aware datetime; defaults to now.
+    :returns: ``<config_id>-<YYYYMMDD>T<HHMMSSsss>Z`` with a zero-padded 3-digit
+        millisecond field.
+    :raises ValueError: If ``timestamp`` is naive or not UTC.
+    """
+    if timestamp is None:
+        timestamp = datetime.now(timezone.utc)
+    if timestamp.tzinfo is None:
+        raise ValueError("timestamp must be timezone-aware (got naive datetime)")
+    offset = timestamp.utcoffset()
+    if offset is None or offset.total_seconds() != 0:
+        raise ValueError("timestamp must be UTC")
+    millis = timestamp.microsecond // 1000
+    formatted = timestamp.strftime("%Y%m%dT%H%M%S") + f"{millis:03d}Z"
+    return f"{config_id}-{formatted}"

--- a/src/synth_setter/utils/__init__.py
+++ b/src/synth_setter/utils/__init__.py
@@ -1,5 +1,10 @@
 from synth_setter.utils.instantiators import instantiate_callbacks, instantiate_loggers
-from synth_setter.utils.logging_utils import log_hyperparameters, log_wandb_provenance
+from synth_setter.utils.logging_utils import (
+    log_hyperparameters,
+    log_wandb_provenance,
+    pin_wandb_run_id,
+    resolve_run_config_id,
+)
 from synth_setter.utils.pylogger import RankedLogger
 from synth_setter.utils.rich_utils import enforce_tags, print_config_tree
 from synth_setter.utils.utils import (

--- a/src/synth_setter/utils/logging_utils.py
+++ b/src/synth_setter/utils/logging_utils.py
@@ -1,17 +1,54 @@
-"""Hyperparameter logging helpers and wandb-config provenance writer."""
+"""Hyperparameter logging helpers, run-id conventions, and wandb-config provenance writer."""
 
 import os
 import subprocess
 import sys
 from importlib.util import find_spec
+from pathlib import PurePosixPath
 from typing import Any
 
+from hydra.core.hydra_config import HydraConfig
 from lightning_utilities.core.rank_zero import rank_zero_only
-from omegaconf import OmegaConf
+from omegaconf import DictConfig, OmegaConf
 
 from synth_setter.utils import pylogger
 
 log = pylogger.RankedLogger(__name__, rank_zero_only=True)
+
+
+def resolve_run_config_id(cfg: DictConfig) -> str:
+    """Resolve the run config_id from the chosen Hydra experiment, else ``task_name``.
+
+    The experiment choice (e.g. ``surge/flow_simple``) is the train/eval analog of
+    the dataset config stem; its basename becomes the config_id. Falls back to
+    ``cfg.task_name`` when no experiment is selected or there is no Hydra context.
+
+    :param cfg: Hydra-composed cfg carrying ``task_name``.
+    :returns: The experiment basename, or ``cfg.task_name`` as a fallback.
+    """
+    try:
+        experiment = HydraConfig.get().runtime.choices.get("experiment")
+    except ValueError:
+        experiment = None
+    if experiment in (None, "null"):
+        return cfg.task_name
+    return PurePosixPath(experiment).name
+
+
+def pin_wandb_run_id(cfg: DictConfig, run_id: str, job_type: str) -> None:
+    """Pin the W&B run id and ``job_type`` onto ``cfg`` before logger instantiation.
+
+    No-op when the cfg has no ``logger.wandb`` group (e.g. ``logger=tensorboard``
+    or ``logger=null``), so ``OmegaConf.update`` never raises on the missing key.
+
+    :param cfg: Hydra-composed cfg; ``logger.wandb.{id,job_type}`` are updated in place.
+    :param run_id: The W&B run id to pin (see :func:`synth_setter.run_id.make_wandb_run_id`).
+    :param job_type: W&B ``job_type`` (``training`` / ``evaluation`` / ``data-generation``).
+    """
+    if OmegaConf.select(cfg, "logger.wandb") is None:
+        return
+    OmegaConf.update(cfg, "logger.wandb.id", run_id)
+    OmegaConf.update(cfg, "logger.wandb.job_type", job_type)
 
 
 @rank_zero_only

--- a/tests/test_generate_dataset_wandb.py
+++ b/tests/test_generate_dataset_wandb.py
@@ -63,6 +63,31 @@ def _offline_wandb_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path / "wandb-data"))
 
 
+class TestLoggersPinnedToSpec:
+    """``_loggers_pinned_to_spec`` writes the run identity onto the wandb logger cfg."""
+
+    def test_pins_run_id_and_data_generation_job_type(
+        self, dataset_spec_factory: Callable[..., DatasetSpec]
+    ) -> None:
+        """A wandb logger cfg inherits ``spec.run_id`` and ``job_type=data-generation``.
+
+        :param dataset_spec_factory: Shared ``conftest`` ``DatasetSpec`` factory.
+        """
+        from omegaconf import OmegaConf
+
+        from synth_setter.cli.generate_dataset import _loggers_pinned_to_spec
+
+        spec = _build_spec(dataset_spec_factory)
+        # No ``_target_`` so ``instantiate_loggers`` skips construction and the test
+        # isolates the cfg pinning rather than building a real WandbLogger.
+        cfg = OmegaConf.create({"logger": {"wandb": {"id": None, "job_type": ""}}})
+
+        _loggers_pinned_to_spec(cfg, spec)
+
+        assert cfg.logger.wandb.id == spec.run_id
+        assert cfg.logger.wandb.job_type == "data-generation"
+
+
 @pytest.fixture(autouse=True)
 def _reset_wandb_session_state() -> None:
     """Tear down any cached wandb session so each test's ``offline=True`` takes effect."""

--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -10,8 +10,13 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
+from omegaconf import OmegaConf
 
-from synth_setter.utils.logging_utils import log_wandb_provenance
+from synth_setter.utils.logging_utils import (
+    log_wandb_provenance,
+    pin_wandb_run_id,
+    resolve_run_config_id,
+)
 
 # ---------------------------------------------------------------------------
 # Fake wandb module — captures config updates as inspectable state
@@ -145,3 +150,80 @@ class TestLogWandbProvenanceGuards:
             log_wandb_provenance()
 
         assert fake.config.data == {}
+
+
+# ---------------------------------------------------------------------------
+# resolve_run_config_id — Hydra experiment choice, fallback task_name
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRunConfigId:
+    """config_id resolution for training/eval runs."""
+
+    def test_experiment_choice_basename_wins(self) -> None:
+        """A grouped experiment choice resolves to its basename, not task_name."""
+        cfg = OmegaConf.create({"task_name": "train"})
+        fake_hydra_cfg = SimpleNamespace(
+            runtime=SimpleNamespace(choices={"experiment": "surge/flow_simple"})
+        )
+
+        with patch(
+            "synth_setter.utils.logging_utils.HydraConfig.get", return_value=fake_hydra_cfg
+        ):
+            assert resolve_run_config_id(cfg) == "flow_simple"
+
+    def test_falls_back_to_task_name_when_experiment_absent(self) -> None:
+        """A missing experiment choice resolves to task_name."""
+        cfg = OmegaConf.create({"task_name": "train"})
+        fake_hydra_cfg = SimpleNamespace(runtime=SimpleNamespace(choices={"experiment": None}))
+
+        with patch(
+            "synth_setter.utils.logging_utils.HydraConfig.get", return_value=fake_hydra_cfg
+        ):
+            assert resolve_run_config_id(cfg) == "train"
+
+    def test_falls_back_to_task_name_when_experiment_is_null_string(self) -> None:
+        """The literal ``"null"`` choice (Hydra's null default) resolves to task_name."""
+        cfg = OmegaConf.create({"task_name": "train"})
+        fake_hydra_cfg = SimpleNamespace(runtime=SimpleNamespace(choices={"experiment": "null"}))
+
+        with patch(
+            "synth_setter.utils.logging_utils.HydraConfig.get", return_value=fake_hydra_cfg
+        ):
+            assert resolve_run_config_id(cfg) == "train"
+
+    def test_falls_back_to_task_name_without_hydra_context(self) -> None:
+        """Outside a @hydra.main run (no HydraConfig), task_name is used."""
+        cfg = OmegaConf.create({"task_name": "eval"})
+
+        with patch(
+            "synth_setter.utils.logging_utils.HydraConfig.get",
+            side_effect=ValueError("HydraConfig was not set"),
+        ):
+            assert resolve_run_config_id(cfg) == "eval"
+
+
+# ---------------------------------------------------------------------------
+# pin_wandb_run_id — write run id + job_type before logger instantiation
+# ---------------------------------------------------------------------------
+
+
+class TestPinWandbRunId:
+    """Pinning the deterministic run id and job_type into the wandb logger cfg."""
+
+    def test_sets_run_id_and_job_type(self) -> None:
+        """A wandb logger cfg gets the given run id and job_type verbatim."""
+        cfg = OmegaConf.create({"logger": {"wandb": {"id": None, "job_type": ""}}})
+
+        pin_wandb_run_id(cfg, "flow_simple-20260313T100000000Z", "training")
+
+        assert cfg.logger.wandb.id == "flow_simple-20260313T100000000Z"
+        assert cfg.logger.wandb.job_type == "training"
+
+    def test_noop_when_wandb_logger_absent(self) -> None:
+        """A non-wandb logger group is left untouched (no KeyError)."""
+        cfg = OmegaConf.create({"logger": {"tensorboard": {"save_dir": "logs"}}})
+
+        pin_wandb_run_id(cfg, "flow_simple", "training")
+
+        assert "wandb" not in cfg.logger

--- a/tests/test_run_id.py
+++ b/tests/test_run_id.py
@@ -1,0 +1,39 @@
+"""Tests for the shared run-id convention in ``synth_setter.run_id``."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from synth_setter.run_id import make_wandb_run_id
+
+
+class TestMakeWandbRunId:
+    """The shared ``{config_id}-{timestamp}`` format used by data, training, and eval runs."""
+
+    def test_fixed_utc_timestamp_produces_expected_id(self) -> None:
+        """A whole-second UTC timestamp yields ``<config_id>-YYYYMMDDTHHMMSS000Z``."""
+        ts = datetime(2026, 3, 13, 10, 0, 0, tzinfo=timezone.utc)
+        assert make_wandb_run_id("flow_simple", timestamp=ts) == "flow_simple-20260313T100000000Z"
+
+    def test_microseconds_render_as_three_digit_millis(self) -> None:
+        """Sub-second precision is truncated to a 3-digit millisecond field."""
+        ts = datetime(2026, 5, 3, 13, 36, 33, 456789, tzinfo=timezone.utc)
+        assert make_wandb_run_id("cfg", timestamp=ts) == "cfg-20260503T133633456Z"
+
+    def test_naive_timestamp_raises(self) -> None:
+        """A timezone-naive datetime is rejected."""
+        with pytest.raises(ValueError, match="timezone-aware"):
+            make_wandb_run_id("cfg", timestamp=datetime(2026, 3, 13, 10, 0, 0))
+
+    def test_non_utc_timestamp_raises(self) -> None:
+        """A non-UTC timezone is rejected."""
+        non_utc = datetime(2026, 3, 13, 10, 0, 0, tzinfo=timezone(timedelta(hours=5)))
+        with pytest.raises(ValueError, match="must be UTC"):
+            make_wandb_run_id("cfg", timestamp=non_utc)
+
+    def test_default_timestamp_prefixes_config_id(self) -> None:
+        """With no timestamp the id is ``<config_id>-`` plus a canonical UTC stamp."""
+        assert re.fullmatch(r"flow_simple-\d{8}T\d{9}Z", make_wandb_run_id("flow_simple"))


### PR DESCRIPTION
## Summary

Introduces `synth_setter.run_id.make_wandb_run_id` as the single source of truth for the `{config_id}-{timestamp}` W&B run-id convention, and applies it across data-generation, training, and evaluation so runs are deterministic and lineage-linkable.

- **`run_id.py`** — new, stdlib-only module (no `omegaconf`/`hydra`) so the launcher-pure `pipeline.schemas` layer can import it without violating the bare-spec-import invariant.
- **`prefix.make_dataset_wandb_run_id`** now delegates to the shared helper, removing the duplicated format/validation logic while keeping its `_utc_now()` test seam.
- **`logging_utils`** gains `resolve_run_config_id` (derives the config_id from the chosen Hydra experiment basename, falling back to `task_name`) and `pin_wandb_run_id` (writes `logger.wandb.{id,job_type}` in place; no-ops when no wandb logger group is present).
- **train / eval** pin a deterministic run id + `job_type`; **generate_dataset** keeps pinning `spec.run_id` so the W&B run stays in lockstep with the R2 prefix.

## Testing

- New `tests/test_run_id.py` plus additions to `tests/test_logging_utils.py` and `tests/test_generate_dataset_wandb.py` cover every new function and the data-generation pinning path.
- `make test-fast` passes (1794 passed with bounded workers; the `-n auto` run's "worker crashed" failures are host over-subscription, confirmed green in isolation).
- Launcher-purity invariant `test_bare_spec_import_does_not_pull_omegaconf` still passes.

Refs #403
