### PR TITLE
fix(testing): give citest checkpoint artifacts run-scoped names

### DIFF
--- a/tests/helpers/test_wandb_artifacts.py
+++ b/tests/helpers/test_wandb_artifacts.py
@@ -1,0 +1,67 @@
+"""Unit tests for the citest checkpoint-artifact helper's offline-testable seams.
+
+The live round-trip (publish → resolve → cleanup) is exercised by the slow,
+``WANDB_API_KEY``-gated tests in ``test_train`` / ``test_eval``. These cover the
+two pieces that need no network: run-scoped naming and best-effort deletion.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.helpers import wandb_artifacts
+
+
+def test_run_scoped_name_distinct_runs_distinct_names() -> None:
+    """Distinct run ids yield distinct, base-prefixed collection names."""
+    base = "model-citest-ffn_full-resume"
+    name_a = wandb_artifacts._run_scoped_name(base, "abc123")
+    name_b = wandb_artifacts._run_scoped_name(base, "def456")
+
+    assert name_a != name_b, "same name across runs would collide on the shared collection"
+    assert name_a.startswith(f"{base}-") and name_b.startswith(f"{base}-")
+    assert "abc123" in name_a and "def456" in name_b
+
+
+def test_delete_artifact_best_effort_api_error_does_not_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing delete is swallowed — scratch cleanup must never fail the test.
+
+    :param monkeypatch: Stubs ``wandb.Api`` to raise on construction.
+    """
+    import wandb
+
+    def _raise() -> None:
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(wandb, "Api", _raise)
+    # Must return normally despite the API blowing up.
+    wandb_artifacts._delete_artifact_best_effort("entity/proj/name:latest")
+
+
+def test_delete_artifact_best_effort_passes_delete_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The version carries a ``:latest`` alias, so deletion must pass ``delete_aliases=True``.
+
+    :param monkeypatch: Stubs ``wandb.Api`` with a fake recording the delete call.
+    """
+    import wandb
+
+    calls: dict[str, object] = {}
+
+    class _FakeArtifact:
+        def delete(self, delete_aliases: bool = False) -> None:
+            calls["delete_aliases"] = delete_aliases
+
+    class _FakeApi:
+        def artifact(self, ref: str) -> _FakeArtifact:
+            calls["ref"] = ref
+            return _FakeArtifact()
+
+    monkeypatch.setattr(wandb, "Api", _FakeApi)
+    wandb_artifacts._delete_artifact_best_effort("entity/proj/name:latest")
+
+    assert calls["ref"] == "entity/proj/name:latest"
+    assert calls["delete_aliases"] is True

--- a/tests/helpers/test_wandb_artifacts.py
+++ b/tests/helpers/test_wandb_artifacts.py
@@ -2,10 +2,14 @@
 
 The live round-trip (publish → resolve → cleanup) is exercised by the slow,
 ``WANDB_API_KEY``-gated tests in ``test_train`` / ``test_eval``. These cover the
-two pieces that need no network: run-scoped naming and best-effort deletion.
+pieces that need no network: run-scoped naming, cleanup-on-exit, and best-effort
+deletion — using ``MagicMock`` to stand in for the W&B publish/delete surface.
 """
 
 from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -23,6 +27,42 @@ def test_run_scoped_name_distinct_runs_distinct_names() -> None:
     assert "abc123" in name_a and "def456" in name_b
 
 
+def test_published_checkpoint_artifact_deletes_version_when_body_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Cleanup deletes the run-scoped version even when the ``with`` body raises.
+
+    Pins the context manager's core guarantee — and that the ref it yields is run-scoped —
+    without touching the network, by faking the W&B publish + delete surface.
+
+    :param monkeypatch: Stubs the ``wandb`` init/Artifact/Api surface with mocks.
+    :param tmp_path: Source for the (faked) checkpoint file the helper embeds.
+    """
+    import wandb
+
+    fake_run = MagicMock(id="run42", entity="ent")
+    fake_api = MagicMock()
+    monkeypatch.setattr(wandb, "init", lambda **_kwargs: fake_run)
+    monkeypatch.setattr(wandb, "Artifact", lambda **_kwargs: MagicMock())
+    monkeypatch.setattr(wandb, "Api", lambda: fake_api)
+    ckpt = tmp_path / "model.ckpt"
+    ckpt.write_bytes(b"x")
+    expected_ref = "ent/synth-setter-citest/model-citest-x-run42:latest"
+
+    def _boom() -> None:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):  # noqa: PT012 - the with-body is the scenario
+        with wandb_artifacts.published_checkpoint_artifact(
+            ckpt, "model-citest-x", tmp_path
+        ) as ref:
+            assert ref == expected_ref
+            _boom()
+
+    fake_api.artifact.assert_called_once_with(expected_ref)
+    fake_api.artifact.return_value.delete.assert_called_once_with(delete_aliases=True)
+
+
 def test_delete_artifact_best_effort_api_error_does_not_raise(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -32,10 +72,7 @@ def test_delete_artifact_best_effort_api_error_does_not_raise(
     """
     import wandb
 
