### PR TITLE
chore(devcontainer): chown root-owned bind mount so dev can write .git

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -56,12 +56,16 @@ git config --global --add safe.directory "$(pwd)"
 
 # Correct workspace ownership before the first .git write below. A root-owned
 # host checkout bind-mounts in with every file root-owned, so `dev` can't write
-# .git, run `pre-commit install`, or commit. Guard on the top-level owner so an
-# already-correct rebuild skips the recursive walk (post-create time budget),
-# via the NOPASSWD sudo from common-utils. Capture the owner first so a stat
-# failure aborts under `set -e` rather than falling through to the chown.
+# .git, run `pre-commit install`, or commit. Guard on both the workspace root
+# and `.git` so a mixed-ownership tree (e.g. `.git` left root-owned by an
+# earlier DEVCONTAINER_USER=root session) still self-heals — `.git` is the
+# dir the failing writes target. The recursive chown is skipped only when both
+# are already correct (post-create time budget), via the NOPASSWD sudo from
+# common-utils. `.git` is a real dir here (initialize.sh refuses pointer-file
+# `.git`). Capture owners first so a stat failure aborts under `set -e`.
 workspace_owner="$(stat -c %u "$dir")"
-if [ "$workspace_owner" != "$(id -u)" ]; then
+gitdir_owner="$(stat -c %u "$dir/.git")"
+if [ "$workspace_owner" != "$(id -u)" ] || [ "$gitdir_owner" != "$(id -u)" ]; then
   sudo chown -R "$(id -u):$(id -g)" "$dir"
 fi
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -54,6 +54,17 @@ cd "$dir"
 # before later git config calls and pre-commit install.
 git config --global --add safe.directory "$(pwd)"
 
+# Correct workspace ownership before the first .git write below. A root-owned
+# host checkout bind-mounts in with every file root-owned, so `dev` can't write
+# .git, run `pre-commit install`, or commit. Guard on the top-level owner so an
+# already-correct rebuild skips the recursive walk (post-create time budget),
+# via the NOPASSWD sudo from common-utils. Capture the owner first so a stat
+# failure aborts under `set -e` rather than falling through to the chown.
+workspace_owner="$(stat -c %u "$dir")"
+if [ "$workspace_owner" != "$(id -u)" ]; then
+  sudo chown -R "$(id -u):$(id -g)" "$dir"
+fi
+
 if [ -n "${RESTRICTED_AGENT_GIT_PAT:-}" ]; then
   # Strip surrounding double or single quotes if present
   # (Docker's --env-file doesn't strip them like shell `source` does)

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -242,7 +242,7 @@ docs:
       - pattern: ".devcontainer/initialize.sh"
         covers: "Host-side initializeCommand — refuses pointer-file `.git` (worktree/submodule/--separate-git-dir), ensures .env exists"
       - pattern: ".devcontainer/post-create.sh"
-        covers: "First-run setup — git safety, pre-commit install, root-to-dev privilege drop, install ~/.tmux.conf for both root and dev users"
+        covers: "First-run setup — git safety, pre-commit install, root-to-dev privilege drop, bind-mount ownership fix (guarded recursive chown before .git writes), install ~/.tmux.conf for both root and dev users"
       - pattern: "src/synth_setter/configs/logger/many_loggers.yaml"
         covers: "Default logger compose — referenced in §4c for enable/disable workflow"
         scope: "wandb-config"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -736,8 +736,13 @@ credentials are required.
    optionally authenticates with `RESTRICTED_AGENT_GIT_PAT`, and installs
    pre-commit hooks. If invoked as root (Codespaces default, or opt-in
    `DEVCONTAINER_USER=root` locally), it drops to the `dev` user first so
