### PR TITLE
feat(data-pipeline): add CLAP audio-embedding producer and read seam

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ torch = [
   "torchaudio>=2.0.0",
   "lightning>=2.6.0",
   "torchmetrics>=0.11.4",
+  "transformers>=4.40.0",
 ]
 config = [
   "hydra-core==1.3.2",

--- a/src/synth_setter/data/surge_datamodule.py
+++ b/src/synth_setter/data/surge_datamodule.py
@@ -151,8 +151,10 @@ class SurgeXTDataset(torch.utils.data.Dataset):
         param_array = torch.from_numpy(param_array).to(dtype=torch.float32)
         noise = torch.randn_like(param_array)
         if self.ot:
-            noise, param_array, mel_spec, audio = _hungarian_match(
-                noise, param_array, mel_spec, audio
+            # Every conditioning modality must ride the same OT permutation as
+            # params, else embeddings misalign from their parameter rows.
+            noise, param_array, mel_spec, audio, m2l, clap = _hungarian_match(
+                noise, param_array, mel_spec, audio, m2l, clap
             )
 
         return dict(

--- a/src/synth_setter/data/surge_datamodule.py
+++ b/src/synth_setter/data/surge_datamodule.py
@@ -10,6 +10,7 @@ import torch
 from lightning import LightningDataModule
 
 from synth_setter.data.ot import _hungarian_match
+from synth_setter.data.vst.shapes import CLAP_EMBEDDING_DIM
 from synth_setter.pipeline import r2_io
 
 
@@ -25,6 +26,7 @@ class SurgeXTDataset(torch.utils.data.Dataset):
         read_audio: bool = False,
         read_mel: bool = True,
         read_m2l: bool = False,
+        read_clap: bool = False,
         use_saved_mean_and_variance: bool = True,
         rescale_params: bool = True,
         fake: bool = False,
@@ -36,6 +38,7 @@ class SurgeXTDataset(torch.utils.data.Dataset):
         self.read_audio = read_audio
         self.read_mel = read_mel
         self.read_m2l = read_m2l
+        self.read_clap = read_clap
 
         self.rescale_params = rescale_params
 
@@ -81,6 +84,7 @@ class SurgeXTDataset(torch.utils.data.Dataset):
         audio = torch.randn(self.batch_size, 2, 44100 * 4) if self.read_audio else None
         mel_spec = torch.randn(self.batch_size, 2, 128, 401) if self.read_mel else None
         m2l = torch.randn(self.batch_size, 128, 42) if self.read_m2l else None
+        clap = torch.randn(self.batch_size, CLAP_EMBEDDING_DIM) if self.read_clap else None
         param_array = torch.rand(self.batch_size, 189)
 
         if self.rescale_params:
@@ -91,6 +95,7 @@ class SurgeXTDataset(torch.utils.data.Dataset):
         return dict(
             mel_spec=mel_spec,
             m2l=m2l,
+            clap=clap,
             params=param_array,
             noise=noise,
             audio=audio,
@@ -134,6 +139,12 @@ class SurgeXTDataset(torch.utils.data.Dataset):
         else:
             m2l = None
 
+        if self.read_clap:
+            clap = self._index_dataset(self.dataset_file["clap"], idx)
+            clap = torch.from_numpy(clap).to(dtype=torch.float32)
+        else:
+            clap = None
+
         param_array = self._index_dataset(self.dataset_file["param_array"], idx)
         if self.rescale_params:
             param_array = param_array * 2 - 1
@@ -147,6 +158,7 @@ class SurgeXTDataset(torch.utils.data.Dataset):
         return dict(
             mel_spec=mel_spec.contiguous() if mel_spec is not None else None,
             m2l=m2l.contiguous() if m2l is not None else None,
+            clap=clap.contiguous() if clap is not None else None,
             params=param_array.contiguous(),
             noise=noise.contiguous(),
             audio=audio.contiguous() if audio is not None else None,
@@ -243,7 +255,7 @@ class SurgeDataModule(LightningDataModule):
         fake: bool = False,
         repeat_first_batch: bool = False,
         predict_file: str | None = None,
-        conditioning: Literal["mel", "m2l"] = "mel",
+        conditioning: Literal["mel", "m2l", "clap"] = "mel",
         pin_memory: bool = True,
     ):
         super().__init__()
@@ -284,6 +296,7 @@ class SurgeDataModule(LightningDataModule):
             repeat_first_batch=self.repeat_first_batch,
             read_mel=self.conditioning == "mel",
             read_m2l=self.conditioning == "m2l",
+            read_clap=self.conditioning == "clap",
         )
         self.val_dataset = SurgeXTDataset(
             self.dataset_root / "val.h5",
@@ -294,6 +307,7 @@ class SurgeDataModule(LightningDataModule):
             repeat_first_batch=self.repeat_first_batch,
             read_mel=self.conditioning == "mel",
             read_m2l=self.conditioning == "m2l",
+            read_clap=self.conditioning == "clap",
         )
         self.test_dataset = SurgeXTDataset(
             self.dataset_root / "test.h5",
@@ -304,6 +318,7 @@ class SurgeDataModule(LightningDataModule):
             repeat_first_batch=self.repeat_first_batch,
             read_mel=self.conditioning == "mel",
             read_m2l=self.conditioning == "m2l",
+            read_clap=self.conditioning == "clap",
         )
         self.predict_dataset = SurgeXTDataset(
             self.predict_file,
@@ -314,6 +329,7 @@ class SurgeDataModule(LightningDataModule):
             fake=self.fake,
             read_mel=self.conditioning == "mel",
             read_m2l=self.conditioning == "m2l",
+            read_clap=self.conditioning == "clap",
         )
 
     def train_dataloader(self):

--- a/src/synth_setter/data/vst/shapes.py
+++ b/src/synth_setter/data/vst/shapes.py
@@ -16,7 +16,13 @@ import numpy as np
 AUDIO_FIELD: str = "audio"
 MEL_SPEC_FIELD: str = "mel_spec"
 PARAM_ARRAY_FIELD: str = "param_array"
+CLAP_FIELD: str = "clap"
 DATASET_FIELD_NAMES: tuple[str, ...] = (AUDIO_FIELD, MEL_SPEC_FIELD, PARAM_ARRAY_FIELD)
+
+# Pooled-projection width of the LAION CLAP HTSAT audio tower; the row dimension
+# of the post-finalization ``clap`` side embedding. Single source for the
+# producer's default-checkpoint width guard and the datamodule's fake-mode shape.
+CLAP_EMBEDDING_DIM: int = 512
 
 # Per-field on-disk dtype, matching what the HDF5 / wds writers emit. Audio is
 # stored as ``float16`` for compressed storage efficiency; mel and params stay

--- a/src/synth_setter/pipeline/data/add_clap.py
+++ b/src/synth_setter/pipeline/data/add_clap.py
@@ -1,0 +1,217 @@
+"""Inject LAION CLAP audio embeddings into finalized dataset split files.
+
+Post-finalization producer: reads each split file's ``audio`` dataset, downmixes
+to mono, runs a CLAP audio encoder, and writes a real ``clap`` dataset ``(N, D)``
+into the same file. Mirrors the music2latent injection but targets the split
+files (``train/val/test.h5``) the datamodule opens directly — the resharder's
+virtual layout only carries the core fields, so a side embedding must live in
+the split file itself.
+
+The HDF5 plumbing (:func:`add_clap_embeddings`) takes an injected ``encode``
+callable so it is testable without loading CLAP; :func:`load_clap_audio_encoder`
+is the thin shell that builds the real encoder (lazy ``transformers`` import).
+
+Run as ``python -m synth_setter.pipeline.data.add_clap <data_dir>``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, cast
+
+import click
+import h5py
+import numpy as np
+import structlog
+
+from synth_setter.data.vst.shapes import AUDIO_FIELD, CLAP_EMBEDDING_DIM, CLAP_FIELD
+
+logger = structlog.get_logger(__name__)
+
+DEFAULT_CLAP_CHECKPOINT = "laion/clap-htsat-unfused"
+# Default project render rate, used when a shard lacks a sample_rate attr.
+DEFAULT_SAMPLE_RATE = 44100
+# CLAP's feature extractor rejects any other input rate, so audio is resampled to
+# this before encoding.
+CLAP_SAMPLE_RATE = 48000
+# Boolean attr set on the output dataset only after every row is written, so a
+# crash mid-write leaves the field present-but-incomplete and a rerun recomputes
+# it instead of trusting a partially-zero dataset.
+COMPLETE_ATTR = "clap_complete"
+_SPLIT_FILENAMES = ("train.h5", "val.h5", "test.h5")
+
+# Maps a mono ``(B, T)`` batch and its sample rate to a ``(B, D)`` embedding batch.
+EncodeFn = Callable[[np.ndarray, int], np.ndarray]
+
+
+def _downmix_to_mono(audio: np.ndarray) -> np.ndarray:
+    """Average the channel axis of an ``(B, C, T)`` batch into ``(B, T)`` mono float32.
+
+    :param audio: Audio batch shaped ``(B, C, T)``.
+    :returns: Mono batch shaped ``(B, T)`` as float32.
+    """
+    return audio.mean(axis=1, dtype=np.float32)
+
+
+def add_clap_embeddings(
+    h5_path: str | Path,
+    encode: EncodeFn,
+    *,
+    batch_size: int = 256,
+    field: str = CLAP_FIELD,
+    expected_dim: int | None = None,
+    overwrite: bool = False,
+) -> int:
+    """Compute and store CLAP embeddings for every row of one HDF5 split file.
+
+    Reads ``audio`` in batches, downmixes to mono, calls ``encode``, and writes a
+    real ``field`` dataset ``(N, D)`` whose width ``D`` is taken from the encoder
+    output. The ``audio`` dataset may be virtual; it resolves against sibling
+    shards. A ``field`` that already carries the completion marker is skipped
+    unless ``overwrite`` is set; a present-but-incomplete field (crashed run) is
+    recomputed.
+
+    :param h5_path: Split/shard file, opened read-write.
+    :param encode: Maps a mono ``(B, T)`` batch and sample rate to a ``(B, D)``
+        float32 embedding batch.
+    :param batch_size: Rows per encode call.
+    :param field: Output dataset name.
+    :param expected_dim: When set, the encoder's output width ``D`` is asserted to
+        equal it (guards the default checkpoint against a silent width change);
+        ``None`` accepts whatever width the encoder produces.
+    :param overwrite: Recompute even a completed ``field`` instead of skipping it.
+    :returns: Rows encoded; 0 when a completed field is skipped.
+    :raises ValueError: If ``expected_dim`` is set and the encoder width differs.
+    """
+    h5_path = Path(h5_path)
+    with h5py.File(h5_path, "r+") as f:
+        if field in f:
+            if not overwrite and f[field].attrs.get(COMPLETE_ATTR, False):
+                logger.info("clap_field_complete_skipping", path=str(h5_path), field=field)
+                return 0
+            del f[field]
+
+        audio_ds = cast(h5py.Dataset, f[AUDIO_FIELD])
+        num_rows = audio_ds.shape[0]
+        sample_rate = int(audio_ds.attrs.get("sample_rate", DEFAULT_SAMPLE_RATE))
+
+        out_ds: h5py.Dataset | None = None
+        for start in range(0, num_rows, batch_size):
+            end = min(start + batch_size, num_rows)
+            # _downmix_to_mono's mean(dtype=float32) promotes the fp16 slice, so no
+            # separate full-batch upcast; np.asarray coerces a torch tensor to ndarray.
+            mono = _downmix_to_mono(audio_ds[start:end])
+            embeddings = np.asarray(encode(mono, sample_rate))
+            if out_ds is None:
+                width = embeddings.shape[1]
+                if expected_dim is not None and width != expected_dim:
+                    raise ValueError(
+                        f"CLAP encoder produced width {width}, expected {expected_dim}"
+                    )
+                out_ds = f.create_dataset(field, shape=(num_rows, width), dtype=np.float32)
+            out_ds[start:end] = embeddings
+        if out_ds is not None:
+            out_ds.attrs[COMPLETE_ATTR] = True
+        f.flush()
+
+    logger.info("clap_embeddings_written", path=str(h5_path), rows=num_rows, field=field)
+    return num_rows
+
+
+def load_clap_audio_encoder(
+    checkpoint: str = DEFAULT_CLAP_CHECKPOINT,
+    device: str | None = None,
+) -> EncodeFn:
+    """Load a CLAP checkpoint and return a mono-batch encode callable.
+
+    The ``transformers`` and ``torch`` imports are deferred so the HDF5 core stays
+    importable (and testable with a fake encoder) without the heavy dependency or
+    a model download.
+
+    :param checkpoint: HuggingFace CLAP model id.
+    :param device: Torch device string; defaults to cuda when available, else cpu.
+    :returns: Encode callable mapping a mono ``(B, T)`` batch and sample rate to a
+        ``(B, D)`` float32 embedding batch.
+    """
+    import torch
+    import torchaudio.functional as audio_fn
+    from transformers import ClapModel, ClapProcessor
+
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+    # transformers' processor/model call surface is dynamically typed; Any at this
+    # external boundary keeps the type checker honest about what it cannot verify.
+    model: Any = ClapModel.from_pretrained(checkpoint)
+    model = model.to(device).eval()
+    processor: Any = ClapProcessor.from_pretrained(checkpoint)
+
+    @torch.no_grad()
+    def encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+        wav = torch.from_numpy(np.ascontiguousarray(mono))
+        if sample_rate != CLAP_SAMPLE_RATE:
+            wav = audio_fn.resample(wav, sample_rate, CLAP_SAMPLE_RATE)
+        inputs = processor(
+            audio=list(wav.numpy()), sampling_rate=CLAP_SAMPLE_RATE, return_tensors="pt"
+        )
+        inputs = {key: value.to(device) for key, value in inputs.items()}
+        # get_audio_features returns the audio-tower output whose pooler_output
+        # holds the projected, L2-normalized joint-space embedding (B, D).
+        features = model.get_audio_features(**inputs)
+        return features.pooler_output.cpu().numpy()
+
+    return encode
+
+
+@click.command()
+@click.argument("data_dir", type=click.Path(exists=True, file_okay=False, path_type=Path))
+@click.option(
+    "--checkpoint", default=DEFAULT_CLAP_CHECKPOINT, show_default=True, help="HuggingFace CLAP id."
+)
+@click.option(
+    "--batch-size", "-b", type=int, default=256, show_default=True, help="Rows per batch."
+)
+@click.option("--device", default=None, help="Torch device (default: cuda if available else cpu).")
+@click.option("--field", default=CLAP_FIELD, show_default=True, help="Output dataset name.")
+@click.option(
+    "--overwrite", is_flag=True, help="Replace an existing CLAP field instead of skipping."
+)
+def main(
+    data_dir: Path,
+    checkpoint: str,
+    batch_size: int,
+    device: str | None,
+    field: str,
+    overwrite: bool,
+) -> None:
+    """Inject CLAP embeddings into each ``train/val/test.h5`` under DATA_DIR.
+
+    :param data_dir: Finalized dataset root holding the split files.
+    :param checkpoint: HuggingFace CLAP model id.
+    :param batch_size: Rows per encode call.
+    :param device: Torch device string, or None to auto-select.
+    :param field: Output dataset name.
+    :param overwrite: Replace an existing CLAP field instead of skipping.
+    :raises click.ClickException: When no split files are found under DATA_DIR.
+    """
+    split_paths = [data_dir / name for name in _SPLIT_FILENAMES if (data_dir / name).exists()]
+    if not split_paths:
+        raise click.ClickException(f"No split files {_SPLIT_FILENAMES} found under {data_dir}")
+
+    # Only pin the width for the default checkpoint; alternates may project to a
+    # different dimension and must be free to write their own width.
+    expected_dim = CLAP_EMBEDDING_DIM if checkpoint == DEFAULT_CLAP_CHECKPOINT else None
+    encode = load_clap_audio_encoder(checkpoint, device)
+    for path in split_paths:
+        add_clap_embeddings(
+            path,
+            encode,
+            batch_size=batch_size,
+            field=field,
+            expected_dim=expected_dim,
+            overwrite=overwrite,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/synth_setter/pipeline/data/add_clap.py
+++ b/src/synth_setter/pipeline/data/add_clap.py
@@ -22,6 +22,7 @@ from typing import Any, cast
 
 import click
 import h5py
+import hdf5plugin
 import numpy as np
 import structlog
 
@@ -109,7 +110,14 @@ def add_clap_embeddings(
                     raise ValueError(
                         f"CLAP encoder produced width {width}, expected {expected_dim}"
                     )
-                out_ds = f.create_dataset(field, shape=(num_rows, width), dtype=np.float32)
+                # Blosc2 to match the core datasets' on-disk compression. Blosc2 is
+                # hdf5plugin's documented public API but absent from its stub __all__.
+                out_ds = f.create_dataset(
+                    field,
+                    shape=(num_rows, width),
+                    dtype=np.float32,
+                    compression=hdf5plugin.Blosc2(),  # pyright: ignore[reportPrivateImportUsage]
+                )
             out_ds[start:end] = embeddings
         if out_ds is not None:
             out_ds.attrs[COMPLETE_ATTR] = True

--- a/tests/data/test_surge_datamodule.py
+++ b/tests/data/test_surge_datamodule.py
@@ -337,7 +337,7 @@ class TestSurgeXTDatasetFakeMode:
         assert _unwrap(item["noise"]).shape == _unwrap(item["params"]).shape
 
     def test_fake_mode_returns_full_key_set(self) -> None:
-        """The returned dict always exposes all five keys (some may be ``None``)."""
+        """The returned dict always exposes all six keys (some may be ``None``)."""
         dataset = SurgeXTDataset("ignored", batch_size=2, fake=True)
         item = dataset[0]
         assert set(item.keys()) == set(_ALL_TENSOR_KEYS)
@@ -739,7 +739,7 @@ class TestSurgeXTDatasetH5Mode:
         assert torch.equal(_unwrap(item["m2l"])[:, 0, 0], param_ids)
 
     def test_returned_dict_always_exposes_full_key_set(self, single_h5: Path) -> None:
-        """Every ``__getitem__`` return dict exposes the same five-key contract.
+        """Every ``__getitem__`` return dict exposes the same six-key contract.
 
         :param single_h5: Fixture-provided single-shard HDF5 path.
         """

--- a/tests/data/test_surge_datamodule.py
+++ b/tests/data/test_surge_datamodule.py
@@ -51,9 +51,10 @@ _MEL_N_MELS = 4
 _MEL_N_FRAMES = 5
 _M2L_DIM_1 = 6
 _M2L_DIM_2 = 7
+_CLAP_DIM = 8
 _NUM_PARAMS = 11
 
-_ALL_TENSOR_KEYS = ("audio", "mel_spec", "m2l", "params", "noise")
+_ALL_TENSOR_KEYS = ("audio", "mel_spec", "m2l", "clap", "params", "noise")
 
 
 @pytest.fixture()
@@ -157,6 +158,10 @@ def _write_h5_shard(
         f.create_dataset(
             "music2latent",
             data=rng.standard_normal((num_rows, _M2L_DIM_1, _M2L_DIM_2)).astype(np.float32),
+        )
+        f.create_dataset(
+            "clap",
+            data=rng.standard_normal((num_rows, _CLAP_DIM)).astype(np.float32),
         )
         # params in [0, 1) so the rescale_params=True branch lands in [-1, 1).
         f.create_dataset(
@@ -272,6 +277,16 @@ class TestSurgeXTDatasetFakeMode:
         """``read_m2l=True`` populates the ``m2l`` slot with the documented shape."""
         dataset = SurgeXTDataset("ignored", batch_size=2, fake=True, read_m2l=True)
         assert _unwrap(dataset[0]["m2l"]).shape == (2, 128, 42)
+
+    def test_fake_mode_read_clap_returns_clap_tensor(self) -> None:
+        """``read_clap=True`` populates the ``clap`` slot with the 512-d CLAP shape."""
+        dataset = SurgeXTDataset("ignored", batch_size=2, fake=True, read_clap=True)
+        assert _unwrap(dataset[0]["clap"]).shape == (2, 512)
+
+    def test_fake_mode_read_clap_false_returns_none_clap(self) -> None:
+        """``read_clap=False`` (default) drops the ``clap`` slot to ``None``."""
+        dataset = SurgeXTDataset("ignored", batch_size=2, fake=True)
+        assert dataset[0]["clap"] is None
 
     def test_fake_mode_read_mel_false_returns_none_mel(self) -> None:
         """``read_mel=False`` drops the ``mel_spec`` slot to ``None``."""
@@ -407,6 +422,7 @@ class TestSurgeXTDatasetH5Mode:
             read_audio=True,
             read_mel=True,
             read_m2l=True,
+            read_clap=True,
         )
         item = dataset[0]
         for key in _ALL_TENSOR_KEYS:
@@ -425,6 +441,7 @@ class TestSurgeXTDatasetH5Mode:
             read_audio=True,
             read_mel=True,
             read_m2l=True,
+            read_clap=True,
         )
         item = dataset[0]
         for key in _ALL_TENSOR_KEYS:
@@ -463,6 +480,30 @@ class TestSurgeXTDatasetH5Mode:
             read_m2l=True,
         )
         assert _unwrap(dataset[0]["m2l"]).shape == (2, _M2L_DIM_1, _M2L_DIM_2)
+
+    def test_read_clap_true_returns_clap_tensor(self, single_h5: Path) -> None:
+        """``read_clap=True`` reads the ``clap`` dataset under the ``clap`` key.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
+        dataset = SurgeXTDataset(
+            single_h5,
+            batch_size=2,
+            ot=False,
+            use_saved_mean_and_variance=False,
+            read_clap=True,
+        )
+        assert _unwrap(dataset[0]["clap"]).shape == (2, _CLAP_DIM)
+
+    def test_read_clap_false_returns_none_clap(self, single_h5: Path) -> None:
+        """``read_clap=False`` (default) leaves the ``clap`` slot at ``None``.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        """
+        dataset = SurgeXTDataset(
+            single_h5, batch_size=2, ot=False, use_saved_mean_and_variance=False
+        )
+        assert dataset[0]["clap"] is None
 
     def test_rescale_params_centers_to_minus_one_to_one(self, single_h5: Path) -> None:
         """``rescale_params=True`` applies ``p * 2 - 1`` element-wise before tensor conversion.
@@ -951,6 +992,19 @@ class TestSurgeDataModule:
             assert module.predict_dataset is not None
             assert module.predict_dataset.read_mel is False
             assert module.predict_dataset.read_m2l is True
+
+    def test_conditioning_clap_routes_to_clap_reads(self, dataset_root: Path) -> None:
+        """``conditioning='clap'`` flips the read flags to the CLAP channel on every split.
+
+        :param dataset_root: Fixture-provided dataset-root directory.
+        """
+        with _set_up_module(
+            dataset_root=dataset_root, batch_size=2, ot=False, conditioning="clap"
+        ) as module:
+            for split in (module.train_dataset, module.val_dataset, module.test_dataset):
+                assert split.read_mel is False
+                assert split.read_m2l is False
+                assert split.read_clap is True
 
     def test_train_dataloader_uses_shifted_batch_sampler(self, dataset_root: Path) -> None:
         """``train_dataloader`` wires the ``ShiftedBatchSampler`` (not the global random one).

--- a/tests/data/test_surge_datamodule.py
+++ b/tests/data/test_surge_datamodule.py
@@ -602,8 +602,12 @@ class TestSurgeXTDatasetH5Mode:
             _ = dataset[0]
         mock_match.assert_not_called()
 
-    def test_ot_true_calls_hungarian_match_with_all_four_tensors(self, single_h5: Path) -> None:
-        """``ot=True`` routes through ``_hungarian_match(noise, params, mel_spec, audio)``.
+    def test_ot_true_calls_hungarian_match_with_all_six_tensors(self, single_h5: Path) -> None:
+        """``ot=True`` routes every conditioning modality through ``_hungarian_match``.
+
+        All of ``mel_spec``/``audio``/``m2l``/``clap`` must ride the same OT
+        permutation as ``params`` to stay row-aligned, so each is threaded
+        positionally after ``(noise, params)``.
 
         :param single_h5: Fixture-provided single-shard HDF5 path.
         """
@@ -617,15 +621,17 @@ class TestSurgeXTDatasetH5Mode:
                 ot=True,
                 use_saved_mean_and_variance=False,
                 read_audio=True,
+                read_m2l=True,
+                read_clap=True,
             )
             _ = dataset[0]
         mock_match.assert_called_once()
         positional = mock_match.call_args.args
-        assert len(positional) == 4
-        # Positional contract: (noise, params, mel_spec, audio). Pin each slot's
-        # shape so a regression that swaps positions is caught — bare arity does
-        # not distinguish `(noise, params, audio, mel_spec)` from the correct order.
-        noise, params, mel_spec, audio = positional
+        assert len(positional) == 6
+        # Positional contract: (noise, params, mel_spec, audio, m2l, clap). Pin
+        # each slot's shape so a regression that swaps positions is caught —
+        # bare arity does not distinguish a reordering from the correct order.
+        noise, params, mel_spec, audio, m2l, clap = positional
         assert isinstance(noise, torch.Tensor) and noise.shape == (2, _NUM_PARAMS)
         assert isinstance(params, torch.Tensor) and params.shape == (2, _NUM_PARAMS)
         assert isinstance(mel_spec, torch.Tensor) and mel_spec.shape == (
@@ -639,6 +645,8 @@ class TestSurgeXTDatasetH5Mode:
             _AUDIO_CHANNELS,
             _AUDIO_SAMPLES,
         )
+        assert isinstance(m2l, torch.Tensor) and m2l.shape == (2, _M2L_DIM_1, _M2L_DIM_2)
+        assert isinstance(clap, torch.Tensor) and clap.shape == (2, _CLAP_DIM)
 
     def test_ot_with_disabled_modalities_passes_none_through(self, single_h5: Path) -> None:
         """``_hungarian_match`` still receives ``None`` placeholders when modalities are off.
@@ -657,16 +665,78 @@ class TestSurgeXTDatasetH5Mode:
                 read_audio=False,
                 read_mel=False,
                 read_m2l=False,
+                read_clap=False,
             )
             item = dataset[0]
         mock_match.assert_called_once()
         positional = mock_match.call_args.args
-        # Positional contract: noise, params, mel_spec, audio — the trailing
-        # two are None when their read flags are off.
+        # Positional contract: noise, params, mel_spec, audio, m2l, clap — the
+        # trailing four are None when their read flags are off.
         assert positional[2] is None
         assert positional[3] is None
+        assert positional[4] is None
+        assert positional[5] is None
         assert item["mel_spec"] is None
         assert item["audio"] is None
+        assert item["m2l"] is None
+        assert item["clap"] is None
+
+    def test_ot_keeps_clap_and_m2l_aligned_with_permuted_params(self, tmp_path: Path) -> None:
+        """OT permutes ``clap``/``m2l`` with ``params`` so conditioning stays row-aligned.
+
+        Writes a shard where row ``i`` carries the same fingerprint ``i`` in
+        ``param_array``, ``clap``, and ``music2latent``. With ``rescale_params``
+        off, ``params`` rows are returned verbatim, so for every output row the
+        ``clap``/``m2l`` fingerprint must equal the ``params`` fingerprint —
+        which only holds if all three rode the identical ``_hungarian_match``
+        permutation. The seed forces a non-identity permutation.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
+        num_rows = 8
+        h5_path = tmp_path / "train.h5"
+        row_ids = np.arange(num_rows, dtype=np.float32)
+        with h5py.File(h5_path, "w") as f:
+            f.create_dataset(
+                "audio",
+                data=np.zeros((num_rows, _AUDIO_CHANNELS, _AUDIO_SAMPLES), dtype=np.float32),
+            )
+            f.create_dataset(
+                "mel_spec",
+                data=np.zeros(
+                    (num_rows, _MEL_CHANNELS, _MEL_N_MELS, _MEL_N_FRAMES), dtype=np.float32
+                ),
+            )
+            # Same per-row fingerprint across all three so misalignment is detectable.
+            f.create_dataset(
+                "music2latent",
+                data=np.broadcast_to(
+                    row_ids[:, None, None], (num_rows, _M2L_DIM_1, _M2L_DIM_2)
+                ).copy(),
+            )
+            f.create_dataset(
+                "clap", data=np.broadcast_to(row_ids[:, None], (num_rows, _CLAP_DIM)).copy()
+            )
+            f.create_dataset(
+                "param_array",
+                data=np.broadcast_to(row_ids[:, None], (num_rows, _NUM_PARAMS)).copy(),
+            )
+        dataset = SurgeXTDataset(
+            h5_path,
+            batch_size=num_rows,
+            ot=True,
+            use_saved_mean_and_variance=False,
+            rescale_params=False,
+            read_m2l=True,
+            read_clap=True,
+        )
+        torch.manual_seed(0)
+        item = dataset[0]
+        param_ids = _unwrap(item["params"])[:, 0]
+        # A real permutation must have occurred, else the test can't detect misalignment.
+        assert not torch.equal(param_ids, torch.from_numpy(row_ids))
+        assert torch.equal(_unwrap(item["clap"])[:, 0], param_ids)
+        assert torch.equal(_unwrap(item["m2l"])[:, 0, 0], param_ids)
 
     def test_returned_dict_always_exposes_full_key_set(self, single_h5: Path) -> None:
         """Every ``__getitem__`` return dict exposes the same five-key contract.

--- a/tests/pipeline/data/test_add_clap.py
+++ b/tests/pipeline/data/test_add_clap.py
@@ -15,6 +15,7 @@ from typing import cast
 from unittest import mock
 
 import h5py
+import hdf5plugin  # noqa: F401  # side-effect import: registers Blosc2 so h5py can read the clap field
 import numpy as np
 import pytest
 

--- a/tests/pipeline/data/test_add_clap.py
+++ b/tests/pipeline/data/test_add_clap.py
@@ -1,0 +1,301 @@
+"""Tests for `synth_setter.pipeline.data.add_clap` HDF5 embedding injection.
+
+The CLAP model itself is never loaded here: the HDF5-plumbing tests inject a
+fake ``encode`` callable (dataset creation, batching, channel downmix,
+sample-rate propagation, idempotency), and the encoder-contract test mocks the
+``transformers`` boundary to pin the v5 call shape (``audio=`` kwarg, 48 kHz
+resample, ``pooler_output`` projection).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest import mock
+
+import h5py
+import numpy as np
+import pytest
+
+from synth_setter.pipeline.data import add_clap
+
+
+def _clap(f: h5py.File) -> h5py.Dataset:
+    """Return the ``clap`` dataset narrowed from h5py's group/dataset union.
+
+    :param f: Open HDF5 file holding a ``clap`` dataset.
+    :returns: The ``clap`` dataset.
+    """
+    return cast(h5py.Dataset, f["clap"])
+
+
+def _write_audio_h5(
+    path: Path,
+    audio: np.ndarray,
+    *,
+    sample_rate: int | None = None,
+) -> None:
+    """Write a one-dataset shard holding only ``audio`` (optionally a sample_rate attr).
+
+    :param path: Destination ``.h5`` file.
+    :param audio: ``(N, C, T)`` array written verbatim as the ``audio`` dataset.
+    :param sample_rate: When set, stored as the ``sample_rate`` attr the encoder reads.
+    """
+    with h5py.File(path, "w") as f:
+        dset = f.create_dataset("audio", data=audio.astype(np.float16))
+        if sample_rate is not None:
+            dset.attrs["sample_rate"] = sample_rate
+
+
+def _width_four_encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+    """Fake encoder: column 0 = per-row mean, column 1 = sample_rate, rest zero.
+
+    Encoding the mono mean lets a test assert row order and channel downmix; the
+    sample_rate column lets a test assert the attr was propagated.
+
+    :param mono: ``(B, T)`` mono batch.
+    :param sample_rate: Rate forwarded from the caller.
+    :returns: ``(B, 4)`` float32 embedding batch.
+    """
+    out = np.zeros((mono.shape[0], 4), dtype=np.float32)
+    out[:, 0] = mono.mean(axis=1)
+    out[:, 1] = sample_rate
+    return out
+
+
+def test_add_clap_embeddings_creates_field_with_encoder_width_and_float32(
+    tmp_path: Path,
+) -> None:
+    """The ``clap`` dataset is created with the encoder's output width as float32.
+
+    :param tmp_path: Per-test tmpdir.
+    """
+    path = tmp_path / "train.h5"
+    _write_audio_h5(path, np.zeros((5, 2, 8), dtype=np.float32))
+
+    add_clap.add_clap_embeddings(path, _width_four_encode, batch_size=2)
+
+    with h5py.File(path, "r") as f:
+        assert _clap(f).shape == (5, 4)
+        assert _clap(f).dtype == np.float32
+
+
+def test_add_clap_embeddings_preserves_row_order_across_ragged_batches(
+    tmp_path: Path,
+) -> None:
+    """Each row's embedding stays aligned to its audio row when N is not a batch multiple.
+
+    :param tmp_path: Per-test tmpdir.
+    """
+    path = tmp_path / "train.h5"
+    # Row i is filled with the constant i, so the fake encoder's mean column == i.
+    audio = np.stack([np.full((2, 8), float(i)) for i in range(5)]).astype(np.float32)
+    _write_audio_h5(path, audio)
+
+    add_clap.add_clap_embeddings(path, _width_four_encode, batch_size=2)
+
+    with h5py.File(path, "r") as f:
+        assert _clap(f)[:, 0].tolist() == [0.0, 1.0, 2.0, 3.0, 4.0]
+
+
+def test_add_clap_embeddings_downmixes_stereo_to_mono_mean(tmp_path: Path) -> None:
+    """A row's channels are averaged before encoding (L=2, R=4 → mono 3).
+
+    :param tmp_path: Per-test tmpdir.
+    """
+    path = tmp_path / "train.h5"
+    audio = np.empty((1, 2, 8), dtype=np.float32)
+    audio[:, 0, :] = 2.0
+    audio[:, 1, :] = 4.0
+    _write_audio_h5(path, audio)
+
+    add_clap.add_clap_embeddings(path, _width_four_encode, batch_size=4)
+
+    with h5py.File(path, "r") as f:
+        assert _clap(f)[0, 0] == 3.0
+
+
+def test_add_clap_embeddings_reads_sample_rate_from_audio_attrs(tmp_path: Path) -> None:
+    """The encoder receives the shard's stored ``sample_rate`` attr.
+
+    :param tmp_path: Per-test tmpdir.
+    """
+    path = tmp_path / "train.h5"
+    _write_audio_h5(path, np.zeros((1, 2, 8), dtype=np.float32), sample_rate=48000)
+
+    add_clap.add_clap_embeddings(path, _width_four_encode, batch_size=4)
+
+    with h5py.File(path, "r") as f:
+        assert _clap(f)[0, 1] == 48000.0
+
+
+def test_add_clap_embeddings_defaults_sample_rate_when_attr_absent(tmp_path: Path) -> None:
+    """With no ``sample_rate`` attr the encoder receives the 44100 project default.
+
+    :param tmp_path: Per-test tmpdir.
+    """
+    path = tmp_path / "train.h5"
+    _write_audio_h5(path, np.zeros((1, 2, 8), dtype=np.float32))
+
+    add_clap.add_clap_embeddings(path, _width_four_encode, batch_size=4)
+
+    with h5py.File(path, "r") as f:
+        assert _clap(f)[0, 1] == float(add_clap.DEFAULT_SAMPLE_RATE)
+
+
+def _exploding_encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+    """Encoder that fails if invoked — proves a skip path bypasses encoding.
+
+    :param mono: Unused mono batch.
+    :param sample_rate: Unused sample rate.
+    :returns: Never returns.
+    :raises AssertionError: Always.
+    """
+    raise AssertionError("encoder must not run on a completed field")
+
+
+def _write_clap_field(path: Path, data: np.ndarray, *, complete: bool) -> None:
+    """Pre-create a ``clap`` dataset, optionally marked complete.
+
+    :param path: HDF5 file to mutate.
+    :param data: Values for the ``clap`` dataset.
+    :param complete: Whether to set the completion marker attr.
+    """
+    with h5py.File(path, "r+") as f:
+        dset = f.create_dataset("clap", data=data)
+        if complete:
+            dset.attrs[add_clap.COMPLETE_ATTR] = True
+
+
+def test_add_clap_embeddings_skips_completed_field_without_overwrite(tmp_path: Path) -> None:
+    """A field carrying the completion marker is left untouched and the encoder never runs.
+
+    :param tmp_path: Per-test tmpdir.
+    """
+    path = tmp_path / "train.h5"
+    _write_audio_h5(path, np.zeros((2, 2, 8), dtype=np.float32))
+    _write_clap_field(path, np.full((2, 4), 7.0, dtype=np.float32), complete=True)
+
+    written = add_clap.add_clap_embeddings(path, _exploding_encode, batch_size=2)
+
+    assert written == 0
+    with h5py.File(path, "r") as f:
+        assert np.all(_clap(f)[:] == 7.0)
+
+
+def test_add_clap_embeddings_recomputes_incomplete_field(tmp_path: Path) -> None:
+    """A present-but-incomplete field (crashed run) is recomputed, not trusted.
+
+    :param tmp_path: Per-test tmpdir.
+    """
+    path = tmp_path / "train.h5"
+    _write_audio_h5(path, np.zeros((2, 2, 8), dtype=np.float32))
+    _write_clap_field(path, np.full((2, 4), 7.0, dtype=np.float32), complete=False)
+
+    written = add_clap.add_clap_embeddings(path, _width_four_encode, batch_size=2)
+
+    assert written == 2
+    with h5py.File(path, "r") as f:
+        assert np.all(_clap(f)[:, 0] == 0.0)
+
+
+def test_add_clap_embeddings_marks_field_complete_after_writing(tmp_path: Path) -> None:
+    """A fully-written field carries the completion marker so reruns can skip it.
+
+    :param tmp_path: Per-test tmpdir.
+    """
+    path = tmp_path / "train.h5"
+    _write_audio_h5(path, np.zeros((3, 2, 8), dtype=np.float32))
+
+    add_clap.add_clap_embeddings(path, _width_four_encode, batch_size=2)
+
+    with h5py.File(path, "r") as f:
+        assert _clap(f).attrs[add_clap.COMPLETE_ATTR]
+
+
+def test_add_clap_embeddings_overwrites_completed_field_when_requested(tmp_path: Path) -> None:
+    """``overwrite=True`` recomputes even a completed ``clap`` field.
+
+    :param tmp_path: Per-test tmpdir.
+    """
+    path = tmp_path / "train.h5"
+    _write_audio_h5(path, np.zeros((2, 2, 8), dtype=np.float32))
+    _write_clap_field(path, np.full((2, 4), 7.0, dtype=np.float32), complete=True)
+
+    add_clap.add_clap_embeddings(path, _width_four_encode, batch_size=2, overwrite=True)
+
+    with h5py.File(path, "r") as f:
+        assert np.all(_clap(f)[:, 0] == 0.0)
+
+
+def test_add_clap_embeddings_raises_when_width_differs_from_expected_dim(tmp_path: Path) -> None:
+    """A ``expected_dim`` mismatch with the encoder width raises before writing.
+
+    :param tmp_path: Per-test tmpdir.
+    """
+    path = tmp_path / "train.h5"
+    _write_audio_h5(path, np.zeros((2, 2, 8), dtype=np.float32))
+
+    # _width_four_encode emits width 4; expecting 512 must fail.
+    with pytest.raises(ValueError, match="width 4, expected 512"):
+        add_clap.add_clap_embeddings(path, _width_four_encode, batch_size=2, expected_dim=512)
+
+    with h5py.File(path, "r") as f:
+        assert "clap" not in f
+
+
+def test_add_clap_embeddings_accepts_matching_expected_dim(tmp_path: Path) -> None:
+    """A ``expected_dim`` equal to the encoder width writes normally.
+
+    :param tmp_path: Per-test tmpdir.
+    """
+    path = tmp_path / "train.h5"
+    _write_audio_h5(path, np.zeros((2, 2, 8), dtype=np.float32))
+
+    add_clap.add_clap_embeddings(path, _width_four_encode, batch_size=2, expected_dim=4)
+
+    with h5py.File(path, "r") as f:
+        assert _clap(f).shape == (2, 4)
+
+
+def test_load_clap_audio_encoder_resamples_to_48k_and_returns_pooler_output() -> None:
+    """The encoder closure resamples to 48 kHz, passes ``audio=``, and returns pooler_output.
+
+    Mocks the ``transformers``/``torchaudio`` boundary so the v5 call contract is
+    pinned without a model download (regression guard for the ``audio=`` kwarg,
+    the 48 kHz resample, and the ``pooler_output`` projection).
+    """
+    import torch
+
+    captured: dict[str, object] = {}
+
+    def fake_processor(audio: object, sampling_rate: int, return_tensors: str) -> dict:
+        captured["sampling_rate"] = sampling_rate
+        captured["batch"] = len(audio)  # type: ignore[arg-type]
+        return {"input_features": torch.zeros((len(audio), 1))}  # type: ignore[arg-type]
+
+    def fake_get_audio_features(**kwargs: object) -> SimpleNamespace:
+        rows = kwargs["input_features"].shape[0]  # type: ignore[union-attr]
+        return SimpleNamespace(pooler_output=torch.ones((rows, 4), dtype=torch.float32))
+
+    fake_model = mock.Mock()
+    fake_model.to.return_value = fake_model
+    fake_model.eval.return_value = fake_model
+    fake_model.get_audio_features.side_effect = fake_get_audio_features
+
+    with (
+        mock.patch("transformers.ClapModel.from_pretrained", return_value=fake_model),
+        mock.patch("transformers.ClapProcessor.from_pretrained", return_value=fake_processor),
+        mock.patch("torch.cuda.is_available", return_value=False),
+        mock.patch(
+            "torchaudio.functional.resample", side_effect=lambda wav, orig, new: wav
+        ) as resample,
+    ):
+        encode = add_clap.load_clap_audio_encoder()
+        out = encode(np.zeros((2, 16), dtype=np.float32), add_clap.DEFAULT_SAMPLE_RATE)
+
+    assert out.shape == (2, 4)
+    assert captured["sampling_rate"] == add_clap.CLAP_SAMPLE_RATE
+    resample.assert_called_once()
+    assert resample.call_args.args[1:] == (add_clap.DEFAULT_SAMPLE_RATE, add_clap.CLAP_SAMPLE_RATE)

--- a/uv.lock
+++ b/uv.lock
@@ -2210,6 +2210,30 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/d8/5c06fc76461418326a7decf8367480c35be11a41fd938633929c60a9ec6b/hf_xet-1.5.0.tar.gz", hash = "sha256:e0fb0a34d9f406eed88233e829a67ec016bec5af19e480eac65a233ea289a948", size = 837196, upload-time = "2026-05-06T06:18:15.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/9b/6912c99070915a4f28119e3c5b52a9abd1eec0ad5cb293b8c967a0c6f5a2/hf_xet-1.5.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:7d70fe2ce97b9db73b9c9b9c81fe3693640aec83416a966c446afea54acfae3c", size = 4023383, upload-time = "2026-05-06T06:17:53.947Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/6d/9563cfde59b5d8128a9c7ec972a087f4c782e4f7bac5a85234edfd5d5e49/hf_xet-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:73a0dae8c71de3b0633a45c73f4a4a5ed09e94b43441d82981a781d4f12baa42", size = 3792751, upload-time = "2026-05-06T06:17:51.791Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a5/ed5a0cf35b49a0571af5a8f53416dad1877a718c021c9937c3a53cb45781/hf_xet-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a60290ec57e9b71767fba7c3645ddafdd0759974b540441510c629c6db6db24a", size = 4456058, upload-time = "2026-05-06T06:17:40.735Z" },
+    { url = "https://files.pythonhosted.org/packages/60/fb/3ae8bf2a7a37a4197d0195d7247fd25b3952e15cb8a599e285dfaa6f52b3/hf_xet-1.5.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e5de0f6deada0dada870bb376a11bcd1f08abf3a968a6d118f33e72d1b1eb480", size = 4250783, upload-time = "2026-05-06T06:17:38.412Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/8bae40d4d91525085137196e84eb0ed49cf65b5e96e5c3ecdadd8bd0fac2/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c799d49f1a5544a0ef7591c0ee75e0d6b93d6f56dc7a4979f59f7518d2872216", size = 4445594, upload-time = "2026-05-06T06:18:04.219Z" },
+    { url = "https://files.pythonhosted.org/packages/13/59/c74efbbd4e8728172b2cc72a2bc014d2947a4b7bdced932fbd3f5da1a4e5/hf_xet-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2baea1b0b989e5c152fe81425f7745ddc8901280ba3d97c98d8cdece7b706c60", size = 4663995, upload-time = "2026-05-06T06:18:06.1Z" },
+    { url = "https://files.pythonhosted.org/packages/73/32/8e1e0410af64cda9b139d1dcebdc993a8ff9c8c7c0e2696ae356d75ccc0d/hf_xet-1.5.0-cp313-cp313t-win_amd64.whl", hash = "sha256:526345b3ed45f374f6317349df489167606736c876241ba984105afe7fd4839d", size = 3966608, upload-time = "2026-05-06T06:18:19.74Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/34/a8febc8f4edbea8b3e21b02ebc8b628679b84ba7e45cde624a7736b51500/hf_xet-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:786d28e2eb8315d5035544b9d137b4a842d600c434bb91bf7d0d953cce906ad4", size = 3796946, upload-time = "2026-05-06T06:18:17.568Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/fb/69ff198a82cae7eb1a69fb84d93b3a3e4816564d76817fe541ddc96874eb/hf_xet-1.5.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dad0dc84e941b8ba3c860659fe1fdc35c049d47cce293f003287757e971a8f56", size = 4030814, upload-time = "2026-05-06T06:17:57.933Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ff/edcc2b40162bef3ff78e14ab637e5f3b89243d6aee72f5949d3bb6a5af83/hf_xet-1.5.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:fd6e5a9b0fdac4ed03ed45ef79254a655b1aaab514a02202617fbf643f5fdf7a", size = 3798444, upload-time = "2026-05-06T06:17:55.79Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4d/103f76b04310e5e57656696cc184690d20c466af0bca3ca88f8c8ea5d4f3/hf_xet-1.5.0-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3531b1823a0e6d77d80f9ed15ca0e00f0d115094f8ac033d5cae88f4564cc949", size = 4465986, upload-time = "2026-05-06T06:17:44.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/a2/546f47f464737b3edbab6f8ddb57f2599b93d2cbb66f06abb475ccb48651/hf_xet-1.5.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9a0ee58cd18d5ea799f7ed11290bbccbe56bdd8b1d97ca74b9cc49a3945d7a3b", size = 4259865, upload-time = "2026-05-06T06:17:42.639Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7f/1be593c1f28613be2e196473481cd81bfc5910795e30a34e8f744f6cac4f/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e60df5a42e9bed8628b6416af2cba4cba57ae9f02de226a06b020d98e1aab18", size = 4459835, upload-time = "2026-05-06T06:18:08.026Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b2/703569fc881f3284487e68cda7b42179978480da3c438042a6bbbb4a671c/hf_xet-1.5.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4b35549ce62601b84da4ff9b24d970032ace3d4430f52d91bcbb26c901d6c690", size = 4672414, upload-time = "2026-05-06T06:18:09.864Z" },
+    { url = "https://files.pythonhosted.org/packages/af/37/1b6def445c567286b50aa3b33828158e135b1be44938dde59f11382a500c/hf_xet-1.5.0-cp37-abi3-win_amd64.whl", hash = "sha256:2806c7c17b4d23f8d88f7c4814f838c3b6150773fe339c20af23e1cfaf2797e4", size = 3977238, upload-time = "2026-05-06T06:18:23.621Z" },
+    { url = "https://files.pythonhosted.org/packages/62/94/3b66b148778ee100dcfd69c2ca22b57b41b44d3063ceec934f209e9184ce/hf_xet-1.5.0-cp37-abi3-win_arm64.whl", hash = "sha256:b6c9df403040248c76d808d3e047d64db2d923bae593eb244c41e425cf6cd7be", size = 3806916, upload-time = "2026-05-06T06:18:21.7Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2271,6 +2295,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
 ]
 
 [[package]]
@@ -5238,6 +5282,95 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ed/0ad2c8edf634918eb4484365d3819fa7bd7f58daf807fe7fb21812c316e5/regex-2026.5.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a9e1328e17c84c1a5d22ec9f785ecef4a967fab9a42b6a8dc3bcbebd0a0c9e44", size = 489438, upload-time = "2026-05-09T23:11:29.374Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a9/4ed972ad263963b860b7c3e86e0e1bcc791def47b43b8c8efe57e710f139/regex-2026.5.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bfe1ce50cbfb569d74e1e4337da6468961f31dbea55fd85aa5de59c0947a805a", size = 291270, upload-time = "2026-05-09T23:11:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/16/81/075930d9fa28c4ea1f53398dd015ee7c882f623539759113cda1257f4b82/regex-2026.5.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:15ee42209947f4ca045412eae98416317238163618ace2a8e54f99586a466733", size = 289198, upload-time = "2026-05-09T23:11:35.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/c8/5cdfbf0b5dc6599e1b6131eff43262e5275d4ec3469ce10216061659aadb/regex-2026.5.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4bb445ff3f725f59df8f6014edb547ee928ec7023a774f6a39a3f953038cbb2", size = 784765, upload-time = "2026-05-09T23:11:37.689Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ca/ae5fd6edc59b7f84b904b31d6ec39a860cbcecd10f64bd5a062ca83a4864/regex-2026.5.9-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:446ddd671e43ab535810c4b21cff7104945c701d4a14d1e6d1cd6f4e445a8bea", size = 852115, upload-time = "2026-05-09T23:11:39.973Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ce/a91cf555afb51f3b74a182e24ba073b91ea7bb64592fc4b315c111bb19fd/regex-2026.5.9-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b92817338591505f282cf3864c145244b1edcf5381d237038df955001091538", size = 899503, upload-time = "2026-05-09T23:11:42.48Z" },
+    { url = "https://files.pythonhosted.org/packages/55/7f/725a0a2b245a4cf0c4bab29d0e97c74285d94136a65d1b55a6459a583502/regex-2026.5.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6b8a143aca6c39b446ea8092cde25cc8fe9304d4f5fecfbc1a9dbb0282703c2", size = 794093, upload-time = "2026-05-09T23:11:44.681Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2a/996efbd59ce6b5d4a09e3af6180ceb62af171f4a9a6fb557d2f0ae0d462b/regex-2026.5.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0f03aa6898aaaac4592479821df16e68e8d0e29e903e65d8f2dfb2f19028a989", size = 786234, upload-time = "2026-05-09T23:11:46.882Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/0a/8731e8b8806174c9cdd5903f80a14990331c1f42fc4209b540952e9e010d/regex-2026.5.9-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ed457d8e98ae812ed7732bef7bf78de78e834eae0372a74e23ca90ef21d910f9", size = 769895, upload-time = "2026-05-09T23:11:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/0b/932473194bd563f342a412ae2ffbbd6da608306a2bc4e99249a41c2b0b92/regex-2026.5.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71b61c5bfe1c806332defc42ad6c780b3c55f661986d7f40283a3a88274b4c00", size = 774991, upload-time = "2026-05-09T23:11:51.261Z" },
+    { url = "https://files.pythonhosted.org/packages/98/80/9523d196010031df25f7177ee0a467efbee436324038e5d99def17a57515/regex-2026.5.9-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:3b1e39888c5e0c7d92cea4fc777396c4a90363b05de75d02eb459a4752200808", size = 848790, upload-time = "2026-05-09T23:11:53.232Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/07/56987b35e89edf47e4a38cf2845aeee476bfa688a6bdbd3e820cda461dc1/regex-2026.5.9-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:6ba42b2e7e7f46cf68cc6a5ca36fa07959f9bbd9c6bdcc47b6ee76549a590248", size = 757679, upload-time = "2026-05-09T23:11:55.82Z" },
+    { url = "https://files.pythonhosted.org/packages/04/2a/ff713fff0c566507c06a4ce2dc0ae8e7eeebc88811a95fc81cf1e7d534dd/regex-2026.5.9-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:c010eb8caca74bdb40c07498d7ece26b4428fd3f04aa8a72c9ac6f79e8faaac6", size = 837116, upload-time = "2026-05-09T23:11:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/77/90/df6d982b03e3614785c6937ba51b57f6733d97d2ee1c9bc7531dbfab3a54/regex-2026.5.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a6a563446a41adc451393dc6b8e6ad87979efaee3c8738690a8d1b08ebead1b4", size = 782081, upload-time = "2026-05-09T23:11:59.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/8a/4e88a5f7c3e98489aac4dd23142723d907b2a595b4a6abcbacabefeded09/regex-2026.5.9-cp310-cp310-win32.whl", hash = "sha256:954cc214c04663ee6d266fc61739cad83054683048de65c5bd1d640ad28098ac", size = 266247, upload-time = "2026-05-09T23:12:01.116Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/40/4b224cb0582b2dca1786726e6cdabe26abbf757d7f6718332f186da155d2/regex-2026.5.9-cp310-cp310-win_amd64.whl", hash = "sha256:b310768746dd314ea6e2ff4cc89ef215426813396ff4e94ee8e6f7096c8b6e03", size = 278416, upload-time = "2026-05-09T23:12:03.2Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4d/014fbe803204cab0947ee428f09f658a29632053dde1d3c6176bb4f0fd4c/regex-2026.5.9-cp310-cp310-win_arm64.whl", hash = "sha256:19c16ceb4a267a8789e25733e583983eeab9f0f8664e66b0bd1c5d21f14c2d4b", size = 270413, upload-time = "2026-05-09T23:12:04.649Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/dc/c1f2df4027e82fc54b5a473e4b250f5139faca49a0fbe29a48668d228f34/regex-2026.5.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccf5249114cc3e772ecdd88a98a86eca0fd74c61ce32a94743758c083fc05d48", size = 489445, upload-time = "2026-05-09T23:12:06.111Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/59f01110660081cce9c0bc30ebd0b5ee250dacf658e3248ed92f01e0e8ee/regex-2026.5.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46f1326ca6e65b0879d23ca302c0f2415aad42ff0309b9c818e7949fe19a41d8", size = 291271, upload-time = "2026-05-09T23:12:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b6/14b2c84ff90ddb370c81d27503f4a0fcf071496416f4855f6cc8c5d81c35/regex-2026.5.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef31cbfe458e21c6122ba8150ff060e0c7789ed0d26eb423f25472584920b555", size = 289212, upload-time = "2026-05-09T23:12:09.266Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d0/4db86529117320de0c84afd90e70bb47434625875e34fcef9d8c127c5b16/regex-2026.5.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:992604d02e6d9c6d786c24a706a71ecffe1020fc1ef264044474cd81fa2c3919", size = 792310, upload-time = "2026-05-09T23:12:11.416Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/fe4800cd322f862ecffd2d553409b20d80650e5ed71b9d178f853d020b82/regex-2026.5.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9411dd64ca95477225734a93dfc8583b51916b8d5942f99d6cac21e09965451", size = 861721, upload-time = "2026-05-09T23:12:13.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d0/b3618a895dd8feb897c61bb2954edd265e1767d82a01d53065d5871127a3/regex-2026.5.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4a3ff360dfb836fecdb93a4598f9d6e2ac81e3e397125145c6221bf58cf4c", size = 906460, upload-time = "2026-05-09T23:12:15.443Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6f/1481597e859ef19508b345eec4afd1416ed6e6b459c75a64026ef193aecf/regex-2026.5.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a661a7d270a61f7cf460caee8b9fa2d5ef9e5c681234bcb9e0fe14f488e7dfc", size = 799843, upload-time = "2026-05-09T23:12:16.892Z" },
+    { url = "https://files.pythonhosted.org/packages/73/59/955734c803f59108deccba3597ae440c76b62a652733c0006e6243758420/regex-2026.5.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f079e50a0d3cc3cd5091fa9ff45869a2e6b2cd35895731edafb0327901a8d86d", size = 773610, upload-time = "2026-05-09T23:12:19.127Z" },
+    { url = "https://files.pythonhosted.org/packages/68/8f/70c04a236d651c81881dac42ef8538bddda6121434509d0a22d9e601503b/regex-2026.5.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4ebe8f0b5ec5a5024dc4a4c59f444c4e9afc5f2abdbb8962065b75d27fb971f9", size = 781645, upload-time = "2026-05-09T23:12:20.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/96/05c7434d88185e5d27fe54aeb74df86bd77cd79f52f0b4eae54faa8fea70/regex-2026.5.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:97cf3bc1b7d7d2306772ec07366c80d9df00ff79e79cea32898883a646d2fae2", size = 854473, upload-time = "2026-05-09T23:12:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/6e3d8202d981f3117004bf341ee74893ba4ba8a9fbaf4b94615846550a08/regex-2026.5.9-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0f9eede6a5cbdc02d4978090186390936e1776a7d1359b21e41014c609880bcf", size = 763311, upload-time = "2026-05-09T23:12:24.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c7/e7737f1526b3fb32bd4c337fd6c71c3ebb5c8296fc34d11197e0955d2e35/regex-2026.5.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:01f0f5f55f4b64dacec85dc116d3c05fd23ad3ff037bbc73a2085775953c2611", size = 844593, upload-time = "2026-05-09T23:12:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/0daffb1a535bb39f422c3d200f4ab023c71110ad66a32b366bee708baba0/regex-2026.5.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1268eddd8486dc561d08eee1156e40aa3a8fe10f4bdec8fa653b455fcbffd12c", size = 789167, upload-time = "2026-05-09T23:12:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fc/294fe4fac4f2ed67207b17471815870c1c45b3a489e08e0ac96daea16ef6/regex-2026.5.9-cp311-cp311-win32.whl", hash = "sha256:8676474c07469d6f33dd1085ca2cd45f65785f32518f2b20e36d9953ca07f994", size = 266249, upload-time = "2026-05-09T23:12:30.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b0/8dce459f6245bcf8f6e9f23ac9569f1a0f15c131cc0745e82b43226204cf/regex-2026.5.9-cp311-cp311-win_amd64.whl", hash = "sha256:246de9d60aa3f8538b519834dd95cbf276ea263d6a7bd5a3666dc3fa0230505b", size = 278423, upload-time = "2026-05-09T23:12:31.676Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/f9aeff6ad63a3ef720386f2907e6d34a35a510a6e498ebad28b0fb3f6ab6/regex-2026.5.9-cp311-cp311-win_arm64.whl", hash = "sha256:d726ca3f0d76969bf1e8e477d160d3d666bbf999f6860bd314889e5345782046", size = 270420, upload-time = "2026-05-09T23:12:33.194Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5667,6 +5800,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
+    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
+    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
+    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
+    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6a/4d08d89a6fcbe905c5ae68b8b34f0791850882fc19782d0d02c65abbdf3b/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f4729811a6640d019a4b7ba8638ee2fd21fa5ca8c7e7bdf0fed62068fcaac737", size = 492430, upload-time = "2025-11-19T15:18:11.884Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/29/59ed8152b30f72c42d00d241e58eaca558ae9dbfa5695206e2e0f54c7063/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12f49080303fa6bb424b362149a12949dfbbf1e06811a88f2307276b0c131afd", size = 503977, upload-time = "2025-11-19T15:18:17.523Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0b/4811bfec67fa260e791369b16dab105e4bae82686120554cc484064e22b4/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0071bffba4150c2f46cae1432d31995d77acfd9f8db598b5d1a2ce67e8440ad2", size = 623890, upload-time = "2025-11-19T15:18:22.666Z" },
+    { url = "https://files.pythonhosted.org/packages/58/5b/632a58724221ef03d78ab65062e82a1010e1bef8e8e0b9d7c6d7b8044841/safetensors-0.7.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:473b32699f4200e69801bf5abf93f1a4ecd432a70984df164fc22ccf39c4a6f3", size = 531885, upload-time = "2025-11-19T15:18:27.146Z" },
 ]
 
 [[package]]
@@ -6352,6 +6511,7 @@ dev = [
     { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "transformers" },
     { name = "wandb" },
     { name = "webdataset" },
 ]
@@ -6415,6 +6575,7 @@ runtime = [
     { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "transformers" },
     { name = "wandb" },
     { name = "webdataset" },
 ]
@@ -6430,6 +6591,7 @@ torch = [
     { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "transformers" },
 ]
 util = [
     { name = "click" },
@@ -6550,6 +6712,7 @@ dev = [
     { name = "torchaudio", specifier = ">=2.0.0" },
     { name = "torchmetrics", specifier = ">=0.11.4" },
     { name = "torchvision", specifier = ">=0.15.0" },
+    { name = "transformers", specifier = ">=4.40.0" },
     { name = "wandb" },
     { name = "webdataset" },
 ]
@@ -6606,6 +6769,7 @@ runtime = [
     { name = "torchaudio", specifier = ">=2.0.0" },
     { name = "torchmetrics", specifier = ">=0.11.4" },
     { name = "torchvision", specifier = ">=0.15.0" },
+    { name = "transformers", specifier = ">=4.40.0" },
     { name = "wandb" },
     { name = "webdataset" },
 ]
@@ -6615,6 +6779,7 @@ torch = [
     { name = "torchaudio", specifier = ">=2.0.0" },
     { name = "torchmetrics", specifier = ">=0.11.4" },
     { name = "torchvision", specifier = ">=0.15.0" },
+    { name = "transformers", specifier = ">=4.40.0" },
 ]
 util = [
     { name = "click", specifier = "<8.2" },
@@ -6710,6 +6875,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+    { url = "https://files.pythonhosted.org/packages/84/04/655b79dbcc9b3ac5f1479f18e931a344af67e5b7d3b251d2dcdcd7558592/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:753d47ebd4542742ef9261d9da92cd545b2cacbb48349a1225466745bb866ec4", size = 3282301, upload-time = "2026-01-05T10:40:34.858Z" },
+    { url = "https://files.pythonhosted.org/packages/46/cd/e4851401f3d8f6f45d8480262ab6a5c8cb9c4302a790a35aa14eeed6d2fd/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e10bf9113d209be7cd046d40fbabbaf3278ff6d18eb4da4c500443185dc1896c", size = 3161308, upload-time = "2026-01-05T10:40:40.737Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6e/55553992a89982cd12d4a66dddb5e02126c58677ea3931efcbe601d419db/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64d94e84f6660764e64e7e0b22baa72f6cd942279fdbb21d46abd70d179f0195", size = 3718964, upload-time = "2026-01-05T10:40:46.56Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/b1c87148aa15e099243ec9f0cf9d0e970cc2234c3257d558c25a2c5304e6/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f01a9c019878532f98927d2bacb79bbb404b43d3437455522a00a30718cdedb5", size = 3373542, upload-time = "2026-01-05T10:40:52.803Z" },
 ]
 
 [[package]]
@@ -7187,6 +7382,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/c1/bd361c24a76e7c0d137e299ca1e86bbe188e4c08e3e46674a285aa762051/tqdm_loggable-0.4.1.tar.gz", hash = "sha256:49123ffcb2deb948edb7121d7e09a6008914e0d0333154f060e435deba9e547a", size = 8170, upload-time = "2026-03-16T18:38:50.774Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/24/303708f276f2a81bd0551f5e93b5dd51201ca0d73aed0dc50be6976a3443/tqdm_loggable-0.4.1-py3-none-any.whl", hash = "sha256:e3b394a6fc85a1b1b0dad52a63ac926ecb3b478acf4f4bae570d9189f00ab91d", size = 10527, upload-time = "2026-03-16T18:38:49.808Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/38/d5f978bd5091019e89aef29b9a831f5cd70f2598963a3ead8b9570cab592/transformers-5.10.2.tar.gz", hash = "sha256:f9a44b9c8ca9ab1156b467f574d832ea066284299c2fd0ed84641ccb592751fc", size = 8799687, upload-time = "2026-06-04T18:43:49.119Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/6f/e1564b0cc182afa05e219a8e09a8e770ffaab879b6b824b56c819bd221da/transformers-5.10.2-py3-none-any.whl", hash = "sha256:8a669db546f82c7c3618cb46ceb0f0afd89292bc70f319c058f8332ec63e268d", size = 11003830, upload-time = "2026-06-04T18:43:45.303Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -6391,7 +6391,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.30.0"
+version = "8.31.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Adds **LAION CLAP audio-embedding conditioning** to the dataset/dataloader path (steps 1–4 of the plan; model-side consumption is a follow-up).

- **Producer** `src/synth_setter/pipeline/data/add_clap.py`: a post-finalization CLI that reads each split file's virtual `audio`, downmixes to mono, runs an injected CLAP encoder, and writes a real `clap` `(N, D)` dataset into the same split file. The functional core takes an injected `encode` callable (fully tested without a model download); `load_clap_audio_encoder` is the thin shell that builds the real encoder via a lazy `transformers` import.
- **Datamodule** `surge_datamodule.py`: `read_clap` flag through `SurgeXTDataset` and a `conditioning="clap"` route in `SurgeDataModule`, mirroring `read_m2l`.
- **Shared constant** `CLAP_EMBEDDING_DIM` single-sourced in `data/vst/shapes.py`; `transformers` added to the `torch` dependency group.

### Why split files, not shards
The resharder's virtual layout only carries the core `DATASET_FIELD_DTYPES`, so a side embedding must live in the split file (`train/val/test.h5`) the datamodule opens directly.

### Robustness
- **Idempotent / crash-safe**: a `clap_complete` marker attr is set only after every row is written; a present-but-incomplete field (crashed run) is recomputed, a completed field is skipped, `--overwrite` forces recompute.
- **Width guard**: `add_clap_embeddings(expected_dim=…)` asserts the encoder width before writing; `main()` pins it to `CLAP_EMBEDDING_DIM` only for the default checkpoint, leaving alternates free to project their own width.

### Deviations from the issue's written scope (by design)
- Uses the HF `transformers` `ClapModel` rather than `laion_clap` (decided with the requester — same LAION weights, cleaner checkpoint pinning).
- HDF5 only; the webdataset path is deferred.
- Includes the datamodule read seam, which #1570 lists as a follow-up — it's the natural consumer of the new field.

### Known follow-ups (advisory, not blocking)
- Model-side `conditioning="clap"` consumption (`SurgeFlowMatchingModule` + a CLAP encoder config) — step 5, separate PR.
- Like `m2l`, `clap` is **not** threaded through `_hungarian_match`, so `ot=True` + `conditioning="clap"` would misalign the embedding from its permuted params. The `m2l` half of this is fixed in #1573 (branch `fix/ot-thread-side-embeddings`); `clap` needs the same one-line follower addition once both land.
- CLI `main()` / real-encoder shell are uncovered (model-download trade-off). Manual e2e: `python -m synth_setter.pipeline.data.add_clap <dataset_dir>` against a small finalized dataset, then train with `datamodule.conditioning=clap`.

## Test plan
- `uv run pytest tests/pipeline/data/test_add_clap.py tests/data/test_surge_datamodule.py` → 83 passed.
- `make format` → clean (ruff, ruff-format, pyright, pydoclint, etc.).
- HDF5 core exercised via an injected fake encoder: ragged batches, mono downmix, sample-rate propagation, completion-marker idempotency (skip/recompute/overwrite), and the `expected_dim` width guard (raise + accept).

Refs #1570
