### PR TITLE
ci(vst-slow): raise VST Slow Tests job timeout to 120 min

### DIFF
--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -78,7 +78,7 @@ jobs:
   run_vst_slow_tests:
     name: VST slow tests (Docker)
     runs-on: ubuntu-latest-4core
-    timeout-minutes: 60
+    timeout-minutes: 120
 
     # Job-level grant so only this job can push to ``gh-pages`` for the
     # benchmark history. Workflow-level default is ``contents: read``.


### PR DESCRIPTION
## What

Raise `timeout-minutes` from 60 to 120 on the `run_vst_slow_tests` job in `.github/workflows/test-vst-slow.yml`.

## Why

The `VST Slow Tests` workflow chronically exceeds the 60-min job timeout and is **cancelled** rather than failing on an assertion — **3 of the last 5 `main` runs** were cancelled at the 60-min mark. The cancellation also surfaces as a red (non-required) check on unrelated PRs. The job runs on `ubuntu-latest-4core`; the larger budget only applies when the slow audio-similarity suite actually needs it.

## Scope

Single-line value change. No renderer, test, or benchmark code is touched.

Fixes #1521