### PR TITLE
test(skypilot): deflake TestDispatchViaSkypilot via inline executor

### DIFF
--- a/tests/pipeline/entrypoints/test_skypilot_launch.py
+++ b/tests/pipeline/entrypoints/test_skypilot_launch.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import os
 import re
+from concurrent.futures import Future
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, create_autospec
@@ -764,8 +765,50 @@ class TestWorkerSpecUriEnvConstant:
         assert WORKER_SPEC_URI_ENV == "WORKER_SPEC_URI"
 
 
+class _InlineExecutor:
+    """Synchronous stand-in for ``ThreadPoolExecutor`` that runs each task on the calling thread.
+
+    The launcher's per-rank fan-out targets a shared ``mock_sky`` MagicMock, whose
+    call recording (``call_args_list`` / ``call_count``) is not thread-safe; under
+    CPU contention concurrent ``submit``s race the record step and a rank goes
+    missing or duplicated. These tests assert env-wiring, not concurrency, so
+    running ranks inline makes mock recording deterministic.
+    """
+
+    def __init__(self, max_workers: int | None = None) -> None:
+        """Accept ``ThreadPoolExecutor``'s constructor signature; pool size is irrelevant inline.
+
+        :param max_workers: Ignored — tasks run on the calling thread.
+        """
+        del max_workers
+
+    def __enter__(self) -> _InlineExecutor:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        return None
+
+    def submit(self, fn: Any, /, *args: Any, **kwargs: Any) -> Future[Any]:
+        future: Future[Any] = Future()
+        try:
+            future.set_result(fn(*args, **kwargs))
+        except BaseException as exc:  # noqa: BLE001 — mirror Future's exception capture.
+            future.set_exception(exc)
+        return future
+
+
 class TestDispatchViaSkypilot:
     """``dispatch_via_skypilot`` rejects degenerate cfgs and threads per-rank fanout through."""
+
+    @pytest.fixture(autouse=True)
+    def _inline_executor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Run the launcher's per-rank fan-out inline so mock recording is deterministic.
+
+        :param monkeypatch: Pytest fixture for attribute patching.
+        """
+        monkeypatch.setattr(
+            "synth_setter.pipeline.skypilot_launch.ThreadPoolExecutor", _InlineExecutor
+        )
 
     def test_missing_compute_template_raises(self) -> None:
         """``compute_template=None`` is the "don't dispatch" sentinel — calling here is a bug."""


### PR DESCRIPTION
## Problem

`TestDispatchViaSkypilot` (in `tests/pipeline/entrypoints/test_skypilot_launch.py`) fails intermittently, only on the busy ubuntu xdist shards:

- `test_multi_worker_fans_out_one_task_per_rank` — `assert ['0', '2'] == ['0', '1', '2']` (a rank dropped)
- `test_extra_envs_forwarded_to_each_rank` — `assert 1 == 2`
- `test_launcher_does_not_emit_worker_spec_uri_without_extra_envs` — `assert 1 == 2`
- Sibling tests asserting on `update_envs.call_args_list` / `.call_count` are equally at risk.

## Root cause

`dispatch_via_skypilot` fans ranks out via `ThreadPoolExecutor`, calling into the shared `mock_sky` MagicMock from multiple threads concurrently. `unittest.mock` call recording (`call_args_list`, `call_count`) is not thread-safe: under CPU contention two threads interleave the record step and a rank's call is dropped or duplicated, so the count comes up short or a rank goes missing. The product code is correct; only the tests' reliance on thread-unsafe mock recording is wrong.

## Fix (test-only)

Patch the launcher's module-level `ThreadPoolExecutor` with a synchronous `_InlineExecutor` via a class-scoped autouse fixture, so the per-rank fan-out runs on the calling thread and mock recording is deterministic. These are env-wiring unit tests, not concurrency tests — removing parallelism from the unit-under-test is legitimate and keeps every assertion's intent intact (same ranks, counts, env keys). The single seam covers all `ThreadPoolExecutor` call sites in the launcher.

No `src/` changes.

## Verification

- Confirmed the root cause by driving `dispatch_via_skypilot` with `num_workers=24` under full-core CPU contention: the parallel path dropped/duplicated ranks within a few runs.
- With the fix, stressed the three affected tests 40x under full-core CPU contention — all pass.
- `make test-fast`: 1877 passed, 6 skipped.
- `make format`: all pre-commit hooks pass.

Fixes #1531