### PR TITLE
automation(agent-skills): project skill pack into ~/.agents/skills

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -110,4 +110,8 @@ unset __ss_root
 EOF
 fi
 
+# Project skills into ~/.agents/skills for Gemini/Antigravity discovery;
+# best-effort (`|| true` keeps a fresh box without the plugin from failing). See #1561.
+"$dir/scripts/dev/link-skills.sh" || true
+
 echo "Dev container ready. Run 'make test-fast' to verify."

--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,9 @@ link-thoughts: ## Symlink this worktree's thoughts/ to the primary checkout's ce
 	ln -sfn "$$central" "$$here/thoughts"; \
 	echo "linked thoughts/ -> $$central"
 
+link-skills: ## Project the installed skills marketplace into ~/.agents/skills for Gemini/Antigravity discovery
+	@scripts/dev/link-skills.sh
+
 # Mirrors the --cov flags used by .github/workflows/test.yml so local
 # coverage runs reproduce CI output (xml report feeds Codecov; html is for
 # local browsing).

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -229,7 +229,7 @@ docs:
     description: Onboarding — local dev, Codespaces, and dev container flows
     sources:
       - pattern: "Makefile"
-        covers: "Local dev targets — install (uv + .venv + deps + pre-commit), install-surge-xt (download + md5 verify + extract Surge XT VST3), link-plugins (mirror primary's plugins/ into a worktree), link-thoughts (symlink a worktree's thoughts/ to the primary's central copy; no-op in primary), SURGE_XT_VERSION + related vars"
+        covers: "Local dev targets — install (uv + .venv + deps + pre-commit), install-surge-xt (download + md5 verify + extract Surge XT VST3), link-plugins (mirror primary's plugins/ into a worktree), link-thoughts (symlink a worktree's thoughts/ to the primary's central copy; no-op in primary), link-skills (project the installed skills marketplace into ~/.agents/skills for Gemini/Antigravity discovery), SURGE_XT_VERSION + related vars"
         scope: "local-dev"
       - pattern: ".devcontainer/cpu/devcontainer.json"
         covers: "CPU dev container config — remoteUser, mounts (bash-history named volume + per-user zellij-cache named volumes for dev and root + plugins/ anonymous overlay), --env-file .env, initializeCommand, postCreateCommand, VS Code terminal profile defaulting to zellij (tmux still selectable)"
@@ -242,7 +242,7 @@ docs:
       - pattern: ".devcontainer/initialize.sh"
         covers: "Host-side initializeCommand — refuses pointer-file `.git` (worktree/submodule/--separate-git-dir), ensures .env exists"
       - pattern: ".devcontainer/post-create.sh"
-        covers: "First-run setup — git safety, pre-commit install, root-to-dev privilege drop, install ~/.tmux.conf for both root and dev users"
+        covers: "First-run setup — git safety, pre-commit install, root-to-dev privilege drop, install ~/.tmux.conf for both root and dev users, best-effort skill projection into ~/.agents/skills via scripts/dev/link-skills.sh (#1561)"
       - pattern: "src/synth_setter/configs/logger/many_loggers.yaml"
         covers: "Default logger compose — referenced in §4c for enable/disable workflow"
         scope: "wandb-config"
@@ -332,6 +332,8 @@ docs:
     sources:
       - pattern: "agent/hooks/_lib.sh"
         covers: "has_skill discovery globs for the Claude marketplace and Codex plugin-manifest layouts"
+      - pattern: "scripts/dev/link-skills.sh"
+        covers: "Projects the installed tinaudio/skills marketplace into ~/.agents/skills so Agent-Skills-standard CLIs (Gemini, Antigravity) discover the full pack; wired via make link-skills + post-create.sh"
       - pattern: "agent/hooks/worktree-guard.sh"
         covers: "WORKTREE_GUARD_MODE block/warn/off tiering (local-safety, no CI backstop)"
       - pattern: "agent/hooks/no-baseline-additions.sh"

