### PR TITLE
feat(storage): log dataset W&B artifact with R2 refs on finalize

### DIFF
--- a/.github/workflows/finalize-dataset.yaml
+++ b/.github/workflows/finalize-dataset.yaml
@@ -110,10 +110,14 @@ jobs:
       - name: Install project deps (uv sync --frozen, CPU torch)
         run: uv sync --frozen --extra cpu --no-default-groups --group dev
 
+      # WANDB_API_KEY (inherited secret) lets finalize resume the data-generation
+      # run and log the canonical dataset artifact; absent, finalize degrades to
+      # a best-effort no-op rather than failing.
       - name: Run synth-setter-finalize-dataset
         env:
           DATASET_SPEC_URI: ${{ inputs.dataset_spec_uri }}
           PROJECT_ROOT: ${{ github.workspace }}
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
         run: |
           set -euo pipefail
           uv run synth-setter-finalize-dataset \

--- a/docs/design/storage-provenance-spec.md
+++ b/docs/design/storage-provenance-spec.md
@@ -116,13 +116,13 @@ ______________________________________________________________________
 
 ## 4. W&B Artifact Types
 
-| Type           | Name Pattern               | Logged By                         | Example name        |
-| -------------- | -------------------------- | --------------------------------- | ------------------- |
-| `dataset`      | `data-{dataset_config_id}` | `pipeline.cli finalize` (planned) | `data-diva-v1`      |
-| `model`        | `model-{train_config_id}`  | `src/synth_setter/cli/train.py`   | `model-flow-simple` |
-| `eval-results` | `eval-{eval_config_id}`    | eval script                       | `eval-nsynth-v1`    |
+| Type           | Name Pattern               | Logged By                                  | Example name        |
+| -------------- | -------------------------- | ------------------------------------------ | ------------------- |
+| `dataset`      | `data-{dataset_config_id}` | `src/synth_setter/cli/finalize_dataset.py` | `data-diva-v1`      |
+| `model`        | `model-{train_config_id}`  | `src/synth_setter/cli/train.py`            | `model-flow-simple` |
+| `eval-results` | `eval-{eval_config_id}`    | eval script                                | `eval-nsynth-v1`    |
 
