### PR TITLE
internal-feat(gemini-support): add Gemini CLI harness configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,9 +10,3 @@ FROM tinaudio/synth-setter:devcontainer-tools
 #   RUN apt-get update && apt-get install -y <package> \
 #     && rm -rf /var/lib/apt/lists/*
 #   USER dev
-
-USER dev
-ARG GEMINI_CLI_VERSION=latest
-RUN export HOME="/home/dev" \
- && npm install -g "@google/gemini-cli@${GEMINI_CLI_VERSION}" \
- && gemini --version

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,3 +10,9 @@ FROM tinaudio/synth-setter:devcontainer-tools
 #   RUN apt-get update && apt-get install -y <package> \
 #     && rm -rf /var/lib/apt/lists/*
 #   USER dev
+
+USER dev
+ARG GEMINI_CLI_VERSION=latest
+RUN export HOME="/home/dev" \
+ && npm install -g "@google/gemini-cli@${GEMINI_CLI_VERSION}" \
+ && gemini --version

--- a/.gemini/commands/fix/review-comments.toml
+++ b/.gemini/commands/fix/review-comments.toml
@@ -1,0 +1,132 @@
+description = "Apply every comment-hygiene finding from the pre-PR review sentinel, then refresh the sentinel so the gate passes. Use this after `/repo-review-full-no-comments` reports comment-hygiene BLOCK/WARN findings, whenever `gh pr create` is blocked with \"unresolved comment-hygiene finding(s)\", or any time you want the comment/docstring findings in the latest review applied in one pass. Reads the sentinel written by `agent/_shared/review_sentinel.py`; pairs with the `comment-hygiene` skill for the checklist and rewrite rules."
+prompt = '''
+# fix-review-comments — Apply Comment-Hygiene Findings From the Sentinel
+
+`/repo-review-full-no-comments` writes a rendered review to a sentinel file
+keyed by HEAD's SHA. The `pre-pr-review-gate.sh` hook blocks `gh pr create`
+while that sentinel still lists `[comment-hygiene:warn]` / `[comment-hygiene:block]`
+findings (`REVIEW_COMMENT_GATE=block`, the default). This skill drains those
+findings: apply each rewrite, commit, then re-review so the refreshed sentinel
+is clean and the gate opens.
+
+The fix is an **apply step, not a re-judgment**. Consistency comes from
+applying the rewrite the review already produced — not from re-deriving one.
+You MUST complete every step in order.
+
+## Step 1: Locate and read the sentinel
+
+```bash
+REVIEW_PATH=$(python3 agent/_shared/review_sentinel.py path "$(git rev-parse HEAD)")
+test -f "$REVIEW_PATH" || echo "MISSING: $REVIEW_PATH"
+```
+
+If the file is missing, the review hasn't run against this HEAD. Stop and tell
+the user to run `/repo-review-full-no-comments` first — do not fabricate one.
+
+Read the whole sentinel. The findings you act on are the lines tagged
+`**[comment-hygiene:warn]**` or `**[comment-hygiene:block]**`, grouped under
+their `### \`<path>\`\` headers. Ignore every other skill's findings — they are
+out of scope here.
+
+## Step 2: Extract one work-item per comment-hygiene finding
+
+For each tagged finding, capture:
+
+- `path` and `line` (from the `**L<line>**` anchor and its `### \`<path>\`\` header).
+- The **C-id** (`C1`–`C12`) named in the description.
+- The verbatim `Before:` / `After:` rewrite **if the body carried one**. The
+  review preserves code fences, so most findings ship their own rewrite.
+
+When a finding's body is terse and carries no usable `After:`, read the cited
+`path:line` (±2 lines) and derive the rewrite straight from the
+`comment-hygiene` checklist for that C-id. This is the only place judgment
+re-enters; keep it mechanical — apply the rule, don't re-litigate whether the
+finding is valid.
+
+## Step 3: Bucket each finding — apply now vs. surface
+
+| Bucket            | C-ids                       | Action                                                                         |
+| ----------------- | --------------------------- | ------------------------------------------------------------------------------ |
+| **Mechanical**    | C2, C3, C6, C7, C8, C9, C11 | Apply the rewrite (deletion or tightening) verbatim.                           |
+| **Move-in-place** | C1                          | Lift the comment above the `- name:` step. Surface if the move is non-obvious. |
+| **Needs a ref**   | C5, C10                     | Apply only when a real issue/rationale is available (Step 4). Else surface.    |
+| **Rewrite-ship**  | C12                         | Apply the `After:` if present; else tighten per the doc-map rules.             |
+
+The **mitigation that keeps the hard gate honest**: never invent a placeholder
+issue number to satisfy C5/C10. A fake `# … — see #0` would pass both the
+checklist pattern and the gate while baking wrong content into the code. If you
+can't source a real ref, leave that one finding unfixed and report it — the
+gate legitimately stays closed until a human supplies it (or sets
+`REVIEW_COMMENT_GATE=off` for a genuinely intentional finding).
+
+## Step 4: Source a real issue ref for C5 / C10 (mitigation)
+
+Before surfacing a needs-a-ref finding, try to find a real number already tied
+to this work:
+
+```bash
+gh pr view --json body -q .body 2>/dev/null | grep -oE '(Refs|Closes|Fixes|Part of) #[0-9]+'
+git log -1 --pretty=%B | grep -oE '#[0-9]+'
+```
+
+Use a number only if it actually governs this change (the PR's linked issue or
+the commit's trailer). If nothing applies, do not guess — surface the finding.
+
+## Step 5: Apply the fixes — content-anchored, bottom-up
+
+Findings are anchored to `path:line`, so editing top-down shifts every later
+line in the same file. Apply **per file, in descending line order**, and match
+on the verbatim `Before:` text (exact-match `Edit`), not on the line number.
+Content-anchoring survives any drift the review's line numbers may already
+have.
+
+Do not touch code the findings don't cite. This skill changes inline text
+only — comments, docstrings, YAML comments, `doc-map.yaml` prose.
+
+## Step 6: Commit the fixes
+
+The re-review in Step 7 reads committed history (`base..HEAD`), so uncommitted
+edits won't clear the findings. Commit the applied fixes:
+
+```bash
+git add -A
+git commit -m "chore(comments): apply comment-hygiene fixes from pre-PR review"
+```
+
+Conventional-commit + gitlint rules apply (see `/github-taxonomy` for scope).
+If these fixes belong with an unpushed WIP commit, squash them in instead of
+adding a separate commit — your call based on whether the prior commit is
+already pushed.
+
+## Step 7: Re-review to refresh the sentinel
+
+Run `/repo-review-full-no-comments` again. It writes a fresh sentinel against
+the new HEAD. This both regenerates the gate's contract at the current SHA and
+re-reviews your fixes (a bad rewrite gets re-flagged here rather than shipping).
+
+## Step 8: Report
+
+Summarize:
+
+- **Applied** — count by C-id, with `path:line` for each.
+- **Surfaced** — every finding left unfixed and why (needs a real issue ref, a
+  rationale decision, or a non-obvious C1 move). These are what the user must
+  resolve before the gate opens.
+- **Gate status** — whether the refreshed sentinel is clean. If findings
+  remain, name the `gh pr create … # REVIEW_FULL=<path>` follow-up, and note
+  that `REVIEW_COMMENT_GATE=off` bypasses the sub-gate for an intentional
+  finding the user has accepted.
+
+## Notes
+
+- This skill is the remediation half of the pre-PR comment gate; the detection
+  half is `/repo-review-full-no-comments` + `pre-pr-review-gate.sh`. Keep the
+  three in sync — the gate greps for the `[comment-hygiene:<severity>]` tag the
+  review emits.
+- Rewrite semantics (what each C-id means, the `.. attribute ::` and
+  no-`:param self:` pydoclint rules) live in the `comment-hygiene` skill. When
+  re-deriving a fix in Step 2, that skill is authoritative — do not reinvent the
+  rules here.
+- Re-running is cheap relative to shipping wrong content. If a fix looks
+  ambiguous, surface it rather than guessing.
+'''

--- a/.gemini/commands/lint/cleanup.toml
+++ b/.gemini/commands/lint/cleanup.toml
@@ -1,0 +1,20 @@
+description = "Run the lint-cleanup workflow on a legacy file from `.pydoclint-baseline.txt` (#938) or another exclusion list (#25)"
+prompt = '''
+Run the lint-cleanup workflow from
+[`.github/agents/lint-cleanup.md`](../../.github/agents/lint-cleanup.md) on
+the file `{{args}}`.
+
+If `{{args}}` is empty, pick the target by following the canonical
+runbook's [**Picking the next file**](../../.github/agents/lint-cleanup.md#picking-the-next-file)
+section — do not reproduce its rules here.
+
+Spawn the `lint-cleanup` subagent (defined in
+`.claude/agents/lint-cleanup.md`) in an isolated worktree to do the work.
+Hand it the path and remind it of the hard rules: one file per PR, no
+behavioral changes, branch `chore/lint-cleanup/<name>`, commit prefix
+`chore(lint):`, PR body has `Refs #938` (pydoclint baseline drains) or
+`Refs #25` (other lint stacks) — not `Fixes`/`Closes`. Pydoclint cleanup
+edits `.pydoclint-baseline.txt` (regenerate with
+`pydoclint --generate-baseline=1 src/ tests/ scripts/`), never
+`[tool.pydoclint].exclude`.
+'''

--- a/.gemini/commands/pr/readiness.toml
+++ b/.gemini/commands/pr/readiness.toml
@@ -1,0 +1,62 @@
+description = "Drive a pushed PR through the four readiness gates until it is genuinely ready — watch CI, fix red, confirm mergeable, reply inline to every open review comment, and wait out Copilot's re-review. Use this skill after every push to a PR branch, when the pr-readiness-stop hook blocks a turn, or when the user says \"drive the PR to ready\", \"is this PR ready\", \"finish the readiness loop\", \"/pr-readiness\", or anything about getting a PR past CI + review + Copilot. Implements docs/pr-readiness-loop.md as an invocable procedure."
+prompt = '''
+# pr-readiness — drive the PR readiness loop
+
+Run the loop in [`docs/pr-readiness-loop.md`](../../../docs/pr-readiness-loop.md)
+until all four gates hold. That doc is canonical — read it for the exact
+commands, endpoints, and traps. This skill is the invocable driver; do not
+duplicate the doc's prose, follow it.
+
+"I pushed the fix" is **not** "the PR is ready." Do not stop after the first
+push.
+
+## The four gates
+
+A PR is ready only when **all four** hold (AND-ed):
+
+1. **CI fully green** — every required and optional check passing. Pending or
+   errored counts as not ready.
+2. **`mergeable=MERGEABLE`** — `UNKNOWN` and `CONFLICTING` both fail.
+3. **Every open review comment has an inline reply** — humans and Copilot.
+4. **No fresh Copilot findings since the last push.**
+
+## Procedure
+
+Resolve the PR once up front:
+
+```bash
+PR=$(gh pr view "$(git branch --show-current)" --json number -q .number)
+```
+
+Then iterate until all four gates hold. Use `/loop` for the waiting steps
+(e.g. `/loop 2m gh pr checks "$PR"`).
+
+1. **Watch CI** — `gh pr checks "$PR" --watch`. On any failure, diagnose, fix,
+   commit, push, and return to step 1. Never move on with red CI.
+
+2. **Check mergeability** — `gh pr view "$PR" --json mergeable -q .mergeable`:
+
+   - `CONFLICTING` → rebase or merge the base branch, resolve, push, back to 1.
+   - `UNKNOWN` → GitHub is still computing; poll again.
+   - `MERGEABLE` → continue.
+
+3. **Reply inline to every open review comment.** Delegate to
+   `/pr-review-resolver`, which triages each comment, fixes what's actionable,
+   and replies inline with the fix-commit SHA or a justification. If any reply
+   required a code change, push and return to step 1.
+
+4. **Wait for Copilot's post-push review** (~60s, allow up to 15 min). Check
+   both the inline-comments and top-level reviews endpoints
+   (docs/pr-readiness-loop.md step 6). Filter to findings newer than your last
+   push. Address new actionable findings as in step 3, then loop. A "no
+   findings" review is silence, not a comment. If 15 min elapse with no
+   activity, manually re-request Copilot per step 6a (at most once).
+
+5. **Done** only when all four gates hold simultaneously.
+
+## Relationship to the Stop hook
+
+`agent/hooks/pr-readiness-stop.sh` blocks the turn from ending while gates 1-2
+fail; it cannot decide gates 3-4 in bash, so it points here. Running this skill
+to completion is what clears the block.
+'''

