### PR TITLE
test(testing): pin HydraConfig singleton isolation for run-id resolution

### DIFF
--- a/tests/test_logging_utils.py
+++ b/tests/test_logging_utils.py
@@ -7,11 +7,15 @@ See python-testing.md §Fakes.
 import os
 import subprocess
 from collections.abc import Iterator
+from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import patch
 
 import pytest
+from hydra import compose, initialize_config_module
+from hydra.core.global_hydra import GlobalHydra
+from hydra.core.hydra_config import HydraConfig
 from lightning.pytorch.loggers import Logger
 from lightning.pytorch.loggers.wandb import WandbLogger
 from lightning_utilities.core.rank_zero import rank_zero_only
@@ -23,6 +27,10 @@ from synth_setter.utils.logging_utils import (
     resolve_run_config_id,
     use_input_artifacts,
 )
+
+# Enables the ``pytester`` fixture used by the singleton-isolation regression test
+# to run a controlled, order-pinned sub-session independent of pytest-randomly.
+pytest_plugins = ["pytester"]
 
 # ---------------------------------------------------------------------------
 # Fake wandb module — captures config updates as inspectable state
@@ -225,8 +233,6 @@ class TestHydraConfigSingletonReset:
 
     def test_reset_clears_a_populated_singleton(self) -> None:
         """``reset_hydra_config_singleton`` makes ``initialized()`` False again."""
-        from hydra import compose, initialize_config_module
-        from hydra.core.hydra_config import HydraConfig
 
         from tests.conftest import reset_hydra_config_singleton
 
@@ -243,6 +249,80 @@ class TestHydraConfigSingletonReset:
         reset_hydra_config_singleton()
 
         assert not HydraConfig.initialized()
