### PR TITLE
ci: take an integer dataset size for the #489 cadence sweep

### DIFF
--- a/.github/workflows/cadence-investigation-489.yml
+++ b/.github/workflows/cadence-investigation-489.yml
@@ -41,9 +41,9 @@ jobs:
 
     env:
       IMAGE: tinaudio/synth-setter:${{ inputs.image_tag || 'dev-snapshot' }}
-      # No dispatch input on pull_request, so this resolves to 2 (the smoke size)
-      # and a bare PR self-validation stays cheap.
-      CADENCE_SIZE: ${{ inputs.cadence_size || 2 }}
+      # github.event.inputs keeps a dispatched value a string, so an explicit 0
+      # fails fast rather than masking to 2; absent on pull_request it falls back to 2.
+      CADENCE_SIZE: ${{ github.event.inputs.cadence_size || 2 }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/cadence-investigation-489.yml
+++ b/.github/workflows/cadence-investigation-489.yml
@@ -13,13 +13,10 @@ on:
         description: "Docker image tag (e.g. dev-snapshot, dev-snapshot-<sha>)"
         required: false
         default: "dev-snapshot"
-      cadence_scale:
-        description: "Dataset size for the cadence sweep"
-        type: choice
-        options:
-          - smoke
-          - full
-        default: smoke
+      cadence_size:
+        description: "Dataset size N for the cadence sweep (5 -> [5,5,5] splits)"
+        type: number
+        default: 2
   pull_request:
     paths:
       - ".github/workflows/cadence-investigation-489.yml"
@@ -44,9 +41,9 @@ jobs:
 
     env:
       IMAGE: tinaudio/synth-setter:${{ inputs.image_tag || 'dev-snapshot' }}
-      # No dispatch input on pull_request, so this resolves to smoke and a bare
-      # PR self-validation stays cheap.
-      CADENCE_SCALE: ${{ inputs.cadence_scale || 'smoke' }}
+      # No dispatch input on pull_request, so this resolves to 2 (the smoke size)
+      # and a bare PR self-validation stays cheap.
+      CADENCE_SIZE: ${{ inputs.cadence_size || 2 }}
 
     steps:
       - name: Checkout
@@ -71,7 +68,7 @@ jobs:
         # The wandb-online e2e self-skips without WANDB_API_KEY or reachable R2;
         # the three W&B vars plus five RCLONE_CONFIG_R2_* (set above) are forwarded.
         # WANDB_ENTITY / WANDB_PROJECT redirect sweeps off the script's personal-pin
-        # default; CADENCE_SCALE picks the dataset size. The headless wrapper
+        # default; CADENCE_SIZE picks the dataset size N. The headless wrapper
         # supplies the X display Surge XT needs, and ensure_plugin_symlinks.sh
         # restores the Surge symlink the bind-mount shadows so the subprocess's
         # relative render.plugin_path resolves — same as generate-dataset-shards.yaml.
@@ -84,7 +81,7 @@ jobs:
             -v "${{ github.workspace }}:/home/build/synth-setter" \
             -e HYDRA_FULL_ERROR=1 \
             -e "SYNTH_SETTER_PLUGIN_PATH=/usr/lib/vst3/Surge XT.vst3" \
-            -e CADENCE_SCALE \
+            -e CADENCE_SIZE \
             -e WANDB_API_KEY \
             -e WANDB_ENTITY \
             -e WANDB_PROJECT \

--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -86,14 +86,25 @@ class Scale:
     samples_per_shard: int
     reuse_depths: tuple[int, ...]
 
+    @classmethod
+    def from_size(cls, size: int) -> Scale:
+        """Build a cubic scale from one dataset-size int.
 
-# Full #489 run: reuse depths straddle the junk onset (~12 reuses, #706).
-FULL = Scale(sizes=(40, 40, 40), samples_per_shard=20, reuse_depths=(4, 20, 40, 80))
-# Smallest run that still exercises generate -> copy -> oracle for tests.
-SMOKE = Scale(sizes=(2, 2, 2), samples_per_shard=2, reuse_depths=(1, 2))
-# Named dataset sizes selectable via the CLI ``--scale`` flag (and the cadence
-# workflow's ``cadence_scale`` input, which the e2e test reads from the env).
-SCALES: dict[str, Scale] = {"full": FULL, "smoke": SMOKE}
+        :param size: Per-split sample count ``N``; yields ``sizes=(N, N, N)`` with
+            one shard per split (``samples_per_shard=N``) and a no-reuse/full-reuse
+            depth sweep ``(1, N)`` (deduped to ``(1,)`` at ``N == 1``).
+        :returns: The scale feeding source generation and the copy probes in lockstep.
+        :raises ValueError: ``size`` is below 1, so no split would hold a sample.
+        """
+        if size < 1:
+            raise ValueError(f"dataset size must be >= 1, got {size}")
+        reuse_depths = tuple(dict.fromkeys((1, size)))
+        return cls(sizes=(size, size, size), samples_per_shard=size, reuse_depths=reuse_depths)
+
+
+# CLI default dataset size: the full #489 run (40 samples per split). The cadence
+# workflow's ``cadence_size`` input overrides it (and defaults smaller) per run.
+DEFAULT_SIZE = 40
 
 
 @dataclass(frozen=True)
@@ -474,7 +485,7 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     """Parse the orchestrator CLI arguments.
 
     :param argv: Argument vector; ``None`` falls back to ``sys.argv[1:]``.
-    :returns: Flags for ``run_investigation`` — launcher, scale, only, prefix_root, count, dry_run.
+    :returns: Flags for ``run_investigation`` — launcher, size, only, prefix_root, count, dry_run.
     """
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -484,10 +495,10 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         help="wandb sweeps + agents (default) or a single-box subprocess loop",
     )
     parser.add_argument(
-        "--scale",
-        choices=tuple(SCALES),
-        default="full",
-        help="full #489 sizes (default) or a tiny end-to-end smoke run",
+        "--size",
+        type=int,
+        default=DEFAULT_SIZE,
+        help=f"dataset size N -> [N,N,N] splits (default: {DEFAULT_SIZE}, the full #489 run)",
     )
     parser.add_argument(
         "--only",
@@ -519,7 +530,7 @@ def main(argv: list[str] | None = None) -> None:
     """
     args = _parse_args(argv)
     run_investigation(
-        scale=SCALES[args.scale],
+        scale=Scale.from_size(args.size),
         launcher=args.launcher,
         prefix_root=args.prefix_root,
         only=[name for name in (n.strip() for n in args.only.split(",")) if name]

--- a/tests/integration/test_cadence_investigation_489_e2e.py
+++ b/tests/integration/test_cadence_investigation_489_e2e.py
@@ -43,21 +43,25 @@ pytestmark = [
 # shard-000000 is the first train shard, present under both the source and copy run roots.
 _FIRST_SHARD = "shard-000000.h5"
 
-# Dataset size for the online sweep, set by the cadence workflow's ``cadence_scale``
-# input; defaults to ``smoke`` so a bare PR self-validation stays cheap.
-_CADENCE_SCALE_ENV = "CADENCE_SCALE"
+# Dataset size N for the online sweep, set by the cadence workflow's ``cadence_size``
+# input; defaults to 2 (the smoke size) so a bare PR self-validation stays cheap.
+_CADENCE_SIZE_ENV = "CADENCE_SIZE"
 
 
-def _selected_scale_name() -> str:
-    """Return the cadence dataset-size name from the environment.
+def _selected_size() -> int:
+    """Return the cadence dataset size ``N`` from the environment.
 
-    :returns: ``CADENCE_SCALE`` if set, else ``"smoke"``.
-    :raises ValueError: The env value is not a known scale name.
+    :returns: ``CADENCE_SIZE`` as an int if set, else 2.
+    :raises ValueError: The env value is not an integer or is below 1.
     """
-    name = os.environ.get(_CADENCE_SCALE_ENV, "smoke")
-    if name not in inv.SCALES:
-        raise ValueError(f"{_CADENCE_SCALE_ENV}={name!r} is not one of {sorted(inv.SCALES)}")
-    return name
+    raw = os.environ.get(_CADENCE_SIZE_ENV, "2")
+    try:
+        size = int(raw)
+    except ValueError:
+        raise ValueError(f"{_CADENCE_SIZE_ENV}={raw!r} is not an integer") from None
+    if size < 1:
+        raise ValueError(f"{_CADENCE_SIZE_ENV}={raw!r} must be >= 1")
+    return size
 
 
 def _prepend_pythonpath(entry: Path) -> str:
@@ -102,15 +106,17 @@ def test_smoke_investigation_local_replays_source_params_into_copy_probe(
     monkeypatch.setenv("WANDB_MODE", "offline")
     monkeypatch.setenv("PYTHONPATH", _prepend_pythonpath(worktree_src))
 
-    copy_probe = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "copy_repro")
+    copy_probe = next(
+        e for e in inv.build_experiments(inv.Scale.from_size(2)) if e.name == "copy_repro"
+    )
 
     try:
         inv.main(
             [
                 "--launcher",
                 "local",
-                "--scale",
-                "smoke",
+                "--size",
+                "2",
                 "--prefix-root",
                 prefix_root,
                 "--only",
@@ -190,9 +196,9 @@ def test_full_investigation_wandb_online_runs_every_experiment_at_configured_sca
 ) -> None:
     """Run the full investigation via a real wandb-online sweep + agent at the env scale.
 
-    The dataset size is ``CADENCE_SCALE`` (default ``smoke``), so the cadence
-    workflow's ``cadence_scale`` input drives both the source generation and the
-    copy probes through one :class:`~inv.Scale`.
+    The dataset size is ``CADENCE_SIZE`` (default 2), so the cadence workflow's
+    ``cadence_size`` input drives both the source generation and the copy probes
+    through one :class:`~inv.Scale`.
 
     All five experiments and every grid cell run; the test asserts on real R2 state.
 
@@ -219,11 +225,11 @@ def test_full_investigation_wandb_online_runs_every_experiment_at_configured_sca
     monkeypatch.setattr(inv, "ENTITY", os.environ.get("WANDB_ENTITY", inv.ENTITY))
     monkeypatch.setattr(inv, "PROJECT", os.environ.get("WANDB_PROJECT", inv.PROJECT))
 
-    scale_name = _selected_scale_name()
-    experiments = inv.build_experiments(inv.SCALES[scale_name])
+    size = _selected_size()
+    experiments = inv.build_experiments(inv.Scale.from_size(size))
 
     try:
-        inv.main(["--launcher", "wandb", "--scale", scale_name, "--prefix-root", prefix_root])
+        inv.main(["--launcher", "wandb", "--size", str(size), "--prefix-root", prefix_root])
 
         source_root = inv.reference_copy_uri(prefix_root=prefix_root)
         source_shard = join_uri(source_root, _FIRST_SHARD)

--- a/tests/integration/test_cadence_investigation_489_e2e.py
+++ b/tests/integration/test_cadence_investigation_489_e2e.py
@@ -194,7 +194,7 @@ def _expected_shards(experiment: inv.Experiment) -> int:
 def test_full_investigation_wandb_online_runs_every_experiment_at_configured_scale(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Run the full investigation via a real wandb-online sweep + agent at the env scale.
+    """Run the full investigation via a real wandb-online sweep + agent at the env-set size.
 
     The dataset size is ``CADENCE_SIZE`` (default 2), so the cadence workflow's
     ``cadence_size`` input drives both the source generation and the copy probes

--- a/tests/tools/test_cadence_investigation_489.py
+++ b/tests/tools/test_cadence_investigation_489.py
@@ -14,6 +14,9 @@ import pytest
 
 from synth_setter.tools import cadence_investigation_489 as inv
 
+# Smallest end-to-end scale (one shard per split), reused across the plan tests.
+SMOKE = inv.Scale.from_size(2)
+
 
 def test_reference_copy_uri_default_prefix_root_matches_canonical_run_root() -> None:
     """The derived copy-source URI equals the canonical reference run root.
@@ -34,7 +37,7 @@ def test_reference_copy_uri_custom_prefix_root_is_isolated_under_that_root() -> 
 
 def test_build_experiments_returns_two_within_run_and_three_copy_probes() -> None:
     """The investigation is exactly five experiments; three replay the copy source."""
-    experiments = inv.build_experiments(inv.SMOKE)
+    experiments = inv.build_experiments(SMOKE)
 
     names = [e.name for e in experiments]
     assert names == [
@@ -53,13 +56,13 @@ def test_build_experiments_returns_two_within_run_and_three_copy_probes() -> Non
 
 def test_reuse_depth_grid_tracks_scale_reuse_depths() -> None:
     """Reuse depth is the swept knob, so its grid is the scale's reuse depths."""
-    reuse = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "reuse_depth")
+    reuse = next(e for e in inv.build_experiments(SMOKE) if e.name == "reuse_depth")
     assert reuse.grid == {"render.samples_per_shard": [1, 2]}
 
 
 def test_build_sweep_config_for_copy_experiment_pins_program_and_injects_uri() -> None:
     """A copy sweep's command pins the program, injects the URI, and ends with args."""
-    copy_reload = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "copy_reload")
+    copy_reload = next(e for e in inv.build_experiments(SMOKE) if e.name == "copy_reload")
     uri = "r2://intermediate-data/test-runs/x/ref-surge-xt-489/paired-ref-v1"
 
     cfg = inv.build_sweep_config(copy_reload, copy_uri=uri)
