### PR TITLE
feat(data-pipeline): add LAION-CLAP embeddings to h5/wds shards

### DIFF
--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -1151,12 +1151,13 @@ The following are of interest for next steps but are out of scope for this docum
 
 Additional stages could follow the same contract (§5) without modifying existing stages:
 
-| Stage              | Input        | Output                 | Compute |
-| ------------------ | ------------ | ---------------------- | ------- |
-| **augment-reverb** | raw shards   | augmented shards       | CPU     |
-| **add-captions**   | audio shards | shards + text column   | GPU     |
-| **add-embeddings** | audio shards | shards + latent column | GPU     |
-| **render-presets** | preset bank  | audio shards           | CPU     |
+| Stage              | Input        | Output               | Compute |
+| ------------------ | ------------ | -------------------- | ------- |
+| **augment-reverb** | raw shards   | augmented shards     | CPU     |
+| **add-captions**   | audio shards | shards + text column | GPU     |
+| **render-presets** | preset bank  | audio shards         | CPU     |
+
+The **add-embeddings** stage (audio shards → shards + embedding column, GPU) is implemented in `src/synth_setter/pipeline/data/add_clap.py` (LAION-CLAP, #1571): an idempotent CLI that writes a 512-d embedding into each shard — a `clap` HDF5 dataset, or a `<key>.clap.npy` webdataset member. `laion_clap` is imported lazily and lives in the optional `embeddings` dependency-group, outside `runtime`.
 
 Stage order would remain static and explicit — user runs commands in sequence. If the number of stages grows to 4-6 and manual commands become unwieldy, adopt Prefect rather than building a homegrown orchestrator.
 

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -90,6 +90,8 @@ docs:
         covers: "Nightly + workflow_dispatch running generate-dataset with `++render.parallel=true` against real Surge XT + real R2, then validating spec + shards via `pipeline.ci.{validate_spec,validate_shard}`. Per-run unique `task_name` scopes the ephemeral R2 prefix to `data/<task_name>/<run_id>/` (preserves the `data/` invariant); always-on rclone purge on cleanup. Fills the CI gap left by the slow + requires_vst Linux Xvfb integration test."
       - pattern: "src/synth_setter/pipeline/ci/**"
         covers: "CI validation scripts, spec materialization, shard validation, and spec-URI extraction (`spec_uri.py` / `synth-setter-spec-uri`)"
+      - pattern: "src/synth_setter/pipeline/data/add_clap.py"
+        covers: "add-embeddings stage: idempotent CLI (`python -m synth_setter.pipeline.data.add_clap DATA_DIR`) writing 512-d LAION-CLAP audio embeddings into existing shards — a `clap` HDF5 dataset or a `<key>.clap.npy` webdataset member (tar rewritten in place via temp-file + atomic os.replace). Audio is downmixed to mono and resampled to 48 kHz before encoding; `laion_clap` is imported lazily behind the `ClapEmbedder` Protocol and lives in the optional `embeddings` dependency-group."
       - pattern: "src/synth_setter/pipeline/r2_io.py"
         covers: "rclone-backed R2 helpers — URI handling, download, upload, size probe; single rclone call site shared by CI validators and the worker entrypoint's skip-existing probe"
       - pattern: "src/synth_setter/pipeline/spec_io.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,13 @@ metrics = [
   "POT",
   "einops",
 ]
