### PR TITLE
ci: split #489 cadence job into its own workflow with configurable size

### DIFF
--- a/.github/workflows/cadence-investigation-489.yml
+++ b/.github/workflows/cadence-investigation-489.yml
@@ -36,6 +36,9 @@ permissions:
 jobs:
   run_cadence_investigation:
     name: "#489 cadence investigation (real W&B sweep)"
+    # Fork PRs can't read the R2/W&B secrets the run needs, so skip them rather
+    # than fail in setup-r2's required inputs; dispatch and same-repo PRs run.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest-4core
     timeout-minutes: 120
 

--- a/.github/workflows/cadence-investigation-489.yml
+++ b/.github/workflows/cadence-investigation-489.yml
@@ -1,0 +1,102 @@
+name: Cadence Investigation (#489)
+
+# Real wandb-online end-to-end run of the #489 surge_xt cadence investigation
+# (``tests/integration/test_cadence_investigation_489_e2e.py``) in the
+# ``tinaudio/synth-setter:dev-snapshot`` Docker image. Opt-in because it creates
+# persistent W&B sweeps, spends render compute, and round-trips R2: a manual
+# dispatch, or a PR editing the cadence sources gated below.
+
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: "Docker image tag (e.g. dev-snapshot, dev-snapshot-<sha>)"
+        required: false
+        default: "dev-snapshot"
+      cadence_scale:
+        description: "Dataset size for the cadence sweep"
+        type: choice
+        options:
+          - smoke
+          - full
+        default: smoke
+  pull_request:
+    paths:
+      - ".github/workflows/cadence-investigation-489.yml"
+      - "src/synth_setter/tools/cadence_investigation_489.py"
+      - "tests/integration/test_cadence_investigation_489_e2e.py"
+
+concurrency:
+  group: cadence-investigation-489-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  run_cadence_investigation:
+    name: "#489 cadence investigation (real W&B sweep)"
+    runs-on: ubuntu-latest-4core
+    timeout-minutes: 120
+
+    env:
+      IMAGE: tinaudio/synth-setter:${{ inputs.image_tag || 'dev-snapshot' }}
+      # No dispatch input on pull_request, so this resolves to smoke and a bare
+      # PR self-validation stays cheap.
+      CADENCE_SCALE: ${{ inputs.cadence_scale || 'smoke' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Pull image
+        run: docker pull "$IMAGE"
+
+      # Export RCLONE_CONFIG_R2_* into $GITHUB_ENV so the docker step can
+      # forward them with bare ``-e`` flags. ``install-rclone: false`` because
+      # rclone runs inside the dev image (Dockerfile installs it), not on the
+      # host runner.
+      - name: Configure R2 credentials
+        uses: ./.github/actions/setup-r2
+        with:
+          access-key-id: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
+          secret-access-key: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
+          endpoint: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
+          install-rclone: "false"
+
+      - name: Run #489 cadence investigation in Docker
+        # The wandb-online e2e self-skips without WANDB_API_KEY or reachable R2;
+        # the three W&B vars plus five RCLONE_CONFIG_R2_* (set above) are forwarded.
+        # WANDB_ENTITY / WANDB_PROJECT redirect sweeps off the script's personal-pin
+        # default; CADENCE_SCALE picks the dataset size. The headless wrapper
+        # supplies the X display Surge XT needs, and ensure_plugin_symlinks.sh
+        # restores the Surge symlink the bind-mount shadows so the subprocess's
+        # relative render.plugin_path resolves — same as generate-dataset-shards.yaml.
+        env:
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          WANDB_ENTITY: ${{ secrets.WANDB_ENTITY }}
+          WANDB_PROJECT: ${{ secrets.WANDB_PROJECT }}
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/home/build/synth-setter" \
+            -e HYDRA_FULL_ERROR=1 \
+            -e "SYNTH_SETTER_PLUGIN_PATH=/usr/lib/vst3/Surge XT.vst3" \
+            -e CADENCE_SCALE \
+            -e WANDB_API_KEY \
+            -e WANDB_ENTITY \
+            -e WANDB_PROJECT \
+            -e RCLONE_CONFIG_R2_TYPE \
+            -e RCLONE_CONFIG_R2_PROVIDER \
+            -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
+            -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
+            -e RCLONE_CONFIG_R2_ENDPOINT \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              cd /home/build/synth-setter
+              git config --global --add safe.directory /home/build/synth-setter
+              bash docker/ubuntu22_04/ensure_plugin_symlinks.sh
+              src/synth_setter/scripts/run-linux-vst-headless.sh \
+                pytest -vv -s \
+                  tests/integration/test_cadence_investigation_489_e2e.py
+            '

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -31,13 +31,6 @@ on:
         description: "Push run metrics to gh-pages (creates the page on first run)"
         type: boolean
         default: false
-      run_cadence_sweep:
-        # Opt-in dispatch for the #489 cadence investigation (real W&B sweeps +
-        # render compute + R2) in place of the VST suite. Off by default — each
-        # run leaves persistent sweeps in the W&B UI. See the job's if: below.
-        description: "Run the #489 cadence investigation (real W&B sweep) instead of the VST suite"
-        type: boolean
-        default: false
   push:
     # ``test/vst-roundtrip-xfail-tests`` listed temporarily so we can bootstrap
     # the ``gh-pages`` benchmark chart from this PR before merging to main.
@@ -84,9 +77,6 @@ permissions:
 jobs:
   run_vst_slow_tests:
     name: VST slow tests (Docker)
-    # A cadence-sweep dispatch runs the cadence job below instead, so skip the
-    # 90-min VST suite in that case; every other trigger runs it as before.
-    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.run_cadence_sweep == true) }}
     runs-on: ubuntu-latest-4core
     timeout-minutes: 120
 
