### PR TITLE
test: cgroup-aware cpu count for pytest-xdist -n auto

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -826,6 +826,52 @@ def dataset_spec_factory() -> Callable[..., DatasetSpec]:
     return factory
 
 
+def _cgroup_aware_cpu_count() -> int:
+    """Return the number of CPUs available to this process, honouring cgroup limits.
+
+    Reads ``sched_getaffinity`` (respects ``--cpuset-cpus``) and the cgroup CPU
+    quota (respects ``--cpus``), then takes the minimum so that dev-container
+    over-subscription doesn't cause pytest-xdist to spawn more workers than the
+    container's actual allocation — the root cause of "worker crashed" failures
+    when ``-n auto`` resolves to the host's full core count.
+
+    :returns: Usable CPU count, always at least 1.
+    """
+    if hasattr(os, "sched_getaffinity"):
+        affinity = len(os.sched_getaffinity(0))
+    else:
+        affinity = os.cpu_count() or 1
+
+    quota: float | None = None
+    try:  # cgroup v2
+        with open("/sys/fs/cgroup/cpu.max") as fh:
+            parts = fh.read().split()
+            if parts[0] != "max":
+                quota = int(parts[0]) / int(parts[1])
+    except OSError:
+        try:  # cgroup v1
+            with open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") as fh:
+                q = int(fh.read())
+            with open("/sys/fs/cgroup/cpu/cpu.cfs_period_us") as fh:
+                p = int(fh.read())
+            if q > 0:
+                quota = q / p
+        except OSError:
+            pass
+
+    cpus = affinity if quota is None else min(affinity, quota)
+    return max(1, int(cpus))
+
+
+def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:  # noqa: ARG001
+    """Override pytest-xdist ``-n auto`` to respect the container's cgroup CPU quota.
+
+    :param config: The pytest config object (unused; required by the hook signature).
+    :returns: Worker count clamped to the container's real CPU allocation.
+    """
+    return _cgroup_aware_cpu_count()
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register custom CLI options for the test suite."""
     parser.addoption(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -827,13 +827,10 @@ def dataset_spec_factory() -> Callable[..., DatasetSpec]:
 
 
 def _cgroup_aware_cpu_count() -> int:
-    """Return the number of CPUs available to this process, honouring cgroup limits.
+    """Return CPUs available to this process, honouring cgroup quota and affinity.
 
-    Reads ``sched_getaffinity`` (respects ``--cpuset-cpus``) and the cgroup CPU
-    quota (respects ``--cpus``), then takes the minimum so that dev-container
-    over-subscription doesn't cause pytest-xdist to spawn more workers than the
-    container's actual allocation — the root cause of "worker crashed" failures
-    when ``-n auto`` resolves to the host's full core count.
+    Takes min(affinity, cgroup_quota) so ``-n auto`` doesn't over-subscribe the
+    container — see #1490 for the "worker crashed" failure mode this fixes.
 
     :returns: Usable CPU count, always at least 1.
     """
@@ -843,21 +840,21 @@ def _cgroup_aware_cpu_count() -> int:
         affinity = os.cpu_count() or 1
 
     quota: float | None = None
-    try:  # cgroup v2
+    try:  # cgroup v2: unified hierarchy, kernel >= 4.5
         with open("/sys/fs/cgroup/cpu.max") as fh:
             parts = fh.read().split()
-            if parts[0] != "max":
+            if len(parts) >= 2 and parts[0] != "max":
                 quota = int(parts[0]) / int(parts[1])
-    except OSError:
-        try:  # cgroup v1
+    except (OSError, ValueError, ZeroDivisionError):
+        try:  # cgroup v1: legacy per-subsystem hierarchy
             with open("/sys/fs/cgroup/cpu/cpu.cfs_quota_us") as fh:
-                q = int(fh.read())
+                quota_us = int(fh.read())
             with open("/sys/fs/cgroup/cpu/cpu.cfs_period_us") as fh:
-                p = int(fh.read())
-            if q > 0:
-                quota = q / p
-        except OSError:
-            pass
+                period_us = int(fh.read())
+            if quota_us > 0 and period_us > 0:
+                quota = quota_us / period_us
+        except (OSError, ValueError, ZeroDivisionError):
+            pass  # no cgroup limit; use affinity only
 
     cpus = affinity if quota is None else min(affinity, quota)
     return max(1, int(cpus))
