### PR TITLE
chore(lint): disable docformatter summary wrap (ruff D205 deadlock)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -398,8 +398,10 @@ ignore-init-method = true
 ignore-module = true
 ignore-nested-functions = true
 
+# wrap-summaries = 0 (not 99): a wrapped summary's 2nd line trips ruff D205, which
+# no tool auto-fixes. Pinned by tests/infra/test_docstring_tooling_consistency.py.
 [tool.docformatter]
-wrap-summaries = 99
+wrap-summaries = 0
 wrap-descriptions = 99
 style = "sphinx"
 black = true

--- a/tests/infra/test_docstring_tooling_consistency.py
+++ b/tests/infra/test_docstring_tooling_consistency.py
@@ -14,23 +14,88 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:
     import tomli as tomllib
 
 
+def _longest_prefix_len(code: str, selectors: list[str]) -> int:
+    """Length of the most specific selector that enables ``code``, or -1 if none.
+
+    Mirrors ruff's prefix matching: a selector enables a rule when it is a
+    prefix of the rule code (``"D"``, ``"D2"``, ``"D205"``), and ``"ALL"``
+    enables every rule. Specificity is the prefix length, so ``"ALL"`` is the
+    least specific (0) and an exact code the most.
+
+    :param code: The rule code to test, e.g. ``"D205"``.
+    :param selectors: A ruff select/ignore list.
+    :returns: The winning selector's specificity (prefix length, 0 for ``"ALL"``), or -1.
+    """
+    lengths = [
+        0 if sel == "ALL" else len(sel)
+        for sel in selectors
+        if sel == "ALL" or code.startswith(sel)
+    ]
+    return max(lengths) if lengths else -1
+
+
+def _rule_enabled(code: str, select: list[str], ignore: list[str]) -> bool:
+    """Whether ``code`` is effectively enabled given ruff select/ignore lists.
+
+    Ruff resolves select-vs-ignore conflicts by specificity: the longer
+    (more specific) matching prefix wins, and select wins ties.
+
+    :param code: The rule code to test, e.g. ``"D205"``.
+    :param select: The effective select list (``select`` + ``extend-select``).
+    :param ignore: The effective ignore list (``ignore`` + ``extend-ignore``).
+    :returns: True when ``code`` is selected and no more-specific ignore overrides it.
+    """
+    selected = _longest_prefix_len(code, select)
+    return selected >= 0 and selected >= _longest_prefix_len(code, ignore)
+
+
+@pytest.mark.parametrize(
+    ("select", "ignore", "expected"),
+    [
+        (["D205"], [], True),  # exact code
+        (["D"], [], True),  # family prefix
+        (["D2"], [], True),  # partial prefix
+        (["ALL"], [], True),  # select-all
+        (["E", "F"], [], False),  # unrelated codes only
+        ([], [], False),  # nothing selected
+        (["D"], ["D205"], False),  # ignore is more specific than select
+        (["D205"], ["D"], True),  # select is more specific than ignore
+        (["ALL"], ["D205"], False),  # specific ignore overrides select-all
+    ],
+)
+def test_rule_enabled_resolves_d205_through_ruff_prefix_semantics(
+    select: list[str], ignore: list[str], expected: bool
+) -> None:
+    """``_rule_enabled`` matches ruff's prefix + specificity resolution for D205.
+
+    :param select: Effective ruff select list for the case.
+    :param ignore: Effective ruff ignore list for the case.
+    :param expected: Whether D205 should be reported as enabled.
+    """
+    assert _rule_enabled("D205", select, ignore) is expected
+
+
 def test_docformatter_disables_summary_wrap_while_ruff_enforces_d205(project_root: Path) -> None:
