### PR TITLE
fix(eval): namespace inline oracle-eval audio metrics per split

### DIFF
--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -58,7 +58,7 @@ docs:
       - pattern: "src/synth_setter/cli/eval.py"
         covers: "Checkpoint resolution from W&B, evaluation logging"
       - pattern: "src/synth_setter/cli/generate_dataset.py"
-        covers: "WandbLogger lifecycle for dataset generation: spec → hyperparams + dataset-spec artifact, per-shard + summary history rows, run id pinned to spec.run_id, inline oracle eval resuming the run to append audio/* rows"
+        covers: "WandbLogger lifecycle for dataset generation: spec → hyperparams + dataset-spec artifact, per-shard + summary history rows, run id pinned to spec.run_id, inline oracle eval resuming the run to append per-split-namespaced audio rows (test bare audio/*; train/val under <split>/audio/* via +evaluation.metric_prefix)"
       - pattern: "src/synth_setter/configs/dataset.yaml"
         covers: "Default `logger: wandb` for dataset generation; entity/project sourced from logger/wandb.yaml"
       - pattern: "sweeps/**"

--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -268,10 +268,14 @@ When `oracle_eval_inline=true`, the local-run path shells out to
 `synth_setter.cli.eval` **once per split (train, val, test)** after `generate(...)` has closed its run.
 `_run_oracle_eval_subprocess` (`src/synth_setter/cli/generate_dataset.py`)
 re-opens the same run via `logger.wandb.id=<spec.run_id> +logger.wandb.resume=must`, runs `mode=predict` with `render=surge_simple` to
-re-render the predicted params, and deposits `audio/*` audio-similarity
-metrics onto the generate run — a `wandb sync` then merges both phases under
-one run id. The eval subprocess inherits `WANDB_MODE` from the launcher, so
-its offline/online posture follows the parent's.
+re-render the predicted params, and deposits audio-similarity metrics onto the
+generate run — a `wandb sync` then merges both phases under one run id. Because
+all three splits resume the **same** run, the metric keys are namespaced per
+split so they don't overwrite each other's run summary: `test` keeps the bare
+`audio/*` key, while `train`/`val` are logged under `train/audio/*` and
+`val/audio/*` (via `+evaluation.metric_prefix=<split>/`). The eval subprocess
+inherits `WANDB_MODE` from the launcher, so its offline/online posture follows
+the parent's.
 
 ______________________________________________________________________
 

--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -273,7 +273,9 @@ generate run — a `wandb sync` then merges both phases under one run id. Becaus
 all three splits resume the **same** run, the metric keys are namespaced per
 split so they don't overwrite each other's run summary: `test` keeps the bare
 `audio/*` key, while `train`/`val` are logged under `train/audio/*` and
-`val/audio/*` (via `+evaluation.metric_prefix=<split>/`). The eval subprocess
+`val/audio/*` (via `+evaluation.metric_prefix=<split>/`). The prefix applies to
+every metric key, so the `shuffled_audio/*` keys (§2) become `train/shuffled_audio/*`
+etc. too. The eval subprocess
 inherits `WANDB_MODE` from the launcher, so its offline/online posture follows
 the parent's.
 

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -116,11 +116,13 @@ def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: D
     always forwarded; the render-order probe (#489) runs automatically inside
     ``compute_audio_metrics`` when all sample dirs have identical params.
 
-    :param cfg: Reads ``cfg.evaluation`` (gates + ``num_workers`` + ``shuffle_seed``),
-        ``cfg.render`` (param spec, preset, optional plugin path), and
-        ``cfg.paths.output_dir`` (base for ``predictions/``, ``audio/``, ``metrics/``).
-    :returns: ``{"audio/<name>_<stat>": value}`` when ``compute_metrics`` ran;
-        empty dict otherwise. Always rank-zero — the caller gates DDP duplication.
+    :param cfg: Reads ``cfg.evaluation`` (gates + ``num_workers`` + ``shuffle_seed``
+        + optional ``metric_prefix``), ``cfg.render`` (param spec, preset, optional
+        plugin path), and ``cfg.paths.output_dir`` (base for ``predictions/``,
+        ``audio/``, ``metrics/``).
+    :returns: ``{"<metric_prefix>audio/<name>_<stat>": value}`` when ``compute_metrics``
+        ran (``metric_prefix`` empty by default); empty dict otherwise. Always
+        rank-zero — the caller gates DDP duplication.
     :raises ValueError: if ``evaluation.render_vst`` is enabled but ``cfg.render`` is
         unset, or the expected input directory for a stage is missing.
     :raises subprocess.CalledProcessError: propagated from a non-zero subprocess exit.
@@ -208,6 +210,11 @@ def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: D
             timeout=_SUBPROCESS_TIMEOUT_SECONDS,
         )
         audio_metrics = _load_audio_metrics(metrics_dir)
