### PR TITLE
fix(data-pipeline): finalize cadence sweeps left stuck in RUNNING

### DIFF
--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -436,7 +436,13 @@ def _launch_wandb(
     try:
         wandb.agent(sweep_id, entity=ENTITY, project=PROJECT, count=count)
     finally:
-        _finish_sweep(sweep_id)
+        # Best-effort cleanup: a finalize failure (network error, or a backend
+        # race moving the sweep terminal between the read and write) must not
+        # mask the agent's outcome — its exception, or its success.
+        try:
+            _finish_sweep(sweep_id)
+        except Exception as exc:  # noqa: BLE001 — cleanup must not mask the agent outcome
+            logger.warning(f"could not finalize sweep {ENTITY}/{PROJECT}/{sweep_id}: {exc}")
 
 
 def _finish_sweep(sweep_id: str) -> None:

--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -31,6 +31,7 @@ from typing import Any
 import wandb
 import wandb.env
 from loguru import logger
+from wandb.apis.internal import Api as InternalApi
 
 from synth_setter.pipeline.schemas.prefix import DEFAULT_R2_PREFIX_ROOT, make_r2_prefix
 
@@ -432,7 +433,28 @@ def _launch_wandb(
     # wandb.old.core sets, so the agent crashes with AttributeError unless flapping
     # is disabled; the grid is already bounded by count, so flapping adds no value.
     os.environ.setdefault(wandb.env.AGENT_DISABLE_FLAPPING, "true")
-    wandb.agent(sweep_id, entity=ENTITY, project=PROJECT, count=count)
+    try:
+        wandb.agent(sweep_id, entity=ENTITY, project=PROJECT, count=count)
+    finally:
+        _finish_sweep(sweep_id)
+
+
+def _finish_sweep(sweep_id: str) -> None:
+    """Mark a sweep FINISHED unless the backend already moved it off an active state.
+
+    The legacy agent exits without the heartbeat that finalizes a sweep (count
+    caps, failure shutdowns), leaving it RUNNING forever; this orchestrator runs
+    the sweep's only agent, so once that agent stops it closes the sweep.
+
+    :param sweep_id: Sweep to finalize within ``ENTITY``/``PROJECT``.
+    """
+    api = InternalApi()
+    state = api.get_sweep_state(sweep=sweep_id, entity=ENTITY, project=PROJECT)
+    # Writing to an already-terminal sweep raises in the wandb API, so skip it.
+    if state not in ("RUNNING", "PENDING", "PAUSED"):
+        return
+    api.set_sweep_state(sweep=sweep_id, state="FINISHED", entity=ENTITY, project=PROJECT)
+    logger.info(f"marked sweep {ENTITY}/{PROJECT}/{sweep_id} {state} -> FINISHED")
 
 
 def run_investigation(

--- a/tests/integration/test_cadence_investigation_489_e2e.py
+++ b/tests/integration/test_cadence_investigation_489_e2e.py
@@ -26,6 +26,7 @@ from pathlib import Path
 import h5py
 import numpy as np
 import pytest
+import wandb
 
 from synth_setter.data.vst.shapes import PARAM_ARRAY_FIELD
 from synth_setter.pipeline import r2_io
@@ -228,8 +229,31 @@ def test_full_investigation_wandb_online_runs_every_experiment_at_configured_sca
     size = _selected_size()
     experiments = inv.build_experiments(inv.Scale.from_size(size))
 
+    # Record every sweep the orchestrator creates so their final backend
+    # states can be asserted after the run.
+    created_sweeps: list[str] = []
+    real_sweep = inv.wandb.sweep
+
+    def _recording_sweep(config: dict[str, object], *, entity: str, project: str) -> str:
+        sweep_id = real_sweep(config, entity=entity, project=project)
+        created_sweeps.append(sweep_id)
+        return sweep_id
+
+    monkeypatch.setattr(inv.wandb, "sweep", _recording_sweep)
+
     try:
         inv.main(["--launcher", "wandb", "--size", str(size), "--prefix-root", prefix_root])
+
+        # The orchestrator must close its sweeps: one left RUNNING after its
+        # only agent exits dangles in the W&B UI forever.
+        assert len(created_sweeps) == len(experiments)
+        api = wandb.Api(timeout=60)
+        for sweep_id in created_sweeps:
+            sweep = api.sweep(f"{inv.ENTITY}/{inv.PROJECT}/{sweep_id}")
+            assert sweep.state == "FINISHED", (
+                f"sweep {sweep_id} ended {sweep.state}, not FINISHED — the "
+                "launcher did not finalize it after its agent stopped"
+            )
 
         source_root = inv.reference_copy_uri(prefix_root=prefix_root)
         source_shard = join_uri(source_root, _FIRST_SHARD)

--- a/tests/tools/test_cadence_investigation_489.py
+++ b/tests/tools/test_cadence_investigation_489.py
@@ -346,6 +346,56 @@ def test_wandb_launch_backend_finalized_sweep_skips_state_write(
     assert fake.state == "FINISHED"
 
 
+class _FinalizeBoomApi:
+    """Sweep-state API whose read fails, so finalization raises (network/race)."""
+
+    def get_sweep_state(
+        self, sweep: str, entity: str | None = None, project: str | None = None
+    ) -> str:
+        raise RuntimeError("finalize boom")
+
+    def set_sweep_state(
+        self, sweep: str, state: str, entity: str | None = None, project: str | None = None
+    ) -> None:
+        raise AssertionError("set_sweep_state must not be reached when the read fails")
+
+
+def test_wandb_launch_finalize_error_does_not_mask_agent_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A finalization failure after a clean agent run is swallowed, not raised.
+
+    Finalization is best-effort cleanup in a ``finally``; letting it raise would
+    turn a successful run into a failure.
+
+    :param monkeypatch: Stubs sweep/agent and makes the finalize read raise.
+    """
+    monkeypatch.setattr(inv.wandb, "sweep", lambda *a, **k: "sweep-id")
+    monkeypatch.setattr(inv.wandb, "agent", lambda *a, **k: None)
+    monkeypatch.setattr(inv, "InternalApi", lambda: _FinalizeBoomApi())
+
+    inv.main(["--launcher", "wandb", "--size", "2", "--only", "shuffle_probe"])
+
+
+def test_wandb_launch_finalize_error_does_not_mask_agent_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the agent raises, a finalize failure must not replace that exception.
+
+    :param monkeypatch: Stubs sweep, makes the agent raise, and makes the finalize read raise too.
+    """
+    monkeypatch.setattr(inv.wandb, "sweep", lambda *a, **k: "sweep-id")
+    monkeypatch.setattr(inv, "InternalApi", lambda: _FinalizeBoomApi())
+
+    def _agent_dies(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("agent crashed")
+
+    monkeypatch.setattr(inv.wandb, "agent", _agent_dies)
+
+    with pytest.raises(RuntimeError, match="agent crashed"):
+        inv.main(["--launcher", "wandb", "--size", "2", "--only", "shuffle_probe"])
+
+
 def test_local_count_caps_cells_run_per_experiment(monkeypatch: pytest.MonkeyPatch) -> None:
     """``--count`` caps how many cells each local experiment runs.
 

--- a/tests/tools/test_cadence_investigation_489.py
+++ b/tests/tools/test_cadence_investigation_489.py
@@ -18,6 +18,20 @@ from synth_setter.tools import cadence_investigation_489 as inv
 SMOKE = inv.Scale.from_size(2)
 
 
+@pytest.fixture(autouse=True)
+def _no_agent_flapping_env_leak(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Stop the wandb launcher's flapping-flag env mutation from leaking between tests.
+
+    ``_launch_wandb`` sets ``AGENT_DISABLE_FLAPPING`` directly via
+    ``os.environ.setdefault``; recording the flag through ``monkeypatch`` here
+    makes teardown restore the original env, so a wandb-launch test cannot change
+    a later test's behavior.
+
+    :param monkeypatch: Records the flag's pre-test state for teardown to restore.
+    """
+    monkeypatch.delenv(inv.wandb.env.AGENT_DISABLE_FLAPPING, raising=False)
+
+
 def test_reference_copy_uri_default_prefix_root_matches_canonical_run_root() -> None:
     """The derived copy-source URI equals the canonical reference run root.
 

--- a/tests/tools/test_cadence_investigation_489.py
+++ b/tests/tools/test_cadence_investigation_489.py
@@ -235,6 +235,7 @@ def test_wandb_launch_disables_agent_flapping(monkeypatch: pytest.MonkeyPatch) -
 
     monkeypatch.delenv(wandb.env.AGENT_DISABLE_FLAPPING, raising=False)
     monkeypatch.setattr(inv.wandb, "sweep", lambda *a, **k: "sweep-id")
+    monkeypatch.setattr(inv, "InternalApi", lambda: _FakeSweepStateApi())
     seen: dict[str, str | None] = {}
     monkeypatch.setattr(
         inv.wandb,
@@ -245,6 +246,104 @@ def test_wandb_launch_disables_agent_flapping(monkeypatch: pytest.MonkeyPatch) -
     inv.main(["--launcher", "wandb", "--size", "2", "--only", "shuffle_probe"])
 
     assert seen["flapping"] == "true"
+
+
+class _FakeSweepStateApi:
+    """In-memory stand-in for the internal wandb API's sweep-state calls.
+
+    Mirrors the real ``set_sweep_state`` guard: writing to a sweep that is no
+    longer RUNNING/PENDING/PAUSED raises, so these tests catch an
+    implementation that writes unconditionally.
+    """
+
+    def __init__(self, state: str = "RUNNING") -> None:
+        """Start the fake sweep in ``state``.
+
+        :param state: Backend sweep state the fake reports until written to.
+        """
+        self.state = state
+
+    def get_sweep_state(
+        self, sweep: str, entity: str | None = None, project: str | None = None
+    ) -> str:
+        return self.state
+
+    def set_sweep_state(
+        self, sweep: str, state: str, entity: str | None = None, project: str | None = None
+    ) -> None:
+        if self.state not in ("RUNNING", "PENDING", "PAUSED"):
+            raise RuntimeError(f"Sweep already {self.state.lower()}.")
+        self.state = state
+
+
+def _stub_wandb_launch(monkeypatch: pytest.MonkeyPatch, fake_api: _FakeSweepStateApi) -> None:
+    """Stub sweep creation and the agent, and route state calls to ``fake_api``.
+
+    :param monkeypatch: Applies the stubs for the calling test.
+    :param fake_api: Receives every sweep-state read/write the launcher makes.
+    """
+    monkeypatch.setattr(inv.wandb, "sweep", lambda *a, **k: "sweep-id")
+    monkeypatch.setattr(inv.wandb, "agent", lambda *a, **k: None)
+    monkeypatch.setattr(inv, "InternalApi", lambda: fake_api)
+
+
+def test_wandb_launch_agent_completion_marks_sweep_finished(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After the agent returns, the still-RUNNING sweep is marked FINISHED.
+
+    The backend finalizes a sweep only when an agent heartbeat polls past grid exhaustion, which
+    the legacy agent skips on count caps and failure shutdowns, so the orchestrator must close its
+    own sweep.
+
+    :param monkeypatch: Stubs sweep/agent and routes state calls to the fake API.
+    """
+    fake = _FakeSweepStateApi(state="RUNNING")
+    _stub_wandb_launch(monkeypatch, fake)
+
+    inv.main(["--launcher", "wandb", "--size", "2", "--only", "shuffle_probe"])
+
+    assert fake.state == "FINISHED"
+
+
+def test_wandb_launch_agent_failure_still_marks_sweep_finished(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An agent that raises still leaves its sweep FINISHED, then propagates.
+
+    :param monkeypatch: Stubs sweep creation, makes the agent raise, and routes state calls to the
+        fake API.
+    """
+    fake = _FakeSweepStateApi(state="RUNNING")
+    _stub_wandb_launch(monkeypatch, fake)
+
+    def _agent_dies(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("agent crashed")
+
+    monkeypatch.setattr(inv.wandb, "agent", _agent_dies)
+
+    with pytest.raises(RuntimeError, match="agent crashed"):
+        inv.main(["--launcher", "wandb", "--size", "2", "--only", "shuffle_probe"])
+
+    assert fake.state == "FINISHED"
+
+
+def test_wandb_launch_backend_finalized_sweep_skips_state_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A sweep the backend already finalized is left untouched (no failing write).
+
+    The fake raises on any write to a terminal-state sweep, exactly like the real API, so this
+    passes only when the launcher checks before writing.
+
+    :param monkeypatch: Stubs sweep/agent and routes state calls to the fake API.
+    """
+    fake = _FakeSweepStateApi(state="FINISHED")
+    _stub_wandb_launch(monkeypatch, fake)
+
+    inv.main(["--launcher", "wandb", "--size", "2", "--only", "shuffle_probe"])
+
+    assert fake.state == "FINISHED"
 
 
 def test_local_count_caps_cells_run_per_experiment(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

Every sweep created by the #489 cadence-investigation orchestrator (`synth_setter.tools.cadence_investigation_489`) was stuck in `RUNNING` in the W&B UI, even though all its runs had already `finished`/`crashed`. Dozens of `generate_dataset_cadence_*` / `generate_dataset_shuffle_probe_*` sweeps in the `synth-setter` project showed `state=RUNNING` with a full set of terminal runs and nothing executing.

## Root cause

`_launch_wandb()` created a sweep and ran a single bounded `wandb.agent(sweep_id, count=count)`, then returned. The W&B backend transitions a sweep to `FINISHED` only when an **agent heartbeat** reports the grid exhausted. The legacy agent exits *without* that terminal heartbeat when it stops on a `count` cap or a failure/flapping shutdown — so the sweep was never closed. Since this orchestrator runs each sweep's only agent, the sweep is over once the agent returns, yet it dangled in `RUNNING` indefinitely.

## Fix

`_launch_wandb` now finalizes the sweep in a `finally` (so it also runs when the agent raises), via a new `_finish_sweep` that writes `FINISHED` through the internal W&B API. A `get_sweep_state` guard skips the write when the backend already moved the sweep off an active state, since `set_sweep_state` raises on a terminal sweep.

## Tests

- Three unit tests pin the completion, agent-failure (finalize + re-raise), and already-finalized (skip-write) paths against a `_FakeSweepStateApi` that mirrors the real API's terminal-write guard — driving the real `inv.main → _launch_wandb → _finish_sweep` path, not a mock of the SUT.
- The online e2e (`test_full_investigation_wandb_online_…`) now asserts every created sweep ends `FINISHED` via `wandb.Api().sweep(...).state`.

Fixes #1605
Refs #489
