### PR TITLE
test(provenance): pin run-id resolution against leaked HydraConfig

### DIFF
--- a/tests/test_eval_provenance.py
+++ b/tests/test_eval_provenance.py
@@ -17,12 +17,27 @@ from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from hydra.conf import HydraConf
+from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig, OmegaConf
 
 from synth_setter.cli.eval import evaluate
 
 # ``make_wandb_run_id`` output: ``<config_id>-YYYYMMDDTHHMMSSsssZ``.
 _RUN_ID_PATTERN = r"{config_id}-\d{{8}}T\d{{9}}Z"
+
+
+def _leak_foreign_experiment_into_hydra_singleton() -> None:
+    """Populate the process-global ``HydraConfig`` with a foreign experiment choice.
+
+    Mimics a sibling test that composed an experiment and left the ``HydraConfig``
+    singleton set, so ``resolve_run_config_id`` would read
+    ``runtime.choices.experiment`` instead of falling back to ``task_name`` — the
+    leak that flaked the provenance run-id tests under xdist (#1518, #1523).
+    """
+    hydra_conf = OmegaConf.structured(HydraConf)
+    OmegaConf.update(hydra_conf, "runtime.choices.experiment", "surge/some_other_exp")
+    HydraConfig.instance().set_config(OmegaConf.create({"hydra": hydra_conf}))
 
 
 def _wandb_logger_cfg() -> DictConfig:
