### PR TITLE
internal-fix(monitoring): wandb console=wrap fixes empty data-gen logs

### DIFF
--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -30,7 +30,7 @@ ______________________________________________________________________
 | Checkpoint upload | `log_model: "all"`                                                                                                                                                                    | `src/synth_setter/configs/logger/wandb.yaml:11`                 |
 | Code saving       | `wandb.Settings(code_dir=".")`                                                                                                                                                        | `src/synth_setter/configs/logger/wandb.yaml` § `wandb.settings` |
 | Console capture   | `wandb.Settings(console="wrap")` — `redirect` captures into a local `output.log` that wandb 0.26.x never uploads (empty UI Logs tab); `wrap` is the only mode that reaches the server | `src/synth_setter/configs/logger/wandb.yaml` § `wandb.settings` |
-| Run teardown      | `wandb.finish()` in `task_wrapper` finally block                                                                                                                                      | `src/synth_setter/utils/utils.py:101-106`                       |
+| Run teardown      | `wandb.finish()` in `task_wrapper` finally block                                                                                                                                      | `src/synth_setter/utils/utils.py:98-108`                        |
 
 **No direct `wandb.init()` calls exist in runtime code.** One `wandb.config.update()` call exists: `log_wandb_provenance()` in `src/synth_setter/utils/logging_utils.py:91` writes provenance metadata (see [2g](#2g-provenance-metadata-logged-once-at-run-start)).
 

--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -21,16 +21,16 @@ ______________________________________________________________________
 
 ## 1. Initialization
 
-| Concern           | How it works                                                                                                                      | File                                                            |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| W&B run creation  | `WandbLogger` instantiated by Hydra — included in the default `many_loggers` compose (W&B + CSV + TB)                             | `src/synth_setter/configs/logger/wandb.yaml`                    |
-| Entity / project  | Env-var driven: `entity: ${oc.env:WANDB_ENTITY,null}`, `project: "${oc.env:WANDB_PROJECT,synth-setter}"`                          | `src/synth_setter/configs/logger/wandb.yaml:10,13`              |
-| Default compose   | `many_loggers` composes `csv + tensorboard + wandb` (W&B enabled by default)                                                      | `src/synth_setter/configs/logger/many_loggers.yaml`             |
-| Run ID            | `null` (W&B auto-generates)                                                                                                       | `src/synth_setter/configs/logger/wandb.yaml:8`                  |
-| Checkpoint upload | `log_model: "all"`                                                                                                                | `src/synth_setter/configs/logger/wandb.yaml:11`                 |
-| Code saving       | `wandb.Settings(code_dir=".")`                                                                                                    | `src/synth_setter/configs/logger/wandb.yaml` § `wandb.settings` |
-| Console capture   | `wandb.Settings(console="redirect")` — fd-level redirect so non-TTY worker logs (loguru stderr + subprocess output) reach the run | `src/synth_setter/configs/logger/wandb.yaml` § `wandb.settings` |
-| Run teardown      | `wandb.finish()` in `task_wrapper` finally block                                                                                  | `src/synth_setter/utils/utils.py:101-106`                       |
+| Concern           | How it works                                                                                                                                                                          | File                                                            |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| W&B run creation  | `WandbLogger` instantiated by Hydra — included in the default `many_loggers` compose (W&B + CSV + TB)                                                                                 | `src/synth_setter/configs/logger/wandb.yaml`                    |
+| Entity / project  | Env-var driven: `entity: ${oc.env:WANDB_ENTITY,null}`, `project: "${oc.env:WANDB_PROJECT,synth-setter}"`                                                                              | `src/synth_setter/configs/logger/wandb.yaml:10,13`              |
+| Default compose   | `many_loggers` composes `csv + tensorboard + wandb` (W&B enabled by default)                                                                                                          | `src/synth_setter/configs/logger/many_loggers.yaml`             |
+| Run ID            | `null` (W&B auto-generates)                                                                                                                                                           | `src/synth_setter/configs/logger/wandb.yaml:8`                  |
+| Checkpoint upload | `log_model: "all"`                                                                                                                                                                    | `src/synth_setter/configs/logger/wandb.yaml:11`                 |
+| Code saving       | `wandb.Settings(code_dir=".")`                                                                                                                                                        | `src/synth_setter/configs/logger/wandb.yaml` § `wandb.settings` |
+| Console capture   | `wandb.Settings(console="wrap")` — `redirect` captures into a local `output.log` that wandb 0.26.x never uploads (empty UI Logs tab); `wrap` is the only mode that reaches the server | `src/synth_setter/configs/logger/wandb.yaml` § `wandb.settings` |
+| Run teardown      | `wandb.finish()` in `task_wrapper` finally block                                                                                                                                      | `src/synth_setter/utils/utils.py:101-106`                       |
 
 **No direct `wandb.init()` calls exist in runtime code.** One `wandb.config.update()` call exists: `log_wandb_provenance()` in `src/synth_setter/utils/logging_utils.py:91` writes provenance metadata (see [2g](#2g-provenance-metadata-logged-once-at-run-start)).
 

--- a/src/synth_setter/configs/logger/wandb.yaml
+++ b/src/synth_setter/configs/logger/wandb.yaml
@@ -17,6 +17,6 @@ wandb:
   settings:
     _target_: wandb.Settings
     code_dir: .
-    # fd-level capture, needed because ``auto`` picks ``wrap`` on non-TTY workers
-    # — ``wrap`` misses loguru's import-time stderr and subprocess output entirely.
-    console: redirect
+    # ``wrap`` not ``redirect``: redirect's local output.log is never uploaded by
+    # wandb 0.26.x, so the UI Logs tab is empty (#1465); wrap drops subprocess output.
+    console: wrap

--- a/tests/schemas/test_logger_config.py
+++ b/tests/schemas/test_logger_config.py
@@ -49,18 +49,17 @@ class TestLoggerConfigAcceptsEveryComposition:
 
 
 class TestWandbConsoleCapture:
-    """The wandb logger must capture console output at the file-descriptor level."""
+    """The wandb logger must stream console output to the run's server-side Logs tab."""
 
-    def test_wandb_settings_console_is_redirect(self) -> None:
-        """The composed ``wandb.settings.console`` pins ``redirect`` (not the ``auto`` default).
+    def test_wandb_settings_console_is_wrap(self) -> None:
+        """The composed ``wandb.settings.console`` pins ``wrap`` (not ``redirect``/``auto``).
 
-        Config-pin guard: asserts the value, not the runtime capture. ``redirect`` is required
-        because ``auto`` resolves to ``wrap`` on non-TTY workers, which patches ``sys.stdout``
-        only and so misses loguru's import-time ``sys.stderr`` binding and subprocess output —
-        leaving the run's log stream empty.
+        Config-pin guard: asserts the value, not runtime capture. ``redirect``'s local
+        ``output.log`` is never uploaded by wandb 0.26.x, leaving the UI Logs tab empty;
+        ``wrap`` is the only mode whose output reaches the server (#1465).
         """
         logger_subtree = compose_subtree("logger", "wandb")
-        assert logger_subtree["wandb"]["settings"]["console"] == "redirect"
+        assert logger_subtree["wandb"]["settings"]["console"] == "wrap"
 
 
 _VALID_LOGGER = {


### PR DESCRIPTION
## Problem

`generate_dataset` W&B runs show an **empty Logs tab** in the UI — confirmed against finished cloud runs (e.g. `smoke-shard-20260606T061132238Z`): `logLineCount=0` and no `output.log` on the server, even though the run finished cleanly with full summary/system metrics.

## Root cause

`configs/logger/wandb.yaml` set `console: redirect` (PR #1466). In wandb 0.26.x, `redirect` captures stdout/stderr into a **local** `output.log` at the fd level but **never transmits that file to the run's filestream**, so the server-side Logs tab stays empty even on a clean `finish()`.

## Fix

Pin `console: wrap` — the only console mode whose output reliably reaches the server. Trade-off: `wrap` patches the parent process's `sys.stdout`/`sys.stderr` only, so it omits child render-subprocess output (that output remains in the SkyPilot worker job logs). Capturing it in the UI would require piping subprocess output back through the parent and is out of scope (YAGNI).

## Verification (end-to-end, online)

| console | local `output.log` | server `output.log` | server `logLineCount` |
| --- | --- | --- | --- |
| `redirect` (before) | 81 KB | **absent** | **0** |
| `wrap` (after) | 2.8 KB | 2.8 KB uploaded | 16 |

Verified with the committed config via the headless VST wrapper against an online run (`smoke-shard-20260606T070016782Z`): `logLineCount=16`, `output.log` uploaded.

## Tests

Inverted the existing config-pin guard `TestWandbConsoleCapture` to assert `console == "wrap"` (red on `redirect`, green on `wrap`). The server-upload behavior is not observable in CI (local `output.log` is non-empty under both modes), so a config-pin guard at the Hydra-composition altitude is the appropriate regression test; the e2e evidence lives here.

Fixes #1465