@@ -866,9 +863,16 @@ def _cgroup_aware_cpu_count() -> int:
 def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:  # noqa: ARG001
     """Override pytest-xdist ``-n auto`` to respect the container's cgroup CPU quota.
 
+    Checks ``PYTEST_XDIST_AUTO_NUM_WORKERS`` first so the env-var escape hatch
+    that xdist's built-in implementation honours is preserved even when this
+    hook wins the ``firstresult`` race.
+
     :param config: The pytest config object (unused; required by the hook signature).
     :returns: Worker count clamped to the container's real CPU allocation.
     """
+    env_override = os.environ.get("PYTEST_XDIST_AUTO_NUM_WORKERS")
+    if env_override is not None:
+        return max(1, int(env_override))
     return _cgroup_aware_cpu_count()
 
 

--- a/tests/test__conftest_cpu.py
+++ b/tests/test__conftest_cpu.py
@@ -1,0 +1,193 @@
+"""Tests for the _cgroup_aware_cpu_count helper in tests/conftest.py."""
+
+import io
+import os
+from collections.abc import Callable
+from unittest.mock import patch
+
+import pytest
+
+from tests.conftest import _cgroup_aware_cpu_count
+
+_V2_PATH = "/sys/fs/cgroup/cpu.max"
+_V1_QUOTA_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
+_V1_PERIOD_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_period_us"
+
+
+def _open_v2(quota: int, period: int) -> Callable[..., io.StringIO]:
+    """Return an ``open()`` side-effect that serves one cgroup v2 ``cpu.max`` file.
+
+    :param quota: Raw CPU quota microseconds to embed in the fake file content.
+    :param period: Raw CPU period microseconds to embed in the fake file content.
+    :returns: Callable suitable for use as ``patch("builtins.open", side_effect=...)``.
+    """
+
+    def _side(path: str, *_args: object, **_kwargs: object) -> io.StringIO:
+        if path == _V2_PATH:
+            return io.StringIO(f"{quota} {period}")
+        raise OSError(f"not found: {path}")
+
+    return _side
+
+
+def _open_v1(quota_us: int, period_us: int) -> Callable[..., io.StringIO]:
+    """Return an ``open()`` side-effect that rejects cgroup v2 and serves v1 files.
+
+    :param quota_us: ``cfs_quota_us`` value to write into the fake v1 quota file.
+    :param period_us: ``cfs_period_us`` value to write into the fake v1 period file.
+    :returns: Callable suitable for use as ``patch("builtins.open", side_effect=...)``.
+    """
+
+    def _side(path: str, *_args: object, **_kwargs: object) -> io.StringIO:
+        if path == _V2_PATH:
+            raise OSError("no v2")
+        if path == _V1_QUOTA_PATH:
+            return io.StringIO(str(quota_us))
+        if path == _V1_PERIOD_PATH:
+            return io.StringIO(str(period_us))
+        raise OSError(f"not found: {path}")
+
+    return _side
+
+
+def _open_none(path: str) -> io.StringIO:
+    """Simulate a host with no cgroup filesystem at all.
+
+    :param path: The path that was requested (included in the error message).
+    :raises OSError: Always — no cgroup files exist on this simulated host.
+    :returns: Never returns; always raises.
+    """
+    raise OSError(f"not found: {path}")
+
+
+class TestCgroupAwareCpuCount:
+    """Unit tests for _cgroup_aware_cpu_count covering every branch."""
+
+    def test_no_cgroup_returns_affinity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No cgroup files → falls back to affinity count.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2, 3})
+        with patch("builtins.open", side_effect=_open_none):
+            assert _cgroup_aware_cpu_count() == 4
+
+    def test_cgroupv2_quota_clamps_below_affinity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """V2 quota < affinity → returns quota (200ms/100ms = 2 CPUs).
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(8)))
+        with patch("builtins.open", side_effect=_open_v2(200_000, 100_000)):
+            assert _cgroup_aware_cpu_count() == 2
+
+    def test_cgroupv2_quota_above_affinity_uses_affinity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """V2 quota > affinity → returns affinity (min wins).
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1})
+        with patch("builtins.open", side_effect=_open_v2(800_000, 100_000)):
+            assert _cgroup_aware_cpu_count() == 2
+
+    def test_cgroupv2_max_sentinel_uses_affinity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """V2 ``max <period>`` means no quota → uses affinity.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2})
+
+        def _max_open(path: str, *_a: object, **_k: object) -> io.StringIO:
+            if path == _V2_PATH:
+                return io.StringIO("max 100000")
+            raise OSError(path)
+
+        with patch("builtins.open", side_effect=_max_open):
+            assert _cgroup_aware_cpu_count() == 3
+
+    def test_cgroupv1_quota_clamps_below_affinity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """V1 quota_us / period_us = 1 CPU < 4 affinity → returns 1.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(4)))
+        with patch("builtins.open", side_effect=_open_v1(100_000, 100_000)):
+            assert _cgroup_aware_cpu_count() == 1
+
+    def test_cgroupv1_negative_quota_uses_affinity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """V1 quota_us = -1 (unlimited sentinel) → uses affinity.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2})
+        with patch("builtins.open", side_effect=_open_v1(-1, 100_000)):
+            assert _cgroup_aware_cpu_count() == 3
+
+    def test_fractional_quota_floors_to_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Quota of 0.5 CPUs → max(1, int(0.5)) = 1, not 0.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(4)))
+        with patch("builtins.open", side_effect=_open_v2(50_000, 100_000)):
+            assert _cgroup_aware_cpu_count() == 1
+
+    def test_malformed_cgroupv2_empty_uses_affinity(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Empty v2 file → len(parts) < 2 guard skips quota, uses affinity.
+
+        An empty ``cpu.max`` has no usable quota token; the ``len(parts) >= 2``
+        guard treats it as no-limit rather than raising ``IndexError``.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(8)))
+
+        def _empty_v2(path: str, *_a: object, **_k: object) -> io.StringIO:
+            if path == _V2_PATH:
+                return io.StringIO("")
+            raise OSError(path)
+
+        with patch("builtins.open", side_effect=_empty_v2):
+            assert _cgroup_aware_cpu_count() == 8
+
+    def test_invalid_token_cgroupv2_falls_back_to_v1(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-integer v2 quota token → ValueError caught, falls through to v1.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(8)))
+
+        def _bad_v2_good_v1(path: str, *_a: object, **_k: object) -> io.StringIO:
+            if path == _V2_PATH:
+                return io.StringIO("broken 100000")  # int("broken") → ValueError
+            if path == _V1_QUOTA_PATH:
+                return io.StringIO("200000")
+            if path == _V1_PERIOD_PATH:
+                return io.StringIO("100000")
+            raise OSError(path)
+
+        with patch("builtins.open", side_effect=_bad_v2_good_v1):
+            assert _cgroup_aware_cpu_count() == 2
+
+    def test_malformed_cgroupv1_falls_back_to_affinity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Malformed v1 file (non-integer) → ValueError caught, uses affinity.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2})
+
+        def _bad_all(path: str, *_a: object, **_k: object) -> io.StringIO:
+            if path == _V2_PATH:
+                raise OSError("no v2")
+            if path == _V1_QUOTA_PATH:
+                return io.StringIO("not-a-number")
+            raise OSError(path)
+
+        with patch("builtins.open", side_effect=_bad_all):
+            assert _cgroup_aware_cpu_count() == 3

--- a/tests/test__conftest_cpu.py
+++ b/tests/test__conftest_cpu.py
@@ -68,7 +68,7 @@ class TestCgroupAwareCpuCount:
 
         :param monkeypatch: Pytest monkeypatch fixture.
         """
