### PR TITLE
refactor(testing): centralize Surge XT plugin path in tests/_vst.py

### DIFF
--- a/.github/workflows/cpu-slow.yml
+++ b/.github/workflows/cpu-slow.yml
@@ -4,8 +4,9 @@ name: CPU Slow Tests
 # `test-vst-slow.yml`, which runs the Surge XT suite inside the project's
 # Docker dev image; this workflow no longer installs Surge XT or the headless
 # X11 stack. The pytest marker filter excludes `gpu`, `mps`, and `requires_vst`
-# so any leftover VST-marked tests are skipped at collection time rather than
-# relying on the runtime `skip_no_vst` decorator.
+# so any leftover VST-marked tests are deselected here; absent that filter, the
+# `pytest_collection_modifyitems` hook in `tests/conftest.py` still auto-skips
+# them when no plugin is present.
 # Triggered post-merge on main (and via manual dispatch).
 on:
   workflow_dispatch:

--- a/tests/_vst.py
+++ b/tests/_vst.py
@@ -1,0 +1,19 @@
+"""Single source of truth for Surge XT VST plugin discovery in tests.
+
+The plugin path is overridable via ``SYNTH_SETTER_PLUGIN_PATH`` (set by CI and the
+devcontainer); absent or empty, it falls back to the in-repo bundle. Importers use
+``PLUGIN_PATH`` for the path and ``VST_AVAILABLE`` for the presence check that
+``conftest.pytest_collection_modifyitems`` consults when auto-skipping
+``requires_vst`` tests.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# ``or`` (not a get default) so an empty override also falls back to the bundle.
+PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
+
+# Probed once at import: a filesystem stat, no plugin load and no network hit.
+VST_AVAILABLE = Path(PLUGIN_PATH).exists()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,7 @@ from synth_setter.resources import vst_headless_wrapper
 from synth_setter.utils.utils import register_resolvers
 from synth_setter.workspace import operator_workspace
 from tests._baseline_worktree import worktree_for_ref  # noqa: F401 — pytest fixture re-export
+from tests._vst import PLUGIN_PATH, VST_AVAILABLE
 from tests.data.vst._fake_plugin import FakeVST3Plugin
 from tests.pipeline.conftest import fake_r2_remote  # noqa: F401 — pytest fixture re-export
 
@@ -39,7 +40,6 @@ _SURGE_FIXTURE_DURATION_SECONDS = 4.0
 _SURGE_FIXTURE_VELOCITY = 100
 _SURGE_FIXTURE_MIN_LOUDNESS = -55.0
 _SURGE_FIXTURE_RENDERER_VERSION = "1.3.4"
-_SURGE_FIXTURE_PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH", "plugins/Surge XT.vst3")
 _SURGE_AUDIO_SAMPLES_PER_CLIP = int(_SURGE_FIXTURE_SAMPLE_RATE * _SURGE_FIXTURE_DURATION_SECONDS)
 _SURGE_AUDIO_CHANNELS = _SURGE_FIXTURE_CHANNELS
 _SURGE_MEL_SHAPE = (2, 128, 401)
@@ -57,9 +57,8 @@ _VST_SUBPROCESS_TIMEOUT_SECONDS = 600
 
 NUM_FIXTURE_SAMPLES = 5
 
-# Probed once at module import; _R2_AVAILABLE uses the env var (no network hit)
-# — AGENTS.md's `rclone lsd r2:` is for interactive verification, not the skip criterion.
-_VST_AVAILABLE = Path(_SURGE_FIXTURE_PLUGIN_PATH).exists()
+# Probed from the env var, no network hit — AGENTS.md's `rclone lsd r2:` is for
+# interactive verification, not the skip criterion. VST presence lives in tests._vst.
 _R2_AVAILABLE = bool(os.environ.get("RCLONE_CONFIG_R2_ACCESS_KEY_ID"))
 
 
@@ -69,7 +68,7 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     :param items: mutated in-place to insert skip markers for missing resources.
     """
     skip_vst = pytest.mark.skip(
-        reason=f"Surge XT VST not found at {_SURGE_FIXTURE_PLUGIN_PATH!r} "
+        reason=f"Surge XT VST not found at {PLUGIN_PATH!r} "
         f"(set SYNTH_SETTER_PLUGIN_PATH or place plugin at that path)"
     )
     skip_r2 = pytest.mark.skip(
@@ -77,7 +76,7 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
         "run `rclone lsd r2:` to verify"
     )
     for item in items:
-        if "requires_vst" in item.keywords and not _VST_AVAILABLE:
+        if "requires_vst" in item.keywords and not VST_AVAILABLE:
             item.add_marker(skip_vst)
         if "integration_r2" in item.keywords and not _R2_AVAILABLE:
             item.add_marker(skip_r2)
@@ -630,7 +629,7 @@ def surge_xt_smoke_datasets(tmp_path: Path, param_spec_name: str) -> Path:
         sys.executable,
         "src/synth_setter/data/vst/generate_vst_dataset.py",
         str(smoke_dataset_dir / "train.h5"),
