### PR TITLE
build(devcontainer): move claude-code to per-user npm prefix

### DIFF
--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -438,16 +438,16 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
       > /etc/apt/sources.list.d/github-cli.list \
   && apt-get update && apt-get install -y --no-install-recommends gh
 
-# --- Node.js + Claude Code CLI (system-wide) ---
-ARG CLAUDE_CODE_VERSION=latest
+# --- Node.js (system-wide) ---
+# CLI agents (claude-code, codex) install per-user below: a root-owned /usr/local/bin
+# copy would shadow dev's auto-updated ~/.npm-global copy in PATH, pinning the version.
 COPY --from=node:20-bullseye-slim /usr/local/bin/node /usr/local/bin/node
 COPY --from=node:20-bullseye-slim /usr/local/lib/node_modules /usr/local/lib/node_modules
 
 RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
  && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
  && node --version \
- && npm --version \
- && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}"
+ && npm --version
 
 # Zellij terminal multiplexer (https://github.com/zellij-org/zellij) — not in
 # the Ubuntu 22.04 apt repos, so install the upstream static musl binary,
@@ -500,14 +500,18 @@ ENV PATH="$PATH:/home/${USERNAME}/.npm-global/bin:/home/${USERNAME}/.local/bin"
 # the devcontainer (see #1423); stage under .cache, which wandb creates on demand.
 ENV WANDB_DATA_DIR="/home/${USERNAME}/.cache/wandb"
 
-# dev's `npm install -g` would EACCES on the root-owned global tree (claude-code
-# is baked in as root); a per-user prefix sends it to a writable one. $HOME is
-# unset after USER, so export it per-RUN (not ENV — that leaks to root sessions).
+# dev's `npm install -g` would EACCES on the root-owned global tree (/usr/local);
+# a per-user prefix sends it to a writable one, so the in-app updater can replace
+# claude-code in place. $HOME is unset after USER, so export it per-RUN (not ENV —
+# that leaks to root sessions).
+ARG CLAUDE_CODE_VERSION=latest
 ARG CODEX_VERSION=latest
 RUN export HOME="/home/${USERNAME}" \
  && npm config set prefix "/home/${USERNAME}/.npm-global" \
+ && npm install -g "@anthropic-ai/claude-code@${CLAUDE_CODE_VERSION}" \
  && npm install -g "@openai/codex@${CODEX_VERSION}" \
  && npm cache clean --force \
+ && claude --version \
  && codex --version
 
 # Antigravity (Google) ships the standalone `agy` binary, not on npm; its

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -115,10 +115,11 @@ The `devcontainer-tools` stage is a sibling of `dev-snapshot` — both stages
 build `FROM dev-base`, the shared parent that holds Surge XT, the venv, and
 the synth-setter source. `devcontainer-tools` adds interactive CLI tooling
 (see the stage's `apt-get install` list and the GitHub CLI install block),
-Node.js + `@anthropic-ai/claude-code` installed system-wide, the OpenAI
-`@openai/codex` CLI installed for the `dev` user via a per-user npm prefix
-(`~/.npm-global`, on PATH) so later `npm install -g` runs avoid EACCES on the
-root-owned global tree, the Google Antigravity (`agy`) CLI installed by its
+Node.js installed system-wide, the `@anthropic-ai/claude-code` and
+`@openai/codex` CLIs installed for the `dev` user via a per-user npm prefix
+(`~/.npm-global`, on PATH) so later `npm install -g` runs — including
+claude-code's in-app self-update — avoid EACCES on the root-owned global tree
+and are not shadowed by a system-wide copy, the Google Antigravity (`agy`) CLI installed by its
 upstream `install.sh` into `~/.local/bin` (also on PATH), the zellij
 terminal multiplexer (pinned upstream musl binary, SHA256-verified, in
 `/usr/local/bin`), a non-root

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -119,8 +119,8 @@ Node.js installed system-wide, the `@anthropic-ai/claude-code` and
 `@openai/codex` CLIs installed for the `dev` user via a per-user npm prefix
 (`~/.npm-global`, on PATH) — so later `npm install -g` runs, including
 claude-code's in-app self-update, avoid EACCES on the root-owned tree and aren't
-shadowed by a system-wide copy; the Google Antigravity (`agy`) CLI installed by its
-upstream `install.sh` into `~/.local/bin` (also on PATH), the zellij
+shadowed by a system-wide copy. It also adds the Google Antigravity (`agy`) CLI
+installed by its upstream `install.sh` into `~/.local/bin` (also on PATH), the zellij
 terminal multiplexer (pinned upstream musl binary, SHA256-verified, in
 `/usr/local/bin`), a non-root
 `dev` user, chowns the baked uv venv at `/venv/main` to `dev` so

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -1,6 +1,6 @@
 # Docker Reference
 
-> **Last verified:** 2026-06-02
+> **Last verified:** 2026-06-10
 
 How to build, run, and debug Docker images for the synth-setter training
 pipeline. Intended for developers working locally or in CI environments.
@@ -117,9 +117,9 @@ the synth-setter source. `devcontainer-tools` adds interactive CLI tooling
 (see the stage's `apt-get install` list and the GitHub CLI install block),
 Node.js installed system-wide, the `@anthropic-ai/claude-code` and
 `@openai/codex` CLIs installed for the `dev` user via a per-user npm prefix
-(`~/.npm-global`, on PATH) so later `npm install -g` runs — including
-claude-code's in-app self-update — avoid EACCES on the root-owned global tree
-and are not shadowed by a system-wide copy, the Google Antigravity (`agy`) CLI installed by its
+(`~/.npm-global`, on PATH) — so later `npm install -g` runs, including
+claude-code's in-app self-update, avoid EACCES on the root-owned tree and aren't
+shadowed by a system-wide copy; the Google Antigravity (`agy`) CLI installed by its
 upstream `install.sh` into `~/.local/bin` (also on PATH), the zellij
 terminal multiplexer (pinned upstream musl binary, SHA256-verified, in
 `/usr/local/bin`), a non-root


### PR DESCRIPTION
## What

Moves `@anthropic-ai/claude-code` out of the system-wide root install and into
the `dev` user's per-user npm prefix (`~/.npm-global`), exactly as
`@openai/codex` already is. Node.js stays system-wide.

## Why

The image baked claude-code into `/usr/local/lib/node_modules` **as root**,
exposing `/usr/local/bin/claude`. `PATH` lists that system bin ahead of
`~/.npm-global/bin`, so claude-code's in-app self-update — which writes to the
per-user prefix — was silently shadowed. Every session stayed pinned to the
build-time version no matter how many times the UI reported a successful
upgrade.

Repro that surfaced this: a dev stuck on `claude` v2.1.167 while
`~/.npm-global/bin/claude` had already auto-updated to v2.1.170, with
`/usr/local/bin/claude` winning the PATH lookup.

This is the per-user-prefix migration #1351 applied to codex, extended to the
one CLI it missed.

## Tradeoff (accepted)

Root-default sessions (`root_gpu`) no longer ship the claude CLI — symmetric
with how codex is already handled (codex is dev-only too). The VS Code
`anthropic.claude-code` extension is unaffected.

## Verification

- `make format` / pre-commit: pass on both changed files.
- Build correctness reviewed: ARG scope valid at its new position;
  `claude --version` resolves at build time via the already-on-PATH
  `~/.npm-global/bin`; no dangling `&&` in the trimmed Node `RUN`; no leftover
  reference to the removed system-wide install.
- Image rebuild not run locally (no `make docker-*` without sign-off).

Fixes #1592
