### PR TITLE
feat(eval): add paired-copy reproducibility-floor sweep for #489

### DIFF
--- a/sweeps/generate_dataset_copy_paired_repro_surge_xt.yaml
+++ b/sweeps/generate_dataset_copy_paired_repro_surge_xt.yaml
@@ -1,0 +1,28 @@
+program: src/synth_setter/cli/generate_dataset.py
+# Pinned in YAML — wandb sweep CLI does not support OmegaConf resolvers and ignores
+# WANDB_ENTITY / WANDB_PROJECT at sweep-creation time (those only steer wandb.init in each trial).
+entity: tinaudio
+project: synth-setter
+# Phase-init reproducibility floor for #489: re-render the fixed surge_xt reference patches three
+# times under one config, so run-to-run spread isolates the phase-init noise floor (needs PR #1551).
+command:
+  - ${interpreter}
+  - ${program}
+  - experiment=generate_dataset/copy-paired-surge-xt
+  - copy_dataset_root_uri=r2://intermediate-data/data/ref-surge-xt-489/paired-ref-v1
+  - ${args_no_hyphens}
+name: generate_dataset_copy_paired_repro_surge_xt
+method: grid
+# grid ignores `metric` at scheduling time; the field stays for dashboard
+# legibility on runs that do log it. mss_mean is the oracle-eval audio loss.
+metric:
+  goal: minimize
+  name: audio/mss_mean
+# Three identical replays of the same patches; run_id is the only knob (distinct W&B run + R2 prefix
+# per trial). The cross-trial spread of each patch's metrics is the phase-init nondeterminism floor.
+parameters:
+  run_id:
+    values:
+      - paired-repro-t1
+      - paired-repro-t2
+      - paired-repro-t3

--- a/tests/test_sweep_yaml_structure.py
+++ b/tests/test_sweep_yaml_structure.py
@@ -1,7 +1,8 @@
-"""Offline structural assertions for the operator-facing ``sweeps/*.yaml``.
+"""Offline structural assertions for the operator-facing sweeps covered below.
 