@@ -235,102 +225,3 @@ jobs:
           comment-on-alert: true
           fail-on-alert: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
-
-  # Flags whether a PR edits this workflow so the cadence job below can
-  # self-validate pre-merge without firing the costly sweep on every PR.
-  detect_changes:
-    name: Detect cadence-workflow edits
-    if: ${{ github.event_name == 'pull_request' }}
-    runs-on: ubuntu-latest
-    outputs:
-      cadence_workflow_changed: ${{ steps.changed.outputs.any_changed }}
-    steps:
-      # fetch-depth: 0 so tj-actions/changed-files can diff against the PR base.
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Detect changes to this workflow
-        id: changed
-        uses: tj-actions/changed-files@v45
-        with:
-          files: .github/workflows/test-vst-slow.yml
-
-  # #489 cadence investigation: real wandb-online e2e (W&B sweeps + render
-  # compute + R2). The if: below gates it to dispatch opt-in or a PR editing
-  # this workflow (validated pre-merge); mutually exclusive with the VST suite.
-  run_cadence_investigation:
-    name: "#489 cadence investigation (real W&B sweep)"
-    # ``!cancelled()`` lets this run when ``detect_changes`` is skipped (dispatch).
-    needs: detect_changes
-    if: >-
-      ${{ !cancelled() && (
-        (github.event_name == 'workflow_dispatch' && inputs.run_cadence_sweep == true) ||
-        (github.event_name == 'pull_request' && needs.detect_changes.outputs.cadence_workflow_changed == 'true')
-      ) }}
-    runs-on: ubuntu-latest-4core
-    timeout-minutes: 120
-
-    permissions:
-      contents: read
-
-    env:
-      IMAGE: tinaudio/synth-setter:${{ inputs.image_tag || 'dev-snapshot' }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Pull image
-        run: docker pull "$IMAGE"
-
-      # Export RCLONE_CONFIG_R2_* into $GITHUB_ENV so the docker step can
-      # forward them with bare ``-e`` flags. ``install-rclone: false`` because
-      # rclone runs inside the dev image (Dockerfile installs it), not on the
-      # host runner.
-      - name: Configure R2 credentials
-        uses: ./.github/actions/setup-r2
-        with:
-          access-key-id: ${{ secrets.RCLONE_CONFIG_R2_ACCESS_KEY_ID }}
-          secret-access-key: ${{ secrets.RCLONE_CONFIG_R2_SECRET_ACCESS_KEY }}
-          endpoint: ${{ secrets.RCLONE_CONFIG_R2_ENDPOINT }}
-          install-rclone: "false"
-
-      - name: Run #489 cadence investigation in Docker
-        # The wandb-online e2e self-skips without WANDB_API_KEY or reachable
-        # R2, so all three W&B vars plus the five RCLONE_CONFIG_R2_* (set by
-        # the step above) are forwarded into the container. WANDB_ENTITY /
-        # WANDB_PROJECT redirect the sweeps off the script's personal-pin
-        # default onto the shared entity. The headless wrapper supplies the X
-        # display the Surge XT renderer needs, same as the VST suite above.
-        # ensure_plugin_symlinks.sh restores the Surge symlink the bind-mount
-        # shadows so the subprocess's relative render.plugin_path resolves,
-        # same as generate-dataset-shards.yaml.
-        env:
-          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
-          WANDB_ENTITY: ${{ secrets.WANDB_ENTITY }}
-          WANDB_PROJECT: ${{ secrets.WANDB_PROJECT }}
-        run: |
-          docker run --rm \
-            -v ${{ github.workspace }}:/home/build/synth-setter \
-            -e HYDRA_FULL_ERROR=1 \
-            -e "SYNTH_SETTER_PLUGIN_PATH=/usr/lib/vst3/Surge XT.vst3" \
-            -e WANDB_API_KEY \
-            -e WANDB_ENTITY \
-            -e WANDB_PROJECT \
-            -e RCLONE_CONFIG_R2_TYPE \
-            -e RCLONE_CONFIG_R2_PROVIDER \
-            -e RCLONE_CONFIG_R2_ACCESS_KEY_ID \
-            -e RCLONE_CONFIG_R2_SECRET_ACCESS_KEY \
-            -e RCLONE_CONFIG_R2_ENDPOINT \
-            "$IMAGE" \
-            bash -c '
-              set -euo pipefail
-              cd /home/build/synth-setter
-              git config --global --add safe.directory /home/build/synth-setter
-              bash docker/ubuntu22_04/ensure_plugin_symlinks.sh
-              src/synth_setter/scripts/run-linux-vst-headless.sh \
-                pytest -vv -s \
-                  tests/integration/test_cadence_investigation_489_e2e.py
-            '

--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -91,6 +91,9 @@ class Scale:
 FULL = Scale(sizes=(40, 40, 40), samples_per_shard=20, reuse_depths=(4, 20, 40, 80))
 # Smallest run that still exercises generate -> copy -> oracle for tests.
 SMOKE = Scale(sizes=(2, 2, 2), samples_per_shard=2, reuse_depths=(1, 2))
+# Named dataset sizes selectable via the CLI ``--scale`` flag (and the cadence
+# workflow's ``cadence_scale`` input, which the e2e test reads from the env).
+SCALES: dict[str, Scale] = {"full": FULL, "smoke": SMOKE}
 
 
 @dataclass(frozen=True)
@@ -482,7 +485,7 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--scale",
-        choices=("full", "smoke"),
+        choices=tuple(SCALES),
         default="full",
         help="full #489 sizes (default) or a tiny end-to-end smoke run",
     )