-        f"--plugin_path={_SURGE_FIXTURE_PLUGIN_PATH}",
+        f"--plugin_path={PLUGIN_PATH}",
         f"--preset_path={preset_paths[param_spec_name]}",
         f"--param_spec_name={param_spec_name}",
         f"--renderer_version={_SURGE_FIXTURE_RENDERER_VERSION}",
@@ -714,7 +713,7 @@ def fake_surge_smoke_datasets(
     train_h5 = smoke_dataset_dir / "train.h5"
 
     render_cfg = RenderConfig(
-        plugin_path=_SURGE_FIXTURE_PLUGIN_PATH,
+        plugin_path=PLUGIN_PATH,
         preset_path=str(preset_paths[param_spec_name]),
         param_spec_name=param_spec_name,
         renderer_version=_SURGE_FIXTURE_RENDERER_VERSION,
@@ -800,7 +799,7 @@ def cfg_surge_xt_eval(
         cfg.render = {
             "param_spec_name": param_spec_name,
             "preset_path": preset_paths[param_spec_name],
-            "plugin_path": _SURGE_FIXTURE_PLUGIN_PATH,
+            "plugin_path": PLUGIN_PATH,
         }
 
     yield cfg

--- a/tests/data/vst/test_always_on_integration.py
+++ b/tests/data/vst/test_always_on_integration.py
@@ -27,27 +27,16 @@ from synth_setter.data.vst.writers import make_hdf5_dataset
 
 _ = hdf5plugin  # keep type checkers from flagging the side-effect import
 
-# ``_PLUGIN_PATH`` is imported with the helpers so the ``skip_no_vst`` mark
-# tracks the same path that ``_render_cfg`` embeds in the produced
-# ``RenderConfig`` — a local copy could drift if the canonical default ever
-# changed.
 from tests.data.vst.test_generate_vst_dataset import (  # noqa: E402  pinned canonical patch
     _HARDCODED_NOTE_PARAMS,
     _HARDCODED_SYNTH_PARAMS,
-    _PLUGIN_PATH,
     _render_cfg,
 )
 from tests.helpers.logger_assertions import assert_no_logger_exceptions  # noqa: E402
 
-skip_no_vst = pytest.mark.skipif(
-    not Path(_PLUGIN_PATH).exists(),
-    reason=f"VST plugin not found at {_PLUGIN_PATH}",
-)
-
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_always_on_renders_small_shard_end_to_end(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -20,6 +20,8 @@ _ = hdf5plugin  # keep type checkers from flagging the side-effect import
 import numpy as np
 import pytest
 
+from tests._vst import PLUGIN_PATH
+
 from synth_setter.data.vst import param_specs
 from synth_setter.data.vst.core import load_plugin, load_preset, render_params
 from synth_setter.data.vst.generate_vst_dataset import fixed_params_from_dataset
@@ -36,7 +38,6 @@ from synth_setter.pipeline.schemas.spec import RenderConfig
 
 log = logging.getLogger(__name__)
 
-_PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
 _PRESET_PATH = "presets/surge-base.vstpreset"
 _NUM_SAMPLES = 5
 _SAMPLE_RATE = 44100.0
@@ -79,7 +80,7 @@ def _render_cfg(
     :return: ``RenderConfig`` populated with the module's test defaults.
     """
     return RenderConfig(
-        plugin_path=_PLUGIN_PATH,
+        plugin_path=PLUGIN_PATH,
         preset_path=_PRESET_PATH,
         param_spec_name=_SPEC_NAME,
         renderer_version=_RENDERER_VERSION,
@@ -123,10 +124,6 @@ _AUDIO_PEAK_SILENCE_FLOOR = 1e-4
 #   - `_SURGE_MEL_SHAPE` in `tests/conftest.py` — mirror, keep in sync.
 _PER_SAMPLE_MEL_SHAPE = (2, 128, 401)
 
-skip_no_vst = pytest.mark.skipif(
-    not Path(_PLUGIN_PATH).exists(),
-    reason=f"VST plugin not found at {_PLUGIN_PATH}",
-)
 
 # Known-good loudness-passing patch captured from a prior random-sampled run
 # (sample 4 of a 5-sample candidates dataset for the surge_xt spec). Used by
@@ -752,7 +749,6 @@ def _assert_round_trip_matches(
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_datasets_from_hardcoded_params_are_identical(
     tmp_path: Path,
 ) -> None:
@@ -834,7 +830,6 @@ def test_datasets_from_hardcoded_params_are_identical(
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
     """make_hdf5_dataset reproduces a previous dataset row-for-row when params are replayed.
 
@@ -940,7 +935,6 @@ def test_datasets_from_sampled_params_are_identical(tmp_path: Path) -> None:
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_make_dataset(tmp_path: Path) -> None:
     """make_hdf5_dataset with the natural random source writes a valid h5."""
     out = tmp_path / "random.h5"
@@ -959,7 +953,6 @@ def test_make_dataset(tmp_path: Path) -> None:
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_show_editor_warmup_does_not_change_rendered_audio() -> None:
     """``show_editor`` warm-up in ``load_plugin`` does not change rendered audio.
 
@@ -985,7 +978,7 @@ def test_show_editor_warmup_does_not_change_rendered_audio() -> None:
     def _render_n(n: int) -> list[np.ndarray]:
         return [
             render_params(
-                _PLUGIN_PATH,
+                PLUGIN_PATH,
                 _HARDCODED_SYNTH_PARAMS,
                 pitch,
                 _VELOCITY,
@@ -1016,7 +1009,6 @@ def test_show_editor_warmup_does_not_change_rendered_audio() -> None:
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_reload_per_render_matches_cached_plugin() -> None:
     """Cached-plugin renders match reload-per-render renders within audio thresholds.
 
@@ -1031,7 +1023,7 @@ def test_reload_per_render_matches_cached_plugin() -> None:
     def _render_n_reload() -> list[np.ndarray]:
         return [
             render_params(
-                _PLUGIN_PATH,
+                PLUGIN_PATH,
                 _HARDCODED_SYNTH_PARAMS,
                 pitch,
                 _VELOCITY,
@@ -1045,11 +1037,11 @@ def test_reload_per_render_matches_cached_plugin() -> None:
         ]
 
     def _render_n_cached() -> list[np.ndarray]:
-        plugin = load_plugin(_PLUGIN_PATH)
+        plugin = load_plugin(PLUGIN_PATH)
         load_preset(plugin, _PRESET_PATH)
         return [
             render_params(
-                _PLUGIN_PATH,
+                PLUGIN_PATH,
                 _HARDCODED_SYNTH_PARAMS,
                 pitch,
                 _VELOCITY,
@@ -1144,7 +1136,7 @@ def test_generate_sample_raises_when_fixed_synth_params_renders_silent(
 
     with pytest.raises(ValueError, match="fixed_synth_params render produced loudness"):
         generate_vst_dataset.generate_sample(
-            plugin_path=_PLUGIN_PATH,
+            plugin_path=PLUGIN_PATH,
             velocity=_VELOCITY,
             signal_duration_seconds=_DURATION,
             sample_rate=_SAMPLE_RATE,
@@ -1168,7 +1160,7 @@ def test_generate_sample_raises_when_both_fixed_renders_silent(
 
     with pytest.raises(ValueError, match="fixed_synth_params render produced loudness"):
         generate_vst_dataset.generate_sample(
-            plugin_path=_PLUGIN_PATH,
+            plugin_path=PLUGIN_PATH,
             velocity=_VELOCITY,
             signal_duration_seconds=_DURATION,
             sample_rate=_SAMPLE_RATE,
@@ -1210,7 +1202,7 @@ def test_generate_sample_retries_when_only_fixed_note_params(
     monkeypatch.setattr(spec, "sample", lambda: next(sample_returns))
 
     sample = generate_vst_dataset.generate_sample(
-        plugin_path=_PLUGIN_PATH,
+        plugin_path=PLUGIN_PATH,
         velocity=_VELOCITY,
         signal_duration_seconds=_DURATION,
         sample_rate=_SAMPLE_RATE,
@@ -1287,7 +1279,7 @@ def test_generate_sample_warmups_once_regardless_of_retries(
     warmup_mock = _install_fake_render_params(monkeypatch, spec, num_retries=num_retries)
 
     generate_vst_dataset.generate_sample(
-        plugin_path=_PLUGIN_PATH,
+        plugin_path=PLUGIN_PATH,
         velocity=_VELOCITY,
         signal_duration_seconds=_DURATION,
         sample_rate=_SAMPLE_RATE,
@@ -1321,7 +1313,7 @@ def test_generate_sample_with_warmup_false_never_warms_across_retries(
     warmup_mock = _install_fake_render_params(monkeypatch, spec, num_retries=num_retries)
 
     generate_vst_dataset.generate_sample(
-        plugin_path=_PLUGIN_PATH,
+        plugin_path=PLUGIN_PATH,
         velocity=_VELOCITY,
         signal_duration_seconds=_DURATION,
         sample_rate=_SAMPLE_RATE,
@@ -1354,7 +1346,7 @@ def test_generate_sample_with_warmup_true_no_retries_warms_exactly_once(
     warmup_mock = _install_fake_render_params(monkeypatch, spec, num_retries=0)
 
     generate_vst_dataset.generate_sample(
-        plugin_path=_PLUGIN_PATH,
+        plugin_path=PLUGIN_PATH,
         velocity=_VELOCITY,
         signal_duration_seconds=_DURATION,
         sample_rate=_SAMPLE_RATE,
@@ -1371,7 +1363,6 @@ def test_generate_sample_with_warmup_true_no_retries_warms_exactly_once(
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_make_dataset_uses_fixed_params_lists_when_provided(
     tmp_path: Path,
 ) -> None:
@@ -1851,7 +1842,6 @@ def test_make_hdf5_resume_indexes_fixed_params_by_absolute_row(
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_copy_dataset_reproduces_source_param_array(tmp_path: Path) -> None:
     """A copy run re-renders a source dataset's params, reproducing its param_array.
 

--- a/tests/data/vst/test_pedalboard_threading_contract.py
+++ b/tests/data/vst/test_pedalboard_threading_contract.py
@@ -17,24 +17,16 @@ existing ``test-vst-slow.yml`` workflow.
 
 from __future__ import annotations
 
-import os
 import threading
-from pathlib import Path
 
 import pytest
 from pedalboard import VST3Plugin
 
-_PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
-
-skip_no_vst = pytest.mark.skipif(
-    not Path(_PLUGIN_PATH).exists(),
-    reason=f"VST plugin not found at {_PLUGIN_PATH}",
-)
+from tests._vst import PLUGIN_PATH
 
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_show_editor_rejects_non_main_thread() -> None:
     """``VST3Plugin.show_editor`` raises ``RuntimeError`` from a non-main thread.
 
@@ -45,7 +37,7 @@ def test_show_editor_rejects_non_main_thread() -> None:
     match is intentional because pedalboard exposes no typed subclass for this
     contract.
     """
-    plugin = VST3Plugin(_PLUGIN_PATH)
+    plugin = VST3Plugin(PLUGIN_PATH)
     captured: list[BaseException] = []
     close = threading.Event()
     close.set()  # pre-arm so a regression path (no raise) returns immediately

--- a/tests/data/vst/test_preset_coverage.py
+++ b/tests/data/vst/test_preset_coverage.py
@@ -18,11 +18,12 @@ import sys
 from pathlib import Path
 
 import pytest
+
+from tests._vst import PLUGIN_PATH
 from pedalboard import VST3Plugin
 
 from synth_setter.data.vst.core import warmup_plugin
 
-_PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
 _PRESET_DIR = Path("presets")
 _SAMPLE_RATE = 44100.0
 _CHANNELS = 2
@@ -34,10 +35,6 @@ _FLUSH_BLOCK_SIZE = 2048
 # type: ignore[attr-defined] for this reason.
 
 requires_vst = pytest.mark.requires_vst
-skip_no_vst = pytest.mark.skipif(
-    not Path(_PLUGIN_PATH).exists(),
-    reason=f"VST plugin not found at {_PLUGIN_PATH}",
-)
 skip_darwin = pytest.mark.skipif(
     sys.platform == "darwin",
     reason="show_editor SIGTRAPs on Darwin (#714) — the very crash this PR avoids",
@@ -64,16 +61,15 @@ def _read_all_params(plugin: VST3Plugin) -> dict[str, float]:
 )
 @pytest.mark.slow
 @requires_vst
-@skip_no_vst
 @skip_darwin
 def test_flush_pattern_matches_show_editor_pattern(preset_path: str) -> None:
     """Flush pattern in render_params is sufficient to commit Surge XT preset state."""
-    p_no = VST3Plugin(_PLUGIN_PATH)
+    p_no = VST3Plugin(PLUGIN_PATH)
     p_no.load_preset(preset_path)
     _flush(p_no)
     no_editor_state = _read_all_params(p_no)
 
-    p_we = VST3Plugin(_PLUGIN_PATH)
+    p_we = VST3Plugin(PLUGIN_PATH)
     # Production's editor warm-up (spotify/pedalboard#394): show_editor closes via
     # the threading.Event the editor exposes, not a test-local wall-clock sleep.
     warmup_plugin(p_we)

--- a/tests/data/vst/test_preset_coverage.py
+++ b/tests/data/vst/test_preset_coverage.py
@@ -13,16 +13,14 @@ Pattern compared:
        workaround order, kept on Linux)
 """
 
-import os
 import sys
 from pathlib import Path
 
 import pytest
-
-from tests._vst import PLUGIN_PATH
 from pedalboard import VST3Plugin
 
 from synth_setter.data.vst.core import warmup_plugin
+from tests._vst import PLUGIN_PATH
 
 _PRESET_DIR = Path("presets")
 _SAMPLE_RATE = 44100.0

--- a/tests/data/vst/test_preset_params.py
+++ b/tests/data/vst/test_preset_params.py
@@ -9,9 +9,7 @@ load_preset().
 Regression for: https://github.com/tinaudio/synth-setter/issues/225
 """
 
-import os
 import sys
-from pathlib import Path
 
 import pytest
 

--- a/tests/data/vst/test_preset_params.py
+++ b/tests/data/vst/test_preset_params.py
@@ -15,7 +15,8 @@ from pathlib import Path
 
 import pytest
 
-PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
+from tests._vst import PLUGIN_PATH
+
 PRESET_PATH = "presets/surge-base.vstpreset"
 
 # pedalboard.VST3Plugin.parameters is a dynamic C extension attribute that
@@ -23,10 +24,6 @@ PRESET_PATH = "presets/surge-base.vstpreset"
 # type: ignore[attr-defined] for this reason.
 
 requires_vst = pytest.mark.requires_vst
-skip_no_vst = pytest.mark.skipif(
-    not Path(PLUGIN_PATH).exists(),
-    reason=f"VST plugin not found at {PLUGIN_PATH}",
-)
 
 skip_linux = pytest.mark.skipif(
     sys.platform == "linux",
@@ -35,7 +32,6 @@ skip_linux = pytest.mark.skipif(
 
 
 @requires_vst
-@skip_no_vst
 def test_preset_dependent_params_accessible_after_flush():
     """Preset-dependent params (e.g. sawtooth) exist after load + flush + reset."""
     from pedalboard import VST3Plugin
@@ -51,7 +47,6 @@ def test_preset_dependent_params_accessible_after_flush():
 
 
 @requires_vst
-@skip_no_vst
 def test_preset_dependent_params_missing_without_flush():
     """Without flush+reset after load_preset, dynamic params are not exposed."""
     from pedalboard import VST3Plugin
@@ -63,7 +58,6 @@ def test_preset_dependent_params_missing_without_flush():
 
 
 @requires_vst
-@skip_no_vst
 @skip_linux
 def test_render_params_sets_preset_dependent_param():
     """render_params must successfully set preset-dependent params without raising."""

--- a/tests/data/vst/test_run_with_editor_held_open_real_plugin.py
+++ b/tests/data/vst/test_run_with_editor_held_open_real_plugin.py
@@ -14,16 +14,10 @@ workflow.
 
 from __future__ import annotations
 
-import os
-from pathlib import Path
-
 import pytest
 
-from tests._vst import PLUGIN_PATH
-
 from synth_setter.data.vst import core
-
-
+from tests._vst import PLUGIN_PATH
 
 
 @pytest.mark.slow

--- a/tests/data/vst/test_run_with_editor_held_open_real_plugin.py
+++ b/tests/data/vst/test_run_with_editor_held_open_real_plugin.py
@@ -19,19 +19,15 @@ from pathlib import Path
 
 import pytest
 
+from tests._vst import PLUGIN_PATH
+
 from synth_setter.data.vst import core
 
-_PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
 
-skip_no_vst = pytest.mark.skipif(
-    not Path(_PLUGIN_PATH).exists(),
-    reason=f"VST plugin not found at {_PLUGIN_PATH}",
-)
 
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_run_with_editor_held_open_completes_cleanly_on_real_plugin() -> None:
     """``run_with_editor_held_open(real_plugin, body)`` returns without raising.
 
@@ -45,7 +41,7 @@ def test_run_with_editor_held_open_completes_cleanly_on_real_plugin() -> None:
     assertion focused on the threading contract so a failure cannot be
     confused with a render/writer regression.
     """
-    plugin = core.load_plugin(_PLUGIN_PATH)
+    plugin = core.load_plugin(PLUGIN_PATH)
 
     result = core.run_with_editor_held_open(plugin, lambda: None)
 

--- a/tests/data/vst/test_writers_wds_e2e.py
+++ b/tests/data/vst/test_writers_wds_e2e.py
@@ -25,24 +25,15 @@ from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
 
 _ = hdf5plugin  # keep type checkers from flagging the side-effect import
 
-# Hardcoded loudness-passing patch, h5↔h5 phase-robust comparison helpers, and
-# the canonical ``_PLUGIN_PATH`` are reused verbatim from
-# ``test_generate_vst_dataset.py`` so this module's h5↔wds parity check uses
-# the same thresholds the h5↔h5 round-trip tests already pin, and the
-# ``skip_no_vst`` mark below tracks the same plugin path that ``_render_cfg``
-# embeds in the produced ``RenderConfig``.
+# Hardcoded loudness-passing patch and h5↔h5 phase-robust comparison helpers are
+# reused verbatim from ``test_generate_vst_dataset.py`` so this module's h5↔wds
+# parity check uses the same thresholds the h5↔h5 round-trip tests already pin.
 from tests.data.vst.test_generate_vst_dataset import (  # noqa: E402  pinned canonical patch
     _HARDCODED_NOTE_PARAMS,
     _HARDCODED_SYNTH_PARAMS,
     _MEL_MEAN_ABS_MAX,
-    _PLUGIN_PATH,
     _assert_audio_metrics_within_thresholds,
     _render_cfg,
-)
-
-skip_no_vst = pytest.mark.skipif(
-    not Path(_PLUGIN_PATH).exists(),
-    reason=f"VST plugin not found at {_PLUGIN_PATH}",
 )
 
 
@@ -74,7 +65,6 @@ def _load_npy_bytes(raw: bytes) -> np.ndarray:
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_make_wds_dataset_writes_per_batch_npy_members(tmp_path: Path) -> None:
     """A 4-sample shard with batch_size=2 emits two batches of three npy members plus metadata.
 
@@ -109,7 +99,6 @@ def test_make_wds_dataset_writes_per_batch_npy_members(tmp_path: Path) -> None:
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_make_wds_dataset_metadata_json_is_strict_shard_metadata(tmp_path: Path) -> None:
     """The shard's ``metadata.json`` member parses as a strict ``ShardMetadata`` matching the cfg.
 
@@ -137,7 +126,6 @@ def test_make_wds_dataset_metadata_json_is_strict_shard_metadata(tmp_path: Path)
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_make_wds_dataset_audio_is_float16(tmp_path: Path) -> None:
     """Audio members are ``float16`` so they match the h5 path's storage precision.
 
@@ -164,7 +152,6 @@ def test_make_wds_dataset_audio_is_float16(tmp_path: Path) -> None:
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_h5_and_wds_outputs_are_equivalent(tmp_path: Path) -> None:
     """Same params written through both writers produce equivalent on-disk arrays.
 
@@ -283,7 +270,6 @@ def test_h5_and_wds_outputs_are_equivalent(tmp_path: Path) -> None:
 
 @pytest.mark.slow
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_make_wds_dataset_metadata_json_strict_rejects_extra(tmp_path: Path) -> None:
     """The metadata.json member round-trips through strict ``ShardMetadata`` validation.
 

--- a/tests/docker/test_smoke.py
+++ b/tests/docker/test_smoke.py
@@ -32,6 +32,7 @@ def test_pedalboard_importable():
 
 @pytest.mark.docker_smoke
 @pytest.mark.requires_vst
+@skip_no_pedalboard
 def test_surge_xt_loads():
     """Verify Surge XT VST3 plugin loads and exposes parameters."""
     from pedalboard import VST3Plugin

--- a/tests/docker/test_smoke.py
+++ b/tests/docker/test_smoke.py
@@ -11,20 +11,13 @@ To run all smoke tests manually inside a container:
         pytest tests/docker/test_smoke.py -m "docker_smoke and requires_vst" -v
 """
 
-import os
-from pathlib import Path
-
 import pytest
 
-PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
+from tests._vst import PLUGIN_PATH
 
 skip_no_pedalboard = pytest.mark.skipif(
     not __import__("importlib").util.find_spec("pedalboard"),
     reason="pedalboard not installed (run inside Docker image)",
-)
-skip_no_vst = pytest.mark.skipif(
-    not Path(PLUGIN_PATH).exists(),
-    reason=f"VST plugin not found at {PLUGIN_PATH} (run inside Docker image)",
 )
 
 
@@ -39,7 +32,6 @@ def test_pedalboard_importable():
 
 @pytest.mark.docker_smoke
 @pytest.mark.requires_vst
-@skip_no_vst
 def test_surge_xt_loads():
     """Verify Surge XT VST3 plugin loads and exposes parameters."""
     from pedalboard import VST3Plugin

--- a/tests/infra/test_conftest_skip_hooks.py
+++ b/tests/infra/test_conftest_skip_hooks.py
@@ -36,9 +36,9 @@ class _FakeItem:
 def test_requires_vst_item_skipped_when_vst_absent(monkeypatch: pytest.MonkeyPatch) -> None:
     """requires_vst item gets a skip marker with a path-specific reason when VST is absent.
 
-    :param monkeypatch: rebinds ``_VST_AVAILABLE`` on ``conftest_module``.
+    :param monkeypatch: rebinds ``VST_AVAILABLE`` on ``conftest_module``.
     """
-    monkeypatch.setattr(conftest_module, "_VST_AVAILABLE", False)
+    monkeypatch.setattr(conftest_module, "VST_AVAILABLE", False)
     item = _FakeItem({"requires_vst": pytest.mark.requires_vst})
     conftest_module.pytest_collection_modifyitems(items=cast(list[pytest.Item], [item]))
     assert len(item.added_markers) == 1
@@ -62,9 +62,9 @@ def test_integration_r2_item_skipped_when_r2_absent(monkeypatch: pytest.MonkeyPa
 def test_requires_vst_item_not_skipped_when_vst_present(monkeypatch: pytest.MonkeyPatch) -> None:
     """requires_vst item receives no skip marker when VST is present.
 
-    :param monkeypatch: rebinds ``_VST_AVAILABLE`` on ``conftest_module``.
+    :param monkeypatch: rebinds ``VST_AVAILABLE`` on ``conftest_module``.
     """
-    monkeypatch.setattr(conftest_module, "_VST_AVAILABLE", True)
+    monkeypatch.setattr(conftest_module, "VST_AVAILABLE", True)
     item = _FakeItem({"requires_vst": pytest.mark.requires_vst})
     conftest_module.pytest_collection_modifyitems(items=cast(list[pytest.Item], [item]))
     assert item.added_markers == []
@@ -86,9 +86,9 @@ def test_integration_r2_item_not_skipped_when_r2_present(monkeypatch: pytest.Mon
 def test_unmarked_item_receives_no_skip_markers(monkeypatch: pytest.MonkeyPatch) -> None:
     """An item with no VST/R2 markers is untouched regardless of resource availability.
 
-    :param monkeypatch: rebinds both ``_VST_AVAILABLE`` and ``_R2_AVAILABLE`` to False.
+    :param monkeypatch: rebinds both ``VST_AVAILABLE`` and ``_R2_AVAILABLE`` to False.
     """
-    monkeypatch.setattr(conftest_module, "_VST_AVAILABLE", False)
+    monkeypatch.setattr(conftest_module, "VST_AVAILABLE", False)
     monkeypatch.setattr(conftest_module, "_R2_AVAILABLE", False)
     item = _FakeItem({"slow": pytest.mark.slow})
     conftest_module.pytest_collection_modifyitems(items=cast(list[pytest.Item], [item]))

--- a/tests/infra/test_vst_helper.py
+++ b/tests/infra/test_vst_helper.py
@@ -8,12 +8,14 @@ to restore the real-environment values for the rest of the session.
 from __future__ import annotations
 
 import importlib
+import os
 from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
 
 import pytest
 
+_ENV_VAR = "SYNTH_SETTER_PLUGIN_PATH"
 _DEFAULT_PATH = "plugins/Surge XT.vst3"
 
 
@@ -21,14 +23,27 @@ _DEFAULT_PATH = "plugins/Surge XT.vst3"
 def reload_vst(request: pytest.FixtureRequest) -> Callable[[], ModuleType]:
     """Reload ``tests._vst`` on demand, restoring real-env values at teardown.
 
-    :param request: registers the teardown reload that restores real-env constants.
+    The finalizer restores ``SYNTH_SETTER_PLUGIN_PATH`` itself (not via
+    ``monkeypatch``, whose teardown may run after this one) before the final
+    reload, so the module is left resolved against the real environment
+    regardless of fixture-finalization order.
+
+    :param request: registers the teardown that restores env + reloads the module.
     :returns: a callable that reloads and returns the freshly imported module.
     """
+    original = os.environ.get(_ENV_VAR)
 
     def _reload() -> ModuleType:
         return importlib.reload(importlib.import_module("tests._vst"))
 
-    request.addfinalizer(lambda: importlib.reload(importlib.import_module("tests._vst")))
+    def _restore() -> None:
+        if original is None:
+            os.environ.pop(_ENV_VAR, None)
+        else:
+            os.environ[_ENV_VAR] = original
+        _reload()
+
+    request.addfinalizer(_restore)
     return _reload
 
 

--- a/tests/infra/test_vst_helper.py
+++ b/tests/infra/test_vst_helper.py
@@ -1,0 +1,101 @@
+"""Tests for the shared VST plugin-discovery helper (``tests._vst``).
+
+``PLUGIN_PATH`` and ``VST_AVAILABLE`` are resolved at import, so each case reloads
+the module under a patched environment and the fixture reloads once more at teardown
+to restore the real-environment values for the rest of the session.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_DEFAULT_PATH = "plugins/Surge XT.vst3"
+
+
+@pytest.fixture
+def reload_vst(request: pytest.FixtureRequest) -> Callable[[], ModuleType]:
+    """Reload ``tests._vst`` on demand, restoring real-env values at teardown.
+
+    :param request: registers the teardown reload that restores real-env constants.
+    :returns: a callable that reloads and returns the freshly imported module.
+    """
+
+    def _reload() -> ModuleType:
+        return importlib.reload(importlib.import_module("tests._vst"))
+
+    request.addfinalizer(lambda: importlib.reload(importlib.import_module("tests._vst")))
+    return _reload
+
+
+@pytest.mark.infra
+def test_plugin_path_defaults_to_bundle_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch, reload_vst: Callable[[], ModuleType]
+) -> None:
+    """PLUGIN_PATH falls back to the in-repo bundle when the override is unset.
+
+    :param monkeypatch: removes ``SYNTH_SETTER_PLUGIN_PATH``.
+    :param reload_vst: re-resolves the module constants under the patched env.
+    """
+    monkeypatch.delenv("SYNTH_SETTER_PLUGIN_PATH", raising=False)
+    assert reload_vst().PLUGIN_PATH == _DEFAULT_PATH
+
+
+@pytest.mark.infra
+def test_plugin_path_uses_env_override_when_set(
+    monkeypatch: pytest.MonkeyPatch, reload_vst: Callable[[], ModuleType]
+) -> None:
+    """PLUGIN_PATH honors a non-empty ``SYNTH_SETTER_PLUGIN_PATH`` override.
+
+    :param monkeypatch: sets a custom override path.
+    :param reload_vst: re-resolves the module constants under the patched env.
+    """
+    monkeypatch.setenv("SYNTH_SETTER_PLUGIN_PATH", "/custom/Surge XT.vst3")
+    assert reload_vst().PLUGIN_PATH == "/custom/Surge XT.vst3"
+
+
+@pytest.mark.infra
+def test_plugin_path_falls_back_to_bundle_when_env_empty(
+    monkeypatch: pytest.MonkeyPatch, reload_vst: Callable[[], ModuleType]
+) -> None:
+    """An empty override falls back to the bundle (the normalized ``or`` semantic).
+
+    :param monkeypatch: sets an empty ``SYNTH_SETTER_PLUGIN_PATH``.
+    :param reload_vst: re-resolves the module constants under the patched env.
+    """
+    monkeypatch.setenv("SYNTH_SETTER_PLUGIN_PATH", "")
+    assert reload_vst().PLUGIN_PATH == _DEFAULT_PATH
+
+
+@pytest.mark.infra
+def test_vst_available_true_when_path_exists(
+    monkeypatch: pytest.MonkeyPatch, reload_vst: Callable[[], ModuleType], tmp_path: Path
+) -> None:
+    """VST_AVAILABLE is True when the resolved path exists on disk.
+
+    :param monkeypatch: points the override at an existing file.
+    :param reload_vst: re-resolves the module constants under the patched env.
+    :param tmp_path: provides a real path to stand in for the plugin bundle.
+    """
+    plugin = tmp_path / "Surge XT.vst3"
+    plugin.touch()
+    monkeypatch.setenv("SYNTH_SETTER_PLUGIN_PATH", str(plugin))
+    assert reload_vst().VST_AVAILABLE is True
+
+
+@pytest.mark.infra
+def test_vst_available_false_when_path_absent(
+    monkeypatch: pytest.MonkeyPatch, reload_vst: Callable[[], ModuleType], tmp_path: Path
+) -> None:
+    """VST_AVAILABLE is False when the resolved path does not exist.
+
+    :param monkeypatch: points the override at a nonexistent path.
+    :param reload_vst: re-resolves the module constants under the patched env.
+    :param tmp_path: supplies a guaranteed-absent path.
+    """
+    monkeypatch.setenv("SYNTH_SETTER_PLUGIN_PATH", str(tmp_path / "missing.vst3"))
+    assert reload_vst().VST_AVAILABLE is False

--- a/tests/integration/test_parallel_shard_render_linux.py
+++ b/tests/integration/test_parallel_shard_render_linux.py
@@ -38,6 +38,7 @@ from synth_setter.cli.generate_dataset import generate
 from synth_setter.data.vst.core import extract_renderer_version
 from synth_setter.data.vst.shapes import AUDIO_FIELD
 from synth_setter.pipeline.schemas.spec import DatasetSpec
+from tests._vst import PLUGIN_PATH
 
 pytestmark = [
     pytest.mark.slow,
@@ -45,7 +46,6 @@ pytestmark = [
     pytest.mark.skipif(sys.platform != "linux", reason="X11 wrapper is Linux-only"),
 ]
 
-PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
 PRESET_PATH = "presets/surge-base.vstpreset"
 
 _NUM_SHARDS = 4
@@ -62,10 +62,6 @@ _CADENCE_CELLS = [
 ]
 
 
-@pytest.mark.skipif(
-    not Path(PLUGIN_PATH).exists(),
-    reason=f"VST plugin not found at {PLUGIN_PATH}",
-)
 @pytest.mark.parametrize(
     ("gui_toggle_cadence", "plugin_reload_cadence"),
     _CADENCE_CELLS,

--- a/tests/test_generate_dataset_cli_overrides.py
+++ b/tests/test_generate_dataset_cli_overrides.py
@@ -8,24 +8,22 @@ with whatever override combinations you want to pin.
 
 from __future__ import annotations
 
-import os
 import shlex
 import subprocess
 
 import pytest
 
+from tests._vst import PLUGIN_PATH
+
 _ENTRYPOINT = "synth-setter-generate-dataset"
 
-# ``render/surge_xt.yaml`` hardcodes ``plugin_path``, so the env var only
-# reaches the CLI when baked into the override string below. Matches the
-# convention in ``tests/data/vst/test_preset_params.py`` and friends.
-_PLUGIN_PATH = os.environ.get("SYNTH_SETTER_PLUGIN_PATH") or "plugins/Surge XT.vst3"
-
+# ``render/surge_xt.yaml`` hardcodes ``plugin_path``, so the path only reaches
+# the CLI when baked into the override string below.
 OVERRIDE_ARGS: list[str] = [
     # ``--help`` still walks the defaults list, so an ``experiment=`` override
     # is required even for the cheapest invocation.
     "experiment=generate_dataset/smoke-shard --help",
-    f"experiment=generate_dataset/smoke-shard render.plugin_path={shlex.quote(_PLUGIN_PATH)}",
+    f"experiment=generate_dataset/smoke-shard render.plugin_path={shlex.quote(PLUGIN_PATH)}",
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.29.0"
+version = "8.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What

Centralize the Surge XT plugin-path resolution that was copy-pasted across the test suite into a single helper, `tests/_vst.py`.

## Why

The plugin path (`SYNTH_SETTER_PLUGIN_PATH` → default `plugins/Surge XT.vst3`) and its presence flag were re-derived independently in ~10 test modules, with **two inconsistent default-resolution idioms** (`os.environ.get(x, default)` vs `os.environ.get(x) or default`, which differ when the override is an empty string) and a **cross-test-module import** of a private `_PLUGIN_PATH` constant. Every VST module also carried a per-file `skip_no_vst` skipif that **duplicated** the `pytest_collection_modifyitems` auto-skip already in `conftest.py`.

## Changes

- **Single source of truth** — new `tests/_vst.py` exports `PLUGIN_PATH` (normalized `os.environ.get(...) or "plugins/Surge XT.vst3"`, so an empty override also falls back) and `VST_AVAILABLE`.
- **Repoint consumers** — `conftest.py` and every VST test module import from the helper; the cross-module `_PLUGIN_PATH` import is gone. `conftest._VST_AVAILABLE`/`_SURGE_FIXTURE_PLUGIN_PATH` collapse into the shared names (skip-hooks test updated in lockstep).
- **Drop the redundant gate** — removed every per-file `skip_no_vst` skipif. The conftest collection hook already auto-skips each `requires_vst` test when the plugin is absent; verified every removed skipif was paired with `@requires_vst`, so skip behavior is unchanged.
- **Contract tests** — `tests/infra/test_vst_helper.py` pins default / override / empty-fallback / `VST_AVAILABLE` both ways.
- Updated the now-stale `cpu-slow.yml` comment that named the removed decorator; dropped imports orphaned by the skipif removal.

## Verification

- `make test-fast`: 1999 passed, 6 skipped.
- The plugin is present in this environment, so the migrated `requires_vst` tests **run and pass** (not merely skip) — behavior preserved.
- `make format` clean (ruff, pyright, pydoclint, …).

No behavior change: `requires_vst` tests run when the plugin is present and skip with the conftest reason when it is not.

Fixes #1550