+# Optional, GPU-only embedding backends. Heavy (pulls a second transformers /
+# torchlibrosa stack) and gated behind a checkpoint download, so kept out of
+# `runtime`; `add_clap` imports laion_clap lazily. Install with
+# `uv sync --group embeddings` on the box that runs the embedder.
+embeddings = [
+  "laion-clap",
+]
 util = [
   "click<8.2",
   "structlog",

--- a/src/synth_setter/pipeline/data/add_clap.py
+++ b/src/synth_setter/pipeline/data/add_clap.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python
+"""Add LAION-CLAP audio embeddings to existing HDF5 or webdataset shards.
+
+CLAP expects mono audio at 48 kHz; each shard's stored audio is downmixed and
+resampled before encoding. The 512-d embedding is written back into the same
+shard — as a ``clap`` dataset for HDF5, or a ``<key>.clap.npy`` member for
+webdataset tars (rewritten in place). Both paths are idempotent: a shard that
+already carries the embedding is skipped, so a re-run only fills the gaps.
+
+The CLAP model is imported lazily (see :class:`LaionClapEmbedder`) so importing
+this module — and running its tests against an injected fake — needs neither the
+``laion_clap`` package nor a checkpoint download.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import tarfile
+from pathlib import Path
+from typing import Protocol, cast
+
+import click
+import h5py
+import librosa
+import numpy as np
+import structlog
+
+from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
+
+CLAP_FIELD = "clap"
+CLAP_SAMPLE_RATE = 48_000
+CLAP_EMBED_DIM = 512
+_AUDIO_MEMBER_SUFFIX = ".audio.npy"
+_CLAP_MEMBER_SUFFIX = ".clap.npy"
+_METADATA_MEMBER = "metadata.json"
+
+log = structlog.get_logger(__name__)
+
+
+class ClapEmbedder(Protocol):
+    """Encodes a batch of mono 48 kHz waveforms into CLAP embeddings."""
+
+    def embed(self, audio_48k_mono: np.ndarray) -> np.ndarray:
+        """Encode mono 48 kHz waveforms into CLAP embeddings.
+
+        :param audio_48k_mono: ``(B, T)`` mono audio at 48 kHz.
+        :returns: ``(B, CLAP_EMBED_DIM)`` float embeddings.
+        """
+        ...
+
+
+def to_clap_input(audio: np.ndarray, source_sr: int) -> np.ndarray:
+    """Downmix to mono and resample to CLAP's 48 kHz rate.
+
+    :param audio: Shard audio of shape ``(B, C, T)`` at ``source_sr``.
+    :param source_sr: Sample rate of ``audio`` in Hz.
+    :returns: ``(B, T')`` float32 mono audio at :data:`CLAP_SAMPLE_RATE`.
+    """
+    mono = audio.astype(np.float32).mean(axis=1)
+    if source_sr != CLAP_SAMPLE_RATE:
+        mono = librosa.resample(mono, orig_sr=source_sr, target_sr=CLAP_SAMPLE_RATE, axis=-1)
+    return np.ascontiguousarray(mono, dtype=np.float32)
+
+
+def embed_audio_batch(audio: np.ndarray, source_sr: int, embedder: ClapEmbedder) -> np.ndarray:
+    """Encode one batch of shard audio into CLAP embeddings.
+
+    :param audio: Shard audio of shape ``(B, C, T)`` at ``source_sr``.
+    :param source_sr: Sample rate of ``audio`` in Hz.
+    :param embedder: CLAP encoder applied to the mono 48 kHz batch.
+    :returns: ``(B, CLAP_EMBED_DIM)`` float32 embeddings.
+    :raises ValueError: If the embedder returns an unexpected shape.
+    """
+    clap_input = to_clap_input(audio, source_sr)
+    embeddings = np.asarray(embedder.embed(clap_input))
+    expected = (clap_input.shape[0], CLAP_EMBED_DIM)
+    if embeddings.shape != expected:
+        raise ValueError(
+            f"embedder returned {embeddings.shape}, expected {expected} (dim {CLAP_EMBED_DIM})"
+        )
+    return embeddings.astype(np.float32)
+
+
+def add_clap_to_h5(path: Path, embedder: ClapEmbedder, *, batch_size: int) -> int:
+    """Add a ``clap`` dataset to an HDF5 shard, reading the rate from ``audio.attrs``.
+
+    :param path: HDF5 shard opened read/write.
+    :param embedder: CLAP encoder.
+    :param batch_size: Rows encoded per embedder call.
+    :returns: Rows embedded, or 0 if the shard already carries the field.
+    :raises ValueError: If the audio dataset has no ``sample_rate`` attr.
+    """
+    with h5py.File(path, "r+") as f:
+        if CLAP_FIELD in f:
+            log.info("clap.h5.skip", shard=path.name, reason="field already present")
+            return 0
+        audio = cast(h5py.Dataset, f["audio"])
+        num_rows = audio.shape[0]
+        if "sample_rate" not in audio.attrs:
+            raise ValueError(f"{path.name}: audio dataset is missing the 'sample_rate' attr")
+        source_sr = int(cast(int, audio.attrs["sample_rate"]))
+        clap = f.create_dataset(CLAP_FIELD, shape=(num_rows, CLAP_EMBED_DIM), dtype=np.float32)
+        for start in range(0, num_rows, batch_size):
+            end = min(start + batch_size, num_rows)
+            clap[start:end] = embed_audio_batch(audio[start:end], source_sr, embedder)
+    log.info("clap.h5.done", shard=path.name, rows=num_rows)
+    return num_rows
+
+
+def add_clap_to_wds(path: Path, embedder: ClapEmbedder, *, batch_size: int) -> int:
+    """Rewrite a webdataset tar in place, adding a ``<key>.clap.npy`` per audio member.
+
+    :param path: Webdataset tar shard.
+    :param embedder: CLAP encoder.
+    :param batch_size: Rows encoded per embedder call.
+    :returns: Rows embedded, or 0 if the shard already carries CLAP members.
+    """
+    if _wds_has_clap(path):
+        log.info("clap.wds.skip", shard=path.name, reason="clap members already present")
+        return 0
+    source_sr = _read_wds_sample_rate(path)
+
+    rows = 0
+    tmp_path = path.with_name(path.name + ".tmp")
+    try:
+        with tarfile.open(path, "r") as src, tarfile.open(tmp_path, "w") as dst:
+            for member in src.getmembers():
+                extracted = src.extractfile(member) if member.isfile() else None
+                payload = extracted.read() if extracted is not None else b""
+                dst.addfile(member, io.BytesIO(payload))
+                if not member.name.endswith(_AUDIO_MEMBER_SUFFIX):
+                    continue
+                key = member.name[: -len(_AUDIO_MEMBER_SUFFIX)]
+                audio = np.load(io.BytesIO(payload))
+                embeddings = _embed_in_batches(audio, source_sr, embedder, batch_size)
+                _add_npy_member(dst, f"{key}{_CLAP_MEMBER_SUFFIX}", embeddings)
+                rows += audio.shape[0]
+        os.replace(tmp_path, path)
+    finally:
+        # On success os.replace consumed tmp_path; on failure remove the partial rewrite.
+        tmp_path.unlink(missing_ok=True)
+    log.info("clap.wds.done", shard=path.name, rows=rows)
+    return rows
+
+
+def add_clap_to_shard(path: Path, embedder: ClapEmbedder, *, batch_size: int) -> int:
+    """Dispatch a shard to the HDF5 or webdataset path by file suffix.
+
+    :param path: Shard path ending in ``.h5`` or ``.tar``.
+    :param embedder: CLAP encoder.
+    :param batch_size: Rows encoded per embedder call.
+    :returns: Rows embedded.
+    :raises ValueError: If the suffix is neither ``.h5`` nor ``.tar``.
+    """
+    if path.suffix == ".h5":
+        return add_clap_to_h5(path, embedder, batch_size=batch_size)
+    if path.suffix == ".tar":
+        return add_clap_to_wds(path, embedder, batch_size=batch_size)
+    raise ValueError(f"unsupported shard type {path.suffix!r}: expected .h5 or .tar")
+
+
+def _embed_in_batches(
+    audio: np.ndarray, source_sr: int, embedder: ClapEmbedder, batch_size: int
+) -> np.ndarray:
+    """Encode ``(N, C, T)`` audio in ``batch_size`` chunks.
+
+    :param audio: ``(N, C, T)`` shard audio at ``source_sr``.
+    :param source_sr: Sample rate of ``audio`` in Hz.
+    :param embedder: CLAP encoder.
+    :param batch_size: Rows per embedder call.
+    :returns: ``(N, CLAP_EMBED_DIM)`` float32 embeddings.
+    """
+    batches = [
+        embed_audio_batch(audio[start : start + batch_size], source_sr, embedder)
+        for start in range(0, audio.shape[0], batch_size)
+    ]
+    return np.concatenate(batches, axis=0)
+
+
+def _read_wds_sample_rate(path: Path) -> int:
+    """Read the shard sample rate from the tar's ``metadata.json`` member.
+
+    :param path: Webdataset tar shard.
+    :returns: Sample rate in Hz.
+    :raises ValueError: If the tar has no ``metadata.json`` member.
+    """
+    with tarfile.open(path, "r") as tar:
+        member = next(
+            (m for m in tar.getmembers() if m.isfile() and m.name == _METADATA_MEMBER), None
+        )
+        extracted = tar.extractfile(member) if member is not None else None
+        if extracted is None:
+            raise ValueError(f"{path.name}: missing {_METADATA_MEMBER}")
+        return ShardMetadata.model_validate_json(extracted.read()).sample_rate
+
+
+def _wds_has_clap(path: Path) -> bool:
+    """Whether the tar already contains any ``<key>.clap.npy`` member.
+
+    :param path: Webdataset tar shard.
+    :returns: True if any CLAP member is present.
+    """
+    with tarfile.open(path, "r") as tar:
+        return any(name.endswith(_CLAP_MEMBER_SUFFIX) for name in tar.getnames())
+
+
+def _add_npy_member(tar: tarfile.TarFile, name: str, array: np.ndarray) -> None:
+    """Append ``array`` to ``tar`` as a ``.npy`` member.
+
+    :param tar: Open tar archive in write mode.
+    :param name: Member name (e.g. ``00000000.clap.npy``).
+    :param array: Array serialized via ``numpy.save``.
+    """
+    buf = io.BytesIO()
+    np.save(buf, array)
+    info = tarfile.TarInfo(name=name)
+    info.size = buf.tell()
+    buf.seek(0)
+    tar.addfile(info, buf)
+
+
+def _build_embedder(ckpt: str | None) -> ClapEmbedder:
+    """Construct the real CLAP encoder; indirected so tests can inject a fake.
+
+    :param ckpt: CLAP checkpoint path, or None for the default general audioset model.
+    :returns: A ready-to-use CLAP encoder.
+    """
+    return LaionClapEmbedder(ckpt)
+
+
+class LaionClapEmbedder:
+    """:class:`ClapEmbedder` backed by ``laion_clap.CLAP_Module`` (general audioset)."""
+
+    def __init__(self, ckpt: str | None = None, *, enable_fusion: bool = False) -> None:
+        """Load the CLAP checkpoint (the default general audioset model when ``ckpt`` is None).
+
+        :param ckpt: Path to a CLAP checkpoint, or None for the bundled default.
+        :param enable_fusion: Whether to enable CLAP's feature-fusion variant.
+        """
+        import laion_clap  # noqa: PLC0415 — heavy optional dependency, imported on demand
+
+        self._model = laion_clap.CLAP_Module(enable_fusion=enable_fusion)
+        self._model.load_ckpt(ckpt)
+
+    def embed(self, audio_48k_mono: np.ndarray) -> np.ndarray:
+        """Encode a mono 48 kHz batch into CLAP embeddings.
+
+        :param audio_48k_mono: ``(B, T)`` mono audio at 48 kHz.
+        :returns: ``(B, CLAP_EMBED_DIM)`` float embeddings.
+        """
+        return self._model.get_audio_embedding_from_data(x=audio_48k_mono, use_tensor=False)
+
+
+@click.command()
+@click.argument("data_dir", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option("--batch-size", "-b", type=int, default=256, help="Rows encoded per CLAP call.")
+@click.option(
+    "--ckpt", type=str, default=None, help="CLAP checkpoint path (default: general audioset)."
+)
+def main(data_dir: Path, batch_size: int, ckpt: str | None) -> None:
+    """Add CLAP embeddings to every ``shard-*.h5`` / ``shard-*.tar`` under DATA_DIR.
+
+    :param data_dir: Directory of dataset shards.
+    :param batch_size: Rows encoded per CLAP call.
+    :param ckpt: CLAP checkpoint path, or None for the default general audioset model.
+    :raises click.ClickException: If no matching shards are found.
+    """
+    shards = sorted(p for p in data_dir.glob("shard-*") if p.suffix in {".h5", ".tar"})
+    if not shards:
+        raise click.ClickException(f"no shard-*.h5 or shard-*.tar found under {data_dir}")
+
+    embedder = _build_embedder(ckpt)
+    for shard in shards:
+        add_clap_to_shard(shard, embedder, batch_size=batch_size)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/pipeline/data/test_add_clap.py
+++ b/tests/pipeline/data/test_add_clap.py
@@ -1,0 +1,381 @@
+"""Behavioral tests for ``add_clap`` — the CLAP-embedding shard augmenter.
+
+The CLAP model is the one mocked boundary (it needs a GPU and a checkpoint download); every other
+path — HDF5/tar I/O, downmix/resample, the Click entrypoint — runs for real against tiny fixtures.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import tarfile
+from pathlib import Path
+from typing import cast
+
+import h5py
+import numpy as np
+import pytest
+from click.testing import CliRunner
+
+from synth_setter.pipeline.data import add_clap
+from synth_setter.pipeline.data.add_clap import (
+    CLAP_EMBED_DIM,
+    CLAP_FIELD,
+    CLAP_SAMPLE_RATE,
+)
+
+
+class FirstSampleEmbedder:
+    """Fake CLAP encoder whose embedding for each row is its first sample tiled to 512.
+
+    Deterministic and free of production logic, so a test can pin
+    ``clap[i] == <row i's first mono sample>`` without mirroring the real model.
+    """
+
+    def embed(self, audio_48k_mono: np.ndarray) -> np.ndarray:
+        """Return each row's first sample broadcast across the embedding dimension.
+
+        :param audio_48k_mono: ``(B, T)`` mono audio.
+        :returns: ``(B, CLAP_EMBED_DIM)`` embeddings.
+        """
+        first = audio_48k_mono[:, :1]
+        return np.repeat(first, CLAP_EMBED_DIM, axis=1).astype(np.float32)
+
+
+def _write_h5_shard(path: Path, row_values: list[float], *, sample_rate: int) -> None:
+    """Write an HDF5 shard whose row ``i`` is a stereo constant-valued signal.
+
+    :param path: Destination HDF5 path.
+    :param row_values: Constant value for each row's audio; length sets the row count.
+    :param sample_rate: Stored in ``audio.attrs`` for the augmenter to read.
+    """
+    audio = np.zeros((len(row_values), 2, 8), dtype=np.float16)
+    for i, value in enumerate(row_values):
+        audio[i] = value
+    with h5py.File(path, "w") as f:
+        ds = f.create_dataset("audio", data=audio)
+        ds.attrs["sample_rate"] = sample_rate
+
+
+def _write_wds_shard(
+    path: Path, key_to_values: dict[str, list[float]], *, sample_rate: int
+) -> None:
+    """Write a webdataset tar mirroring the production layout (audio/mel/param + metadata.json).
+
+    :param path: Destination tar path.
+    :param key_to_values: Per-key row values; each row is a stereo constant-valued signal.
+    :param sample_rate: Written into the ``metadata.json`` sidecar.
+    """
+    metadata = {
+        "velocity": 100,
+        "signal_duration_seconds": 1.0,
+        "sample_rate": sample_rate,
+        "channels": 2,
+        "min_loudness": -40.0,
+    }
+    with tarfile.open(path, "w") as tar:
+        for key, values in key_to_values.items():
+            audio = np.zeros((len(values), 2, 8), dtype=np.float16)
+            for i, value in enumerate(values):
+                audio[i] = value
+            _add_npy(tar, f"{key}.audio.npy", audio)
+            _add_npy(
+                tar, f"{key}.mel_spec.npy", np.zeros((len(values), 2, 4, 4), dtype=np.float32)
+            )
+            _add_npy(tar, f"{key}.param_array.npy", np.zeros((len(values), 3), dtype=np.float32))
+        _add_bytes(tar, "metadata.json", json.dumps(metadata).encode("utf-8"))
+
+
+def _add_npy(tar: tarfile.TarFile, name: str, array: np.ndarray) -> None:
+    """Append ``array`` to ``tar`` as a ``.npy`` member.
+
+    :param tar: Open tar in write mode.
+    :param name: Member name.
+    :param array: Array to serialize.
+    """
+    buf = io.BytesIO()
+    np.save(buf, array)
+    _add_bytes(tar, name, buf.getvalue())
+
+
+def _add_bytes(tar: tarfile.TarFile, name: str, data: bytes) -> None:
+    """Append raw ``data`` to ``tar`` as a member.
+
+    :param tar: Open tar in write mode.
+    :param name: Member name.
+    :param data: Raw member bytes.
+    """
+    info = tarfile.TarInfo(name=name)
+    info.size = len(data)
+    tar.addfile(info, io.BytesIO(data))
+
+
+def _read_tar_npy(path: Path, name: str) -> np.ndarray:
+    """Load a ``.npy`` member from a tar.
+
+    :param path: Tar path.
+    :param name: Member name.
+    :returns: The decoded array.
+    """
+    with tarfile.open(path, "r") as tar:
+        extracted = tar.extractfile(name)
+        assert extracted is not None
+        return np.load(io.BytesIO(extracted.read()))
+
+
+def _tar_member_names(path: Path) -> list[str]:
+    """Return the member names in a tar.
+
+    :param path: Tar path.
+    :returns: Member names in archive order.
+    """
+    with tarfile.open(path, "r") as tar:
+        return tar.getnames()
+
+
+def _read_h5(path: Path, field: str) -> np.ndarray:
+    """Read a full HDF5 dataset into memory.
+
+    :param path: HDF5 shard path.
+    :param field: Dataset name.
+    :returns: The dataset contents.
+    """
+    with h5py.File(path, "r") as f:
+        return cast(h5py.Dataset, f[field])[:]
+
+
+def test_to_clap_input_stereo_downmixed_to_mono_mean() -> None:
+    """Stereo audio collapses to the channel-wise mean."""
+    audio = np.array([[[2.0, 4.0], [6.0, 8.0]]], dtype=np.float16)  # (1, 2, 2)
+
+    out = add_clap.to_clap_input(audio, source_sr=CLAP_SAMPLE_RATE)
+
+    assert out.shape == (1, 2)
+    assert out.dtype == np.float32
+    np.testing.assert_allclose(out[0], [4.0, 6.0])
+
+
+def test_to_clap_input_resamples_to_clap_rate_changing_length() -> None:
+    """Audio below 48 kHz is resampled, lengthening the waveform proportionally."""
+    audio = np.ones((1, 1, 100), dtype=np.float16)
+
+    out = add_clap.to_clap_input(audio, source_sr=CLAP_SAMPLE_RATE // 2)
+
+    assert out.shape == (1, 200)
+
+
+def test_embed_audio_batch_returns_embedder_output_as_float32() -> None:
+    """A batch is preprocessed and encoded, returning the embedder output as float32."""
+    audio = np.full((3, 1, 8), 5.0, dtype=np.float16)
+
+    out = add_clap.embed_audio_batch(audio, CLAP_SAMPLE_RATE, FirstSampleEmbedder())
+
+    assert out.shape == (3, CLAP_EMBED_DIM)
+    assert out.dtype == np.float32
+    np.testing.assert_array_equal(out, np.full((3, CLAP_EMBED_DIM), 5.0))
+
+
+def test_embed_audio_batch_rejects_wrong_embedding_dim() -> None:
+    """An embedder returning the wrong dimension raises a ValueError naming the expected dim."""
+
+    class WrongDimEmbedder:
+        def embed(self, audio_48k_mono: np.ndarray) -> np.ndarray:
+            return np.zeros((audio_48k_mono.shape[0], CLAP_EMBED_DIM + 1), dtype=np.float32)
+
+    with pytest.raises(ValueError, match=str(CLAP_EMBED_DIM)):
+        add_clap.embed_audio_batch(
+            np.ones((2, 1, 8), dtype=np.float16), CLAP_SAMPLE_RATE, WrongDimEmbedder()
+        )
+
+
+def test_add_clap_to_h5_creates_embedding_dataset_per_row(tmp_path: Path) -> None:
+    """Each HDF5 row gets a 512-d embedding derived from its audio.
+
+    :param tmp_path: Pytest temp directory.
+    """
+    shard = tmp_path / "shard-000000.h5"
+    _write_h5_shard(shard, [0.0, 1.0, 2.0, 3.0], sample_rate=CLAP_SAMPLE_RATE)
+
+    rows = add_clap.add_clap_to_h5(shard, FirstSampleEmbedder(), batch_size=2)
+
+    clap = _read_h5(shard, CLAP_FIELD)
+    assert rows == 4
+    assert clap.shape == (4, CLAP_EMBED_DIM)
+    assert clap.dtype == np.float32
+    np.testing.assert_array_equal(clap[:, 0], [0.0, 1.0, 2.0, 3.0])
+
+
+def test_add_clap_to_h5_is_idempotent_when_field_present(tmp_path: Path) -> None:
+    """Re-running on a shard that already has the field is a no-op.
+
+    :param tmp_path: Pytest temp directory.
+    """
+    shard = tmp_path / "shard-000000.h5"
+    _write_h5_shard(shard, [0.0, 1.0], sample_rate=CLAP_SAMPLE_RATE)
+    add_clap.add_clap_to_h5(shard, FirstSampleEmbedder(), batch_size=2)
+    before = _read_h5(shard, CLAP_FIELD)
+
+    rows = add_clap.add_clap_to_h5(shard, FirstSampleEmbedder(), batch_size=2)
+
+    assert rows == 0
+    np.testing.assert_array_equal(before, _read_h5(shard, CLAP_FIELD))
+
+
+def test_add_clap_to_h5_threads_stored_sample_rate_through_resample(tmp_path: Path) -> None:
+    """A sub-48 kHz shard is resampled via its stored rate, still yielding one row per sample.
+
+    :param tmp_path: Pytest temp directory.
+    """
+    shard = tmp_path / "shard-000000.h5"
+    _write_h5_shard(shard, [1.0, 2.0, 3.0], sample_rate=CLAP_SAMPLE_RATE // 2)
+
+    rows = add_clap.add_clap_to_h5(shard, FirstSampleEmbedder(), batch_size=2)
+
+    clap = _read_h5(shard, CLAP_FIELD)
+    assert rows == 3
+    assert clap.shape == (3, CLAP_EMBED_DIM)
+    assert np.isfinite(clap).all()
+
+
+def test_add_clap_to_h5_missing_sample_rate_attr_raises(tmp_path: Path) -> None:
+    """A shard whose audio lacks the sample_rate attr fails loudly, naming the shard.
+
+    :param tmp_path: Pytest temp directory.
+    """
+    shard = tmp_path / "shard-000000.h5"
+    with h5py.File(shard, "w") as f:
+        f.create_dataset("audio", data=np.zeros((1, 2, 8), dtype=np.float16))
+
+    with pytest.raises(ValueError, match="sample_rate"):
+        add_clap.add_clap_to_h5(shard, FirstSampleEmbedder(), batch_size=2)
+
+
+def test_add_clap_to_wds_adds_clap_member_per_key(tmp_path: Path) -> None:
+    """Every tar key gains a ``<key>.clap.npy`` member matching its row count.
+
+    :param tmp_path: Pytest temp directory.
+    """
+    shard = tmp_path / "shard-000000.tar"
+    _write_wds_shard(
+        shard, {"00000000": [1.0, 2.0], "00000002": [3.0]}, sample_rate=CLAP_SAMPLE_RATE
+    )
+
+    rows = add_clap.add_clap_to_wds(shard, FirstSampleEmbedder(), batch_size=8)
+
+    first = _read_tar_npy(shard, "00000000.clap.npy")
+    second = _read_tar_npy(shard, "00000002.clap.npy")
+    assert rows == 3
+    assert first.shape == (2, CLAP_EMBED_DIM)
+    assert second.shape == (1, CLAP_EMBED_DIM)
+    np.testing.assert_array_equal(first[:, 0], [1.0, 2.0])
+    np.testing.assert_array_equal(second[:, 0], [3.0])
+
+
+def test_add_clap_to_wds_preserves_existing_members(tmp_path: Path) -> None:
+    """The rewrite keeps the original audio/mel/param/metadata members intact.
+
+    :param tmp_path: Pytest temp directory.
+    """
+    shard = tmp_path / "shard-000000.tar"
+    _write_wds_shard(shard, {"00000000": [1.0, 2.0]}, sample_rate=CLAP_SAMPLE_RATE)
+
+    add_clap.add_clap_to_wds(shard, FirstSampleEmbedder(), batch_size=8)
+
+    names = _tar_member_names(shard)
+    assert "00000000.audio.npy" in names
+    assert "00000000.mel_spec.npy" in names
+    assert "00000000.param_array.npy" in names
+    assert "metadata.json" in names
+    assert _read_tar_npy(shard, "00000000.audio.npy").shape == (2, 2, 8)
+
+
+def test_add_clap_to_wds_is_idempotent_when_member_present(tmp_path: Path) -> None:
+    """Re-running on a shard that already has CLAP members adds no duplicates.
+
+    :param tmp_path: Pytest temp directory.
+    """
+    shard = tmp_path / "shard-000000.tar"
+    _write_wds_shard(shard, {"00000000": [1.0, 2.0]}, sample_rate=CLAP_SAMPLE_RATE)
+    add_clap.add_clap_to_wds(shard, FirstSampleEmbedder(), batch_size=8)
+
+    rows = add_clap.add_clap_to_wds(shard, FirstSampleEmbedder(), batch_size=8)
+
+    assert rows == 0
+    assert _tar_member_names(shard).count("00000000.clap.npy") == 1
+
+
+def test_add_clap_to_wds_concatenates_across_batches(tmp_path: Path) -> None:
+    """A key with more rows than the batch size is embedded across batches and concatenated.
+
+    :param tmp_path: Pytest temp directory.
+    """
+    shard = tmp_path / "shard-000000.tar"
+    _write_wds_shard(shard, {"00000000": [1.0, 2.0, 3.0]}, sample_rate=CLAP_SAMPLE_RATE)
+
+    add_clap.add_clap_to_wds(shard, FirstSampleEmbedder(), batch_size=1)
+
+    clap = _read_tar_npy(shard, "00000000.clap.npy")
+    assert clap.shape == (3, CLAP_EMBED_DIM)
+    np.testing.assert_array_equal(clap[:, 0], [1.0, 2.0, 3.0])
+
+
+def test_add_clap_to_wds_missing_metadata_raises(tmp_path: Path) -> None:
+    """A tar without the metadata.json sidecar fails loudly, naming the shard.
+
+    :param tmp_path: Pytest temp directory.
+    """
+    shard = tmp_path / "shard-000000.tar"
+    with tarfile.open(shard, "w") as tar:
+        _add_npy(tar, "00000000.audio.npy", np.zeros((1, 2, 8), dtype=np.float16))
+
+    with pytest.raises(ValueError, match="metadata.json"):
+        add_clap.add_clap_to_wds(shard, FirstSampleEmbedder(), batch_size=8)
+
+
+def test_add_clap_to_shard_unsupported_suffix_raises(tmp_path: Path) -> None:
+    """A shard path that is neither .h5 nor .tar is rejected.
+
+    :param tmp_path: Pytest temp directory.
+    """
+    with pytest.raises(ValueError, match="unsupported shard type"):
+        add_clap.add_clap_to_shard(
+            tmp_path / "shard-000000.wav", FirstSampleEmbedder(), batch_size=8
+        )
+
+
+def test_cli_errors_when_no_shards_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The CLI exits non-zero when the directory has no matching shards.
+
+    :param tmp_path: Pytest temp directory.
+    :param monkeypatch: Injects the fake embedder so no real model is built.
+    """
+    monkeypatch.setattr(add_clap, "_build_embedder", lambda ckpt: FirstSampleEmbedder())
+
+    result = CliRunner().invoke(add_clap.main, [str(tmp_path)])
+
+    assert result.exit_code != 0
+    assert "no shard" in result.output
+
+
+def test_cli_adds_clap_to_every_shard_in_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CLI augments both an HDF5 and a webdataset shard under the given directory.
+
+    :param tmp_path: Pytest temp directory.
+    :param monkeypatch: Used to inject the fake embedder for the heavy CLAP model.
+    """
+    _write_h5_shard(tmp_path / "shard-000000.h5", [1.0, 2.0], sample_rate=CLAP_SAMPLE_RATE)
+    _write_wds_shard(
+        tmp_path / "shard-000001.tar", {"00000000": [3.0]}, sample_rate=CLAP_SAMPLE_RATE
+    )
+    monkeypatch.setattr(add_clap, "_build_embedder", lambda ckpt: FirstSampleEmbedder())
+
+    result = CliRunner().invoke(add_clap.main, [str(tmp_path)])
+
+    assert result.exit_code == 0, result.output
+    assert _read_h5(tmp_path / "shard-000000.h5", CLAP_FIELD).shape == (2, CLAP_EMBED_DIM)
+    assert _read_tar_npy(tmp_path / "shard-000001.tar", "00000000.clap.npy").shape == (
+        1,
+        CLAP_EMBED_DIM,
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1960,6 +1960,18 @@ http = [
 ]
 
 [[package]]
+name = "ftfy"
+version = "6.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/d3/8650919bc3c7c6e90ee3fa7fd618bf373cbbe55dff043bd67353dbb20cd8/ftfy-6.3.1.tar.gz", hash = "sha256:9b3c3d90f84fb267fe64d375a07b7f8912d817cf86009ae134aa03e1819506ec", size = 308927, upload-time = "2024-10-26T00:50:35.149Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/6e/81d47999aebc1b155f81eca4477a616a70f238a2549848c38983f3c22a82/ftfy-6.3.1-py3-none-any.whl", hash = "sha256:7c70eb532015cd2f9adb53f101fb6c7945988d023a085d127d1573dc49dd0083", size = 44821, upload-time = "2024-10-26T00:50:33.425Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2210,6 +2222,30 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/9b/6912c99070915a4f28119e3c5b52a9abd1eec0ad5cb293b8c967a0c6f5a2/hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c", size = 4023383, upload-time = "2026-05-06T06:17:53.947Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6d/9563cfde59b5d8128a9c7ec972a087f4c782e4f7bac5a85234edfd5d5e49/hf_xet-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42", size = 3792751, upload-time = "2026-05-06T06:17:51.791Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a5/ed5a0cf35b49a0571af5a8f53416dad1877a718c021c9937c3a53cb45781/hf_xet-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a", size = 4456058, upload-time = "2026-05-06T06:17:40.735Z" },
+    { url = "https://files.pythonhosted.org/packages/60/fb/3ae8bf2a7a37a4197d0195d7247fd25b3952e15cb8a599e285dfaa6f52b3/hf_xet-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480", size = 4250783, upload-time = "2026-05-06T06:17:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/8bae40d4d91525085137196e84eb0ed49cf65b5e96e5c3ecdadd8bd0fac2/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216", size = 4445594, upload-time = "2026-05-06T06:18:04.219Z" },
+    { url = "https://files.pythonhosted.org/packages/13/59/c74efbbd4e8728172b2cc72a2bc014d2947a4b7bdced932fbd3f5da1a4e5/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60", size = 4663995, upload-time = "2026-05-06T06:18:06.1Z" },
+    { url = "https://files.pythonhosted.org/packages/73/32/8e1e0410af64cda9b139d1dcebdc993a8ff9c8c7c0e2696ae356d75ccc0d/hf_xet-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d", size = 3966608, upload-time = "2026-05-06T06:18:19.74Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/34/a8febc8f4edbea8b3e21b02ebc8b628679b84ba7e45cde624a7736b51500/hf_xet-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4", size = 3796946, upload-time = "2026-05-06T06:18:17.568Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fb/69ff198a82cae7eb1a69fb84d93b3a3e4816564d76817fe541ddc96874eb/hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56", size = 4030814, upload-time = "2026-05-06T06:17:57.933Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/edcc2b40162bef3ff78e14ab637e5f3b89243d6aee72f5949d3bb6a5af83/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a", size = 3798444, upload-time = "2026-05-06T06:17:55.79Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4d/103f76b04310e5e57656696cc184690d20c466af0bca3ca88f8c8ea5d4f3/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949", size = 4465986, upload-time = "2026-05-06T06:17:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a2/546f47f464737b3edbab6f8ddb57f2599b93d2cbb66f06abb475ccb48651/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b", size = 4259865, upload-time = "2026-05-06T06:17:42.639Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7f/1be593c1f28613be2e196473481cd81bfc5910795e30a34e8f744f6cac4f/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18", size = 4459835, upload-time = "2026-05-06T06:18:08.026Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
+    { url = "https://files.pythonhosted.org/packages/af/37/1b6def445c567286b50aa3b33828158e135b1be44938dde59f11382a500c/hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4", size = 3977238, upload-time = "2026-05-06T06:18:23.621Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/3b66b148778ee100dcfd69c2ca22b57b41b44d3063ceec934f209e9184ce/hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be", size = 3806916, upload-time = "2026-05-06T06:18:21.7Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2271,6 +2307,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
 ]
 
 [[package]]
@@ -2650,6 +2706,36 @@ dependencies = [
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/b1/28bad41e1d44e6f085c5e59d921824e0b2bcaea5b2bdebe4d1647c9e5841/kymatio-0.3.0-py3-none-any.whl", hash = "sha256:e517113bc98a52795144eb80549f0686ee8a57dbbd9839b935f10dbceba0ec6b", size = 87598, upload-time = "2022-09-05T07:24:49.079Z" },
+]
+
+[[package]]
+name = "laion-clap"
+version = "1.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "braceexpand" },
+    { name = "ftfy" },
+    { name = "h5py" },
+    { name = "librosa" },
+    { name = "llvmlite" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "progressbar" },
+    { name = "regex" },
+    { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "scipy" },
+    { name = "soundfile" },
+    { name = "torchlibrosa" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "wandb" },
+    { name = "webdataset" },
+    { name = "wget" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/a9/5ffb0794d8faefa159505b51654cd2db360582625afc61ded0d5eecbc197/laion_clap-1.1.5.tar.gz", hash = "sha256:ad390c34dd1edc68b2406486630edbe8fb1bf9307fdd0f8308a5f2579db143e7", size = 1478277, upload-time = "2024-07-09T00:55:46.633Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/5e/c26fa4892830eea6b4694afd0c31b0c678cfd058c5e26aea48270cd8fcf4/laion_clap-1.1.5-py3-none-any.whl", hash = "sha256:7f7b277600ff3705bc5f597670b740ba191864284ca3ce9fbbc71c344f985d4b", size = 1498740, upload-time = "2024-07-09T00:55:43.887Z" },
 ]
 
 [[package]]
@@ -4423,6 +4509,12 @@ wheels = [
 ]
 
 [[package]]
+name = "progressbar"
+version = "2.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/a6/b8e451f6cff1c99b4747a2f7235aa904d2d49e8e1464e0b798272aa84358/progressbar-2.5.tar.gz", hash = "sha256:5d81cb529da2e223b53962afd6c8ca0f05c6670e40309a7219eacc36af9b6c63", size = 10046, upload-time = "2018-06-29T02:32:00.222Z" }
+
+[[package]]
 name = "prometheus-client"
 version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5238,6 +5330,95 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ed/0ad2c8edf634918eb4484365d3819fa7bd7f58daf807fe7fb21812c316e5/regex-2026.5.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a9e1328e17c84c1a5d22ec9f785ecef4a967fab9a42b6a8dc3bcbebd0a0c9e44", size = 489438, upload-time = "2026-05-09T23:11:29.374Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a9/4ed972ad263963b860b7c3e86e0e1bcc791def47b43b8c8efe57e710f139/regex-2026.5.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bfe1ce50cbfb569d74e1e4337da6468961f31dbea55fd85aa5de59c0947a805a", size = 291270, upload-time = "2026-05-09T23:11:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/16/81/075930d9fa28c4ea1f53398dd015ee7c882f623539759113cda1257f4b82/regex-2026.5.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:15ee42209947f4ca045412eae98416317238163618ace2a8e54f99586a466733", size = 289198, upload-time = "2026-05-09T23:11:35.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/c8/5cdfbf0b5dc6599e1b6131eff43262e5275d4ec3469ce10216061659aadb/regex-2026.5.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4bb445ff3f725f59df8f6014edb547ee928ec7023a774f6a39a3f953038cbb2", size = 784765, upload-time = "2026-05-09T23:11:37.689Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ca/ae5fd6edc59b7f84b904b31d6ec39a860cbcecd10f64bd5a062ca83a4864/regex-2026.5.9-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:446ddd671e43ab535810c4b21cff7104945c701d4a14d1e6d1cd6f4e445a8bea", size = 852115, upload-time = "2026-05-09T23:11:39.973Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ce/a91cf555afb51f3b74a182e24ba073b91ea7bb64592fc4b315c111bb19fd/regex-2026.5.9-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b92817338591505f282cf3864c145244b1edcf5381d237038df955001091538", size = 899503, upload-time = "2026-05-09T23:11:42.48Z" },
+    { url = "https://files.pythonhosted.org/packages/55/7f/725a0a2b245a4cf0c4bab29d0e97c74285d94136a65d1b55a6459a583502/regex-2026.5.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6b8a143aca6c39b446ea8092cde25cc8fe9304d4f5fecfbc1a9dbb0282703c2", size = 794093, upload-time = "2026-05-09T23:11:44.681Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2a/996efbd59ce6b5d4a09e3af6180ceb62af171f4a9a6fb557d2f0ae0d462b/regex-2026.5.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0f03aa6898aaaac4592479821df16e68e8d0e29e903e65d8f2dfb2f19028a989", size = 786234, upload-time = "2026-05-09T23:11:46.882Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/0a/8731e8b8806174c9cdd5903f80a14990331c1f42fc4209b540952e9e010d/regex-2026.5.9-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ed457d8e98ae812ed7732bef7bf78de78e834eae0372a74e23ca90ef21d910f9", size = 769895, upload-time = "2026-05-09T23:11:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/0b/932473194bd563f342a412ae2ffbbd6da608306a2bc4e99249a41c2b0b92/regex-2026.5.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71b61c5bfe1c806332defc42ad6c780b3c55f661986d7f40283a3a88274b4c00", size = 774991, upload-time = "2026-05-09T23:11:51.261Z" },
+    { url = "https://files.pythonhosted.org/packages/98/80/9523d196010031df25f7177ee0a467efbee436324038e5d99def17a57515/regex-2026.5.9-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:3b1e39888c5e0c7d92cea4fc777396c4a90363b05de75d02eb459a4752200808", size = 848790, upload-time = "2026-05-09T23:11:53.232Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/07/56987b35e89edf47e4a38cf2845aeee476bfa688a6bdbd3e820cda461dc1/regex-2026.5.9-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:6ba42b2e7e7f46cf68cc6a5ca36fa07959f9bbd9c6bdcc47b6ee76549a590248", size = 757679, upload-time = "2026-05-09T23:11:55.82Z" },
+    { url = "https://files.pythonhosted.org/packages/04/2a/ff713fff0c566507c06a4ce2dc0ae8e7eeebc88811a95fc81cf1e7d534dd/regex-2026.5.9-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:c010eb8caca74bdb40c07498d7ece26b4428fd3f04aa8a72c9ac6f79e8faaac6", size = 837116, upload-time = "2026-05-09T23:11:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/77/90/df6d982b03e3614785c6937ba51b57f6733d97d2ee1c9bc7531dbfab3a54/regex-2026.5.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a6a563446a41adc451393dc6b8e6ad87979efaee3c8738690a8d1b08ebead1b4", size = 782081, upload-time = "2026-05-09T23:11:59.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/8a/4e88a5f7c3e98489aac4dd23142723d907b2a595b4a6abcbacabefeded09/regex-2026.5.9-cp310-cp310-win32.whl", hash = "sha256:954cc214c04663ee6d266fc61739cad83054683048de65c5bd1d640ad28098ac", size = 266247, upload-time = "2026-05-09T23:12:01.116Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/40/4b224cb0582b2dca1786726e6cdabe26abbf757d7f6718332f186da155d2/regex-2026.5.9-cp310-cp310-win_amd64.whl", hash = "sha256:b310768746dd314ea6e2ff4cc89ef215426813396ff4e94ee8e6f7096c8b6e03", size = 278416, upload-time = "2026-05-09T23:12:03.2Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4d/014fbe803204cab0947ee428f09f658a29632053dde1d3c6176bb4f0fd4c/regex-2026.5.9-cp310-cp310-win_arm64.whl", hash = "sha256:19c16ceb4a267a8789e25733e583983eeab9f0f8664e66b0bd1c5d21f14c2d4b", size = 270413, upload-time = "2026-05-09T23:12:04.649Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/dc/c1f2df4027e82fc54b5a473e4b250f5139faca49a0fbe29a48668d228f34/regex-2026.5.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccf5249114cc3e772ecdd88a98a86eca0fd74c61ce32a94743758c083fc05d48", size = 489445, upload-time = "2026-05-09T23:12:06.111Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/59f01110660081cce9c0bc30ebd0b5ee250dacf658e3248ed92f01e0e8ee/regex-2026.5.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46f1326ca6e65b0879d23ca302c0f2415aad42ff0309b9c818e7949fe19a41d8", size = 291271, upload-time = "2026-05-09T23:12:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b6/14b2c84ff90ddb370c81d27503f4a0fcf071496416f4855f6cc8c5d81c35/regex-2026.5.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef31cbfe458e21c6122ba8150ff060e0c7789ed0d26eb423f25472584920b555", size = 289212, upload-time = "2026-05-09T23:12:09.266Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d0/4db86529117320de0c84afd90e70bb47434625875e34fcef9d8c127c5b16/regex-2026.5.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:992604d02e6d9c6d786c24a706a71ecffe1020fc1ef264044474cd81fa2c3919", size = 792310, upload-time = "2026-05-09T23:12:11.416Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/fe4800cd322f862ecffd2d553409b20d80650e5ed71b9d178f853d020b82/regex-2026.5.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9411dd64ca95477225734a93dfc8583b51916b8d5942f99d6cac21e09965451", size = 861721, upload-time = "2026-05-09T23:12:13.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d0/b3618a895dd8feb897c61bb2954edd265e1767d82a01d53065d5871127a3/regex-2026.5.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4a3ff360dfb836fecdb93a4598f9d6e2ac81e3e397125145c6221bf58cf4c", size = 906460, upload-time = "2026-05-09T23:12:15.443Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6f/1481597e859ef19508b345eec4afd1416ed6e6b459c75a64026ef193aecf/regex-2026.5.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a661a7d270a61f7cf460caee8b9fa2d5ef9e5c681234bcb9e0fe14f488e7dfc", size = 799843, upload-time = "2026-05-09T23:12:16.892Z" },
+    { url = "https://files.pythonhosted.org/packages/73/59/955734c803f59108deccba3597ae440c76b62a652733c0006e6243758420/regex-2026.5.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f079e50a0d3cc3cd5091fa9ff45869a2e6b2cd35895731edafb0327901a8d86d", size = 773610, upload-time = "2026-05-09T23:12:19.127Z" },
+    { url = "https://files.pythonhosted.org/packages/68/8f/70c04a236d651c81881dac42ef8538bddda6121434509d0a22d9e601503b/regex-2026.5.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4ebe8f0b5ec5a5024dc4a4c59f444c4e9afc5f2abdbb8962065b75d27fb971f9", size = 781645, upload-time = "2026-05-09T23:12:20.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/96/05c7434d88185e5d27fe54aeb74df86bd77cd79f52f0b4eae54faa8fea70/regex-2026.5.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:97cf3bc1b7d7d2306772ec07366c80d9df00ff79e79cea32898883a646d2fae2", size = 854473, upload-time = "2026-05-09T23:12:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/6e3d8202d981f3117004bf341ee74893ba4ba8a9fbaf4b94615846550a08/regex-2026.5.9-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0f9eede6a5cbdc02d4978090186390936e1776a7d1359b21e41014c609880bcf", size = 763311, upload-time = "2026-05-09T23:12:24.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c7/e7737f1526b3fb32bd4c337fd6c71c3ebb5c8296fc34d11197e0955d2e35/regex-2026.5.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:01f0f5f55f4b64dacec85dc116d3c05fd23ad3ff037bbc73a2085775953c2611", size = 844593, upload-time = "2026-05-09T23:12:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/0daffb1a535bb39f422c3d200f4ab023c71110ad66a32b366bee708baba0/regex-2026.5.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1268eddd8486dc561d08eee1156e40aa3a8fe10f4bdec8fa653b455fcbffd12c", size = 789167, upload-time = "2026-05-09T23:12:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fc/294fe4fac4f2ed67207b17471815870c1c45b3a489e08e0ac96daea16ef6/regex-2026.5.9-cp311-cp311-win32.whl", hash = "sha256:8676474c07469d6f33dd1085ca2cd45f65785f32518f2b20e36d9953ca07f994", size = 266249, upload-time = "2026-05-09T23:12:30.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b0/8dce459f6245bcf8f6e9f23ac9569f1a0f15c131cc0745e82b43226204cf/regex-2026.5.9-cp311-cp311-win_amd64.whl", hash = "sha256:246de9d60aa3f8538b519834dd95cbf276ea263d6a7bd5a3666dc3fa0230505b", size = 278423, upload-time = "2026-05-09T23:12:31.676Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/f9aeff6ad63a3ef720386f2907e6d34a35a510a6e498ebad28b0fb3f6ab6/regex-2026.5.9-cp311-cp311-win_arm64.whl", hash = "sha256:d726ca3f0d76969bf1e8e477d160d3d666bbf999f6860bd314889e5345782046", size = 270420, upload-time = "2026-05-09T23:12:33.194Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5667,6 +5848,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6a/4d08d89a6fcbe905c5ae68b8b34f0791850882fc19782d0d02c65abbdf3b/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4729811a6640d019a4b7ba8638ee2fd21fa5ca8c7e7bdf0fed62068fcaac737", size = 492430, upload-time = "2025-11-19T15:18:11.884Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/29/59ed8152b30f72c42d00d241e58eaca558ae9dbfa5695206e2e0f54c7063/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12f49080303fa6bb424b362149a12949dfbbf1e06811a88f2307276b0c131afd", size = 503977, upload-time = "2025-11-19T15:18:17.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/4811bfec67fa260e791369b16dab105e4bae82686120554cc484064e22b4/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0071bffba4150c2f46cae1432d31995d77acfd9f8db598b5d1a2ce67e8440ad2", size = 623890, upload-time = "2025-11-19T15:18:22.666Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5b/632a58724221ef03d78ab65062e82a1010e1bef8e8e0b9d7c6d7b8044841/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:473b32699f4200e69801bf5abf93f1a4ecd432a70984df164fc22ccf39c4a6f3", size = 531885, upload-time = "2025-11-19T15:18:27.146Z" },
 ]
 
 [[package]]
@@ -6361,6 +6568,9 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
+embeddings = [
+    { name = "laion-clap" },
+]
 metrics = [
     { name = "dtw-python" },
     { name = "einops" },
@@ -6559,6 +6769,7 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extras = ["python"] },
 ]
+embeddings = [{ name = "laion-clap" }]
 metrics = [
     { name = "dtw-python", specifier = "==1.7.4" },
     { name = "einops" },
@@ -6710,6 +6921,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+    { url = "https://files.pythonhosted.org/packages/84/04/655b79dbcc9b3ac5f1479f18e931a344af67e5b7d3b251d2dcdcd7558592/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:753d47ebd4542742ef9261d9da92cd545b2cacbb48349a1225466745bb866ec4", size = 3282301, upload-time = "2026-01-05T10:40:34.858Z" },
+    { url = "https://files.pythonhosted.org/packages/46/cd/e4851401f3d8f6f45d8480262ab6a5c8cb9c4302a790a35aa14eeed6d2fd/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e10bf9113d209be7cd046d40fbabbaf3278ff6d18eb4da4c500443185dc1896c", size = 3161308, upload-time = "2026-01-05T10:40:40.737Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6e/55553992a89982cd12d4a66dddb5e02126c58677ea3931efcbe601d419db/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64d94e84f6660764e64e7e0b22baa72f6cd942279fdbb21d46abd70d179f0195", size = 3718964, upload-time = "2026-01-05T10:40:46.56Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/b1c87148aa15e099243ec9f0cf9d0e970cc2234c3257d558c25a2c5304e6/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f01a9c019878532f98927d2bacb79bbb404b43d3437455522a00a30718cdedb5", size = 3373542, upload-time = "2026-01-05T10:40:52.803Z" },
 ]
 
 [[package]]
@@ -7021,6 +7262,19 @@ wheels = [
 ]
 
 [[package]]
+name = "torchlibrosa"
+version = "0.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "librosa" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/67/e4c79da3f15777b9bc2b655d47dac553fc31e40360500fef5e66d6877ce8/torchlibrosa-0.1.0.tar.gz", hash = "sha256:62a8beedf9c9b4141a06234df3f10229f7ba86e67678ccee02489ec4ef044028", size = 11719, upload-time = "2023-02-21T09:40:54.968Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3e/af/ccf007edf442c3c0cd3a98be2c82bc99edc957c04436a759b6e1e01077e0/torchlibrosa-0.1.0-py3-none-any.whl", hash = "sha256:89b65fd28b833ceb6bc74a3d0d87e2924ddc5a845d0a246b194952a4e12a38cb", size = 11741, upload-time = "2023-02-21T09:40:52.58Z" },
+]
+
+[[package]]
 name = "torchmetrics"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -7187,6 +7441,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/c1/bd361c24a76e7c0d137e299ca1e86bbe188e4c08e3e46674a285aa762051/tqdm_loggable-0.4.1.tar.gz", hash = "sha256:49123ffcb2deb948edb7121d7e09a6008914e0d0333154f060e435deba9e547a", size = 8170, upload-time = "2026-03-16T18:38:50.774Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/24/303708f276f2a81bd0551f5e93b5dd51201ca0d73aed0dc50be6976a3443/tqdm_loggable-0.4.1-py3-none-any.whl", hash = "sha256:e3b394a6fc85a1b1b0dad52a63ac926ecb3b478acf4f4bae570d9189f00ab91d", size = 10527, upload-time = "2026-03-16T18:38:49.808Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/38/d5f978bd5091019e89aef29b9a831f5cd70f2598963a3ead8b9570cab592/transformers-5.10.2.tar.gz", hash = "sha256:f9a44b9c8ca9ab1156b467f574d832ea066284299c2fd0ed84641ccb592751fc", size = 8799687, upload-time = "2026-06-04T18:43:49.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/6f/e1564b0cc182afa05e219a8e09a8e770ffaab879b6b824b56c819bd221da/transformers-5.10.2-py3-none-any.whl", hash = "sha256:8a669db546f82c7c3618cb46ceb0f0afd89292bc70f319c058f8332ec63e268d", size = 11003830, upload-time = "2026-06-04T18:43:45.303Z" },
 ]
 
 [[package]]
