### PR TITLE
test(testing): clamp pytest-xdist -n auto by available memory

### DIFF
--- a/.devcontainer/cpu/devcontainer.json
+++ b/.devcontainer/cpu/devcontainer.json
@@ -16,7 +16,8 @@
     ".env"
   ],
   "containerEnv": {
-    "MODE": "idle"
+    "MODE": "idle",
+    "PYTEST_XDIST_AUTO_NUM_WORKERS": "4"
   },
   "remoteUser": "${localEnv:DEVCONTAINER_USER:dev}",
   "mounts": [

--- a/.devcontainer/gpu/devcontainer.json
+++ b/.devcontainer/gpu/devcontainer.json
@@ -19,7 +19,8 @@
     ".env"
   ],
   "containerEnv": {
-    "MODE": "idle"
+    "MODE": "idle",
+    "PYTEST_XDIST_AUTO_NUM_WORKERS": "4"
   },
   "remoteUser": "${localEnv:DEVCONTAINER_USER:dev}",
   "mounts": [

--- a/.devcontainer/root_gpu/devcontainer.json
+++ b/.devcontainer/root_gpu/devcontainer.json
@@ -21,7 +21,8 @@
     ".env"
   ],
   "containerEnv": {
-    "MODE": "idle"
+    "MODE": "idle",
+    "PYTEST_XDIST_AUTO_NUM_WORKERS": "4"
   },
   "remoteUser": "${localEnv:DEVCONTAINER_USER:root}",
   "updateRemoteUserUID": true,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -919,20 +919,107 @@ def _cgroup_aware_cpu_count() -> int:
     return max(1, int(cpus))
 
 