@@ -516,7 +519,7 @@ def main(argv: list[str] | None = None) -> None:
     """
     args = _parse_args(argv)
     run_investigation(
-        scale=SMOKE if args.scale == "smoke" else FULL,
+        scale=SCALES[args.scale],
         launcher=args.launcher,
         prefix_root=args.prefix_root,
         only=[name for name in (n.strip() for n in args.only.split(",")) if name]

--- a/tests/integration/test_cadence_investigation_489_e2e.py
+++ b/tests/integration/test_cadence_investigation_489_e2e.py
@@ -43,6 +43,22 @@ pytestmark = [
 # shard-000000 is the first train shard, present under both the source and copy run roots.
 _FIRST_SHARD = "shard-000000.h5"
 
+# Dataset size for the online sweep, set by the cadence workflow's ``cadence_scale``
+# input; defaults to ``smoke`` so a bare PR self-validation stays cheap.
+_CADENCE_SCALE_ENV = "CADENCE_SCALE"
+
+
+def _selected_scale_name() -> str:
+    """Return the cadence dataset-size name from the environment.
+
+    :returns: ``CADENCE_SCALE`` if set, else ``"smoke"``.
+    :raises ValueError: The env value is not a known scale name.
+    """
+    name = os.environ.get(_CADENCE_SCALE_ENV, "smoke")
+    if name not in inv.SCALES:
+        raise ValueError(f"{_CADENCE_SCALE_ENV}={name!r} is not one of {sorted(inv.SCALES)}")
+    return name
+
 
 def _prepend_pythonpath(entry: Path) -> str:
     """Prepend ``entry`` to the inherited ``PYTHONPATH``.
@@ -169,10 +185,14 @@ def _expected_shards(experiment: inv.Experiment) -> int:
 # integration_r2/r2/requires_vst/slow come from the module-level pytestmark;
 # only `network` is extra to this online-sweep test.
 @pytest.mark.network