--- a/.gemini/commands/qrspi/design.toml
+++ b/.gemini/commands/qrspi/design.toml
@@ -1,0 +1,6 @@
+description = "QRSPI D — produce a ~200-line design doc; this is where opinions are invited"
+prompt = '''
+Invoke the `tinaudio-synth-setter-skills:qrspi-design` skill via the Skill
+tool, passing `{{args}}` through unchanged. That skill carries the canonical
+QRSPI D implementation; this file is a short-name alias.
+'''

--- a/.gemini/commands/qrspi/implement.toml
+++ b/.gemini/commands/qrspi/implement.toml
@@ -1,0 +1,6 @@
+description = "QRSPI I — autonomously implement P-doc phases via implement_plan + tdd + code-health"
+prompt = '''
+Invoke the `tinaudio-synth-setter-skills:qrspi-implement` skill via the Skill
+tool, passing `{{args}}` through unchanged. That skill carries the canonical
+QRSPI I implementation; this file is a short-name alias.
+'''

--- a/.gemini/commands/qrspi/plan.toml
+++ b/.gemini/commands/qrspi/plan.toml
@@ -1,0 +1,6 @@
+description = "QRSPI P — write the tactical implementation plan; do not re-open design decisions"
+prompt = '''
+Invoke the `tinaudio-synth-setter-skills:qrspi-plan` skill via the Skill
+tool, passing `{{args}}` through unchanged. That skill carries the canonical
+QRSPI P implementation; this file is a short-name alias.
+'''

--- a/.gemini/commands/qrspi/pr.toml
+++ b/.gemini/commands/qrspi/pr.toml
@@ -1,0 +1,7 @@
+description = "QRSPI PR — open the PR, drive CI green, and resolve every inline comment"
+prompt = '''
+Invoke the `tinaudio-synth-setter-skills:qrspi-pr` skill via the Skill tool,
+passing `{{args}}` through unchanged (empty is fine — the skill autodetects
+the PR from the current branch). That skill carries the canonical QRSPI PR
+implementation; this file is a short-name alias.
+'''

--- a/.gemini/commands/qrspi/questions.toml
+++ b/.gemini/commands/qrspi/questions.toml
@@ -1,0 +1,6 @@
+description = "QRSPI Q — turn a ticket into factual questions about the existing codebase"
+prompt = '''
+Invoke the `tinaudio-synth-setter-skills:qrspi-questions` skill via the Skill
+tool, passing `{{args}}` through unchanged. That skill carries the canonical
+QRSPI Q implementation; this file is a short-name alias.
+'''

--- a/.gemini/commands/qrspi/research.toml
+++ b/.gemini/commands/qrspi/research.toml
@@ -1,0 +1,6 @@
+description = "QRSPI R — document the codebase ticket-blind, answering only the Q-stage questions"
+prompt = '''
+Invoke the `tinaudio-synth-setter-skills:qrspi-research` skill via the Skill
+tool, passing `{{args}}` through unchanged. That skill carries the canonical
+QRSPI R implementation; this file is a short-name alias.
+'''

--- a/.gemini/commands/qrspi/structure.toml
+++ b/.gemini/commands/qrspi/structure.toml
@@ -1,0 +1,6 @@
+description = "QRSPI S — vertical-slice implementation outline (header-file style)"
+prompt = '''
+Invoke the `tinaudio-synth-setter-skills:qrspi-structure` skill via the Skill
+tool, passing `{{args}}` through unchanged. That skill carries the canonical
+QRSPI S implementation; this file is a short-name alias.
+'''

--- a/.gemini/commands/qrspi/worktree.toml
+++ b/.gemini/commands/qrspi/worktree.toml
@@ -1,0 +1,6 @@
+description = "QRSPI W — delegate to wave-orchestration for branch/worktree assignment from a P doc"
+prompt = '''
+Invoke the `tinaudio-synth-setter-skills:qrspi-worktree` skill via the Skill
+tool, passing `{{args}}` through unchanged. That skill carries the canonical
+QRSPI W implementation; this file is a short-name alias.
+'''

--- a/.gemini/commands/repo/review-full-no-comments.toml
+++ b/.gemini/commands/repo/review-full-no-comments.toml
@@ -1,0 +1,200 @@
+description = "Multi-skill review (same fan-out as `/repo-review-full`) that prints the aggregated BLOCK/WARN report to the user instead of posting inline comments on GitHub. Works against either an open PR or a local branch that has not been pushed yet — use it as a pre-PR gate or whenever GitHub side effects are undesirable. Requires the tinaudio-synth-setter-skills plugin."
+prompt = '''
+# repo-review-full-no-comments — Multi-Skill Review Without Posting
+
+Same analysis as `/repo-review-full`, with two differences:
+
+1. The final delivery step renders findings inline in chat instead of
+   submitting a GitHub review.
+2. A PR is **not** required. If no PR exists for the current branch, this skill
+   reviews the local branch vs. the default branch.
+
+You MUST complete every step in order.
+
+## Step 1: Resolve the target (PR or local branch)
+
+Pick whichever mode applies. Steps 3–6 work the same once the metadata is in
+hand.
+
+**PR mode.** Use this when the caller passed an explicit `<N>`, or when
+`gh pr view --json number` resolves a PR for the current branch:
+
+```bash
+gh pr view <N> --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \
+  --json number,headRefOid,baseRefOid,files,title,headRefName,mergeable,mergeStateStatus,statusCheckRollup
+```
+
+This is the exact call from `agent/skills/_shared/repo-review-full-analysis.md`
+Step 1 — use that file's guidance for parsing it.
+
+**Local-branch mode.** Use this when no `<N>` was passed AND
+`gh pr view --json number` fails / returns nothing for the current branch.
+Derive the same fields from local git:
+
+```bash
+base_ref=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+base_sha=$(git merge-base HEAD "origin/${base_ref}")
+head_sha=$(git rev-parse HEAD)
+head_ref=$(git rev-parse --abbrev-ref HEAD)
+# File list with status (for tdd-refactor R-detection in Step 3)
+git diff --name-status "${base_sha}..${head_sha}"
+```
+
+Build a synthetic metadata object equivalent to the `gh pr view` JSON:
+
+- `number`: `null` — no PR yet; use the branch name in any user-facing text.
+- `headRefOid`: `head_sha`
+- `baseRefOid`: `base_sha`
+- `headRefName`: `head_ref`
+- `title`: `git log -1 --pretty=%s` (informational only).
+- `files`: parsed `git diff --name-status` output.
+- `mergeable`, `mergeStateStatus`, `statusCheckRollup`: **not available** — Step
+  2 handles this.
+
+If there are zero changed files between `base_sha` and `head_sha`, stop and
+reply `PASS — no diff vs ${base_ref}`.
+
+## Step 2: Inspect PR health
+
+**PR mode.** Follow `agent/skills/_shared/repo-review-full-analysis.md` Step 2
+exactly as written (merge conflicts + failing checks).
+
+**Local-branch mode.** Skip the GitHub-side `mergeable` and `statusCheckRollup`
+checks — they don't exist pre-PR. Do not synthesize PR-health BLOCKs and do not
+emit a `## PR health` section in Step 6's JSON. Instead, Step 6 prepends a
+one-line caveat to the `review_body` so the user knows merge/CI health was not
+verified.
+
+## Steps 3–6: Run the shared analysis pipeline
+
+Read and follow `agent/skills/_shared/repo-review-full-analysis.md` Steps 3
+through 6 using the metadata from Step 1 above. The shared file owns skill
+selection, the parallel fan-out, finding aggregation, and the findings-JSON
+construction; it is mode-agnostic.
+
+When the shared file says "the calling skill," that's this skill:
+
+- Use `repo-review-full-no-comments` as the calling-skill name in any
+  `[<calling-skill>:block]` prefixes inside the `## PR health` bullets (PR mode
+  only — local-branch mode has no PR-health bullets).
+
+- Write the findings JSON to `/tmp/repo-review-full-no-comments-findings.json`.
+
+- For `pr_number` in the JSON: use the resolved PR number in PR mode, or
+  `null` in local-branch mode. Do not place branch names in `pr_number`; keep
+  branch/target details in `review_body` and, if the shared JSON builder
+  supports it, a separate metadata field such as `target`.
+
+- Phrase the `review_body` lead-in to reflect what was reviewed and that
+  nothing was posted. In PR mode, write:
+
+  > Multi-skill dry-run review of PR #\<N> — \<K> parallel passes (\<list of skills>). Findings below; no inline comments posted.
+
+  In local-branch mode, write:
+
+  > Multi-skill dry-run review of branch \<head_ref> vs \<base_ref> (no PR yet) — \<K> parallel passes (\<list of skills>). Findings below; no inline comments posted. Merge/CI health not checked — rerun after opening the PR for that.
+
+Return here once Step 6 has produced the JSON payload on disk.
+
+## Step 7: Render the findings — write the sentinel file **and** print to chat
+
+Do NOT invoke `post_review.py`. Do NOT call any `gh api .../reviews` or
+`gh pr review` command. This skill has zero GitHub side effects.
+
+Transform the JSON payload at `/tmp/repo-review-full-no-comments-findings.json`
+into a Markdown report. The report is **both** printed to chat (human
+delivery surface) **and** written to a sentinel file. The
+`pre-pr-review-gate.sh` PreToolUse hook validates the path supplied via
+`REVIEW_FULL=<path>` on `gh pr create` by parsing this filename.
+
+**Compute the sentinel path** — the format is owned by
+`agent/_shared/review_sentinel.py` (single source of truth shared with the
+gate hook):
+
+```bash
+REVIEW_PATH=$(python3 agent/_shared/review_sentinel.py path "$(git rev-parse HEAD)")
+mkdir -p "$(dirname "$REVIEW_PATH")"
+```
+
+The result is of the form
+`.agent-reviews/repo-review-full-no-comments.<40-char-sha>.md`. **Do not
+hand-write the filename** — always go through the helper.
+
+**Write the report to `$REVIEW_PATH` and print the same content to chat**,
+using this layout:
+
+```markdown
+# repo-review-full-no-comments — <target>
+
+<review_body verbatim, including the `## PR health` section if present>
+
+## Inline findings (would be posted by `/repo-review-full`)
+
+### `<path>`
+- **L<line>** — <body>
+- **L<line>** — <body>
+
+### `<other path>`
+- **L<line>** — <body>
+
+## Summary
+
+- B BLOCK, W WARN across K skills
+- PR-health flags: <M merge-conflict / F failing-check>  (omit if zero or in local-branch mode)
+- Reviewed at: <full-sha-from-git-rev-parse-HEAD>
+- <next-step tip>
+```
+
+For `<target>` in the header, use `PR #<N>` in PR mode or
+`branch <head_ref>` in local-branch mode.
+
+For `<next-step tip>` in the Summary section, use (substitute
+`<REVIEW_PATH>` with the actual path computed above before printing — do
+not emit the literal placeholder):
+
+- PR mode: `Run /repo-review-full <N> to post these as inline review comments.`
+- Local-branch mode: `Open a PR with REVIEW_FULL=<REVIEW_PATH> in the command. Then run /repo-review-full to post these as inline review comments if desired.`
+
+Rules for the rendering:
+
+- Group inline findings by `path`, then list each finding as `**L<line>** — <body>`.
+  Use the same `body` text you put into the JSON (`**[<short-tag>:<severity>]** <description>`).
+
+- Preserve the PR-health bullets from `review_body` verbatim — they are
+  important for human reviewers and easy to lose if you re-summarize.
+
+- **PASS short form.** If the JSON has no findings AND no PR-health flags,
+  still write the sentinel file. The gate's size guard rejects files under
+  200 bytes, and the header + `PASS` line + `Reviewed at:` line are
+  ~130 bytes — pad with a one-line context summary so the total is ≥200
+  bytes. Use this exact template (substitute `<target>` and `<sha>`):
+
+  ```markdown
+  # repo-review-full-no-comments — <target>
+
+  PASS — no findings across all skills (code-health, comment-hygiene,
+  python-style, shell-style, synth-setter, tdd-impl, ml-test).
+
+  ## Summary
+
+  - 0 BLOCK, 0 WARN
+  - Reviewed at: <sha>
+  ```
+
+  Print the same content to chat.
+
+- The sentinel file is the gate's contract; the chat output is the human
+  deliverable. Always produce both.
+
+## Notes
+
+- This skill is intentionally side-effect-free on GitHub. If a future caller
+  wants the comments posted after all, they can rerun with `/repo-review-full`
+  — the analysis is deterministic enough that re-running is cheap relative to
+  the value of an explicit "no, don't post" mode.
+- Like `/repo-review-full`, this skill depends on the
+  `tinaudio-synth-setter-skills` plugin being enabled. If a sub-skill
+  invocation fails, surface the error — don't silently skip.
+- Do not dedupe findings across skills. Keep each skill's signal independent,
+  same as `/repo-review-full`.
+'''