+        # Namespace every key (audio/* and shuffled_audio/*) per caller — e.g. one
+        # wandb run shared across splits — so passes don't overwrite each other.
+        prefix = cfg.evaluation.get("metric_prefix", "")
+        if prefix:
+            audio_metrics = {f"{prefix}{key}": value for key, value in audio_metrics.items()}
         _log_audio_metrics_to_wandb(audio_metrics)
         return audio_metrics
 

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -81,6 +81,7 @@ def _run_oracle_eval_subprocess(
     render: RenderConfig,
     num_workers: int,
     predict_file: Path,
+    metric_prefix: str = "",
 ) -> None:
     """Run the fake-oracle eval over one split of ``dataset_root``.
 
@@ -108,6 +109,11 @@ def _run_oracle_eval_subprocess(
         handle that cannot be pickled.
     :param predict_file: HDF5 split file for the datamodule's predict dataloader
         (e.g. ``dataset_root / "train.h5"``).
+    :param metric_prefix: Prepended to every audio metric key the eval logs
+        (both ``audio/*`` and ``shuffled_audio/*``). All splits resume one wandb
+        run, so a bare key is overwritten by the last split; pass ``"<split>/"``
+        to namespace it. Empty (the default) leaves keys bare — used for the
+        canonical ``test`` split.
     :raises FileNotFoundError: ``dataset_root`` is missing any finalized split
         or ``stats.npz`` — e.g. a resume where ``finalize_from_spec``
         short-circuited on an existing R2 marker without repopulating it.
@@ -163,6 +169,10 @@ def _run_oracle_eval_subprocess(
         f"datamodule.predict_file={predict_file}",
         "mode=predict",
     ]
+    # +append: metric_prefix is absent from eval.yaml's evaluation group. Empty
+    # (test split) leaves keys bare so existing sweeps/dashboards keep resolving.
+    if metric_prefix:
+        argv.append(f"+evaluation.metric_prefix={metric_prefix}")
     logger.info(f"oracle_eval_inline subprocess: {argv}")
     subprocess.run(argv, check=True, timeout=_ORACLE_EVAL_TIMEOUT_SECONDS)  # noqa: S603
 
@@ -868,6 +878,9 @@ def main(cfg: DictConfig) -> None:
             # basename, so read them in place — no R2 round-trip.
             output_dir = Path(cfg.paths.output_dir)
             for split in ("train", "val", "test"):
+                # test stays bare; train/val are namespaced so the shared run
+                # keeps one summary key per split (see _run_oracle_eval_subprocess).
+                metric_prefix = "" if split == "test" else f"{split}/"
                 _run_oracle_eval_subprocess(
                     output_dir,
                     output_dir / "oracle_eval" / split / spec.run_id,
@@ -875,6 +888,7 @@ def main(cfg: DictConfig) -> None:
                     render=spec.render,
                     num_workers=cfg.datamodule.num_workers,
                     predict_file=output_dir / f"{split}.h5",
+                    metric_prefix=metric_prefix,
                 )
         return
 

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -1812,7 +1812,12 @@ class TestMainDispatchBranches:
         assert isinstance(output_dir, Path)
         splits = ("train", "val", "test")
         split_h5s = ("train.h5", "val.h5", "test.h5")
-        for call, split, split_h5 in zip(oracle_mock.call_args_list, splits, split_h5s):
+        # test stays bare ``audio/*``; train/val are namespaced so the shared
+        # wandb run keeps one summary key per split instead of overwriting.
+        split_prefixes = ("train/", "val/", "")
+        for call, split, split_h5, prefix in zip(
+            oracle_mock.call_args_list, splits, split_h5s, split_prefixes
+        ):
             dataset_root, run_dir, _run_id = call[0]
             # The whole generation RenderConfig flows through (keyword-only) so
             # the eval re-renders through the same spec; smoke-shard is surge_simple.
@@ -1837,6 +1842,7 @@ class TestMainDispatchBranches:
             )
             assert run_dir.parent.name == split
             assert run_dir.parent.parent.parent == dataset_root
+            assert call.kwargs["metric_prefix"] == prefix
 
     def test_run_oracle_eval_subprocess_builds_expected_argv(
         self,
@@ -1920,6 +1926,49 @@ class TestMainDispatchBranches:
         assert "mode=predict" in called_argv
         # predict_file routes the datamodule to this split's HDF5.
         assert f"datamodule.predict_file={predict_file}" in called_argv
+        # Default (test split) carries no prefix override: its keys stay bare
+        # ``audio/*`` so existing sweeps/dashboards keep working.
+        assert not any(a.startswith("+evaluation.metric_prefix=") for a in called_argv)
+
+    def test_run_oracle_eval_subprocess_metric_prefix_adds_override(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        spec: DatasetSpec,
+    ) -> None:
+        """A non-empty ``metric_prefix`` appends the eval override that namespaces audio keys.
+
+        The override routes through to ``cfg.evaluation.metric_prefix`` in the
+        eval subprocess, which prepends it to every ``audio/*`` key so the
+        per-split passes don't overwrite each other on the shared wandb run.
+
+        :param monkeypatch: Patches the module's ``subprocess.run``.
+        :param tmp_path: Roots the dataset-root and eval run dirs.
+        :param spec: Source of a valid ``RenderConfig``.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        run_mock = MagicMock()
+        monkeypatch.setattr(gd.subprocess, "run", run_mock)
+
+        dataset_root = tmp_path / "data"
+        dataset_root.mkdir()
+        for name in ("train.h5", "val.h5", "test.h5", "stats.npz"):
+            (dataset_root / name).touch()
+        predict_file = dataset_root / "train.h5"
+        gd._run_oracle_eval_subprocess(
+            dataset_root,
+            tmp_path / "oracle_eval" / "train" / "some-run-id",
+            "some-run-id",
+            render=spec.render,
+            num_workers=0,
+            predict_file=predict_file,
+            metric_prefix="train/",
+        )
+
+        called_argv = run_mock.call_args[0][0]
+        # ``+`` appends the key: it is absent from eval.yaml's evaluation group.
+        assert "+evaluation.metric_prefix=train/" in called_argv
 
     def test_run_oracle_eval_subprocess_missing_local_artifacts_raises(
         self,

--- a/tests/test_eval_postprocessing.py
+++ b/tests/test_eval_postprocessing.py
@@ -49,6 +49,7 @@ def _build_postprocess_cfg(
     rerender_target: bool = True,
     num_workers: int = 1,
     shuffle_seed: int = 0,
+    metric_prefix: str = "",
     render: dict[str, Any] | None = None,
 ) -> DictConfig:
     """Build a minimal cfg accepted by ``_run_predict_postprocessing``.
@@ -60,6 +61,8 @@ def _build_postprocess_cfg(
     :param rerender_target: Drives ``cfg.evaluation.rerender_target``.
     :param num_workers: Drives ``cfg.evaluation.num_workers``.
     :param shuffle_seed: Drives ``cfg.evaluation.shuffle_seed``.
+    :param metric_prefix: Drives ``cfg.evaluation.metric_prefix``; prepended to
+        every returned audio metric key.
     :param render: Drives ``cfg.render``; pass ``None`` to test the unset-render branch.
     :returns: Minimal :class:`DictConfig` shaped the way the helper reads it.
     """
@@ -72,6 +75,7 @@ def _build_postprocess_cfg(
                 "rerender_target": rerender_target,
                 "num_workers": num_workers,
                 "shuffle_seed": shuffle_seed,
+                "metric_prefix": metric_prefix,
             },
             "render": render,
         }
@@ -561,6 +565,50 @@ def test_postprocessing_returns_shuffled_audio_metrics_when_subprocess_writes_sh
     assert result["shuffled_audio/mss_std"] == pytest.approx(0.12)
     assert "audio/mss_mean" in result
     assert result["audio/mss_mean"] == pytest.approx(0.5)
+
+
+def test_postprocessing_prefixes_audio_metric_keys_when_metric_prefix_set(
+    monkeypatch: pytest.MonkeyPatch,
+    predictions_tree: Path,
+) -> None:
+    """``metric_prefix`` is prepended to every returned key so per-split runs stay distinct.
+
+    The inline oracle eval resumes one wandb run for all splits; without a
+    prefix the bare ``audio/<name>_<stat>`` summary key is overwritten by the
+    last split. A non-empty prefix namespaces every key (both ``audio/*`` and
+    ``shuffled_audio/*``), e.g. ``train/``.
+
+    :param monkeypatch: Replaces ``subprocess.run`` with a fake that writes both
+        aggregated CSVs before returning.
+    :param predictions_tree: ``tmp_path`` with ``predictions/`` + ``audio/`` pre-created.
+    """
+    metrics_dir = predictions_tree / "metrics"
+
+    def _writes_both_csvs(args: list[str], **_kwargs: Any) -> None:
+        if _COMPUTE_AUDIO_METRICS_MODULE not in args:
+            return
+        metrics_dir.mkdir(parents=True, exist_ok=True)
+        (metrics_dir / "aggregated_metrics.csv").write_text(_AGGREGATED_METRICS_CSV)
+        (metrics_dir / "aggregated_metrics_shuffled.csv").write_text(
+            _AGGREGATED_METRICS_SHUFFLED_CSV
+        )
+
+    monkeypatch.setattr(eval_mod.subprocess, "run", _writes_both_csvs)
+    cfg = _build_postprocess_cfg(
+        predictions_tree,
+        render_vst=False,
+        compute_metrics=True,
+        metric_prefix="train/",
+    )
+
+    result = _run_predict_postprocessing(cfg)
+
+    # Both groups are namespaced — the prefix applies to every loaded key.
+    assert result["train/audio/mss_mean"] == pytest.approx(0.5)
+    assert result["train/shuffled_audio/mss_mean"] == pytest.approx(0.6)
+    # The bare keys must be gone: that is exactly the cross-split collision the prefix fixes.
+    assert "audio/mss_mean" not in result
+    assert "shuffled_audio/mss_mean" not in result
 
 
 def test_postprocessing_render_subprocess_nonzero_exit_raises(

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -429,10 +429,10 @@ def test_oracle_eval_inline_writes_bounded_audio_metrics(
             # All splits resume one wandb run: test keeps the bare ``audio/*`` key
             # while train/val are namespaced ``<split>/audio/*`` so none overwrites.
             split = mf.parent.parent.parent.name
-            prefix = "" if split == "test" else f"{split}/"
+            metric_prefix = "" if split == "test" else f"{split}/"
             for name in _ORACLE_AUDIO_METRICS:
                 for stat in ("mean", "std"):
-                    key = f"{prefix}audio/{name}_{stat}"
+                    key = f"{metric_prefix}audio/{name}_{stat}"
                     value = metrics.get(key)
                     assert isinstance(value, float) and math.isfinite(value), (
                         f"{key} is not a finite float: {value!r} (split={split}, metrics={metrics})"
@@ -441,10 +441,10 @@ def test_oracle_eval_inline_writes_bounded_audio_metrics(
             # fake_oracle returns params verbatim, so the re-rendered audio matches
             # the target up to Surge XT render jitter: mean distances stay under the
             # canonical envelope and the rms cosine stays above its floor.
-            assert metrics[f"{prefix}audio/mss_mean"] < bounds.mss_max, (split, metrics)
-            assert metrics[f"{prefix}audio/wmfcc_mean"] < bounds.wmfcc_max, (split, metrics)
-            assert metrics[f"{prefix}audio/sot_mean"] < bounds.sot_max, (split, metrics)
-            assert metrics[f"{prefix}audio/rms_mean"] > bounds.rms_min, (split, metrics)
+            assert metrics[f"{metric_prefix}audio/mss_mean"] < bounds.mss_max, (split, metrics)
+            assert metrics[f"{metric_prefix}audio/wmfcc_mean"] < bounds.wmfcc_max, (split, metrics)
+            assert metrics[f"{metric_prefix}audio/sot_mean"] < bounds.sot_max, (split, metrics)
+            assert metrics[f"{metric_prefix}audio/rms_mean"] > bounds.rms_min, (split, metrics)
     finally:
         r2_io.purge_prefix(cfg_dataset.r2.bucket, f"{prefix_root}/")
 
@@ -530,11 +530,11 @@ def test_oracle_eval_inline_writes_shuffled_audio_metrics_when_params_uniform(
             # test keeps bare keys; train/val are namespaced — the prefix applies
             # to both the audio/ and shuffled_audio/ groups.
             split = mf.parent.parent.parent.name
-            prefix = "" if split == "test" else f"{split}/"
+            metric_prefix = "" if split == "test" else f"{split}/"
             for name in _ORACLE_AUDIO_METRICS:
                 for stat in ("mean", "std"):
                     for group in ("audio", "shuffled_audio"):
-                        key = f"{prefix}{group}/{name}_{stat}"
+                        key = f"{metric_prefix}{group}/{name}_{stat}"
                         value = metrics.get(key)
                         assert isinstance(value, float) and math.isfinite(value), (
                             f"{key} is not a finite float: {value!r} "
@@ -544,9 +544,21 @@ def test_oracle_eval_inline_writes_shuffled_audio_metrics_when_params_uniform(
             # Uniform params → shuffled pred matches the same target; means satisfy
             # the same oracle envelope as the non-shuffled pass.
             for group in ("audio", "shuffled_audio"):
-                assert metrics[f"{prefix}{group}/mss_mean"] < bounds.mss_max, (split, metrics)
-                assert metrics[f"{prefix}{group}/wmfcc_mean"] < bounds.wmfcc_max, (split, metrics)
-                assert metrics[f"{prefix}{group}/sot_mean"] < bounds.sot_max, (split, metrics)
-                assert metrics[f"{prefix}{group}/rms_mean"] > bounds.rms_min, (split, metrics)
+                assert metrics[f"{metric_prefix}{group}/mss_mean"] < bounds.mss_max, (
+                    split,
+                    metrics,
+                )
+                assert metrics[f"{metric_prefix}{group}/wmfcc_mean"] < bounds.wmfcc_max, (
+                    split,
+                    metrics,
+                )
+                assert metrics[f"{metric_prefix}{group}/sot_mean"] < bounds.sot_max, (
+                    split,
+                    metrics,
+                )
+                assert metrics[f"{metric_prefix}{group}/rms_mean"] > bounds.rms_min, (
+                    split,
+                    metrics,
+                )
     finally:
         r2_io.purge_prefix(cfg_dataset.r2.bucket, f"{r2_prefix_root}/")

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -5,9 +5,11 @@ an ``integration_r2``-gated end-to-end render that drives ``from_hydra``
 against ``cfg_dataset`` and asserts every shard lands at the spec-derived R2
 URI in real Cloudflare R2; an ``integration_r2`` subprocess run of the
 ``smoke-shard-with-oracle-eval`` experiment that asserts the inline oracle
-eval's ``metrics.json`` holds bounded ``audio/*`` metrics; and a variant with
-``param_sample_cadence=shard`` that asserts ``shuffled_audio/*`` metrics also
-appear when all sample dirs share uniform ``params.csv`` (#489). The
+eval's per-split ``metrics.json`` holds bounded audio metrics under the bare
+``audio/*`` key for ``test`` and the namespaced ``<split>/audio/*`` key for
+``train``/``val``; and a variant with ``param_sample_cadence=shard`` that
+asserts the ``shuffled_audio/*`` group also appears (under the same per-split
+prefix) when all sample dirs share uniform ``params.csv`` (#489). The
 integration tests auto-skip when ``rclone`` / R2 creds are absent.
 
 Keep this module to tests that drive ``from_hydra`` or the real CLI subprocess.
@@ -424,34 +426,25 @@ def test_oracle_eval_inline_writes_bounded_audio_metrics(
         bounds = ORACLE_AUDIO_METRIC_BOUNDS
         for mf in metrics_files:
             metrics = json.loads(mf.read_text())
+            # All splits resume one wandb run: test keeps the bare ``audio/*`` key
+            # while train/val are namespaced ``<split>/audio/*`` so none overwrites.
+            split = mf.parent.parent.parent.name
+            prefix = "" if split == "test" else f"{split}/"
             for name in _ORACLE_AUDIO_METRICS:
                 for stat in ("mean", "std"):
-                    key = f"audio/{name}_{stat}"
+                    key = f"{prefix}audio/{name}_{stat}"
                     value = metrics.get(key)
                     assert isinstance(value, float) and math.isfinite(value), (
-                        f"{key} is not a finite float: {value!r} (split={mf.parent.parent.parent.name}, "
-                        f"metrics={metrics})"
+                        f"{key} is not a finite float: {value!r} (split={split}, metrics={metrics})"
                     )
 
             # fake_oracle returns params verbatim, so the re-rendered audio matches
             # the target up to Surge XT render jitter: mean distances stay under the
             # canonical envelope and the rms cosine stays above its floor.
-            assert metrics["audio/mss_mean"] < bounds.mss_max, (
-                mf.parent.parent.parent.name,
-                metrics,
-            )
-            assert metrics["audio/wmfcc_mean"] < bounds.wmfcc_max, (
-                mf.parent.parent.parent.name,
-                metrics,
-            )
-            assert metrics["audio/sot_mean"] < bounds.sot_max, (
-                mf.parent.parent.parent.name,
-                metrics,
-            )
-            assert metrics["audio/rms_mean"] > bounds.rms_min, (
-                mf.parent.parent.parent.name,
-                metrics,
-            )
+            assert metrics[f"{prefix}audio/mss_mean"] < bounds.mss_max, (split, metrics)
+            assert metrics[f"{prefix}audio/wmfcc_mean"] < bounds.wmfcc_max, (split, metrics)
+            assert metrics[f"{prefix}audio/sot_mean"] < bounds.sot_max, (split, metrics)
+            assert metrics[f"{prefix}audio/rms_mean"] > bounds.rms_min, (split, metrics)
     finally:
         r2_io.purge_prefix(cfg_dataset.r2.bucket, f"{prefix_root}/")
 
@@ -522,34 +515,38 @@ def test_oracle_eval_inline_writes_shuffled_audio_metrics_when_params_uniform(
             f"--- STDERR (tail) ---\n{result.stderr[-2000:]}"
         )
 
-        # One metrics.json per split: oracle_eval/<split>/<run_id>/metrics/metrics.json.
+        # One metrics.json per split: oracle_eval/<split>/<run_id>/. Each split is
+        # a single 4-sample shard, so cadence=shard makes every split's params
+        # uniform and the shuffle probe fires for all three.
         metrics_files = list(run_dir.glob("oracle_eval/*/*/metrics/metrics.json"))
         assert len(metrics_files) == 3, (
-            f"expected three oracle-eval metrics.json under {run_dir}/oracle_eval/; "
-            f"got {metrics_files}"
+            f"expected three oracle-eval metrics.json files (one per split) under "
+            f"{run_dir}/oracle_eval/; got {metrics_files}"
         )
 
         bounds = ORACLE_AUDIO_METRIC_BOUNDS
