### PR TITLE
internal-feat(ci-automation): solidify Claude+Codex hook/skill parity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,7 @@ on:
       - "scripts/**"
       - "pyproject.toml"
       - "codecov.yml"
+      - "agent/hooks/**"
       - ".github/workflows/test.yml"
   pull_request:
     branches: [main, "release/*", "dev"]
@@ -21,6 +22,7 @@ on:
       - "scripts/**"
       - "pyproject.toml"
       - "codecov.yml"
+      - "agent/hooks/**"
       - ".github/workflows/test.yml"
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ on:
       - "pyproject.toml"
       - "codecov.yml"
       - "agent/hooks/**"
+      - "agent/skills/**"
       - ".github/workflows/test.yml"
   pull_request:
     branches: [main, "release/*", "dev"]
@@ -23,6 +24,7 @@ on:
       - "pyproject.toml"
       - "codecov.yml"
       - "agent/hooks/**"
+      - "agent/skills/**"
       - ".github/workflows/test.yml"
 
 jobs:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,23 @@ Python 3.10+, PyTorch Lightning, Hydra, distributed data pipeline on
 SkyPilot-managed compute (RunPod + OCI), stored in Cloudflare R2.
 Architecture: [docs/architecture.md](docs/architecture.md).
 
+## Harnesses (Claude + Codex)
+
+This file is the canonical contract for both Claude Code and the Codex CLI. The
+shared assets live under `agent/` (`hooks/`, `skills/`); `.claude/{hooks,skills}`
+symlink to them, and Codex discovers the same skills through its plugin manifest
+(`~/.codex/plugins/<marketplace>/codex/synth-setter-skills/<name>/SKILL.md`, or
+`~/.codex/skills/<name>/SKILL.md`). `agent/hooks/_lib.sh`'s `has_skill` resolves
+either layout; `tests/claude_hooks/test_skill_discovery_parity.py` keeps them
+symmetric.
+
+The one real divergence is hook enforcement. Claude's `PreToolUse` / `Stop`
+hooks can **block** an action (exit 2); Codex only observes after the fact, so
+under Codex a blocking hook runs in observe mode and the **server-side CI gate
+is the real control**. Each blocking hook's CI backstop is audited in
+[docs/reference/agent-harness-parity.md](docs/reference/agent-harness-parity.md) —
+read it before relying on a client-side block under Codex.
+
 ## Always
 
 - **Always work in an isolated git worktree.** Branch switching and stash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,11 @@ Architecture: [docs/architecture.md](docs/architecture.md).
 This file is the canonical contract for both Claude Code and the Codex CLI. The
 shared assets live under `agent/` (`hooks/`, `skills/`); `.claude/{hooks,skills}`
 symlink to them, and Codex discovers the same skills through its plugin manifest
-(`~/.codex/plugins/<marketplace>/codex/synth-setter-skills/<name>/SKILL.md`, or
-`~/.codex/skills/<name>/SKILL.md`). `agent/hooks/_lib.sh`'s `has_skill` resolves
-either layout; `tests/claude_hooks/test_skill_discovery_parity.py` keeps them
-symmetric.
+(`~/.codex/plugins/<marketplace>/codex/synth-setter-skills/<name>/SKILL.md` or
+`~/.codex/plugins/<marketplace>/skills/<name>/SKILL.md`) or the flat
+`~/.codex/skills/<name>/SKILL.md`. `agent/hooks/_lib.sh`'s `has_skill` resolves
+any of these layouts; `tests/claude_hooks/test_skill_discovery_parity.py` keeps
+them symmetric.
 
 The one real divergence is hook enforcement. Claude's `PreToolUse` / `Stop`
 hooks can **block** an action (exit 2); Codex only observes after the fact, so

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,24 +9,6 @@ Python 3.10+, PyTorch Lightning, Hydra, distributed data pipeline on
 SkyPilot-managed compute (RunPod + OCI), stored in Cloudflare R2.
 Architecture: [docs/architecture.md](docs/architecture.md).
 
