### PR TITLE
automation: warn on unmaterialized .claude symlinks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,8 @@ Architecture: [docs/architecture.md](docs/architecture.md).
   The primary checkout is read-only — `git log`, exploration, `rclone ls`.
   Never edit files there. A `SessionStart` hook
   (`agent/hooks/session-start-cwd-banner.sh`) prints a primary-vs-worktree
-  banner on startup/resume/clear/compact; a `PreToolUse` hook
+  banner on startup/resume/clear/compact (and warns when `.claude/{skills,hooks}`
+  symlinks didn't materialize, e.g. `core.symlinks=false`); a `PreToolUse` hook
   (`agent/hooks/worktree-guard.sh`) warns on Edit/Write inside the primary
   checkout (`WORKTREE_GUARD_MODE`: `warn` default / `block` / `off`); a
   `PostToolUse` hook (`agent/hooks/worktree-post-setup.sh`) automatically

--- a/agent/hooks/session-start-cwd-banner.sh
+++ b/agent/hooks/session-start-cwd-banner.sh
@@ -61,15 +61,15 @@ main() {
   fi
 
   # .claude/{skills,hooks} are committed as symlinks into the canonical agent/
-  # tree; an unmaterialized symlink (core.symlinks=false, Windows, zip export)
-  # is a plain file, so Claude discovers zero project skills. `-d` follows
-  # symlinks: a resolved link passes, only a plain/dangling file warns. Advisory.
+  # tree; an unmaterialized (core.symlinks=false, Windows, zip) or dangling link
+  # means Claude discovers zero project skills. Warn on any entry that isn't a
+  # resolved dir: -d follows symlinks, -L catches a broken link that -e misses.
   local repo_top asset asset_path
   repo_top=$(git rev-parse --show-toplevel 2>/dev/null || true)
   [[ -n "$repo_top" ]] || return 0
   for asset in skills hooks; do
     asset_path="$repo_top/.claude/$asset"
-    [[ -e "$asset_path" && ! -d "$asset_path" ]] || continue
+    [[ ( -e "$asset_path" || -L "$asset_path" ) && ! -d "$asset_path" ]] || continue
     printf '\n  WARNING: .claude/%s did not materialize as a directory — Claude skill/hook discovery is BROKEN.\n' "$asset"
     printf "    Fix: git -C '%s' config core.symlinks true && git -C '%s' checkout -- .claude\n" "$repo_top" "$repo_top"
   done

--- a/agent/hooks/session-start-cwd-banner.sh
+++ b/agent/hooks/session-start-cwd-banner.sh
@@ -59,6 +59,20 @@ main() {
     # shellcheck disable=SC2016  # backticks are literal markdown-style hint to the agent, not command substitution
     printf '  worktrees: %s active (run `git worktree list` for paths)\n' "$worktree_count"
   fi
+
+  # .claude/{skills,hooks} are committed as symlinks into the canonical agent/
+  # tree; an unmaterialized symlink (core.symlinks=false, Windows, zip export)
+  # is a plain file, so Claude discovers zero project skills. `-d` follows
+  # symlinks: a resolved link passes, only a plain/dangling file warns. Advisory.
+  local repo_top asset asset_path
+  repo_top=$(git rev-parse --show-toplevel 2>/dev/null || true)
+  [[ -n "$repo_top" ]] || return 0
+  for asset in skills hooks; do
+    asset_path="$repo_top/.claude/$asset"
+    [[ -e "$asset_path" && ! -d "$asset_path" ]] || continue
+    printf '\n  WARNING: .claude/%s did not materialize as a directory — Claude skill/hook discovery is BROKEN.\n' "$asset"
+    printf "    Fix: git -C '%s' config core.symlinks true && git -C '%s' checkout -- .claude\n" "$repo_top" "$repo_top"
+  done
 }
 
 main "$@"

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -1440,6 +1440,43 @@ T_session_start_banner_remediation_path_is_absolute_from_subdir() {
 }
 it "session-start-banner: remediation path anchored to primary_root (works from any subdir)" T_session_start_banner_remediation_path_is_absolute_from_subdir
 
+T_session_start_banner_warns_when_claude_skills_symlink_unmaterialized() {
+  # A checkout that didn't materialize symlinks (core.symlinks=false, Windows,
+  # zip export) turns .claude/skills into a plain text file holding the link
+  # target, so Claude discovers zero project skills. The banner must surface it.
+  local out
+  mkdir -p "$SANDBOX/.claude"
+  printf '../agent/skills' > "$SANDBOX/.claude/skills"
+  out=$(bash agent/hooks/session-start-cwd-banner.sh </dev/null 2>&1; echo "EXIT:$?")
+  rm -rf "$SANDBOX/.claude"
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "guard must never block (expected EXIT:0); got: $out"; return 1; }
+  [[ "$out" == *".claude/skills"* && "$out" == *"did not materialize"* ]] || {
+    echo "banner should warn that .claude/skills did not materialize; got: $out"
+    return 1
+  }
+  [[ "$out" == *"core.symlinks"* ]] || {
+    echo "warning should include the core.symlinks remediation; got: $out"
+    return 1
+  }
+}
+it "session-start-banner: .claude/skills is a plain file (symlink unmaterialized) → loud warning + core.symlinks fix, exit 0" T_session_start_banner_warns_when_claude_skills_symlink_unmaterialized
+
+T_session_start_banner_silent_when_claude_assets_materialized() {
+  # A symlink that resolves to a directory is healthy: no materialization warning.
+  local out
+  mkdir -p "$SANDBOX/.claude" "$SANDBOX/agent/skills"
+  ln -sfn ../agent/skills "$SANDBOX/.claude/skills"
+  ln -sfn ../agent/hooks "$SANDBOX/.claude/hooks"
+  out=$(bash agent/hooks/session-start-cwd-banner.sh </dev/null 2>&1; echo "EXIT:$?")
+  rm -rf "$SANDBOX/.claude" "$SANDBOX/agent/skills"
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "expected EXIT:0, got: $out"; return 1; }
+  [[ "$out" != *"did not materialize"* ]] || {
+    echo "a symlink that resolves to a directory must not warn; got: $out"
+    return 1
+  }
+}
+it "session-start-banner: .claude/{skills,hooks} resolve to directories → no materialization warning" T_session_start_banner_silent_when_claude_assets_materialized
+
 # ===========================================================================
 # pr-readiness-stop.sh — Stop-hook gate enforcement + no-op contexts
 # ===========================================================================

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -1461,6 +1461,23 @@ T_session_start_banner_warns_when_claude_skills_symlink_unmaterialized() {
 }
 it "session-start-banner: .claude/skills is a plain file (symlink unmaterialized) → loud warning + core.symlinks fix, exit 0" T_session_start_banner_warns_when_claude_skills_symlink_unmaterialized
 