-        for metrics_file in metrics_files:
-            metrics = json.loads(metrics_file.read_text())
-
-            # Both audio/ and shuffled_audio/ must be present for each metric split.
+        for mf in metrics_files:
+            metrics = json.loads(mf.read_text())
+            # test keeps bare keys; train/val are namespaced — the prefix applies
+            # to both the audio/ and shuffled_audio/ groups.
+            split = mf.parent.parent.parent.name
+            prefix = "" if split == "test" else f"{split}/"
             for name in _ORACLE_AUDIO_METRICS:
                 for stat in ("mean", "std"):
                     for group in ("audio", "shuffled_audio"):
-                        key = f"{group}/{name}_{stat}"
+                        key = f"{prefix}{group}/{name}_{stat}"
                         value = metrics.get(key)
                         assert isinstance(value, float) and math.isfinite(value), (
                             f"{key} is not a finite float: {value!r} "
-                            f"(split={metrics_file.parent.parent.name}, metrics={metrics})"
+                            f"(split={split}, metrics={metrics})"
                         )
 
-            # Uniform params → shuffled pred matches same target; means satisfy
+            # Uniform params → shuffled pred matches the same target; means satisfy
             # the same oracle envelope as the non-shuffled pass.
             for group in ("audio", "shuffled_audio"):
