### PR TITLE
feat(eval): add paired-copy reload-cadence sweep for #489

### DIFF
--- a/sweeps/generate_dataset_copy_paired_reload_surge_xt.yaml
+++ b/sweeps/generate_dataset_copy_paired_reload_surge_xt.yaml
@@ -1,0 +1,27 @@
+program: src/synth_setter/cli/generate_dataset.py
+# Pinned in YAML — wandb sweep CLI does not support OmegaConf resolvers and ignores
+# WANDB_ENTITY / WANDB_PROJECT at sweep-creation time (those only steer wandb.init in each trial).
+entity: tinaudio
+project: synth-setter
+# Paired plugin_reload_cadence probe for #489: copy_dataset_root_uri replays the fixed surge_xt
+# reference patches, so once-vs-render is paired per patch (needs the copy base + reference, PR #1551).
+command:
+  - ${interpreter}
+  - ${program}
+  - experiment=generate_dataset/copy-paired-surge-xt
+  - copy_dataset_root_uri=r2://intermediate-data/data/ref-surge-xt-489/paired-ref-v1
+  - ${args_no_hyphens}
+name: generate_dataset_copy_paired_reload_surge_xt
+method: grid
+# grid ignores `metric` at scheduling time; the field stays for dashboard
+# legibility on runs that do log it. mss_mean is the oracle-eval audio loss.
+metric:
+  goal: minimize
+  name: audio/mss_mean
+# Both arms replay the same patches, so a paired test (Wilcoxon on per-patch deltas) answers whether
+# the prior unpaired cadence null was real or just underpowered by the patch confound.
+parameters:
+  render.plugin_reload_cadence:
+    values:
+      - once
+      - render

--- a/tests/test_sweep_yaml_structure.py
+++ b/tests/test_sweep_yaml_structure.py
@@ -1,8 +1,8 @@
-"""Offline structural assertion for ``sweeps/generate_dataset_cadence.yaml``.
+"""Offline structural assertions for the operator-facing ``sweeps/*.yaml``.
 
-Pins the operator-facing sweep YAML's ``command:`` shape and parameter
-grid so the contract that ``wandb agent`` executes (subprocess launch
-via ``${interpreter} ${program} ... ${args_no_hyphens}``) cannot drift
+Pins each sweep YAML's ``command:`` shape and parameter grid so the
+contract that ``wandb agent`` executes (subprocess launch via
+``${interpreter} ${program} ... ${args_no_hyphens}``) cannot drift
 silently. Complements any live-backend sweep e2e by catching shape
 breakage without touching the W&B API.
 """
@@ -13,7 +13,9 @@ from pathlib import Path
 
 import yaml
 
-_SWEEP_YAML = Path(__file__).resolve().parent.parent / "sweeps" / "generate_dataset_cadence.yaml"
+_SWEEPS_DIR = Path(__file__).resolve().parent.parent / "sweeps"
+_SWEEP_YAML = _SWEEPS_DIR / "generate_dataset_cadence.yaml"
+_COPY_RELOAD_YAML = _SWEEPS_DIR / "generate_dataset_copy_paired_reload_surge_xt.yaml"
 
 
 def test_generate_dataset_cadence_yaml_shape() -> None:
@@ -31,3 +33,24 @@ def test_generate_dataset_cadence_yaml_shape() -> None:
         "render.plugin_reload_cadence",
         "render.gui_toggle_cadence",
     }
+
+
+def test_generate_dataset_copy_paired_reload_yaml_shape() -> None:
+    """Paired-copy reload sweep pins the copy base + reference URI and grids reload cadence."""
+    cfg = yaml.safe_load(_COPY_RELOAD_YAML.read_text())
+
+    assert cfg["program"] == "src/synth_setter/cli/generate_dataset.py"
+    assert cfg["method"] == "grid"  # both arms must be exhausted deterministically
+
+    cmd = cfg["command"]
+    assert cmd[:2] == ["${interpreter}", "${program}"]
+    assert "${args_no_hyphens}" in cmd
+    # The copy base fixes the match set + gate-off; the reference URI is the patch set every
+    # arm replays. Drift on either voids the per-patch pairing.
+    assert "experiment=generate_dataset/copy-paired-surge-xt" in cmd
+    assert (
+        "copy_dataset_root_uri=r2://intermediate-data/data/ref-surge-xt-489/paired-ref-v1" in cmd
+    )
+
+    assert set(cfg["parameters"].keys()) == {"render.plugin_reload_cadence"}
+    assert cfg["parameters"]["render.plugin_reload_cadence"]["values"] == ["once", "render"]

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.29.0"
+version = "8.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Adds `sweeps/generate_dataset_copy_paired_reload_surge_xt.yaml` — the **paired plugin_reload_cadence** experiment (Exp 2) for the #489 investigation, now possible via the merged `copy_dataset_root_uri` feature (#1548).

## What it does

Grids `render.plugin_reload_cadence ∈ {once, render}` on the copy base (`experiment=generate_dataset/copy-paired-surge-xt`), replaying the **fixed 120-patch surge_xt reference** (`copy_dataset_root_uri=r2://intermediate-data/data/ref-surge-xt-489/paired-ref-v1`) in **both arms**. Because both arms render the *same* patches, the once-vs-render contrast is **paired per patch**.

## Question it answers

The prior #489 cadence studies found no `once`-vs-`render` effect — but **unpaired** (the unseeded param RNG, #884, drew different patches each run), so cross-run patch variance swamped the signal. This sweep removes that confound: a **Wilcoxon signed-rank on the per-patch metric deltas** is ~an order of magnitude more sensitive. Still null → strong confound-free confirmation that cadence doesn't matter; a real effect emerges → the prior null was underpowered.

## Dependency

Needs **PR #1551** (the `copy-paired-surge-xt` base config + the reference dataset). **Merge #1551 first.** CI here only structurally validates the sweep YAML, so it's green independently.

## Validation

The copy mechanism was validated end-to-end against the live reference (from the #1551 worktree): `_validate_copy_source` logged *"dataset-copy source OK: r2://…/ref-surge-xt-489/paired-ref-v1 matches the target spec"*, 120 patches re-rendered under `plugin_reload_cadence=once`, finalized to `dataset.complete`, and the inline oracle eval produced `train/audio/mss_mean=2.00`. The structural test pins the copy base, the exact reference URI, `method=grid`, and the `{once,render}` grid.

## Testing

- `tests/test_sweep_yaml_structure.py` — 2 passed.
- Copy mechanism validated end-to-end (preflight + re-render + finalize + oracle eval).
- Pre-PR `repo-review-full-no-comments` — 0 BLOCK across 5 skills.

Refs #489