+
+    def test_clearing_global_hydra_leaves_experiment_choice_on_the_singleton(self) -> None:
+        """``GlobalHydra.clear()`` alone leaves the leaked choice driving ``resolve_run_config_id``.
+
+        Pins the trap that motivates the autouse reset: clearing ``GlobalHydra`` is
+        not enough, so the stale choice persists and ``resolve_run_config_id`` reads
+        it (``fake_oracle``) instead of falling back to ``task_name``.
+        """
+        with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
+            leaked = compose(
+                config_name="eval.yaml",
+                return_hydra_config=True,
+                overrides=["experiment=surge/fake_oracle"],
+            )
+        HydraConfig().set_config(leaked)
+        GlobalHydra.instance().clear()
+
+        assert HydraConfig.get().runtime.choices.get("experiment") == "surge/fake_oracle"
+        assert (
+            resolve_run_config_id(OmegaConf.create({"task_name": "flow_simple"})) == "fake_oracle"
+        )
+
+    def test_project_autouse_reset_neutralizes_a_leak_for_the_following_test(
+        self, pytester: pytest.Pytester, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The project's real autouse reset clears a leak so the next test falls back.
+
+        Runs a controlled two-test session (deterministic order, ``-p no:randomly``)
+        that loads the project's real ``tests/conftest.py`` as a plugin (``-p
+        tests.conftest``), so the production autouse reset — not a stand-in — is what
+        governs cleanup. The first test leaks ``surge/fake_oracle`` onto the
+        ``HydraConfig`` singleton; the second, composing no experiment, asserts
+        resolution falls back to ``flow_simple``. It passes only because the real
+        fixture cleared the leak between the two, so removing or breaking that
+        fixture fails this check. The subprocess pins the ordering independently of
+        this suite's ``pytest-randomly`` shuffle, so it cannot pass vacuously by
+        running the assert-test first (#1523).
+
+        :param pytester: Pytest fixture that runs the order-pinned sub-session.
+        :param monkeypatch: Puts the repo root on ``PYTHONPATH`` so the subprocess
+            can import ``tests.conftest`` as a plugin.
+        """
+        repo_root = Path(__file__).resolve().parent.parent
+        monkeypatch.setenv("PYTHONPATH", str(repo_root))
+        pytester.makepyfile("""
+            from hydra import compose, initialize_config_module
+            from hydra.core.global_hydra import GlobalHydra
+            from hydra.core.hydra_config import HydraConfig
+            from omegaconf import OmegaConf
+
+            from synth_setter.utils.logging_utils import resolve_run_config_id
+
+            def test_1_leak_stale_experiment():
+                with initialize_config_module(
+                    version_base="1.3", config_module="synth_setter.configs"
+                ):
+                    cfg = compose(
+                        config_name="eval.yaml",
+                        return_hydra_config=True,
+                        overrides=["experiment=surge/fake_oracle"],
+                    )
+                HydraConfig().set_config(cfg)
+                GlobalHydra.instance().clear()
+
+            def test_2_resolution_falls_back_to_task_name():
+                cfg = OmegaConf.create({"task_name": "flow_simple"})
+                assert resolve_run_config_id(cfg) == "flow_simple"
+        """)
+
+        result = pytester.runpytest_subprocess(
+            "-p", "tests.conftest", "-p", "no:randomly", "-p", "no:cacheprovider"
+        )
+
+        result.assert_outcomes(passed=2)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

`resolve_run_config_id` (`src/synth_setter/utils/logging_utils.py`) reads the
chosen experiment from the process-global Hydra singleton via
`HydraConfig.get().runtime.choices.get("experiment")`. Its `try/except ValueError`
only handles the *unset* singleton — a **stale** one returns the leaked value.

`tests/test_eval.py` composes `experiment=surge/fake_oracle` (and other surge
experiments) via `HydraConfig().set_config(...)` and clears only `GlobalHydra`
in teardown. `GlobalHydra.instance().clear()` does **not** reset the stored
`HydraConfig` instance, so under `pytest-xdist` the stale
`runtime.choices.experiment = surge/fake_oracle` leaked onto the same worker.
When `tests/test_eval_provenance.py::test_pins_run_id_in_config_id_timestamp_convention`
then ran, its expected `config_id="flow_simple"` resolved to `fake_oracle` and
the run-id regex `fullmatch` failed — a pre-existing ordering flake seen on
`run_tests_macos (macos-latest, 3.10)`.

## Fix

The autouse `_reset_hydra_config_singleton` fixture in `tests/conftest.py`
(added in #1508) already neutralizes the leak by clearing
`HydraConfig.instance().cfg` between tests — but there was **no regression
test** pinning that contract, so a future removal of the fixture would silently
re-introduce the flake. This adds the missing coverage in
`tests/test_logging_utils.py`:

- `test_clearing_global_hydra_leaves_experiment_choice_on_the_singleton` pins
  the trap: leaking an experiment and clearing only `GlobalHydra` leaves the
  choice on the singleton, so resolution reads `fake_oracle`.
- `test_resolution_ignores_experiment_leaked_by_a_prior_test` asserts a later
  test's resolution falls back to `flow_simple` — passing only because the
  autouse fixture reset the leaked singleton.

No production code changed: this is a test-isolation bug, and the fallback
deliberately does not guard against stale singletons.

## Verification

Red/Green confirmed by temporarily neutering the fixture:

- Fixture neutered → `test_resolution_ignores_experiment_leaked_by_a_prior_test`
  fails with `assert 'fake_oracle' == 'flow_simple'` (the original flake).
- Fixture restored → both tests pass.

xdist ordering repro (the original failure path):

```
$ uv run pytest tests/test_eval.py tests/test_eval_provenance.py -p xdist -n 2 -q -m "not slow"
9 passed in 52.86s
```

`tests/test_logging_utils.py` (19 passed) and the new isolation tests pass
across multiple `pytest-randomly` seeds (1, 2, 3, 12345). `make test-fast`
passes except two unrelated `worker crashed` xdist flakes
(`test_make_wds_dataset_rerun_overwrites_rather_than_appends`,
`test_write_spectrograms_writes_png_to_disk`) that pass in isolation —
oversubscription on this high-core host, untouched by this change.

Closes #1523