### PR TITLE
fix(storage): make finalize R2 prefix check advisory, not fatal

### DIFF
--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -81,7 +81,7 @@ docs:
       - pattern: "src/synth_setter/configs/finalize_dataset.yaml"
         covers: "Finalize @hydra.main entry config; required `dataset_spec_uri` loads the persisted DatasetSpec from R2 (file://, r2://, or bare path); overrides `hydra.run.dir` because `task_name`/`run_name` are not in this cfg; composes the `logger: wandb` group so finalize logs the dataset artifact (best-effort no-op without `WANDB_API_KEY`)"
       - pattern: "src/synth_setter/cli/finalize_dataset.py"
-        covers: "Finalize entrypoint: loads the frozen DatasetSpec, dispatches on `spec.output_format` (wds → `finalize_wds`, hdf5 → `finalize_hdf5`), asserts the R2 prefix before any write, writes the `dataset.complete` marker last for idempotency, then logs the canonical `data-{config_id}` dataset W&B artifact with s3:// R2 references"
+        covers: "Finalize entrypoint: loads the frozen DatasetSpec, dispatches on `spec.output_format` (wds → `finalize_wds`, hdf5 → `finalize_hdf5`), warns (never aborts) on a non-canonical R2 prefix, writes the `dataset.complete` marker last for idempotency, then logs the canonical `data-{config_id}` dataset W&B artifact with s3:// R2 references"
       - pattern: ".github/workflows/generate-dataset-shards.yaml"
         covers: "Reusable launcher fan-out across providers (skypilot-local kind, runpod, oci); per-provider artifact upload; emits a `spec_uri` workflow output (the materialized spec's canonical under-prefix `input_spec.json` URI, computed by the `synth-setter-spec-uri` console script — see `src/synth_setter/pipeline/ci/spec_uri.py`) consumed by validate-dataset-shards"
       - pattern: ".github/workflows/validate-dataset-shards.yaml"

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -59,7 +59,7 @@ synth-setter-finalize-dataset dataset_spec_uri=r2://…/input_spec.json
   → @hydra.main composes DictConfig from src/synth_setter/configs/finalize_dataset.yaml
     → load_spec_from_uri(cfg.dataset_spec_uri) → DatasetSpec (the frozen spec generate uploaded)
       → r2_io.object_size(spec.r2.dataset_complete_marker_uri()) probe (idempotency short-circuit)