--- a/docs/reference/agent-harness-parity.md
+++ b/docs/reference/agent-harness-parity.md
@@ -40,12 +40,15 @@ tracked follow-up work, not part of this parity layer (YAGNI until a Codex user 
 
 ## Skill discovery parity
 
-`agent/hooks/_lib.sh`'s `has_skill` resolves a skill across both harness install layouts:
+`agent/hooks/_lib.sh`'s `has_skill` resolves a skill across each supported install layout:
 
 - Claude marketplace: `~/.claude/plugins/<marketplace>/skills/<name>/SKILL.md`
 - Codex plugin manifest: `~/.codex/plugins/<marketplace>/codex/synth-setter-skills/<name>/SKILL.md`
   or `~/.codex/plugins/<marketplace>/skills/<name>/SKILL.md`, and the flat
   `~/.codex/skills/<name>/SKILL.md`
+- Agent-Skills standard (Gemini / Antigravity): `.agents/skills/<name>/SKILL.md` (repo-relative)
+  and `~/.agents/skills/<name>/SKILL.md` — the user-level alias populated by
+  `scripts/dev/link-skills.sh` (`make link-skills`)
 
 `tests/claude_hooks/test_skill_discovery_parity.py` asserts every shipped `agent/skills/<name>`
 resolves through *both* globs, so the two stay symmetric as skills are added. The full bash hook

--- a/scripts/dev/link-skills.sh
+++ b/scripts/dev/link-skills.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Project the installed tinaudio/skills marketplace into ~/.agents/skills so
+# Agent-Skills-standard CLIs (Gemini, Antigravity) see the full pack. See #1561.
+set -euo pipefail
+shopt -s nullglob
+
+src="${HOME}/.claude/plugins/marketplaces/tinaudio-skills"
+dest="${HOME}/.agents/skills"
+
+if [[ ! -d "${src}" ]]; then
+  # The cache only exists once Claude has installed the plugin, so a fresh box
+  # legitimately has nothing to project — skip rather than fail.
+  echo "link-skills: no skills marketplace at ${src} — install the tinaudio/skills plugin first; skipping." >&2
+  exit 0
+fi
+
+mkdir -p "${dest}"
+linked=0
+for skill_dir in "${src}"/*/; do
+  [[ -f "${skill_dir}SKILL.md" ]] || continue
+  ln -sfn "${skill_dir%/}" "${dest}/$(basename "${skill_dir}")"
+  linked=$((linked + 1))
+done
+
+echo "link-skills: projected ${linked} skill(s) from ${src} into ${dest}."

--- a/tests/infra/test_link_skills.py
+++ b/tests/infra/test_link_skills.py
@@ -1,0 +1,107 @@
+"""Tests for the ``link-skills`` projection into ``~/.agents/skills``."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LINK_SKILLS = REPO_ROOT / "scripts" / "dev" / "link-skills.sh"
+MARKETPLACE_REL = ".claude/plugins/marketplaces/tinaudio-skills"
+
+
+def _write_marketplace_skill(home: Path, name: str) -> Path:
+    """Create a fake installed marketplace skill under the Claude plugin cache.
+
+    :param home: Fake home directory.
+    :param name: Skill name.
+    :returns: The created skill directory.
+    """
+    skill_dir = home / MARKETPLACE_REL / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
+    return skill_dir
+
+
+def _run_link_skills(home: Path) -> subprocess.CompletedProcess[str]:
+    """Run ``link-skills.sh`` with an isolated home.
+
+    :param home: Fake home directory the script reads and writes through.
+    :returns: Completed process for assertions.
+    """
+    env = {**os.environ, "HOME": str(home)}
+    return subprocess.run(  # noqa: S603
+        ["bash", str(LINK_SKILLS)],  # noqa: S607 - bash is required for the shell script
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_link_skills_projects_marketplace_skills_into_agents_skills(tmp_path: Path) -> None:
+    """Each marketplace skill dir becomes a resolvable ``~/.agents/skills`` symlink.
+
+    :param tmp_path: Temporary test root.
+    """
+    home = tmp_path / "home"
+    code_health = _write_marketplace_skill(home, "code-health")
+    tdd = _write_marketplace_skill(home, "tdd-implementation")
+
+    result = _run_link_skills(home)
+
+    assert result.returncode == 0, result.stderr
+    dest = home / ".agents" / "skills"
+    for name, source in (("code-health", code_health), ("tdd-implementation", tdd)):
+        link = dest / name
+        assert link.is_symlink()
+        assert link.resolve() == source.resolve()
+
+
+def test_link_skills_skips_marketplace_dirs_without_a_skill_file(tmp_path: Path) -> None:
+    """A marketplace subdir lacking ``SKILL.md`` (e.g. ``_shared``) is not projected.
+
+    :param tmp_path: Temporary test root.
+    """
+    home = tmp_path / "home"
+    _write_marketplace_skill(home, "code-health")
+    (home / MARKETPLACE_REL / "_shared").mkdir(parents=True)
+
+    result = _run_link_skills(home)
+
+    assert result.returncode == 0, result.stderr
+    assert not (home / ".agents" / "skills" / "_shared").exists()
+
+
+def test_link_skills_without_marketplace_cache_is_noop(tmp_path: Path) -> None:
+    """Absent the marketplace cache the script exits 0 and creates no links.
+
+    :param tmp_path: Temporary test root.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+
+    result = _run_link_skills(home)
+
+    assert result.returncode == 0, result.stderr
+    assert not (home / ".agents" / "skills").exists()
+
+
+def test_link_skills_is_idempotent(tmp_path: Path) -> None:
+    """Re-running over an already-projected home stays green and keeps the link.
+
+    :param tmp_path: Temporary test root.
+    """
+    home = tmp_path / "home"
+    source = _write_marketplace_skill(home, "code-health")
+
+    first = _run_link_skills(home)
+    second = _run_link_skills(home)
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    link = home / ".agents" / "skills" / "code-health"
+    assert link.is_symlink()
+    assert link.resolve() == source.resolve()


### PR DESCRIPTION
## Summary

Project the full installed skills pack into `~/.agents/skills/` so Agent-Skills-standard CLIs (Gemini CLI, Antigravity) discover every skill natively — not just the repo-local review skills the `.agents/skills → agent/skills` symlink (#1576) carries.

- `scripts/dev/link-skills.sh` — symlink each `<name>/SKILL.md` dir from `~/.claude/plugins/marketplaces/tinaudio-skills` into `~/.agents/skills/`. No-ops with a clear message when the plugin isn't installed yet, so it never fails a fresh box.
- `make link-skills` — thin wrapper, next to `link-plugins` / `link-thoughts`.
- `.devcontainer/post-create.sh` — best-effort call (`|| true`) so the container projects on creation.
- `tests/infra/test_link_skills.py` — projection, non-skill-dir skip, no-cache no-op, idempotency.

Stacked on #1577 (`codex-hook-skill-discovery`), whose `has_skill()` already probes the `~/.agents/skills` discovery root this populates. Together they let Gemini/Antigravity run the same skills as Claude/Codex, which removes the need for #1578's per-skill TOML-command generator.

Refs #1561

## Verification

- `uv run pytest tests/infra/test_link_skills.py -q` — 4 passed
- `make link-skills` on a box with the marketplace cache projects 28 skills, each a resolvable symlink to a reachable `SKILL.md`
- pre-commit (shellcheck, ruff, pydoclint, …) green on all changed files
- Pre-PR gate: `/repo-review-full-no-comments` — 0 BLOCK; code-health / python-style / tdd / comment-hygiene PASS; one intentional shell-style WARN (env-bash shebang, matching sibling scripts)
