### PR TITLE
feat(data-pipeline): add surge_xt paired-copy harness configs

### DIFF
--- a/src/synth_setter/configs/experiment/generate_dataset/copy-paired-surge-xt.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/copy-paired-surge-xt.yaml
@@ -1,0 +1,20 @@
+# @package _global_
+
+# Shared base for the #489 paired-copy sweeps: pins the copy-preflight match set to
+# reference-surge-xt-paired.yaml so a copy replays its exact patches. Each sweep adds
+# copy_dataset_root_uri and grids one render knob (see #489).
+defaults:
+  - /experiment/generate_dataset/smoke-shard-with-oracle-eval@_global_
+  - _self_
+
+task_name: copy-paired-surge-xt
+
+train_val_test_sizes: [40, 40, 40]
+
+render:
+  param_spec_name: surge_xt
+  preset_path: presets/surge-base.vstpreset
+  samples_per_shard: 20
+  # Gate off: copy can't resample a sub-floor re-render, it raises (#724); -1000.0 lets junk/quiet
+  # renders reach the oracle to be measured. Only true silence (-inf) trips this floor.
+  min_loudness: -1000.0

--- a/src/synth_setter/configs/experiment/generate_dataset/reference-surge-xt-paired.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/reference-surge-xt-paired.yaml
@@ -1,0 +1,19 @@
+# @package _global_
+
+# Reference surge_xt patches for the #489 paired-copy sweeps. Fixed task_name + run_id give a stable
+# copy_dataset_root_uri; param_spec_name / samples_per_shard / train_val_test_sizes are the
+# copy-preflight match set the sweeps must echo exactly (see #489).
+defaults:
+  - /experiment/generate_dataset/smoke-shard@_global_
+  - _self_
+
+task_name: ref-surge-xt-489
+run_id: paired-ref-v1
+
+# 2 shards per split (size / samples_per_shard).
+train_val_test_sizes: [40, 40, 40]
+
+render:
+  param_spec_name: surge_xt
+  preset_path: presets/surge-base.vstpreset
+  samples_per_shard: 20

--- a/tests/pipeline/configs/test_experiment_yamls.py
+++ b/tests/pipeline/configs/test_experiment_yamls.py
@@ -41,6 +41,8 @@ DATASET_EXPERIMENTS: dict[str, str] = {
     "generate_dataset/surge-simple-480k-10k": "surge-simple-480k-10k",
     "generate_dataset/smoke-shard-with-finalize": "smoke-shard",
     "generate_dataset/smoke-shard-with-oracle-eval": "smoke-shard",
+    "generate_dataset/reference-surge-xt-paired": "ref-surge-xt-489",
+    "generate_dataset/copy-paired-surge-xt": "copy-paired-surge-xt",
 }
 
 
@@ -81,3 +83,32 @@ def test_experiment_yaml_json_round_trips(experiment: str) -> None:
     spec = _compose_dataset_spec(experiment)
     restored = DatasetSpec.model_validate_json(spec.model_dump_json())
     assert restored == spec
+
+
+def test_reference_surge_xt_paired_pins_deterministic_uri_fields() -> None:
+    """The paired-copy reference pins the fixed task_name + run_id that make its URI stable.
+
+    The #489 copy sweeps pin that URI; drift on task_name/run_id moves the dataset out from under
+    them. param_spec_name / samples_per_shard / train_val_test_sizes are the copy-preflight match
+    set, checked end-to-end by ``test_copy_base_matches_reference_for_copy_preflight``.
+    """
+    spec = _compose_dataset_spec("generate_dataset/reference-surge-xt-paired")
+    assert spec.task_name == "ref-surge-xt-489"
+    assert spec.run_id == "paired-ref-v1"
+    assert spec.render.param_spec_name == "surge_xt"
+    assert spec.render.samples_per_shard == 20
+    assert spec.train_val_test_sizes == (40, 40, 40)
+
+
+def test_copy_base_matches_reference_for_copy_preflight() -> None:
+    """The copy base passes ``validate_copy_source`` against the reference — the real preflight.
+
+    A paired copy replays the reference's patches only if this check accepts the pair, so drift on
+    the match set (param_spec_name / samples_per_shard / train_val_test_sizes / output_format) in
+    either config raises here exactly as it would abort a real copy run. Also pins the gate-off
+    sentinel so a tidy-up back to the inherited default can't silently re-arm the loudness gate.
+    """
+    reference = _compose_dataset_spec("generate_dataset/reference-surge-xt-paired")
+    copy = _compose_dataset_spec("generate_dataset/copy-paired-surge-xt")
+    copy.validate_copy_source(reference)  # raises ValueError on any match-set mismatch
+    assert copy.render.min_loudness == -1000.0

