### PR TITLE
feat(eval): add surge_xt reuse-depth junk-probe sweep for #489

### DIFF
--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -62,7 +62,7 @@ docs:
       - pattern: "src/synth_setter/configs/dataset.yaml"
         covers: "Default `logger: wandb` for dataset generation; entity/project sourced from logger/wandb.yaml"
       - pattern: "sweeps/**"
-        covers: "Operator-authored W&B sweep configs driving `synth-setter-generate-dataset`; entity/project pinned in YAML, cadence-grid parameters threaded as Hydra overrides"
+        covers: "Operator-authored W&B sweep configs driving `synth-setter-generate-dataset`; entity/project pinned in YAML, grid parameters (render cadences, reuse depth) threaded as Hydra overrides"
       - pattern: "src/synth_setter/utils/logging_utils.py"
         covers: "Metric logging helpers, hyperparameter logging, log_hyperparameters"
       - pattern: "src/synth_setter/utils/callbacks.py"

--- a/sweeps/generate_dataset_reuse_depth_surge_xt.yaml
+++ b/sweeps/generate_dataset_reuse_depth_surge_xt.yaml
@@ -1,0 +1,35 @@
+program: src/synth_setter/cli/generate_dataset.py
+# Pinned in YAML — wandb sweep CLI does not support OmegaConf resolvers and ignores
+# WANDB_ENTITY / WANDB_PROJECT at sweep-creation time (those only steer wandb.init in each trial).
+entity: tinaudio
+project: synth-setter
+# Reuse-depth junk probe for #489: param_sample_cadence=shard + plugin_reload_cadence=once reuse one
+# cached plugin instance across one identical patch, exposing the every-other-render junk (mss~21, #706).
+command:
+  - ${interpreter}
+  - ${program}
+  - experiment=generate_dataset/smoke-shard-with-oracle-eval
+  - render.param_spec_name=surge_xt
+  - render.preset_path=presets/surge-base.vstpreset
+  - render.param_sample_cadence=shard
+  - render.plugin_reload_cadence=once
+  - render.gui_toggle_cadence=never
+  # 80 is a multiple of every swept reuse depth, so each split is a whole number of shards.
+  - train_val_test_sizes=[80,80,80]
+  - ${args_no_hyphens}
+name: generate_dataset_reuse_depth_surge_xt
+method: grid
+# grid ignores `metric` at scheduling time; the field stays for dashboard legibility on runs that do
+# log it. The science is the junk tail (mss_max / %mss>3); mss_mean is just the W&B handle.
+metric:
+  goal: minimize
+  name: audio/mss_mean
+# samples_per_shard is the reuse depth (renders sharing one instance + one patch); the shuffle probe
+# auto-fires, attributing junk per depth. Junk appears past ~12 reuses — see #706.
+parameters:
+  render.samples_per_shard:
+    values:
+      - 4
+      - 20
+      - 40
+      - 80

