### PR TITLE
test: accept lineage + wandb console keys in baseline diff

### DIFF
--- a/tests/test_compare_baseline_configs.py
+++ b/tests/test_compare_baseline_configs.py
@@ -314,6 +314,7 @@ ACCEPTED_DIFFS: tuple[str, ...] = (
     "logger.wandb.entity",  # env-derived (${oc.env:WANDB_ENTITY,null})
     "logger.wandb.log_model",  # changed `true` → "all" (artifact upload policy, not training)
     "logger.wandb.project",  # env-derived (${oc.env:WANDB_PROJECT,synth-setter})
+    "logger.wandb.settings.console",  # `wrap` added in #1506; console capture, no model impact
     # Cleared to `???` (mandatory override) in #809 — dataset locality, not a model knob.
     "datamodule.dataset_root",
     "datamodule.predict_file",
@@ -321,7 +322,13 @@ ACCEPTED_DIFFS: tuple[str, ...] = (
     # Optional R2-download URI added in #1338; absent in v0.0.0 — locality, not a model knob.
     "datamodule.download_dataset_root_uri",
     "evaluation",  # eval CLI predict-mode post-processing block; not a model knob
-    "training.upload_checkpoints_uri",  # opt-in model-artifact checkpoint-upload block (#1472); not a model knob
+    # Opt-in W&B artifact-lineage block (#1508/#1509); absent in v0.0.0 — provenance,
+    # not a model knob. `training`'s sole member is upload_checkpoints_uri (#1472), so
+    # the whole block is stripped; re-narrow to a dotted path if it ever gains a model knob.
+    "training",
+    "consumed_train_config_id",
+    "consumed_dataset_config_id",
+    "consumed_artifact_alias",
 )
 
 # Leaf-name keys stripped at every nesting depth. Use this list (vs. ACCEPTED_DIFFS)
@@ -396,6 +403,38 @@ def _normalize_for_compare(cfg: dict) -> dict:
     renamed = _rename_data_group_to_datamodule(cfg)
     stripped = _strip_dotted_keys(renamed, INVOCATION_PATH_KEYS + ACCEPTED_DIFFS)
     return _strip_leaf_keys(stripped, ACCEPTED_DIFF_LEAVES)
+
+
+# Unit tests for _strip_dotted_keys. The end-to-end resolved-config tests exercise
+# this indirectly, but they're slow (~10min); a focused unit test pins the
+# top-level-vs-nested path handling and the asymmetric no-op-when-absent contract.
+class TestStripDottedKeys:
+    """Unit tests for the ``_strip_dotted_keys`` config-pruning helper."""
+
+    def test_removes_top_level_single_segment_key(self) -> None:
+        """A dot-free path pops the key off the root (the ``training`` / ``consumed_*`` case)."""
+        result = _strip_dotted_keys({"training": {"a": 1}, "keep": 2}, ("training",))
+        assert result == {"keep": 2}
+
+    def test_removes_nested_key_at_dotted_path(self) -> None:
+        cfg = {"logger": {"wandb": {"settings": {"console": "wrap", "code_dir": "."}}}}
+        result = _strip_dotted_keys(cfg, ("logger.wandb.settings.console",))
+        assert result == {"logger": {"wandb": {"settings": {"code_dir": "."}}}}
+
+    def test_absent_path_is_no_op(self) -> None:
+        """The asymmetric contract: a key absent on this side leaves the config untouched."""
+        cfg = {"keep": 1}
+        assert _strip_dotted_keys(cfg, ("consumed_artifact_alias",)) == {"keep": 1}
+
+    def test_path_through_non_dict_is_no_op(self) -> None:
+        """A path whose intermediate segment isn't a dict is skipped, not an error."""
+        cfg = {"training": None}
+        assert _strip_dotted_keys(cfg, ("training.upload_checkpoints_uri",)) == {"training": None}
+
+    def test_does_not_mutate_input(self) -> None:
+        cfg = {"training": {"a": 1}, "logger": {"wandb": {"x": 2}}}
+        _ = _strip_dotted_keys(cfg, ("training", "logger.wandb.x"))
+        assert cfg == {"training": {"a": 1}, "logger": {"wandb": {"x": 2}}}
 
 
 # Unit tests for _strip_leaf_keys. The end-to-end resolved-config tests exercise

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.26.0"
+version = "8.26.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
The cpu-slow suite ([run 27071945474](https://github.com/tinaudio/synth-setter/actions/runs/27071945474/job/79902681645)) went red on every `test_predict_configs_are_equal`, `test_kosc_train_configs_are_equal`, and `test_surge_train_configs_are_equal` parametrization (~120 cases).

## Root cause

Recent merges added top-level keys to the live train/eval configs that the frozen `v0.0.0` baseline lacks, so `test_compare_baseline_configs.py`'s resolved-config equality check flags them:

- **#1508 / #1509** (W&B artifact lineage): `consumed_train_config_id`, `consumed_dataset_config_id`, `consumed_artifact_alias` on `eval.yaml` (predict) and `train.yaml`, plus a top-level `training:` block (sole member `upload_checkpoints_uri`, #1472).
- **#1506** (wandb console fix): `logger.wandb.settings.console: wrap`.

## Fix

Extend `ACCEPTED_DIFFS` with the new lineage/provenance keys and `logger.wandb.settings.console` — each an audit-able non-model-knob divergence, same treatment as the existing `evaluation` / `logger.tensorboard` entries. The bare `training` entry replaces the now-subsumed `training.upload_checkpoints_uri` (stripping only the leaf would leave a residual empty `training: {}` that still diverges); the comment records the re-narrow condition if `training` ever gains a model knob.

Also adds a `TestStripDottedKeys` fast unit class pinning the top-level-vs-nested path handling and the asymmetric no-op-when-absent contract — matching the existing `TestStripLeafKeys` / `TestRenameDataGroupToDatamodule` coverage so the helper is exercised in `make test-fast`, not only the ~10-min network shard.

The `uv.lock` version bump (8.26.0 → 8.26.1) resyncs the lock with `pyproject.toml`; the `8.26.1 [skip ci]` release commit bumped the version without regenerating the lock.

## Verification

- Representative predict/kosc/surge slow cases pass locally; full `test_compare_baseline_configs.py` slow suite (70 cases) green.
- New `TestStripDottedKeys` unit tests pass; `make format` clean.

Fixes #1541