-Pins each sweep YAML's ``command:`` shape and parameter grid so the
-contract that ``wandb agent`` executes (subprocess launch via
+Each test pins one ``sweeps/*.yaml`` file's ``command:`` shape and
+parameter grid (this is a curated set, not every file under ``sweeps/``)
+so the contract that ``wandb agent`` executes (subprocess launch via
 ``${interpreter} ${program} ... ${args_no_hyphens}``) cannot drift
 silently. Complements any live-backend sweep e2e by catching shape
 breakage without touching the W&B API.

--- a/tests/test_sweep_yaml_structure.py
+++ b/tests/test_sweep_yaml_structure.py
@@ -1,8 +1,8 @@
-"""Offline structural assertion for ``sweeps/generate_dataset_cadence.yaml``.
+"""Offline structural assertions for the operator-facing ``sweeps/*.yaml``.
 
-Pins the operator-facing sweep YAML's ``command:`` shape and parameter
-grid so the contract that ``wandb agent`` executes (subprocess launch
-via ``${interpreter} ${program} ... ${args_no_hyphens}``) cannot drift
+Pins each sweep YAML's ``command:`` shape and parameter grid so the
+contract that ``wandb agent`` executes (subprocess launch via
+``${interpreter} ${program} ... ${args_no_hyphens}``) cannot drift
 silently. Complements any live-backend sweep e2e by catching shape
 breakage without touching the W&B API.
 """
@@ -13,7 +13,11 @@ from pathlib import Path
 
 import yaml
 
-_SWEEP_YAML = Path(__file__).resolve().parent.parent / "sweeps" / "generate_dataset_cadence.yaml"
+_SWEEPS_DIR = Path(__file__).resolve().parent.parent / "sweeps"
+_SWEEP_YAML = _SWEEPS_DIR / "generate_dataset_cadence.yaml"
+_COPY_REPRO_YAML = _SWEEPS_DIR / "generate_dataset_copy_paired_repro_surge_xt.yaml"
+
+_REFERENCE_URI = "copy_dataset_root_uri=r2://intermediate-data/data/ref-surge-xt-489/paired-ref-v1"
 
 
 def test_generate_dataset_cadence_yaml_shape() -> None:
@@ -31,3 +35,27 @@ def test_generate_dataset_cadence_yaml_shape() -> None:
         "render.plugin_reload_cadence",
         "render.gui_toggle_cadence",
     }
+
+
+def test_generate_dataset_copy_paired_repro_yaml_shape() -> None:
+    """Reproducibility-floor sweep replays the reference under run_id-only trial replicates."""
+    cfg = yaml.safe_load(_COPY_REPRO_YAML.read_text())
+
+    assert cfg["program"] == "src/synth_setter/cli/generate_dataset.py"
+    assert cfg["method"] == "grid"
+
+    cmd = cfg["command"]
+    assert cmd[:2] == ["${interpreter}", "${program}"]
+    assert "${args_no_hyphens}" in cmd
+    # The copy base fixes the match set + gate-off; the reference URI is the patch set every
+    # trial replays. Drift on either voids the floor measurement.
+    assert "experiment=generate_dataset/copy-paired-surge-xt" in cmd
+    assert _REFERENCE_URI in cmd
+
+    # run_id is the only knob: each trial is an identical replay (distinct W&B run + R2 prefix), so
+    # the cross-trial spread isolates phase-init nondeterminism. Need >= 2 distinct trials, else two
+    # trials collapse onto one R2 prefix and silently halve the sample.
+    assert set(cfg["parameters"].keys()) == {"run_id"}
+    trials = cfg["parameters"]["run_id"]["values"]
+    assert len(trials) >= 2
+    assert len(set(trials)) == len(trials)

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.29.0"
+version = "8.30.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Adds `sweeps/generate_dataset_copy_paired_repro_surge_xt.yaml` — the **phase-init reproducibility-floor** experiment (Exp 5′) for the #489 investigation, using the merged `copy_dataset_root_uri` feature (#1548).

## What it does

Replays the **fixed 120-patch surge_xt reference** three times under one config, gridding **only `run_id`** (`paired-repro-t1/t2/t3`) so each trial is an identical replay with a distinct W&B run + R2 prefix. The **cross-trial spread of each patch's oracle metrics is the phase-init nondeterminism floor**.

## Question it answers

The prior #489 studies named phase-init as the dominant residual divergence term but never measured it *directly* on known patches. Because every trial re-renders the *same* reference patches, the only thing that varies between trials is Surge XT's per-render oscillator phase-init — so the run-to-run spread is a clean, confound-free estimate of the floor that bounds how reproducible identical-param rendering can ever be.

## Why `run_id` is the knob

`run_id` is a supported Hydra override that pins both `wandb.run.id` and the R2 output prefix (`<root>/<task>/<run_id>/`), so the three trials get distinct runs + prefixes without colliding, and `run_id` is **not** in the copy-preflight match set — all three replay the same patches preflight-safe. The structural test pins that the three `run_id` values are **distinct** (a duplicate would collapse two trials onto one prefix and halve the sample).

## Dependency

Needs **PR #1551** (the `copy-paired-surge-xt` base + reference dataset). **Merge #1551 first.** Shares the `tests/test_sweep_yaml_structure.py` edit with the sibling gui-cadence PR — second to merge rebases (trivial). CI here is green independently.

## Validation

The copy mechanism was validated end-to-end against the live reference (preflight passed, 120 patches re-rendered + finalized + oracle-measured; `train/audio/mss_mean=2.00`). Each repro trial is that same copy run with a different `run_id`.

## Testing

- `tests/test_sweep_yaml_structure.py` — 2 passed.
- Copy mechanism validated end-to-end (shared with #1553).
- Pre-PR `repo-review-full-no-comments` — 0 BLOCK across 5 skills.

Refs #489