--- a/.gemini/commands/repo/review-full.toml
+++ b/.gemini/commands/repo/review-full.toml
@@ -1,0 +1,53 @@
+description = "Full multi-skill PR review. Fans out one parallel agent per applicable plugin checklist (selection rules in the shared analysis file) and posts every diff-anchored BLOCK/WARN as an individual unresolved inline PR review comment; non-diff findings (merge conflicts, failing checks) go in a `## PR health` section in the review body. Requires the tinaudio-synth-setter-skills plugin."
+prompt = '''
+# repo-review-full — Multi-Skill Parallel PR Review
+
+You MUST complete every step in order.
+
+## Steps 1–6: Run the shared analysis pipeline
+
+Read and follow `agent/skills/_shared/repo-review-full-analysis.md` Steps 1
+through 6. That file owns PR resolution, PR-health inspection, skill selection,
+the parallel fan-out, finding aggregation, and the findings-JSON construction.
+
+When the shared file says "the calling skill," that's this skill:
+
+- Use `repo-review-full` as the calling-skill name in any `[<calling-skill>:block]`
+  prefixes inside the `## PR health` bullets.
+- Write the findings JSON to `/tmp/repo-review-full-findings.json`.
+- Phrase the `review_body` lead-in to reflect that every BLOCK/WARN is being
+  posted as an unresolved inline thread (sample wording is already in the
+  shared file).
+- Set the top-level `"event"` field in the JSON payload: `REQUEST_CHANGES` if
+  any finding is a BLOCK (any `[*:block]`, including the folded PR-health
+  BLOCKs), else `COMMENT` if any WARN exists, else `APPROVE`. The self-review
+  COMMENT fallback (when the bot is the PR author) is automatic in
+  `post_review.py`.
+
+Return here once Step 6 has produced the JSON payload on disk.
+
+## Step 7: Submit the review
+
+```bash
+python3 agent/skills/_shared/post_review.py < /tmp/repo-review-full-findings.json
+```
+
+`post_review.py`:
+
+- Anchors each finding to its target line if that line falls inside a diff hunk.
+- Falls back to the nearest in-hunk line on the same file with a cross-ref note prepended to the body.
+- Rolls orphan findings (file outside the diff) into the review body under `## Findings on files outside the diff`.
+- Submits with the payload's `event` (REQUEST_CHANGES / COMMENT / APPROVE). On a self-review 422 (the bot is the PR author) it retries once as `event=COMMENT` with an event-aware intent banner prepended — `⛔ N BLOCKING finding(s) — changes required` for a REQUEST_CHANGES downgrade, `✅ No findings` for an APPROVE downgrade — so the original intent stays visible. Threads stay unresolved.
+
+Report the helper's `html_url` back to the user along with a one-line summary (`Posted N findings: B BLOCK + W WARN across K skills; PR-health flags: <M merge-conflict / F failing-check>`). If PR-health found nothing, drop the trailing `; PR-health flags: ...` clause.
+
+## When to use the no-comments sibling instead
+
+`/repo-review-full-no-comments` runs the same analysis pipeline (delegating
+Steps 3–6 to the shared file; it owns Steps 1–2 itself so it can also run
+against a local branch with no PR open) but prints the aggregated report to
+the user instead of posting inline comments. Reach for it when you want a
+local dry-run of the review (no GitHub side effects), as a pre-PR gate before
+the branch is pushed, when you're iterating on a PR before it's ready for
+reviewers, or when posting publicly is undesirable for any reason.
+'''

