### PR TITLE
test(testing): guard non-integer PYTEST_XDIST_AUTO_NUM_WORKERS override

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1017,15 +1017,19 @@ def pytest_xdist_auto_num_workers(config: pytest.Config) -> int:  # noqa: ARG001
 
     Checks ``PYTEST_XDIST_AUTO_NUM_WORKERS`` first so the env-var escape hatch
     that xdist's built-in implementation honours is preserved even when this
-    hook wins the ``firstresult`` race. Otherwise returns ``min(cpu, memory)``
-    so neither resource is over-subscribed.
+    hook wins the ``firstresult`` race. A non-integer or empty pin is ignored,
+    not fatal. Otherwise returns ``min(cpu, memory)`` so neither resource is
+    over-subscribed.
 
     :param config: The pytest config object (unused; required by the hook signature).
     :returns: Worker count clamped to the host's real CPU and memory allocation.
     """
     env_override = os.environ.get("PYTEST_XDIST_AUTO_NUM_WORKERS")
-    if env_override is not None:
-        return max(1, int(env_override))
+    if env_override:
+        try:
+            return max(1, int(env_override))
+        except ValueError:
+            pass  # non-integer pin -> ignore and fall through to the adaptive clamps
     cpu_workers = _cgroup_aware_cpu_count()
     mem_workers = _memory_aware_worker_count()
     return cpu_workers if mem_workers is None else min(cpu_workers, mem_workers)

--- a/tests/test__conftest_mem.py
+++ b/tests/test__conftest_mem.py
@@ -216,3 +216,29 @@ class TestHookCombinesCpuAndMemory:
         """
         monkeypatch.setenv("PYTEST_XDIST_AUTO_NUM_WORKERS", "0")
         assert pytest_xdist_auto_num_workers(cast("pytest.Config", None)) == 1
+
+    def test_env_override_non_integer_falls_back_to_clamps(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-integer env override is ignored, not fatal — clamps still apply.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("PYTEST_XDIST_AUTO_NUM_WORKERS", "auto")
+        monkeypatch.delenv("PYTEST_XDIST_WORKER_MEM_MB", raising=False)
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2}, raising=False)
+        with patch("builtins.open", side_effect=_make_open({})):
+            assert pytest_xdist_auto_num_workers(cast("pytest.Config", None)) == 3
+
+    def test_env_override_empty_string_falls_back_to_clamps(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty env override means "unset" → fall through to the clamps.
+
+        :param monkeypatch: Pytest monkeypatch fixture.
+        """
+        monkeypatch.setenv("PYTEST_XDIST_AUTO_NUM_WORKERS", "")
+        monkeypatch.delenv("PYTEST_XDIST_WORKER_MEM_MB", raising=False)
+        monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: {0, 1, 2, 3}, raising=False)
+        with patch("builtins.open", side_effect=_make_open({})):
+            assert pytest_xdist_auto_num_workers(cast("pytest.Config", None)) == 4

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.24.0"
+version = "8.26.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Problem

A non-integer or empty `PYTEST_XDIST_AUTO_NUM_WORKERS` (a typo like `=auto`) raised `ValueError` in the `pytest_xdist_auto_num_workers` hook (`tests/conftest.py:1019` on main), aborting pytest collection before any test ran — the same "suite dies before it starts" failure class the `-n auto` memory clamp (#1524) was added to prevent. Pre-existing since the CPU-aware clamp (#1492); surfaced while reviewing #1524.

## Change

Guard the env-var escape hatch: treat a non-integer/empty pin as "no override" and fall through to the adaptive CPU/memory clamps, mirroring the malformed-input handling already used for `PYTEST_XDIST_WORKER_MEM_MB`.

```python
env_override = os.environ.get("PYTEST_XDIST_AUTO_NUM_WORKERS")
if env_override:
    try:
        return max(1, int(env_override))
    except ValueError:
        pass  # non-integer pin -> ignore and fall through to the adaptive clamps
```

The `if env_override:` (truthy) change also treats an empty string as "unset", which is the more correct reading of a blank env var.

## Tests

Two regression tests added to `tests/test__conftest_mem.py` (`"auto"` non-integer, `""` empty) — both fail against the pre-fix code (ValueError) and pass with the guard, asserting the hook falls through to the affinity-derived clamp count. 32 tests pass (`tests/test__conftest_mem.py` + `tests/test__conftest_cpu.py`).

Fixes #1528