### PR TITLE
feat(storage): R2 prefix write-time assertion helper

### DIFF
--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -1425,7 +1425,7 @@ src/
       __init__.py
       spec.py           # DatasetSpec (unified config + runtime; built by its own from_hydra_cfg classmethod, called via spec_from_cfg in cli/generate_dataset.py), RenderConfig, ShardSpec; OutputFormat str-enum carrying format↔suffix dispatch (.extension property + .from_extension reverse lookup)
       shard_metadata.py # ShardMetadata — wds tar metadata.json sidecar (leaf module, no project imports)
-      prefix.py         # DatasetConfigId, DatasetRunId, R2Prefix helpers
+      prefix.py         # DatasetConfigId, DatasetRunId, R2Prefix, assert_r2_prefix_matches helpers
       image_config.py   # Docker image configuration
 
     ci/                 # CI validation scripts (implemented)

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -81,7 +81,7 @@ docs:
       - pattern: "src/synth_setter/configs/finalize_dataset.yaml"
         covers: "Finalize @hydra.main entry config; required `dataset_spec_uri` loads the persisted DatasetSpec from R2 (file://, r2://, or bare path); overrides `hydra.run.dir` because `task_name`/`run_name` are not in this cfg"
       - pattern: "src/synth_setter/cli/finalize_dataset.py"
-        covers: "Finalize entrypoint: loads DatasetSpec from `cfg.dataset_spec_uri` via `load_spec_from_uri`, dispatches on `spec.output_format` (wds → `finalize_wds` streaming Welford / hdf5 → `finalize_hdf5` reshard + stats), writes `dataset.complete` marker last (R2 source-of-truth idempotency)"
+        covers: "Finalize entrypoint: loads DatasetSpec from `cfg.dataset_spec_uri` via `load_spec_from_uri`, dispatches on `spec.output_format` (wds → `finalize_wds` streaming Welford / hdf5 → `finalize_hdf5` reshard + stats), writes `dataset.complete` marker last (R2 source-of-truth idempotency); calls assert_r2_prefix_matches before any R2 writes to catch prefix drift"
       - pattern: ".github/workflows/generate-dataset-shards.yaml"
         covers: "Reusable launcher fan-out across providers (skypilot-local kind, runpod, oci); per-provider artifact upload; emits a `spec_uri` workflow output (the materialized spec's canonical under-prefix `input_spec.json` URI, computed by the `synth-setter-spec-uri` console script — see `src/synth_setter/pipeline/ci/spec_uri.py`) consumed by validate-dataset-shards"
       - pattern: ".github/workflows/validate-dataset-shards.yaml"
@@ -275,7 +275,7 @@ docs:
       - pattern: "src/synth_setter/configs/logger/wandb.yaml"
         covers: "W&B logger config, log_model, entity/project"
       - pattern: "src/synth_setter/pipeline/schemas/prefix.py"
-        covers: "DatasetConfigId, DatasetRunId, R2Prefix, make_r2_prefix()"
+        covers: "DatasetConfigId, DatasetRunId, R2Prefix, make_r2_prefix(), assert_r2_prefix_matches()"
       - pattern: "src/synth_setter/pipeline/constants.py"
         covers: "INPUT_SPEC_FILENAME constant"
 

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -59,6 +59,7 @@ synth-setter-finalize-dataset dataset_spec_uri=r2://…/input_spec.json
   → @hydra.main composes DictConfig from src/synth_setter/configs/finalize_dataset.yaml
     → load_spec_from_uri(cfg.dataset_spec_uri) → DatasetSpec (the frozen spec generate uploaded)
       → r2_io.object_size(spec.r2.dataset_complete_marker_uri()) probe (idempotency short-circuit)
+      → assert_r2_prefix_matches(spec.r2.prefix, spec.task_name, spec.run_id, spec.r2.prefix_root) (prefix-drift guard)
       → branch on spec.output_format:
           ├─ wds:  finalize_wds  — Welford-stream stats over train shards → upload stats.npz
           └─ hdf5: finalize_hdf5 — download every shard → reshard into {train,val,test}.h5 → stats.npz

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -27,6 +27,7 @@ from synth_setter.pipeline.constants import (
 )
 from synth_setter.pipeline.data.reshard import reshard_dataset
 from synth_setter.pipeline.data.stats import get_stats_hdf5, stream_stats_wds
+from synth_setter.pipeline.schemas.prefix import assert_r2_prefix_matches
 from synth_setter.pipeline.schemas.spec import DatasetSpec, OutputFormat
 from synth_setter.pipeline.spec_io import load_spec_from_uri, write_spec_to_path
 from synth_setter.workspace import operator_workspace
