### PR TITLE
chore(data-pipeline): harden copy-source localization + r2 copy tests

### DIFF
--- a/src/synth_setter/pipeline/spec_io.py
+++ b/src/synth_setter/pipeline/spec_io.py
@@ -90,13 +90,20 @@ def localized_uri(uri: str) -> Iterator[Path]:  # noqa: DOC502
 
     :param uri: Local filesystem path, ``file://`` URI, or ``r2://`` URI.
     :yields Path: A local path readable for the duration of the context.
+    :raises FileNotFoundError: a bare or ``file://`` ``uri`` resolves to a path
+        that does not exist (the ``r2://`` branch already fails in the fetch).
     :raises ValueError: ``uri`` carries a scheme other than ``file://`` or
         ``r2://``, or is a malformed ``file://`` URI (propagated from
         :func:`~synth_setter.pipeline.file_uri.file_uri_to_path`).
     """
     scheme = urlparse(uri).scheme
     if scheme in _LOCAL_FILESYSTEM_SCHEMES:
-        yield file_uri_to_path(uri) if scheme == "file" else Path(uri)
+        local = file_uri_to_path(uri) if scheme == "file" else Path(uri)
+        # Fail here, naming the URI, rather than deeper in an opaque h5py /
+        # read_text error that has lost which source went missing.
+        if not local.exists():
+            raise FileNotFoundError(f"no file at {uri!r} (resolved to {local})")
+        yield local
     elif scheme in _REMOTE_OBJECT_SCHEMES:
         with downloaded_to_tempfile(uri) as fetched:
             yield fetched

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import os
-import shutil
+import subprocess
 import sys
 import time
 from collections.abc import Iterator
@@ -1685,36 +1685,31 @@ def test_main_copy_dataset_root_uri_feeds_decoded_params_to_writer(
 
 
 def test_main_copy_dataset_root_uri_downloads_r2_source_shard(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, fake_r2_remote: Path
 ) -> None:
     """An ``r2://`` copy root URI downloads the same-named shard before decoding it.
 
-    The rclone subprocess is stubbed to copy the local fixture into the tempfile
-    ``localized_uri`` requests, so the assertion is that the worker resolves an
-    ``r2://`` root to a local shard and feeds its decoded params to the writer.
+    Drives the real ``rclone`` binary through ``fake_r2_remote`` (local-backed
+    ``r2:``) so actual argv/flag construction is exercised; asserts the worker
+    resolves the ``r2://`` root to a local shard and feeds its decoded params to
+    the writer.
 