-def test_full_smoke_investigation_wandb_online_runs_every_experiment(
+def test_full_investigation_wandb_online_runs_every_experiment_at_configured_scale(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Run the full investigation at smoke size via a real wandb-online sweep + agent.
+    """Run the full investigation via a real wandb-online sweep + agent at the env scale.
+
+    The dataset size is ``CADENCE_SCALE`` (default ``smoke``), so the cadence
+    workflow's ``cadence_scale`` input drives both the source generation and the
+    copy probes through one :class:`~inv.Scale`.
 
     All five experiments and every grid cell run; the test asserts on real R2 state.
 
@@ -192,17 +212,18 @@ def test_full_smoke_investigation_wandb_online_runs_every_experiment(
     if not os.environ.get("WANDB_API_KEY"):
         pytest.skip("WANDB_API_KEY required for the online wandb run")
 
-    prefix_root = f"test-runs/test_full_smoke_investigation_wandb/{uuid.uuid4().hex[:12]}"
+    prefix_root = f"test-runs/test_full_investigation_wandb/{uuid.uuid4().hex[:12]}"
     worktree_src = Path(__file__).resolve().parents[2] / "src"
     monkeypatch.setenv("PYTHONPATH", _prepend_pythonpath(worktree_src))
     monkeypatch.delenv("WANDB_MODE", raising=False)
     monkeypatch.setattr(inv, "ENTITY", os.environ.get("WANDB_ENTITY", inv.ENTITY))
     monkeypatch.setattr(inv, "PROJECT", os.environ.get("WANDB_PROJECT", inv.PROJECT))
 
-    experiments = inv.build_experiments(inv.SMOKE)
+    scale_name = _selected_scale_name()
+    experiments = inv.build_experiments(inv.SCALES[scale_name])
 
     try:
-        inv.main(["--launcher", "wandb", "--scale", "smoke", "--prefix-root", prefix_root])
+        inv.main(["--launcher", "wandb", "--scale", scale_name, "--prefix-root", prefix_root])
 
         source_root = inv.reference_copy_uri(prefix_root=prefix_root)
         source_shard = join_uri(source_root, _FIRST_SHARD)

--- a/tests/tools/test_cadence_investigation_489.py
+++ b/tests/tools/test_cadence_investigation_489.py
@@ -159,6 +159,27 @@ def test_build_sweep_config_threads_prefix_root_into_command() -> None:
     assert "r2.prefix_root=test-runs/x" in cfg["command"]
 
 
+def test_scales_maps_names_to_size_presets() -> None:
+    """``SCALES`` exposes the named dataset sizes the CLI ``--scale`` flag accepts."""
+    assert inv.SCALES == {"full": inv.FULL, "smoke": inv.SMOKE}
+
+
+def test_main_maps_scale_name_to_preset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--scale`` selects the matching :class:`Scale` preset for the run.
+
+    :param monkeypatch: Replaces ``run_investigation`` with a recorder so the
+        resolved scale is observed without launching any real run.
+    """
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(inv, "run_investigation", lambda **kwargs: captured.update(kwargs))
+
+    inv.main(["--scale", "full"])
+    assert captured["scale"] is inv.FULL
+
+    inv.main(["--scale", "smoke"])
+    assert captured["scale"] is inv.SMOKE
+
+
 def test_dry_run_executes_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
     """``--dry-run`` plans only: no generate subprocess, no wandb calls.
 

--- a/uv.lock
+++ b/uv.lock
@@ -6232,7 +6232,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.30.0"
+version = "8.32.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Why

PR #1575 fixed the #489 cadence investigation job and gated it to self-validate on PRs, but it left two rough edges: the cadence work lived as two jobs (`detect_changes` + `run_cadence_investigation`) wedged inside `test-vst-slow.yml`, sharing that file's dispatch and forcing a `tj-actions/changed-files` gate plus a mutual-exclusion `if:` on the VST suite; and the sweep always ran at the hardcoded `smoke` dataset size with no way to dispatch a `full` run.

## What changed

- **Split the cadence job into its own workflow** `.github/workflows/cadence-investigation-489.yml`. Because the workflow is now dedicated to cadence, a native `pull_request: paths:` filter (the workflow file, the orchestrator tool, and the e2e test) gates the costly pre-merge self-validation directly — so `detect_changes`, the `tj-actions/changed-files` action, the `fetch-depth: 0` checkout, and the `!cancelled()`/`needs` cross-job plumbing are all dropped.
- **Trimmed `test-vst-slow.yml`**: removed the `run_cadence_sweep` dispatch input, the mutual-exclusion `if:` on `run_vst_slow_tests` (the VST suite now always runs), and both cadence jobs.
- **Made the dataset size configurable**: a `cadence_scale` choice input (`smoke` | `full`, default `smoke`) flows in as `CADENCE_SCALE`, which the e2e test resolves through the new `tools.cadence_investigation_489.SCALES` map to pick the matching `Scale` for both source generation and the copy probes. The CLI `--scale` choices now derive from `tuple(SCALES)` so the flag and the lookup table can't drift. A bare PR self-validation gets no dispatch input and defaults to `smoke` to stay cheap.

## Test plan

- `tests/tools/test_cadence_investigation_489.py`: added `test_scales_maps_names_to_size_presets` and `test_main_maps_scale_name_to_preset` (21 tests green, fast lane).
- `tests/integration/test_cadence_investigation_489_e2e.py`: renamed to `..._at_configured_scale`, reads `CADENCE_SCALE` (default `smoke`). Collects clean; self-skips without VST/R2/W&B.
- This PR edits all three `pull_request: paths:` entries, so the cadence workflow runs its real-W&B self-validation at smoke scale on this PR — that green run is the proof the split works end-to-end.
- `make format` (pre-commit) clean.

Refs #489