-> **Note:** `pipeline.cli finalize` is the target CLI (Phase 5). In Docker, the finalize step runs as `MODE=finalize-shards` (scoped, validated on experiment branch — [#408](https://github.com/tinaudio/synth-setter/issues/408)). Current entrypoint: `pipeline.entrypoints.generate_dataset`.
+> **Note:** `finalize_dataset.py` logs the `dataset` artifact (`build_dataset_artifact` / `_log_dataset_artifact`), resuming the data-generation run pinned to `spec.run_id` so the artifact lands on the producer node of the lineage DAG. It composes a `WandbLogger` from `configs/finalize_dataset.yaml`'s `logger: wandb` default and degrades to a best-effort no-op without `WANDB_API_KEY`. In Docker the finalize step runs as `MODE=finalize-shards` (scoped, validated on experiment branch — [#408](https://github.com/tinaudio/synth-setter/issues/408)).
 
 - W&B auto-versions artifacts (`:v0`, `:v1`, `:v2`). Each new run of the same config produces the next version.
 - The `*_wandb_run_id` is stored in `artifact.metadata`, not the artifact name

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -81,7 +81,7 @@ docs:
       - pattern: "src/synth_setter/configs/finalize_dataset.yaml"
         covers: "Finalize @hydra.main entry config; required `dataset_spec_uri` loads the persisted DatasetSpec from R2 (file://, r2://, or bare path); overrides `hydra.run.dir` because `task_name`/`run_name` are not in this cfg"
       - pattern: "src/synth_setter/cli/finalize_dataset.py"
-        covers: "Finalize entrypoint: loads DatasetSpec from `cfg.dataset_spec_uri` via `load_spec_from_uri`, dispatches on `spec.output_format` (wds → `finalize_wds` streaming Welford / hdf5 → `finalize_hdf5` reshard + stats), writes `dataset.complete` marker last (R2 source-of-truth idempotency); calls assert_r2_prefix_matches before any R2 writes to catch prefix drift; logs the canonical `data-{config_id}` dataset W&B artifact (build_dataset_artifact) with s3:// R2 references to any configured WandbLogger"
+        covers: "Finalize entrypoint: loads the frozen DatasetSpec, dispatches on `spec.output_format` (wds → `finalize_wds`, hdf5 → `finalize_hdf5`), asserts the R2 prefix before any write, writes the `dataset.complete` marker last for idempotency, then logs the canonical `data-{config_id}` dataset W&B artifact with s3:// R2 references"
       - pattern: ".github/workflows/generate-dataset-shards.yaml"
         covers: "Reusable launcher fan-out across providers (skypilot-local kind, runpod, oci); per-provider artifact upload; emits a `spec_uri` workflow output (the materialized spec's canonical under-prefix `input_spec.json` URI, computed by the `synth-setter-spec-uri` console script — see `src/synth_setter/pipeline/ci/spec_uri.py`) consumed by validate-dataset-shards"
       - pattern: ".github/workflows/validate-dataset-shards.yaml"

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -79,7 +79,7 @@ docs:
       - pattern: "src/synth_setter/cli/generate_dataset.py"
         covers: "Dataset generation entrypoint: sequential or (when `render.parallel=True`) thread-pool-parallel multi-shard dispatch with R2 skip-existing probe (worker-side resumability MVP, #750) and per-shard `render.max_retries` retry loop around the renderer subprocess; @hydra.main CLI (`python -m synth_setter.cli.generate_dataset experiment=<id>`) composed from src/synth_setter/configs/dataset.yaml"
       - pattern: "src/synth_setter/configs/finalize_dataset.yaml"
-        covers: "Finalize @hydra.main entry config; required `dataset_spec_uri` loads the persisted DatasetSpec from R2 (file://, r2://, or bare path); overrides `hydra.run.dir` because `task_name`/`run_name` are not in this cfg"
+        covers: "Finalize @hydra.main entry config; required `dataset_spec_uri` loads the persisted DatasetSpec from R2 (file://, r2://, or bare path); overrides `hydra.run.dir` because `task_name`/`run_name` are not in this cfg; composes the `logger: wandb` group so finalize logs the dataset artifact (best-effort no-op without `WANDB_API_KEY`)"
       - pattern: "src/synth_setter/cli/finalize_dataset.py"
         covers: "Finalize entrypoint: loads the frozen DatasetSpec, dispatches on `spec.output_format` (wds → `finalize_wds`, hdf5 → `finalize_hdf5`), asserts the R2 prefix before any write, writes the `dataset.complete` marker last for idempotency, then logs the canonical `data-{config_id}` dataset W&B artifact with s3:// R2 references"
       - pattern: ".github/workflows/generate-dataset-shards.yaml"

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -81,7 +81,7 @@ docs:
       - pattern: "src/synth_setter/configs/finalize_dataset.yaml"
         covers: "Finalize @hydra.main entry config; required `dataset_spec_uri` loads the persisted DatasetSpec from R2 (file://, r2://, or bare path); overrides `hydra.run.dir` because `task_name`/`run_name` are not in this cfg"
       - pattern: "src/synth_setter/cli/finalize_dataset.py"
-        covers: "Finalize entrypoint: loads DatasetSpec from `cfg.dataset_spec_uri` via `load_spec_from_uri`, dispatches on `spec.output_format` (wds → `finalize_wds` streaming Welford / hdf5 → `finalize_hdf5` reshard + stats), writes `dataset.complete` marker last (R2 source-of-truth idempotency); calls assert_r2_prefix_matches before any R2 writes to catch prefix drift"
+        covers: "Finalize entrypoint: loads DatasetSpec from `cfg.dataset_spec_uri` via `load_spec_from_uri`, dispatches on `spec.output_format` (wds → `finalize_wds` streaming Welford / hdf5 → `finalize_hdf5` reshard + stats), writes `dataset.complete` marker last (R2 source-of-truth idempotency); calls assert_r2_prefix_matches before any R2 writes to catch prefix drift; logs the canonical `data-{config_id}` dataset W&B artifact (build_dataset_artifact) with s3:// R2 references to any configured WandbLogger"
       - pattern: ".github/workflows/generate-dataset-shards.yaml"
         covers: "Reusable launcher fan-out across providers (skypilot-local kind, runpod, oci); per-provider artifact upload; emits a `spec_uri` workflow output (the materialized spec's canonical under-prefix `input_spec.json` URI, computed by the `synth-setter-spec-uri` console script — see `src/synth_setter/pipeline/ci/spec_uri.py`) consumed by validate-dataset-shards"
       - pattern: ".github/workflows/validate-dataset-shards.yaml"

--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -169,24 +169,26 @@ ______________________________________________________________________
 
 ## 3. Artifacts
 
-| Artifact                 | Source                                                             | When                                                                                                |
-| ------------------------ | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------- |
-| Model checkpoints        | `ModelCheckpoint` + `log_model: "all"`                             | Every 5000 steps (with `default_surge` callbacks) + best + last, all uploaded immediately           |
-| Source code              | `wandb.Settings(code_dir=".")`                                     | Run start                                                                                           |
-| `<task_name>-input-spec` | `_log_spec_artifact` in `src/synth_setter/cli/generate_dataset.py` | Dataset-generation run start; artifact type `dataset-spec`, payload = `DatasetSpec.model_dump_json` |
+| Artifact                 | Source                                                                                           | When                                                                                                                                            |
+| ------------------------ | ------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| Model checkpoints        | `ModelCheckpoint` + `log_model: "all"`                                                           | Every 5000 steps (with `default_surge` callbacks) + best + last, all uploaded immediately                                                       |
+| Source code              | `wandb.Settings(code_dir=".")`                                                                   | Run start                                                                                                                                       |
+| `<task_name>-input-spec` | `_log_spec_artifact` in `src/synth_setter/cli/generate_dataset.py`                               | Dataset-generation run start; artifact type `dataset-spec`, payload = `DatasetSpec.model_dump_json`                                             |
+| `data-{task_name}`       | `build_dataset_artifact` / `_log_dataset_artifact` in `src/synth_setter/cli/finalize_dataset.py` | Finalize, after the R2 outputs land; type `dataset`, `s3://` R2 references (`checksum=False`), metadata `shard_count` / `n_samples` / `git_sha` |
 
 ______________________________________________________________________
 
 ## 4. Entry Points
 
-| Entry point                                | W&B usage                                                                                                                                                                                         | File                                       |
-| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
-| `src/synth_setter/cli/train.py`            | Full: logger init → hparams → provenance → train metrics → test metrics → teardown                                                                                                                | `src/synth_setter/cli/train.py`            |
-| `src/synth_setter/cli/eval.py`             | Full: logger init → hparams → provenance → test/val metrics (+ optional predictions) → predict-mode `audio/<metric>_{mean,std}` keys from `_log_audio_metrics_to_wandb` → teardown                | `src/synth_setter/cli/eval.py`             |
-| `src/synth_setter/cli/generate_dataset.py` | Dataset-generation: logger init pinned to `spec.run_id` → spec hparams → provenance → `<task_name>-input-spec` artifact → per-shard metrics → run summary → `finalize(status)` + `wandb.finish()` | `src/synth_setter/cli/generate_dataset.py` |
+| Entry point                                | W&B usage                                                                                                                                                                                                                                                                                          | File                                       |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ |
+| `src/synth_setter/cli/train.py`            | Full: logger init → hparams → provenance → train metrics → test metrics → teardown                                                                                                                                                                                                                 | `src/synth_setter/cli/train.py`            |
+| `src/synth_setter/cli/eval.py`             | Full: logger init → hparams → provenance → test/val metrics (+ optional predictions) → predict-mode `audio/<metric>_{mean,std}` keys from `_log_audio_metrics_to_wandb` → teardown                                                                                                                 | `src/synth_setter/cli/eval.py`             |
+| `src/synth_setter/cli/generate_dataset.py` | Dataset-generation: logger init pinned to `spec.run_id` → spec hparams → provenance → `<task_name>-input-spec` artifact → per-shard metrics → run summary → `finalize(status)` + `wandb.finish()`                                                                                                  | `src/synth_setter/cli/generate_dataset.py` |
+| `src/synth_setter/cli/finalize_dataset.py` | Dataset-finalize: resumes the data-generation run (`id=spec.run_id`, `job_type=data-generation`, `resume=allow`) → logs the `data-{config_id}` `dataset` artifact with `s3://` R2 references → `close_loggers`. Best-effort: a finalize without `WANDB_API_KEY` / logger group degrades to a no-op | `src/synth_setter/cli/finalize_dataset.py` |
 
 Both training and eval use `@task_wrapper` which ensures `wandb.finish()` runs even on exception.
-`generate_dataset` brackets `generate(...)` in its own `try/finally` that calls `_close_loggers` — see §5 for the metric / run-id contract.
+`generate_dataset` brackets `generate(...)` in its own `try/finally` that calls `close_loggers` (now in `synth_setter.utils.instantiators`, shared with finalize) — see §5 for the metric / run-id contract.
 
 ______________________________________________________________________
 
@@ -231,7 +233,7 @@ Emitted by `_log_summary` after the dispatcher returns. The dispatcher is fail-f
 is no partial-success path. Either every owned shard's contract is fulfilled (rendered or
 short-circuited by the R2-skip probe) and `finalize(status)` records `"success"`, or any
 shard's exception propagates up `generate()`'s `try/except`, `status` flips to `"failed"`,
-the summary is not emitted, and `_close_loggers` calls `finalize("failed")` + `wandb.finish()`
+the summary is not emitted, and `close_loggers` calls `finalize("failed")` + `wandb.finish()`
 in the `finally`.
 
 ### 5d. Linked issues

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -16,8 +16,11 @@ from pathlib import Path
 
 import hydra
 import numpy as np
+import wandb
+from lightning.pytorch.loggers import Logger
+from lightning.pytorch.loggers.wandb import WandbLogger
 from loguru import logger
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from synth_setter.pipeline import r2_io
 from synth_setter.pipeline.constants import (
@@ -30,6 +33,8 @@ from synth_setter.pipeline.data.stats import get_stats_hdf5, stream_stats_wds
 from synth_setter.pipeline.schemas.prefix import assert_r2_prefix_matches
 from synth_setter.pipeline.schemas.spec import DatasetSpec, OutputFormat
 from synth_setter.pipeline.spec_io import load_spec_from_uri, write_spec_to_path
+from synth_setter.utils import pin_wandb_run_id
+from synth_setter.utils.instantiators import close_loggers, instantiate_loggers
 from synth_setter.workspace import operator_workspace
 
 # Resolve workspace at import so ``${oc.env:PROJECT_ROOT}`` in
@@ -194,21 +199,131 @@ def finalize_from_spec(spec: DatasetSpec, work_dir: Path) -> None:
     logger.info("wrote dataset.complete to {}", marker_uri)
 
 
-def finalize(cfg: DictConfig) -> None:
+def _r2_to_s3_uri(r2_uri: str) -> str:
+    """Rewrite an ``r2://`` URI to the ``s3://`` scheme W&B references record.
+
+    R2 exposes an S3-compatible API; only the scheme differs, so the
+    bucket/key path is preserved verbatim. ``storage-provenance-spec.md`` §4
+    logs dataset references as ``s3://``.
+
+    :param r2_uri: An ``r2://<bucket>/<key>`` URI (e.g. from ``R2Location``).
+    :returns: The same location as ``s3://<bucket>/<key>``.
+    :raises ValueError: ``r2_uri`` does not start with the ``r2://`` scheme.
+    """
+    scheme = "r2://"
+    if not r2_uri.startswith(scheme):
+        raise ValueError(f"expected an r2:// URI, got {r2_uri!r}")
+    return f"s3://{r2_uri[len(scheme) :]}"
+
+
+def _finalized_reference_uris(spec: DatasetSpec) -> list[str]:
+    """Return the R2 URIs of the objects finalize materialized for this run.
+
+    hdf5 reshards into per-split ``.h5`` files, so each non-empty split plus
+    ``stats.npz`` is referenced. wds leaves shards in place under the run
+    prefix, so the prefix dir (carrying the tars) plus ``stats.npz`` is
+    referenced. Empty splits contribute nothing — finalize prunes them.
+
+    :param spec: Validated dataset spec.
+    :returns: Canonical ``r2://`` URIs, splits/prefix first then ``stats.npz``.
+    """
+    if spec.output_format is OutputFormat.HDF5:
+        split_uris = [
+            spec.r2.split_h5_uri(split)
+            for split, (lo, hi) in spec.split_shard_ranges.items()
+            if lo < hi
+        ]
+        return [*split_uris, spec.r2.stats_uri()]
+    return [spec.r2.uri(spec.r2.prefix), spec.r2.stats_uri()]
+
+
+def build_dataset_artifact(spec: DatasetSpec) -> wandb.Artifact:
+    """Build the canonical ``dataset`` W&B artifact for a finalized run.
+
+    Names the artifact ``data-{spec.task_name}`` (type ``dataset``) per
+    ``storage-provenance-spec.md`` §4, references the finalized R2 objects as
+    ``s3://`` URIs (split ``.h5`` files or the shard prefix, plus
+    ``stats.npz``), and records ``shard_count`` / ``n_samples`` / ``git_sha``
+    in ``artifact.metadata`` per §6. References use ``checksum=False`` because
+    R2's custom S3 endpoint is not reachable by W&B's default reference
+    handler — the URIs record lineage, not a content hash.
+
+    :param spec: Validated dataset spec; its R2 location and split sizes
+        determine the references and metadata.
+    :returns: An unlogged ``wandb.Artifact`` ready for ``log_artifact``.
+    """
+    artifact = wandb.Artifact(
+        name=f"data-{spec.task_name}",
+        type="dataset",
+        metadata={
+            "shard_count": spec.num_shards,
+            "n_samples": sum(spec.train_val_test_sizes),
+            "git_sha": spec.git_sha,
+        },
+    )
+    for r2_uri in _finalized_reference_uris(spec):
+        artifact.add_reference(_r2_to_s3_uri(r2_uri), checksum=False)
+    return artifact
+
+
+def _log_dataset_artifact(loggers: list[Logger], spec: DatasetSpec) -> None:
+    """Log the canonical ``dataset`` artifact to each ``WandbLogger`` in ``loggers``.
+
+    Mirrors ``generate_dataset._log_spec_artifact``: a wandb failure warns and
+    is swallowed so artifact logging never aborts a completed finalize — the
+    R2 outputs and ``dataset.complete`` marker are already written.
+    Non-``WandbLogger`` entries (and an empty list) are a no-op, which is the
+    path every wandb-free caller (e.g. the existing finalize tests) takes.
+
+    :param loggers: Lightning loggers; only ``WandbLogger`` entries log.
+    :param spec: Validated dataset spec forwarded to :func:`build_dataset_artifact`.
+    """
+    for lg in loggers:
+        if not isinstance(lg, WandbLogger):
+            continue
+        try:
+            lg.experiment.log_artifact(build_dataset_artifact(spec))
+        except Exception as exc:  # noqa: BLE001 — wandb artifact failure must not abort finalize
+            logger.warning(f"_log_dataset_artifact failed on {type(lg).__name__}: {exc}")
+
+
+def finalize(cfg: DictConfig) -> None:  # noqa: DOC503
     """Finalize the R2 prefix for ``cfg.dataset_spec_uri``; idempotent on ``dataset.complete``.
 
-    Loads R2 creds and the spec from ``cfg.dataset_spec_uri``, then delegates
-    to :func:`finalize_from_spec` for the marker-probe → dispatch → marker-upload
-    body.
+    Loads R2 creds and the spec from ``cfg.dataset_spec_uri``, delegates to
+    :func:`finalize_from_spec` for the marker-probe → dispatch → marker-upload
+    body, then logs the canonical ``dataset`` artifact to any configured
+    ``WandbLogger`` (resuming the data-generation run pinned to ``spec.run_id``
+    so the artifact lands on the producer node of the lineage DAG). The wandb
+    run id is pinned and ``resume=allow`` is forced so finalize attaches to the
+    generation run rather than minting a new one; both are no-ops when
+    ``cfg`` carries no ``logger`` group (the wandb-free default). On any
+    failure the loggers are still closed (status ``"failed"``) before the
+    exception re-raises.
 
     :param cfg: Composed cfg with ``dataset_spec_uri`` (URI accepted by
-        :func:`~synth_setter.pipeline.spec_io.load_spec_from_uri`) and
+        :func:`~synth_setter.pipeline.spec_io.load_spec_from_uri`),
         ``paths.output_dir`` (writable scratch dir; created if missing;
-        retained after the call, multi-GB on the hdf5 branch).
+        retained after the call, multi-GB on the hdf5 branch), and an optional
+        ``logger`` group instantiated for W&B artifact logging.
+    :raises ValueError: Propagated from :func:`finalize_from_spec` — a drifted
+        ``spec.r2.prefix`` or an unsupported ``spec.output_format``.
     """
     r2_io.ensure_r2_env_loaded()
     spec = load_spec_from_uri(cfg.dataset_spec_uri)
-    finalize_from_spec(spec, Path(cfg.paths.output_dir))
+    pin_wandb_run_id(cfg, spec.run_id, "data-generation")
+    if OmegaConf.select(cfg, "logger.wandb") is not None:
+        OmegaConf.update(cfg, "logger.wandb.resume", "allow", force_add=True)
+    loggers = instantiate_loggers(cfg.get("logger"))
+    status = "success"
+    try:
+        finalize_from_spec(spec, Path(cfg.paths.output_dir))
+        _log_dataset_artifact(loggers, spec)
+    except BaseException:
+        status = "failed"
+        raise
+    finally:
+        close_loggers(loggers, status)
 
 
 @hydra.main(

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -51,7 +51,7 @@ from synth_setter.pipeline.spec_io import (
 )
 from synth_setter.resources import as_file, vst_headless_wrapper
 from synth_setter.utils import extras, log_wandb_provenance, pin_wandb_run_id, register_resolvers
-from synth_setter.utils.instantiators import instantiate_loggers
+from synth_setter.utils.instantiators import close_loggers, instantiate_loggers
 from synth_setter.workspace import operator_workspace
 
 # Side effect only: publish ``PROJECT_ROOT`` so ``${oc.env:PROJECT_ROOT}``
@@ -314,7 +314,7 @@ def generate(spec: DatasetSpec, work_dir: Path, loggers: list[Logger]) -> None: 
         # leaks un-closed on the helper's exception path.
         _log_hyperparams(loggers, spec)
         # Provenance mutates the process-global ``wandb.run``; only stamp it when
-        # a ``WandbLogger`` here owns the run, mirroring ``_close_loggers`` — else
+        # a ``WandbLogger`` here owns the run, mirroring ``close_loggers`` — else
         # an empty-logger run would stamp a foreign run started elsewhere.
         if any(isinstance(lg, WandbLogger) for lg in loggers):
             log_wandb_provenance()
@@ -371,7 +371,7 @@ def generate(spec: DatasetSpec, work_dir: Path, loggers: list[Logger]) -> None: 
         status = "failed"
         raise
     finally:
-        _close_loggers(loggers, status)
+        close_loggers(loggers, status)
 
 
 def _log_hyperparams(loggers: list[Logger], spec: DatasetSpec) -> None:
@@ -480,34 +480,6 @@ def _log_summary(
             lg.log_metrics(payload)
         except Exception as exc:  # noqa: BLE001 — third-party logger failures must not abort the run
             logger.warning(f"log_metrics(summary) failed on {type(lg).__name__}: {exc}")
-
-
-def _close_loggers(loggers: list[Logger], status: str) -> None:
-    """Finalize each logger and flush any live wandb run.
-
-    ``WandbLogger.finalize`` records status but does not close the run;
-    ``wandb.finish()`` is what flushes the offline ``.wandb`` binary
-    (matches the pattern in ``synth_setter.utils.utils``).
-
-    :param loggers: Lightning loggers — finalize is invoked on each.
-    :param status: ``"success"`` or ``"failed"``; forwarded verbatim to the
-        loggers' ``finalize`` contract.
-    """
-    for lg in loggers:
-        try:
-            lg.finalize(status)
-        except Exception as exc:  # noqa: BLE001 — finalize errors must not mask the original raise
-            logger.warning(f"logger finalize failed on {type(lg).__name__}: {exc}")
-    # Only close the wandb run if a ``WandbLogger`` is in ``loggers`` — i.e. we
-    # opened it. Otherwise a stale ``wandb.run`` started elsewhere in the
-    # process (e.g. another library, a sibling test) would be silently
-    # finished here.
-    have_wandb_logger = any(isinstance(lg, WandbLogger) for lg in loggers)
-    if have_wandb_logger and wandb.run is not None:
-        try:
-            wandb.finish()
-        except Exception as exc:  # noqa: BLE001 — finish errors must not mask the original raise
-            logger.warning(f"wandb.finish() failed: {exc}")
 
 
 def _dispatch_shards_serial(

--- a/src/synth_setter/configs/finalize_dataset.yaml
+++ b/src/synth_setter/configs/finalize_dataset.yaml
@@ -2,9 +2,16 @@
 defaults:
   - paths: default
   - hydra: default
+  - logger: wandb
   - _self_
 
 dataset_spec_uri: ???
+
+# Logger group resumes the data-generation run (id pinned to spec.run_id,
+# resume=allow forced in `finalize`) so the canonical `data-{config_id}`
+# dataset artifact lands on the producer node of the W&B lineage DAG.
+# WandbLogger inits lazily, so a finalize run without WANDB_API_KEY degrades
+# to a best-effort no-op rather than aborting (see `_log_dataset_artifact`).
 
 # Surfaces ${task_name} so hydra/default.yaml's run.dir + job_logging
 # interpolations resolve; run.dir is also overridden below because the

--- a/src/synth_setter/utils/instantiators.py
+++ b/src/synth_setter/utils/instantiators.py
@@ -1,5 +1,7 @@
 """Hydra helpers that turn callback and logger config groups into instantiated objects."""
 
+from importlib.util import find_spec
+
 import hydra
 from lightning import Callback
 from lightning.pytorch.loggers import Logger
@@ -58,3 +60,32 @@ def instantiate_loggers(logger_cfg: DictConfig) -> list[Logger]:
             logger.append(hydra.utils.instantiate(lg_conf))
 
     return logger
+
+
+def close_loggers(loggers: list[Logger], status: str) -> None:
+    """Finalize each logger and flush any live wandb run.
+
+    ``WandbLogger.finalize`` records status but does not close the run;
+    ``wandb.finish()`` is what flushes the offline ``.wandb`` binary. The run
+    is closed only when a ``WandbLogger`` is in ``loggers`` — i.e. this process
+    opened it — so a stale ``wandb.run`` started elsewhere is left untouched.
+
+    :param loggers: Lightning loggers; ``finalize`` is invoked on each.
+    :param status: ``"success"`` or ``"failed"``; forwarded verbatim to each
+        logger's ``finalize`` contract.
+    """
+    for lg in loggers:
+        try:
+            lg.finalize(status)
+        except Exception as exc:  # noqa: BLE001 — finalize errors must not mask the original raise
+            log.warning(f"logger finalize failed on {type(lg).__name__}: {exc}")
+    if not find_spec("wandb"):
+        return
+    import wandb
+    from lightning.pytorch.loggers.wandb import WandbLogger
+
+    if any(isinstance(lg, WandbLogger) for lg in loggers) and wandb.run is not None:
+        try:
+            wandb.finish()
+        except Exception as exc:  # noqa: BLE001 — finish errors must not mask the original raise
+            log.warning(f"wandb.finish() failed: {exc}")

--- a/tests/pipeline/entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/entrypoints/test_finalize_dataset.py
@@ -368,13 +368,16 @@ def test_finalize_dataset_main_resolves_hydra_logging_under_at_hydra_main(
     """Invoking ``main()`` under @hydra.main resolves every interpolation in the shared groups.
 
     The shared ``hydra/default.yaml`` interpolates ``${task_name}`` into both
-    ``run.dir`` and ``job_logging.handlers.file.filename``. A missing override
-    surfaces as a Hydra startup ``InterpolationKeyError`` *before*
-    ``finalize()`` fires — a structure-only compose check (``return_hydra_config=True``)
-    inspects unresolved templates and misses this. Drive the decorated
-    ``main()`` for real with the marker-probe stub set to "present" so the
-    body short-circuits at the idempotency check, isolating the test to
-    Hydra-side resolution.
+    ``run.dir`` and ``job_logging.handlers.file.filename``, and the composed
+    ``logger: wandb`` group interpolates ``${paths.output_dir}`` +
+    ``${oc.env:WANDB_*}``. A missing override surfaces as a Hydra startup
+    ``InterpolationKeyError`` *before* ``finalize()`` fires — a structure-only
+    compose check (``return_hydra_config=True``) inspects unresolved templates
+    and misses this. Drive the decorated ``main()`` for real with the
+    marker-probe stub set to "present" so the body short-circuits at the
+    idempotency check, isolating the test to Hydra-side resolution.
+    ``WANDB_MODE=disabled`` makes the composed WandbLogger a no-op so no
+    network or run dir is created.
 
     :param tmp_path: Hosts ``PROJECT_ROOT``, the on-disk spec JSON, and Hydra's run dir.
     :param monkeypatch: Pytest fixture used to point ``PROJECT_ROOT`` + ``sys.argv``.
@@ -382,6 +385,7 @@ def test_finalize_dataset_main_resolves_hydra_logging_under_at_hydra_main(
         body skips the wds/hdf5 dispatch.
     """
     stub_finalize_setup(0)
+    monkeypatch.setenv("WANDB_MODE", "disabled")
     monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
     spec = _build_wds_smoke_spec(task_name="hydra-startup")
     spec_uri = _write_spec_to_file(spec, tmp_path)
@@ -1214,12 +1218,22 @@ def test_finalize_logs_dataset_artifact_to_offline_wandb_run(
     )
 
     artifact_name = f"data-{spec.task_name}"
+    # The wds run references the prefix dir + stats.npz; pin the exact stats
+    # s3 URI rather than a bare `s3://` so the assertion can't pass on an
+    # incidental reference. Bucket/prefix come straight off the spec.
+    stats_ref = f"s3://{spec.r2.bucket}/{spec.r2.prefix}stats.npz"
     payload = read_run_binary(
         Path(binary_files[0]),
-        until=lambda data: artifact_name.encode() in data and b"s3://" in data,
+        until=lambda data: artifact_name.encode() in data and stats_ref.encode() in data,
     )
     assert artifact_name.encode() in payload, (
         f"dataset artifact {artifact_name!r} not recorded in offline run binary"
     )
     assert b"dataset" in payload, "artifact type 'dataset' not recorded"
-    assert b"s3://" in payload, "no s3:// R2 reference recorded on the artifact"
+    assert stats_ref.encode() in payload, (
+        f"finalized stats reference {stats_ref!r} not recorded on the artifact"
+    )
+    # Metadata block round-trips through the real log → binary path.
+    assert b"n_samples" in payload and b"git_sha" in payload, (
+        "artifact metadata (n_samples / git_sha) not recorded in offline run binary"
+    )

--- a/tests/pipeline/entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/entrypoints/test_finalize_dataset.py
@@ -21,7 +21,9 @@ them cleanly:
 
 from __future__ import annotations
 
+import glob
 import io
+import os
 import shutil
 import tarfile
 from collections.abc import Callable
@@ -31,6 +33,7 @@ from typing import Any, NoReturn, cast
 import h5py
 import numpy as np
 import pytest
+import wandb
 from omegaconf import DictConfig, OmegaConf
 
 from synth_setter.cli import finalize_dataset
@@ -45,6 +48,7 @@ from synth_setter.data.vst.shapes import (
 )
 from synth_setter.pipeline import r2_io
 from synth_setter.pipeline.schemas.spec import DatasetSpec
+from tests.helpers.wandb_offline import read_run_binary
 
 
 def _write_minimal_wds_shard(dest: Path) -> None:
@@ -1091,3 +1095,131 @@ def test_finalize_wds_unlinks_each_shard_after_folding(
     finalize_dataset.finalize_wds(spec, work_dir)
 
     assert concurrent_shards_seen == [1, 1]
+
+
+def test_finalize_from_spec_drifted_prefix_raises_before_any_upload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_finalize_setup: Callable[[int | None], None],  # noqa: ARG001 — installs stubs only
+) -> None:
+    """A drifted ``r2.prefix`` raises ``ValueError`` before any R2 write or scratch dir.
+
+    Integration-level companion to ``test_prefix.py``'s unit coverage of
+    ``assert_r2_prefix_matches``: it pins the guard at the ``finalize_from_spec``
+    call site so a future reordering (e.g. moving the assertion past the
+    dispatch) trips here. The fail-fast ``upload`` stub turns a leaked write
+    into a test failure, proving the abort precedes the marker-last upload
+    sequence; the ``work_dir`` assertion proves it precedes ``work_dir.mkdir``.
+
+    :param tmp_path: Hosts the scratch ``work_dir`` path (asserted never created).
+    :param monkeypatch: Installs a fail-fast ``upload`` stub.
+    :param stub_finalize_setup: Installs the auth + marker-probe stubs so the
+        guard (not the marker check) is the failure surface.
+    """
+    spec = _build_wds_smoke_spec(task_name="finalize-drifted-prefix")
+    drifted_r2 = spec.r2.model_copy(update={"prefix": "data/wrong-cfg/wrong-run/"})
+    drifted_spec = spec.model_copy(update={"r2": drifted_r2})
+
+    def fail_fast_upload(src: str | Path, dst: str) -> NoReturn:
+        raise AssertionError(f"upload must not run on a drifted prefix (got {dst!r})")
+
+    monkeypatch.setattr("synth_setter.pipeline.r2_io.upload", fail_fast_upload)
+    work_dir = tmp_path / "work"
+
+    with pytest.raises(ValueError, match="prefix mismatch"):
+        finalize_dataset.finalize_from_spec(drifted_spec, work_dir)
+    assert not work_dir.exists()
+
+
+def _build_finalize_cfg_with_offline_wandb(
+    spec_uri: str, output_dir: Path, save_dir: Path
+) -> DictConfig:
+    """Build a ``finalize()`` cfg carrying an offline ``WandbLogger`` group.
+
+    Mirrors the production logger composition (``_target_`` + project) but
+    pins ``offline=True`` and a tmp ``save_dir`` so ``finalize`` instantiates a
+    real, hermetic wandb run rather than a no-op empty logger list.
+
+    :param spec_uri: URI passed through to ``load_spec_from_uri``.
+    :param output_dir: Finalize's scratch ``work_dir`` (must exist).
+    :param save_dir: Where the offline run's ``wandb/`` dir is written.
+    :returns: Mutable DictConfig with ``dataset_spec_uri``, ``paths``, ``logger``.
+    """
+    return cast(
+        DictConfig,
+        OmegaConf.create(
+            {
+                "dataset_spec_uri": spec_uri,
+                "paths": {"output_dir": str(output_dir)},
+                "logger": {
+                    "wandb": {
+                        "_target_": "lightning.pytorch.loggers.wandb.WandbLogger",
+                        "offline": True,
+                        "save_dir": str(save_dir),
+                        "id": None,
+                        "job_type": "",
+                        "project": "finalize-wandb-test-project",
+                    }
+                },
+            }
+        ),
+    )
+
+
+def test_finalize_logs_dataset_artifact_to_offline_wandb_run(
+    tmp_path: Path,
+    fake_r2_remote: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_finalize_setup: Callable[[int | None], None],  # noqa: ARG001 — installs stubs only
+) -> None:
+    """``finalize(cfg)`` end-to-end logs a ``data-{id}`` ``dataset`` artifact with an R2 ref.
+
+    Drives the real entrypoint against the local-typed remote (real rclone for
+    the stats + marker writes) and a real ``WandbLogger(offline=True)``, then
+    decodes the offline ``run-*.wandb`` binary to confirm the canonical dataset
+    artifact landed — the producer node of the lineage DAG (#1471). No wandb
+    internals are mocked; the artifact name, type, and ``s3://`` reference are
+    read back from the bytes the live client wrote.
+
+    :param tmp_path: Hosts the spec JSON, scratch work_dir, and offline run dir.
+    :param fake_r2_remote: Local-typed rclone remote; seeded train shards land
+        here so the wds stats pass has real tars to stream.
+    :param monkeypatch: Pins a hermetic offline ``WANDB_*`` env.
+    :param stub_finalize_setup: Installs the auth + marker-probe stubs.
+    """
+    for key in [k for k in os.environ if k.startswith("WANDB_")]:
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("WANDB_MODE", "offline")
+    monkeypatch.setenv("WANDB_DATA_DIR", str(tmp_path / "wandb-data"))
+    wandb.teardown()
+
+    spec = _build_wds_smoke_spec(task_name="finalize-artifact-e2e")
+    _seed_train_shards(fake_r2_remote, spec)
+    output_dir = tmp_path / "work"
+    output_dir.mkdir()
+    cfg = _build_finalize_cfg_with_offline_wandb(
+        _write_spec_to_file(spec, tmp_path), output_dir, tmp_path
+    )
+
+    finalize_dataset.finalize(cfg)
+    assert wandb.run is None, "finalize() did not close the wandb run on return"
+
+    offline_dirs = list((tmp_path / "wandb").glob(f"offline-run-*-{spec.run_id}"))
+    assert len(offline_dirs) == 1, (
+        f"expected one offline-run dir for {spec.run_id}, found {offline_dirs}"
+    )
+    binary_files = glob.glob(str(offline_dirs[0] / "run-*.wandb"))
+    assert len(binary_files) == 1, (
+        f"expected one .wandb binary in {offline_dirs[0]}, found {binary_files}"
+    )
+
+    artifact_name = f"data-{spec.task_name}"
+    payload = read_run_binary(
+        Path(binary_files[0]),
+        until=lambda data: artifact_name.encode() in data and b"s3://" in data,
+    )
+    assert artifact_name.encode() in payload, (
+        f"dataset artifact {artifact_name!r} not recorded in offline run binary"
+    )
+    assert b"dataset" in payload, "artifact type 'dataset' not recorded"
+    assert b"s3://" in payload, "no s3:// R2 reference recorded on the artifact"

--- a/tests/pipeline/entrypoints/test_finalize_dataset_artifact.py
+++ b/tests/pipeline/entrypoints/test_finalize_dataset_artifact.py
@@ -1,0 +1,125 @@
+"""Unit tests for ``finalize_dataset.build_dataset_artifact``.
+
+Asserts on a real ``wandb.Artifact`` object (no run, no network): name,
+type, R2 references, and metadata are all observable on the returned
+artifact, so these tests exercise the real construction rather than a
+mock of it. The offline end-to-end logging path is covered separately in
+``test_finalize_dataset.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from synth_setter.cli.finalize_dataset import build_dataset_artifact
+from synth_setter.pipeline.schemas.spec import DatasetSpec
+
+_RUN_ID = "finalize-art-20260520T000000000Z"
+_BUCKET = "intermediate-data"
+_PREFIX = f"data/finalize-art/{_RUN_ID}/"
+
+
+def _spec(
+    factory: Callable[..., DatasetSpec],
+    output_format: str = "hdf5",
+    train_val_test_sizes: tuple[int, int, int] = (8, 4, 0),
+) -> DatasetSpec:
+    """Build a finalize-artifact spec with a fixed run id, bucket, and prefix.
+
+    :param factory: Shared ``conftest`` ``dataset_spec_factory``.
+    :param output_format: ``hdf5`` or ``wds``; selects the reference shape.
+    :param train_val_test_sizes: Split sample counts (multiples of 4); the
+        default leaves ``test`` empty so the empty-split omission is testable.
+    :returns: A frozen ``DatasetSpec`` whose ``num_shards`` and ``r2`` are
+        deterministic.
+    """
+    return factory(
+        task_name="finalize-art",
+        run_id=_RUN_ID,
+        output_format=output_format,
+        train_val_test_sizes=list(train_val_test_sizes),
+        r2={"bucket": _BUCKET, "prefix": _PREFIX},
+        render={"samples_per_render_batch": 4, "samples_per_shard": 4},
+    )
+
+
+def test_build_dataset_artifact_name_is_data_prefixed_config_id(
+    dataset_spec_factory: Callable[..., DatasetSpec],
+) -> None:
+    """The artifact name is ``data-{task_name}`` per storage-provenance-spec §4.
+
+    :param dataset_spec_factory: Shared ``conftest`` ``DatasetSpec`` factory.
+    """
+    artifact = build_dataset_artifact(_spec(dataset_spec_factory))
+    assert artifact.name == "data-finalize-art"
+
+
+def test_build_dataset_artifact_type_is_dataset(
+    dataset_spec_factory: Callable[..., DatasetSpec],
+) -> None:
+    """The artifact type is ``dataset`` per storage-provenance-spec §4.
+
+    :param dataset_spec_factory: Shared ``conftest`` ``DatasetSpec`` factory.
+    """
+    artifact = build_dataset_artifact(_spec(dataset_spec_factory))
+    assert artifact.type == "dataset"
+
+
+def test_build_dataset_artifact_metadata_carries_shard_count_n_samples_git_sha(
+    dataset_spec_factory: Callable[..., DatasetSpec],
+) -> None:
+    """Metadata records shard_count, n_samples, and git_sha per storage-provenance-spec §6.
+
+    (8 train + 4 val) / 4 per shard = 3 shards; 12 total samples; the factory
+    pins ``git_sha`` to 40 zeros.
+
+    :param dataset_spec_factory: Shared ``conftest`` ``DatasetSpec`` factory.
+    """
+    artifact = build_dataset_artifact(_spec(dataset_spec_factory))
+    assert artifact.metadata == {"shard_count": 3, "n_samples": 12, "git_sha": "0" * 40}
+
+
+def test_build_dataset_artifact_hdf5_references_nonempty_splits_and_stats(
+    dataset_spec_factory: Callable[..., DatasetSpec],
+) -> None:
+    """hdf5 references each non-empty split ``.h5`` plus ``stats.npz`` as ``s3://`` URIs.
+
+    :param dataset_spec_factory: Shared ``conftest`` ``DatasetSpec`` factory.
+    """
+    artifact = build_dataset_artifact(_spec(dataset_spec_factory))
+    refs = {entry.ref for entry in artifact.manifest.entries.values()}
+    assert refs == {
+        f"s3://{_BUCKET}/{_PREFIX}train.h5",
+        f"s3://{_BUCKET}/{_PREFIX}val.h5",
+        f"s3://{_BUCKET}/{_PREFIX}stats.npz",
+    }
+
+
+def test_build_dataset_artifact_hdf5_omits_empty_split_reference(
+    dataset_spec_factory: Callable[..., DatasetSpec],
+) -> None:
+    """An empty split (``test`` size 0) contributes no reference — nothing was finalized there.
+
+    :param dataset_spec_factory: Shared ``conftest`` ``DatasetSpec`` factory.
+    """
+    artifact = build_dataset_artifact(_spec(dataset_spec_factory))
+    refs = {entry.ref for entry in artifact.manifest.entries.values()}
+    assert f"s3://{_BUCKET}/{_PREFIX}test.h5" not in refs
+
+
+def test_build_dataset_artifact_wds_references_run_prefix_and_stats(
+    dataset_spec_factory: Callable[..., DatasetSpec],
+) -> None:
+    """Wds references the run prefix dir (carrying the shard tars) plus ``stats.npz``.
+
+    wds keeps shards in place rather than resharding into split ``.h5`` files,
+    so the dataset footprint is the prefix dir plus the derived ``stats.npz``.
+
+    :param dataset_spec_factory: Shared ``conftest`` ``DatasetSpec`` factory.
+    """
+    artifact = build_dataset_artifact(_spec(dataset_spec_factory, output_format="wds"))
+    refs = {entry.ref for entry in artifact.manifest.entries.values()}
+    assert refs == {
+        f"s3://{_BUCKET}/{_PREFIX}",
+        f"s3://{_BUCKET}/{_PREFIX}stats.npz",
+    }

--- a/tests/pipeline/entrypoints/test_finalize_dataset_artifact.py
+++ b/tests/pipeline/entrypoints/test_finalize_dataset_artifact.py
@@ -11,7 +11,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 
-from synth_setter.cli.finalize_dataset import build_dataset_artifact
+import pytest
+
+from synth_setter.cli.finalize_dataset import _r2_to_s3_uri, build_dataset_artifact
 from synth_setter.pipeline.schemas.spec import DatasetSpec
 
 _RUN_ID = "finalize-art-20260520T000000000Z"
@@ -123,3 +125,13 @@ def test_build_dataset_artifact_wds_references_run_prefix_and_stats(
         f"s3://{_BUCKET}/{_PREFIX}",
         f"s3://{_BUCKET}/{_PREFIX}stats.npz",
     }
+
+
+def test_r2_to_s3_uri_rejects_non_r2_scheme() -> None:
+    """A URI without the ``r2://`` scheme raises ValueError rather than silently passing through.
+
+    Guards against a future reference source handing ``build_dataset_artifact``
+    a non-R2 URI, which would otherwise log a malformed lineage reference.
+    """
+    with pytest.raises(ValueError, match="r2://"):
+        _r2_to_s3_uri("s3://bucket/already-s3.h5")

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.21.0"
+version = "8.22.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Logs the canonical `data-{dataset_config_id}` W&B artifact (type `dataset`) when the data pipeline finalizes, making finalize the **producer node of the W&B lineage DAG** (storage-provenance-spec §4–6). Closes the Tier-2 head of the provenance work tracked in #1467.

## What changed

- **`build_dataset_artifact(spec)`** (`cli/finalize_dataset.py`) — pure constructor: name `data-{config_id}`, type `dataset`, `add_reference(s3://…, checksum=False)` for each finalized R2 object (per-split `.h5` + `stats.npz` for hdf5; the shard prefix + `stats.npz` for wds), and `metadata = {shard_count, n_samples, git_sha}`. `r2://`→`s3://` per spec §4; `checksum=False` because R2's custom S3 endpoint isn't reachable by W&B's reference handler (lineage-only reference).
- **`_log_dataset_artifact(loggers, spec)`** — best-effort logging to any `WandbLogger`, mirroring `_log_spec_artifact` (a wandb failure warns, never aborts a completed finalize).
- **`finalize(cfg)`** now composes a wandb logger pinned to `spec.run_id` with `job_type=data-generation` + `resume=allow`, so the artifact attaches to the data-generation run. `finalize_dataset.yaml` gains `- logger: wandb`, and `finalize-dataset.yaml` forwards the inherited `WANDB_API_KEY` so the live `generate→finalize` chain actually logs it. WandbLogger inits lazily + logging is best-effort, so a finalize without `WANDB_API_KEY` degrades to a no-op rather than aborting.
- **Refactor:** extracted the logger-finalize + guarded `wandb.finish()` dance from `generate_dataset._close_loggers` into a public `utils.instantiators.close_loggers`, reused by both data-pipeline entrypoints (behavior-preserving).
- **Chore:** synced `uv.lock` to 8.22.0 (the `[skip ci]` release bumped `pyproject.toml` but not the lock), unblocking CI's lock-check.

## Testing

- `tests/.../test_finalize_dataset_artifact.py` — asserts on a **real** `wandb.Artifact` (name/type/refs/metadata, empty-split omission, hdf5-vs-wds reference shapes) + the `_r2_to_s3_uri` non-`r2://` guard.
- `tests/.../test_finalize_dataset.py` — a real-entrypoint **offline e2e**: drives `finalize(cfg)` against `fake_r2_remote` (real rclone) + `WandbLogger(offline=True)`, then decodes the `run-*.wandb` binary to confirm the artifact name, the exact `stats.npz` s3 reference, and the metadata round-trip. Also pins the merged #281 prefix-drift guard at the `finalize_from_spec` call site.

## Pre-PR review

`/repo-review-full-no-comments` ran 7 parallel passes. The one BLOCK (artifact logging dead in production) and the one comment-hygiene WARN were fixed in this branch and re-verified; remaining items are advisory (e.g. wds reference precision, best-effort resume can't guarantee attach). Sentinel: `.agent-reviews/repo-review-full-no-comments.<sha>.md`.

Closes #1471
Refs #1470, #1467