-## Harnesses (Claude + Codex)
-
-This file is the canonical contract for both Claude Code and the Codex CLI. The
-shared assets live under `agent/` (`hooks/`, `skills/`); `.claude/{hooks,skills}`
-symlink to them, and Codex discovers the same skills through its plugin manifest
-(`~/.codex/plugins/<marketplace>/codex/synth-setter-skills/<name>/SKILL.md` or
-`~/.codex/plugins/<marketplace>/skills/<name>/SKILL.md`) or the flat
-`~/.codex/skills/<name>/SKILL.md`. `agent/hooks/_lib.sh`'s `has_skill` resolves
-any of these layouts; `tests/claude_hooks/test_skill_discovery_parity.py` keeps
-them symmetric.
-
-The one real divergence is hook enforcement. Claude's `PreToolUse` / `Stop`
-hooks can **block** an action (exit 2); Codex only observes after the fact, so
-under Codex a blocking hook runs in observe mode and the **server-side CI gate
-is the real control**. Each blocking hook's CI backstop is audited in
-[docs/reference/agent-harness-parity.md](docs/reference/agent-harness-parity.md) —
-read it before relying on a client-side block under Codex.
-
 ## Always
 
 - **Always work in an isolated git worktree.** Branch switching and stash

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -1840,6 +1840,61 @@ MAKE_STUB
 it "worktree-post-setup: echo with quoted 'git worktree add' — boundary guard rejects, make not called" T_wt_post_setup_quoted_substring_not_matched
 
 # ===========================================================================
+# _lib.sh has_skill — cross-harness skill discovery (#1561)
+# ===========================================================================
+# `has_skill` resolves a skill across both the Claude and Codex install
+# layouts so the same hooks work under either harness. Each test points HOME
+# at a throwaway tree and runs has_skill in a subshell sourcing _lib.sh; the
+# sandbox carries no `agent/skills/`, so only the HOME-rooted globs can match.
+
+has_skill_in_home() {
+  # Usage: has_skill_in_home <fake-home> <skill-name>
+  # Runs has_skill with HOME overridden; returns its exit code.
+  HOME="$1" bash -c 'source agent/hooks/_lib.sh; has_skill "$1"' _ "$2"
+}
+
+T_has_skill_codex_plugin_manifest_layout() {
+  local home dir
+  home="$TEST_DIR/skill-codex-mp"
+  dir="$home/.codex/plugins/tinaudio-synth-setter-skills/codex/synth-setter-skills/simplify"
+  mkdir -p "$dir"
+  printf -- '---\nname: simplify\n---\n' > "$dir/SKILL.md"
+  has_skill_in_home "$home" simplify || { echo "Codex plugin-manifest skill not resolved"; return 1; }
+}
+it "has_skill: resolves a skill installed via the Codex plugin manifest" T_has_skill_codex_plugin_manifest_layout
+
+T_has_skill_codex_skills_layout() {
+  local home dir
+  home="$TEST_DIR/skill-codex-flat"
+  dir="$home/.codex/skills/simplify"
+  mkdir -p "$dir"
+  printf -- '---\nname: simplify\n---\n' > "$dir/SKILL.md"
+  has_skill_in_home "$home" simplify || { echo "Codex ~/.codex/skills skill not resolved"; return 1; }
+}
+it "has_skill: resolves a skill under ~/.codex/skills/<name>/SKILL.md" T_has_skill_codex_skills_layout
+
+T_has_skill_claude_marketplace_layout() {
+  local home dir
+  home="$TEST_DIR/skill-claude-mp"
+  dir="$home/.claude/plugins/tinaudio-synth-setter-skills/skills/simplify"
+  mkdir -p "$dir"
+  printf -- '---\nname: simplify\n---\n' > "$dir/SKILL.md"
+  has_skill_in_home "$home" simplify || { echo "Claude marketplace skill not resolved"; return 1; }
+}
+it "has_skill: resolves a skill installed via the Claude plugin marketplace" T_has_skill_claude_marketplace_layout
+
+T_has_skill_absent_returns_nonzero() {
+  local home
+  home="$TEST_DIR/skill-empty-home"
+  mkdir -p "$home"
+  # Empty HOME and a sandbox without agent/skills/ — nothing can match.
+  if has_skill_in_home "$home" definitely-not-a-real-skill; then
+    echo "has_skill must return non-zero for an uninstalled skill"; return 1
+  fi
+}
+it "has_skill: unknown skill with no install present → non-zero" T_has_skill_absent_returns_nonzero
+
+# ===========================================================================
 # Run
 # ===========================================================================
 run_tests

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -324,6 +324,29 @@ docs:
       - pattern: ".github/workflows/test-local-launcher-roundtrip.yml"
         covers: "Fast PR-tier (~8-10 min) lane for `tests/integration/`: invokes the `synth-setter-generate-dataset` CLI entrypoint (`cli.generate_dataset.main()`, which then calls `generate()` internally) end-to-end against real R2 with the VST renderer subprocess stubbed; no kind, no sky.launch, no dev-snapshot image pull. Gated on same-repo PRs (forks skipped). Unique per-run R2 prefix + best-effort rclone purge teardown. PR #1170; tracks #1164."
 