-    def _raise() -> None:
-        raise RuntimeError("network down")
-
-    monkeypatch.setattr(wandb, "Api", _raise)
+    monkeypatch.setattr(wandb, "Api", MagicMock(side_effect=RuntimeError("network down")))
     # Must return normally despite the API blowing up.
     wandb_artifacts._delete_artifact_best_effort("entity/proj/name:latest")
 
@@ -45,23 +82,14 @@ def test_delete_artifact_best_effort_passes_delete_aliases(
 ) -> None:
     """The version carries a ``:latest`` alias, so deletion must pass ``delete_aliases=True``.
 
-    :param monkeypatch: Stubs ``wandb.Api`` with a fake recording the delete call.
+    :param monkeypatch: Stubs ``wandb.Api`` with a mock recording the delete call.
     """
     import wandb
 
-    calls: dict[str, object] = {}
+    fake_api = MagicMock()
+    monkeypatch.setattr(wandb, "Api", lambda: fake_api)
 
-    class _FakeArtifact:
-        def delete(self, delete_aliases: bool = False) -> None:
-            calls["delete_aliases"] = delete_aliases
-
-    class _FakeApi:
-        def artifact(self, ref: str) -> _FakeArtifact:
-            calls["ref"] = ref
-            return _FakeArtifact()
-
-    monkeypatch.setattr(wandb, "Api", _FakeApi)
     wandb_artifacts._delete_artifact_best_effort("entity/proj/name:latest")
 
-    assert calls["ref"] == "entity/proj/name:latest"
-    assert calls["delete_aliases"] is True
+    fake_api.artifact.assert_called_once_with("entity/proj/name:latest")
+    fake_api.artifact.return_value.delete.assert_called_once_with(delete_aliases=True)

--- a/tests/helpers/wandb_artifacts.py
+++ b/tests/helpers/wandb_artifacts.py
@@ -9,7 +9,12 @@ the live download path. To keep these test writes out of the production model re
 
 from __future__ import annotations
 
+import contextlib
+import logging
+from collections.abc import Iterator
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # Dedicated test project so round-trip uploads never touch the production model registry.
 # The entity is the key's default (read back from the run), so this works under whatever
@@ -17,18 +22,39 @@ from pathlib import Path
 CITEST_PROJECT = "synth-setter-citest"
 
 
-def publish_checkpoint_artifact(ckpt_path: Path, artifact_name: str, run_dir: Path) -> str:
-    """Upload ``ckpt_path`` as ``model.ckpt`` in a W&B model artifact, returning its resolver ref.
+def _run_scoped_name(artifact_name: str, run_id: str) -> str:
+    """Suffix a collection name with the run id so each run owns its own collection.
+
+    A fixed shared name can wedge: deleting its versions leaves the collection in W&B's
+    ``PENDING_DELETION`` state, which rejects new manifests (HTTP 400) until async GC
+    finalizes, and concurrent runs race on its ``:latest`` alias. A run-scoped name avoids
+    both — a brand-new collection per run, never colliding with a half-deleted one.
+
+    :param artifact_name: Base name, e.g. ``model-citest-ffn_full-resume``.
+    :param run_id: The W&B run id, unique per run.
+    :returns: ``<artifact_name>-<run_id>``.
+    """
+    return f"{artifact_name}-{run_id}"
+
+
+@contextlib.contextmanager
+def published_checkpoint_artifact(
+    ckpt_path: Path, artifact_name: str, run_dir: Path
+) -> Iterator[str]:
+    """Publish ``ckpt_path`` as ``model.ckpt`` in a W&B model artifact, yielding its resolver ref.
 
     Logs to :data:`CITEST_PROJECT` under the key's default entity (never the production
