### PR TITLE
fix(test): correct split-name depth in oracle-eval assertion

### DIFF
--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -541,7 +541,7 @@ def test_oracle_eval_inline_writes_shuffled_audio_metrics_when_params_uniform(
                         value = metrics.get(key)
                         assert isinstance(value, float) and math.isfinite(value), (
                             f"{key} is not a finite float: {value!r} "
-                            f"(split={metrics_file.parent.parent.name}, metrics={metrics})"
+                            f"(split={metrics_file.parent.parent.parent.name}, metrics={metrics})"
                         )
 
             # Uniform params → shuffled pred matches same target; means satisfy

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -553,3 +553,24 @@ def test_oracle_eval_inline_writes_shuffled_audio_metrics_when_params_uniform(
                 assert metrics[f"{group}/rms_mean"] > bounds.rms_min, metrics
     finally:
         r2_io.purge_prefix(cfg_dataset.r2.bucket, f"{r2_prefix_root}/")
+
+
+def test_oracle_eval_metrics_file_parent_depth_resolves_to_split_name(
+    tmp_path: Path,
+) -> None:
+    """Path depth used in oracle-eval assertions: .parent.parent.parent.name == split.
+
+    oracle_eval/<split>/<run_id>/metrics/metrics.json
+    - .parent       -> metrics/
+    - .parent.parent      -> <run_id>/
+    - .parent.parent.parent -> <split>/  ← the correct level
+
+    :param tmp_path: pytest temporary directory fixture.
+    """
+    split = "val"
+    run_id = "dataset-config-20250101-120000-abc"
+    metrics_file = tmp_path / "oracle_eval" / split / run_id / "metrics" / "metrics.json"
+    metrics_file.parent.mkdir(parents=True)
+    metrics_file.write_text("{}")
+
+    assert metrics_file.parent.parent.parent.name == split


### PR DESCRIPTION
## Summary

- `metrics_file.parent.parent.name` in the shuffled-metrics assertion resolves to `<run_id>`, not `<split>` — the path is `oracle_eval/<split>/<run_id>/metrics/metrics.json` so `.parent.parent` is the `<run_id>` directory
- Fix uses `.parent.parent.parent.name` to correctly reach `<split>` (train/val/test)
- Adds `test_oracle_eval_metrics_file_parent_depth_resolves_to_split_name` to pin the depth so a regression is caught by fast tests, not only by integration failure messages

Landed in the wrong direction in #1495 — the fix was intended for the assertion message introduced in commit `b826013` (Copilot suggestion), but the parent-chain depth was off by one.

## Test plan

- [ ] `pytest tests/test_generate_dataset.py::test_oracle_eval_metrics_file_parent_depth_resolves_to_split_name -v` — fast unit test green
- [ ] Full test suite green in CI

Refs #489
