### PR TITLE
test(testing): auto-delete citest W&B round-trip checkpoint artifacts

### DIFF
--- a/tests/helpers/wandb_artifacts.py
+++ b/tests/helpers/wandb_artifacts.py
@@ -63,7 +63,10 @@ def publish_checkpoint_artifact(
         artifact.wait()
         yield f"{entity}/{CITEST_PROJECT}/{unique_name}:latest"
     finally:
-        run.finish()
+        # Teardown is best-effort: a finish() comm error must neither fail the test nor
+        # skip deletion, so suppress it and always reach the artifact/run cleanup.
+        with contextlib.suppress(Exception):
+            run.finish()
         _delete_citest_artifact_and_run(entity, unique_name, run_id)
 
 

--- a/tests/helpers/wandb_artifacts.py
+++ b/tests/helpers/wandb_artifacts.py
@@ -3,12 +3,16 @@
 The ``${wandb:...}`` resolver round-trip tests (``test_eval`` / ``test_train``) need a
 genuine artifact in W&B that the resolver can download — a fake stub proves nothing about
 the live download path. To keep these test writes out of the production model registry
-(``model-<id>`` in the production project), everything lands in the dedicated
-``synth-setter-citest`` project under ``model-citest-<id>`` names.
+(``model-<id>`` in the production project) and off the shared 5 GB W&B storage budget,
+everything lands in the dedicated ``synth-setter-citest`` project under a per-call-unique
+``model-citest-<id>-<token>`` name and is deleted — artifact and run — when the context exits.
 """
 
 from __future__ import annotations
 
+import contextlib
+import uuid
+from collections.abc import Iterator
 from pathlib import Path
 
 # Dedicated test project so round-trip uploads never touch the production model registry.
@@ -17,21 +21,29 @@ from pathlib import Path
 CITEST_PROJECT = "synth-setter-citest"
 
 
-def publish_checkpoint_artifact(ckpt_path: Path, artifact_name: str, run_dir: Path) -> str:
-    """Upload ``ckpt_path`` as ``model.ckpt`` in a W&B model artifact, returning its resolver ref.
+@contextlib.contextmanager
+def publish_checkpoint_artifact(
+    ckpt_path: Path, artifact_name: str, run_dir: Path
+) -> Iterator[str]:
+    """Publish ``ckpt_path`` as ``model.ckpt`` in a W&B model artifact, yielding its resolver ref.
 
     Logs to :data:`CITEST_PROJECT` under the key's default entity (never the production
     registry) and blocks on ``artifact.wait()`` so the artifact is committed before the
-    caller resolves it. Requires a live ``WANDB_API_KEY`` in the environment — callers gate on it.
+    caller resolves it. The name carries a per-call random suffix so concurrent CI runs never
+    collide on ``:latest`` and teardown targets exactly one version. On exit the artifact and
+    its run are deleted (best-effort) so each round-trip leaves no W&B storage behind. Requires
+    a live ``WANDB_API_KEY`` in the environment — callers gate on it.
 
     :param ckpt_path: Local Lightning checkpoint embedded into the artifact as ``model.ckpt``.
-    :param artifact_name: Artifact name, e.g. ``model-citest-ffn_full``.
+    :param artifact_name: Base artifact name (e.g. ``model-citest-ffn_full``); a random suffix
+        is appended for per-call uniqueness.
     :param run_dir: Directory for the wandb run's local files, kept off the repo tree.
-    :returns: The ``entity/project/name:latest`` ref the resolver consumes — wrap in
+    :yields str: The ``entity/project/name:latest`` ref the resolver consumes — wrap in
         ``${wandb:<ref>}`` to pin it as a ``ckpt_path``.
     """
     import wandb
 
+    unique_name = f"{artifact_name}-{uuid.uuid4().hex[:8]}"
     # Pin a short host: W&B rejects a run whose machine hostname exceeds 64 chars
     # ("CommError: 64 limit exceeded for Host"), and self-hosted CI runners (e.g. the
     # MPS box) have hostnames well over that. None (the default) would record
@@ -42,13 +54,35 @@ def publish_checkpoint_artifact(ckpt_path: Path, artifact_name: str, run_dir: Pa
         dir=str(run_dir),
         settings=wandb.Settings(host="synth-setter-ci"),
     )
+    # Read the entity back from the run so refs match whatever account the key owns.
+    entity, run_id = run.entity, run.id
     try:
-        artifact = wandb.Artifact(name=artifact_name, type="model")
+        artifact = wandb.Artifact(name=unique_name, type="model")
         artifact.add_file(str(ckpt_path), name="model.ckpt")
         run.log_artifact(artifact)
         artifact.wait()
-        # Read the entity back from the run so the ref matches whatever account the key owns.
-        ref = f"{run.entity}/{CITEST_PROJECT}/{artifact_name}:latest"
+        yield f"{entity}/{CITEST_PROJECT}/{unique_name}:latest"
     finally:
         run.finish()
-    return ref
+        _delete_citest_artifact_and_run(entity, unique_name, run_id)
+
+
+def _delete_citest_artifact_and_run(entity: str, artifact_name: str, run_id: str) -> None:
+    """Best-effort delete of a citest artifact and its run so a round-trip leaves no storage.
+
+    Each deletion is independently suppressed: cleanup runs in a test ``finally`` and must
+    never mask the test's own result, and a partial failure (e.g. a transient W&B 5xx) is
+    recovered by the next run reusing the same project, not by aborting here.
+
+    :param entity: W&B entity owning :data:`CITEST_PROJECT`.
+    :param artifact_name: Unique artifact name whose ``:latest`` version is removed.
+    :param run_id: Run id deleted after its artifact.
+    """
+    import wandb
+
+    api = wandb.Api()
+    project = f"{entity}/{CITEST_PROJECT}"
+    with contextlib.suppress(Exception):
+        api.artifact(f"{project}/{artifact_name}:latest").delete(delete_aliases=True)
+    with contextlib.suppress(Exception):
+        api.run(f"{project}/{run_id}").delete()

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -578,19 +578,21 @@ def test_evaluate_loads_wandb_resolved_checkpoint_and_runs_inference(
     ckpt = Path(cfg_surge_xt_eval.ckpt_path)
     assert ckpt.is_file(), "train step did not write the checkpoint"
 
-    ref = publish_checkpoint_artifact(ckpt, "model-citest-ffn_full-eval", tmp_path / "wandb")
+    # Body runs inside the ``with`` so the resolver downloads before the artifact/run teardown.
+    with publish_checkpoint_artifact(
+        ckpt, "model-citest-ffn_full-eval", tmp_path / "wandb"
+    ) as ref:
+        # Contain the resolver's download cache under tmp_path so each run fetches fresh (a warm
+        # self-hosted runner must not reuse a stale cached ckpt for the same :latest ref).
+        monkeypatch.setenv("SYNTH_SETTER_WORKSPACE", str(tmp_path))
+        monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+        operator_workspace.cache_clear()
+        register_resolvers()
+        with open_dict(cfg_surge_xt_eval):
+            cfg_surge_xt_eval.ckpt_path = "${wandb:" + ref + "}"
 
-    # Contain the resolver's download cache under tmp_path so each run fetches fresh (a warm
-    # self-hosted runner must not reuse a stale cached ckpt for the same :latest ref).
-    monkeypatch.setenv("SYNTH_SETTER_WORKSPACE", str(tmp_path))
-    monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
-    operator_workspace.cache_clear()
-    register_resolvers()
-    with open_dict(cfg_surge_xt_eval):
-        cfg_surge_xt_eval.ckpt_path = "${wandb:" + ref + "}"
-
-    HydraConfig().set_config(cfg_surge_xt_eval)
-    evaluate(cfg_surge_xt_eval)
+        HydraConfig().set_config(cfg_surge_xt_eval)
+        evaluate(cfg_surge_xt_eval)
 
     assert (tmp_path / ".cache" / "checkpoints").is_dir(), "resolver did not download the artifact"
     predictions_dir = tmp_path / "predictions"

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -400,21 +400,23 @@ def test_train_resumes_from_wandb_resolved_checkpoint(
     ckpt = tmp_path / "checkpoints" / "last.ckpt"
     assert ckpt.is_file(), "first train step did not write last.ckpt"
 
-    ref = publish_checkpoint_artifact(ckpt, "model-citest-ffn_full-resume", tmp_path / "wandb")
+    # Body runs inside the ``with`` so the resolver downloads before the artifact/run teardown.
+    with publish_checkpoint_artifact(
+        ckpt, "model-citest-ffn_full-resume", tmp_path / "wandb"
+    ) as ref:
+        # Contain the resolver's download cache under tmp_path so each run fetches fresh (a warm
+        # self-hosted runner must not reuse a stale cached ckpt for the same :latest ref).
+        monkeypatch.setenv("SYNTH_SETTER_WORKSPACE", str(tmp_path))
+        monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
+        operator_workspace.cache_clear()
+        register_resolvers()
+        with open_dict(cfg_surge_xt):
+            cfg_surge_xt.ckpt_path = "${wandb:" + ref + "}"
+            cfg_surge_xt.trainer.max_steps = step_after_first + 1
 
-    # Contain the resolver's download cache under tmp_path so each run fetches fresh (a warm
-    # self-hosted runner must not reuse a stale cached ckpt for the same :latest ref).
-    monkeypatch.setenv("SYNTH_SETTER_WORKSPACE", str(tmp_path))
-    monkeypatch.setenv("PROJECT_ROOT", str(tmp_path))
-    operator_workspace.cache_clear()
-    register_resolvers()
-    with open_dict(cfg_surge_xt):
-        cfg_surge_xt.ckpt_path = "${wandb:" + ref + "}"
-        cfg_surge_xt.trainer.max_steps = step_after_first + 1
-
-    HydraConfig().set_config(cfg_surge_xt)
-    _, second = train(cfg_surge_xt)
-    step_after_resume = second["trainer"].global_step
+        HydraConfig().set_config(cfg_surge_xt)
+        _, second = train(cfg_surge_xt)
+        step_after_resume = second["trainer"].global_step
 
     assert (tmp_path / ".cache" / "checkpoints").is_dir(), "resolver did not download the artifact"
     assert step_after_resume > step_after_first, (

--- a/tests/test_wandb_artifacts_helper.py
+++ b/tests/test_wandb_artifacts_helper.py
@@ -130,3 +130,26 @@ def test_publish_checkpoint_artifact_swallows_cleanup_failure(
     # delete must not short-circuit the rest of teardown.
     fake.init.return_value.finish.assert_called_once()
     fake.Api.return_value.run.return_value.delete.assert_called_once()
+
+
+def test_publish_checkpoint_artifact_finish_failure_does_not_skip_deletion(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A ``run.finish()`` error is swallowed and still reaches the artifact and run deletion.
+
+    :param monkeypatch: Installs the fake ``wandb`` SDK in ``sys.modules``.
+    :param tmp_path: Holds the dummy checkpoint and the run dir.
+    """
+    fake = _install_fake_wandb(monkeypatch)
+    fake.init.return_value.finish.side_effect = RuntimeError("wandb comm error")
+    from tests.helpers.wandb_artifacts import publish_checkpoint_artifact
+
+    ckpt = tmp_path / "model.ckpt"
+    ckpt.write_text("weights")
+
+    # A finish() failure must neither propagate out of the context nor skip cleanup.
+    with publish_checkpoint_artifact(ckpt, "model-citest-ffn_full", tmp_path) as ref:
+        assert ref
+
+    fake.Api.return_value.artifact.return_value.delete.assert_called_once()
+    fake.Api.return_value.run.return_value.delete.assert_called_once()

--- a/tests/test_wandb_artifacts_helper.py
+++ b/tests/test_wandb_artifacts_helper.py
@@ -1,0 +1,132 @@
+"""Unit tests for the citest checkpoint-artifact publisher's naming and teardown.
+
+``publish_checkpoint_artifact`` uploads a real checkpoint to W&B for the live
+``${wandb:...}`` resolver round-trip tests. These stub the ``wandb`` SDK so the
+unique-naming and delete-on-exit contract — which keeps the round-trips off the
+shared W&B storage budget — is pinned without a network call or a live key.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+
+def _install_fake_wandb(monkeypatch: pytest.MonkeyPatch) -> mock.MagicMock:
+    fake = mock.MagicMock()
+    run = fake.init.return_value
+    run.entity = "ent"
+    run.id = "run123"
+    monkeypatch.setitem(sys.modules, "wandb", fake)
+    return fake
+
+
+def _raise_inside_context() -> None:
+    """Fail inside the publisher context so teardown-on-exception can be asserted.
+
+    :raises RuntimeError: Always.
+    """
+    raise RuntimeError("boom")
+
+
+def test_publish_checkpoint_artifact_embeds_ckpt_and_yields_suffixed_latest_ref(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The yielded ref pins ``:latest`` on a per-call-suffixed citest name; ckpt is ``model.ckpt``.
+
+    :param monkeypatch: Installs the fake ``wandb`` SDK in ``sys.modules``.
+    :param tmp_path: Holds the dummy checkpoint and the run dir.
+    """
+    fake = _install_fake_wandb(monkeypatch)
+    from tests.helpers.wandb_artifacts import publish_checkpoint_artifact
+
+    ckpt = tmp_path / "model.ckpt"
+    ckpt.write_text("weights")
+
+    with publish_checkpoint_artifact(ckpt, "model-citest-ffn_full", tmp_path) as ref:
+        assert ref.startswith("ent/synth-setter-citest/model-citest-ffn_full-")
+        assert ref.endswith(":latest")
+        fake.Artifact.return_value.add_file.assert_called_once_with(str(ckpt), name="model.ckpt")
+        # Nothing is deleted while the context is still open.
+        fake.Api.return_value.artifact.assert_not_called()
+
+    name = fake.Artifact.call_args.kwargs["name"]
+    assert name.startswith("model-citest-ffn_full-") and name != "model-citest-ffn_full"
+
+
+def test_publish_checkpoint_artifact_deletes_artifact_and_run_on_exit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Leaving the context finishes the run and deletes both the artifact and the run.
+
+    :param monkeypatch: Installs the fake ``wandb`` SDK in ``sys.modules``.
+    :param tmp_path: Holds the dummy checkpoint and the run dir.
+    """
+    fake = _install_fake_wandb(monkeypatch)
+    from tests.helpers.wandb_artifacts import publish_checkpoint_artifact
+
+    ckpt = tmp_path / "model.ckpt"
+    ckpt.write_text("weights")
+
+    with publish_checkpoint_artifact(ckpt, "model-citest-ffn_full", tmp_path) as ref:
+        artifact_name = ref.split("/")[-1].removesuffix(":latest")
+
+    api = fake.Api.return_value
+    fake.init.return_value.finish.assert_called_once()
+    api.artifact.assert_called_once()
+    assert api.artifact.call_args.args[0] == f"ent/synth-setter-citest/{artifact_name}:latest"
+    api.artifact.return_value.delete.assert_called_once()
+    api.run.assert_called_once_with("ent/synth-setter-citest/run123")
+    api.run.return_value.delete.assert_called_once()
+
+
+def test_publish_checkpoint_artifact_deletes_even_when_body_raises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failing context body still triggers artifact and run deletion (cleanup is in ``finally``).
+
+    :param monkeypatch: Installs the fake ``wandb`` SDK in ``sys.modules``.
+    :param tmp_path: Holds the dummy checkpoint and the run dir.
+    """
+    fake = _install_fake_wandb(monkeypatch)
+    from tests.helpers.wandb_artifacts import publish_checkpoint_artifact
+
+    ckpt = tmp_path / "model.ckpt"
+    ckpt.write_text("weights")
+
+    with (
+        pytest.raises(RuntimeError, match="boom"),
+        publish_checkpoint_artifact(ckpt, "model-citest-ffn_full", tmp_path),
+    ):
+        _raise_inside_context()
+
+    fake.Api.return_value.artifact.return_value.delete.assert_called_once()
+    fake.Api.return_value.run.return_value.delete.assert_called_once()
+
+
+def test_publish_checkpoint_artifact_swallows_cleanup_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A W&B error during teardown is swallowed so it never masks the test's own result.
+
+    :param monkeypatch: Installs the fake ``wandb`` SDK in ``sys.modules``.
+    :param tmp_path: Holds the dummy checkpoint and the run dir.
+    """
+    fake = _install_fake_wandb(monkeypatch)
+    fake.Api.return_value.artifact.side_effect = RuntimeError("wandb 503")
+    from tests.helpers.wandb_artifacts import publish_checkpoint_artifact
+
+    ckpt = tmp_path / "model.ckpt"
+    ckpt.write_text("weights")
+
+    # Exiting the context must not re-raise the artifact-delete failure.
+    with publish_checkpoint_artifact(ckpt, "model-citest-ffn_full", tmp_path) as ref:
+        assert ref
+
+    # The run is still finished and the run-delete is still attempted — a failed artifact
+    # delete must not short-circuit the rest of teardown.
+    fake.init.return_value.finish.assert_called_once()
+    fake.Api.return_value.run.return_value.delete.assert_called_once()


### PR DESCRIPTION
## Problem

The live `${wandb:...}` resolver round-trip tests — `test_eval.py::test_evaluate_loads_wandb_resolved_checkpoint_and_runs_inference` and `test_train.py::test_train_resumes_from_wandb_resolved_checkpoint` — published a full Lightning checkpoint to the `synth-setter-citest` project via `tests/helpers/wandb_artifacts.py::publish_checkpoint_artifact` under a **fixed** artifact name. Every CI run committed a new `:latest` version that was **never deleted**, slowly accumulating against the shared 5 GB W&B storage budget that #1572 set out to protect, and risking `:latest` collisions across parallel runs.

These were the only remaining sites uploading full checkpoint *bytes* to W&B; production code is reference-only after #1572.

## Change

- `publish_checkpoint_artifact` is now a context manager that names each artifact `model-citest-<id>-<token>` (unique per run, so parallel CI never collides on `:latest`) and deletes **both the artifact and its run** on context exit — best-effort, so a teardown failure never masks the test result.
- Both call sites run inside the `with` block so the resolver downloads before teardown.
- Adds network-free unit tests (mocked `wandb` SDK) pinning unique-naming, delete-on-exit, delete-on-exception, and swallowed-cleanup-failure.

## Verification

- New unit tests: 4 passed. `ruff` / `ruff format` / `pyright` / `pydoclint` / full pre-commit on the changed files: pass.
- **Live W&B round-trip:** `test_train_resumes_from_wandb_resolved_checkpoint[cpu]` passed (77s). A direct probe confirmed the artifact resolves **inside** the context (`COMMITTED`) and `Api().artifact()` raises `CommError` **after** exit — real deletion verified.
- Pre-PR `/repo-review-full-no-comments`: 0 BLOCK across 5 skills; the actionable WARNs were addressed.

Fixes #1585
Refs #92