-                assert metrics[f"{group}/mss_mean"] < bounds.mss_max, metrics
-                assert metrics[f"{group}/wmfcc_mean"] < bounds.wmfcc_max, metrics
-                assert metrics[f"{group}/sot_mean"] < bounds.sot_max, metrics
-                assert metrics[f"{group}/rms_mean"] > bounds.rms_min, metrics
+                assert metrics[f"{prefix}{group}/mss_mean"] < bounds.mss_max, (split, metrics)
+                assert metrics[f"{prefix}{group}/wmfcc_mean"] < bounds.wmfcc_max, (split, metrics)
+                assert metrics[f"{prefix}{group}/sot_mean"] < bounds.sot_max, (split, metrics)
+                assert metrics[f"{prefix}{group}/rms_mean"] > bounds.rms_min, (split, metrics)
     finally:
         r2_io.purge_prefix(cfg_dataset.r2.bucket, f"{r2_prefix_root}/")

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.22.0"
+version = "8.23.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

The inline oracle eval (`oracle_eval_inline=true`) shells out to `synth_setter.cli.eval` **once per split** (train, val, test), and every subprocess resumes the **same** wandb run via `logger.wandb.id=<spec.run_id> +logger.wandb.resume=must`. Each split logged the **bare** `audio/<name>_<stat>` key, so the run summary kept only the **last** split (test) and silently overwrote train/val — and any sweep optimizing `audio/mss_mean` was tuning on test alone, mislabeled as the whole dataset.