+  # ── Agent harness parity (Claude + Codex) ───────────────────────
+  - doc: docs/reference/agent-harness-parity.md
+    description: Claude/Codex hook-enforcement divergence, per-hook CI backstops, skill-discovery parity
+    sources:
+      - pattern: "agent/hooks/_lib.sh"
+        covers: "has_skill discovery globs for the Claude marketplace and Codex plugin-manifest layouts"
+      - pattern: "agent/hooks/worktree-guard.sh"
+        covers: "WORKTREE_GUARD_MODE block/warn/off tiering (local-safety, no CI backstop)"
+      - pattern: "agent/hooks/no-baseline-additions.sh"
+        covers: "Pydoclint-baseline-row block; CI runs pydoclint but does not gate on baseline-row growth"
+      - pattern: "agent/hooks/git-commit-trailer-check.sh"
+        covers: "Co-Authored-By / attribution-trailer block; no dedicated CI gate, PR-title gitlint is the residual"
+      - pattern: "agent/hooks/no-yaml-run-comments.sh"
+        covers: "YAML run/setup block-scalar comment block; CI backstop via test-act.yaml + test_workflows_under_act.py"
+      - pattern: "agent/hooks/pre-pr-review-gate.sh"
+        covers: "Pre-PR review-sentinel gate; CI backstop via test.yml + code-quality-pr.yaml + pr-metadata-gate.yaml"
+      - pattern: "agent/hooks/pr-readiness-stop.sh"
+        covers: "Stop-gate on red CI / non-mergeable; CI backstop via branch protection + required checks"
+      - pattern: "tests/claude_hooks/test_skill_discovery_parity.py"
+        covers: "Parity assertion that every agent/skills/* resolves via both the Claude and Codex globs"
+      - pattern: "tests/infra/test_agent_hooks_suite.py"
+        covers: "Runs the full agent/hooks/test.sh bash suite in CI under a simulated Codex skill layout"
+
   # ── macOS VM provisioning (Tart) ────────────────────────────────
   - doc: docs/getting-started.md
     description: macOS VM dev-env path via Tart — prebuilt image or Packer build (§ B.3)

