### PR TITLE
feat(eval): one-command #489 cadence-investigation orchestrator

### DIFF
--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -31,6 +31,15 @@ on:
         description: "Push run metrics to gh-pages (creates the page on first run)"
         type: boolean
         default: false
+      run_cadence_sweep:
+        # Opt-in: runs the #489 cadence investigation (real W&B sweeps +
+        # render compute + R2 round-trips) instead of the VST suite. Off by
+        # default because each run creates persistent sweeps in the W&B UI and
+        # spends real compute; it only fires on explicit dispatch, never on
+        # push/PR. Mutually exclusive with the VST suite job below.
+        description: "Run the #489 cadence investigation (real W&B sweep) instead of the VST suite"
+        type: boolean
+        default: false
   push:
     # ``test/vst-roundtrip-xfail-tests`` listed temporarily so we can bootstrap
     # the ``gh-pages`` benchmark chart from this PR before merging to main.
@@ -77,6 +86,9 @@ permissions:
 jobs:
   run_vst_slow_tests:
     name: VST slow tests (Docker)
+    # A cadence-sweep dispatch runs the cadence job below instead, so skip the
+    # 90-min VST suite in that case; every other trigger runs it as before.
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.run_cadence_sweep == true) }}
     runs-on: ubuntu-latest-4core
     timeout-minutes: 120
 
@@ -225,3 +237,72 @@ jobs:
           comment-on-alert: true
           fail-on-alert: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  # Operator-dispatched #489 cadence investigation. Runs the real