@@ -175,6 +176,7 @@ def finalize_from_spec(spec: DatasetSpec, work_dir: Path) -> None:
         logger.info("skip: {} already exists, run is finalized", marker_uri)
         return
 
+    assert_r2_prefix_matches(spec.r2.prefix, spec.task_name, spec.run_id, spec.r2.prefix_root)
     work_dir.mkdir(parents=True, exist_ok=True)
     if spec.output_format is OutputFormat.WDS:
         finalize_wds(spec, work_dir)

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -169,7 +169,10 @@ def finalize_from_spec(spec: DatasetSpec, work_dir: Path) -> None:
     :param spec: Validated dataset spec.
     :param work_dir: Writable scratch dir; created if missing; retained
         after the call (multi-GB on the hdf5 branch).
-    :raises ValueError: ``spec.output_format`` is neither ``"hdf5"`` nor ``"wds"``.
+    :raises ValueError: ``spec.r2.prefix`` does not match
+        ``make_r2_prefix(spec.task_name, spec.run_id, spec.r2.prefix_root)``
+        (prefix drift detected before any R2 writes), or ``spec.output_format``
+        is neither ``"hdf5"`` nor ``"wds"``.
     """
     marker_uri = spec.r2.dataset_complete_marker_uri()
     if r2_io.object_size(marker_uri) is not None:

--- a/src/synth_setter/pipeline/schemas/prefix.py
+++ b/src/synth_setter/pipeline/schemas/prefix.py
@@ -78,9 +78,9 @@ def assert_r2_prefix_matches(
         ``make_r2_prefix(dataset_config_id, dataset_wandb_run_id, prefix_root)``.
     """
     expected = make_r2_prefix(dataset_config_id, dataset_wandb_run_id, prefix_root)
-    if str(prefix) != str(expected):
+    if prefix != expected:
         raise ValueError(
-            f"R2 prefix mismatch: got {str(prefix)!r}, expected {str(expected)!r} "
+            f"R2 prefix mismatch: got {prefix!r}, expected {expected!r} "
             f"(config_id={dataset_config_id!r}, run_id={dataset_wandb_run_id!r}, "
             f"prefix_root={prefix_root!r})"
         )

