### PR TITLE
fix(testing): remove duplicated subprocess.run args in hooks test

### DIFF
--- a/tests/claude_hooks/test_settings_hooks.py
+++ b/tests/claude_hooks/test_settings_hooks.py
@@ -298,12 +298,6 @@ def test_hook_lib_finds_codex_skill_layouts(tmp_path: Path, skill_path: Path) ->
         text=True,
         check=False,
     )
-        capture_output=True,
-        cwd=tmp_path,
-        env={**os.environ, "HOME": str(tmp_path)},
-        text=True,
-        check=False,
-    )
 
     assert result.returncode == 0, result.stderr
 


### PR DESCRIPTION
## Why

`main` HEAD is broken: #1577 left an orphaned duplicate copy of `subprocess.run`'s keyword arguments (`capture_output`/`cwd`/`env`/`text`/`check`) dangling after the call already closed with `)` in `tests/claude_hooks/test_settings_hooks.py`. That is an `IndentationError`, and pytest aborts the **entire session** on a collection error — so every open PR's `Tests` and `MPS Tests` jobs fail before running a single test:

```
ERROR collecting tests/claude_hooks/test_settings_hooks.py
E   IndentationError: unexpected indent (line 301)
!!! Interrupted: 2 errors during collection !!!
```

## What changed

Delete the 6 orphaned duplicate lines. The surviving `subprocess.run(...)` call in `test_hook_lib_finds_codex_skill_layouts` is the original, valid single call.

## Test plan

- `python -m py_compile tests/claude_hooks/test_settings_hooks.py` — compiles.
- `uv run pytest tests/claude_hooks/test_settings_hooks.py --collect-only` — **123 tests collected** (was `2 errors during collection`).
- `uv run pytest tests/claude_hooks/test_settings_hooks.py -m "not slow"` — **123 passed**, including the previously-broken `test_hook_lib_finds_codex_skill_layouts`.
- `/repo-review-full-no-comments`: 5 parallel passes, **0 BLOCK / 0 WARN**.

Note: `scripts/dev/codex-doctor.sh` also has shell syntax errors on current `main` (from the same automation batch), but that only fails `shellcheck` under `--all-files`; PR CI runs pre-commit on the diff, so it does not block PR CI. Tracked separately.

Refs #155
