### PR TITLE
build(tart): local helper to validate/build the macOS VM template

### DIFF
--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -323,7 +323,7 @@ docs:
     description: macOS VM dev-env path via Tart — prebuilt image or Packer build (§ B.3)
     sources:
       - pattern: "tart/**"
-        covers: "Packer template, packer variables (synth_setter_git_ref/torch_backend/python_version/vm_name), provisioner steps, brew packages, venv layout, VST3 path, smoke tests, .zshrc auto-activation, prebuilt image at registry-1.docker.io/tinaudio/synth-setter-macos, Docker Hub publishing workflow"
+        covers: "Packer template, packer variables (synth_setter_git_ref/torch_backend/python_version/vm_name), provisioner steps, brew packages, venv layout, VST3 path, smoke tests, .zshrc auto-activation, prebuilt image at registry-1.docker.io/tinaudio/synth-setter-macos, Docker Hub publishing workflow, local validate/build helper (build.sh)"
         scope: "tart"
 
   # ── Surge XT interactive guide ──────────────────────────────────

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -850,3 +850,14 @@ brew install cirruslabs/cli/tart packer
 packer init tart/macos.pkr.hcl
 packer build -var "synth_setter_git_ref=$(git rev-parse HEAD)" tart/macos.pkr.hcl
 ```
+
+Or use the [`tart/build.sh`](../tart/build.sh) helper, which runs the same
+`fmt -check`/`init`/`validate` gates CI runs and, with `--build`, the full build
+into a throwaway `synth-setter-macos-build` VM (pinned to the current HEAD):
+
+```bash
+tart/build.sh            # fast presubmit: packer fmt -check, init, validate
+tart/build.sh --build    # full build (~30 min, Apple Silicon host)
+```
+
+Override the baked git ref or VM name with `SYNTH_SETTER_GIT_REF` / `VM_NAME`.

--- a/tart/build.sh
+++ b/tart/build.sh
@@ -1,19 +1,15 @@
 #!/usr/bin/env bash
 #
-# Validate — and optionally build — the Tart macOS dev-VM Packer template.
-#
-# Runs the Packer validate/build steps for macos.pkr.hcl — the same gates CI
-# runs on the template — so contributors can catch regressions locally before
-# pushing:
-#
+# Validate — and optionally build — the Tart macOS dev-VM Packer template,
+# mirroring the gates CI runs on macos.pkr.hcl so contributors catch
+# regressions locally before pushing:
 #   - validate (default; fast, host-agnostic): packer fmt -check, init, validate.
-#   - build (--build): the full `packer build` — pulls the base image and runs
-#     every provisioner including the in-VM pytest gate. Needs an Apple Silicon
-#     host with Virtualization.framework; takes ~30 min.
+#   - build (--build): full `packer build` — pulls the base image, runs every
+#     provisioner incl. the in-VM pytest gate. Apple Silicon host; ~30 min.
 #
-# The build pins the cloned synth-setter ref to the current git HEAD (override
-# with SYNTH_SETTER_GIT_REF) and uses a throwaway VM name (override with
-# VM_NAME) so it never clobbers a running `synth-setter-macos` VM.
+# --build pins the cloned ref to the current git HEAD (override:
+# SYNTH_SETTER_GIT_REF) and uses a throwaway VM name (override: VM_NAME) so it
+# never clobbers a running `synth-setter-macos` VM.
 set -euo pipefail
 
 readonly TEMPLATE="macos.pkr.hcl"
@@ -59,7 +55,7 @@ main() {
   esac
 
   if ! command -v packer >/dev/null; then
-    err "packer not found on PATH — install with: brew install packer"
+    err "packer not found on PATH — see https://developer.hashicorp.com/packer/install (macOS: brew install packer)"
     return 127
   fi
 
@@ -74,8 +70,11 @@ main() {
 
   # --build drives Tart's Virtualization.framework — Apple Silicon macOS only.
   # Fail fast here rather than leaving Packer/Tart to emit a cryptic error.
-  if [[ "$(uname -sm)" != "Darwin arm64" ]]; then
-    err "--build needs an Apple Silicon macOS host (got: $(uname -sm))"
+  # `hw.optional.arm64` reports the hardware, so it stays 1 even under Rosetta
+  # (where `uname -m` would misreport x86_64).
+  if [[ "$(uname -s)" != "Darwin" ]] ||
+    [[ "$(sysctl -n hw.optional.arm64 2>/dev/null)" != "1" ]]; then
+    err "--build needs an Apple Silicon macOS host"
     return 1
   fi
   if ! command -v tart >/dev/null; then
@@ -84,7 +83,12 @@ main() {
   fi
 
   local git_ref vm_name
-  git_ref="${SYNTH_SETTER_GIT_REF:-$(git -C "${HERE}" rev-parse HEAD)}"
+  if [[ -n "${SYNTH_SETTER_GIT_REF:-}" ]]; then
+    git_ref="${SYNTH_SETTER_GIT_REF}"
+  elif ! git_ref="$(git -C "${HERE}" rev-parse HEAD 2>/dev/null)"; then
+    err "could not resolve git HEAD — set SYNTH_SETTER_GIT_REF to the ref to build"
+    return 1
+  fi
   vm_name="${VM_NAME:-synth-setter-macos-build}"
   err "building VM '${vm_name}' at ref ${git_ref} (this takes ~30 min)…"
   packer build \

--- a/tart/build.sh
+++ b/tart/build.sh
@@ -64,6 +64,17 @@ main() {
     return 0
   fi
 
+  # --build drives Tart's Virtualization.framework — Apple Silicon macOS only.
+  # Fail fast here rather than leaving Packer/Tart to emit a cryptic error.
+  if [[ "$(uname -sm)" != "Darwin arm64" ]]; then
+    err "--build needs an Apple Silicon macOS host (got: $(uname -sm))"
+    return 1
+  fi
+  if ! command -v tart >/dev/null; then
+    err "tart not found on PATH — install: brew install cirruslabs/cli/tart"
+    return 127
+  fi
+
   local git_ref vm_name
   git_ref="${SYNTH_SETTER_GIT_REF:-$(git -C "${HERE}" rev-parse HEAD)}"
   vm_name="${VM_NAME:-synth-setter-macos-build}"

--- a/tart/build.sh
+++ b/tart/build.sh
@@ -38,6 +38,14 @@ err() {
 }
 
 main() {
+  # The script takes at most one argument; reject extras so unknown flags
+  # after a valid one (e.g. `--build --nope`) error rather than being ignored.
+  if [[ $# -gt 1 ]]; then
+    err "too many arguments — expected at most one"
+    usage >&2
+    return 2
+  fi
+
   local do_build="false"
   case "${1:-}" in
     --build) do_build="true" ;;

--- a/tart/build.sh
+++ b/tart/build.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Validate — and optionally build — the Tart macOS dev-VM Packer template.
+#
+# Runs the Packer validate/build steps for macos.pkr.hcl — the same gates CI
+# runs on the template — so contributors can catch regressions locally before
+# pushing:
+#
+#   - validate (default; fast, host-agnostic): packer fmt -check, init, validate.
+#   - build (--build): the full `packer build` — pulls the base image and runs
+#     every provisioner including the in-VM pytest gate. Needs an Apple Silicon
+#     host with Virtualization.framework; takes ~30 min.
+#
+# The build pins the cloned synth-setter ref to the current git HEAD (override
+# with SYNTH_SETTER_GIT_REF) and uses a throwaway VM name (override with
+# VM_NAME) so it never clobbers a running `synth-setter-macos` VM.
+set -euo pipefail
+
+readonly TEMPLATE="macos.pkr.hcl"
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly HERE
+
+usage() {
+  cat <<'EOF'
+Usage: tart/build.sh [--build] [-h|--help]
+
+  (no args)  Run packer fmt -check, init, and validate (fast presubmit).
+  --build    Also run the full packer build (Apple Silicon host, ~30 min).
+
+Environment overrides (only consulted with --build):
+  SYNTH_SETTER_GIT_REF  Git ref baked into the VM (default: current HEAD).
+  VM_NAME               Built VM name (default: synth-setter-macos-build).
+EOF
+}
+
+err() {
+  echo "[tart/build.sh] $*" >&2
+}
+
+main() {
+  local do_build="false"
+  case "${1:-}" in
+    --build) do_build="true" ;;
+    -h | --help) usage; return 0 ;;
+    "") ;;
+    *)
+      err "unknown argument: ${1}"
+      usage >&2
+      return 2
+      ;;
+  esac
+
+  if ! command -v packer >/dev/null; then
+    err "packer not found on PATH — install with: brew install packer"
+    return 127
+  fi
+
+  cd "${HERE}"
+  packer fmt -check "${TEMPLATE}"
+  packer init "${TEMPLATE}"
+  packer validate "${TEMPLATE}"
+
+  if [[ "${do_build}" == "false" ]]; then
+    return 0
+  fi
+
+  local git_ref vm_name
+  git_ref="${SYNTH_SETTER_GIT_REF:-$(git -C "${HERE}" rev-parse HEAD)}"
+  vm_name="${VM_NAME:-synth-setter-macos-build}"
+  err "building VM '${vm_name}' at ref ${git_ref} (this takes ~30 min)…"
+  packer build \
+    -var "synth_setter_git_ref=${git_ref}" \
+    -var "vm_name=${vm_name}" \
+    "${TEMPLATE}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds `tart/build.sh`, a small bash helper that runs the Packer validate/build
steps for the Tart macOS dev-VM template (`tart/macos.pkr.hcl`) locally so
contributors can catch template regressions before pushing — the same gates CI
runs on the template.

- **Default (fast, host-agnostic):** `packer fmt -check` → `packer init` →
  `packer validate`.
- **`--build`:** the full `packer build` — pulls the base image and runs every
  provisioner including the in-VM `pytest` gate. Needs an Apple Silicon host;
  takes ~30 min. The build pins the cloned synth-setter ref to the current git
  HEAD (override via `SYNTH_SETTER_GIT_REF`) and uses a throwaway VM name
  (override via `VM_NAME`) so it never clobbers a running `synth-setter-macos`
  VM.

Unknown args exit `2` with usage; `-h/--help` prints usage to stdout; a missing
`packer` binary fails with an actionable message rather than a raw
`command not found`.

## Test plan

- [x] `shellcheck tart/build.sh` — clean.
- [x] Full pre-commit on the file (trailing-whitespace, end-of-file,
      executable-shebang, codespell, shellcheck) — all pass.
- [x] No-arg run executes `packer fmt -check` + `init` + `validate` end-to-end:
      `The configuration is valid.`
- [x] `--help` exits 0 to stdout; unknown arg exits 2 with usage to stderr.
- [x] The `--build` path was exercised end-to-end while validating PR #1537
      (same `packer build -var synth_setter_git_ref=… -var vm_name=…` shape):
      build finished, in-VM smoke test + `pytest -k 'not slow'` →
      **1948 passed, 7 skipped, 0 failed**.
- [x] `/repo-review-full-no-comments` — 0 BLOCK, 3 WARN across code-health +
      shell-style + synth-setter-project-standards. The substantive WARN (a
      header reference to the not-yet-merged `tart-image-build.yml`) was
      reworded away; remaining WARNs are optional polish.

## Notes

- Kept additive and decoupled: this does **not** refactor any CI workflow to
  call the script.
- The repo has no shell test harness (testing is pytest-only), so the script is
  verified by shellcheck + direct execution of every code path rather than by
  adding a new bats dependency.

Closes #1539.