+# Per-worker resident-memory budget for the -n auto memory clamp, overridable
+# via PYTEST_XDIST_WORKER_MEM_MB. 1 GiB suits a torch+h5py+Hydra worker.
+_DEFAULT_WORKER_MEM_MB = 1024
+
+# A v1 memory.limit_in_bytes at or above this is the kernel's unlimited sentinel.
+_MEM_UNLIMITED_SENTINEL = 1 << 62
+
+
+def _meminfo_available_bytes() -> int | None:
+    """Read ``MemAvailable`` from ``/proc/meminfo`` as bytes.
+
+    :returns: Host available memory in bytes, or None if the field is unreadable.
+    """
+    try:
+        with open("/proc/meminfo") as fh:
+            for line in fh:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) * 1024  # field is in kibibytes
+    except (OSError, ValueError, IndexError):
+        pass
+    return None
+
+
+def _cgroup_memory_limit_bytes() -> int | None:
+    """Read the cgroup memory limit in bytes, honouring v2 then v1.
+
+    :returns: The cgroup memory cap in bytes, or None when unset or unlimited.
+    """
+    try:  # cgroup v2: unified hierarchy, kernel >= 4.5
+        with open("/sys/fs/cgroup/memory.max") as fh:
+            limit_field = fh.read().split()[0]
+            if limit_field != "max":
+                return int(limit_field)
+            return None
+    except (OSError, ValueError, IndexError):
+        pass
+    try:  # cgroup v1: legacy per-subsystem hierarchy
+        with open("/sys/fs/cgroup/memory/memory.limit_in_bytes") as fh:
+            limit = int(fh.read())
+        if 0 < limit < _MEM_UNLIMITED_SENTINEL:
+            return limit
+    except (OSError, ValueError):
+        pass
+    return None
+
+
+def _available_memory_bytes() -> int | None:
+    """Return usable memory as ``min(host MemAvailable, cgroup limit)``.
+
+    On a shared host the cgroup limit is usually unset, so host MemAvailable is the real ceiling;
+    in a memory-capped container the cgroup limit wins.
+
+    :returns: The tighter of the two figures in bytes, or None if neither is known.
+    """
+    candidates = [
+        value
+        for value in (_meminfo_available_bytes(), _cgroup_memory_limit_bytes())
+        if value is not None
+    ]
+    return min(candidates) if candidates else None
+
+
+def _memory_aware_worker_count() -> int | None:
+    """Cap ``-n auto`` workers by available memory and a per-worker budget.
+
+    Divides available memory by ``PYTEST_XDIST_WORKER_MEM_MB`` (default 1 GiB) so
+    a busy shared host doesn't OOM-kill the run — the failure #1490's CPU clamp
+    can't catch, since neither cpu.max nor memory.max is set on a shared host.
+
+    :returns: Memory-bounded worker count (>=1), or None when memory is unknown.
+    """
+    available = _available_memory_bytes()
+    if available is None:
+        return None
+    raw_budget = os.environ.get("PYTEST_XDIST_WORKER_MEM_MB")
+    try:
+        budget_mb = int(raw_budget) if raw_budget else _DEFAULT_WORKER_MEM_MB
+    except ValueError:
+        budget_mb = _DEFAULT_WORKER_MEM_MB
+    if budget_mb <= 0:
+        budget_mb = _DEFAULT_WORKER_MEM_MB
+    return max(1, available // (budget_mb * 1024 * 1024))
+
+
 def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:  # noqa: ARG001
-    """Override pytest-xdist ``-n auto`` to respect the container's cgroup CPU quota.
+    """Override pytest-xdist ``-n auto`` to fit the host's CPU and memory headroom.
 
     Checks ``PYTEST_XDIST_AUTO_NUM_WORKERS`` first so the env-var escape hatch
     that xdist's built-in implementation honours is preserved even when this
-    hook wins the ``firstresult`` race.
+    hook wins the ``firstresult`` race. Otherwise returns ``min(cpu, memory)``
+    so neither resource is over-subscribed.
 
     :param config: The pytest config object (unused; required by the hook signature).
-    :returns: Worker count clamped to the container's real CPU allocation.
+    :returns: Worker count clamped to the host's real CPU and memory allocation.
     """
     env_override = os.environ.get("PYTEST_XDIST_AUTO_NUM_WORKERS")
     if env_override is not None:
         return max(1, int(env_override))
-    return _cgroup_aware_cpu_count()
+    cpu_workers = _cgroup_aware_cpu_count()
+    mem_workers = _memory_aware_worker_count()
+    return cpu_workers if mem_workers is None else min(cpu_workers, mem_workers)
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/test__conftest_mem.py
+++ b/tests/test__conftest_mem.py
@@ -1,0 +1,218 @@
+"""Tests for the memory-aware xdist worker helpers in tests/conftest.py."""
+
+import io
+import os
+from collections.abc import Callable
+from typing import cast
+from unittest.mock import patch
+
+import pytest
+
+from tests.conftest import (
+    _available_memory_bytes,
+    _memory_aware_worker_count,
+    pytest_xdist_auto_num_workers,
+)
+
+_MEMINFO = "/proc/meminfo"
+_V2_MEM = "/sys/fs/cgroup/memory.max"
+_V1_MEM = "/sys/fs/cgroup/memory/memory.limit_in_bytes"
+
+_GIB = 1024**3
+
+
+def _make_open(files: dict[str, str]) -> Callable[..., io.StringIO]:
+    """Return an ``open()`` side-effect serving in-memory content for known paths.
+
+    :param files: Mapping of absolute path to the file body it should yield.
+    :returns: Callable suitable for use as ``patch("builtins.open", side_effect=...)``.
+    """
+
+    def _side(path: str, *_args: object, **_kwargs: object) -> io.StringIO:
+        if path in files:
+            return io.StringIO(files[path])
+        raise OSError(f"not found: {path}")
+
+    return _side
+
+
+def _meminfo(avail_kb: int) -> str:
+    """Render a minimal ``/proc/meminfo`` body carrying a ``MemAvailable`` line.
+
+    :param avail_kb: Value to report for ``MemAvailable`` (kibibytes).
+    :returns: Multi-line meminfo text with realistic surrounding fields.
+    """
+    return (
+        f"MemTotal:       32000000 kB\nMemAvailable:   {avail_kb} kB\nBuffers:          100 kB\n"
+    )
+
+
+class TestAvailableMemoryBytes:
+    """Unit tests for _available_memory_bytes covering the min(host, cgroup) logic."""
+
+    def test_host_only_no_cgroup_limit_returns_host_avail(self) -> None:
+        """V2 ``max`` sentinel means no cgroup cap → host MemAvailable wins."""
+        files = {_MEMINFO: _meminfo(20 * 1024 * 1024), _V2_MEM: "max\n"}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert _available_memory_bytes() == 20 * _GIB
+
+    def test_cgroup_below_host_returns_cgroup(self) -> None:
+        """V2 cgroup limit < host avail → min picks the cgroup limit."""
+        files = {_MEMINFO: _meminfo(20 * 1024 * 1024), _V2_MEM: str(4 * _GIB)}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert _available_memory_bytes() == 4 * _GIB
+
+    def test_cgroup_above_host_returns_host(self) -> None:
+        """V2 cgroup limit > host avail → min picks the host figure."""
+        files = {_MEMINFO: _meminfo(6 * 1024 * 1024), _V2_MEM: str(64 * _GIB)}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert _available_memory_bytes() == 6 * _GIB
+
+    def test_v1_unlimited_sentinel_ignored(self) -> None:
+        """V1 huge sentinel (effectively unlimited) is dropped → host avail wins."""
+        files = {_MEMINFO: _meminfo(8 * 1024 * 1024), _V1_MEM: "9223372036854771712\n"}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert _available_memory_bytes() == 8 * _GIB
+
+    def test_v1_limit_below_host_returns_v1(self) -> None:
+        """V2 absent, V1 limit < host avail → min picks the V1 limit."""
+        files = {_MEMINFO: _meminfo(20 * 1024 * 1024), _V1_MEM: str(2 * _GIB)}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert _available_memory_bytes() == 2 * _GIB
+
+    def test_v2_limit_only_no_meminfo_returns_v2(self) -> None:
+        """Meminfo unreadable, V2 limit set → the cgroup limit is the sole signal."""
+        files = {_V2_MEM: str(3 * _GIB)}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert _available_memory_bytes() == 3 * _GIB
+
+    def test_invalid_v2_falls_back_to_v1(self) -> None:
+        """Non-integer V2 token → ValueError caught, falls through to the V1 limit."""
+        files = {_V2_MEM: "garbage", _V1_MEM: str(2 * _GIB)}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert _available_memory_bytes() == 2 * _GIB
+
+    def test_v1_zero_limit_treated_as_unlimited(self) -> None:
+        """V1 limit of 0 fails the ``0 < limit`` guard → no cgroup signal (None)."""
+        files = {_V1_MEM: "0"}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert _available_memory_bytes() is None
+
+    def test_no_signal_returns_none(self) -> None:
+        """Neither meminfo nor cgroup readable → no memory signal (None)."""
+        with patch("builtins.open", side_effect=_make_open({})):
+            assert _available_memory_bytes() is None
+
+    def test_malformed_meminfo_no_cgroup_returns_none(self) -> None:
+        """Meminfo missing MemAvailable and no cgroup cap → None, not a crash."""
+        files = {_MEMINFO: "MemTotal: 32000000 kB\n", _V2_MEM: "max\n"}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert _available_memory_bytes() is None
+
+
+class TestMemoryAwareWorkerCount:
+    """Unit tests for _memory_aware_worker_count covering budget division."""
+
+    def test_divides_avail_by_default_budget(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """20 GiB avail / 1 GiB default budget → 20 workers.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.delenv("PYTEST_XDIST_WORKER_MEM_MB", raising=False)
+        files = {_MEMINFO: _meminfo(20 * 1024 * 1024), _V2_MEM: "max\n"}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert _memory_aware_worker_count() == 20
+
+    def test_fractional_floors_to_at_least_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """1.5 GiB avail / 1 GiB budget → floored to 1, never 0.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.delenv("PYTEST_XDIST_WORKER_MEM_MB", raising=False)
+        files = {_MEMINFO: _meminfo(int(1.5 * 1024 * 1024)), _V2_MEM: "max\n"}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert _memory_aware_worker_count() == 1
+
+    def test_env_budget_override_changes_divisor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """PYTEST_XDIST_WORKER_MEM_MB=2048 → 16 GiB / 2 GiB = 8 workers.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("PYTEST_XDIST_WORKER_MEM_MB", "2048")
+        files = {_MEMINFO: _meminfo(16 * 1024 * 1024), _V2_MEM: "max\n"}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert _memory_aware_worker_count() == 8
+
+    def test_invalid_env_budget_falls_back_to_default(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-integer budget env → default 1 GiB divisor, not a crash.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("PYTEST_XDIST_WORKER_MEM_MB", "not-a-number")
+        files = {_MEMINFO: _meminfo(8 * 1024 * 1024), _V2_MEM: "max\n"}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert _memory_aware_worker_count() == 8
+
+    def test_no_memory_signal_returns_none(self) -> None:
+        """No readable memory signal → None so the caller falls back to CPU count."""
+        with patch("builtins.open", side_effect=_make_open({})):
+            assert _memory_aware_worker_count() is None
+
+
+class TestHookCombinesCpuAndMemory:
+    """The hook returns min(cpu, memory), with the env var as a hard override."""
+
+    def test_memory_clamps_below_cpu(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Plenty of CPUs but tight memory → memory count wins the min.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.delenv("PYTEST_XDIST_AUTO_NUM_WORKERS", raising=False)
+        monkeypatch.delenv("PYTEST_XDIST_WORKER_MEM_MB", raising=False)
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(32)), raising=False)
+        files = {_MEMINFO: _meminfo(4 * 1024 * 1024), _V2_MEM: "max\n"}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert pytest_xdist_auto_num_workers(cast("pytest.Config", None)) == 4
+
+    def test_cpu_clamps_below_memory(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Plenty of memory but few CPUs → cpu count wins the min.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.delenv("PYTEST_XDIST_AUTO_NUM_WORKERS", raising=False)
+        monkeypatch.delenv("PYTEST_XDIST_WORKER_MEM_MB", raising=False)
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1}, raising=False)
+        files = {_MEMINFO: _meminfo(64 * 1024 * 1024), _V2_MEM: "max\n"}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert pytest_xdist_auto_num_workers(cast("pytest.Config", None)) == 2
+
+    def test_no_memory_signal_uses_cpu_count(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No memory signal → hook falls back to the CPU count alone.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.delenv("PYTEST_XDIST_AUTO_NUM_WORKERS", raising=False)
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2}, raising=False)
+        with patch("builtins.open", side_effect=_make_open({})):
+            assert pytest_xdist_auto_num_workers(cast("pytest.Config", None)) == 3
+
+    def test_env_override_wins_over_clamps(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Explicit PYTEST_XDIST_AUTO_NUM_WORKERS short-circuits both clamps.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("PYTEST_XDIST_AUTO_NUM_WORKERS", "7")
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1}, raising=False)
+        files = {_MEMINFO: _meminfo(1 * 1024 * 1024), _V2_MEM: "max\n"}
+        with patch("builtins.open", side_effect=_make_open(files)):
+            assert pytest_xdist_auto_num_workers(cast("pytest.Config", None)) == 7
+
+    def test_env_override_zero_floors_to_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A 0/negative env override floors to 1 so xdist never gets ``-n 0``.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("PYTEST_XDIST_AUTO_NUM_WORKERS", "0")
+        assert pytest_xdist_auto_num_workers(cast("pytest.Config", None)) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.23.2"
+version = "8.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Problem