-      → assert_r2_prefix_matches(spec.r2.prefix, spec.task_name, spec.run_id, spec.r2.prefix_root) (prefix-drift guard)
+      → assert_r2_prefix_matches(…) (advisory: warns on a non-canonical prefix, never aborts — custom prefixes like the oracle-eval e2e's test-runs/ are legitimate)
       → branch on spec.output_format:
           ├─ wds:  finalize_wds  — Welford-stream stats over train shards → upload stats.npz
           └─ hdf5: finalize_hdf5 — download every shard → reshard into {train,val,test}.h5 → stats.npz

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -174,17 +174,21 @@ def finalize_from_spec(spec: DatasetSpec, work_dir: Path) -> None:
     :param spec: Validated dataset spec.
     :param work_dir: Writable scratch dir; created if missing; retained
         after the call (multi-GB on the hdf5 branch).
-    :raises ValueError: ``spec.r2.prefix`` does not match
-        ``make_r2_prefix(spec.task_name, spec.run_id, spec.r2.prefix_root)``
-        (prefix drift detected before any R2 writes), or ``spec.output_format``
-        is neither ``"hdf5"`` nor ``"wds"``.
+    :raises ValueError: ``spec.output_format`` is neither ``"hdf5"`` nor ``"wds"``.
     """
     marker_uri = spec.r2.dataset_complete_marker_uri()
     if r2_io.object_size(marker_uri) is not None:
         logger.info("skip: {} already exists, run is finalized", marker_uri)
         return
 
-    assert_r2_prefix_matches(spec.r2.prefix, spec.task_name, spec.run_id, spec.r2.prefix_root)
+    # A custom ``r2.prefix`` (e.g. the oracle-eval e2e isolating objects under
+    # ``test-runs/<test>/<uuid>/``) is legitimate: finalize reads the same prefix
+    # generate wrote to, so the spec is self-consistent. Surface a divergence
+    # from the canonical ``make_r2_prefix`` shape as a warning, never an abort.
+    try:
+        assert_r2_prefix_matches(spec.r2.prefix, spec.task_name, spec.run_id, spec.r2.prefix_root)
+    except ValueError as exc:
+        logger.warning("non-canonical r2 prefix (finalizing anyway): {}", exc)
     work_dir.mkdir(parents=True, exist_ok=True)
     if spec.output_format is OutputFormat.WDS:
         finalize_wds(spec, work_dir)

--- a/src/synth_setter/pipeline/schemas/prefix.py
+++ b/src/synth_setter/pipeline/schemas/prefix.py
@@ -65,9 +65,10 @@ def assert_r2_prefix_matches(
 ) -> None:
     """Assert a materialized R2 prefix matches the canonical value for the given IDs.
 
-    Call this at write time (e.g. in finalize) to catch prefix drift before any
-    R2 objects are written — a mismatch means the spec's config/run IDs diverge
-    from the prefix it carries.
+    A mismatch means the spec's config/run IDs diverge from the prefix it
+    carries. Callers decide whether that is fatal: finalize treats it as
+    advisory (logs and proceeds, since custom prefixes are legitimate), while
+    a strict caller may let the ``ValueError`` propagate.
 
     :param prefix: The materialized prefix to check (from ``R2Location.prefix``).
     :param dataset_config_id: The dataset config identifier (e.g. ``spec.task_name``).

--- a/tests/pipeline/entrypoints/test_finalize_dataset.py
+++ b/tests/pipeline/entrypoints/test_finalize_dataset.py
@@ -29,6 +29,7 @@ import tarfile
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, NoReturn, cast
+from unittest.mock import MagicMock
 
 import h5py
 import numpy as np
@@ -291,6 +292,51 @@ def test_finalize_from_spec_uploads_stats_then_marker_at_canonical_uris(
     assert upload_order.count(marker_uri) == 1
     assert upload_order.index(marker_uri) == len(upload_order) - 1
     assert upload_order.index(stats_uri) < upload_order.index(marker_uri)
+
+
+def test_finalize_from_spec_non_canonical_prefix_warns_and_proceeds(
+    tmp_path: Path,
+    fake_r2_remote: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_finalize_setup: Callable[[int | None], None],  # noqa: ARG001 — installs stubs only
+) -> None:
+    """A custom (non-canonical) ``r2.prefix`` is finalized, not rejected.
+
+    Specs may set ``r2.prefix`` independently of ``task_name``/``run_id`` — e.g.
+    the oracle-eval e2e isolates its objects under ``test-runs/<test>/<uuid>/``.
+    finalize reads the same prefix generate wrote to, so the spec is
+    self-consistent; a prefix that diverges from ``make_r2_prefix`` is advisory
+    (logged), never fatal. Pins both halves: finalize emits the warning and
+    still lands its artifacts at the custom prefix.
+
+    :param tmp_path: Hosts the scratch ``work_dir``.
+    :param fake_r2_remote: Local-typed rclone remote; shards + outputs land here.
+    :param monkeypatch: Patches ``finalize_dataset.logger`` with a recording
+        mock (loguru output does not reach pytest ``caplog``).
+    :param stub_finalize_setup: Installs the auth + marker-probe stubs.
+    """
+    spec = _build_wds_smoke_spec(task_name="finalize-custom-prefix")
+    custom_r2 = spec.r2.model_copy(
+        update={"prefix": "test-runs/finalize-custom-prefix/abc123def456/"}
+    )
+    custom_spec = spec.model_copy(update={"r2": custom_r2})
+    _seed_train_shards(fake_r2_remote, custom_spec)
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+
+    recording_logger = MagicMock(wraps=finalize_dataset.logger)
+    monkeypatch.setattr(finalize_dataset, "logger", recording_logger)
+
+    finalize_dataset.finalize_from_spec(custom_spec, work_dir)
+
+    assert _uri_to_local_path(fake_r2_remote, custom_spec.r2.stats_uri()).is_file()
+    assert _uri_to_local_path(
+        fake_r2_remote, custom_spec.r2.dataset_complete_marker_uri()
+    ).is_file()
+    assert any(
+        "non-canonical r2 prefix" in str(call.args[0])
+        for call in recording_logger.warning.call_args_list
+    ), recording_logger.warning.call_args_list
 
 
 def test_finalize_is_idempotent_when_marker_already_exists(
@@ -1099,40 +1145,6 @@ def test_finalize_wds_unlinks_each_shard_after_folding(
     finalize_dataset.finalize_wds(spec, work_dir)
 
     assert concurrent_shards_seen == [1, 1]
-
-
-def test_finalize_from_spec_drifted_prefix_raises_before_any_upload(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    stub_finalize_setup: Callable[[int | None], None],  # noqa: ARG001 — installs stubs only
-) -> None:
-    """A drifted ``r2.prefix`` raises ``ValueError`` before any R2 write or scratch dir.
-
-    Integration-level companion to ``test_prefix.py``'s unit coverage of
-    ``assert_r2_prefix_matches``: it pins the guard at the ``finalize_from_spec``
-    call site so a future reordering (e.g. moving the assertion past the
-    dispatch) trips here. The fail-fast ``upload`` stub turns a leaked write
-    into a test failure, proving the abort precedes the marker-last upload
-    sequence; the ``work_dir`` assertion proves it precedes ``work_dir.mkdir``.
-
-    :param tmp_path: Hosts the scratch ``work_dir`` path (asserted never created).
-    :param monkeypatch: Installs a fail-fast ``upload`` stub.
-    :param stub_finalize_setup: Installs the auth + marker-probe stubs so the
-        guard (not the marker check) is the failure surface.
-    """
-    spec = _build_wds_smoke_spec(task_name="finalize-drifted-prefix")
-    drifted_r2 = spec.r2.model_copy(update={"prefix": "data/wrong-cfg/wrong-run/"})
-    drifted_spec = spec.model_copy(update={"r2": drifted_r2})
-
-    def fail_fast_upload(src: str | Path, dst: str) -> NoReturn:
-        raise AssertionError(f"upload must not run on a drifted prefix (got {dst!r})")
-
-    monkeypatch.setattr("synth_setter.pipeline.r2_io.upload", fail_fast_upload)
-    work_dir = tmp_path / "work"
-
-    with pytest.raises(ValueError, match="prefix mismatch"):
-        finalize_dataset.finalize_from_spec(drifted_spec, work_dir)
-    assert not work_dir.exists()
 
 
 def _build_finalize_cfg_with_offline_wandb(

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.23.0"
+version = "8.23.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Makes the finalize-time R2 prefix check **advisory** (warn, never abort). The merged #281 guard (`assert_r2_prefix_matches` in `finalize_from_spec`) aborted finalize whenever `spec.r2.prefix` diverged from the canonical `data/{task_name}/{run_id}/` shape — but a custom prefix is legitimate, so the guard could not tell intentional override from drift.

## Why this is needed

`generate-dataset-shards.yaml`'s unconditional finalize chain runs the **"Generate dataset shards → real R2 (Docker + VST)"** job, whose `test_oracle_eval_inline/shuffled_audio_metrics` cases isolate their R2 objects under `test-runs/<test>/<uuid>/`. The #281 guard rejected that prefix and aborted finalize, turning the job red. (#1494's merge commit never ran this job, so the regression landed undetected; it surfaced on #1498's CI.)

finalize reads the **same** prefix generate wrote to, so the spec is self-consistent — a non-canonical prefix is not a data-integrity risk. Marker-last ordering, idempotency, and the format dispatch are unchanged.

## Changes

- `finalize_from_spec`: wrap the `assert_r2_prefix_matches` call in `try/except ValueError` → log a warning and proceed. The helper and its `test_prefix.py` unit tests are untouched (still strict for callers that want it).
- Replace the obsolete `test_finalize_from_spec_drifted_prefix_raises_before_any_upload` (which pinned the now-removed abort, landed via #1498) with `test_finalize_from_spec_non_canonical_prefix_warns_and_proceeds` — seeds shards at a custom prefix on the real `fake_r2_remote` rclone backend and asserts finalize both **warns** and **lands** stats + marker there.
- `doc-map.yaml`: describe the advisory behavior.
- `uv.lock`: sync to 8.23.1 (the release bumped `pyproject.toml` but not the lock).

## Follow-up (not in scope)

A custom-prefix finalize still logs the W&B artifact under the canonical `data-{task_name}` name; namespacing/skipping artifact logging for non-canonical prefixes is a candidate follow-up (latent — the e2e runs without `WANDB_API_KEY`).

Refs #281, #1471
