### PR TITLE
feat(eval): add paired-copy gui-cadence sweep for #489

### DIFF
--- a/sweeps/generate_dataset_copy_paired_gui_surge_xt.yaml
+++ b/sweeps/generate_dataset_copy_paired_gui_surge_xt.yaml
@@ -1,0 +1,28 @@
+program: src/synth_setter/cli/generate_dataset.py
+# Pinned in YAML — wandb sweep CLI does not support OmegaConf resolvers and ignores
+# WANDB_ENTITY / WANDB_PROJECT at sweep-creation time (those only steer wandb.init in each trial).
+entity: tinaudio
+project: synth-setter
+# Paired gui_toggle_cadence probe for #489: copy_dataset_root_uri replays the fixed surge_xt
+# reference patches, so the GUI-realisation contrast is paired per patch (needs PR #1551).
+command:
+  - ${interpreter}
+  - ${program}
+  - experiment=generate_dataset/copy-paired-surge-xt
+  - copy_dataset_root_uri=r2://intermediate-data/data/ref-surge-xt-489/paired-ref-v1
+  - ${args_no_hyphens}
+name: generate_dataset_copy_paired_gui_surge_xt
+method: grid
+# grid ignores `metric` at scheduling time; the field stays for dashboard
+# legibility on runs that do log it. mss_mean is the oracle-eval audio loss.
+metric:
+  goal: minimize
+  name: audio/mss_mean
+# Isolates the GUI-realisation cadence on identical patches (the copy base keeps reload at render).
+# always_on is excluded — it requires plugin_reload_cadence=once, which would confound the contrast.
+parameters:
+  render.gui_toggle_cadence:
+    values:
+      - never
+      - once
+      - render

--- a/tests/test_sweep_yaml_structure.py
+++ b/tests/test_sweep_yaml_structure.py
@@ -1,8 +1,8 @@
-"""Offline structural assertion for ``sweeps/generate_dataset_cadence.yaml``.
+"""Offline structural assertions for the operator-facing ``sweeps/*.yaml``.
 
-Pins the operator-facing sweep YAML's ``command:`` shape and parameter
-grid so the contract that ``wandb agent`` executes (subprocess launch
-via ``${interpreter} ${program} ... ${args_no_hyphens}``) cannot drift
+Pins each sweep YAML's ``command:`` shape and parameter grid so the
+contract that ``wandb agent`` executes (subprocess launch via
+``${interpreter} ${program} ... ${args_no_hyphens}``) cannot drift
 silently. Complements any live-backend sweep e2e by catching shape
 breakage without touching the W&B API.
 """
@@ -13,7 +13,11 @@ from pathlib import Path
 
 import yaml
 
-_SWEEP_YAML = Path(__file__).resolve().parent.parent / "sweeps" / "generate_dataset_cadence.yaml"
+_SWEEPS_DIR = Path(__file__).resolve().parent.parent / "sweeps"
+_SWEEP_YAML = _SWEEPS_DIR / "generate_dataset_cadence.yaml"
+_COPY_GUI_YAML = _SWEEPS_DIR / "generate_dataset_copy_paired_gui_surge_xt.yaml"
+
+_REFERENCE_URI = "copy_dataset_root_uri=r2://intermediate-data/data/ref-surge-xt-489/paired-ref-v1"
 
 
 def test_generate_dataset_cadence_yaml_shape() -> None:
@@ -31,3 +35,23 @@ def test_generate_dataset_cadence_yaml_shape() -> None:
         "render.plugin_reload_cadence",
         "render.gui_toggle_cadence",
     }
+
+
+def test_generate_dataset_copy_paired_gui_yaml_shape() -> None:
+    """Paired-copy GUI sweep pins the copy base + reference URI and grids gui_toggle_cadence."""
+    cfg = yaml.safe_load(_COPY_GUI_YAML.read_text())
+
+    assert cfg["program"] == "src/synth_setter/cli/generate_dataset.py"
+    assert cfg["method"] == "grid"
+
+    cmd = cfg["command"]
+    assert cmd[:2] == ["${interpreter}", "${program}"]
+    assert "${args_no_hyphens}" in cmd
+    # The copy base fixes the match set + gate-off; the reference URI is the patch set every
+    # arm replays. Drift on either voids the per-patch pairing.
+    assert "experiment=generate_dataset/copy-paired-surge-xt" in cmd
+    assert _REFERENCE_URI in cmd
+
+    assert set(cfg["parameters"].keys()) == {"render.gui_toggle_cadence"}
+    # always_on is excluded — it requires plugin_reload_cadence=once and would confound the contrast.
+    assert cfg["parameters"]["render.gui_toggle_cadence"]["values"] == ["never", "once", "render"]

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.29.0"
+version = "8.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Adds `sweeps/generate_dataset_copy_paired_gui_surge_xt.yaml` — the **paired `gui_toggle_cadence`** experiment (Exp 4′) for the #489 investigation, using the merged `copy_dataset_root_uri` feature (#1548).

## What it does

Grids `render.gui_toggle_cadence ∈ {never, once, render}` on the copy base (`experiment=generate_dataset/copy-paired-surge-xt`), replaying the **fixed 120-patch surge_xt reference** in every arm. `plugin_reload_cadence` is held at the base's `render`, so this isolates **GUI-realisation cadence** on identical patches — paired per patch. `always_on` is excluded because it requires `plugin_reload_cadence=once`, which would confound the contrast.

## Question it answers

The prior #489 studies bundled `gui_toggle_cadence` into an unpaired grid and found no effect. This re-checks it **paired** (same patches each arm), removing the patch confound — a far more sensitive test of whether GUI realisation perturbs the round-trip.

## Dependency

Needs **PR #1551** (the `copy-paired-surge-xt` base + reference dataset). **Merge #1551 first.** Also touches `tests/test_sweep_yaml_structure.py` like the sibling repro-floor PR — whichever merges second rebases (trivial). CI here is green independently (structural test only).

## Validation

The copy mechanism was validated end-to-end against the live reference (preflight *"dataset-copy source OK … matches the target spec"*, 120 patches re-rendered + finalized + oracle eval). The structural test pins the copy base, the exact reference URI, `method=grid`, and the `{never,once,render}` grid (and documents the `always_on` exclusion).

## Testing

- `tests/test_sweep_yaml_structure.py` — 2 passed.
- Copy mechanism validated end-to-end (shared with #1553).
- Pre-PR `repo-review-full-no-comments` — 0 BLOCK across 5 skills.

Refs #489