--- a/tests/test_sweep_yaml_structure.py
+++ b/tests/test_sweep_yaml_structure.py
@@ -1,8 +1,8 @@
-"""Offline structural assertion for ``sweeps/generate_dataset_cadence.yaml``.
+"""Offline structural assertions for the operator-facing ``sweeps/*.yaml``.
 
-Pins the operator-facing sweep YAML's ``command:`` shape and parameter
-grid so the contract that ``wandb agent`` executes (subprocess launch
-via ``${interpreter} ${program} ... ${args_no_hyphens}``) cannot drift
+Pins each sweep YAML's ``command:`` shape and parameter grid so the
+contract that ``wandb agent`` executes (subprocess launch via
+``${interpreter} ${program} ... ${args_no_hyphens}``) cannot drift
 silently. Complements any live-backend sweep e2e by catching shape
 breakage without touching the W&B API.
 """
@@ -13,7 +13,9 @@ from pathlib import Path
 
 import yaml
 
-_SWEEP_YAML = Path(__file__).resolve().parent.parent / "sweeps" / "generate_dataset_cadence.yaml"
+_SWEEPS_DIR = Path(__file__).resolve().parent.parent / "sweeps"
+_SWEEP_YAML = _SWEEPS_DIR / "generate_dataset_cadence.yaml"
+_REUSE_DEPTH_YAML = _SWEEPS_DIR / "generate_dataset_reuse_depth_surge_xt.yaml"
 
 
 def test_generate_dataset_cadence_yaml_shape() -> None:
@@ -31,3 +33,29 @@ def test_generate_dataset_cadence_yaml_shape() -> None:
         "render.plugin_reload_cadence",
         "render.gui_toggle_cadence",
     }
+
+
+def test_generate_dataset_reuse_depth_yaml_shape() -> None:
+    """Reuse-depth sweep pins the once+shard reuse path and grids samples_per_shard."""
+    cfg = yaml.safe_load(_REUSE_DEPTH_YAML.read_text())
+
+    assert cfg["program"] == "src/synth_setter/cli/generate_dataset.py"
+
+    cmd = cfg["command"]
+    assert cmd[:2] == ["${interpreter}", "${program}"]
+    assert "${args_no_hyphens}" in cmd
+    assert any(isinstance(t, str) and t.startswith("experiment=") for t in cmd)
+    # These four pins ARE the experiment — drift on any silently voids the probe.
+    assert "render.param_sample_cadence=shard" in cmd
+    assert "render.plugin_reload_cadence=once" in cmd
+    assert "render.gui_toggle_cadence=never" in cmd
+    assert "render.param_spec_name=surge_xt" in cmd
+
+    assert set(cfg["parameters"].keys()) == {"render.samples_per_shard"}
+    depths = cfg["parameters"]["render.samples_per_shard"]["values"]
+    # Each split size must be a multiple of every swept depth, else that depth's grid cell fails
+    # DatasetSpec validation. Check against the pinned split, not a literal, so the two stay coupled.
+    (sizes_arg,) = [t for t in cmd if isinstance(t, str) and t.startswith("train_val_test_sizes=")]
+    sizes = [int(x) for x in sizes_arg.split("=", 1)[1].strip("[]").split(",")]
+    assert all(size % depth == 0 for size in sizes for depth in depths)
+    assert max(depths) >= 40  # past PR #706's ~12-reuse junk threshold


### PR DESCRIPTION
## Summary

Adds `sweeps/generate_dataset_reuse_depth_surge_xt.yaml` — the **reuse-depth junk-reproduction** experiment for the #489 non-deterministic-rendering investigation (Experiment 3 of the batch). It aims to reproduce the every-other-render junk (`mss≈21`, PR #706) inside the instrumented oracle harness, scaled across reuse depth — something the prior #489 studies never managed (their Tier 3 only reached `samples_per_shard=40`).

## What it does

Grids `render.samples_per_shard ∈ {4, 20, 40, 80}` on the full `surge_xt` set with `render.param_sample_cadence=shard` + `render.plugin_reload_cadence=once` pinned. That combination reuses **one cached plugin instance** across **one identical patch** for the whole shard, so `samples_per_shard` *is* the reuse depth. Only sample 0 is loudness-gated, so the reused samples expose any stale-state junk the gate would otherwise resample away. `train_val_test_sizes` is pinned to `[80,80,80]` so every split is a whole number of shards at all four depths.

## Question it answers

The #489 status update explicitly asked for a **strict regression guard** that fails if `plugin_reload_cadence="once"` reintroduces the every-other-render variance. This sweep is the controlled instrument for that:

- If `mss` blows up only at deep reuse → the junk is reuse-depth-dependent stale state → the per-render-reload workaround is load-bearing and surgepy migration is justified.
- If even depth 80 stays clean → strong evidence the catastrophe was specific to the raw-VST path the reload workaround already eliminated → #489 can be de-escalated.

Because shard cadence makes params uniform, the **shuffle render-order probe auto-fires** at every depth (`shuffled_audio/*` vs `audio/*`), attributing any junk to render-order vs phase-init — complementing the sibling shuffle-probe PR #1545.

## Validation

Ran one grid cell (depth 20, one shard/split of 20 reuses) end-to-end locally on the real Surge XT VST (Xvfb, offline) at a reduced split size. Generation + inline oracle eval completed and the shuffle probe fired. A parallel offline structural test (`tests/test_sweep_yaml_structure.py::test_generate_dataset_reuse_depth_yaml_shape`) pins the command shape, the load-bearing reuse overrides (`param_sample_cadence=shard`, `plugin_reload_cadence=once`, `gui_toggle_cadence=never`, `param_spec_name=surge_xt`), and that every pinned split size is a multiple of every swept depth (mirroring the real `DatasetSpec` validator).

## Testing

- `tests/test_sweep_yaml_structure.py` — 2 passed.
- Local end-to-end smoke run of one depth-20 grid cell — green, shuffle probe fired.
- Pre-PR `repo-review-full-no-comments` — 0 BLOCK across 5 skills.

Refs #489