@@ -79,6 +94,28 @@ class TestEvalProvenanceWiring:
 
         :param stubbed_eval_entrypoint: Collaborator-stub fixture.
         """
+        cfg = _wandb_logger_cfg()
+
+        evaluate(cfg)
+
+        assert re.fullmatch(_RUN_ID_PATTERN.format(config_id="flow_simple"), cfg.logger.wandb.id)
+
+    def test_pins_run_id_to_task_name_after_leaked_experiment_is_reset(
+        self, stubbed_eval_entrypoint: MagicMock
+    ) -> None:
+        """Clearing a leaked ``HydraConfig`` restores the ``task_name`` run-id fallback.
+
+        Regression guard for the ``_reset_hydra_config_singleton`` autouse fixture
+        (``tests/conftest.py``): a foreign ``runtime.choices.experiment`` left in the
+        process-global singleton must not bleed into the pinned run id once the
+        singleton is cleared between tests, so the id resolves to
+        ``{task_name}-{timestamp}`` rather than the leaked experiment basename
+        (#1518, #1523).
+
+        :param stubbed_eval_entrypoint: Collaborator-stub fixture.
+        """
+        _leak_foreign_experiment_into_hydra_singleton()
+        HydraConfig.instance().cfg = None
         cfg = _wandb_logger_cfg()
 
         evaluate(cfg)

--- a/tests/test_eval_provenance.py
+++ b/tests/test_eval_provenance.py
@@ -105,12 +105,12 @@ class TestEvalProvenanceWiring:
     ) -> None:
         """Clearing a leaked ``HydraConfig`` restores the ``task_name`` run-id fallback.
 
-        Regression guard for the ``_reset_hydra_config_singleton`` autouse fixture
-        (``tests/conftest.py``): a foreign ``runtime.choices.experiment`` left in the
-        process-global singleton must not bleed into the pinned run id once the
-        singleton is cleared between tests, so the id resolves to
-        ``{task_name}-{timestamp}`` rather than the leaked experiment basename
-        (#1518, #1523).
+        Pins the contract that the autouse ``_reset_hydra_config_singleton`` fixture
+        (``tests/conftest.py``) relies on: after a foreign
+        ``runtime.choices.experiment`` is cleared from the process-global singleton,
+        the pinned run id resolves to ``{task_name}-{timestamp}`` rather than the
+        leaked experiment basename — the xdist flake fixed in #1518, #1523. The test
+        clears the singleton itself so it is deterministic regardless of ordering.
 
         :param stubbed_eval_entrypoint: Collaborator-stub fixture.
         """

--- a/tests/test_train_provenance.py
+++ b/tests/test_train_provenance.py
@@ -17,12 +17,27 @@ from collections.abc import Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
+from hydra.conf import HydraConf
+from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig, OmegaConf
 
 from synth_setter.cli.train import train
 
 # ``make_wandb_run_id`` output: ``<config_id>-YYYYMMDDTHHMMSSsssZ``.
 _RUN_ID_PATTERN = r"{config_id}-\d{{8}}T\d{{9}}Z"
+
+
+def _leak_foreign_experiment_into_hydra_singleton() -> None:
+    """Populate the process-global ``HydraConfig`` with a foreign experiment choice.
+
+    Mimics a sibling test that composed an experiment and left the ``HydraConfig``
+    singleton set, so ``resolve_run_config_id`` would read
+    ``runtime.choices.experiment`` instead of falling back to ``task_name`` — the
+    leak that flaked the provenance run-id tests under xdist (#1518, #1523).
+    """
+    hydra_conf = OmegaConf.structured(HydraConf)
+    OmegaConf.update(hydra_conf, "runtime.choices.experiment", "surge/some_other_exp")
+    HydraConfig.instance().set_config(OmegaConf.create({"hydra": hydra_conf}))
 
 
 def _wandb_logger_cfg() -> DictConfig:
@@ -79,6 +94,28 @@ class TestTrainProvenanceWiring:
 
         :param stubbed_train_entrypoint: Collaborator-stub fixture.
         """
+        cfg = _wandb_logger_cfg()
+
+        train(cfg)
+
+        assert re.fullmatch(_RUN_ID_PATTERN.format(config_id="flow_simple"), cfg.logger.wandb.id)
+
+    def test_pins_run_id_to_task_name_after_leaked_experiment_is_reset(
+        self, stubbed_train_entrypoint: MagicMock
+    ) -> None:
+        """Clearing a leaked ``HydraConfig`` restores the ``task_name`` run-id fallback.
+
+        Regression guard for the ``_reset_hydra_config_singleton`` autouse fixture
+        (``tests/conftest.py``): a foreign ``runtime.choices.experiment`` left in the
+        process-global singleton must not bleed into the pinned run id once the
+        singleton is cleared between tests, so the id resolves to
+        ``{task_name}-{timestamp}`` rather than the leaked experiment basename
+        (#1518, #1523).
+
+        :param stubbed_train_entrypoint: Collaborator-stub fixture.
+        """
+        _leak_foreign_experiment_into_hydra_singleton()
+        HydraConfig.instance().cfg = None
         cfg = _wandb_logger_cfg()
 
         train(cfg)

--- a/tests/test_train_provenance.py
+++ b/tests/test_train_provenance.py
@@ -105,12 +105,12 @@ class TestTrainProvenanceWiring:
     ) -> None:
         """Clearing a leaked ``HydraConfig`` restores the ``task_name`` run-id fallback.
 
-        Regression guard for the ``_reset_hydra_config_singleton`` autouse fixture
-        (``tests/conftest.py``): a foreign ``runtime.choices.experiment`` left in the
-        process-global singleton must not bleed into the pinned run id once the
-        singleton is cleared between tests, so the id resolves to
-        ``{task_name}-{timestamp}`` rather than the leaked experiment basename
-        (#1518, #1523).
+        Pins the contract that the autouse ``_reset_hydra_config_singleton`` fixture
+        (``tests/conftest.py``) relies on: after a foreign
+        ``runtime.choices.experiment`` is cleared from the process-global singleton,
+        the pinned run id resolves to ``{task_name}-{timestamp}`` rather than the
+        leaked experiment basename — the xdist flake fixed in #1518, #1523. The test
+        clears the singleton itself so it is deterministic regardless of ordering.
 
         :param stubbed_train_entrypoint: Collaborator-stub fixture.
         """


### PR DESCRIPTION
## Problem

A docstring summary longer than 99 columns deadlocks two pre-commit hooks configured in `pyproject.toml`:

- `[tool.docformatter]` `wrap-summaries = 99` reflows the over-long summary onto a **second physical line**.
- ruff `D205` ("1 blank line required between summary line and description") then reads that continuation as a *description* with no preceding blank line and errors.

The error is **not auto-fixable** — not by `ruff --fix`, not even `--unsafe-fixes` — and docformatter will not undo its own wrap. The file is byte-stable but permanently red, and it only surfaces on the *next* hook run after docformatter rewrites the file, making it a confusing two-pass trap. History shows this recurring as manual reflow workarounds (e.g. the #1270 CI failure: "docformatter wanted the two-line summary joined onto the 100-col second line"; `_download_finalized_splits` summary shortened to stay on one line).

## Fix

Set `wrap-summaries = 0` so docformatter never wraps a summary onto a second physical line — the one-line shape `D205` and pydoclint's parser assume. Descriptions still wrap at 99 (they sit after the blank line, so `D205` does not apply). Verified: the previously deadlocking >99-col summary now stays on one line and passes `D205`; collapse of short multi-line docstrings and description wrapping are unaffected; docformatter + ruff-format remain idempotent.

Add a config-invariant regression test (`tests/infra/test_docstring_tooling_consistency.py`) pinning `D205 selected ⇒ wrap-summaries == 0`, verified red on the old config and green on the new.

The `uv.lock` hunk is a pre-existing version sync (8.23.1 → 8.23.2) the `uv-lock` hook applied.

Fixes #1514