-   workspace mutations under `.git/` land with dev ownership. Then the
-   terminal is ready.
+   workspace mutations under `.git/` land with dev ownership. On a
+   root-owned host bind mount (the local-devcontainer case, where the
+   privilege drop alone can't fix files that arrive pre-owned by root), it
+   also recursively chowns the workspace to the running user — guarded by a
+   `stat`-based ownership check — before any `.git` write, so
+   `pre-commit install` and commits don't fail with permission denied. Then
+   the terminal is ready.
 4. Default terminal profile is configured in `.devcontainer/*/devcontainer.json`.
 
 **Verify:**

--- a/tests/infra/test_post_create_ownership.py
+++ b/tests/infra/test_post_create_ownership.py
@@ -101,3 +101,27 @@ def test_post_create_ownership_fix_is_guarded_for_idempotency(
         "the chown must be guarded by an ownership check (stat -c %u) so it "
         "only runs when the workspace is not already owned by the dev user."
     )
+
+
+@pytest.mark.infra
+def test_post_create_ownership_guard_also_checks_git_dir(
+    post_create_script: Path,
+) -> None:
+    """The guard checks `.git` ownership, not just the workspace root.
+
+    A mixed-ownership tree — workspace root already `dev`-owned but `.git`
+    left root-owned by an earlier `DEVCONTAINER_USER=root` session — would
+    otherwise skip the chown, and the later `git config --local` /
+    `pre-commit install` writes would still fail. `.git` is the dir those
+    writes target, so it must be part of the guard.
+
+    :param post_create_script: Path to `.devcontainer/post-create.sh`.
+    """
+    text = post_create_script.read_text()
+    chown_idx = _line_index(text, r"\bchown\s+-R\b")
+    assert chown_idx != -1, "no chown found in post-create.sh"
+    preceding = "\n".join(text.splitlines()[:chown_idx])
+    assert re.search(r"""stat\s+-c\s+%u\s+["']?\$dir/\.git\b""", preceding), (
+        "the guard must also stat `$dir/.git` so a mixed-ownership tree "
+        "(root-owned .git under a dev-owned workspace root) still self-heals."
+    )

--- a/tests/infra/test_post_create_ownership.py
+++ b/tests/infra/test_post_create_ownership.py
@@ -1,0 +1,103 @@
+"""Invariant: post-create.sh corrects bind-mount ownership before it writes .git.
+
+The local devcontainer bind-mounts the host checkout, so a root-owned host tree
+lands every file root-owned inside the container. Unless post-create.sh fixes
+ownership first, the unprivileged `dev` user can't write `.git`, run
+`pre-commit install`, or commit. These are static checks on the script text —
+running the script for real has destructive side effects in a populated
+workspace (see test_post_create_performance.py).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+
+def _line_index(text: str, pattern: str) -> int:
+    """Return the index of the first non-comment line matching `pattern`.
+
+    Only full-line `^\\s*#…` comments are skipped, so a pattern that also appears in the script's
+    prose (e.g. `pre-commit install`, named in several comments) matches the actual command line.
+
+    :param text: The script source to scan.
+    :param pattern: A regex searched against each non-comment line.
+    :returns: 0-based index of the first matching line, or -1 if none match.
+    """
+    for idx, line in enumerate(text.splitlines()):
+        if re.match(r"^\s*#", line):
+            continue
+        if re.search(pattern, line):
+            return idx
+    return -1
+
+
+@pytest.mark.infra
+def test_post_create_chowns_workspace_recursively_to_current_user(
+    post_create_script: Path,
+) -> None:
+    """The script recursively chowns the workspace tree to the running user.
+
+    :param post_create_script: Path to `.devcontainer/post-create.sh`.
+    """
+    text = post_create_script.read_text()
+    chown_idx = _line_index(text, r"\bchown\s+-R\b")
+    assert chown_idx != -1, (
+        "post-create.sh must recursively chown the workspace so a root-owned "
+        "host bind mount doesn't leave .git unwritable for the dev user."
+    )
+    chown_line = text.splitlines()[chown_idx]
+    assert re.search(r"\$\(id\s+-u\)", chown_line), (
+        "the chown must target the running user — `$(id -u)` — not a literal "
+        f"uid; got: {chown_line.strip()!r}"
+    )
+
+
+@pytest.mark.infra
+def test_post_create_ownership_fix_precedes_git_writes(
+    post_create_script: Path,
+) -> None:
+    """The chown runs before `pre-commit install`, which writes `.git/hooks`.
+
+    `pre-commit install` is the unambiguous marker for a workspace-`.git`
+    write: the dev-block `git config --local/--worktree` loop that also writes
+    `.git/config` sits just above it in the same block, so anchoring here pins
+    the chown above the whole dev-block git section. (`core.hooksPath` itself
+    is a poor anchor — it also appears in the root pre-exec block's
+    `--system`/`--global` unset, which never touches the workspace `.git`.)
+
+    :param post_create_script: Path to `.devcontainer/post-create.sh`.
+    """
+    text = post_create_script.read_text()
+    chown_idx = _line_index(text, r"\bchown\s+-R\b")
+    precommit_idx = _line_index(text, r"\bpre-commit\s+install\b")
+    assert chown_idx != -1, "no chown found in post-create.sh"
+    assert precommit_idx != -1, "no `pre-commit install` found in post-create.sh"
+    assert chown_idx < precommit_idx, (
+        f"chown (line {chown_idx + 1}) must precede `pre-commit install` "
+        f"(line {precommit_idx + 1}); otherwise the .git write fails on a "
+        "root-owned bind mount before ownership is corrected."
+    )
+
+
+@pytest.mark.infra
+def test_post_create_ownership_fix_is_guarded_for_idempotency(
+    post_create_script: Path,
+) -> None:
+    """The chown is conditional so an already-correct rebuild skips the recursive walk.
+
+    An unconditional recursive chown on every container create would burn the post-create time
+    budget and churn inode metadata for no reason once the tree is already dev-owned.
+
+    :param post_create_script: Path to `.devcontainer/post-create.sh`.
+    """
+    text = post_create_script.read_text()
+    chown_idx = _line_index(text, r"\bchown\s+-R\b")
+    assert chown_idx != -1, "no chown found in post-create.sh"
+    preceding = "\n".join(text.splitlines()[:chown_idx])
+    assert re.search(r"\bstat\s+-c\s+%u\b", preceding), (
+        "the chown must be guarded by an ownership check (stat -c %u) so it "
+        "only runs when the workspace is not already owned by the dev user."
+    )


### PR DESCRIPTION
## Problem

In the local CPU devcontainer, every git operation that writes `.git/` (commit, `git worktree add`, `pre-commit install`) fails with **permission denied**.

The devcontainer bind-mounts the host checkout:

```
workspaceMount: type=bind,source=${localWorkspaceFolder},target=/home/build/synth-setter
```

A bind mount mirrors host-side ownership 1:1. When the host checkout is owned by `root` (cloned as root, or written by an earlier root-running container), every file lands `root`-owned inside the container, which runs as `dev` (uid 1000) — so `dev` can't write `.git`.

`updateRemoteUserUID` aligns `dev`'s UID to the host **user**, not `root`, so it doesn't help; `safe.directory` only silences git's warning. The existing chown/drop-privilege path in `post-create.sh` runs only on the Codespaces (root) branch — locally `postCreateCommand` runs as `dev`, so pre-existing root ownership is never corrected.

## Fix

Chown the workspace tree to the running user early in `post-create.sh`, before the first `.git` write. The owner is captured first (`workspace_owner="$(stat -c %u "$dir")"`) so a `stat` failure aborts under `set -e` instead of falling through to the chown, and the chown is guarded on the top-level owner so an already-correct rebuild skips the recursive walk (post-create time budget). Runs on every container **create**, so future devcontainers self-heal.

Adds static invariant tests pinning the chown, its ordering before `pre-commit install`, the `$(id -u)` target, and the idempotency guard.

## Verification

- `make format` (pre-commit) clean on both files; shellcheck clean.
- `tests/infra/test_post_create_ownership.py` (3 tests) + `test_post_create_performance.py` pass; the recursive `chown` does not trip the no-slow-operations performance check.
- Pre-PR multi-skill review (6 skills): 0 BLOCK, comment-hygiene clean.

Fixes #1588