--- a/tests/pipeline/configs/test_experiment_yamls.py
+++ b/tests/pipeline/configs/test_experiment_yamls.py
@@ -99,6 +99,12 @@ def test_reference_surge_xt_paired_pins_deterministic_uri_fields() -> None:
     assert spec.render.samples_per_shard == 20
     assert spec.train_val_test_sizes == (40, 40, 40)
 
+    # Pin the full R2 location the copy sweeps hard-code, not just task_name/run_id: bucket +
+    # prefix_root (from configs/r2/default.yaml) also form the URI, so an r2 config change can't
+    # silently move the dataset out from under the pinned copy_dataset_root_uri.
+    assert spec.r2.bucket == "intermediate-data"
+    assert spec.r2.prefix == "data/ref-surge-xt-489/paired-ref-v1/"
+
 
 def test_copy_base_matches_reference_for_copy_preflight() -> None:
     """The copy base passes ``validate_copy_source`` against the reference — the real preflight.

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.29.0"
+version = "8.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Adds the two Hydra experiment configs that set up the **#489 paired dataset-copy experiments** (Exp 2 / 4′ / 5′ of the batch). These replay an identical set of saved `surge_xt` patches across different render conditions — the paired design that removes the unseeded-RNG patch confound the prior #489 studies were stuck with (#884 per-sample seeding is still unimplemented, so dataset-copy is the only route to identical patches across runs).

## Configs

- **`reference-surge-xt-paired.yaml`** — generates a fixed **120-patch** `surge_xt` reference dataset (`samples_per_shard=20`, `train_val_test_sizes=[40,40,40]`) under a fixed `task_name`+`run_id`, so it lands at a **deterministic, pinnable URI**: `r2://intermediate-data/data/ref-surge-xt-489/paired-ref-v1/`. Generation only — copy reads the raw shards + `input_spec.json` by name.
- **`copy-paired-surge-xt.yaml`** — shared base for the copy sweeps. Echoes the reference's copy-preflight match set (`param_spec_name`/`samples_per_shard`/`train_val_test_sizes`) so `validate_copy_source` accepts the pair, and sets `min_loudness=-1000.0` so a junk/quiet **re-render of a fixed patch is measured by the oracle rather than raising** (copy can't resample fixed params — #724; `-inf` was ruled out because it fails pydantic JSON round-trip). Each sweep adds `copy_dataset_root_uri` and grids one render knob.

## The reference dataset has been created

Running `experiment=generate_dataset/reference-surge-xt-paired` materialized the 120-patch dataset at the pinned URI (6 shards + `input_spec.json` in R2). The three copy-sweep PRs pin that URI.

## Testing

- Both configs added to the `test_experiment_yamls` allowlist (compose → `DatasetSpec` → JSON round-trip).
- `test_reference_surge_xt_paired_pins_deterministic_uri_fields` — pins the fixed `task_name`/`run_id` that keep the URI stable.
- `test_copy_base_matches_reference_for_copy_preflight` — composes both specs and runs the **real production preflight** `copy.validate_copy_source(reference)`, so match-set drift in either config fails CI exactly as it would abort a copy run; also pins the `min_loudness=-1000.0` gate-off sentinel.
- 24 passed in `test_experiment_yamls.py`.
- Pre-PR `repo-review-full-no-comments` — 0 BLOCK across 5 skills.

Refs #489