`make test-fast` (`pytest -n auto`) is OOM-killed (SIGTERM, exit 143) on the shared dev host running 60+ worktrees.

The existing `pytest_xdist_auto_num_workers` hook is **CPU-quota-only**. On the shared host neither `cpu.max` nor `memory.max` is set, so `sched_getaffinity` returns all 32 host cores and `-n auto` spawns 32 torch-importing workers. Aggregate worker RSS — compounded by other concurrent worktree runs — exhausts host RAM and the kernel OOM-killer reaps the run. The CPU clamp can only catch a single container over-subscribing its own CPU quota; it can't see host memory pressure.

## Change

- **Memory-aware clamp** in `tests/conftest.py`: `min(host MemAvailable, cgroup memory limit)` ÷ a per-worker budget (`PYTEST_XDIST_WORKER_MEM_MB`, default 1 GiB). The hook now returns `min(cpu_workers, mem_workers)`, falling back to CPU-only when no memory signal is readable. Mirrors the v2-then-v1 structure of the CPU helper; the v1 unlimited sentinel and `memory.max=max` both degrade to "no cap".
- **Low default** `PYTEST_XDIST_AUTO_NUM_WORKERS: "4"` added to all three devcontainer `containerEnv` blocks (cpu/gpu/root_gpu) so every worktree on the shared host defaults low; the per-run override is preserved.