--- a/src/synth_setter/pipeline/schemas/prefix.py
+++ b/src/synth_setter/pipeline/schemas/prefix.py
@@ -55,3 +55,32 @@ def make_r2_prefix(
     if not normalized_root:
         raise ValueError(f"prefix_root must not be empty or slash-only (got {prefix_root!r})")
     return R2Prefix(f"{normalized_root}/{dataset_config_id}/{dataset_wandb_run_id}/")
+
+
+def assert_r2_prefix_matches(
+    prefix: R2Prefix | str,
+    dataset_config_id: DatasetConfigId | str,
+    dataset_wandb_run_id: DatasetRunId | str,
+    prefix_root: str = DEFAULT_R2_PREFIX_ROOT,
+) -> None:
+    """Assert a materialized R2 prefix matches the canonical value for the given IDs.
+
+    Call this at write time (e.g. in finalize) to catch prefix drift before any
+    R2 objects are written — a mismatch means the spec's config/run IDs diverge
+    from the prefix it carries.
+
+    :param prefix: The materialized prefix to check (from ``R2Location.prefix``).
+    :param dataset_config_id: The dataset config identifier (e.g. ``spec.task_name``).
+    :param dataset_wandb_run_id: The W&B run ID (e.g. ``spec.run_id``).
+    :param prefix_root: Root path component (default ``"data"``); must match the
+        root used when the prefix was originally built.
+    :raises ValueError: If ``prefix`` differs from
+        ``make_r2_prefix(dataset_config_id, dataset_wandb_run_id, prefix_root)``.
+    """
+    expected = make_r2_prefix(dataset_config_id, dataset_wandb_run_id, prefix_root)
+    if str(prefix) != str(expected):
+        raise ValueError(
+            f"R2 prefix mismatch: got {str(prefix)!r}, expected {str(expected)!r} "
+            f"(config_id={dataset_config_id!r}, run_id={dataset_wandb_run_id!r}, "
+            f"prefix_root={prefix_root!r})"
+        )

--- a/tests/pipeline/schemas/test_prefix.py
+++ b/tests/pipeline/schemas/test_prefix.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
+import pytest
+
 from synth_setter.pipeline.schemas.prefix import (
     DatasetConfigId,
     DatasetRunId,
+    assert_r2_prefix_matches,
     make_dataset_wandb_run_id,
     make_r2_prefix,
 )
@@ -50,7 +53,6 @@ class TestMakeDatasetWandbRunId:
 
     def test_make_run_id_rejects_naive_timestamp(self):
         """Naive datetime (no tzinfo) raises ValueError."""
-        import pytest
 
         naive = datetime(2026, 3, 13, 10, 0, 0)
         with pytest.raises(ValueError, match="timezone-aware"):
@@ -58,7 +60,6 @@ class TestMakeDatasetWandbRunId:
 
     def test_make_run_id_rejects_non_utc_timezone(self):
         """Non-UTC timezone raises ValueError."""
-        import pytest
 
         non_utc = datetime(2026, 3, 13, 10, 0, 0, tzinfo=timezone(timedelta(hours=5)))
         with pytest.raises(ValueError, match="must be UTC"):
@@ -108,8 +109,52 @@ class TestMakeR2Prefix:
 
     def test_make_r2_prefix_rejects_empty_root(self):
         """Slash-only or empty ``prefix_root`` raises rather than producing ``/a/b/``."""
-        import pytest
 
         for bad in ("", "/", "///"):
             with pytest.raises(ValueError, match="prefix_root"):
                 make_r2_prefix(DatasetConfigId("a"), DatasetRunId("b"), prefix_root=bad)
+
+
+class TestAssertR2PrefixMatches:
+    """Tests for assert_r2_prefix_matches."""
+
+    _CONFIG_ID = DatasetConfigId("surge-simple")
+    _RUN_ID = DatasetRunId("surge-simple-20260313T100000000Z")
+    _EXPECTED = "data/surge-simple/surge-simple-20260313T100000000Z/"
+
+    def test_matching_prefix_does_not_raise(self) -> None:
+        """No exception when the materialized prefix matches the derived value."""
+        assert_r2_prefix_matches(self._EXPECTED, self._CONFIG_ID, self._RUN_ID)
+
+    def test_matching_prefix_with_explicit_root_does_not_raise(self) -> None:
+        """Custom prefix_root matches when prefix was built with the same root."""
+        prefix = make_r2_prefix(self._CONFIG_ID, self._RUN_ID, prefix_root="datasets")
+        assert_r2_prefix_matches(prefix, self._CONFIG_ID, self._RUN_ID, prefix_root="datasets")
+
+    def test_wrong_config_id_raises(self) -> None:
+        """ValueError when config_id doesn't match what the prefix encodes."""
+        with pytest.raises(ValueError, match="mismatch"):
+            assert_r2_prefix_matches(self._EXPECTED, DatasetConfigId("other-cfg"), self._RUN_ID)
+
+    def test_wrong_run_id_raises(self) -> None:
+        """ValueError when run_id doesn't match what the prefix encodes."""
+        with pytest.raises(ValueError, match="mismatch"):
+            assert_r2_prefix_matches(
+                self._EXPECTED, self._CONFIG_ID, DatasetRunId("other-20260313T100000000Z")
+            )
+
+    def test_wrong_prefix_root_raises(self) -> None:
+        """ValueError when the prefix_root doesn't match the prefix's root segment."""
+        with pytest.raises(ValueError, match="mismatch"):
+            assert_r2_prefix_matches(
+                self._EXPECTED, self._CONFIG_ID, self._RUN_ID, prefix_root="train"
+            )
+
+    def test_error_message_includes_actual_and_expected(self) -> None:
+        """ValueError message carries both the received and expected prefix strings."""
+        bad_prefix = "data/wrong-cfg/wrong-run/"
+        with pytest.raises(ValueError) as exc_info:
+            assert_r2_prefix_matches(bad_prefix, self._CONFIG_ID, self._RUN_ID)
+        msg = str(exc_info.value)
+        assert bad_prefix in msg
+        assert self._EXPECTED in msg

--- a/tests/pipeline/schemas/test_prefix.py
+++ b/tests/pipeline/schemas/test_prefix.py
@@ -115,46 +115,49 @@ class TestMakeR2Prefix:
                 make_r2_prefix(DatasetConfigId("a"), DatasetRunId("b"), prefix_root=bad)
 
 
+_ASSERT_CONFIG_ID = DatasetConfigId("surge-simple")
+_ASSERT_RUN_ID = DatasetRunId("surge-simple-20260313T100000000Z")
+_ASSERT_EXPECTED = make_r2_prefix(_ASSERT_CONFIG_ID, _ASSERT_RUN_ID)
+
+
 class TestAssertR2PrefixMatches:
     """Tests for assert_r2_prefix_matches."""
 
-    _CONFIG_ID = DatasetConfigId("surge-simple")
-    _RUN_ID = DatasetRunId("surge-simple-20260313T100000000Z")
-    _EXPECTED = "data/surge-simple/surge-simple-20260313T100000000Z/"
-
     def test_matching_prefix_does_not_raise(self) -> None:
         """No exception when the materialized prefix matches the derived value."""
-        assert_r2_prefix_matches(self._EXPECTED, self._CONFIG_ID, self._RUN_ID)
+        assert_r2_prefix_matches(_ASSERT_EXPECTED, _ASSERT_CONFIG_ID, _ASSERT_RUN_ID)
 
     def test_matching_prefix_with_explicit_root_does_not_raise(self) -> None:
         """Custom prefix_root matches when prefix was built with the same root."""
-        prefix = make_r2_prefix(self._CONFIG_ID, self._RUN_ID, prefix_root="datasets")
-        assert_r2_prefix_matches(prefix, self._CONFIG_ID, self._RUN_ID, prefix_root="datasets")
+        prefix = make_r2_prefix(_ASSERT_CONFIG_ID, _ASSERT_RUN_ID, prefix_root="datasets")
+        assert_r2_prefix_matches(prefix, _ASSERT_CONFIG_ID, _ASSERT_RUN_ID, prefix_root="datasets")
 
     def test_wrong_config_id_raises(self) -> None:
         """ValueError when config_id doesn't match what the prefix encodes."""
         with pytest.raises(ValueError, match="mismatch"):
-            assert_r2_prefix_matches(self._EXPECTED, DatasetConfigId("other-cfg"), self._RUN_ID)
+            assert_r2_prefix_matches(
+                _ASSERT_EXPECTED, DatasetConfigId("other-cfg"), _ASSERT_RUN_ID
+            )
 
     def test_wrong_run_id_raises(self) -> None:
         """ValueError when run_id doesn't match what the prefix encodes."""
         with pytest.raises(ValueError, match="mismatch"):
             assert_r2_prefix_matches(
-                self._EXPECTED, self._CONFIG_ID, DatasetRunId("other-20260313T100000000Z")
+                _ASSERT_EXPECTED, _ASSERT_CONFIG_ID, DatasetRunId("other-20260313T100000000Z")
             )
 
     def test_wrong_prefix_root_raises(self) -> None:
         """ValueError when the prefix_root doesn't match the prefix's root segment."""
         with pytest.raises(ValueError, match="mismatch"):
             assert_r2_prefix_matches(
-                self._EXPECTED, self._CONFIG_ID, self._RUN_ID, prefix_root="train"
+                _ASSERT_EXPECTED, _ASSERT_CONFIG_ID, _ASSERT_RUN_ID, prefix_root="train"
             )
 
     def test_error_message_includes_actual_and_expected(self) -> None:
         """ValueError message carries both the received and expected prefix strings."""
         bad_prefix = "data/wrong-cfg/wrong-run/"
-        with pytest.raises(ValueError) as exc_info:
-            assert_r2_prefix_matches(bad_prefix, self._CONFIG_ID, self._RUN_ID)
+        with pytest.raises(ValueError, match="mismatch") as exc_info:
+            assert_r2_prefix_matches(bad_prefix, _ASSERT_CONFIG_ID, _ASSERT_RUN_ID)
         msg = str(exc_info.value)
         assert bad_prefix in msg
-        assert self._EXPECTED in msg
+        assert _ASSERT_EXPECTED in msg


### PR DESCRIPTION
## Summary

- Adds `assert_r2_prefix_matches()` to `pipeline/schemas/prefix.py` — a write-time guard that verifies a materialized `R2Location.prefix` matches what `make_r2_prefix()` would derive from the same `config_id`, `run_id`, and `prefix_root`.
- Calls it in `finalize_from_spec()` after the idempotency probe, before any directory creation or R2 writes, so a drifted prefix aborts cleanly.
- 6 new tests in `TestAssertR2PrefixMatches` covering match, custom root, all three mismatch axes, and error-message content.

## Test plan

- [ ] `uv run pytest tests/pipeline/schemas/test_prefix.py tests/pipeline/entrypoints/test_finalize_dataset.py -x -q` — 41 passed
- [ ] `make format` — all hooks passed

Closes #281
Refs #1467
