### PR TITLE
internal-fix(codex): repair main broken by #1577 autofix merge

### DIFF
--- a/scripts/dev/codex-doctor.sh
+++ b/scripts/dev/codex-doctor.sh
@@ -56,6 +56,8 @@ main() {
     printf 'If tinaudio plugin skills are missing, install/enable the plugin, then start a new Codex thread:\n'
     printf '  codex plugin marketplace add tinaudio/skills\n'
     printf '  /plugins -> tinaudio Skills -> tinaudio-synth-setter-skills\n'
+    printf 'Repo-local skills (e.g. pr-readiness) come from the repo skill projection, not the plugin.\n'
+  fi
 
   if [[ "$failures" -gt 0 ]]; then
     printf '\nCodex setup has %s issue(s).\n' "$failures"

--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -298,12 +298,6 @@ def test_hook_lib_finds_codex_skill_layouts(tmp_path: Path, skill_path: Path) ->
         text=True,
         check=False,
     )
-        capture_output=True,
-        cwd=tmp_path,
-        env={**os.environ, "HOME": str(tmp_path)},
-        text=True,
-        check=False,
-    )
 
     assert result.returncode == 0, result.stderr
 

--- a/tests/infra/test_codex_doctor.py
+++ b/tests/infra/test_codex_doctor.py
@@ -93,4 +93,8 @@ def test_codex_doctor_missing_plugin_skills_prints_install_command(
 
     assert result.returncode == 1
     assert "codex plugin marketplace add tinaudio/skills" in result.stdout
-    assert "Install or enable the tinaudio skill plugin" in result.stdout
+    assert "If tinaudio plugin skills are missing" in result.stdout
+    assert (
+        "Repo-local skills (e.g. pr-readiness) come from the repo skill projection"
+        in result.stdout
+    )


### PR DESCRIPTION
## Summary

PR #1577 was merged at the broken Copilot "Apply suggestions" autofix commit (`29615ca2`). The repair commit (`dca2a48`) landed on the branch only *after* the merge, so it never reached main. As a result the squash-merge `166b5fb7` shipped broken code to main:

- `scripts/dev/codex-doctor.sh` — missing the closing `fi` of the `missing_skills` block (**bash syntax error**; `make codex-doctor` and `tests/infra/test_codex_doctor.py` fail).
- `tests/claude_hooks/test_settings_hooks.py` — duplicated `subprocess.run` kwargs block (**IndentationError**; the whole module fails to collect).

Main CI on `166b5fb7` is red: `Tests`, `Tests (conda)`, `Code Quality Main`, `CPU Slow Tests`, and `Docker Image Build` all failing.

This restores the closing `fi` + repo-local-skills remediation line, removes the duplicated kwargs block, and aligns `test_codex_doctor.py` assertions with the repaired doctor output. The content is identical to the post-merge repair (`dca2a48`) that never reached main.

Refs #1561

## Verification

- `bash -n scripts/dev/codex-doctor.sh` — clean
- both test files parse cleanly (`ast.parse`)
- `pytest tests/infra/test_codex_doctor.py tests/claude_hooks/test_settings_hooks.py` — 125 passed
- `make test-fast` (equivalent tree) — 2078 passed, 6 skipped
- pre-commit (ruff, ruff-format, pydoclint, shellcheck, pyright) — all pass