+T_session_start_banner_warns_on_dangling_claude_symlink() {
+  # A symlink whose target is missing resolves nowhere and -e is false for it,
+  # so the guard must also probe -L to catch the broken link (discovery is
+  # still broken).
+  local out
+  mkdir -p "$SANDBOX/.claude"
+  ln -sfn ../agent/does-not-exist "$SANDBOX/.claude/skills"
+  out=$(bash agent/hooks/session-start-cwd-banner.sh </dev/null 2>&1; echo "EXIT:$?")
+  rm -rf "$SANDBOX/.claude"
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "guard must never block (expected EXIT:0); got: $out"; return 1; }
+  [[ "$out" == *"did not materialize"* ]] || {
+    echo "banner should warn on a dangling .claude/skills symlink; got: $out"
+    return 1
+  }
+}
+it "session-start-banner: .claude/skills is a dangling symlink → warning, exit 0" T_session_start_banner_warns_on_dangling_claude_symlink
+
 T_session_start_banner_silent_when_claude_assets_materialized() {
   # A symlink that resolves to a directory is healthy: no materialization warning.
   local out


### PR DESCRIPTION
## What

Replaces the six in-flight #489 PRs — one paired-copy harness (#1551) plus five
sweep YAMLs (#1545, #1546, #1553, #1555, #1556) — with a single operator script,
`python -m synth_setter.tools.cadence_investigation_489`, so the whole #489
surge_xt cadence investigation is one command.

The script:

1. Generates the fixed surge_xt copy-source dataset.
2. Derives its R2 run-root URI (asserted byte-identical to the string the old
   copy sweeps hardcoded).
3. Feeds that URI to the three paired-copy probes, and runs all five experiments
   — render-order shuffle, reuse-depth junk, paired reload/gui/repro cadence.

A single `Scale` feeds both the source generation and the copy probes, so the
copy-preflight match set (`param_spec_name` / `samples_per_shard` /
`train_val_test_sizes`) **cannot drift** between producer and consumer — the
fragility that the hardcoded `copy_dataset_root_uri` across six files invited.

## Usage

```bash
python -m synth_setter.tools.cadence_investigation_489            # wandb sweeps + agents
python -m synth_setter.tools.cadence_investigation_489 --dry-run  # print the plan only
python -m synth_setter.tools.cadence_investigation_489 --launcher local   # single-box subprocess loop
```

`--scale smoke`, `--only`, and `--count` bound a run.

## Tests

- Fast unit tests pin the plan-building core: URI derivation, the experiment
  set, sweep-config shape, grid expansion, the source↔copy match-set invariant,
  `--dry-run` side-effect freedom, the `--count` cap, and the source-skip guard.
- A `requires_vst` + `integration_r2` e2e runs the **real** investigation (real
  Surge XT plugin renders, real R2 copy round-trip to a throwaway prefix, inline
  finalize + oracle eval) and asserts the copy probe replays the source
  `param_array` verbatim — proving the derived URI is piped through, no mocks.
  Verified locally: passes end-to-end (~3 min at `--scale smoke --count 1`).

Supersedes #1545, #1546, #1551, #1553, #1555, #1556.

Refs #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)