## Fix

Add an opt-in `evaluation.metric_prefix` that `_run_predict_postprocessing` prepends to **every** audio metric key (both `audio/*` and `shuffled_audio/*`). `generate_dataset` passes `train/` and `val/` for those splits and leaves `test` bare, so the three passes land as distinct, labeled summary keys:

- `audio/mss_mean` (test — unchanged)
- `train/audio/mss_mean`
- `val/audio/mss_mean`

Default is empty, preserving the bare-key behavior for every other caller and keeping the sweep's `audio/mss_mean` target pointed at the test split.

## Verification

- **Fast CI:** per-split argv override (`+evaluation.metric_prefix=<split>/`) and key prefixing pinned in `tests/pipeline/entrypoints/test_generate_dataset_unit.py` and `tests/test_eval_postprocessing.py` (incl. the `shuffled_audio/*` group and the `assert "audio/mss_mean" not in result` anti-collision check).
- **Integration (R2/VST-gated):** `tests/test_generate_dataset.py` asserts the per-split namespaced keys in each split's `metrics.json`; the shuffled variant's stale 2-level glob was corrected to the real 3-level layout.
- `docs/reference/wandb-integration.md` §5f updated to describe the per-split namespacing.

Distinct from #1398 (eval run *identity* hijacked by the cadence sweep — a cross-run problem); this is the cross-**split** key collision within one run.

Fixes #1499