--- a/docs/reference/agent-harness-parity.md
+++ b/docs/reference/agent-harness-parity.md
@@ -1,0 +1,53 @@
+# Agent harness parity: Claude Code and Codex
+
+synth-setter keeps a single agent contract in [`AGENTS.md`](../../AGENTS.md) and a single set of
+shared assets under `agent/` (`hooks/`, `skills/`). `.claude/{hooks,skills}` are symlinks to that
+tree, and the Codex CLI discovers the same skills through its plugin manifest. This doc records the
+one place the two harnesses genuinely diverge — **hook enforcement** — and the server-side CI gate
+that backstops each blocking hook when the client-side block is unavailable.
+
+## Why hooks are the divergence
+
+Claude Code runs `PreToolUse` and `Stop` hooks that can **block** an action before it happens
+(exit 2). Codex observes tool use *after the fact* (its `AfterAgent` / `AfterToolUse` model) and
+relies on its sandbox + approval policy rather than a pre-execution veto. The hook scripts under
+`agent/hooks/` are provider-neutral bash and run identically under either harness; what differs is
+whether a non-zero exit *prevents* the action. So a workflow invariant must never depend solely on
+a client-side blocking hook — every blocking hook needs a server-side backstop, and that is what
+the audit below pins.
+
+The capability tier is expressed through the existing mode env-vars
+(`WORKTREE_GUARD_MODE`, `REVIEW_*_GATE`, `PR_READINESS_GATE`: `block` / `warn` / `off`), not a
+rewrite: under Codex, a `warn`-mode hook still emits its message post-hoc, and the CI gate is the
+real control.
+
+## Blocking-hook audit
+
+| Hook (event)                                       | What it blocks                                                          | Client-side mode                                                                | Server-side CI backstop                                                                                                                                                                                                                                                                                               |
+| -------------------------------------------------- | ----------------------------------------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `worktree-guard.sh` (PreToolUse Edit/Write)        | Edits inside the primary checkout                                       | `WORKTREE_GUARD_MODE` (default `warn`)                                          | None needed — every change reaches `main` only through a PR branch, so a wrong-checkout edit is caught by ordinary git/PR review, not CI. Local-safety only.                                                                                                                                                          |
+| `no-baseline-additions.sh` (PreToolUse Edit/Write) | New rows in `.pydoclint-baseline.txt`                                   | Always blocks (no mode knob)                                                    | **Partial.** `code-quality-pr.yaml` runs pydoclint on changed files and the `check_no_new_funcs_in_pydoclint_excluded.py` ratchet (#938), but neither fails on baseline-*row* growth — the baseline is an allowlist that keeps pydoclint green. This hook is the primary control; PR review is the residual backstop. |
+| `git-commit-trailer-check.sh` (PreToolUse Bash)    | `Co-Authored-By` / agent-attribution trailers                           | Always blocks (no mode knob)                                                    | **Partial.** No dedicated server-side trailer gate. Squash-merge composes the merge commit from the PR and drops per-commit trailers; `pr-metadata-gate.yaml`'s `check-pr-title` gitlint pass covers the resulting subject line.                                                                                      |
+| `no-yaml-run-comments.sh` (PreToolUse Edit/Write)  | Comments inside YAML `run:` / `setup:` block scalars                    | Always blocks (no mode knob)                                                    | **Strong.** A malformed block scalar fails the workflow at execution; `test-act.yaml` parses every workflow (`act -l` / `-n`) and `tests/infra/test_workflows_under_act.py` exercises them on each PR.                                                                                                                |
+| `pre-pr-review-gate.sh` (PreToolUse Bash)          | `gh pr create` without a fresh `/repo-review-full-no-comments` sentinel | `REVIEW_COMMENT_GATE` / `REVIEW_BLOCK_GATE` / `PR_TITLE_GATE` (default `block`) | **Strong.** This gate only front-loads findings locally. The real merge gates are `test.yml` (unit suite), `code-quality-pr.yaml` (pre-commit), `pr-metadata-gate.yaml` (linked issue + title), and Copilot review.                                                                                                   |
+| `pr-readiness-stop.sh` (Stop)                      | Ending a turn while CI is red or the PR is not `MERGEABLE`              | `PR_READINESS_GATE` (default `block`)                                           | **Strong.** Branch protection + required status checks + Copilot review gate the merge regardless of whether the local Stop hook fired; `warn` mode loses only the turn-level nag, not merge safety.                                                                                                                  |
+
+Reading the table: under Codex (observe-only), the **Strong** rows are fully covered server-side, so
+losing the client-side block costs nothing but earlier feedback. The two **Partial** rows
+(`no-baseline-additions`, `git-commit-trailer-check`) are the residual risk — there the hook is the
+primary control and human PR review is the only backstop. Adding a server-side check for either is
+tracked follow-up work, not part of this parity layer (YAGNI until a Codex user actually hits it).
+
+## Skill discovery parity
+
+`agent/hooks/_lib.sh`'s `has_skill` resolves a skill across both harness install layouts:
+
+- Claude marketplace: `~/.claude/plugins/<marketplace>/skills/<name>/SKILL.md`
+- Codex plugin manifest: `~/.codex/plugins/<marketplace>/codex/synth-setter-skills/<name>/SKILL.md`
+  or `~/.codex/plugins/<marketplace>/skills/<name>/SKILL.md`, and the flat
+  `~/.codex/skills/<name>/SKILL.md`
+
+`tests/claude_hooks/test_skill_discovery_parity.py` asserts every shipped `agent/skills/<name>`
+resolves through *both* globs, so the two stay symmetric as skills are added. The full bash hook
+suite (`agent/hooks/test.sh`) runs in CI via
+`tests/infra/test_agent_hooks_suite.py` under a simulated Codex skill layout.

--- a/tests/claude_hooks/test_skill_discovery_parity.py
+++ b/tests/claude_hooks/test_skill_discovery_parity.py
@@ -1,0 +1,141 @@
+"""Parity: every shipped skill resolves through both the Claude and Codex discovery globs.
+
+`agent/hooks/_lib.sh`'s ``has_skill`` is the single discovery point shared by the headless hooks
+(`pr-review-resolver`, `doc-drift`). #1558 taught it the Codex plugin-manifest layout alongside the
+Claude one; this test pins that the two stay symmetric — for each ``agent/skills/<name>``, a skill
+installed only via the Claude marketplace glob and one installed only via the Codex plugin-manifest
+glob are both found. The repo-relative ``agent/skills/`` fallback is deliberately sidestepped by
+running from a non-repo cwd so the install-path globs — not the source tree — are what's exercised.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_LIB = _REPO_ROOT / "agent" / "hooks" / "_lib.sh"
+_MARKETPLACE = "tinaudio-synth-setter-skills"
+
+
+def _shipped_skill_names() -> list[str]:
+    """Return every ``agent/skills/<name>`` directory that ships a ``SKILL.md``.
+
+    :returns: Sorted skill names (``_shared`` and other SKILL.md-less dirs excluded).
+    """
+    skills_dir = _REPO_ROOT / "agent" / "skills"
+    return sorted(p.parent.name for p in skills_dir.glob("*/SKILL.md"))
+
+
+_SKILL_NAMES = _shipped_skill_names()
+
+
+def _claude_skill_path(home: Path, name: str) -> Path:
+    """Path a skill occupies when installed via the Claude plugin marketplace.
+
+    :param home: Simulated ``$HOME`` install root.
+    :param name: Skill name.
+    :returns: The ``SKILL.md`` path under the Claude marketplace layout.
+    """
+    return home / ".claude" / "plugins" / _MARKETPLACE / "skills" / name / "SKILL.md"
+
+
+def _codex_skill_path(home: Path, name: str) -> Path:
+    """Path a skill occupies when installed via the Codex plugin manifest.
+
+    :param home: Simulated ``$HOME`` install root.
+    :param name: Skill name.
+    :returns: The ``SKILL.md`` path under the Codex plugin-manifest layout.
+    """
+    return (
+        home
+        / ".codex"
+        / "plugins"
+        / _MARKETPLACE
+        / "codex"
+        / "synth-setter-skills"
+        / name
+        / "SKILL.md"
+    )
+
+
+def _install(skill_file: Path) -> None:
+    """Create a minimal ``SKILL.md`` at ``skill_file``.
+
+    :param skill_file: Destination ``SKILL.md`` path (parents created).
+    """
+    skill_file.parent.mkdir(parents=True, exist_ok=True)
+    skill_file.write_text("---\nname: stub\n---\n")
+
+
+def _has_skill(name: str, home: Path, cwd: Path) -> bool:
+    """Run ``has_skill <name>`` with ``$HOME`` and cwd overridden.
+
+    cwd is a non-repo directory so ``has_skill``'s repo-relative ``agent/skills/`` lookups cannot
+    short-circuit the install-path globs under test.
+
+    :param name: Skill name to resolve.
+    :param home: Value for ``$HOME`` (the simulated install root).
+    :param cwd: Working directory to run from (outside any git repo).
+    :returns: True when ``has_skill`` exits 0.
+    """
+    result = subprocess.run(  # noqa: S603 — fixed argv, no shell string
+        ["bash", "-c", 'source "$1"; has_skill "$2"', "_", str(_LIB), name],  # noqa: S607 — bash on PATH
+        cwd=cwd,
+        env={**os.environ, "HOME": str(home)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def test_skills_are_shipped() -> None:
+    """The discovery set is non-empty, so the parity test below is not vacuously green."""
+    assert _SKILL_NAMES
+
+
+def test_uninstalled_skill_is_not_found(tmp_path: Path) -> None:
+    """With no install present, ``has_skill`` returns non-zero.
+
+    Guards the parity tests against silently passing because the repo-relative fallback (rather than
+    an install glob) matched.
+
+    :param tmp_path: Scratch dir holding an empty fake ``$HOME`` and a non-repo cwd.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    assert not _has_skill("repo-review", home, cwd)
+
+
+@pytest.mark.parametrize("name", _SKILL_NAMES)
+def test_skill_resolves_via_claude_marketplace_glob(name: str, tmp_path: Path) -> None:
+    """A skill installed only through the Claude marketplace glob is discoverable.
+
+    :param name: Shipped skill name under test.
+    :param tmp_path: Scratch dir holding both the fake ``$HOME`` and a non-repo cwd.
+    """
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _install(_claude_skill_path(home, name))
+    assert _has_skill(name, home, cwd)
+
+
+@pytest.mark.parametrize("name", _SKILL_NAMES)
+def test_skill_resolves_via_codex_plugin_manifest_glob(name: str, tmp_path: Path) -> None:
+    """A skill installed only through the Codex plugin-manifest glob is discoverable.
+
+    :param name: Shipped skill name under test.
+    :param tmp_path: Scratch dir holding both the fake ``$HOME`` and a non-repo cwd.
+    """
+    home = tmp_path / "home"
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    _install(_codex_skill_path(home, name))
+    assert _has_skill(name, home, cwd)

--- a/tests/infra/test_agent_hooks_suite.py
+++ b/tests/infra/test_agent_hooks_suite.py
@@ -9,6 +9,7 @@ install so the run reflects a Codex-shaped environment rather than only the Clau
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import subprocess
 from pathlib import Path
@@ -70,6 +71,11 @@ def test_agent_hooks_bash_suite_passes_under_codex_skill_layout(tmp_path: Path) 
     )
 
     assert result.returncode == 0, f"hook suite failed:\n{result.stdout}\n{result.stderr}"
