### PR TITLE
docs(agents): add import-ordering rule to avoid F401 autofix churn

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,9 @@ Architecture: [docs/architecture.md](docs/architecture.md).
   from R2, worker reports). Dataclasses for internal typed containers.
 - `structlog` in pipeline code; stdlib `logging` elsewhere.
 - All `rclone` operations use `--checksum`.
+- Add an import in the same edit as its first use, or add imports last —
+  ruff's `F401` autofix deletes an import that is momentarily unused if
+  `make format` runs before the using code lands, costing a re-add cycle.
 - Run `make format` before committing. Pre-commit (ruff, ruff-format,
   pydoclint, prettier, mdformat, gitlint) is authoritative; suppressing
   rules to make CI green is forbidden — see

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ Never run `make docker-*` or RunPod commands without asking — they spend money
 - Pydantic `BaseModel(strict=True)` at trust boundaries (config parsing, JSON from R2, worker reports); dataclasses for internal typed containers.
 - `structlog` in pipeline code; stdlib `logging` elsewhere.
 - All `rclone` operations use `--checksum`.
+- Add an import in the same edit as its first use, or add imports last — ruff's `F401` autofix deletes an import that is momentarily unused if `make format` runs before the using code lands, costing a re-add cycle.
 
 </important>
 


### PR DESCRIPTION
## Problem

Agents repeatedly lose a cycle to ruff's `F401` autofix: an import is added in
one edit, `make format` (pre-commit `ruff --fix`) runs before the using code
lands, the momentarily-unused import is deleted, and the agent has to re-add it
once the usage exists. This recurs across sessions and drags on velocity.

## Change

Document the ordering rule so every agent avoids the trap:

> Add an import in the same edit as its first use, or add imports last — ruff's
> `F401` autofix deletes an import that is momentarily unused if `make format`
> runs before the using code lands, costing a re-add cycle.

- **AGENTS.md** (canonical) — added to the "Writing code" section.
- **CLAUDE.md** — mirrored into the "writing or modifying Python code" block so
  the two stay in sync (no generator exists between them).

Docs-only; no Python/CI changes.

## Relationship to #1431

`Refs #1431`. That issue stops VS Code's on-save ruff from deleting unused
imports but explicitly leaves the CLI / pre-commit (`make format`) path
unchanged. This PR documents the guidance for exactly that path — the
complementary half of the same F401 friction.

Refs #1431