-    """While ruff selects D205, docformatter must not wrap summaries.
+    """While ruff enforces D205, docformatter must not wrap summaries.
 
     :param project_root: Repo root holding ``pyproject.toml`` (from conftest).
     """
     with (project_root / "pyproject.toml").open("rb") as fh:
         pyproject = tomllib.load(fh)
-    ruff_select = pyproject["tool"]["ruff"]["lint"]["select"]
+    lint = pyproject["tool"]["ruff"]["lint"]
+    select = lint.get("select", []) + lint.get("extend-select", [])
+    ignore = lint.get("ignore", []) + lint.get("extend-ignore", [])
     wrap_summaries = pyproject["tool"]["docformatter"]["wrap-summaries"]
 
-    if "D205" in ruff_select:
+    if _rule_enabled("D205", select, ignore):
         assert wrap_summaries == 0, (
             "ruff's D205 rejects multi-line summaries, but docformatter is configured to "
             f"wrap summaries at {wrap_summaries} columns. A summary longer than that wraps "

--- a/tests/infra/test_docstring_tooling_consistency.py
+++ b/tests/infra/test_docstring_tooling_consistency.py
@@ -1,0 +1,39 @@
+"""Pin the docformatter ↔ ruff D205 invariant so the two cannot deadlock.
+
+docformatter's ``wrap-summaries`` reflows an over-length summary onto a second
+physical line. ruff's ``D205`` ("1 blank line required between summary line and
+description") then reads that continuation as a description with no preceding
+blank line and raises an error that no tool can auto-fix (not even
+``--unsafe-fixes``) and that docformatter will not undo. The only stable state
+is to keep summaries on one physical line: ``wrap-summaries = 0``. This test
+fails fast if either side drifts back into the conflicting combination.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
+
+
+def test_docformatter_disables_summary_wrap_while_ruff_enforces_d205(project_root: Path) -> None:
+    """While ruff selects D205, docformatter must not wrap summaries.
+
+    :param project_root: Repo root holding ``pyproject.toml`` (from conftest).
+    """
+    with (project_root / "pyproject.toml").open("rb") as fh:
+        pyproject = tomllib.load(fh)
+    ruff_select = pyproject["tool"]["ruff"]["lint"]["select"]
+    wrap_summaries = pyproject["tool"]["docformatter"]["wrap-summaries"]
+
+    if "D205" in ruff_select:
+        assert wrap_summaries == 0, (
+            "ruff's D205 rejects multi-line summaries, but docformatter is configured to "
+            f"wrap summaries at {wrap_summaries} columns. A summary longer than that wraps "
+            "onto a second physical line that D205 flags and no tool can auto-fix. Set "
+            "[tool.docformatter] wrap-summaries = 0, or drop D205 from [tool.ruff.lint] select."
+        )

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.23.1"
+version = "8.23.2"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Problem

A docstring summary longer than 99 columns deadlocks two pre-commit hooks configured in `pyproject.toml`:

- `[tool.docformatter]` `wrap-summaries = 99` reflows the over-long summary onto a **second physical line**.
- ruff `D205` ("1 blank line required between summary line and description") then reads that continuation as a *description* with no preceding blank line and errors.

The error is **not auto-fixable** — not by `ruff --fix`, not even `--unsafe-fixes` — and docformatter will not undo its own wrap. The file is byte-stable but permanently red, and it only surfaces on the *next* hook run after docformatter rewrites the file, making it a confusing two-pass trap. History shows this recurring as manual reflow workarounds (e.g. the #1270 CI failure: "docformatter wanted the two-line summary joined onto the 100-col second line"; `_download_finalized_splits` summary shortened to stay on one line).

## Fix

Set `wrap-summaries = 0` so docformatter never wraps a summary onto a second physical line — the one-line shape `D205` and pydoclint's parser assume. Descriptions still wrap at 99 (they sit after the blank line, so `D205` does not apply). Verified: the previously deadlocking >99-col summary now stays on one line and passes `D205`; collapse of short multi-line docstrings and description wrapping are unaffected; docformatter + ruff-format remain idempotent.

Add a config-invariant regression test (`tests/infra/test_docstring_tooling_consistency.py`) pinning `D205 selected ⇒ wrap-summaries == 0`, verified red on the old config and green on the new.

The `uv.lock` hunk is a pre-existing version sync (8.23.1 → 8.23.2) the `uv-lock` hook applied.

Fixes #1514