-        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2, 3})
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2, 3}, raising=False)
         with patch("builtins.open", side_effect=_open_none):
             assert _cgroup_aware_cpu_count() == 4
 
@@ -77,7 +77,7 @@ class TestCgroupAwareCpuCount:
 
         :param monkeypatch: Pytest monkeypatch fixture.
         """
-        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(8)))
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(8)), raising=False)
         with patch("builtins.open", side_effect=_open_v2(200_000, 100_000)):
             assert _cgroup_aware_cpu_count() == 2
 
@@ -88,7 +88,7 @@ class TestCgroupAwareCpuCount:
 
         :param monkeypatch: Pytest monkeypatch fixture.
         """
-        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1})
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1}, raising=False)
         with patch("builtins.open", side_effect=_open_v2(800_000, 100_000)):
             assert _cgroup_aware_cpu_count() == 2
 
@@ -97,7 +97,7 @@ class TestCgroupAwareCpuCount:
 
         :param monkeypatch: Pytest monkeypatch fixture.
         """
-        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2})
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2}, raising=False)
 
         def _max_open(path: str, *_a: object, **_k: object) -> io.StringIO:
             if path == _V2_PATH:
@@ -112,7 +112,7 @@ class TestCgroupAwareCpuCount:
 
         :param monkeypatch: Pytest monkeypatch fixture.
         """