-    :param tmp_path: Pytest temp dir holding the source fixture and output path.
-    :param monkeypatch: Patches ``sys.argv``, the writer, and rclone.
+    :param tmp_path: Pytest temp dir holding the output path.
+    :param monkeypatch: Patches ``sys.argv`` and the writer.
+    :param fake_r2_remote: Local-backed ``r2:`` remote root (``<root>/<bucket>/<key>``).
     """
     from synth_setter.data.vst import generate_vst_dataset, writers
-    from synth_setter.pipeline import r2_io
 
     spec = param_specs[_SPEC_NAME]
     num_rows = 3
     rows = [spec.encode(*spec.sample()) for _ in range(num_rows)]
-    fixture_shard = tmp_path / "fixture" / "shard-000000.h5"
-    fixture_shard.parent.mkdir()
-    _write_param_array_shard(fixture_shard, np.stack(rows).astype(np.float32))
-    expected_synth, expected_note = fixed_params_from_dataset(fixture_shard, spec)
-
-    rclone_args: dict[str, list[str]] = {}
-
-    def _fake_check_call(args: list[str]) -> None:
-        # rclone copyto <remote> <dest>; serve the fixture as the downloaded shard.
-        rclone_args["args"] = args
-        shutil.copy(fixture_shard, args[-1])
-
-    monkeypatch.setattr(r2_io.subprocess, "check_call", _fake_check_call)
+    # Materialize the source shard where rclone resolves r2://<bucket>/<key>; the
+    # local path and the URI must encode the same key, so derive one from the other.
+    copy_root_uri = "r2://bucket/prefix/task/run"
+    source_shard = fake_r2_remote / copy_root_uri.removeprefix("r2://") / "shard-000000.h5"
+    source_shard.parent.mkdir(parents=True)
+    _write_param_array_shard(source_shard, np.stack(rows).astype(np.float32))
+    expected_synth, expected_note = fixed_params_from_dataset(source_shard, spec)
 
     captured: dict[str, object] = {}
 
@@ -1730,20 +1725,53 @@ def test_main_copy_dataset_root_uri_downloads_r2_source_shard(
 
     monkeypatch.setattr(writers, "make_hdf5_dataset", _fake_make_hdf5_dataset)
 
-    out = tmp_path / "shard-000000.h5"
+    out = tmp_path / "out" / "shard-000000.h5"
     argv = ["generate_vst_dataset", str(out)]
     for key, value in _render_cfg(num_rows).model_dump().items():
         argv += [f"--{key}", str(value)]
-    argv += ["--copy_dataset_root_uri", "r2://bucket/prefix/task/run"]
+    argv += ["--copy_dataset_root_uri", copy_root_uri]
     monkeypatch.setattr(sys, "argv", argv)
 
     generate_vst_dataset.main()
 
-    # rclone must target the shard joined under the root (basename preserved); r2_io
-    # rewrites the r2:// URI to rclone's r2: remote syntax.
-    assert "r2:bucket/prefix/task/run/shard-000000.h5" in rclone_args["args"]
     assert captured["fixed_synth_params_list"] == expected_synth
     assert captured["fixed_note_params_list"] == expected_note
+
+
+def test_main_copy_dataset_root_uri_propagates_r2_fetch_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-zero rclone exit fetching the ``r2://`` source shard surfaces out of main().
+
+    The per-shard fetch sits on the renderer hot path; a transient object-store
+    failure must propagate (fail-fast) rather than be swallowed into a silent
+    re-render with no copied params.
+
+    :param tmp_path: Pytest temp dir for the would-be output path.
+    :param monkeypatch: Patches ``sys.argv`` and rclone.
+    """
+    from synth_setter.data.vst import generate_vst_dataset, writers
+    from synth_setter.pipeline import r2_io
+
+    def _fail_rclone(args: list[str]) -> NoReturn:
+        raise subprocess.CalledProcessError(7, args)
+
+    monkeypatch.setattr(r2_io.subprocess, "check_call", _fail_rclone)
+
+    def _writer_must_not_run(*_args: object, **_kwargs: object) -> NoReturn:
+        raise AssertionError("writer ran despite a failed copy-source fetch")
+
+    monkeypatch.setattr(writers, "make_hdf5_dataset", _writer_must_not_run)
+
+    out = tmp_path / "shard-000000.h5"
+    argv = ["generate_vst_dataset", str(out)]
+    for key, value in _render_cfg(2).model_dump().items():
+        argv += [f"--{key}", str(value)]
+    argv += ["--copy_dataset_root_uri", "r2://bucket/prefix/task/run"]
+    monkeypatch.setattr(sys, "argv", argv)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        generate_vst_dataset.main()
 
 
 def test_main_copy_dataset_root_uri_rejects_wds_output(

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -1692,7 +1692,7 @@ def test_main_copy_dataset_root_uri_downloads_r2_source_shard(
     Drives the real ``rclone`` binary through ``fake_r2_remote`` (local-backed
     ``r2:``) so actual argv/flag construction is exercised; asserts the worker
     resolves the ``r2://`` root to a local shard and feeds its decoded params to
-    the writer.
+    writer.
 
     :param tmp_path: Pytest temp dir holding the output path.
     :param monkeypatch: Patches ``sys.argv`` and the writer.

--- a/tests/pipeline/test_spec_io.py
+++ b/tests/pipeline/test_spec_io.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
@@ -419,6 +420,28 @@ class TestLocalizedUri:
                 assert local.read_text() == "from-r2"
                 fetched = local
         assert not fetched.exists()
+
+    def test_missing_bare_local_path_raises_filenotfound_naming_uri(self, tmp_path: Path) -> None:
+        """A non-existent bare path fails up front, naming the URI, not later at the reader.
+
+        :param tmp_path: Pytest tmp dir; the target is intentionally never created.
+        """
+        missing = tmp_path / "absent.h5"
+
+        with pytest.raises(FileNotFoundError, match=re.escape(f"no file at '{missing}'")):
+            with spec_io.localized_uri(str(missing)):
+                pass
+
+    def test_missing_file_uri_raises_filenotfound_naming_uri(self, tmp_path: Path) -> None:
+        """A non-existent ``file://`` URI fails up front, naming the URI.
+
+        :param tmp_path: Pytest tmp dir; the target is intentionally never created.
+        """
+        missing = tmp_path / "absent.h5"
+
+        with pytest.raises(FileNotFoundError, match=re.escape(missing.as_uri())):
+            with spec_io.localized_uri(missing.as_uri()):
+                pass
 
     def test_unsupported_scheme_is_rejected_with_value_error(self) -> None:
         """An unsupported scheme (e.g. ``s3://``) raises a clear ``ValueError``."""

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.29.0"
+version = "8.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Follow-up to #1548 (`copy_dataset_root_uri` accepts `file://` and `r2://`), which merged with several review WARN advisories deferred as follow-ups. This PR closes the ones **not** already handled inside #1548's own follow-up commits.

- **`spec_io.localized_uri` fails fast on a missing local source.** A bare / `file://` path that doesn't exist now raises a `FileNotFoundError` naming the URI, instead of surfacing deep in an opaque `h5py` / `read_text` error that has lost which copy source went missing. The `FileNotFoundError` type is preserved, so `_validate_copy_source` still maps a missing source spec to its "sync the source spec" message.
- **`test_main_copy_dataset_root_uri_downloads_r2_source_shard` drives real rclone.** It now uses the `fake_r2_remote` fixture (local-backed `r2:`) instead of stubbing `subprocess.check_call`, so it exercises actual argv/flag construction and no longer couples to `args[-1]` positional ordering. The on-disk source path is derived from the URI so the key can't silently drift.
- **New `test_main_copy_dataset_root_uri_propagates_r2_fetch_failure`.** A non-zero rclone exit on the per-shard `r2://` fetch must propagate (fail-fast) out of `main()`; the test also asserts the writer never runs, pinning the "no silent re-render" contract.

## Out of scope

Items already resolved in #1548's follow-up commits (the `CalledProcessError`/`FileNotFoundError` split in `_validate_copy_source`, `load_spec_from_root` reuse, retry/timeout flags on `download_to_path`, the malformed-`file://` and failure-path tempfile-cleanup tests) and the Windows drive-letter case (declined as YAGNI — Linux-only pipeline).

## Testing

- `make format` clean (ruff, pydoclint, pyright, etc.).
- Affected suites green: `tests/pipeline/test_spec_io.py`, `tests/data/vst/test_generate_vst_dataset.py`, `tests/pipeline/entrypoints/test_generate_dataset_unit.py` (160 passed).

## Review

Pre-PR `/repo-review-full-no-comments` (7 parallel passes): 0 BLOCK. First pass's advisory WARNs were all addressed; the lone remaining WARN is an intentional, documented cross-scheme consistency trade-off.

The `uv.lock` line reconciles the editable `synth-setter` version to 8.30.0 (main's release `[skip ci]` bumped `pyproject` but not the lock).

Refs #1549