-    # Secondary guard against a suite that exits 0 while skipping every case;
-    # coupled to test.sh's summary line, so update both together if it changes.
-    assert "FAIL: 0" in result.stdout, result.stdout
+    # Parse the summary counts rather than substring-matching "FAIL: 0": a suite
+    # that registered zero cases also prints "FAIL: 0" and exits 0, so require a
+    # positive PASS count too. Coupled to test.sh's summary lines.
+    passed = re.search(r"^PASS: (\d+)$", result.stdout, re.MULTILINE)
+    failed = re.search(r"^FAIL: (\d+)$", result.stdout, re.MULTILINE)
+    assert passed and failed, f"summary lines not found in:\n{result.stdout}"
+    assert int(failed.group(1)) == 0, result.stdout
+    assert int(passed.group(1)) > 0, f"suite registered no cases:\n{result.stdout}"

--- a/tests/infra/test_agent_hooks_suite.py
+++ b/tests/infra/test_agent_hooks_suite.py
@@ -1,0 +1,75 @@
+"""Run the bash hook suite (`agent/hooks/test.sh`) in CI under a simulated Codex skill layout.
+
+The suite is the authoritative contract for `agent/hooks/*`. Before #1561 only one
+discovery-path case ran in CI (via ``test_settings_hooks.py``); this wrapper runs the whole suite
+so every hook's exit contract is exercised on each PR, with HOME pointed at a Codex plugin-manifest
+install so the run reflects a Codex-shaped environment rather than only the Claude one.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+
+pytestmark = pytest.mark.infra
+
+# The suite spins up sandbox git repos and headless-agent stubs; give it room
+# without letting a hung child wedge the parent CI job indefinitely.
+_TIMEOUT_S = 300
+
+for _tool in ("bash", "git"):
+    if shutil.which(_tool) is None:
+        pytest.skip(f"{_tool} not on PATH", allow_module_level=True)
+
+
+def _simulate_codex_skill_layout(home: Path) -> None:
+    """Materialize a Codex plugin-manifest skill install under a throwaway ``home``.
+
+    Mirrors the discovery glob ``has_skill`` matches
+    (``~/.codex/plugins/*/codex/synth-setter-skills/<name>/SKILL.md``) so the suite runs as it would
+    on a machine onboarded through the Codex CLI.
+
+    :param home: Fake ``$HOME`` to populate.
+    """
+    skill_dir = (
+        home
+        / ".codex"
+        / "plugins"
+        / "tinaudio-synth-setter-skills"
+        / "codex"
+        / "synth-setter-skills"
+        / "simplify"
+    )
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: simplify\n---\n")
+
+
+def test_agent_hooks_bash_suite_passes_under_codex_skill_layout(tmp_path: Path) -> None:
+    """`agent/hooks/test.sh` reports zero failures when a Codex skill install is present.
+
+    :param tmp_path: Per-test scratch directory used as the simulated ``$HOME``.
+    """
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    _simulate_codex_skill_layout(fake_home)
+
+    result = subprocess.run(  # noqa: S603 — fixed argv, no shell
+        ["bash", "agent/hooks/test.sh"],  # noqa: S607 — bash on PATH, repo-relative script
+        cwd=PROJECT_ROOT,
+        env={**os.environ, "HOME": str(fake_home)},
+        capture_output=True,
+        text=True,
+        timeout=_TIMEOUT_S,
+        check=False,
+    )
+
+    assert result.returncode == 0, f"hook suite failed:\n{result.stdout}\n{result.stderr}"
+    # Secondary guard against a suite that exits 0 while skipping every case;
+    # coupled to test.sh's summary line, so update both together if it changes.
+    assert "FAIL: 0" in result.stdout, result.stdout

--- a/tests/infra/test_agent_hooks_suite.py
+++ b/tests/infra/test_agent_hooks_suite.py
@@ -12,13 +12,22 @@ import os
 import re
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
-pytestmark = pytest.mark.infra
+# The hooks target the Linux devcontainer/CI environment. The bash suite has
+# known macOS-only gaps (no GNU `timeout`/`gtimeout`; `/var`->`/private/var`
+# canonicalization breaks the primary-root-from-subdir checks), so gate the
+# wrapper to Linux — the ubuntu CI cells still exercise all cases. Making the
+# suite itself macOS-clean is separate from this #1561 parity work.
+pytestmark = [
+    pytest.mark.infra,
+    pytest.mark.skipif(sys.platform != "linux", reason="agent/hooks/test.sh is Linux-targeted"),
+]
 
 # The suite spins up sandbox git repos and headless-agent stubs; give it room
 # without letting a hung child wedge the parent CI job indefinitely.


### PR DESCRIPTION
## Summary

Phase 1 of the provider-agnostic agent harness (#1561): make the shared `agent/` contract
verifiably portable between Claude Code and the OpenAI Codex CLI. This builds directly on #1558
(which taught `has_skill` the Codex plugin manifest) and is intentionally tests + docs only — no
hook runtime behavior changes.

## What changed

- **Run the full bash hook suite in CI (Phase 1, item 1).** `tests/infra/test_agent_hooks_suite.py`
  invokes `bash agent/hooks/test.sh` under a simulated Codex skill layout (`$HOME` pointed at a
  Codex plugin-manifest install), so all 104 hook cases run on every PR instead of only the single
  discovery-path case from #1558. `test.yml`'s path filters now include `agent/hooks/**` so a hook
  change triggers the suite even when no test file is touched.
- **Codex skill-layout bash tests.** Four `T_has_skill_*` cases in `agent/hooks/test.sh` cover the
  Claude marketplace glob, the Codex plugin-manifest glob, the flat `~/.codex/skills` glob, and the
  absent-skill negative case.
- **Skill-discovery parity test (Phase 1, item 3).** `tests/claude_hooks/test_skill_discovery_parity.py`
  asserts every shipped `agent/skills/<name>` resolves through *both* the Claude and Codex globs,
  parametrized off the live skills directory. A negative control (`test_uninstalled_skill_is_not_found`)
  prevents the parity tests from passing vacuously via the repo-relative fallback.
- **Observe-mode / CI-backstop audit (Phase 1, item 2).** `docs/reference/agent-harness-parity.md`
  maps each `PreToolUse`/`Stop` blocking hook to its observe-mode behavior under Codex and the
  server-side CI gate that backstops it, honestly flagging the two hooks
  (`no-baseline-additions`, `git-commit-trailer-check`) whose CI coverage is only partial.
- **Codex onboarding in `AGENTS.md` (Phase 1, item 4).** A new "Harnesses (Claude + Codex)" section
  documents skill discovery, the block-vs-observe divergence, and that the CI gate is the real
  control under Codex.
- `docs/doc-map.yaml` maps the new reference doc to its source hooks and tests for doc-drift.

## Verification

| Check                                                                | Result         |
| -------------------------------------------------------------------- | -------------- |
| `bash agent/hooks/test.sh`                                           | PASS — 104/104 |
| `tests/infra/test_agent_hooks_suite.py`                              | PASS           |
| `tests/claude_hooks/` (incl. new parity test)                        | PASS — 198     |
| `tests/infra/test_workflows_under_act.py` (parses edited `test.yml`) | PASS           |
| `pre-commit run` on all changed files                                | PASS           |

Pre-PR review: `/repo-review-full-no-comments` — 0 BLOCK, 4 advisory WARN (all judged intentional;
the comment-hygiene `:param:`/`:returns:` suggestions are superseded by pydoclint, which mandates
them on the new linted files per AGENTS.md).

Refs #1561
