### PR TITLE
internal-feat(ci-automation): enable OpenAI Codex plugin for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,9 +1,15 @@
 {
   "permissions": { "defaultMode": "auto" },
-  "enabledPlugins": { "tinaudio-synth-setter-skills@tinaudio-skills": true },
+  "enabledPlugins": {
+    "tinaudio-synth-setter-skills@tinaudio-skills": true,
+    "codex@openai-codex": true
+  },
   "extraKnownMarketplaces": {
     "tinaudio-skills": {
       "source": { "source": "github", "repo": "tinaudio/skills" }
+    },
+    "openai-codex": {
+      "source": { "source": "github", "repo": "openai/codex-plugin-cc" }
     }
   },
   "hooks": {

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -246,6 +246,8 @@ docs:
       - pattern: "src/synth_setter/configs/logger/many_loggers.yaml"
         covers: "Default logger compose — referenced in §4c for enable/disable workflow"
         scope: "wandb-config"
+      - pattern: ".claude/settings.json"
+        covers: "Claude Code harness config — enabledPlugins + extraKnownMarketplaces (tinaudio-skills, openai-codex), documented in §4f"
 
   # ── GitHub taxonomy ─────────────────────────────────────────────
   - doc: docs/design/github-taxonomy.md

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -407,6 +407,32 @@ If you are exercising the OCI target:
    sky check oci
    ```
 
+### 4f. Codex plugin (Optional -- Codex reviews and task delegation)
+
+The [`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc)
+plugin is enabled by default in `.claude/settings.json`, so Claude Code
+installs it on first launch. It adds review and delegation commands --
+`/codex:review`, `/codex:adversarial-review`, `/codex:rescue`,
+`/codex:status`/`result`, and `/codex:cancel` -- that run code reviews or hand
+tasks to Codex without leaving Claude Code. **You do not need it for local
+development, training, or the data pipeline.**
+
+> **Data egress.** Running any `/codex:*` command sends the relevant code and
+> context to OpenAI through the Codex CLI, exactly as invoking `codex` directly
+> would. Do not use it on code you cannot share with OpenAI.
+
+To use it:
+
+1. Ensure the `@openai/codex` CLI is on PATH (already shipped in the
+   devcontainer -- see [docker.md](reference/docker.md)) and that you have a
+   ChatGPT subscription or an `OPENAI_API_KEY`. `OPENAI_API_KEY` is a secret:
+   keep it in your `.env` alongside the other credentials (section 2e) and
+   never commit it.
+
+2. Run `/codex:setup` once to verify the CLI, authenticate, and (optionally)
+   enable the pre-response review gate. Run `/reload-plugins` first if the
+   commands do not appear.
+
 ______________________________________________________________________
 
 ## 5. Hydra Configuration System


### PR DESCRIPTION
## Summary

Enables the official OpenAI Codex Claude Code plugin
([`openai/codex-plugin-cc`](https://github.com/openai/codex-plugin-cc),
marketplace `openai-codex`, plugin `codex`) **by default for the whole
project** by wiring it into `.claude/settings.json`, mirroring the existing
`tinaudio-skills` marketplace setup. Every contributor's Claude Code session
then exposes the `/codex:*` commands — `review`, `adversarial-review`,
`rescue`, `status`/`result`, `cancel` — for running Codex code reviews or
delegating tasks to Codex without leaving Claude Code.

## Changes

- `.claude/settings.json`: add `codex@openai-codex` to `enabledPlugins` and the
  `openai-codex` marketplace (→ `openai/codex-plugin-cc`) to
  `extraKnownMarketplaces`.
- `docs/getting-started.md`: new optional **§4f** documenting the plugin, the
  `@openai/codex` CLI + OpenAI-auth prerequisites, and the one-time
  `/codex:setup`.

## Notes / caveats

- **Prerequisites.** The plugin wraps the local `@openai/codex` CLI (already
  baked into the devcontainer via #1351) and needs a ChatGPT subscription or
  `OPENAI_API_KEY`. Contributors without Codex auth will see `/codex:*` fail
  until they run `/codex:setup`; the plugin is otherwise inert and is not
  required for development, training, or the data pipeline.
- **Review-gate hooks stay off.** The plugin can install a pre-response review
  gate, but that is opt-in via `/codex:setup` — this PR does not enable it, so
  it does not interact with the repo's existing PreToolUse/Stop hook stack.
- `.agents/plugins/marketplace.json` is intentionally untouched: it declares
  *our* `tinaudio` marketplace and has no code consumer; Codex is not ours to
  publish there.

## Verification

- `make format` (full pre-commit suite) passes; JSON valid, prettier + mdformat
  clean.
- Plugin id `codex@openai-codex` and marketplace repo `openai/codex-plugin-cc`
  verified against upstream's `.claude-plugin/marketplace.json` (marketplace
  name `openai-codex`, plugin name `codex`).
- `/repo-review-full-no-comments`: 0 BLOCK, 2 WARN (config key-ordering nits,
  kept as defensible appends).

Refs #1561