--- a/.gemini/commands/repo/review.toml
+++ b/.gemini/commands/repo/review.toml
@@ -1,0 +1,219 @@
+description = "Quick PR review using the repo's core checklist (AGENTS.md hard rules). Use when the tinaudio-synth-setter-skills plugin isn't available, or for a fast sanity-check before opening for full review. Single agent, no plugin dependency. Posts diff-anchored findings as individual unresolved inline PR review comments via agent/skills/_shared/post_review.py; non-diff findings (merge conflicts, failing checks) go in a `## PR health` section in the review body."
+prompt = '''
+# repo-review — MVP PR Review
+
+You MUST complete every step in order.
+
+## Step 1: Resolve the PR
+
+Determine the PR number:
+
+- If the user invoked `/repo-review <N>`, use `<N>`.
+- Otherwise resolve via `gh pr view --json number` — runs against the current branch's PR.
+
+Fetch the PR's metadata once and remember it:
+
+```bash
+gh pr view <N> --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \
+  --json number,headRefOid,baseRefOid,files,title,headRefName,mergeable,mergeStateStatus,statusCheckRollup
+```
+
+If there is no PR for the current branch, stop and tell the user to push and open a PR first.
+
+## Step 2: Inspect PR health (merge conflicts + failing checks)
+
+Reviewers need to know up front if the PR can't merge or has failing CI — both are independent of the diff but reviewers shouldn't have to dig for them. Surface each as a top-of-review `[repo-review:block]` item folded into the review body in Step 5 (not as inline comments — they have no diff anchor).
+
+Both are hard-gate conditions from AGENTS.md's `### PR Readiness` ("Hard gate (all four must hold)"). A PR with **any failing CI check** or with `mergeable != MERGEABLE` is **not ready**, regardless of how clean the diff is. Always emit the BLOCK lines below when the conditions fire; don't suppress them because the rest of the review is passing.
+
+**Merge conflicts.** From the JSON in Step 1:
+
+- `mergeable == "CONFLICTING"` → record one BLOCK line:
+  ```
+  BLOCK: <PR> — [pr-health] Merge conflict with base branch (mergeStateStatus=<value>). Rebase or merge base before review.
+  ```
+- `mergeable == "UNKNOWN"` → GitHub hasn't computed mergeability yet; skip (no finding).
+- `mergeable == "MERGEABLE"` → no finding.
+
+**Failing checks.** Parse `statusCheckRollup` from Step 1. Each entry is either a check run (has `conclusion`) or a legacy commit status (has `state`). A check is *failing* if any of these hold:
+
+- `conclusion` ∈ {`FAILURE`, `TIMED_OUT`, `STARTUP_FAILURE`, `ACTION_REQUIRED`}.
+- `state` ∈ {`FAILURE`, `ERROR`}.
+
+Skip `SUCCESS`, `SKIPPED`, `NEUTRAL`, `CANCELLED`, and anything still pending/in-progress — they're noise here. For each failing entry record one BLOCK line:
+
+```
+BLOCK: <PR> — [pr-health] Failing check: <name> (<conclusion-or-state>) — <detailsUrl-or-targetUrl>
+```
+
+If `gh pr checks <N>` is easier than parsing the JSON, use it instead — but capture the same fields (name, fail reason, link).
+
+## Step 3: Read the diff
+
+Get the full unified diff:
+
+```bash
+gh pr diff <N> --repo <owner>/<repo>
+```
+
+Read every changed file at the head SHA (use the `Read` tool, not `cat`). Skim the PR description for context on intent.
+
+## Step 4: Apply the core checklist
+
+Evaluate ONLY the changed code. Skip items that don't apply to the diff (e.g. don't flag missing type annotations on a YAML-only PR).
+
+For each finding emit one line:
+
+```
+BLOCK: <path>:<line> — [<category>] <description>
+WARN:  <path>:<line> — [<category>] <description>
+```
+
+Categories: `comment-hygiene`, `yaml-bash`, `python`, `shell`, `pipeline`, `security`, `commit-style`, `pr-link`, `stale-ref`, `secret-doc`.
+
+### The core checklist (sourced from AGENTS.md)
+
+**Comment hygiene (AGENTS.md "Comment Hygiene" + "No Comments Inside YAML run: Block-Scalars")**
+
+Rule IDs `C1`–`C12` are the full BLOCK/WARN schema in the plugin's `comment-hygiene` skill (run via `/repo-review-full` or directly when the plugin is available). The MVP repeats the same rule IDs inline so external contributors and plugin-less environments still get coverage; what the MVP omits is the plugin's per-finding `Before / After` rewrites (and the two NIT-severity items C13–C14). When in doubt about a flag, defer to the plugin's per-finding rewrites.
+
+BLOCK items (hard AGENTS.md rules — always flag):
+
+- [comment-hygiene C1] **No `#`-comments inside `run: |` or `setup: |` block-scalars** in `.github/workflows/*.{yml,yaml}` or `configs/compute/*.yaml`. Comments belong ABOVE the `run:` key, not inside the bash.
+- [comment-hygiene C2] No comment restates a literal constant value next to its assignment (`num = 6  # 6 items`).
+- [comment-hygiene C3] No comment enumerates list contents in prose (`THINGS = [...]  # a, b, c`). The list IS the source of truth.
+- [comment-hygiene C4] No baked-in counts the code already reports (`# 29 comments triaged`, `# 5 metric series`) — belongs in the PR description, not in source.
+
+WARN items (bloat patterns — flag when the diff adds them):
+
+- [comment-hygiene C5] No multi-line comment essay (>2 lines) without a one-line issue/PR pointer alternative.
+- [comment-hygiene C6] No docstring `:param:` / `:return:` / `:raises:` section that only restates the type hint. Pydoclint requires the summary line only; drop the boilerplate.
+- [comment-hygiene C7] No docstring that only restates the function name (`"""Compute the mel spectrogram."""` on `compute_mel_spectrogram`).
+- [comment-hygiene C8] No generic filler opener (`"""This module provides..."""`, `"""Helper function that..."""`, `"""Utility for..."""`, `"""Wrapper around..."""`).
+- [comment-hygiene C9] No decorative banner separator (`# ----- foo -----`, `# === SECTION ===`, `# ###############`).
+- [comment-hygiene C10] No commented-out config block without a rationale comment beside it explaining why it's disabled.
+- [comment-hygiene C11] No tombstone comment for removed code (`# was X`, `# previously Y`, `# removed in #N`). Git log is authoritative.
+- [comment-hygiene C12] No `doc-map.yaml` description that packs 3+ sub-claims, nested parens, internal `§` section pointers, title-restatement, or filler hedges ("various", "several", "general purpose").
+
+**Python (AGENTS.md "Writing Code" + plugin `python-style` BLOCK items)**
+
+- [python] All function signatures are type-annotated. No `Any` — use `Union`, `Optional`, or specific types. (PY8)
+- [python] No bare `except:`. Always catch a specific exception class. (PY2)
+- [python] No mutable default arguments (`def f(x: list = [])` is a footgun — defaults are shared across calls). Use `None` + initialize inside. (PY3)
+- [python] No `assert` for input validation or invariants — `python -O` strips them. Raise an explicit exception. (PY4)
+- [python] Use `with` statements for every file / socket / resource open. No bare `open(...)` without `with`. (PY13)
+- [python] Pydantic `BaseModel` with `strict=True` at trust boundaries (config parsing, JSON from R2, worker reports).
+- [python] `structlog` for logging in pipeline code; Python's `logging` module elsewhere.
+- [python] No `print()` statements in production code. CLI helpers + tests excepted (and exempted in `pyproject.toml` per-file-ignores). (P29)
+
+**Shell (plugin `shell-style` BLOCK items — applies to `.sh` files AND bash inside YAML `run:` / `setup:` block-scalars in `.github/workflows/*.{yml,yaml}` and `configs/compute/*.yaml`)**
+
+- [shell] `set -euo pipefail` at the top of every shell script and every YAML `run: |` / `setup: |` block-scalar. Inner `bash -c '...'` shells get their own `set -euo pipefail`. (SH1)
+- [shell] All variable expansions are double-quoted: `"${VAR}"` not `$VAR`. Exceptions: integers and `$?`. (SH2)
+- [shell] `[[ ]]` not `[ ]` for tests. Single-bracket is BLOCK. (SH3)
+- [shell] Return values of every command are checked — failure of `var=$(cmd)` or `mkdir`, `printf`, `cd` does not silently continue. With `set -e` this is automatic; without it the assignment-substitution variant must be split or wrapped. (SH8)
+- [shell] No `eval`. Refactor whatever needed `eval` into an array invocation or a function. (SH11)
+
+**Pipeline (AGENTS.md "Pipeline-Specific Rules" + plugin invariants)**
+
+- [pipeline] All `rclone` operations include `--checksum`. (P13)
+- [pipeline] No writes to `data/shards/` outside `finalize` stage. (P12)
+- [pipeline] Workers only write under `metadata/workers/`. Finalize only writes to `data/`. (P11)
+- [pipeline] Shard IDs are logical (`shard-000042`), deterministic, infrastructure-independent. No `pod_id` / `host` / `runner_id` in shard names. (P14)
+- [pipeline] Specs are immutable after creation — no code path mutates a frozen spec in place. (P15)
+- [pipeline] `.valid` marker is written as the last step of shard lifecycle (commit point). Earlier writes leave shards in a partial state with no marker. (P16)
+- [pipeline] Array shapes match spec (sample rate, spectrogram bins, parameter count). dtypes are explicit — `float32` where expected, not `float64`. (P23, P24)
+
+**Security (plugin `synth-setter-project-standards` security block)**
+
+- [security] No credential leaks. API keys, tokens, OCIDs do not appear in code, logs, or error messages. Tracing-back-from-an-error to the secret value is also a leak. (P19)
+- [security] No command injection via subprocess. User-controlled input never gets interpolated into a shell command — pass argv arrays, never `shell=True` with concatenated strings. (P20)
+- [security] No unsafe deserialization. `pickle.loads` from untrusted sources is forbidden — use JSON / msgpack / protobuf for cross-trust-boundary data. (P21)
+
+**Commit style (AGENTS.md "Commit Messages")**
+
+- [commit-style] Every commit on this branch uses a conventional-commit prefix (`feat:`, `fix:`, `internal-feat:`, `internal-fix:`, `docs:`, `ci:`, `chore:`, `refactor:`, `test:`, `style:`, `build:`, `monitoring:`, `perf:`, `revert:`).
+- [commit-style] No commit carries a `Co-Authored-By:` trailer.
+- [commit-style] No commit / PR body contains a "generated with an agent" attribution.
+- [commit-style] PR-level prefix matches the user-facing nature of the change (`feat:` for user-visible, `internal-feat:` for groundwork).
+
+**PR link (AGENTS.md "PR & Issue References")**
+
+- [pr-link] PR body includes `Fixes #N`, `Closes #N`, `Refs #N`, or `Part of #N` linking to a taxonomy-compliant issue.
+- [pr-link] Use `Refs #N` (not `Fixes`/`Closes`) for partial fixes / workarounds.
+
+**Stale-reference audit (AGENTS.md "Refactoring")**
+
+- [stale-ref] After any rename / move, references in *all* file types are updated: `.py`, `.yaml`, `.yml`, `.toml`, `.json`, `.md`, `.sh`, Dockerfile. Run a grep to verify; flag any survivors.
+- [stale-ref] If the PR renames a workflow artifact, every doc that names that artifact in a copy-paste command (`gh run download -n <name>`) is updated.
+
+**Secret/input documentation**
+
+- [secret-doc] Every secret the workflow reads (`secrets.X`) is enumerated in the workflow header comment AND in any operator-facing setup doc.
+- [secret-doc] Every `inputs.X` referenced in steps is declared in `workflow_dispatch.inputs`.
+
+End the listing with:
+
+```
+Summary: X BLOCK, Y WARN
+```
+
+If the checklist found zero findings AND Step 2 found no PR-health BLOCKs (no merge conflict, no failing checks), output `PASS` and stop — do not post an empty review. If PR-health turned up anything, always submit so the merge-conflict / failing-check banner reaches the author.
+
+## Step 5: Build the findings JSON
+
+Convert your BLOCK/WARN list to the JSON shape `post_review.py` consumes. Each diff-anchored finding becomes one inline comment with a `[repo-review:<severity>]` prefix.
+
+**Fold the Step 2 PR-health BLOCKs into `review_body`** (they aren't anchored to diff lines, so they can't be inline comments). Prepend a `## PR health` section listing every PR-health BLOCK; if Step 2 produced nothing, omit the section entirely.
+
+Transform each Step 2 BLOCK line into one bullet under `## PR health`: strip the `BLOCK: <PR> — ` prefix and prepend `- **[repo-review:block]** `, leaving the `[pr-health] …` body unchanged. For example, `BLOCK: 897 — [pr-health] Failing check: ci/test (FAILURE) — https://…` becomes `- **[repo-review:block]** [pr-health] Failing check: ci/test (FAILURE) — https://…`.
+
+Example shape when both health flags fire:
+
+```json
+{
+  "pr_number": <N>,
+  "repo": "<owner>/<repo>",
+  "review_body": "Repo-review (MVP): <X> BLOCK, <Y> WARN. Inline core checklist from AGENTS.md.\n\n## PR health\n\n- **[repo-review:block]** [pr-health] Merge conflict with base branch (mergeStateStatus=DIRTY). Rebase or merge base before review.\n- **[repo-review:block]** [pr-health] Failing check: ci/test (FAILURE) — https://github.com/.../runs/123",
+  "findings": [
+    {
+      "path": "<path>",
+      "line": <line>,
+      "body": "**[repo-review:block]** [<category>] <description>"
+    }
+  ]
+}
+```
+
+Count PR-health BLOCKs toward the `<X> BLOCK` total in the summary. If the checklist found zero issues but PR health did, still submit — don't `PASS`-and-stop when there are merge conflicts or failing checks to surface.
+
+Write the JSON to a temp file (do NOT echo it inline — keep it readable):
+
+```bash
+cat > /tmp/repo-review-findings.json <<'JSON'
+... payload ...
+JSON
+```
+
+## Step 6: Submit the review
+
+```bash
+python3 agent/skills/_shared/post_review.py < /tmp/repo-review-findings.json
+```
+
+The helper:
+
+- Fetches the PR diff and parses hunks.
+- Anchors each finding to its target line if that line falls inside a diff hunk.
+- Falls back to the nearest in-hunk line on the same file with a `*(anchored at line X; finding is on line Y, outside the diff hunks)*` cross-ref prepended to the body — preserves the original line number for the human reader.
+- Rolls findings on files entirely outside the diff into a `## Findings on files outside the diff` section in the review body.
+- Submits as `event=COMMENT` so threads stay unresolved without approving or rejecting.
+
+The helper prints the review's `html_url` on success. Report it back to the user.
+
+## Notes
+
+- Severity threshold: post everything (every BLOCK and every WARN). Tuning to top-N or by-category is a follow-up — see issue #778's "Out of scope" list.
+- Idempotency: re-running the skill on the same PR posts a fresh review with fresh comment threads (duplicates by design — easy to delete a whole review, fiddly to dedupe).
+- Drift: this checklist is sourced from AGENTS.md verbatim. When AGENTS.md changes, this SKILL.md should change in the same PR — that's the contract.
+'''

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,182 @@
+{
+  "permissions": {
+    "defaultMode": "auto"
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "description": "Worktree-status banner: prints cwd, current branch, and whether the agent is sitting in the primary checkout (which AGENTS.md marks read-only). Fires on every session start, resume, /clear, and /compact so post-compaction agents see the same context.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/session-start-cwd-banner.sh"
+          }
+        ]
+      }
+    ],
+    "BeforeTool": [
+      {
+        "matcher": "replace_file_content|multi_replace_file_content|write_to_file",
+        "description": "Credential protection: blocks edits to .env, .pem, and .key files. Goal: prevent secrets from being modified or leaked into commits.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/edit-write.sh credential-protect"
+          }
+        ]
+      },
+      {
+        "matcher": "replace_file_content|multi_replace_file_content|write_to_file",
+        "description": "Worktree guard: on Edit/Write inside the primary checkout, prints a WARNING with the exact `git worktree add` command.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/worktree-guard.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "replace_file_content|multi_replace_file_content|write_to_file",
+        "description": "No-baseline-additions: on Edit/Write of .pydoclint-baseline.txt, blocks the call if the post-edit line count exceeds the current count.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/no-baseline-additions.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "replace_file_content|multi_replace_file_content|write_to_file",
+        "description": "No-yaml-run-comments: on Edit/Write of .github/workflows/*.{yml,yaml} or configs/compute/*.{yml,yaml}, blocks the call if the post-edit content has any `#`-comment line inside a `run: |` / `setup: |` block scalar.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/no-yaml-run-comments.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "run_command",
+        "description": "Branch safety: echoes the current branch name before any git commit.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/branch-safety.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "run_command",
+        "description": "Git-commit-trailer-check: blocks `git commit` (and other forms) that carry --no-verify / -n, a Co-Authored-By trailer, or an agent-attribution footer.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/git-commit-trailer-check.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "run_command",
+        "description": "Pre-PR review gate: blocks gh pr create unless REVIEW_FULL=<path> points at a sentinel review file.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/pre-pr-review-gate.sh"
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "description": "PR-readiness gate: on Stop, if there's an open PR for the current branch whose readiness gates don't hold, blocks the turn from ending (exit 2).",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/pr-readiness-stop.sh"
+          }
+        ]
+      }
+    ],
+    "AfterTool": [
+      {
+        "matcher": "replace_file_content|multi_replace_file_content|write_to_file",
+        "description": "Auto-format on every Edit/Write: ruff (Python), mdformat (Markdown), prettier (YAML).",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/edit-write.sh format"
+          }
+        ]
+      },
+      {
+        "matcher": "replace_file_content|multi_replace_file_content|write_to_file",
+        "description": "Auto-test: runs the matching pytest file when src/, scripts/, or tests/ Python files are edited.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/edit-write.sh test"
+          }
+        ]
+      },
+      {
+        "matcher": "run_command",
+        "description": "Worktree post-setup: after `git worktree add`, automatically runs `make link-plugins && make link-thoughts` in the new worktree.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/worktree-post-setup.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "run_command",
+        "description": "Taxonomy verification: validates GitHub metadata after gh issue create, gh pr create, and addSubIssue mutations.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/verify-gh-taxonomy.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "run_command",
+        "description": "PR checkbox trigger: detects gh pr create commands and prompts the agent to invoke the /pr-checkbox skill.",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command // \"\"' | grep -q 'gh pr create' && echo '{\"hookSpecificOutput\":{\"hookEventName\":\"AfterTool\",\"additionalContext\":\"A PR was just created. You MUST now invoke the /pr:checkbox command to add verification checkboxes to this PR.\"}}' || true"
+          }
+        ]
+      },
+      {
+        "description": "Doc-drift advisory review: on gh pr create, runs a headless agent session invoking the doc-drift skill.",
+        "matcher": "run_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/doc-drift.sh"
+          }
+        ]
+      },
+      {
+        "description": "PR review resolver: on git push (excluding main/master), resolves the branch's PR up front.",
+        "matcher": "run_command",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash agent/hooks/pr-review-resolver.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "mcpServers": {
+    "wandb": {
+      "type": "http",
+      "url": "https://mcp.withwandb.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${WANDB_API_KEY}"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,109 +6,254 @@ Shared agent instructions for Claude and Codex; AGENTS.md is the canonical sourc
 
 <important if="you are about to edit, write, or commit any file">
 
-- **Work in an isolated git worktree, never the primary checkout.** Branch switching and stash conflicts have lost work and committed to wrong branches. Use `git worktree add` (or `isolation: "worktree"` when spawning subagents). The primary checkout is read-only — `git log`, exploration, `rclone ls` only. A `SessionStart` banner (`agent/hooks/session-start-cwd-banner.sh`) and a `PreToolUse` guard (`agent/hooks/worktree-guard.sh`, `WORKTREE_GUARD_MODE`: `warn` default / `block` / `off`) enforce this.
-- **Each worktree gets its own `.venv`.** The spawn command runs `uv sync`; `~/.bashrc` then activates `./.venv` per directory, overriding the image's shared `/venv/main`. For one-offs, `uv run <cmd>` targets the worktree env regardless of the inherited `VIRTUAL_ENV`.
-
-</important>
+- **Always work in an isolated git worktree.** Branch switching and stash
+  conflicts have caused lost work and accidental commits to wrong branches.
+  Use `git worktree add` (or `isolation: "worktree"` when spawning subagents).
+  The primary checkout is read-only — `git log`, exploration, `rclone ls`.
+  Never edit files there. A `SessionStart` hook
+  (`agent/hooks/session-start-cwd-banner.sh`) prints a primary-vs-worktree
+  banner on startup/resume/clear/compact (and warns when `.claude/{skills,hooks}`
+  symlinks didn't materialize, e.g. `core.symlinks=false`); a `PreToolUse` hook
+  (`agent/hooks/worktree-guard.sh`) warns on Edit/Write inside the primary
+  checkout (`WORKTREE_GUARD_MODE`: `warn` default / `block` / `off`); a
+  `PostToolUse` hook (`agent/hooks/worktree-post-setup.sh`) automatically
+  runs `make link-plugins && make link-thoughts` in every new worktree after
+  `git worktree add` (fail-safe, exits 0 on any error — see #1343).
+- **Each worktree gets its own `.venv`.** The spawn command runs `uv sync`;
+  `~/.bashrc` (installed by `.devcontainer/post-create.sh`) then activates
+  `./.venv` per directory, overriding the image's shared `/venv/main`. For
+  one-offs, `uv run <cmd>` targets the worktree env regardless of the
+  inherited `VIRTUAL_ENV`.
+- **Always verify the branch before push.** Run `git branch --show-current`
+  and confirm it matches the target PR branch. A hook prints the branch on
+  every `git commit`; don't ignore it.
+- **Pre-commit hooks must not be skipped** — see [`### Commits`](#commits).
+- **Never run `make docker-*` or RunPod commands without asking.** These
+  spend money and burn cluster state.
+  </important>
 
 <important if="you need to run commands to build, test, lint, or format">
 
-| Command              | What it does                           |
-| -------------------- | -------------------------------------- |
-| `make test-fast`     | CPU-only fast tests (the default loop) |
-| `make test-full-cpu` | All CPU tests                          |
-| `make test-full-gpu` | GPU + CPU, serial                      |
-| `make format`        | Run the pre-commit hooks               |
-| `make help`          | Everything else                        |
+```bash
+make test-fast       # CPU-only fast tests
+make test-full-cpu   # all CPU tests
+make test-full-gpu   # GPU + CPU, serial
+make format          # pre-commit hooks
+make help            # everything else
+```
 
-Never run `make docker-*` or RunPod commands without asking — they spend money and burn cluster state.
 </important>
 
 <important if="you are writing or modifying Python code">
 
-- Pydantic `BaseModel(strict=True)` at trust boundaries (config parsing, JSON from R2, worker reports); dataclasses for internal typed containers.
+- Pydantic `BaseModel(strict=True)` at trust boundaries (config parsing, JSON
+  from R2, worker reports). Dataclasses for internal typed containers.
 - `structlog` in pipeline code; stdlib `logging` elsewhere.
 - All `rclone` operations use `--checksum`.
-- Add an import in the same edit as its first use, or add imports last — ruff's `F401` autofix deletes an import that is momentarily unused if `make format` runs before the using code lands, costing a re-add cycle.
-
-</important>
+- Add an import in the same edit as its first use, or add imports last —
+  ruff's `F401` autofix deletes an import that is momentarily unused if
+  `make format` runs before the using code lands, costing a re-add cycle.
+- Run `make format` before committing. Pre-commit (ruff, ruff-format,
+  pydoclint, prettier, mdformat, gitlint) is authoritative; suppressing
+  rules to make CI green is forbidden — see
+  [`### Lint exceptions are append-frozen`](#lint-exceptions-are-append-frozen).
+  </important>
 
 <important if="you are writing inline comments or docstrings">
 
-Code says **what**; comments say **why** — add prose only when it carries a constraint, unit, semantic, or rationale that names and types can't, and describe only current behavior (history belongs in the commit message). Keep comments to one line (cap two), open docstrings with the contract, and supply `:param:` / `:returns:` / `:raises:` semantics wherever pydoclint expects them — full rules in the `comment-hygiene` skill.
+Code says **what**; comments say **why** — add prose only when it carries a
+constraint, unit, semantic, or rationale that names and types can't, and
+describe only current behavior (history belongs in the commit message). Keep
+comments to one line (cap two), open docstrings with the contract, and supply
+`:param:` / `:returns:` / `:raises:` semantics wherever pydoclint expects them —
+full rules in the `comment-hygiene` skill.
 </important>
 
 <important if="you are starting any non-trivial change">
 
-YAGNI. Start minimal and expand only when asked — don't add a class, config schema, or pattern speculatively. Ask "do we need this *now*?" and default to no. Present a plan before writing code.
+YAGNI. Start minimal, expand only when asked. Don't introduce a new class,
+config schema, or pattern speculatively — ask "do we need this *now*?" and
+default to no. Refactoring follows real needs, not anticipated ones. Present
+a plan before writing code for any non-trivial change.
 </important>
 
-<important if="you are modifying non-documentation code (anything beyond .md / docs/ edits)">
+<important if="you are modifying non-documentation code (anything other than .md / docs/ edits)">
 
-Invoke in order: `/tdd-implementation` (drive it test-first) → `/code-health` (review and clean up) → `/simplify` (final reuse and efficiency pass). Pure docs edits are exempt; no other exemptions.
+Whenever an agent modifies non-documentation code (anything other than `.md` /
+`docs/` edits), invoke in order:
+
+1. `/tdd-implementation` — drive the change test-first.
+2. `/code-health` — review and clean up the result.
+3. `/simplify` — final reuse and efficiency pass.
+
+Pure docs edits are exempt; no other exemptions.
 </important>
 
 <important if="you are writing or running tests">
 
+- `make test-fast` is the default CPU loop; `@pytest.mark.slow` for slow.
 - Test names: `test_<what>_<condition>_<expected>`.
-- `@pytest.mark.slow` marks slow tests.
 - Mutation testing: [docs/testing/mutmut.md](docs/testing/mutmut.md).
-
-</important>
+  </important>
 
 <important if="you are committing">
 
-- Conventional commits, gitlint-enforced. `internal-feat:` / `internal-fix:` for unreleased code (no version bump). Scope is skill-bound — see `/github-taxonomy`.
-- Run `make format` first; pre-commit (ruff, ruff-format, pydoclint, prettier, mdformat, gitlint) is authoritative. **Never `--no-verify` / `-n`**, and never suppress a rule to make CI green — fix the underlying cause.
-- **Never add `Co-Authored-By` or agent-attribution trailers** ("Generated with …", "Claude …"). A `PreToolUse` hook (`agent/hooks/git-commit-trailer-check.sh`) blocks them.
-- **Verify the branch before push:** `git branch --show-current` must match the target PR branch.
-
-</important>
+- Conventional commits, gitlint-enforced. `internal-feat:` / `internal-fix:`
+  for unreleased code (no version bump).
+- Scope is skill-bound — see `/github-taxonomy`.
+- **Never `--no-verify` / `-n`.** Pre-commit and gitlint must run. Hooks
+  work inside worktrees.
+- **Never add `Co-Authored-By` trailers** or agent-attribution footers
+  ("Generated with …", "Claude …", etc.).
+- A `PreToolUse` hook (`agent/hooks/git-commit-trailer-check.sh`) blocks
+  violations; if a hook fails, fix the underlying cause — don't bypass.
+  </important>
 
 <important if="a lint, pydoclint, or pyright check fails on a file your change touches">
 
-`.pydoclint-baseline.txt` (#938), `pyproject.toml`'s `[tool.ruff.lint.per-file-ignores]` / `[tool.ruff].extend-exclude`, `.pre-commit-config.yaml` per-hook `exclude:` regexes, and `pyrightconfig.json`'s `"exclude"` are **append-frozen**. The only allowed edit is a **removal** via `/lint-cleanup` (one file per PR, `chore(lint):` prefix); `[tool.pydoclint].exclude` is infra-only (#1044) and must not be edited at all. Fix the underlying lint — never register a file as exempt. A `PreToolUse` hook (`agent/hooks/no-baseline-additions.sh`) blocks new baseline rows.
+`.pydoclint-baseline.txt` (#938), `pyproject.toml`'s
+`[tool.ruff.lint.per-file-ignores]` / `[tool.ruff].extend-exclude`,
+`.pre-commit-config.yaml` per-hook `exclude:` regexes, and
+`pyrightconfig.json`'s `"exclude"` are **append-frozen**. The only allowed
+edit is a **removal** via the `/lint-cleanup` workflow (one file per PR,
+`chore(lint):` prefix). `[tool.pydoclint].exclude` is infra-only after #1044
+and must not be edited at all.
+
+A `PreToolUse` hook (`agent/hooks/no-baseline-additions.sh`) blocks new rows
+in `.pydoclint-baseline.txt`. If a check fails on a file your PR touches,
+the remediation is to fix the underlying lint — never register the file as
+exempt.
 </important>
 
 <important if="you are editing GitHub Actions workflows (.github/workflows/*.yml) or SkyPilot compute configs (src/synth_setter/configs/compute/*.yaml)">
 
-Put comments **above** the step, never inside a `run:` / `setup:` block scalar — the body is bash, and a stray `'`, `` ` ``, `$`, or `\` in a comment has caused unintended shell expansion. A `PreToolUse` hook (`agent/hooks/no-yaml-run-comments.sh`) enforces this.
+In GitHub Actions workflows (`.github/workflows/*.{yml,yaml}`) and SkyPilot
+task configs (`src/synth_setter/configs/compute/*.yaml`'s `run:` / `setup:` blocks), comments
+go **above** the step, never inside the block scalar. The block-scalar body
+is bash and stray `'`, `` ` ``, `$`, or `\` inside a comment has caused
+unintended shell expansion. A `PreToolUse` hook
+(`agent/hooks/no-yaml-run-comments.sh`) enforces this.
 </important>
 
 <important if="you are moving, renaming, or restructuring code">
 
-Grep ALL file types, not just `.py` — include `.yaml`/`.yml`, `.md`, `.json`, `.toml`, `.sh`, and `Dockerfile`. Use `/tdd-refactor`, which exhaustively discovers references and pins the contract.
+When moving or renaming code, grep ALL file types — not just `.py`. Include
+`.yaml`/`.yml`, `.md`, `.json`, `.toml`, `.sh`, and `Dockerfile`. Use
+`/tdd-refactor`, which exhaustively discovers references and pins the
+contract.
 </important>
 
 <important if="you are opening or driving a pull request">
 
-- **Link a taxonomy-compliant issue** in the body via `Closes #N` / `Fixes #N` / `Refs #N` / `Part of #N` (use `Refs` for partial fixes; `Fixes` auto-closes). Every issue traces to an Epic via Phase → Task / Bug / Feature. See `/github-taxonomy`.
-- **PR titles stand alone** — name the specific subject, not just the action; readers don't open the issue.
-- **Pre-PR gate:** run `/repo-review-full-no-comments` and address every BLOCK/WARN. A `PreToolUse` hook (`agent/hooks/pre-pr-review-gate.sh`) blocks `gh pr create` until the command carries `REVIEW_FULL=<path>` pointing at the rendered report (`.agent-reviews/repo-review-full-no-comments.<sha>.md`) — recommended as a trailing comment so other gh-pr-create hooks still fire: `gh pr create … # REVIEW_FULL=.agent-reviews/repo-review-full-no-comments.<sha>.md`. Pass the path bare (no quotes). The encoded SHA must be an ancestor of HEAD within `REVIEW_MAX_LAG` (default 2) first-parent commits. The gate also blocks while the sentinel still lists `[comment-hygiene:warn|block]` findings (`REVIEW_COMMENT_GATE`: `block` default / `warn` / `off`) — run `/fix-review-comments` to apply the rewrites, commit, and re-review in one pass — or any `[<skill>:block]` finding (`REVIEW_BLOCK_GATE`: `block` default / `warn` / `off`), which you resolve by fixing the underlying issue and re-running `/repo-review-full-no-comments`. It also blocks while the PR's inline `--title` is not a conventional commit (`PR_TITLE_GATE`: `block` default / `warn` / `off`) — best-effort and fails open on any uvx/network error, since the `pr-metadata-gate` workflow re-checks the title regardless.
-- **After every push, drive `/pr-readiness` until all four gates hold:** CI green ∧ `mergeable=MERGEABLE` ∧ every review comment has an inline reply ∧ no fresh Copilot findings. Full procedure: [docs/pr-readiness-loop.md](docs/pr-readiness-loop.md). A `Stop` hook (`agent/hooks/pr-readiness-stop.sh`, `PR_READINESS_GATE`: `block` default / `warn` / `off`) blocks ending the turn while gates 1-2 fail.
-- **Reply inline on every open review comment** (humans + Copilot) with a fix-commit SHA or justification, via `/pr-review-resolver`. Verification evidence goes through `/pr-checkbox`.
-- **Advisory rewakes carry an origin-HEAD stamp** — compare the `<sha7>` in a `pr-review-resolver` / `doc-drift` rewake to `git rev-parse HEAD`. If they differ the advisory crossed sessions: read it for context, but don't treat it as current-PR work.
-- **In chat**, use full markdown links for refs (`[#N](https://github.com/tinaudio/synth-setter/issues/N)`); in PR / issue bodies use bare `Fixes #N` so auto-close works.
-
-</important>
+- **Every PR body links a taxonomy-compliant issue** via `Closes #N`,
+  `Fixes #N`, `Refs #N`, or `Part of #N`. Use `Refs #N` for partial fixes
+  (`Fixes` auto-closes). Every issue traces to an Epic via Phase → Task /
+  Bug / Feature. See `/github-taxonomy`.
+- **PR titles stand alone.** Name the specific subject, not just the action:
+  reviewers and `git log` readers don't open the issue. `/github-taxonomy`
+  has the canonical title rule and examples.
+- **Pre-PR review gate.** Before `gh pr create`, run
+  `/repo-review-full-no-comments` and address every BLOCK/WARN (fix code or
+  document why it's intentional). The skill writes the rendered report to
+  `.agent-reviews/repo-review-full-no-comments.<HEAD-sha>.md` — filename
+  format owned by `agent/_shared/review_sentinel.py`, shared with the gate
+  hook. A `PreToolUse` hook (`agent/hooks/pre-pr-review-gate.sh`) blocks
+  `gh pr create` until the command carries `REVIEW_FULL=<path>` pointing at
+  that file — recommended as a trailing comment so other gh-pr-create hooks
+  still fire:
+  `gh pr create … # REVIEW_FULL=.agent-reviews/repo-review-full-no-comments.<sha>.md`.
+  The encoded SHA must be an ancestor of HEAD and within `REVIEW_MAX_LAG`
+  (default 2) first-parent commits of it — merges from main count as one
+  commit, not the dozens they bring in. Set `REVIEW_MAX_LAG=N` for a
+  justified larger gap. The gate also **blocks while the sentinel still lists
+  `[comment-hygiene:warn|block]` findings** (`REVIEW_COMMENT_GATE`: `block` default /
+  `warn` / `off`) and **while it lists any `[<skill>:block]` finding**
+  (`REVIEW_BLOCK_GATE`: `block` default / `warn` / `off`). For comment-hygiene
+  findings, run `/fix-review-comments` to apply the rewrites, commit, and
+  re-review in one pass; other `[<skill>:block]` findings need the underlying
+  issue fixed and `/repo-review-full-no-comments` re-run to regenerate the
+  sentinel. Set `REVIEW_COMMENT_GATE=off` / `REVIEW_BLOCK_GATE=off` only for a
+  finding you've judged intentional. The gate also **blocks while the PR's
+  inline `--title` is not a conventional commit** (`PR_TITLE_GATE`: `block`
+  default / `warn` / `off`) — best-effort and fails open on any uvx/network
+  error, since the `pr-metadata-gate` workflow re-checks the title regardless.
+- **Readiness gates:** CI green ∧ `mergeable=MERGEABLE` ∧ every review
+  comment has an inline reply ∧ no fresh Copilot findings — see
+  `/pr-preflight`.
+- **After every push, drive the readiness loop until all four gates hold.**
+  "I pushed the fix" is not "the PR is ready." Run `/pr-readiness` to drive the
+  loop: watch CI (`gh pr checks <N> --watch` or `/loop`) and fix red; confirm
+  `mergeable=MERGEABLE`; reply inline on every open review comment via
+  `/pr-review-resolver`; then wait ~60s (allow 15 min) for Copilot's post-push
+  review on **both** `repos/<OWNER>/<REPO>/pulls/<N>/comments` and
+  `repos/<OWNER>/<REPO>/pulls/<N>/reviews`; address any new findings and loop.
+  If Copilot is silent past 15 min, manually re-request and repeat at most
+  once. Full procedure (commands, endpoints, traps) in
+  [`docs/pr-readiness-loop.md`](docs/pr-readiness-loop.md). A `Stop` hook
+  (`agent/hooks/pr-readiness-stop.sh`) enforces this: it blocks ending the turn
+  while gates 1-2 (CI green, `mergeable`) fail for the branch's open PR, and
+  points back here for gates 3-4 (`PR_READINESS_GATE`: `block` default /
+  `warn` / `off`).
+- **Always reply inline** on each open PR review comment (humans + Copilot),
+  with a fix-commit SHA or justification. Use `/pr-review-resolver`.
+- **Advisory rewakes carry an origin-HEAD stamp.** The `pr-review-resolver`
+  and `doc-drift` PostToolUse hooks run their headless agents in detached
+  worktrees and re-enter the session via `asyncRewake` with a line like
+  `pr-review-resolver report for PR #N (branch X, origin HEAD <sha7>) at <path>`. Before acting on one, compare `<sha7>` to the first 7
+  characters of `git rev-parse HEAD` (the advisory is the 7-char prefix).
+  If they differ the advisory crossed sessions (it was queued by a prior
+  agent's push/PR-create that finished after that session ended) — read
+  the report for context, but do not treat it as work for the current PR.
+- **Verification evidence** for each behavioral claim goes through
+  `/pr-checkbox`.
+- **In chat**, use full markdown hyperlinks for PR/issue references:
+  `[#N](https://github.com/tinaudio/synth-setter/issues/N)`. In PR / issue
+  bodies, use bare `Fixes #N` so GitHub auto-close works.
+  </important>
 
 <important if="you are reviewing code">
 
-- `/repo-review` — MVP, single agent, inline checklist.
-- `/repo-review-full` — parallel agents, posts inline review comments.
-- `/repo-review-full-no-comments` — same fan-out, renders to chat (the pre-PR gate uses this).
-- `/fix-review-comments` — applies the sentinel's comment-hygiene findings, commits, and re-reviews.
+Local skills wrap the review workflow:
 
-See [agent/skills/repo-review/SKILL.md](agent/skills/repo-review/SKILL.md) and [agent/skills/\_shared/repo-review-full-analysis.md](agent/skills/_shared/repo-review-full-analysis.md).
+- `/repo-review` (MVP, single agent, inline checklist).
+- `/repo-review-full` (parallel agents, posts inline review comments).
+- `/repo-review-full-no-comments` (same fan-out, renders to chat — pre-PR
+  gate uses this).
+- `/fix-review-comments` (applies the sentinel's comment-hygiene findings,
+  commits, and re-reviews — the remediation half of the pre-PR comment gate).
+
+See [`agent/skills/repo-review/SKILL.md`](agent/skills/repo-review/SKILL.md)
+and the shared analysis in
+[`agent/skills/_shared/repo-review-full-analysis.md`](agent/skills/_shared/repo-review-full-analysis.md).
 </important>
 
 <important if="you are about to claim no GPU is available">
 
-Run both probes and paste the output; only skip if BOTH report no usable GPU. If they disagree, document it as an environment/setup mismatch — not "no GPU available".
+Before claiming "no GPU available", run both probes and paste the output:
 
 ```bash
 nvidia-smi --query-gpu=name,memory.free --format=csv,noheader
 python3 -c "import torch; print('cuda:', torch.cuda.is_available(), 'count:', torch.cuda.device_count())"
 ```
 
+Only skip if BOTH report no usable GPU. If they disagree, document it as an
+environment/setup mismatch — not "no GPU available".
+</important>
+
+<important if="you are about to claim no VST or R2 is available">
+
+This devcontainer ships `SYNTH_SETTER_PLUGIN_PATH` (Surge XT VST) and
+`RCLONE_CONFIG_R2_*` (Cloudflare R2 credentials). Before labelling a
+`@pytest.mark.requires_vst` or `@pytest.mark.integration_r2` test as
+unrunnable, probe:
+
+```bash
+ls "${SYNTH_SETTER_PLUGIN_PATH:-plugins/Surge XT.vst3}"
+rclone lsd r2:
+```
+
+Both succeed in this devcontainer. **Run — do not skip — these tests.**
+`make test-vst-cpu` covers `requires_vst`; `uv run pytest -m "integration_r2" -v`
+covers R2 e2e. In PR verification tables, list actual pass/fail results rather
+than "SKIP: requires VST / R2".
 </important>

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,9 @@
+# GEMINI.md
+
+synth-setter: synth inversion, sound matching, and preset-exploration tools — Python 3.10+, PyTorch Lightning, Hydra, with a distributed data pipeline on SkyPilot-managed compute (RunPod + OCI) stored in Cloudflare R2.
+
+Shared agent instructions for Claude, Codex, and Gemini; AGENTS.md is the canonical source. Architecture: [docs/architecture.md](docs/architecture.md).
+
+Read and follow [AGENTS.md](AGENTS.md). That file is the canonical project
+instruction source for Claude, Codex, and Gemini. Keep Gemini-specific compatibility
+notes in `.gemini/`; keep shared hooks and review skills under `agent/`.

--- a/agent/hooks/branch-safety.sh
+++ b/agent/hooks/branch-safety.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# PreToolUse branch-safety gate.
+# Echoes the current branch name before any git commit.
+set -euo pipefail
+
+main() {
+  # stdin is JSON payload containing tool input command
+  local input cmd branch
+  input=$(cat)
+  cmd=$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null)
+
+  # Only run for git commit commands
+  if [[ "$cmd" =~ git[[:space:]]+commit ]]; then
+    branch=$(git branch --show-current 2>/dev/null || true)
+    if [[ -z "$branch" ]]; then
+      branch="DETACHED HEAD"
+    fi
+    echo "Committing to branch: $branch" >&2
+  fi
+  exit 0
+}
+
+main "$@"

--- a/agent/hooks/branch-safety.sh
+++ b/agent/hooks/branch-safety.sh
@@ -7,7 +7,7 @@ main() {
   # stdin is JSON payload containing tool input command
   local input cmd branch
   input=$(cat)
-  cmd=$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null)
+  cmd=$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null || true)
 
   # Only run for git commit commands
   if [[ "$cmd" =~ git[[:space:]]+commit ]]; then

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -504,11 +504,13 @@ ENV WANDB_DATA_DIR="/home/${USERNAME}/.cache/wandb"
 # is baked in as root); a per-user prefix sends it to a writable one. $HOME is
 # unset after USER, so export it per-RUN (not ENV — that leaks to root sessions).
 ARG CODEX_VERSION=latest
+ARG GEMINI_CLI_VERSION=latest
 RUN export HOME="/home/${USERNAME}" \
  && npm config set prefix "/home/${USERNAME}/.npm-global" \
- && npm install -g "@openai/codex@${CODEX_VERSION}" \
+ && npm install -g "@openai/codex@${CODEX_VERSION}" "@google/gemini-cli@${GEMINI_CLI_VERSION}" \
  && npm cache clean --force \
- && codex --version
+ && codex --version \
+ && gemini --version
 
 # Antigravity (Google) ships the standalone `agy` binary, not on npm; its
 # installer fetches a SHA512-verified release into ~/.local/bin (upstream

--- a/scripts/ci/generate_instructions.py
+++ b/scripts/ci/generate_instructions.py
@@ -322,19 +322,34 @@ def format_via_pre_commit(content: str, filename: str, project_root: Path) -> st
     :param project_root: Path to the repository root.
     :returns: Formatted markdown string.
     """
+    try:
+        import pre_commit  # noqa: F401
+
+        has_pre_commit = True
+    except ImportError:
+        has_pre_commit = False
+
+    if not has_pre_commit:
+        return content
+
     temp_path = project_root / f"{filename}.tmp.md"
     temp_path.write_text(content, encoding="utf-8")
 
     try:
-        subprocess.run(  # noqa: S603
+        result = subprocess.run(  # noqa: S603
             [sys.executable, "-m", "pre_commit", "run", "mdformat", "--files", str(temp_path)],
             cwd=str(project_root),
             capture_output=True,
             check=False,
         )
+        if result.returncode not in (0, 1):
+            sys.stderr.write(
+                f"Error: pre-commit failed with exit code {result.returncode}!\n"
+                f"Stdout: {result.stdout.decode('utf-8', errors='ignore')}\n"
+                f"Stderr: {result.stderr.decode('utf-8', errors='ignore')}\n"
+            )
+            sys.exit(result.returncode)
         formatted = temp_path.read_text(encoding="utf-8")
-    except Exception:
-        formatted = content
     finally:
         if temp_path.exists():
             temp_path.unlink()
@@ -465,6 +480,16 @@ def main() -> int:
                 )
                 drift = True
 
+        # Check for unexpected extra files under .gemini/commands/
+        commands_dir = project_root / ".gemini" / "commands"
+        if commands_dir.exists():
+            for existing_path in sorted(commands_dir.rglob("*.toml")):
+                if existing_path.is_file() and existing_path not in projected_commands:
+                    sys.stderr.write(
+                        f"Unexpected extra file found: {existing_path.relative_to(project_root)}\n"
+                    )
+                    drift = True
+
         if drift:
             return 1
         sys.stdout.write("All instruction and command files are in sync.\n")
@@ -480,6 +505,16 @@ def main() -> int:
     gemini_settings_path.parent.mkdir(parents=True, exist_ok=True)
     gemini_settings_path.write_text(generated_settings, encoding="utf-8")
     sys.stdout.write(f"Updated {gemini_settings_path}\n")
+
+    # Clean up stale projected commands
+    commands_dir = project_root / ".gemini" / "commands"
+    if commands_dir.exists():
+        for existing_path in sorted(commands_dir.rglob("*.toml")):
+            if existing_path.is_file() and existing_path not in projected_commands:
+                existing_path.unlink()
+                sys.stdout.write(
+                    f"Removed stale command {existing_path.relative_to(project_root)}\n"
+                )
 
     # Write projected TOML command files
     for dest_path, content in projected_commands.items():

--- a/scripts/ci/generate_instructions.py
+++ b/scripts/ci/generate_instructions.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Generate CLAUDE.md, GEMINI.md, .gemini/settings.json, and .gemini/commands/*.toml."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+CLAUDE_HEADER = """# CLAUDE.md
+
+synth-setter: synth inversion, sound matching, and preset-exploration tools — Python 3.10+, PyTorch Lightning, Hydra, with a distributed data pipeline on SkyPilot-managed compute (RunPod + OCI) stored in Cloudflare R2.
+
+Shared agent instructions for Claude and Codex; AGENTS.md is the canonical source. Architecture: [docs/architecture.md](docs/architecture.md).
+"""
+
+GEMINI_CONTENT = """# GEMINI.md
+
+synth-setter: synth inversion, sound matching, and preset-exploration tools — Python 3.10+, PyTorch Lightning, Hydra, with a distributed data pipeline on SkyPilot-managed compute (RunPod + OCI) stored in Cloudflare R2.
+
+Shared agent instructions for Claude, Codex, and Gemini; AGENTS.md is the canonical source. Architecture: [docs/architecture.md](docs/architecture.md).
+
+Read and follow [AGENTS.md](AGENTS.md). That file is the canonical project
+instruction source for Claude, Codex, and Gemini. Keep Gemini-specific compatibility
+notes in `.gemini/`; keep shared hooks and review skills under `agent/`.
+"""
+
+CLAUDE_SECTION_ORDER = [
+    "Always",
+    "Commands",
+    "Writing code",
+    "Comment hygiene",
+    "Design defaults",
+    "Mandatory skills for code changes",
+    "Testing",
+    "Commits",
+    "Lint exceptions are append-frozen",
+    "YAML `run:` block scalars are bash",
+    "Refactoring",
+    "PRs",
+    "Code review",
+    "GPU verification",
+    "VST and R2 verification",
+]
+
+CLAUDE_CONDITIONS = {
+    "Always": "you are about to edit, write, or commit any file",
+    "Commands": "you need to run commands to build, test, lint, or format",
+    "Writing code": "you are writing or modifying Python code",
+    "Comment hygiene": "you are writing inline comments or docstrings",
+    "Design defaults": "you are starting any non-trivial change",
+    "Mandatory skills for code changes": "you are modifying non-documentation code (anything other than .md / docs/ edits)",
+    "Testing": "you are writing or running tests",
+    "Commits": "you are committing",
+    "Lint exceptions are append-frozen": "a lint, pydoclint, or pyright check fails on a file your change touches",
+    "YAML `run:` block scalars are bash": "you are editing GitHub Actions workflows (.github/workflows/*.yml) or SkyPilot compute configs (src/synth_setter/configs/compute/*.yaml)",
+    "Refactoring": "you are moving, renaming, or restructuring code",
+    "PRs": "you are opening or driving a pull request",
+    "Code review": "you are reviewing code",
+    "GPU verification": "you are about to claim no GPU is available",
+    "VST and R2 verification": "you are about to claim no VST or R2 is available",
+}
+
+SKILL_COMMANDS = {
+    "repo-review": "repo/review",
+    "repo-review-full": "repo/review-full",
+    "repo-review-full-no-comments": "repo/review-full-no-comments",
+    "fix-review-comments": "fix/review-comments",
+    "pr-readiness": "pr/readiness",
+}
+
+SHIM_COMMANDS = {
+    "qrspi-design": "qrspi/design",
+    "qrspi-implement": "qrspi/implement",
+    "qrspi-plan": "qrspi/plan",
+    "qrspi-pr": "qrspi/pr",
+    "qrspi-questions": "qrspi/questions",
+    "qrspi-research": "qrspi/research",
+    "qrspi-structure": "qrspi/structure",
+    "qrspi-worktree": "qrspi/worktree",
+    "lint-cleanup": "lint/cleanup",
+}
+
+GEMINI_HOOKS_CONFIG = {
+    "SessionStart": [
+        {
+            "description": "Worktree-status banner: prints cwd, current branch, and whether the agent is sitting in the primary checkout (which AGENTS.md marks read-only). Fires on every session start, resume, /clear, and /compact so post-compaction agents see the same context.",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/session-start-cwd-banner.sh",
+                }
+            ],
+        }
+    ],
+    "BeforeTool": [
+        {
+            "matcher": "replace_file_content|multi_replace_file_content|write_to_file",
+            "description": "Credential protection: blocks edits to .env, .pem, and .key files. Goal: prevent secrets from being modified or leaked into commits.",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/edit-write.sh credential-protect",
+                }
+            ],
+        },
+        {
+            "matcher": "replace_file_content|multi_replace_file_content|write_to_file",
+            "description": "Worktree guard: on Edit/Write inside the primary checkout, prints a WARNING with the exact `git worktree add` command.",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/worktree-guard.sh",
+                }
+            ],
+        },
+        {
+            "matcher": "replace_file_content|multi_replace_file_content|write_to_file",
+            "description": "No-baseline-additions: on Edit/Write of .pydoclint-baseline.txt, blocks the call if the post-edit line count exceeds the current count.",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/no-baseline-additions.sh",
+                }
+            ],
+        },
+        {
+            "matcher": "replace_file_content|multi_replace_file_content|write_to_file",
+            "description": "No-yaml-run-comments: on Edit/Write of .github/workflows/*.{yml,yaml} or configs/compute/*.{yml,yaml}, blocks the call if the post-edit content has any `#`-comment line inside a `run: |` / `setup: |` block scalar.",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/no-yaml-run-comments.sh",
+                }
+            ],
+        },
+        {
+            "matcher": "run_command",
+            "description": "Branch safety: echoes the current branch name before any git commit.",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/branch-safety.sh",
+                }
+            ],
+        },
+        {
+            "matcher": "run_command",
+            "description": "Git-commit-trailer-check: blocks `git commit` (and other forms) that carry --no-verify / -n, a Co-Authored-By trailer, or an agent-attribution footer.",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/git-commit-trailer-check.sh",
+                }
+            ],
+        },
+        {
+            "matcher": "run_command",
+            "description": "Pre-PR review gate: blocks gh pr create unless REVIEW_FULL=<path> points at a sentinel review file.",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/pre-pr-review-gate.sh",
+                }
+            ],
+        },
+    ],
+    "AfterAgent": [
+        {
+            "description": "PR-readiness gate: on Stop, if there's an open PR for the current branch whose readiness gates don't hold, blocks the turn from ending (exit 2).",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/pr-readiness-stop.sh",
+                }
+            ],
+        }
+    ],
+    "AfterTool": [
+        {
+            "matcher": "replace_file_content|multi_replace_file_content|write_to_file",
+            "description": "Auto-format on every Edit/Write: ruff (Python), mdformat (Markdown), prettier (YAML).",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/edit-write.sh format",
+                }
+            ],
+        },
+        {
+            "matcher": "replace_file_content|multi_replace_file_content|write_to_file",
+            "description": "Auto-test: runs the matching pytest file when src/, scripts/, or tests/ Python files are edited.",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/edit-write.sh test",
+                }
+            ],
+        },
+        {
+            "matcher": "run_command",
+            "description": "Worktree post-setup: after `git worktree add`, automatically runs `make link-plugins && make link-thoughts` in the new worktree.",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/worktree-post-setup.sh",
+                }
+            ],
+        },
+        {
+            "matcher": "run_command",
+            "description": "Taxonomy verification: validates GitHub metadata after gh issue create, gh pr create, and addSubIssue mutations.",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/verify-gh-taxonomy.sh",
+                }
+            ],
+        },
+        {
+            "matcher": "run_command",
+            "description": "PR checkbox trigger: detects gh pr create commands and prompts the agent to invoke the /pr-checkbox skill.",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": 'jq -r \'.tool_input.command // ""\' | grep -q \'gh pr create\' && echo \'{"hookSpecificOutput":{"hookEventName":"AfterTool","additionalContext":"A PR was just created. You MUST now invoke the /pr:checkbox command to add verification checkboxes to this PR."}}\' || true',
+                }
+            ],
+        },
+        {
+            "description": "Doc-drift advisory review: on gh pr create, runs a headless agent session invoking the doc-drift skill.",
+            "matcher": "run_command",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/doc-drift.sh",
+                }
+            ],
+        },
+        {
+            "description": "PR review resolver: on git push (excluding main/master), resolves the branch's PR up front.",
+            "matcher": "run_command",
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": "bash agent/hooks/pr-review-resolver.sh",
+                }
+            ],
+        },
+    ],
+}
+
+
+def parse_agents_md(agents_path: Path) -> dict[str, str]:
+    """Parse sections from AGENTS.md.
+
+    :param agents_path: Path to AGENTS.md.
+    :returns: Map from section header to body text.
+    """
+    content = agents_path.read_text(encoding="utf-8")
+    sections = {}
+
+    parts = content.split("\n## ")
+    for part in parts[1:]:
+        lines = part.split("\n")
+        title = lines[0].strip()
+        body = "\n".join(lines[1:])
+        sections[title] = body
+
+    return sections
+
+
+def parse_markdown_with_frontmatter(file_path: Path) -> tuple[dict[str, str], str]:
+    """Parse markdown file that may contain YAML frontmatter.
+
+    :param file_path: Path to the markdown file.
+    :returns: Tuple of frontmatter dict and body text.
+    """
+    content = file_path.read_text(encoding="utf-8")
+    if not content.startswith("---"):
+        return {}, content.strip()
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {}, content.strip()
+
+    frontmatter_text = parts[1]
+    body = parts[2].strip()
+
+    try:
+        metadata = yaml.safe_load(frontmatter_text) or {}
+    except Exception:
+        metadata = {}
+        for line in frontmatter_text.splitlines():
+            if ":" in line:
+                k, v = line.split(":", 1)
+                metadata[k.strip()] = v.strip()
+
+    return metadata, body
+
+
+def generate_toml_command(description: str, prompt: str) -> str:
+    """Generate the contents of a Gemini CLI TOML command file.
+
+    :param description: Description of the command.
+    :param prompt: Prompt/instructions body.
+    :returns: TOML string content.
+    """
+    description_clean = description.replace("\n", " ").replace('"', '\\"')
+    return f"description = \"{description_clean}\"\nprompt = '''\n{prompt}\n'''\n"
+
+
+def format_via_pre_commit(content: str, filename: str, project_root: Path) -> str:
+    """Format the markdown content using the pre-commit mdformat hook.
+
+    :param content: Unformatted markdown string.
+    :param filename: Name of the file (e.g. 'CLAUDE.md').
+    :param project_root: Path to the repository root.
+    :returns: Formatted markdown string.
+    """
+    temp_path = project_root / f"{filename}.tmp.md"
+    temp_path.write_text(content, encoding="utf-8")
+
+    try:
+        subprocess.run(  # noqa: S603
+            [sys.executable, "-m", "pre_commit", "run", "mdformat", "--files", str(temp_path)],
+            cwd=str(project_root),
+            capture_output=True,
+            check=False,
+        )
+        formatted = temp_path.read_text(encoding="utf-8")
+    except Exception:
+        formatted = content
+    finally:
+        if temp_path.exists():
+            temp_path.unlink()
+
+    return formatted
+
+
+def main() -> int:
+    """Generate or check the instruction and config files.
+
+    :returns: Exit status code.
+    """
+    parser = argparse.ArgumentParser(
+        description="Generate CLAUDE.md/GEMINI.md, .gemini/settings.json, and .gemini/commands/*.toml"
+    )
+    parser.add_argument(
+        "--check", action="store_true", help="Only check for differences without writing"
+    )
+    args = parser.parse_args()
+
+    project_root = Path(__file__).resolve().parents[2]
+    agents_path = project_root / "AGENTS.md"
+    claude_path = project_root / "CLAUDE.md"
+    gemini_path = project_root / "GEMINI.md"
+    mcp_config_path = project_root / ".mcp.json"
+    gemini_settings_path = project_root / ".gemini" / "settings.json"
+
+    if not agents_path.exists():
+        sys.stderr.write(f"Error: AGENTS.md not found at {agents_path}\n")
+        return 1
+
+    sections = parse_agents_md(agents_path)
+
+    # Build CLAUDE.md content
+    claude_parts = [CLAUDE_HEADER.strip()]
+    for title in CLAUDE_SECTION_ORDER:
+        if title not in sections:
+            sys.stderr.write(f"Error: Section {title!r} not found in AGENTS.md\n")
+            return 1
+        body = sections[title].strip()
+        condition = CLAUDE_CONDITIONS[title]
+        claude_parts.append(f'<important if="{condition}">\n\n{body}\n</important>')
+
+    generated_claude = "\n\n".join(claude_parts) + "\n"
+    generated_gemini = GEMINI_CONTENT.strip() + "\n"
+
+    # Format markdown contents through pre-commit
+    generated_claude = format_via_pre_commit(generated_claude, "CLAUDE.md", project_root)
+    generated_gemini = format_via_pre_commit(generated_gemini, "GEMINI.md", project_root)
+
+    # Build .gemini/settings.json content
+    mcp_servers = {}
+    if mcp_config_path.exists():
+        try:
+            mcp_data = json.loads(mcp_config_path.read_text(encoding="utf-8"))
+            mcp_servers = mcp_data.get("mcpServers", {})
+        except Exception as e:
+            sys.stderr.write(f"Warning: Failed to parse .mcp.json: {e}\n")
+
+    settings_dict = {
+        "permissions": {"defaultMode": "auto"},
+        "hooks": GEMINI_HOOKS_CONFIG,
+        "mcpServers": mcp_servers,
+    }
+    generated_settings = json.dumps(settings_dict, indent=2) + "\n"
+
+    # Map command projections
+    projected_commands: dict[Path, str] = {}
+
+    # 1. Project skills
+    for skill_name, relative_path in SKILL_COMMANDS.items():
+        skill_file = project_root / "agent" / "skills" / skill_name / "SKILL.md"
+        if not skill_file.exists():
+            sys.stderr.write(f"Error: Skill file not found at {skill_file}\n")
+            return 1
+        metadata, body = parse_markdown_with_frontmatter(skill_file)
+        desc = metadata.get("description", "").strip() or f"Run the {skill_name} skill."
+        toml_content = generate_toml_command(desc, body)
+        dest_path = project_root / ".gemini" / "commands" / f"{relative_path}.toml"
+        projected_commands[dest_path] = toml_content
+
+    # 2. Project shims
+    for shim_name, relative_path in SHIM_COMMANDS.items():
+        shim_file = project_root / ".claude" / "commands" / f"{shim_name}.md"
+        if not shim_file.exists():
+            sys.stderr.write(f"Error: Claude command file not found at {shim_file}\n")
+            return 1
+        metadata, body = parse_markdown_with_frontmatter(shim_file)
+        desc = metadata.get("description", "").strip() or f"Run the {shim_name} command."
+        body_with_args = body.replace("$ARGUMENTS", "{{args}}")
+        toml_content = generate_toml_command(desc, body_with_args)
+        dest_path = project_root / ".gemini" / "commands" / f"{relative_path}.toml"
+        projected_commands[dest_path] = toml_content
+
+    if args.check:
+        drift = False
+        if not claude_path.exists():
+            sys.stderr.write("CLAUDE.md does not exist.\n")
+            drift = True
+        elif claude_path.read_text(encoding="utf-8") != generated_claude:
+            sys.stderr.write("CLAUDE.md is out of sync with AGENTS.md.\n")
+            drift = True
+
+        if not gemini_path.exists():
+            sys.stderr.write("GEMINI.md does not exist.\n")
+            drift = True
+        elif gemini_path.read_text(encoding="utf-8") != generated_gemini:
+            sys.stderr.write("GEMINI.md is out of sync.\n")
+            drift = True
+
+        if not gemini_settings_path.exists():
+            sys.stderr.write(".gemini/settings.json does not exist.\n")
+            drift = True
+        elif gemini_settings_path.read_text(encoding="utf-8") != generated_settings:
+            sys.stderr.write(".gemini/settings.json is out of sync.\n")
+            drift = True
+
+        # Check projected command TOML files
+        for dest_path, expected_content in projected_commands.items():
+            if not dest_path.exists():
+                sys.stderr.write(
+                    f"Projected command {dest_path.relative_to(project_root)} does not exist.\n"
+                )
+                drift = True
+            elif dest_path.read_text(encoding="utf-8") != expected_content:
+                sys.stderr.write(
+                    f"Projected command {dest_path.relative_to(project_root)} is out of sync.\n"
+                )
+                drift = True
+
+        if drift:
+            return 1
+        sys.stdout.write("All instruction and command files are in sync.\n")
+        return 0
+
+    # Write instruction files
+    claude_path.write_text(generated_claude, encoding="utf-8")
+    sys.stdout.write(f"Updated {claude_path}\n")
+    gemini_path.write_text(generated_gemini, encoding="utf-8")
+    sys.stdout.write(f"Updated {gemini_path}\n")
+
+    # Write settings file
+    gemini_settings_path.parent.mkdir(parents=True, exist_ok=True)
+    gemini_settings_path.write_text(generated_settings, encoding="utf-8")
+    sys.stdout.write(f"Updated {gemini_settings_path}\n")
+
+    # Write projected TOML command files
+    for dest_path, content in projected_commands.items():
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
+        dest_path.write_text(content, encoding="utf-8")
+        sys.stdout.write(f"Updated {dest_path}\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/infra/test_agent_instructions.py
+++ b/tests/infra/test_agent_instructions.py
@@ -1,0 +1,37 @@
+"""Invariant: CLAUDE.md and GEMINI.md are generated from AGENTS.md.
+
+Runs the generator script in check mode to verify no drifts exist between the
+canonical AGENTS.md and the generated CLAUDE.md and GEMINI.md instruction files.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.infra
+def test_agent_instructions_are_in_sync(project_root: Path) -> None:
+    """Run the instruction generator in check mode to assert no drift.
+
+    :param project_root: Path to the repository root.
+    """
+    script_path = project_root / "scripts" / "ci" / "generate_instructions.py"
+
+    # Run the generation script with --check flag
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, str(script_path), "--check"],
+        capture_output=True,
+        text=True,
+        cwd=str(project_root),
+        check=False,
+    )
+
+    assert result.returncode == 0, (
+        f"Agent instruction files are out of sync or drift detected!\n"
+        f"Run `python3 scripts/ci/generate_instructions.py` to regenerate them.\n"
+        f"Stdout:\n{result.stdout}\nStderr:\n{result.stderr}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.30.0"
+version = "8.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Add Gemini CLI support to the devcontainer and agent harness:
- Create `generate_instructions.py` to generate `CLAUDE.md`, `GEMINI.md`, and `settings.json`.
- Project skills and shims into TOML commands under `.gemini/commands/`.
- Add test verifying that generated files match `AGENTS.md` and skills.
- Install `@google/gemini-cli` in the devcontainer.

Closes #1561