+  # wandb-online e2e (creates W&B sweeps + spends render compute + R2
+  # round-trips), so it is gated on the ``run_cadence_sweep`` dispatch input
+  # and never runs on push/PR. Mutually exclusive with the VST suite above.
+  run_cadence_investigation:
+    name: "#489 cadence investigation (real W&B sweep)"
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_cadence_sweep == true }}
+    runs-on: ubuntu-latest-4core
+    timeout-minutes: 120
+
+    permissions:
+      contents: read
+
+    env:
+      IMAGE: tinaudio/synth-setter:${{ inputs.image_tag || 'dev-snapshot' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Pull image
+        run: docker pull "$IMAGE"
+
+      # Export RCLONE_CONFIG_R2_* into $GITHUB_ENV so the docker step can
+      # forward them with bare ``-e`` flags. ``install-rclone: false`` because
+      # rclone runs inside the dev image (Dockerfile installs it), not on the
+      # host runner.
+      - name: Configure R2 credentials
+        uses: ./.github/actions/setup-r2
+        with:
+          access-key-id: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+          endpoint: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+          install-rclone: "false"
+
+      - name: Run #489 cadence investigation in Docker
+        # The wandb-online e2e self-skips without WANDB_API_KEY or reachable
+        # R2, so all three W&B vars plus the five RCLONE_CONFIG_R2_* (set by
+        # the step above) are forwarded into the container. WANDB_ENTITY /
+        # WANDB_PROJECT redirect the sweeps off the script's personal-pin
+        # default onto the shared entity. The headless wrapper supplies the X
+        # display the Surge XT renderer needs, same as the VST suite above.
+        env:
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          WANDB_ENTITY: ${{ secrets.WANDB_ENTITY }}
+          WANDB_PROJECT: ${{ secrets.WANDB_PROJECT }}
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/home/build/synth-setter \
+            -e HYDRA_FULL_ERROR=1 \
+            -e "SYNTH_SETTER_PLUGIN_PATH=/usr/lib/vst3/Surge XT.vst3" \
+            -e WANDB_API_KEY \
+            -e WANDB_ENTITY \
+            -e WANDB_PROJECT \
+            -e RCLONE_CONFIG_R2_TYPE \
+            -e RCLONE_CONFIG_R2_PROVIDER \
+            -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
+            -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
+            -e RCLONE_CONFIG_R2_ENDPOINT \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              git config --global --add safe.directory /home/build/synth-setter
+              src/synth_setter/scripts/run-linux-vst-headless.sh \
+                pytest -vv -s \
+                  tests/integration/test_cadence_investigation_489_e2e.py
+            '

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,11 +18,11 @@ This directory holds **shell / Python tooling that ships outside the `synth_sett
 
 The Python utilities live inside the `synth_setter` package and are invoked as `python -m synth_setter.<subpkg>.<module>`:
 
-| Subpackage                   | Modules                                                                                        |
-| ---------------------------- | ---------------------------------------------------------------------------------------------- |
-| `synth_setter.evaluation`    | `predict_vst_audio`, `compute_audio_metrics`                                                   |
-| `synth_setter.tools`         | `surge_xt_interactive`, `model_from_wandb`, `plot_param2tok`, `paramspec_to_table`, `sig_perf` |
-| `synth_setter.pipeline.data` | `reshard`, `rewrite_to_latest`, `stats`, `r2_report`, `add_music2latent`                       |
+| Subpackage                   | Modules                                                                                                                     |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `synth_setter.evaluation`    | `predict_vst_audio`, `compute_audio_metrics`                                                                                |
+| `synth_setter.tools`         | `surge_xt_interactive`, `model_from_wandb`, `plot_param2tok`, `paramspec_to_table`, `sig_perf`, `cadence_investigation_489` |
+| `synth_setter.pipeline.data` | `reshard`, `rewrite_to_latest`, `stats`, `r2_report`, `add_music2latent`                                                    |
 
 The `synth-setter-train`, `synth-setter-eval`, and `synth-setter-generate-dataset` console scripts (declared in `pyproject.toml`'s `[project.scripts]`) remain the canonical entrypoints for the train / eval / dataset-generation workflows.
 

--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -27,9 +27,9 @@ import sys
 from dataclasses import dataclass
 from typing import Any
 
+import wandb
 from loguru import logger
 
-import wandb
 from synth_setter.pipeline.schemas.prefix import DEFAULT_R2_PREFIX_ROOT, make_r2_prefix
 
 # Temporary: the ``tinaudio`` W&B entity does not exist yet (sweep creation 404s),

--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -1,0 +1,489 @@
+"""One-command orchestrator for the #489 surge_xt cadence investigation.
+
+Replaces the per-experiment sweep YAMLs with a single script that (1) generates
+the fixed surge_xt copy-source dataset, (2) derives its R2 run-root URI, and
+(3) drives the five experiments — two within-run probes (render-order shuffle,
+reuse-depth junk) and three paired-copy probes (reload cadence, gui cadence,
+reproducibility floor) — feeding the derived URI to the copy probes so nothing
+hardcodes where copies read from.
+
+One :class:`Scale` feeds both the source generation and the copy probes, so the
+copy-preflight match set (``param_spec_name`` / ``samples_per_shard`` /
+``train_val_test_sizes``) cannot drift between producer and consumer.
+
+Run the whole investigation::
+
+    python -m synth_setter.tools.cadence_investigation_489               # wandb sweeps + agents
+    python -m synth_setter.tools.cadence_investigation_489 --dry-run     # print the plan only
+    python -m synth_setter.tools.cadence_investigation_489 --launcher local   # single-box subprocess loop
+"""
+
+from __future__ import annotations
+
+import argparse
+import itertools
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any
+
+import wandb
+from loguru import logger
+
+from synth_setter.pipeline.schemas.prefix import DEFAULT_R2_PREFIX_ROOT, make_r2_prefix
+
+ENTITY = "tinaudio"
+PROJECT = "synth-setter"
+BUCKET = "intermediate-data"
+PROGRAM = "src/synth_setter/cli/generate_dataset.py"
+
+PARAM_SPEC = "surge_xt"
+PRESET = "presets/surge-base.vstpreset"
+
+# Fixed reference run identity -> stable copy-source URI the copy probes replay.
+REFERENCE_TASK = "ref-surge-xt-489"
+REFERENCE_RUN_ID = "paired-ref-v1"
+
+# Copy can't resample a sub-floor re-render (#724); -1000 dB lets junk/quiet
+# renders reach the oracle while only true silence (-inf) trips the floor.
+COPY_MIN_LOUDNESS = -1000.0
+
+_GENERATE_EXPERIMENT = "generate_dataset/smoke-shard-with-oracle-eval"
+# Source needs raw param shards only (copy reads same-named shards at the run
+# root), so it skips the with-oracle-eval finalize/eval the probes run.
+_SOURCE_EXPERIMENT = "generate_dataset/smoke-shard"
+
+
+@dataclass(frozen=True)
+class Scale:
+    """Dataset-size knobs shared by source generation and the copy probes.
+
+    .. attribute :: sizes
+
+        ``train_val_test_sizes`` for the copy match set and the shuffle probe.
+
+    .. attribute :: samples_per_shard
+
+        Reuses per shard for the copy match set; equals the source's so filenames align.
+
+    .. attribute :: reuse_depths
+
+        Reuse-depth probe's swept ``samples_per_shard``; split sizes are ``max(reuse_depths)``.
+    """
+
+    sizes: tuple[int, int, int]
+    samples_per_shard: int
+    reuse_depths: tuple[int, ...]
+
+
+# Full #489 run: 2 shards/split at the reference, reuse depths spanning the
+# junk onset (~12 reuses, #706); 80 is a multiple of every depth.
+FULL = Scale(sizes=(40, 40, 40), samples_per_shard=20, reuse_depths=(4, 20, 40, 80))
+# Smallest run that still exercises generate -> copy -> oracle for tests.
+SMOKE = Scale(sizes=(2, 2, 2), samples_per_shard=2, reuse_depths=(1, 2))
+
+
+@dataclass(frozen=True)
+class Experiment:
+    """One investigation experiment: a fixed config plus a one- or two-knob grid.
+
+    .. attribute :: name
+
+        Stable identifier used for ``--only`` selection and labels.
+
+    .. attribute :: task_name
+
+        Distinct ``task_name`` so each experiment gets its own R2 prefix / W&B run.
+
+    .. attribute :: fixed_overrides
+
+        Hydra overrides shared by every cell (the experiment base + pins).
+
+    .. attribute :: grid
+
+        Maps a Hydra key to its swept values; the Cartesian product is the cells.
+
+    .. attribute :: needs_copy_source
+
+        When true, ``copy_dataset_root_uri`` is appended so the cell replays the source.
+    """
+
+    name: str
+    task_name: str
+    fixed_overrides: tuple[str, ...]
+    grid: dict[str, list[object]]
+    needs_copy_source: bool = False
+
+
+def reference_copy_uri(prefix_root: str = DEFAULT_R2_PREFIX_ROOT) -> str:
+    """Return the R2 run-root URI of the copy-source dataset.
+
+    :param prefix_root: R2 prefix root; the default ``"data"`` yields the
+        canonical run root, and a test-scoped root isolates a throwaway run.
+    :returns: ``r2://<bucket>/<prefix_root>/<task>/<run>`` with no trailing slash.
+    """
+    prefix = make_r2_prefix(REFERENCE_TASK, REFERENCE_RUN_ID, prefix_root=prefix_root)
+    return f"r2://{BUCKET}/{prefix.rstrip('/')}"
+
+
+def _sizes_override(sizes: tuple[int, int, int]) -> str:
+    """Return the ``train_val_test_sizes`` Hydra override token for ``sizes``.
+
+    :param sizes: Train/val/test split sizes.
+    :returns: The ``train_val_test_sizes=[...]`` override token.
+    """
+    return f"train_val_test_sizes=[{','.join(str(n) for n in sizes)}]"
+
+
+def reference_overrides(scale: Scale, prefix_root: str = DEFAULT_R2_PREFIX_ROOT) -> list[str]:
+    """Return the ``generate_dataset`` overrides that build the copy source.
+
+    :param scale: Size knobs; ``sizes`` / ``samples_per_shard`` form the match
+        set the copy probes echo.
+    :param prefix_root: R2 prefix root, mirrored into the derived copy URI.
+    :returns: Hydra override tokens for the source generation run.
+    """
+    return [
+        f"experiment={_SOURCE_EXPERIMENT}",
+        f"task_name={REFERENCE_TASK}",
+        f"run_id={REFERENCE_RUN_ID}",
+        f"r2.prefix_root={prefix_root}",
+        f"render.param_spec_name={PARAM_SPEC}",
+        f"render.preset_path={PRESET}",
+        _sizes_override(scale.sizes),
+        f"render.samples_per_shard={scale.samples_per_shard}",
+    ]
+
+
+def _copy_match_overrides(scale: Scale) -> tuple[str, ...]:
+    """Return the pins every copy cell shares with the source generation.
+
+    :param scale: Size knobs supplying the shared split sizes and reuse count.
+    :returns: The copy-preflight match-set overrides plus the copy loudness floor.
+    """
+    return (
+        f"experiment={_GENERATE_EXPERIMENT}",
+        f"render.param_spec_name={PARAM_SPEC}",
+        f"render.preset_path={PRESET}",
+        _sizes_override(scale.sizes),
+        f"render.samples_per_shard={scale.samples_per_shard}",
+        f"render.min_loudness={COPY_MIN_LOUDNESS}",
+    )
+
+
+def build_experiments(scale: Scale) -> list[Experiment]:
+    """Return the five #489 experiments parameterized by ``scale``.
+
+    :param scale: Size knobs threaded into split sizes and the reuse-depth grid.
+    :returns: Ordered experiments — two within-run probes then three copy probes.
+    """
+    # Reuse depth is the swept samples_per_shard; sizes must be a multiple of
+    # the largest depth so every cell splits into whole shards.
+    reuse_size = max(scale.reuse_depths)
+    return [
+        Experiment(
+            name="shuffle_probe",
+            task_name="shuffle-probe-surge-xt",
+            fixed_overrides=(
+                f"experiment={_GENERATE_EXPERIMENT}",
+                f"render.param_spec_name={PARAM_SPEC}",
+                f"render.preset_path={PRESET}",
+                "render.param_sample_cadence=shard",
+                _sizes_override(scale.sizes),
+                f"render.samples_per_shard={scale.samples_per_shard}",
+            ),
+            grid={
+                "render.plugin_reload_cadence": ["once", "render"],
+                "render.gui_toggle_cadence": ["never", "once", "render", "always_on"],
+            },
+        ),
+        Experiment(
+            name="reuse_depth",
+            task_name="reuse-depth-surge-xt",
+            fixed_overrides=(
+                f"experiment={_GENERATE_EXPERIMENT}",
+                f"render.param_spec_name={PARAM_SPEC}",
+                f"render.preset_path={PRESET}",
+                "render.param_sample_cadence=shard",
+                "render.plugin_reload_cadence=once",
+                "render.gui_toggle_cadence=never",
+                _sizes_override((reuse_size, reuse_size, reuse_size)),
+            ),
+            grid={"render.samples_per_shard": list(scale.reuse_depths)},
+        ),
+        Experiment(
+            name="copy_reload",
+            task_name="copy-paired-reload-surge-xt",
+            fixed_overrides=_copy_match_overrides(scale),
+            grid={"render.plugin_reload_cadence": ["once", "render"]},
+            needs_copy_source=True,
+        ),
+        Experiment(
+            name="copy_gui",
+            task_name="copy-paired-gui-surge-xt",
+            fixed_overrides=_copy_match_overrides(scale),
+            grid={"render.gui_toggle_cadence": ["never", "once", "render"]},
+            needs_copy_source=True,
+        ),
+        Experiment(
+            name="copy_repro",
+            task_name="copy-paired-repro-surge-xt",
+            fixed_overrides=_copy_match_overrides(scale),
+            grid={"run_id": ["paired-repro-t1", "paired-repro-t2", "paired-repro-t3"]},
+            needs_copy_source=True,
+        ),
+    ]
+
+
+def _base_overrides(experiment: Experiment, copy_uri: str, prefix_root: str) -> list[str]:
+    """Return the run-identity and pins shared by an experiment's cells and sweep.
+
+    :param experiment: Experiment supplying the task name and fixed overrides.
+    :param copy_uri: Copy-source URI appended only for copy probes.
+    :param prefix_root: R2 prefix root the run writes under.
+    :returns: Overrides common to every cell (the grid knobs are appended later).
+    """
+    overrides = [
+        f"task_name={experiment.task_name}",
+        f"r2.prefix_root={prefix_root}",
+        *experiment.fixed_overrides,
+    ]
+    if experiment.needs_copy_source:
+        overrides.append(f"copy_dataset_root_uri={copy_uri}")
+    return overrides
+
+
+def build_sweep_config(
+    experiment: Experiment,
+    copy_uri: str,
+    prefix_root: str = DEFAULT_R2_PREFIX_ROOT,
+) -> dict[str, Any]:
+    """Return a wandb grid sweep config for one experiment.
+
+    Entity/project are pinned in the config because ``wandb sweep`` ignores
+    ``WANDB_ENTITY`` / ``WANDB_PROJECT`` at sweep-creation time.
+
+    :param experiment: Experiment whose fixed overrides and grid drive the sweep.
+    :param copy_uri: Copy-source URI injected into copy probes (ignored otherwise).
+    :param prefix_root: R2 prefix root every cell writes under (isolates a run).
+    :returns: A ``wandb.sweep``-ready config dict.
+    """
+    command = [
+        "${interpreter}",
+        "${program}",
+        *_base_overrides(experiment, copy_uri, prefix_root),
+        "${args_no_hyphens}",
+    ]
+    return {
+        "program": PROGRAM,
+        "entity": ENTITY,
+        "project": PROJECT,
+        "name": f"generate_dataset_{experiment.name}_surge_xt",
+        "method": "grid",
+        # grid ignores metric at scheduling time; kept for dashboard legibility.
+        "metric": {"goal": "minimize", "name": "audio/mss_mean"},
+        "command": command,
+        "parameters": {key: {"values": values} for key, values in experiment.grid.items()},
+    }
+
+
+def expand_cells(
+    experiment: Experiment,
+    copy_uri: str,
+    prefix_root: str = DEFAULT_R2_PREFIX_ROOT,
+) -> list[list[str]]:
+    """Expand an experiment's grid into one full override list per cell.
+
+    :param experiment: Experiment to expand.
+    :param copy_uri: Copy-source URI injected into copy probes (ignored otherwise).
+    :param prefix_root: R2 prefix root every cell writes under (isolates a run).
+    :returns: One Hydra override list per Cartesian-product cell.
+    """
+    base = _base_overrides(experiment, copy_uri, prefix_root)
+    keys = list(experiment.grid)
+    cells: list[list[str]] = []
+    for combo in itertools.product(*(experiment.grid[key] for key in keys)):
+        cells.append(
+            [
+                *base,
+                *(f"{key}={value}" for key, value in zip(keys, combo)),
+            ]
+        )
+    return cells
+
+
+def _run_generate(overrides: list[str]) -> None:
+    """Run one ``generate_dataset`` invocation as a subprocess (fail-fast).
+
+    A non-zero exit raises ``subprocess.CalledProcessError`` (``check=True``).
+
+    :param overrides: Hydra override tokens for the generate run.
+    """
+    argv = [sys.executable, PROGRAM, *overrides]
+    subprocess.run(argv, check=True)  # noqa: S603 — argv built from validated literals
+
+
+def generate_reference_dataset(scale: Scale, prefix_root: str, *, dry_run: bool) -> str:
+    """Generate the copy-source dataset and return its run-root URI.
+
+    :param scale: Size knobs for the source run.
+    :param prefix_root: R2 prefix root for the source run and the derived URI.
+    :param dry_run: When true, print the command and skip execution.
+    :returns: The copy-source URI the copy probes read from.
+    """
+    overrides = reference_overrides(scale, prefix_root=prefix_root)
+    uri = reference_copy_uri(prefix_root=prefix_root)
+    if dry_run:
+        logger.info(f"[dry-run] generate copy source -> {uri}")
+        logger.info(f"[dry-run]   {' '.join(overrides)}")
+        return uri
+    logger.info(f"generating copy source -> {uri}")
+    _run_generate(overrides)
+    return uri
+
+
+def _launch_local(
+    experiment: Experiment,
+    copy_uri: str,
+    prefix_root: str,
+    *,
+    dry_run: bool,
+    count: int | None,
+) -> None:
+    """Run an experiment's grid cells as local ``generate_dataset`` subprocesses.
+
+    :param experiment: Experiment whose grid cells are run.
+    :param copy_uri: Copy-source URI injected into copy probes.
+    :param prefix_root: R2 prefix root every cell writes under.
+    :param dry_run: When true, log each cell and execute nothing.
+    :param count: Cell cap (``None`` runs every grid cell).
+    """
+    cells = expand_cells(experiment, copy_uri, prefix_root)
+    for cell in cells[:count] if count is not None else cells:
+        if dry_run:
+            logger.info(f"[dry-run] {experiment.name} cell: {' '.join(cell)}")
+            continue
+        logger.info(f"{experiment.name} cell: {' '.join(cell)}")
+        _run_generate(cell)
+
+
+def _launch_wandb(
+    experiment: Experiment,
+    copy_uri: str,
+    prefix_root: str,
+    *,
+    dry_run: bool,
+    count: int | None,
+) -> None:
+    """Create one wandb sweep for the experiment and run an agent over it.
+
+    :param experiment: Experiment whose grid drives the sweep.
+    :param copy_uri: Copy-source URI injected into copy probes.
+    :param prefix_root: R2 prefix root every cell writes under.
+    :param dry_run: When true, log the sweep config and create nothing.
+    :param count: Agent run cap (``None`` runs every grid cell).
+    """
+    config = build_sweep_config(experiment, copy_uri, prefix_root)
+    if dry_run:
+        logger.info(f"[dry-run] wandb sweep {experiment.name}: {config}")
+        return
+    sweep_id = wandb.sweep(config, entity=ENTITY, project=PROJECT)
+    logger.info(f"created sweep {experiment.name} -> {ENTITY}/{PROJECT}/{sweep_id}")
+    wandb.agent(sweep_id, entity=ENTITY, project=PROJECT, count=count)
+
+
+def run_investigation(
+    *,
+    scale: Scale,
+    launcher: str,
+    prefix_root: str,
+    only: list[str] | None,
+    dry_run: bool,
+    count: int | None,
+) -> None:
+    """Generate the copy source, then dispatch each selected experiment.
+
+    :param scale: Size knobs shared by the source and copy probes.
+    :param launcher: ``"wandb"`` (sweeps + agents) or ``"local"`` (subprocess loop).
+    :param prefix_root: R2 prefix root for the source run and copy URI.
+    :param only: Experiment names to run; ``None`` runs all five.
+    :param dry_run: When true, print the plan and execute nothing.
+    :param count: Per-experiment cell cap (``None`` runs every grid cell).
+    :raises ValueError: ``only`` names an unknown experiment.
+    """
+    experiments = build_experiments(scale)
+    by_name = {e.name: e for e in experiments}
+    if only is not None:
+        unknown = [name for name in only if name not in by_name]
+        if unknown:
+            raise ValueError(f"unknown experiment(s): {unknown}; choose from {list(by_name)}")
+        experiments = [by_name[name] for name in only]
+
+    copy_uri = generate_reference_dataset(scale, prefix_root, dry_run=dry_run)
+    for experiment in experiments:
+        if launcher == "local":
+            _launch_local(experiment, copy_uri, prefix_root, dry_run=dry_run, count=count)
+        else:
+            _launch_wandb(experiment, copy_uri, prefix_root, dry_run=dry_run, count=count)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse the orchestrator CLI arguments.
+
+    :param argv: Argument list (defaults to ``sys.argv[1:]``).
+    :returns: Parsed namespace.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--launcher",
+        choices=("wandb", "local"),
+        default="wandb",
+        help="wandb sweeps + agents (default) or a single-box subprocess loop",
+    )
+    parser.add_argument(
+        "--scale",
+        choices=("full", "smoke"),
+        default="full",
+        help="full #489 sizes (default) or a tiny end-to-end smoke run",
+    )
+    parser.add_argument(
+        "--only",
+        help="comma-separated experiment names to run (default: all five)",
+    )
+    parser.add_argument(
+        "--prefix-root",
+        default=DEFAULT_R2_PREFIX_ROOT,
+        help="R2 prefix root for the source run and derived copy URI",
+    )
+    parser.add_argument(
+        "--count",
+        type=int,
+        default=None,
+        help="per-experiment cell cap (wandb agent run cap; default: all cells)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the plan and execute nothing",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI entry: run (or plan) the #489 cadence investigation.
+
+    :param argv: Argument list (defaults to ``sys.argv[1:]``).
+    """
+    args = _parse_args(argv)
+    run_investigation(
+        scale=SMOKE if args.scale == "smoke" else FULL,
+        launcher=args.launcher,
+        prefix_root=args.prefix_root,
+        only=args.only.split(",") if args.only else None,
+        dry_run=args.dry_run,
+        count=args.count,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -432,9 +432,12 @@ def run_investigation(
     :param only: Experiment names to run; ``None`` runs all five.
     :param dry_run: When true, print the plan and execute nothing.
     :param count: Per-experiment cell cap (``None`` runs every grid cell).
-    :raises ValueError: ``only`` names an unknown experiment, or ``count`` is set
-        below 1 (a cap that would silently run no cells).
+    :raises ValueError: ``launcher`` is not ``"wandb"``/``"local"``, ``only`` names
+        an unknown experiment, or ``count`` is set below 1 (a cap that would silently
+        run no cells).
     """
+    if launcher not in ("wandb", "local"):
+        raise ValueError(f"launcher must be 'wandb' or 'local', got {launcher!r}")
     if count is not None and count < 1:
         raise ValueError(f"count must be >= 1 when set, got {count}")
     experiments = build_experiments(scale)
@@ -510,7 +513,9 @@ def main(argv: list[str] | None = None) -> None:
         scale=SMOKE if args.scale == "smoke" else FULL,
         launcher=args.launcher,
         prefix_root=args.prefix_root,
-        only=[name.strip() for name in args.only.split(",")] if args.only else None,
+        only=[name for name in (n.strip() for n in args.only.split(",")) if name]
+        if args.only
+        else None,
         dry_run=args.dry_run,
         count=args.count,
     )

--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -1,11 +1,11 @@
 """One-command orchestrator for the #489 surge_xt cadence investigation.
 
-Replaces the per-experiment sweep YAMLs with a single script that (1) generates
-the fixed surge_xt copy-source dataset, (2) derives its R2 run-root URI, and
-(3) drives the five experiments — two within-run probes (render-order shuffle,
-reuse-depth junk) and three paired-copy probes (reload cadence, gui cadence,
-reproducibility floor) — feeding the derived URI to the copy probes so nothing
-hardcodes where copies read from.
+Runs the whole investigation from one script: (1) generates the fixed surge_xt
+copy-source dataset, (2) derives its R2 run-root URI, and (3) drives the five
+experiments — two within-run probes (render-order shuffle, reuse-depth junk) and
+three paired-copy probes (reload cadence, gui cadence, reproducibility floor) —
+feeding the derived URI to the copy probes so nothing hardcodes where copies
+read from.
 
 One :class:`Scale` feeds both the source generation and the copy probes, so the
 copy-preflight match set (``param_spec_name`` / ``samples_per_shard`` /
@@ -35,7 +35,10 @@ from synth_setter.pipeline.schemas.prefix import DEFAULT_R2_PREFIX_ROOT, make_r2
 ENTITY = "tinaudio"
 PROJECT = "synth-setter"
 BUCKET = "intermediate-data"
+# wandb's ``program:`` field is a repo-relative path (the agent runs it from the
+# repo root); the local launcher uses the import path so it does not depend on cwd.
 PROGRAM = "src/synth_setter/cli/generate_dataset.py"
+_GENERATE_MODULE = "synth_setter.cli.generate_dataset"
 
 PARAM_SPEC = "surge_xt"
 PRESET = "presets/surge-base.vstpreset"
@@ -152,6 +155,9 @@ def reference_overrides(scale: Scale, prefix_root: str = DEFAULT_R2_PREFIX_ROOT)
         f"render.preset_path={PRESET}",
         _sizes_override(scale.sizes),
         f"render.samples_per_shard={scale.samples_per_shard}",
+        # The source only donates params for copy replay, so audio quality is
+        # irrelevant; accept any non-silent render rather than fail the quiet floor.
+        f"render.min_loudness={COPY_MIN_LOUDNESS}",
     ]
 
 
@@ -326,7 +332,8 @@ def _run_generate(overrides: list[str]) -> None:
 
     :param overrides: Hydra override tokens for the generate run.
     """
-    argv = [sys.executable, PROGRAM, *overrides]
+    # ``-m`` resolves the entrypoint by import, so the launcher works from any cwd.
+    argv = [sys.executable, "-m", _GENERATE_MODULE, *overrides]
     # Child inherits the ambient env (R2 creds, WANDB_MODE, PYTHONPATH).
     subprocess.run(argv, check=True)  # noqa: S603 — argv built from validated literals
 
@@ -417,8 +424,11 @@ def run_investigation(
     :param only: Experiment names to run; ``None`` runs all five.
     :param dry_run: When true, print the plan and execute nothing.
     :param count: Per-experiment cell cap (``None`` runs every grid cell).
-    :raises ValueError: ``only`` names an unknown experiment.
+    :raises ValueError: ``only`` names an unknown experiment, or ``count`` is set
+        below 1 (a cap that would silently run no cells).
     """
+    if count is not None and count < 1:
+        raise ValueError(f"count must be >= 1 when set, got {count}")
     experiments = build_experiments(scale)
     by_name = {e.name: e for e in experiments}
     if only is not None:

--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -35,8 +35,7 @@ from synth_setter.pipeline.schemas.prefix import DEFAULT_R2_PREFIX_ROOT, make_r2
 ENTITY = "tinaudio"
 PROJECT = "synth-setter"
 BUCKET = "intermediate-data"
-# wandb's ``program:`` field is a repo-relative path (the agent runs it from the
-# repo root); the local launcher uses the import path so it does not depend on cwd.
+# wandb's ``program:`` field is repo-relative; the local launcher imports by module path.
 PROGRAM = "src/synth_setter/cli/generate_dataset.py"
 _GENERATE_MODULE = "synth_setter.cli.generate_dataset"
 
@@ -84,8 +83,7 @@ class Scale:
     reuse_depths: tuple[int, ...]
 
 
-# Full #489 run: reuse depths span the junk onset (~12 reuses, #706); 80 is a
-# multiple of every depth so each cell splits into whole shards.
+# Full #489 run: reuse depths straddle the junk onset (~12 reuses, #706).
 FULL = Scale(sizes=(40, 40, 40), samples_per_shard=20, reuse_depths=(4, 20, 40, 80))
 # Smallest run that still exercises generate -> copy -> oracle for tests.
 SMOKE = Scale(sizes=(2, 2, 2), samples_per_shard=2, reuse_depths=(1, 2))

--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -27,12 +27,14 @@ import sys
 from dataclasses import dataclass
 from typing import Any
 
-import wandb
 from loguru import logger
 
+import wandb
 from synth_setter.pipeline.schemas.prefix import DEFAULT_R2_PREFIX_ROOT, make_r2_prefix
 
-ENTITY = "tinaudio"
+# Temporary: the ``tinaudio`` W&B entity does not exist yet (sweep creation 404s),
+# so runs target this working entity until #1560 stands up ``tinaudio``.
+ENTITY = "khaledtinubu-n-a"
 PROJECT = "synth-setter"
 BUCKET = "intermediate-data"
 # wandb's ``program:`` field is repo-relative; the local launcher imports by module path.

--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -76,8 +76,8 @@ class Scale:
     reuse_depths: tuple[int, ...]
 
 
-# Full #489 run: 2 shards/split at the reference, reuse depths spanning the
-# junk onset (~12 reuses, #706); 80 is a multiple of every depth.
+# Full #489 run: reuse depths span the junk onset (~12 reuses, #706); 80 is a
+# multiple of every depth so each cell splits into whole shards.
 FULL = Scale(sizes=(40, 40, 40), samples_per_shard=20, reuse_depths=(4, 20, 40, 80))
 # Smallest run that still exercises generate -> copy -> oracle for tests.
 SMOKE = Scale(sizes=(2, 2, 2), samples_per_shard=2, reuse_depths=(1, 2))
@@ -111,7 +111,7 @@ class Experiment:
     name: str
     task_name: str
     fixed_overrides: tuple[str, ...]
-    grid: dict[str, list[object]]
+    grid: dict[str, list[str | int]]
     needs_copy_source: bool = False
 
 
@@ -127,10 +127,10 @@ def reference_copy_uri(prefix_root: str = DEFAULT_R2_PREFIX_ROOT) -> str:
 
 
 def _sizes_override(sizes: tuple[int, int, int]) -> str:
-    """Return the ``train_val_test_sizes`` Hydra override token for ``sizes``.
+    """Build the Hydra override that pins the per-split sample counts.
 
-    :param sizes: Train/val/test split sizes.
-    :returns: The ``train_val_test_sizes=[...]`` override token.
+    :param sizes: Sample counts in ``(train, val, test)`` order.
+    :returns: A ``train_val_test_sizes=[...]`` token for the generate_dataset CLI.
     """
     return f"train_val_test_sizes=[{','.join(str(n) for n in sizes)}]"
 
@@ -176,10 +176,17 @@ def build_experiments(scale: Scale) -> list[Experiment]:
 
     :param scale: Size knobs threaded into split sizes and the reuse-depth grid.
     :returns: Ordered experiments — two within-run probes then three copy probes.
+    :raises ValueError: A reuse depth does not divide the largest depth, so a reuse-depth cell
+        would not split into whole shards.
     """
-    # Reuse depth is the swept samples_per_shard; sizes must be a multiple of
-    # the largest depth so every cell splits into whole shards.
+    # Reuse depth is the swept samples_per_shard; split sizes are the largest
+    # depth, so every depth must divide it for cells to split into whole shards.
     reuse_size = max(scale.reuse_depths)
+    if any(reuse_size % depth for depth in scale.reuse_depths):
+        raise ValueError(
+            f"reuse_depths {scale.reuse_depths} must all divide max {reuse_size} "
+            "so each reuse-depth cell splits into whole shards"
+        )
     return [
         Experiment(
             name="shuffle_probe",
@@ -320,6 +327,7 @@ def _run_generate(overrides: list[str]) -> None:
     :param overrides: Hydra override tokens for the generate run.
     """
     argv = [sys.executable, PROGRAM, *overrides]
+    # Child inherits the ambient env (R2 creds, WANDB_MODE, PYTHONPATH).
     subprocess.run(argv, check=True)  # noqa: S603 — argv built from validated literals
 
 
@@ -419,7 +427,12 @@ def run_investigation(
             raise ValueError(f"unknown experiment(s): {unknown}; choose from {list(by_name)}")
         experiments = [by_name[name] for name in only]
 
-    copy_uri = generate_reference_dataset(scale, prefix_root, dry_run=dry_run)
+    # The copy source is only read by copy probes; skip its (real, costly)
+    # generation when the selection is within-run probes alone.
+    if any(experiment.needs_copy_source for experiment in experiments):
+        copy_uri = generate_reference_dataset(scale, prefix_root, dry_run=dry_run)
+    else:
+        copy_uri = reference_copy_uri(prefix_root=prefix_root)
     for experiment in experiments:
         if launcher == "local":
             _launch_local(experiment, copy_uri, prefix_root, dry_run=dry_run, count=count)
@@ -430,8 +443,8 @@ def run_investigation(
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     """Parse the orchestrator CLI arguments.
 
-    :param argv: Argument list (defaults to ``sys.argv[1:]``).
-    :returns: Parsed namespace.
+    :param argv: Argument vector; ``None`` falls back to ``sys.argv[1:]``.
+    :returns: Flags for ``run_investigation`` — launcher, scale, only, prefix_root, count, dry_run.
     """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -479,7 +492,7 @@ def main(argv: list[str] | None = None) -> None:
         scale=SMOKE if args.scale == "smoke" else FULL,
         launcher=args.launcher,
         prefix_root=args.prefix_root,
-        only=args.only.split(",") if args.only else None,
+        only=[name.strip() for name in args.only.split(",")] if args.only else None,
         dry_run=args.dry_run,
         count=args.count,
     )

--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -22,12 +22,14 @@ from __future__ import annotations
 
 import argparse
 import itertools
+import os
 import subprocess
 import sys
 from dataclasses import dataclass
 from typing import Any
 
 import wandb
+import wandb.env
 from loguru import logger
 
 from synth_setter.pipeline.schemas.prefix import DEFAULT_R2_PREFIX_ROOT, make_r2_prefix
@@ -412,6 +414,10 @@ def _launch_wandb(
         return
     sweep_id = wandb.sweep(config, entity=ENTITY, project=PROJECT)
     logger.info(f"created sweep {experiment.name} -> {ENTITY}/{PROJECT}/{sweep_id}")
+    # wandb 0.26.1's Agent.is_flapping reads wandb.START_TIME, which only the legacy
+    # wandb.old.core sets, so the agent crashes with AttributeError unless flapping
+    # is disabled; the grid is already bounded by count, so flapping adds no value.
+    os.environ.setdefault(wandb.env.AGENT_DISABLE_FLAPPING, "true")
     wandb.agent(sweep_id, entity=ENTITY, project=PROJECT, count=count)
 
 

--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -51,6 +51,11 @@ REFERENCE_RUN_ID = "paired-ref-v1"
 # renders reach the oracle while only true silence (-inf) trips the floor.
 COPY_MIN_LOUDNESS = -1000.0
 
+# Fresh-param experiments occasionally sample a silent (-inf) patch, which is
+# skipped regardless of the floor; retries resample past it. Copy probes replay
+# vetted params and can't resample, so they keep the generate default of 0.
+MAX_RETRIES = 10
+
 _GENERATE_EXPERIMENT = "generate_dataset/smoke-shard-with-oracle-eval"
 # Source needs raw param shards only (copy reads same-named shards at the run
 # root), so it skips the with-oracle-eval finalize/eval the probes run.
@@ -158,6 +163,7 @@ def reference_overrides(scale: Scale, prefix_root: str = DEFAULT_R2_PREFIX_ROOT)
         # The source only donates params for copy replay, so audio quality is
         # irrelevant; accept any non-silent render rather than fail the quiet floor.
         f"render.min_loudness={COPY_MIN_LOUDNESS}",
+        f"render.max_retries={MAX_RETRIES}",
     ]
 
 
@@ -204,6 +210,7 @@ def build_experiments(scale: Scale) -> list[Experiment]:
                 "render.param_sample_cadence=shard",
                 _sizes_override(scale.sizes),
                 f"render.samples_per_shard={scale.samples_per_shard}",
+                f"render.max_retries={MAX_RETRIES}",
             ),
             grid={
                 "render.plugin_reload_cadence": ["once", "render"],
@@ -221,6 +228,7 @@ def build_experiments(scale: Scale) -> list[Experiment]:
                 "render.plugin_reload_cadence=once",
                 "render.gui_toggle_cadence=never",
                 _sizes_override((reuse_size, reuse_size, reuse_size)),
+                f"render.max_retries={MAX_RETRIES}",
             ),
             grid={"render.samples_per_shard": list(scale.reuse_depths)},
         ),

--- a/tests/integration/test_cadence_investigation_489_e2e.py
+++ b/tests/integration/test_cadence_investigation_489_e2e.py
@@ -9,8 +9,7 @@ the generate subprocess (so a non-zero exit fails the test).
 
 Asserts on real R2 state: the source shard exists, the copy probe's output shard
 exists, and the copy shard's ``param_array`` equals the source's — proving the
-derived URI was piped through and the source patches were replayed verbatim,
-which is the whole point of folding the six sweep files into one script.
+derived URI was piped through and the source patches were replayed verbatim.
 
 Gated on ``requires_vst`` (real plugin) and ``integration_r2`` (real R2); both
 auto-skip via ``conftest`` when the resources are absent. The unique prefix is
@@ -29,6 +28,7 @@ import pytest
 
 from synth_setter.data.vst.shapes import PARAM_ARRAY_FIELD
 from synth_setter.pipeline import r2_io
+from synth_setter.pipeline.schemas.prefix import make_r2_prefix
 from synth_setter.pipeline.spec_io import join_uri
 from synth_setter.tools import cadence_investigation_489 as inv
 
@@ -75,6 +75,8 @@ def test_smoke_investigation_local_replays_source_params_into_copy_probe(
     monkeypatch.setenv("WANDB_MODE", "offline")
     monkeypatch.setenv("PYTHONPATH", f"{worktree_src}:{os.environ.get('PYTHONPATH', '')}")
 
+    copy_probe = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "copy_repro")
+
     try:
         inv.main(
             [
@@ -85,7 +87,7 @@ def test_smoke_investigation_local_replays_source_params_into_copy_probe(
                 "--prefix-root",
                 prefix_root,
                 "--only",
-                "copy_repro",
+                copy_probe.name,
                 "--count",
                 "1",
             ]
@@ -95,8 +97,10 @@ def test_smoke_investigation_local_replays_source_params_into_copy_probe(
         source_shard = join_uri(source_root, _FIRST_SHARD)
         assert r2_io.object_size(source_shard) is not None, f"source shard absent: {source_shard}"
 
-        copy_root = f"r2://{inv.BUCKET}/{prefix_root}/copy-paired-repro-surge-xt/paired-repro-t1"
-        copy_shard = join_uri(copy_root, _FIRST_SHARD)
+        # --count 1 runs the first grid cell, so the run_id is the grid's first value.
+        first_run_id = str(copy_probe.grid["run_id"][0])
+        copy_prefix = make_r2_prefix(copy_probe.task_name, first_run_id, prefix_root=prefix_root)
+        copy_shard = join_uri(f"r2://{inv.BUCKET}/{copy_prefix.rstrip('/')}", _FIRST_SHARD)
         assert r2_io.object_size(copy_shard) is not None, f"copy shard absent: {copy_shard}"
 
         assert np.array_equal(_param_array(source_shard), _param_array(copy_shard)), (

--- a/tests/integration/test_cadence_investigation_489_e2e.py
+++ b/tests/integration/test_cadence_investigation_489_e2e.py
@@ -19,6 +19,7 @@ purged on teardown even when the body raises.
 from __future__ import annotations
 
 import os
+import subprocess
 import uuid
 from pathlib import Path
 
@@ -102,6 +103,86 @@ def test_smoke_investigation_local_replays_source_params_into_copy_probe(
         copy_shard = join_uri(f"r2://{inv.BUCKET}/{copy_prefix.rstrip('/')}", _FIRST_SHARD)
         assert r2_io.object_size(copy_shard) is not None, f"copy shard absent: {copy_shard}"
 
+        assert np.array_equal(_param_array(source_shard), _param_array(copy_shard)), (
+            "copy probe did not replay the source params verbatim — the derived "
+            "copy_dataset_root_uri was not piped through"
+        )
+    finally:
+        r2_io.purge_prefix(inv.BUCKET, f"{prefix_root}/")
+
+
+def _shard_count(prefix_uri: str) -> int:
+    """Count ``.h5`` shard objects under an R2 prefix via ``rclone``.
+
+    :param prefix_uri: ``r2://`` prefix to list recursively.
+    :returns: The number of ``.h5`` objects found under the prefix.
+    """
+    rclone_path = prefix_uri.replace("r2://", "r2:", 1)
+    result = subprocess.run(  # noqa: S603 — args are test-controlled literals
+        ["rclone", "lsf", "-R", "--include", "*.h5", rclone_path],  # noqa: S607
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return len([line for line in result.stdout.splitlines() if line.strip()])
+
+
+@pytest.mark.integration_r2
+@pytest.mark.r2
+@pytest.mark.requires_vst
+@pytest.mark.slow
+@pytest.mark.network
+def test_full_smoke_investigation_wandb_online_runs_every_experiment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run the full investigation at smoke size via a real wandb-online sweep + agent.
+
+    All five experiments and every grid cell run; the test asserts on real R2 state.
+
+    It creates real wandb sweeps/runs and spends real render compute, gated only by
+    the standard resource markers — ``requires_vst`` + ``integration_r2`` auto-skip
+    without the plugin / R2, and it skips inline without ``WANDB_API_KEY``. Sweeps go
+    to the ``WANDB_ENTITY`` / ``WANDB_PROJECT`` the creds can write (the script's
+    ``ENTITY`` is a temporary personal pin until #1560 stands up ``tinaudio``).
+    Source + experiment outputs land under a unique throwaway R2 prefix purged on
+    teardown; the wandb sweeps stay for review in the W&B UI.
+
+    :param monkeypatch: Forces wandb online, points the sweeps at the env's
+        entity/project, and puts the worktree ``src`` on the agents' ``PYTHONPATH``.
+    """
+    if not r2_io.is_r2_reachable():
+        pytest.skip("R2 not reachable (rclone not on PATH or `rclone lsd r2:` failed)")
+    if not os.environ.get("WANDB_API_KEY"):
+        pytest.skip("WANDB_API_KEY required for the online wandb run")
+
+    prefix_root = f"test-runs/test_full_smoke_investigation_wandb/{uuid.uuid4().hex[:12]}"
+    worktree_src = Path(__file__).resolve().parents[2] / "src"
+    monkeypatch.setenv("PYTHONPATH", f"{worktree_src}:{os.environ.get('PYTHONPATH', '')}")
+    monkeypatch.delenv("WANDB_MODE", raising=False)
+    monkeypatch.setattr(inv, "ENTITY", os.environ.get("WANDB_ENTITY", inv.ENTITY))
+    monkeypatch.setattr(inv, "PROJECT", os.environ.get("WANDB_PROJECT", inv.PROJECT))
+
+    experiments = inv.build_experiments(inv.SMOKE)
+
+    try:
+        inv.main(["--launcher", "wandb", "--scale", "smoke", "--prefix-root", prefix_root])
+
+        source_root = inv.reference_copy_uri(prefix_root=prefix_root)
+        source_shard = join_uri(source_root, _FIRST_SHARD)
+        assert r2_io.object_size(source_shard) is not None, f"source shard absent: {source_shard}"
+
+        # Every experiment's agent ran and uploaded at least one shard.
+        for exp in experiments:
+            task_prefix = f"r2://{inv.BUCKET}/{prefix_root}/{exp.task_name}"
+            assert _shard_count(task_prefix) >= 1, (
+                f"{exp.name} produced no shards under {task_prefix}"
+            )
+
+        # The repro copy probe replayed the source params verbatim (URI piped through).
+        repro = next(e for e in experiments if e.name == "copy_repro")
+        first_run_id = str(repro.grid["run_id"][0])
+        copy_prefix = make_r2_prefix(repro.task_name, first_run_id, prefix_root=prefix_root)
+        copy_shard = join_uri(f"r2://{inv.BUCKET}/{copy_prefix.rstrip('/')}", _FIRST_SHARD)
         assert np.array_equal(_param_array(source_shard), _param_array(copy_shard)), (
             "copy probe did not replay the source params verbatim — the derived "
             "copy_dataset_root_uri was not piped through"

--- a/tests/integration/test_cadence_investigation_489_e2e.py
+++ b/tests/integration/test_cadence_investigation_489_e2e.py
@@ -1,0 +1,107 @@
+"""End-to-end smoke run of the #489 cadence investigation, no mocks.
+
+Drives the real orchestrator entry point with the ``local`` launcher at
+``smoke`` scale: it generates the copy-source dataset with the **real Surge XT
+plugin**, derives its R2 URI, and runs the ``copy_repro`` probe whose cells
+replay that source. Everything is real — the plugin renders, ``rclone`` uploads
+to a unique throwaway R2 prefix, and the inline finalize + oracle eval run in
+the generate subprocess (so a non-zero exit fails the test).
+
+Asserts on real R2 state: the source shard exists, the copy probe's output shard
+exists, and the copy shard's ``param_array`` equals the source's — proving the
+derived URI was piped through and the source patches were replayed verbatim,
+which is the whole point of folding the six sweep files into one script.
+
+Gated on ``requires_vst`` (real plugin) and ``integration_r2`` (real R2); both
+auto-skip via ``conftest`` when the resources are absent. The unique prefix is
+purged on teardown even when the body raises.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from synth_setter.data.vst.shapes import PARAM_ARRAY_FIELD
+from synth_setter.pipeline import r2_io
+from synth_setter.pipeline.spec_io import join_uri
+from synth_setter.tools import cadence_investigation_489 as inv
+
+pytestmark = [
+    pytest.mark.integration_r2,
+    pytest.mark.r2,
+    pytest.mark.requires_vst,
+    pytest.mark.slow,
+]
+
+# The smoke copy-source partitions into one shard per split; shard 0 is the
+# first train shard, present under both the source and every copy run root.
+_FIRST_SHARD = "shard-000000.h5"
+
+
+def _param_array(shard_uri: str) -> np.ndarray:
+    """Download an R2 HDF5 shard and return its ``param_array`` dataset.
+
+    :param shard_uri: ``r2://`` URI of the shard object.
+    :returns: The shard's ``param_array`` as an in-memory array.
+    """
+    with r2_io.downloaded_to_tempfile(shard_uri) as local:
+        with h5py.File(local, "r") as handle:
+            params = handle[PARAM_ARRAY_FIELD]
+            assert isinstance(params, h5py.Dataset)
+            return params[:]
+
+
+def test_smoke_investigation_local_replays_source_params_into_copy_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A local smoke run generates the source and replays its params into a copy cell.
+
+    :param monkeypatch: Sets ``WANDB_MODE=offline`` and the worktree ``src`` on
+        ``PYTHONPATH`` so the generate subprocesses run offline against this code.
+    """
+    if not r2_io.is_r2_reachable():
+        pytest.skip("R2 not reachable (rclone not on PATH or `rclone lsd r2:` failed)")
+
+    prefix_root = (
+        f"test-runs/test_smoke_investigation_local_replays_source_params/{uuid.uuid4().hex[:12]}"
+    )
+    worktree_src = Path(__file__).resolve().parents[2] / "src"
+    monkeypatch.setenv("WANDB_MODE", "offline")
+    monkeypatch.setenv("PYTHONPATH", f"{worktree_src}:{os.environ.get('PYTHONPATH', '')}")
+
+    try:
+        inv.main(
+            [
+                "--launcher",
+                "local",
+                "--scale",
+                "smoke",
+                "--prefix-root",
+                prefix_root,
+                "--only",
+                "copy_repro",
+                "--count",
+                "1",
+            ]
+        )
+
+        source_root = inv.reference_copy_uri(prefix_root=prefix_root)
+        source_shard = join_uri(source_root, _FIRST_SHARD)
+        assert r2_io.object_size(source_shard), f"source shard absent: {source_shard}"
+
+        copy_root = f"r2://{inv.BUCKET}/{prefix_root}/copy-paired-repro-surge-xt/paired-repro-t1"
+        copy_shard = join_uri(copy_root, _FIRST_SHARD)
+        assert r2_io.object_size(copy_shard), f"copy shard absent: {copy_shard}"
+
+        assert np.array_equal(_param_array(source_shard), _param_array(copy_shard)), (
+            "copy probe did not replay the source params verbatim — the derived "
+            "copy_dataset_root_uri was not piped through"
+        )
+    finally:
+        r2_io.purge_prefix(inv.BUCKET, f"{prefix_root}/")

--- a/tests/integration/test_cadence_investigation_489_e2e.py
+++ b/tests/integration/test_cadence_investigation_489_e2e.py
@@ -130,7 +130,7 @@ def _shard_count(prefix_uri: str) -> int:
     """
     rclone_path = prefix_uri.replace("r2://", "r2:", 1)
     # check=True so an auth/network failure raises instead of being misreported
-    # as zero shards (empty stdout) by the callers' `>= 1` assertions.
+    # as zero shards (empty stdout) by the callers' count assertions.
     result = subprocess.run(  # noqa: S603 — args are test-controlled literals
         ["rclone", "lsf", "-R", "--include", "*.h5", rclone_path],  # noqa: S607
         capture_output=True,
@@ -138,6 +138,28 @@ def _shard_count(prefix_uri: str) -> int:
         check=True,
     )
     return len([line for line in result.stdout.splitlines() if line.strip()])
+
+
+def _expected_shards(experiment: inv.Experiment) -> int:
+    """Return the shard count every schema-valid cell of ``experiment`` should upload.
+
+    The ``gui_toggle_cadence=always_on`` cell is valid only with
+    ``plugin_reload_cadence=once``; the other always_on cell is a logged no-op that
+    uploads nothing, so it is excluded from the expected total.
+
+    :param experiment: Experiment whose cells are summed.
+    :returns: ``sum(train_val_test_sizes) // samples_per_shard`` over the valid cells.
+    """
+    total = 0
+    for cell in inv.expand_cells(experiment, copy_uri="r2://x/y", prefix_root="x"):
+        overrides = dict(tok.split("=", 1) for tok in cell if "=" in tok)
+        gui = overrides.get("render.gui_toggle_cadence")
+        reload_cadence = overrides.get("render.plugin_reload_cadence")
+        if gui == "always_on" and reload_cadence != "once":
+            continue
+        sizes = [int(n) for n in overrides["train_val_test_sizes"].strip("[]").split(",")]
+        total += sum(sizes) // int(overrides["render.samples_per_shard"])
+    return total
 
 
 # integration_r2/r2/requires_vst/slow come from the module-level pytestmark;
@@ -182,11 +204,16 @@ def test_full_smoke_investigation_wandb_online_runs_every_experiment(
         source_shard = join_uri(source_root, _FIRST_SHARD)
         assert r2_io.object_size(source_shard) is not None, f"source shard absent: {source_shard}"
 
-        # Every experiment's agent ran and uploaded at least one shard.
+        # Strict: every schema-valid cell of every experiment uploaded its shards.
+        # A swallowed agent failure (e.g. a render or always_on editor crash) leaves
+        # the count short, so a missing cell fails the test rather than passing on a
+        # partial run.
         for exp in experiments:
             task_prefix = f"r2://{inv.BUCKET}/{prefix_root}/{exp.task_name}"
-            assert _shard_count(task_prefix) >= 1, (
-                f"{exp.name} produced no shards under {task_prefix}"
+            expected = _expected_shards(exp)
+            assert _shard_count(task_prefix) == expected, (
+                f"{exp.name}: expected {expected} shards under {task_prefix}, "
+                "some cell did not produce its shards"
             )
 
         # The repro copy probe replayed the source params verbatim (URI piped through).

--- a/tests/integration/test_cadence_investigation_489_e2e.py
+++ b/tests/integration/test_cadence_investigation_489_e2e.py
@@ -39,8 +39,7 @@ pytestmark = [
     pytest.mark.slow,
 ]
 
-# The smoke copy-source partitions into one shard per split; shard 0 is the
-# first train shard, present under both the source and every copy run root.
+# shard-000000 is the first train shard, present under both the source and copy run roots.
 _FIRST_SHARD = "shard-000000.h5"
 
 

--- a/tests/integration/test_cadence_investigation_489_e2e.py
+++ b/tests/integration/test_cadence_investigation_489_e2e.py
@@ -44,6 +44,17 @@ pytestmark = [
 _FIRST_SHARD = "shard-000000.h5"
 
 
+def _prepend_pythonpath(entry: Path) -> str:
+    """Prepend ``entry`` to the inherited ``PYTHONPATH``.
+
+    :param entry: Directory to place first on the path.
+    :returns: ``PYTHONPATH`` value, joined with ``os.pathsep`` only when an existing
+        value is present so an empty inherited var never adds a CWD-equivalent entry.
+    """
+    existing = os.environ.get("PYTHONPATH", "")
+    return f"{entry}{os.pathsep}{existing}" if existing else str(entry)
+
+
 def _param_array(shard_uri: str) -> np.ndarray:
     """Download an R2 HDF5 shard and return its ``param_array`` dataset.
 
@@ -73,7 +84,7 @@ def test_smoke_investigation_local_replays_source_params_into_copy_probe(
     )
     worktree_src = Path(__file__).resolve().parents[2] / "src"
     monkeypatch.setenv("WANDB_MODE", "offline")
-    monkeypatch.setenv("PYTHONPATH", f"{worktree_src}:{os.environ.get('PYTHONPATH', '')}")
+    monkeypatch.setenv("PYTHONPATH", _prepend_pythonpath(worktree_src))
 
     copy_probe = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "copy_repro")
 
@@ -129,10 +140,8 @@ def _shard_count(prefix_uri: str) -> int:
     return len([line for line in result.stdout.splitlines() if line.strip()])
 
 
-@pytest.mark.integration_r2
-@pytest.mark.r2
-@pytest.mark.requires_vst
-@pytest.mark.slow
+# integration_r2/r2/requires_vst/slow come from the module-level pytestmark;
+# only `network` is extra to this online-sweep test.
 @pytest.mark.network
 def test_full_smoke_investigation_wandb_online_runs_every_experiment(
     monkeypatch: pytest.MonkeyPatch,
@@ -159,7 +168,7 @@ def test_full_smoke_investigation_wandb_online_runs_every_experiment(
 
     prefix_root = f"test-runs/test_full_smoke_investigation_wandb/{uuid.uuid4().hex[:12]}"
     worktree_src = Path(__file__).resolve().parents[2] / "src"
-    monkeypatch.setenv("PYTHONPATH", f"{worktree_src}:{os.environ.get('PYTHONPATH', '')}")
+    monkeypatch.setenv("PYTHONPATH", _prepend_pythonpath(worktree_src))
     monkeypatch.delenv("WANDB_MODE", raising=False)
     monkeypatch.setattr(inv, "ENTITY", os.environ.get("WANDB_ENTITY", inv.ENTITY))
     monkeypatch.setattr(inv, "PROJECT", os.environ.get("WANDB_PROJECT", inv.PROJECT))

--- a/tests/integration/test_cadence_investigation_489_e2e.py
+++ b/tests/integration/test_cadence_investigation_489_e2e.py
@@ -123,16 +123,20 @@ def test_smoke_investigation_local_replays_source_params_into_copy_probe(
 
 
 def _shard_count(prefix_uri: str) -> int:
-    """Count ``.h5`` shard objects under an R2 prefix via ``rclone``.
+    """Count ``shard-*.h5`` shard objects under an R2 prefix via ``rclone``.
+
+    Filtered to ``shard-*.h5`` so finalize's split files (``train.h5`` /
+    ``val.h5`` / ``test.h5``, also ``.h5`` under the same prefix) are excluded
+    and the count reflects shard uploads alone.
 
     :param prefix_uri: ``r2://`` prefix to list recursively.
-    :returns: The number of ``.h5`` objects found under the prefix.
+    :returns: The number of ``shard-*.h5`` objects found under the prefix.
     """
     rclone_path = prefix_uri.replace("r2://", "r2:", 1)
     # check=True so an auth/network failure raises instead of being misreported
     # as zero shards (empty stdout) by the callers' count assertions.
     result = subprocess.run(  # noqa: S603 — args are test-controlled literals
-        ["rclone", "lsf", "-R", "--include", "*.h5", rclone_path],  # noqa: S607
+        ["rclone", "lsf", "-R", "--include", "shard-*.h5", rclone_path],  # noqa: S607
         capture_output=True,
         text=True,
         check=True,

--- a/tests/integration/test_cadence_investigation_489_e2e.py
+++ b/tests/integration/test_cadence_investigation_489_e2e.py
@@ -93,11 +93,11 @@ def test_smoke_investigation_local_replays_source_params_into_copy_probe(
 
         source_root = inv.reference_copy_uri(prefix_root=prefix_root)
         source_shard = join_uri(source_root, _FIRST_SHARD)
-        assert r2_io.object_size(source_shard), f"source shard absent: {source_shard}"
+        assert r2_io.object_size(source_shard) is not None, f"source shard absent: {source_shard}"
 
         copy_root = f"r2://{inv.BUCKET}/{prefix_root}/copy-paired-repro-surge-xt/paired-repro-t1"
         copy_shard = join_uri(copy_root, _FIRST_SHARD)
-        assert r2_io.object_size(copy_shard), f"copy shard absent: {copy_shard}"
+        assert r2_io.object_size(copy_shard) is not None, f"copy shard absent: {copy_shard}"
 
         assert np.array_equal(_param_array(source_shard), _param_array(copy_shard)), (
             "copy probe did not replay the source params verbatim — the derived "

--- a/tests/integration/test_cadence_investigation_489_e2e.py
+++ b/tests/integration/test_cadence_investigation_489_e2e.py
@@ -118,11 +118,13 @@ def _shard_count(prefix_uri: str) -> int:
     :returns: The number of ``.h5`` objects found under the prefix.
     """
     rclone_path = prefix_uri.replace("r2://", "r2:", 1)
+    # check=True so an auth/network failure raises instead of being misreported
+    # as zero shards (empty stdout) by the callers' `>= 1` assertions.
     result = subprocess.run(  # noqa: S603 — args are test-controlled literals
         ["rclone", "lsf", "-R", "--include", "*.h5", rclone_path],  # noqa: S607
         capture_output=True,
         text=True,
-        check=False,
+        check=True,
     )
     return len([line for line in result.stdout.splitlines() if line.strip()])
 

--- a/tests/tools/test_cadence_investigation_489.py
+++ b/tests/tools/test_cadence_investigation_489.py
@@ -90,7 +90,7 @@ def test_expand_cells_is_the_grid_product_with_fixed_overrides_in_every_cell() -
 
     cells = inv.expand_cells(copy_gui, copy_uri=uri)
 
-    # grid is gui_toggle_cadence over three values -> three cells.
+    # copy_gui sweeps gui_toggle_cadence, so the grid product is one cell per value.
     assert len(cells) == 3
     gui_values = sorted(
         tok.split("=", 1)[1]
@@ -193,3 +193,42 @@ def test_local_count_caps_cells_run_per_experiment(monkeypatch: pytest.MonkeyPat
     # copy_reload grids two reload cadences, but --count 1 runs one cell; the
     # source generation is the other invocation.
     assert len(runs) == 2
+
+
+def test_within_run_only_selection_skips_source_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Selecting only within-run probes skips the (costly) copy-source generation.
+
+    :param monkeypatch: Records generate invocations so the absence of a source-generation run is
+        observable without spawning subprocesses.
+    """
+    runs: list[list[str]] = []
+    monkeypatch.setattr(inv, "_run_generate", lambda overrides: runs.append(overrides))
+
+    inv.main(["--launcher", "local", "--scale", "smoke", "--only", "reuse_depth"])
+
+    # reuse_depth grids two depths and needs no copy source, so only its two
+    # cells run — no run carries the reference run_id that source generation does.
+    assert len(runs) == 2
+    assert not any("run_id=paired-ref-v1" in cell for cell in runs)
+
+
+def test_unknown_only_experiment_raises_value_error() -> None:
+    """An unrecognized ``--only`` name fails fast with the valid choices listed."""
+    with pytest.raises(ValueError, match="unknown experiment"):
+        inv.run_investigation(
+            scale=inv.SMOKE,
+            launcher="local",
+            prefix_root="data",
+            only=["does_not_exist"],
+            dry_run=True,
+            count=None,
+        )
+
+
+def test_build_experiments_rejects_indivisible_reuse_depths() -> None:
+    """A reuse depth that does not divide the largest depth is rejected."""
+    bad = inv.Scale(sizes=(8, 8, 8), samples_per_shard=2, reuse_depths=(3, 8))
+    with pytest.raises(ValueError, match="must all divide"):
+        inv.build_experiments(bad)

--- a/tests/tools/test_cadence_investigation_489.py
+++ b/tests/tools/test_cadence_investigation_489.py
@@ -245,3 +245,27 @@ def test_count_below_one_raises_value_error() -> None:
             dry_run=True,
             count=0,
         )
+
+
+def test_unknown_launcher_raises_value_error() -> None:
+    """A launcher other than wandb/local fails fast instead of defaulting to wandb."""
+    with pytest.raises(ValueError, match="launcher must be"):
+        inv.run_investigation(
+            scale=inv.SMOKE,
+            launcher="remote",
+            prefix_root="data",
+            only=["copy_reload"],
+            dry_run=True,
+            count=None,
+        )
+
+
+def test_only_drops_empty_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Trailing/blank ``--only`` tokens are filtered, not surfaced as unknown names.
+
+    :param monkeypatch: Stubs generate so the run plans without spawning subprocesses.
+    """
+    monkeypatch.setattr(inv, "_run_generate", lambda overrides: None)
+
+    # Without filtering, the trailing comma would yield an "" token and raise.
+    inv.main(["--launcher", "local", "--scale", "smoke", "--only", "reuse_depth,"])

--- a/tests/tools/test_cadence_investigation_489.py
+++ b/tests/tools/test_cadence_investigation_489.py
@@ -65,8 +65,8 @@ def test_build_sweep_config_for_copy_experiment_pins_program_and_injects_uri() -
     cfg = inv.build_sweep_config(copy_reload, copy_uri=uri)
 
     assert cfg["program"] == "src/synth_setter/cli/generate_dataset.py"
-    assert cfg["entity"] == "tinaudio"
-    assert cfg["project"] == "synth-setter"
+    assert cfg["entity"] == inv.ENTITY
+    assert cfg["project"] == inv.PROJECT
     assert cfg["method"] == "grid"
     assert cfg["command"][:2] == ["${interpreter}", "${program}"]
     assert cfg["command"][-1] == "${args_no_hyphens}"

--- a/tests/tools/test_cadence_investigation_489.py
+++ b/tests/tools/test_cadence_investigation_489.py
@@ -176,6 +176,34 @@ def test_dry_run_executes_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
     inv.main(["--dry-run", "--scale", "smoke", "--launcher", "wandb"])
 
 
+def test_wandb_launch_disables_agent_flapping(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The agent runs with flapping disabled so wandb 0.26.1 cannot read its unset ``START_TIME``.
+
+    wandb 0.26.1's ``Agent.is_flapping`` references ``wandb.START_TIME``, which only
+    ``wandb.old.core`` sets, so a plain ``wandb.agent`` call crashes with
+    ``AttributeError`` unless flapping is disabled first.
+
+    :param monkeypatch: Stubs ``wandb.sweep``/``wandb.agent`` and clears the
+        flapping env var so the launcher's own setting is observed.
+    """
+    import os
+
+    import wandb.env
+
+    monkeypatch.delenv(wandb.env.AGENT_DISABLE_FLAPPING, raising=False)
+    monkeypatch.setattr(inv.wandb, "sweep", lambda *a, **k: "sweep-id")
+    seen: dict[str, str | None] = {}
+    monkeypatch.setattr(
+        inv.wandb,
+        "agent",
+        lambda *a, **k: seen.update(flapping=os.environ.get(wandb.env.AGENT_DISABLE_FLAPPING)),
+    )
+
+    inv.main(["--launcher", "wandb", "--scale", "smoke", "--only", "shuffle_probe"])
+
+    assert seen["flapping"] == "true"
+
+
 def test_local_count_caps_cells_run_per_experiment(monkeypatch: pytest.MonkeyPatch) -> None:
     """``--count`` caps how many cells each local experiment runs.
 

--- a/tests/tools/test_cadence_investigation_489.py
+++ b/tests/tools/test_cadence_investigation_489.py
@@ -1,0 +1,195 @@
+"""Unit tests for the #489 cadence-investigation orchestrator's functional core.
+
+These pin the pure plan-building behavior — the derived copy-source URI, the
+experiment set, the wandb sweep-config shape, per-cell override expansion, and
+the source/copy match-set consistency that replaces the old hardcoded
+``copy_dataset_root_uri``. The real generate -> copy -> oracle round trip is
+covered end-to-end (real plugin + real R2) in
+``tests/integration/test_cadence_investigation_489_e2e.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from synth_setter.tools import cadence_investigation_489 as inv
+
+
+def test_reference_copy_uri_default_prefix_root_matches_canonical_run_root() -> None:
+    """The derived copy-source URI equals the canonical reference run root.
+
+    This is the exact string the three paired-copy sweeps previously hardcoded, so deriving it
+    (instead of hardcoding) cannot move where copies read from.
+    """
+    assert inv.reference_copy_uri() == "r2://intermediate-data/data/ref-surge-xt-489/paired-ref-v1"
+
+
+def test_reference_copy_uri_custom_prefix_root_is_isolated_under_that_root() -> None:
+    """A non-default prefix_root relocates the whole run root under it."""
+    assert (
+        inv.reference_copy_uri(prefix_root="test-runs/abc")
+        == "r2://intermediate-data/test-runs/abc/ref-surge-xt-489/paired-ref-v1"
+    )
+
+
+def test_build_experiments_returns_two_within_run_and_three_copy_probes() -> None:
+    """The investigation is exactly five experiments; three replay the copy source."""
+    experiments = inv.build_experiments(inv.SMOKE)
+
+    names = [e.name for e in experiments]
+    assert names == [
+        "shuffle_probe",
+        "reuse_depth",
+        "copy_reload",
+        "copy_gui",
+        "copy_repro",
+    ]
+    assert [e.name for e in experiments if e.needs_copy_source] == [
+        "copy_reload",
+        "copy_gui",
+        "copy_repro",
+    ]
+
+
+def test_reuse_depth_grid_tracks_scale_reuse_depths() -> None:
+    """Reuse depth is the swept knob, so its grid is the scale's reuse depths."""
+    reuse = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "reuse_depth")
+    assert reuse.grid == {"render.samples_per_shard": [1, 2]}
+
+
+def test_build_sweep_config_for_copy_experiment_pins_program_and_injects_uri() -> None:
+    """A copy sweep's command pins the program, injects the URI, and ends with args."""
+    copy_reload = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "copy_reload")
+    uri = "r2://intermediate-data/test-runs/x/ref-surge-xt-489/paired-ref-v1"
+
+    cfg = inv.build_sweep_config(copy_reload, copy_uri=uri)
+
+    assert cfg["program"] == "src/synth_setter/cli/generate_dataset.py"
+    assert cfg["entity"] == "tinaudio"
+    assert cfg["project"] == "synth-setter"
+    assert cfg["method"] == "grid"
+    assert cfg["command"][:2] == ["${interpreter}", "${program}"]
+    assert cfg["command"][-1] == "${args_no_hyphens}"
+    assert f"copy_dataset_root_uri={uri}" in cfg["command"]
+    assert cfg["parameters"] == {"render.plugin_reload_cadence": {"values": ["once", "render"]}}
+
+
+def test_build_sweep_config_for_within_run_experiment_omits_copy_uri() -> None:
+    """A within-run sweep never carries a copy URI in its command."""
+    shuffle = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "shuffle_probe")
+
+    cfg = inv.build_sweep_config(shuffle, copy_uri=inv.reference_copy_uri())
+
+    assert not any("copy_dataset_root_uri=" in tok for tok in cfg["command"])
+
+
+def test_expand_cells_is_the_grid_product_with_fixed_overrides_in_every_cell() -> None:
+    """Each cell is the fixed overrides plus one value per gridded knob."""
+    copy_gui = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "copy_gui")
+    uri = inv.reference_copy_uri(prefix_root="test-runs/x")
+
+    cells = inv.expand_cells(copy_gui, copy_uri=uri)
+
+    # grid is gui_toggle_cadence over three values -> three cells.
+    assert len(cells) == 3
+    gui_values = sorted(
+        tok.split("=", 1)[1]
+        for cell in cells
+        for tok in cell
+        if tok.startswith("render.gui_toggle_cadence=")
+    )
+    assert gui_values == ["never", "once", "render"]
+    for cell in cells:
+        assert f"copy_dataset_root_uri={uri}" in cell
+        assert "render.param_spec_name=surge_xt" in cell
+
+
+def test_source_and_copy_experiments_agree_on_the_copy_preflight_match_set() -> None:
+    """Source-gen and every copy cell share param_spec / samples_per_shard / sizes.
+
+    Copy reads same-named shards under the source run root, so a mismatch in the match set would
+    misalign shard filenames or the param encoding. One Scale feeds both sides, so they cannot
+    drift — this asserts that invariant.
+    """
+    scale = inv.SMOKE
+    source = set(inv.reference_overrides(scale, prefix_root="data"))
+    match_keys = (
+        "render.param_spec_name",
+        "render.samples_per_shard",
+        "train_val_test_sizes",
+    )
+
+    def _pick(overrides: list[str]) -> dict[str, str]:
+        return {
+            tok.split("=", 1)[0]: tok.split("=", 1)[1]
+            for tok in overrides
+            if tok.split("=", 1)[0] in match_keys
+        }
+
+    source_match = _pick(list(source))
+    uri = inv.reference_copy_uri(prefix_root="data")
+    for exp in inv.build_experiments(scale):
+        if not exp.needs_copy_source:
+            continue
+        for cell in inv.expand_cells(exp, copy_uri=uri):
+            assert _pick(cell) == source_match, exp.name
+
+
+def test_expand_cells_threads_prefix_root_into_every_cell() -> None:
+    """A custom prefix_root lands in every cell so the whole run stays isolated."""
+    copy_gui = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "copy_gui")
+
+    cells = inv.expand_cells(
+        copy_gui,
+        copy_uri=inv.reference_copy_uri(prefix_root="test-runs/x"),
+        prefix_root="test-runs/x",
+    )
+
+    assert all("r2.prefix_root=test-runs/x" in cell for cell in cells)
+
+
+def test_build_sweep_config_threads_prefix_root_into_command() -> None:
+    """A custom prefix_root reaches the wandb sweep command too."""
+    copy_reload = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "copy_reload")
+
+    cfg = inv.build_sweep_config(
+        copy_reload, copy_uri=inv.reference_copy_uri(), prefix_root="test-runs/x"
+    )
+
+    assert "r2.prefix_root=test-runs/x" in cfg["command"]
+
+
+def test_dry_run_executes_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--dry-run`` plans only: no generate subprocess, no wandb calls.
+
+    :param monkeypatch: Replaces the subprocess and wandb entry points with a
+        sentinel that fails if dry-run ever calls them.
+    """
+
+    def _boom(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("dry-run must not execute side effects")
+
+    monkeypatch.setattr(inv.subprocess, "run", _boom)
+    monkeypatch.setattr(inv.wandb, "sweep", _boom)
+    monkeypatch.setattr(inv.wandb, "agent", _boom)
+
+    inv.main(["--dry-run", "--scale", "smoke", "--launcher", "wandb"])
+
+
+def test_local_count_caps_cells_run_per_experiment(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--count`` caps how many cells each local experiment runs.
+
+    Bounds the heavy real-render work in the e2e to one source run plus one copy
+    cell, so the orchestration cannot fan out unbounded subprocesses.
+
+    :param monkeypatch: Replaces ``_run_generate`` with a recorder so the cap is
+        observed without launching any real generate subprocess.
+    """
+    runs: list[list[str]] = []
+    monkeypatch.setattr(inv, "_run_generate", lambda overrides: runs.append(overrides))
+
+    inv.main(["--launcher", "local", "--scale", "smoke", "--only", "copy_reload", "--count", "1"])
+
+    # copy_reload grids two reload cadences, but --count 1 runs one cell; the
+    # source generation is the other invocation.
+    assert len(runs) == 2

--- a/tests/tools/test_cadence_investigation_489.py
+++ b/tests/tools/test_cadence_investigation_489.py
@@ -2,10 +2,10 @@
 
 These pin the pure plan-building behavior — the derived copy-source URI, the
 experiment set, the wandb sweep-config shape, per-cell override expansion, and
-the source/copy match-set consistency that replaces the old hardcoded
-``copy_dataset_root_uri``. The real generate -> copy -> oracle round trip is
-covered end-to-end (real plugin + real R2) in
-``tests/integration/test_cadence_investigation_489_e2e.py``.
+the source/copy match-set consistency that keeps the derived
+``copy_dataset_root_uri`` aligned across producer and consumer. The real
+generate -> copy -> oracle round trip is covered end-to-end (real plugin + real
+R2) in ``tests/integration/test_cadence_investigation_489_e2e.py``.
 """
 
 from __future__ import annotations
@@ -18,8 +18,8 @@ from synth_setter.tools import cadence_investigation_489 as inv
 def test_reference_copy_uri_default_prefix_root_matches_canonical_run_root() -> None:
     """The derived copy-source URI equals the canonical reference run root.
 
-    This is the exact string the three paired-copy sweeps previously hardcoded, so deriving it
-    (instead of hardcoding) cannot move where copies read from.
+    Deriving the URI from the reference run identity pins exactly where the paired-copy probes read
+    from.
     """
     assert inv.reference_copy_uri() == "r2://intermediate-data/data/ref-surge-xt-489/paired-ref-v1"
 
@@ -232,3 +232,16 @@ def test_build_experiments_rejects_indivisible_reuse_depths() -> None:
     bad = inv.Scale(sizes=(8, 8, 8), samples_per_shard=2, reuse_depths=(3, 8))
     with pytest.raises(ValueError, match="must all divide"):
         inv.build_experiments(bad)
+
+
+def test_count_below_one_raises_value_error() -> None:
+    """A ``--count`` below 1 fails fast instead of silently running no cells."""
+    with pytest.raises(ValueError, match="count must be >= 1"):
+        inv.run_investigation(
+            scale=inv.SMOKE,
+            launcher="local",
+            prefix_root="data",
+            only=["copy_reload"],
+            dry_run=True,
+            count=0,
+        )


### PR DESCRIPTION
## What

Replaces the six in-flight #489 PRs — one paired-copy harness (#1551) plus five
sweep YAMLs (#1545, #1546, #1553, #1555, #1556) — with a single operator script,
`python -m synth_setter.tools.cadence_investigation_489`, so the whole #489
surge_xt cadence investigation is one command.

The script:

1. Generates the fixed surge_xt copy-source dataset.
2. Derives its R2 run-root URI (asserted byte-identical to the string the old
   copy sweeps hardcoded).
3. Feeds that URI to the three paired-copy probes, and runs all five experiments
   — render-order shuffle, reuse-depth junk, paired reload/gui/repro cadence.

A single `Scale` feeds both the source generation and the copy probes, so the
copy-preflight match set (`param_spec_name` / `samples_per_shard` /
`train_val_test_sizes`) **cannot drift** between producer and consumer — the
fragility that the hardcoded `copy_dataset_root_uri` across six files invited.

## Usage

```bash
python -m synth_setter.tools.cadence_investigation_489            # wandb sweeps + agents
python -m synth_setter.tools.cadence_investigation_489 --dry-run  # print the plan only
python -m synth_setter.tools.cadence_investigation_489 --launcher local   # single-box subprocess loop
```

`--scale smoke`, `--only`, and `--count` bound a run.

## Tests

- Fast unit tests pin the plan-building core: URI derivation, the experiment
  set, sweep-config shape, grid expansion, the source↔copy match-set invariant,
  `--dry-run` side-effect freedom, the `--count` cap, and the source-skip guard.
- A `requires_vst` + `integration_r2` e2e runs the **real** investigation (real
  Surge XT plugin renders, real R2 copy round-trip to a throwaway prefix, inline
  finalize + oracle eval) and asserts the copy probe replays the source
  `param_array` verbatim — proving the derived URI is piped through, no mocks.
  Verified locally: passes end-to-end (~3 min at `--scale smoke --count 1`).

Supersedes #1545, #1546, #1551, #1553, #1555, #1556.

Refs #489