@@ -76,7 +79,7 @@ def test_build_sweep_config_for_copy_experiment_pins_program_and_injects_uri() -
 
 def test_build_sweep_config_for_within_run_experiment_omits_copy_uri() -> None:
     """A within-run sweep never carries a copy URI in its command."""
-    shuffle = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "shuffle_probe")
+    shuffle = next(e for e in inv.build_experiments(SMOKE) if e.name == "shuffle_probe")
 
     cfg = inv.build_sweep_config(shuffle, copy_uri=inv.reference_copy_uri())
 
@@ -85,7 +88,7 @@ def test_build_sweep_config_for_within_run_experiment_omits_copy_uri() -> None:
 
 def test_expand_cells_is_the_grid_product_with_fixed_overrides_in_every_cell() -> None:
     """Each cell is the fixed overrides plus one value per gridded knob."""
-    copy_gui = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "copy_gui")
+    copy_gui = next(e for e in inv.build_experiments(SMOKE) if e.name == "copy_gui")
     uri = inv.reference_copy_uri(prefix_root="test-runs/x")
 
     cells = inv.expand_cells(copy_gui, copy_uri=uri)
@@ -111,7 +114,7 @@ def test_source_and_copy_experiments_agree_on_the_copy_preflight_match_set() -> 
     misalign shard filenames or the param encoding. One Scale feeds both sides, so they cannot
     drift — this asserts that invariant.
     """
-    scale = inv.SMOKE
+    scale = SMOKE
     source = set(inv.reference_overrides(scale, prefix_root="data"))
     match_keys = (
         "render.param_spec_name",
@@ -137,7 +140,7 @@ def test_source_and_copy_experiments_agree_on_the_copy_preflight_match_set() -> 
 
 def test_expand_cells_threads_prefix_root_into_every_cell() -> None:
     """A custom prefix_root lands in every cell so the whole run stays isolated."""
-    copy_gui = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "copy_gui")
+    copy_gui = next(e for e in inv.build_experiments(SMOKE) if e.name == "copy_gui")
 
     cells = inv.expand_cells(
         copy_gui,
@@ -150,7 +153,7 @@ def test_expand_cells_threads_prefix_root_into_every_cell() -> None:
 
 def test_build_sweep_config_threads_prefix_root_into_command() -> None:
     """A custom prefix_root reaches the wandb sweep command too."""
-    copy_reload = next(e for e in inv.build_experiments(inv.SMOKE) if e.name == "copy_reload")
+    copy_reload = next(e for e in inv.build_experiments(SMOKE) if e.name == "copy_reload")
 
     cfg = inv.build_sweep_config(
         copy_reload, copy_uri=inv.reference_copy_uri(), prefix_root="test-runs/x"
@@ -159,13 +162,28 @@ def test_build_sweep_config_threads_prefix_root_into_command() -> None:
     assert "r2.prefix_root=test-runs/x" in cfg["command"]
 
 
-def test_scales_maps_names_to_size_presets() -> None:
-    """``SCALES`` exposes the named dataset sizes the CLI ``--scale`` flag accepts."""
-    assert inv.SCALES == {"full": inv.FULL, "smoke": inv.SMOKE}
+def test_from_size_builds_cubic_scale_with_endpoint_reuse_depths() -> None:
+    """``from_size(N)`` yields ``(N,N,N)`` splits, one shard/split, depths ``(1,N)``."""
+    assert inv.Scale.from_size(5) == inv.Scale(
+        sizes=(5, 5, 5), samples_per_shard=5, reuse_depths=(1, 5)
+    )
 
 
-def test_main_maps_scale_name_to_preset(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``--scale`` selects the matching :class:`Scale` preset for the run.
+def test_from_size_one_dedupes_reuse_depths() -> None:
+    """At ``N == 1`` the no-reuse and full-reuse endpoints collapse to one depth."""
+    assert inv.Scale.from_size(1) == inv.Scale(
+        sizes=(1, 1, 1), samples_per_shard=1, reuse_depths=(1,)
+    )
+
+
+def test_from_size_below_one_raises_value_error() -> None:
+    """A size below 1 fails fast: no split could hold a sample."""
+    with pytest.raises(ValueError, match="dataset size must be >= 1"):
+        inv.Scale.from_size(0)
+
+
+def test_main_maps_size_to_scale(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--size N`` resolves to ``Scale.from_size(N)`` for the run.
 
     :param monkeypatch: Replaces ``run_investigation`` with a recorder so the
         resolved scale is observed without launching any real run.
@@ -173,11 +191,15 @@ def test_main_maps_scale_name_to_preset(monkeypatch: pytest.MonkeyPatch) -> None
     captured: dict[str, object] = {}
     monkeypatch.setattr(inv, "run_investigation", lambda **kwargs: captured.update(kwargs))
 
-    inv.main(["--scale", "full"])
-    assert captured["scale"] is inv.FULL
+    inv.main(["--size", "5"])
+    assert captured["scale"] == inv.Scale.from_size(5)
 
-    inv.main(["--scale", "smoke"])
-    assert captured["scale"] is inv.SMOKE
+    inv.main(["--size", "2"])
+    assert captured["scale"] == SMOKE
+
+    # No --size resolves to the CLI default (the full #489 run).
+    inv.main([])
+    assert captured["scale"] == inv.Scale.from_size(inv.DEFAULT_SIZE)
 
 
 def test_dry_run_executes_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -194,7 +216,7 @@ def test_dry_run_executes_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(inv.wandb, "sweep", _boom)
     monkeypatch.setattr(inv.wandb, "agent", _boom)
 
-    inv.main(["--dry-run", "--scale", "smoke", "--launcher", "wandb"])
+    inv.main(["--dry-run", "--size", "2", "--launcher", "wandb"])
 
 
 def test_wandb_launch_disables_agent_flapping(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -220,7 +242,7 @@ def test_wandb_launch_disables_agent_flapping(monkeypatch: pytest.MonkeyPatch) -
         lambda *a, **k: seen.update(flapping=os.environ.get(wandb.env.AGENT_DISABLE_FLAPPING)),
     )
 
-    inv.main(["--launcher", "wandb", "--scale", "smoke", "--only", "shuffle_probe"])
+    inv.main(["--launcher", "wandb", "--size", "2", "--only", "shuffle_probe"])
 
     assert seen["flapping"] == "true"
 
@@ -237,7 +259,7 @@ def test_local_count_caps_cells_run_per_experiment(monkeypatch: pytest.MonkeyPat
     runs: list[list[str]] = []
     monkeypatch.setattr(inv, "_run_generate", lambda overrides: runs.append(overrides))
 
-    inv.main(["--launcher", "local", "--scale", "smoke", "--only", "copy_reload", "--count", "1"])
+    inv.main(["--launcher", "local", "--size", "2", "--only", "copy_reload", "--count", "1"])
 
     # copy_reload grids two reload cadences, but --count 1 runs one cell; the
     # source generation is the other invocation.
@@ -255,7 +277,7 @@ def test_within_run_only_selection_skips_source_generation(
     runs: list[list[str]] = []
     monkeypatch.setattr(inv, "_run_generate", lambda overrides: runs.append(overrides))
 
-    inv.main(["--launcher", "local", "--scale", "smoke", "--only", "reuse_depth"])
+    inv.main(["--launcher", "local", "--size", "2", "--only", "reuse_depth"])
 
     # reuse_depth grids two depths and needs no copy source, so only its two
     # cells run — no run carries the reference run_id that source generation does.
@@ -267,7 +289,7 @@ def test_unknown_only_experiment_raises_value_error() -> None:
     """An unrecognized ``--only`` name fails fast with the valid choices listed."""
     with pytest.raises(ValueError, match="unknown experiment"):
         inv.run_investigation(
-            scale=inv.SMOKE,
+            scale=SMOKE,
             launcher="local",
             prefix_root="data",
             only=["does_not_exist"],
@@ -287,7 +309,7 @@ def test_count_below_one_raises_value_error() -> None:
     """A ``--count`` below 1 fails fast instead of silently running no cells."""
     with pytest.raises(ValueError, match="count must be >= 1"):
         inv.run_investigation(
-            scale=inv.SMOKE,
+            scale=SMOKE,
             launcher="local",
             prefix_root="data",
             only=["copy_reload"],
@@ -300,7 +322,7 @@ def test_unknown_launcher_raises_value_error() -> None:
     """A launcher other than wandb/local fails fast instead of defaulting to wandb."""
     with pytest.raises(ValueError, match="launcher must be"):
         inv.run_investigation(
-            scale=inv.SMOKE,
+            scale=SMOKE,
             launcher="remote",
             prefix_root="data",
             only=["copy_reload"],
@@ -317,4 +339,4 @@ def test_only_drops_empty_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(inv, "_run_generate", lambda overrides: None)
 
     # Without filtering, the trailing comma would yield an "" token and raise.
-    inv.main(["--launcher", "local", "--scale", "smoke", "--only", "reuse_depth,"])
+    inv.main(["--launcher", "local", "--size", "2", "--only", "reuse_depth,"])


### PR DESCRIPTION
## Why

The cadence workflow's `cadence_scale` input only offered a `smoke`/`full` choice backed by two hardcoded `Scale` presets, so dispatching any other dataset size meant a code change. This makes the size a first-class integer knob.

## What changed

- **Workflow** (`.github/workflows/cadence-investigation-489.yml`): replaced the `cadence_scale` choice input with a `cadence_size` `number` input (default `2`), forwarded into the container as `CADENCE_SIZE`.
- **Orchestrator** (`cadence_investigation_489.py`): dropped the `FULL`/`SMOKE`/`SCALES` presets for a `Scale.from_size(N)` factory — `sizes=(N,N,N)`, one shard per split (`samples_per_shard=N`), and a no-reuse/full-reuse depth sweep `(1, N)` (deduped to `(1,)` at `N == 1`). `from_size(2)` reproduces the old smoke scale exactly. The CLI flag is now `--size N` (default `40`, the full #489 run).
- **e2e test**: reads `CADENCE_SIZE` (default `2`) as an int and threads it through `Scale.from_size`.

## Test plan

- `tests/tools/test_cadence_investigation_489.py`: 23 fast tests green; added `from_size` coverage (cubic build, full `N == 1` scale, `< 1` rejection), the CLI-default path, and `test_main_maps_size_to_scale`.
- `tests/integration/test_cadence_investigation_489_e2e.py`: collects clean; self-skips without VST/R2/W&B. This PR edits all three `pull_request: paths:` entries, so the cadence workflow self-validates at size 2 on this PR.
- `make format` (pre-commit) clean; `/repo-review-full-no-comments` ran 8 parallel passes with zero BLOCK findings.

Refs #489