-    registry) and blocks on ``artifact.wait()`` so the artifact is committed before the
-    caller resolves it. Requires a live ``WANDB_API_KEY`` in the environment — callers gate on it.
+    registry) under a run-scoped name (see :func:`_run_scoped_name`), and blocks on
+    ``artifact.wait()`` so the artifact is committed before the body resolves it. On exit
+    the published version is deleted best-effort to keep the scratch project bounded.
+    Requires a live ``WANDB_API_KEY`` in the environment — callers gate on it.
 
     :param ckpt_path: Local Lightning checkpoint embedded into the artifact as ``model.ckpt``.
-    :param artifact_name: Artifact name, e.g. ``model-citest-ffn_full``.
+    :param artifact_name: Base artifact name, e.g. ``model-citest-ffn_full``.
     :param run_dir: Directory for the wandb run's local files, kept off the repo tree.
-    :returns: The ``entity/project/name:latest`` ref the resolver consumes — wrap in
+    :yields: The ``entity/project/name:latest`` ref the resolver consumes — wrap in
         ``${wandb:<ref>}`` to pin it as a ``ckpt_path``.
+    :ytype: str
     """
     import wandb
 
@@ -42,13 +68,33 @@ def publish_checkpoint_artifact(ckpt_path: Path, artifact_name: str, run_dir: Pa
         dir=str(run_dir),
         settings=wandb.Settings(host="synth-setter-ci"),
     )
+    name = _run_scoped_name(artifact_name, run.id)
+    # Read the entity back from the run so the ref matches whatever account the key owns.
+    ref = f"{run.entity}/{CITEST_PROJECT}/{name}:latest"
     try:
-        artifact = wandb.Artifact(name=artifact_name, type="model")
+        artifact = wandb.Artifact(name=name, type="model")
         artifact.add_file(str(ckpt_path), name="model.ckpt")
         run.log_artifact(artifact)
         artifact.wait()
-        # Read the entity back from the run so the ref matches whatever account the key owns.
-        ref = f"{run.entity}/{CITEST_PROJECT}/{artifact_name}:latest"
     finally:
         run.finish()
-    return ref
+    try:
+        yield ref
+    finally:
+        _delete_artifact_best_effort(ref)
+
+
+def _delete_artifact_best_effort(ref: str) -> None:
+    """Delete the published artifact version, never raising — cleanup must not fail the test.
+
+    Passes ``delete_aliases=True`` because the version carries the ``:latest`` alias, which
+    W&B otherwise refuses to delete. Any failure is logged and swallowed.
+
+    :param ref: The ``entity/project/name:latest`` ref to delete.
+    """
+    import wandb
+
+    try:
+        wandb.Api().artifact(ref).delete(delete_aliases=True)
+    except Exception:  # noqa: BLE001 - best-effort scratch cleanup, never fail the test
+        logger.warning("failed to delete citest artifact %s", ref, exc_info=True)

--- a/tests/helpers/wandb_artifacts.py
+++ b/tests/helpers/wandb_artifacts.py
@@ -46,7 +46,8 @@ def published_checkpoint_artifact(
     Logs to :data:`CITEST_PROJECT` under the key's default entity (never the production
     registry) under a run-scoped name (see :func:`_run_scoped_name`), and blocks on
     ``artifact.wait()`` so the artifact is committed before the body resolves it. On exit
-    the published version is deleted best-effort to keep the scratch project bounded.
+    the published version is deleted best-effort so its checkpoint bytes do not accumulate
+    in the scratch project (an empty collection shell is left behind, which stores nothing).
     Requires a live ``WANDB_API_KEY`` in the environment — callers gate on it.
 
     :param ckpt_path: Local Lightning checkpoint embedded into the artifact as ``model.ckpt``.

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -29,7 +29,7 @@ from synth_setter.data.vst import param_specs, preset_paths
 from synth_setter.utils.utils import register_resolvers
 from synth_setter.workspace import operator_workspace
 from tests.helpers.run_if import RunIf
-from tests.helpers.wandb_artifacts import publish_checkpoint_artifact
+from tests.helpers.wandb_artifacts import published_checkpoint_artifact
 
 # Public worker module names the predict-postprocessing subprocesses run; matched
 # as argv substrings so the fake ``subprocess.run`` can route render vs metrics
@@ -578,25 +578,28 @@ def test_evaluate_loads_wandb_resolved_checkpoint_and_runs_inference(
     ckpt = Path(cfg_surge_xt_eval.ckpt_path)
     assert ckpt.is_file(), "train step did not write the checkpoint"
 
-    ref = publish_checkpoint_artifact(ckpt, "model-citest-ffn_full-eval", tmp_path / "wandb")
+    with published_checkpoint_artifact(
+        ckpt, "model-citest-ffn_full-eval", tmp_path / "wandb"
+    ) as ref:
+        # Contain the resolver's download cache under tmp_path so each run fetches fresh (a warm
+        # self-hosted runner must not reuse a stale cached ckpt for the same :latest ref).
+        monkeypatch.setenv("SYNTH_SETTER_WORKSPACE", str(tmp_path))
+        monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+        operator_workspace.cache_clear()
+        register_resolvers()
+        with open_dict(cfg_surge_xt_eval):
+            cfg_surge_xt_eval.ckpt_path = "${wandb:" + ref + "}"
 
-    # Contain the resolver's download cache under tmp_path so each run fetches fresh (a warm
-    # self-hosted runner must not reuse a stale cached ckpt for the same :latest ref).
-    monkeypatch.setenv("SYNTH_SETTER_WORKSPACE", str(tmp_path))
-    monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
-    operator_workspace.cache_clear()
-    register_resolvers()
-    with open_dict(cfg_surge_xt_eval):
-        cfg_surge_xt_eval.ckpt_path = "${wandb:" + ref + "}"
+        HydraConfig().set_config(cfg_surge_xt_eval)
+        evaluate(cfg_surge_xt_eval)
 
-    HydraConfig().set_config(cfg_surge_xt_eval)
-    evaluate(cfg_surge_xt_eval)
-
-    assert (tmp_path / ".cache" / "checkpoints").is_dir(), "resolver did not download the artifact"
-    predictions_dir = tmp_path / "predictions"
-    assert predictions_dir.is_dir()
-    preds = sorted(predictions_dir.glob("pred-*.pt"))
-    assert preds, "predict mode wrote no predictions"
-    for pred_file in preds:
-        tensor = torch.load(pred_file, weights_only=True)
-        assert torch.isfinite(tensor).all(), f"{pred_file.name} contains NaN/Inf"
+        assert (tmp_path / ".cache" / "checkpoints").is_dir(), (
+            "resolver did not download the artifact"
+        )
+        predictions_dir = tmp_path / "predictions"
+        assert predictions_dir.is_dir()
+        preds = sorted(predictions_dir.glob("pred-*.pt"))
+        assert preds, "predict mode wrote no predictions"
+        for pred_file in preds:
+            tensor = torch.load(pred_file, weights_only=True)
+            assert torch.isfinite(tensor).all(), f"{pred_file.name} contains NaN/Inf"

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -28,7 +28,7 @@ from tests.conftest import (
 )
 from tests.evaluation._oracle_helpers import ORACLE_AUDIO_METRIC_BOUNDS
 from tests.helpers.run_if import RunIf
-from tests.helpers.wandb_artifacts import publish_checkpoint_artifact
+from tests.helpers.wandb_artifacts import published_checkpoint_artifact
 
 # Experiments cycled through the Surge XT VST smoke tests below. Single source of truth so
 # the parametrize lists on the two ``test_train_*_surge_xt`` tests cannot drift apart.
@@ -400,23 +400,26 @@ def test_train_resumes_from_wandb_resolved_checkpoint(
     ckpt = tmp_path / "checkpoints" / "last.ckpt"
     assert ckpt.is_file(), "first train step did not write last.ckpt"
 
-    ref = publish_checkpoint_artifact(ckpt, "model-citest-ffn_full-resume", tmp_path / "wandb")
+    with published_checkpoint_artifact(
+        ckpt, "model-citest-ffn_full-resume", tmp_path / "wandb"
+    ) as ref:
+        # Contain the resolver's download cache under tmp_path so each run fetches fresh (a warm
+        # self-hosted runner must not reuse a stale cached ckpt for the same :latest ref).
+        monkeypatch.setenv("SYNTH_SETTER_WORKSPACE", str(tmp_path))
+        monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+        operator_workspace.cache_clear()
+        register_resolvers()
+        with open_dict(cfg_surge_xt):
+            cfg_surge_xt.ckpt_path = "${wandb:" + ref + "}"
+            cfg_surge_xt.trainer.max_steps = step_after_first + 1
 
-    # Contain the resolver's download cache under tmp_path so each run fetches fresh (a warm
-    # self-hosted runner must not reuse a stale cached ckpt for the same :latest ref).
-    monkeypatch.setenv("SYNTH_SETTER_WORKSPACE", str(tmp_path))
-    monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
-    operator_workspace.cache_clear()
-    register_resolvers()
-    with open_dict(cfg_surge_xt):
-        cfg_surge_xt.ckpt_path = "${wandb:" + ref + "}"
-        cfg_surge_xt.trainer.max_steps = step_after_first + 1
+        HydraConfig().set_config(cfg_surge_xt)
+        _, second = train(cfg_surge_xt)
+        step_after_resume = second["trainer"].global_step
 
-    HydraConfig().set_config(cfg_surge_xt)
-    _, second = train(cfg_surge_xt)
-    step_after_resume = second["trainer"].global_step
-
-    assert (tmp_path / ".cache" / "checkpoints").is_dir(), "resolver did not download the artifact"
-    assert step_after_resume > step_after_first, (
-        f"resume did not advance training: before={step_after_first}, after={step_after_resume}"
-    )
+        assert (tmp_path / ".cache" / "checkpoints").is_dir(), (
+            "resolver did not download the artifact"
+        )
+        assert step_after_resume > step_after_first, (
+            f"resume did not advance training: before={step_after_first}, after={step_after_resume}"
+        )


### PR DESCRIPTION
## Why

`test_train_resumes_from_wandb_resolved_checkpoint[mps-surge/ffn_full]` (and the eval equivalent) fail on the MPS CI job with:

```
ValueError: ArtifactSaver.upsertManifest: createManifest returned error 400:
cannot create manifest for artifact in state PENDING_DELETION
```

The failure is **unrelated to the PR's own diff** — it's a wedged W&B server-state. `tests/helpers/wandb_artifacts.py` published every run's smoke checkpoint to a **fixed** collection name (`model-citest-ffn_full-resume` / `-eval`) and read it back via `:latest`. Once that single collection enters W&B's `PENDING_DELETION` state (versions deleted, async GC not finalized), `log_artifact` → `createManifest` is rejected with HTTP 400 and stays wedged until GC completes. A fixed name also races on `:latest` across concurrent runs and risks stale-cache reuse on warm self-hosted runners.

Confirmed live via the W&B API: the collection exists but `…-resume:latest` resolves to *no membership* (zero live versions) while publish still 400s — the half-deleted-collection signature.

## What changed

- `publish_checkpoint_artifact` → **`published_checkpoint_artifact`**, now a `@contextlib.contextmanager`.
- **Run-scoped names**: each run publishes under `<base>-<run.id>` (`_run_scoped_name`), so a half-deleted collection can never block a future run, and the `:latest` race vanishes. The resolver's cache key already hashes the full ref, so unique names cache cleanly.
- **Post-resolve cleanup**: on context exit the published version is deleted best-effort (`delete_aliases=True`, swallow+log on error) so checkpoint bytes don't accumulate in the scratch project.
- Both `test_train` and `test_eval` call sites wrapped in the `with` block.

## Test plan

- `tests/helpers/test_wandb_artifacts.py` (new): 4 fast, network-free tests — run-scoped naming, cleanup-on-exception (the core invariant), best-effort swallow, and `delete_aliases=True`. All green.
- The live publish→resolve→cleanup round-trip stays covered by the `WANDB_API_KEY`-gated slow tests in `test_train` / `test_eval`.
- `make format` (pre-commit) clean.
- `/repo-review-full-no-comments`: 5 parallel passes (code-health, synth-setter-project-standards, python-style, tdd-implementation, comment-hygiene), **0 BLOCK**; the two actionable WARNs were applied.

Refs #155