### Interaction note

The hook checks `PYTEST_XDIST_AUTO_NUM_WORKERS` **first**, so the devcontainer pin short-circuits the memory clamp *inside the devcontainer*. That's intentional: the fixed low pin is the shared-host default, and the adaptive memory clamp is the safety net for every environment that doesn't set the var (CI runners, a future memory-capped container). CI does not consume `devcontainer.json` `containerEnv`, so CI parallelism is unaffected and benefits from the adaptive clamp.

### Notes

- `uv.lock` carries a one-line `8.23.1 → 8.23.2` version sync: the `uv-lock` pre-commit hook auto-corrected pre-existing drift between main's release commit and its lockfile. Unavoidable (reverting just makes the hook redo it) and correct.

## Tests

`tests/test__conftest_mem.py` — 20 new tests covering host/cgroup `min` selection (both directions, v1/v2), the v1 unlimited sentinel and `0` boundary, v2-malformed→v1 fallthrough, fractional floor-to-1, env-budget override and invalid-budget fallback, and the hook-level `min(cpu, memory)` composition with the env hard-override. The 10 existing CPU-hook tests still pass (30 total).

## Verification

Live on this host the clamp drops `-n auto` from 32 → 24 workers (24.6 GiB avail ÷ 1 GiB); with the devcontainer pin it is 4.

Fixes #1520