### PR TITLE
automation(review): scan gh stdout for self-review 422 fallback

### DIFF
--- a/agent/skills/_shared/post_review.py
+++ b/agent/skills/_shared/post_review.py
@@ -373,7 +373,8 @@ def submit_review(
     result = _post_review(repo, pr_number, payload)
     if result.returncode == 0:
         return json.loads(result.stdout)
-    if _SELF_REVIEW_422_RE.search(result.stderr):
+    # gh writes the JSON error body to stdout and only "HTTP 422" to stderr, so scan both.
+    if _SELF_REVIEW_422_RE.search(f"{result.stdout}\n{result.stderr}"):
         sys.stderr.write(
             "Self-review 422: falling back to event=COMMENT with the fallback banner.\n"
         )

--- a/tests/claude_hooks/test_post_review_event.py
+++ b/tests/claude_hooks/test_post_review_event.py
@@ -142,6 +142,44 @@ def test_submit_review_self_review_422_falls_back_to_comment(
     assert "Original review." in retried["body"]
 
 
+def test_submit_review_self_review_422_on_stdout_falls_back_to_comment(
+    helper: ModuleType, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A self-review 422 whose body lands on stdout still retries as COMMENT.
+
+    :param helper: The loaded ``post_review`` module.
+    :param monkeypatch: Pytest fixture for patching ``subprocess.run``.
+    """
+    err_422 = SimpleNamespace(
+        returncode=1,
+        stdout=json.dumps(
+            {
+                "message": "Unprocessable Entity",
+                "errors": ["Review Can not request changes on your own pull request"],
+            }
+        ),
+        stderr="gh: Unprocessable Entity (HTTP 422)",
+    )
+    ok = SimpleNamespace(
+        returncode=0,
+        stdout=json.dumps({"html_url": "https://example/r/4"}),
+        stderr="",
+    )
+    fake_run, calls = _fake_run_factory([err_422, ok])
+    monkeypatch.setattr(helper.subprocess, "run", fake_run)
+    monkeypatch.setattr(helper, "gh_executable", lambda: "/usr/bin/gh")
+
+    payload = {"body": "Original review.", "event": "REQUEST_CHANGES", "comments": []}
+    response = helper.submit_review("o/r", 7, payload, fallback_banner="⛔ BANNER")
+
+    assert response["html_url"] == "https://example/r/4"
+    assert len(calls) == 2
+    retried = json.loads(calls[1])
+    assert retried["event"] == "COMMENT"
+    assert retried["body"].startswith("⛔ BANNER")
+    assert "Original review." in retried["body"]
+
+
 def test_submit_review_self_approve_422_falls_back_to_comment(
     helper: ModuleType, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Problem

`post_review.py`'s `submit_review` retries a self-review 422 ("Can not request changes on your own pull request") as `event=COMMENT` with a banner — but it scanned only `result.stderr` for the self-review signature. `gh api` writes the JSON error body (which carries that message) to **stdout**, and only `gh: Unprocessable Entity (HTTP 422)` to stderr. So on a real self-review the regex never matched, the fallback never fired, and the helper exited 1 — the whole `/repo-review-full` post aborted instead of degrading to COMMENT.

Hit live on PR #1488 (bot is the PR author): the review had to be posted by manually replicating the COMMENT fallback.

## Fix

Scan both streams: `_SELF_REVIEW_422_RE.search(f"{result.stdout}\\n{result.stderr}")`. One-line change plus a regression test that puts the 422 body on stdout (gh's real placement) and asserts the COMMENT downgrade still fires.

Fixes #1533