@@ -7628,6 +7902,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd1
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
 ]
+
+[[package]]
+name = "wget"
+version = "3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/6a/62e288da7bcda82b935ff0c6cfe542970f04e29c756b0e147251b2fb251f/wget-3.2.zip", hash = "sha256:35e630eca2aa50ce998b9b1a127bb26b30dfee573702782aa982f875e3f16061", size = 10857, upload-time = "2015-10-22T15:26:37.51Z" }
 
 [[package]]
 name = "wheel"


### PR DESCRIPTION
## Summary

Adds `src/synth_setter/pipeline/data/add_clap.py` — a CLI that augments existing dataset shards (HDF5 and webdataset) with 512-d **LAION-CLAP** audio embeddings, so downstream sound-matching / preset-exploration work can condition on a pretrained audio embedding space.

- Stored audio is downmixed to mono and resampled to 48 kHz (CLAP's input rate) before encoding.
- The embedding is written back into the same shard: a `clap` HDF5 dataset, or a `<key>.clap.npy` webdataset member (tar rewritten in place via a temp file + atomic `os.replace`).
- **Idempotent** — a shard already carrying the embedding is skipped, so a re-run only fills gaps.
- `laion_clap` is imported lazily behind an injectable `ClapEmbedder` Protocol and declared in a new optional `embeddings` dependency-group, so the package imports and the test suite run without the heavy stack or a checkpoint download. Defaults to the general audioset checkpoint.

## Testing

`uv run pytest tests/pipeline/data/test_add_clap.py` — 16 tests. The CLAP model is the only mocked boundary (needs a GPU + checkpoint); every other path (HDF5/tar I/O, downmix, resample, the Click entrypoint, idempotency, error branches) runs for real against tiny in-test fixtures.

## Out of scope

- Wiring the embedding into datamodules / training (follow-up).
- Text embeddings — this adds audio embeddings only.
- Teaching `validate_shard`'s WDS branch about optional embedding members (pre-existing post-finalize-augmentation gap; see the review sentinel).

Closes #1570
