### PR TITLE
feat(eval): add surge_xt render-order shuffle-probe sweep for #489

### DIFF
--- a/sweeps/generate_dataset_shuffle_probe_surge_xt.yaml
+++ b/sweeps/generate_dataset_shuffle_probe_surge_xt.yaml
@@ -1,0 +1,35 @@
+program: src/synth_setter/cli/generate_dataset.py
+# Pinned in YAML — wandb sweep CLI does not support OmegaConf resolvers and ignores
+# WANDB_ENTITY / WANDB_PROJECT at sweep-creation time (those only steer wandb.init in each trial).
+entity: tinaudio
+project: synth-setter
+# Render-order vs phase-init probe for #489: param_sample_cadence=shard gives every sample one
+# identical patch, so the inline oracle eval auto-fires the shuffle probe (shuffled_audio/* vs audio/*).
+command:
+  - ${interpreter}
+  - ${program}
+  - experiment=generate_dataset/smoke-shard-with-oracle-eval
+  - render.param_spec_name=surge_xt
+  - render.preset_path=presets/surge-base.vstpreset
+  - render.param_sample_cadence=shard
+  - ${args_no_hyphens}
+name: generate_dataset_shuffle_probe_surge_xt
+method: grid
+# grid ignores `metric` at scheduling time; the field stays for dashboard
+# legibility on runs that do log it. mss_mean is the oracle-eval audio loss.
+metric:
+  goal: minimize
+  name: audio/mss_mean
+# 2x4 grid: `once` reuses one plugin instance across the shard (the #489 stale-state hypothesis),
+# `render` reloads per call (phase-init floor). The render x always_on cell is skipped as schema-invalid.
+parameters:
+  render.plugin_reload_cadence:
+    values:
+      - once
+      - render
+  render.gui_toggle_cadence:
+    values:
+      - never
+      - once
+      - render
+      - "always_on"

--- a/tests/test_sweep_yaml_structure.py
+++ b/tests/test_sweep_yaml_structure.py
@@ -1,8 +1,8 @@
-"""Offline structural assertion for ``sweeps/generate_dataset_cadence.yaml``.
+"""Offline structural assertions for the operator-facing ``sweeps/*.yaml``.
 
-Pins the operator-facing sweep YAML's ``command:`` shape and parameter
-grid so the contract that ``wandb agent`` executes (subprocess launch
-via ``${interpreter} ${program} ... ${args_no_hyphens}``) cannot drift
+Pins each sweep YAML's ``command:`` shape and parameter grid so the
+contract that ``wandb agent`` executes (subprocess launch via
+``${interpreter} ${program} ... ${args_no_hyphens}``) cannot drift
 silently. Complements any live-backend sweep e2e by catching shape
 breakage without touching the W&B API.
 """
@@ -13,7 +13,9 @@ from pathlib import Path
 
 import yaml
 
-_SWEEP_YAML = Path(__file__).resolve().parent.parent / "sweeps" / "generate_dataset_cadence.yaml"
+_SWEEPS_DIR = Path(__file__).resolve().parent.parent / "sweeps"
+_SWEEP_YAML = _SWEEPS_DIR / "generate_dataset_cadence.yaml"
+_SHUFFLE_PROBE_YAML = _SWEEPS_DIR / "generate_dataset_shuffle_probe_surge_xt.yaml"
 
 
 def test_generate_dataset_cadence_yaml_shape() -> None:
@@ -31,3 +33,28 @@ def test_generate_dataset_cadence_yaml_shape() -> None:
         "render.plugin_reload_cadence",
         "render.gui_toggle_cadence",
     }
+
+
+def test_generate_dataset_shuffle_probe_yaml_shape() -> None:
+    """Shuffle-probe sweep pins shard param cadence (the probe trigger) and the surge_xt set."""
+    cfg = yaml.safe_load(_SHUFFLE_PROBE_YAML.read_text())
+
+    assert cfg["program"] == "src/synth_setter/cli/generate_dataset.py"
+
+    cmd = cfg["command"]
+    assert cmd[:2] == ["${interpreter}", "${program}"]
+    assert "${args_no_hyphens}" in cmd
+    assert any(isinstance(t, str) and t.startswith("experiment=") for t in cmd)
+    # These three overrides are the probe's load-bearing contract: shard cadence gates the shuffle
+    # probe on uniform params, and surge_xt params are meaningless without the matching base preset.
+    assert "render.param_sample_cadence=shard" in cmd
+    assert "render.param_spec_name=surge_xt" in cmd
+    assert "render.preset_path=presets/surge-base.vstpreset" in cmd
+
+    assert set(cfg["parameters"].keys()) == {
+        "render.plugin_reload_cadence",
+        "render.gui_toggle_cadence",
+    }
+    # Gridding param_sample_cadence would un-gate the probe on the `sample` cells; it must stay a
+    # fixed command override, never a swept dimension.
+    assert "render.param_sample_cadence" not in cfg["parameters"]


### PR DESCRIPTION
## Summary

Adds `sweeps/generate_dataset_shuffle_probe_surge_xt.yaml` — the **render-order vs phase-init attribution** experiment for the #489 non-deterministic-rendering investigation. This is Experiment 1 of a batch designed around functionality that landed since the issue's last study (the shuffle render-order probe, `param_sample_cadence`, per-split inline oracle eval).

## What it does

The sweep drives `generate_dataset/smoke-shard-with-oracle-eval` on the **full `surge_xt` (300-param) set** with `render.param_sample_cadence=shard` pinned, gridding `plugin_reload_cadence {once, render}` × `gui_toggle_cadence {never, once, render, always_on}` (the `render`×`always_on` cell is schema-invalid and skipped).

`param_sample_cadence=shard` makes every sample in a shard render **one identical patch**, so the inline oracle eval sees uniform params and **auto-fires the shuffle render-order probe** (`shuffled_audio/*` beside `audio/*`). Because the patch is identical, the permutation isolates *render-order position* as the only variable.

## Question it answers

The prior #489 cadence studies concluded "phase-init dominates, not stale state" — but only as a **mechanistic inference**, never a measurement, because aggregate divergence can't separate render-order dependence from oscillator phase-init noise. This probe measures it directly:

- **`audio/*` ≈ `shuffled_audio/*`** → divergence is position-independent → **phase-init dominates**.
- **gap opens under `plugin_reload_cadence=once` only** → **render-order / stale plugin state** (the #489 root-cause hypothesis).

## Validation

Ran one grid cell end-to-end locally (surge_xt, `param_sample_cadence=shard`, `plugin_reload_cadence=once`, Xvfb, offline) at the smoke size. The probe fired on all three splits and produced `aggregated_metrics_shuffled.csv`. Preview result: test split `audio/mss_mean=2.32` vs `shuffled_audio/mss_mean=2.33` — at reuse depth 4, render-order is *not* the driver (consistent with the phase-init hypothesis).

A parallel offline structural test (`tests/test_sweep_yaml_structure.py::test_generate_dataset_shuffle_probe_yaml_shape`) pins the sweep's command shape and the probe-trigger overrides (`param_sample_cadence=shard`, `param_spec_name=surge_xt`, `preset_path`), and guards that `param_sample_cadence` stays a fixed override rather than a swept grid dimension.

## Testing

- `tests/test_sweep_yaml_structure.py` — 2 passed.
- Local end-to-end smoke run of one grid cell — green, shuffle probe fired.
- Pre-PR `repo-review-full-no-comments` — 0 BLOCK across 5 skills.

Refs #489
