### PR TITLE
automation(codex): add repo skill projection

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../agent/skills

--- a/agent/hooks/session-start-cwd-banner.sh
+++ b/agent/hooks/session-start-cwd-banner.sh
@@ -60,18 +60,19 @@ main() {
     printf '  worktrees: %s active (run `git worktree list` for paths)\n' "$worktree_count"
   fi
 
-  # .claude/{skills,hooks} are committed as symlinks into the canonical agent/
-  # tree; an unmaterialized (core.symlinks=false, Windows, zip) or dangling link
-  # means Claude discovers zero project skills. Warn on any entry that isn't a
-  # resolved dir: -d follows symlinks, -L catches a broken link that -e misses.
-  local repo_top asset asset_path
+  # Tool discovery paths are committed as symlinks into the canonical agent/
+  # tree; unmaterialized or dangling links mean project assets disappear.
+  local repo_top asset_path
   repo_top=$(git rev-parse --show-toplevel 2>/dev/null || true)
   [[ -n "$repo_top" ]] || return 0
-  for asset in skills hooks; do
-    asset_path="$repo_top/.claude/$asset"
+  for asset_path in \
+    "$repo_top/.agents/skills" \
+    "$repo_top/.claude/hooks" \
+    "$repo_top/.claude/skills"
+  do
     [[ ( -e "$asset_path" || -L "$asset_path" ) && ! -d "$asset_path" ]] || continue
-    printf '\n  WARNING: .claude/%s did not materialize as a directory — Claude skill/hook discovery is BROKEN.\n' "$asset"
-    printf "    Fix: git -C '%s' config core.symlinks true && git -C '%s' checkout -- .claude\n" "$repo_top" "$repo_top"
+    printf '\n  WARNING: %s did not materialize as a directory — agent asset discovery is BROKEN.\n' "${asset_path#"$repo_top/"}"
+    printf "    Fix: git -C '%s' config core.symlinks true && git -C '%s' checkout -- .agents .claude\n" "$repo_top" "$repo_top"
   done
 }
 

--- a/agent/hooks/session-start-cwd-banner.sh
+++ b/agent/hooks/session-start-cwd-banner.sh
@@ -72,7 +72,7 @@ main() {
   do
     [[ ( -e "$asset_path" || -L "$asset_path" ) && ! -d "$asset_path" ]] || continue
     printf '\n  WARNING: %s did not materialize as a directory — agent asset discovery is BROKEN.\n' "${asset_path#"$repo_top/"}"
-    printf "    Fix: git -C '%s' config core.symlinks true && git -C '%s' checkout -- .agents .claude\n" "$repo_top" "$repo_top"
+    printf "    Fix: git -C '%s' config core.symlinks true && git -C '%s' checkout -- '%s'\n" "$repo_top" "$repo_top" "${asset_path#"$repo_top/"}"
   done
 }
 

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -1461,6 +1461,26 @@ T_session_start_banner_warns_when_claude_skills_symlink_unmaterialized() {
 }
 it "session-start-banner: .claude/skills is a plain file (symlink unmaterialized) → loud warning + core.symlinks fix, exit 0" T_session_start_banner_warns_when_claude_skills_symlink_unmaterialized
 
+T_session_start_banner_warns_when_codex_skills_symlink_unmaterialized() {
+  # Codex discovers repo-local skills through .agents/skills, which is also a
+  # symlink into the shared agent tree. Surface broken materialization there.
+  local out
+  mkdir -p "$SANDBOX/.agents"
+  printf '../agent/skills' > "$SANDBOX/.agents/skills"
+  out=$(bash agent/hooks/session-start-cwd-banner.sh </dev/null 2>&1; echo "EXIT:$?")
+  rm -rf "$SANDBOX/.agents"
+  [[ "$(last_exit_line "$out")" == "EXIT:0" ]] || { echo "guard must never block (expected EXIT:0); got: $out"; return 1; }
+  [[ "$out" == *".agents/skills"* && "$out" == *"did not materialize"* ]] || {
+    echo "banner should warn that .agents/skills did not materialize; got: $out"
+    return 1
+  }
+  [[ "$out" == *"core.symlinks"* ]] || {
+    echo "warning should include the core.symlinks remediation; got: $out"
+    return 1
+  }
+}
+it "session-start-banner: .agents/skills is a plain file (symlink unmaterialized) → loud warning + core.symlinks fix, exit 0" T_session_start_banner_warns_when_codex_skills_symlink_unmaterialized
+
 T_session_start_banner_warns_on_dangling_claude_symlink() {
   # A symlink whose target is missing resolves nowhere and -e is false for it,
   # so the guard must also probe -L to catch the broken link (discovery is

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -27,8 +27,9 @@ def _load_settings() -> dict[str, Any]:
 
 
 def test_claude_agent_assets_are_symlinked_to_agent_source() -> None:
-    """The shared ``agent/`` tree is the source of truth for hooks and review skills."""
+    """The shared ``agent/`` tree is the source of truth for tool-discovered assets."""
     expected = {
+        _REPO_ROOT / ".agents" / "skills": _REPO_ROOT / "agent" / "skills",
         _REPO_ROOT / ".claude" / "hooks": _REPO_ROOT / "agent" / "hooks",
         _REPO_ROOT / ".claude" / "skills": _REPO_ROOT / "agent" / "skills",
     }

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -26,7 +26,7 @@ def _load_settings() -> dict[str, Any]:
     return json.loads(_SETTINGS_PATH.read_text())
 
 
-def test_claude_agent_assets_are_symlinked_to_agent_source() -> None:
+def test_agent_assets_are_symlinked_to_agent_source() -> None:
     """The shared ``agent/`` tree is the source of truth for tool-discovered assets."""
     expected = {
         _REPO_ROOT / ".agents" / "skills": _REPO_ROOT / "agent" / "skills",

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.30.0"
+version = "8.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary
- add `.agents/skills` as the Codex repo-local projection of `agent/skills`
- extend the projection invariant test to cover Codex and Claude skill paths
- warn on broken `.agents/skills` symlink materialization at session start
- include the `uv.lock` package-version sync produced by `make format`

Refs #1561

## Verification
- `pytest tests/claude_hooks/test_settings_hooks.py::test_claude_agent_assets_are_symlinked_to_agent_source -q`
- `bash agent/hooks/test.sh`
- `make format`