-        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(4)))
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(4)), raising=False)
         with patch("builtins.open", side_effect=_open_v1(100_000, 100_000)):
             assert _cgroup_aware_cpu_count() == 1
 
@@ -121,7 +121,7 @@ class TestCgroupAwareCpuCount:
 
         :param monkeypatch: Pytest monkeypatch fixture.
         """
-        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2})
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2}, raising=False)
         with patch("builtins.open", side_effect=_open_v1(-1, 100_000)):
             assert _cgroup_aware_cpu_count() == 3
 
@@ -130,7 +130,7 @@ class TestCgroupAwareCpuCount:
 
         :param monkeypatch: Pytest monkeypatch fixture.
         """
-        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(4)))
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(4)), raising=False)
         with patch("builtins.open", side_effect=_open_v2(50_000, 100_000)):
             assert _cgroup_aware_cpu_count() == 1
 
@@ -142,7 +142,7 @@ class TestCgroupAwareCpuCount:
 
         :param monkeypatch: Pytest monkeypatch fixture.
         """
-        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(8)))
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(8)), raising=False)
 
         def _empty_v2(path: str, *_a: object, **_k: object) -> io.StringIO:
             if path == _V2_PATH:
@@ -159,7 +159,7 @@ class TestCgroupAwareCpuCount:
 
         :param monkeypatch: Pytest monkeypatch fixture.
         """
-        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(8)))
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(8)), raising=False)
 
         def _bad_v2_good_v1(path: str, *_a: object, **_k: object) -> io.StringIO:
             if path == _V2_PATH:
@@ -180,7 +180,7 @@ class TestCgroupAwareCpuCount:
 
         :param monkeypatch: Pytest monkeypatch fixture.
         """
-        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2})
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2}, raising=False)
 
         def _bad_all(path: str, *_a: object, **_k: object) -> io.StringIO:
             if path == _V2_PATH:


### PR DESCRIPTION
## Summary

- `pytest-xdist -n auto` resolves worker count from `os.cpu_count()`, which reports the *host's* total cores inside a dev container — not the container's CPU quota. This causes worker over-subscription → OOM → "worker gwN crashed" failures.
- Adds `pytest_xdist_auto_num_workers` hook to `tests/conftest.py` that reads `sched_getaffinity` (respects `--cpuset-cpus`) and cgroup v2/v1 quota (respects `--cpus`), then returns `min(affinity, quota)`. On an unconstrained CI host the result matches the old `auto` value; no change there.
- Preserves the `PYTEST_XDIST_AUTO_NUM_WORKERS` env-var escape hatch that xdist's built-in hook honours.
- Adds 10 unit tests covering every branch: v2 quota, v2 `max` sentinel, v1 quota, v1 `-1` unlimited, no cgroup, quota > affinity, fractional quota floored to 1, empty v2 file, and invalid v2 token falling through to v1.
- Syncs `uv.lock` to 8.20.0 (stale after `[skip ci]` release commit).

## Test plan

- [ ] `make test-fast` passes (was already green with `-n 4`; now `-n auto` uses the cgroup-aware count)
- [ ] New tests: `pytest tests/test__conftest_cpu.py -v` — 10 passed
- [ ] All pre-commit hooks: `make format` — all Passed

Fixes #1493
