### PR TITLE
automation(codex): add setup doctor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ test-vst-cpu: ## VST tests only (slow included; gpu/mps excluded). Linux: bootst
 test-infra: ## Devcontainer + GHA invariant tests — stdlib-only, no torch/Hydra.
 	pytest tests/infra/ --confcutdir=tests/infra
 
+codex-doctor: ## Check Codex CLI, repo skill projection, and tinaudio skill plugin discovery.
+	scripts/dev/codex-doctor.sh
+
 # Single source of truth for the marker expressions CI runs (see #1353): the
 # workflows call these instead of re-spelling pytest, so the filters can't drift.
 

--- a/scripts/dev/codex-doctor.sh
+++ b/scripts/dev/codex-doctor.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+main() {
+  local repo_root failures=0 missing_skills=0 skill
+  repo_root=$(git rev-parse --show-toplevel)
+
+  # shellcheck source=agent/hooks/_lib.sh
+  # shellcheck disable=SC1091
+  source "$repo_root/agent/hooks/_lib.sh"
+
+  if command -v codex >/dev/null 2>&1; then
+    printf 'OK: codex CLI found\n'
+  else
+    printf 'MISSING: codex CLI not found on PATH\n'
+    failures=$((failures + 1))
+  fi
+
+  if [[ -d "$repo_root/.agents/skills" ]]; then
+    printf 'OK: .agents/skills resolves to a directory\n'
+  else
+    printf 'MISSING: .agents/skills does not resolve to a directory\n'
+    failures=$((failures + 1))
+  fi
+
+  if grep -q 'tinaudio/skills' "$repo_root/.agents/plugins/marketplace.json" 2>/dev/null; then
+    printf 'OK: repo marketplace advertises tinaudio/skills\n'
+  else
+    printf 'MISSING: repo marketplace does not advertise tinaudio/skills\n'
+    failures=$((failures + 1))
+  fi
+
+  for skill in \
+    code-health \
+    github-taxonomy \
+    pr-checkbox \
+    pr-readiness \
+    pr-review-resolver \
+    simplify \
+    tdd-implementation
+  do
+    if has_skill "$skill"; then
+      printf 'OK: skill %s is discoverable\n' "$skill"
+    else
+      printf 'MISSING: skill %s is not discoverable\n' "$skill"
+      missing_skills=$((missing_skills + 1))
+    fi
+  done
+
+  if [[ "$missing_skills" -gt 0 ]]; then
+    failures=$((failures + 1))
+    printf '\nInstall or enable the tinaudio skill plugin, then start a new Codex thread:\n'
+    printf '  codex plugin marketplace add tinaudio/skills\n'
+    printf '  /plugins -> tinaudio Skills -> tinaudio-synth-setter-skills\n'
+  fi
+
+  if [[ "$failures" -gt 0 ]]; then
+    printf '\nCodex setup has %s issue(s).\n' "$failures"
+    return 1
+  fi
+
+  printf '\nCodex setup looks ready.\n'
+}
+
+main "$@"

--- a/tests/infra/test_codex_doctor.py
+++ b/tests/infra/test_codex_doctor.py
@@ -1,0 +1,96 @@
+"""Tests for the Codex setup doctor."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCTOR = REPO_ROOT / "scripts" / "dev" / "codex-doctor.sh"
+REQUIRED_PLUGIN_SKILLS = (
+    "code-health",
+    "github-taxonomy",
+    "pr-checkbox",
+    "pr-review-resolver",
+    "simplify",
+    "tdd-implementation",
+)
+
+
+def _write_fake_codex(bin_dir: Path) -> None:
+    """Create a fake ``codex`` executable on PATH.
+
+    :param bin_dir: Directory that will hold the executable.
+    """
+    bin_dir.mkdir()
+    codex = bin_dir / "codex"
+    codex.write_text("#!/usr/bin/env bash\nexit 0\n")
+    codex.chmod(codex.stat().st_mode | stat.S_IXUSR)
+
+
+def _write_user_skill(home: Path, name: str) -> None:
+    """Create a fake user-level Codex skill.
+
+    :param home: Fake home directory.
+    :param name: Skill name.
+    """
+    skill_dir = home / ".agents" / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
+
+
+def _run_doctor(tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    """Run the doctor with an isolated home and PATH.
+
+    :param tmp_path: Temporary test root.
+    :returns: Completed process for assertions.
+    """
+    bin_dir = tmp_path / "bin"
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    _write_fake_codex(bin_dir)
+
+    env = {
+        **os.environ,
+        "HOME": str(home),
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+    }
+    return subprocess.run(  # noqa: S603
+        ["bash", str(DOCTOR)],  # noqa: S607 - bash is required for shell doctor coverage
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_codex_doctor_with_required_plugin_skills_passes(tmp_path: Path) -> None:
+    """Doctor passes when Codex and required reusable skills are discoverable.
+
+    :param tmp_path: Temporary test root.
+    """
+    home = tmp_path / "home"
+    for skill in REQUIRED_PLUGIN_SKILLS:
+        _write_user_skill(home, skill)
+
+    result = _run_doctor(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Codex setup looks ready." in result.stdout
+
+
+def test_codex_doctor_missing_plugin_skills_prints_install_command(
+    tmp_path: Path,
+) -> None:
+    """Doctor reports missing reusable skills without installing plugins.
+
+    :param tmp_path: Temporary test root.
+    """
+    result = _run_doctor(tmp_path)
+
+    assert result.returncode == 1
+    assert "codex plugin marketplace add tinaudio/skills" in result.stdout
+    assert "Install or enable the tinaudio skill plugin" in result.stdout


### PR DESCRIPTION
## Summary
- add `make codex-doctor` as an opt-in Codex setup check
- verify Codex CLI presence, `.agents/skills`, repo marketplace metadata, and required skill discovery
- print the user-approved `codex plugin marketplace add tinaudio/skills` command when reusable plugin skills are missing
- add infra tests for ready and missing-plugin states

Stacked on #1577.
Refs #1561

## Verification
- `pytest tests/infra/test_codex_doctor.py -q`
- `make format`
- `make codex-doctor` exits nonzero in this session as expected because the tinaudio Codex plugin is not installed; it prints the install/enable instructions.
