### PR TITLE
refactor(repo-review): run full review inside one orchestrator agent

### DIFF
--- a/agent/skills/_shared/repo-review-full-analysis.md
+++ b/agent/skills/_shared/repo-review-full-analysis.md
@@ -3,10 +3,14 @@
 Shared analysis pipeline for `repo-review-full` and `repo-review-full-no-comments`.
 Both skills run the same Steps 1–6 below; only the final delivery step (post inline
 comments vs. print the report to the user) differs and lives in each skill's
-SKILL.md.
+orchestrator brief (Step 7 in the calling skill's SKILL.md).
 
-You MUST complete every step below in order, then return to the calling skill's
-SKILL.md for the final delivery step.
+"You" below is the **orchestrator agent** the calling skill spawned to run this
+whole pipeline — not the main agent, which only launches you and relays your
+result.
+
+You MUST complete every step below in order, then return to your orchestrator
+brief's Step 7 for the final delivery step.
 
 ## Step 1: Resolve the PR
 
@@ -69,7 +73,9 @@ Always run `code-health` and `synth-setter-project-standards`. Other skills opt 
 
 ## Step 4: Launch parallel review agents
 
-Launch one `general-purpose` Agent per selected skill. **All agents in a single message** so they run concurrently (an agent supports this — one message with N tool calls = N parallel agents).
+Launch one `general-purpose` Agent per selected skill. **All agents in a single message** so they run concurrently (one message with N tool calls = N parallel agents). You are an orchestrator agent yourself, so these review agents are your sub-agents.
+
+If your harness does not let a sub-agent spawn its own sub-agents, fall back to running each selected skill sequentially in your own context — invoke each `tinaudio-synth-setter-skills:<skill-name>` via the Skill tool one at a time and collect its findings. Parallel fan-out is preferred; the sequential fallback preserves correctness when nesting is unavailable.
 
 Each agent's prompt MUST include:
 
@@ -181,11 +187,11 @@ cat > /tmp/<calling-skill>-findings.json <<'JSON'
 JSON
 ```
 
-Return to the calling skill's SKILL.md for the final delivery step.
+Return to your orchestrator brief's Step 7 for the final delivery step.
 
 ## Notes
 
 - Collapsing WARNs into a single advisory section (instead of one inline thread each) is intentional signal-preservation: posting every finding as its own thread trains reviewers to ignore the whole list, which buries the rare BLOCK that actually gates the merge.
 - This pipeline depends on the `tinaudio-synth-setter-skills` plugin being enabled. If a sub-skill invocation fails, surface the error — don't silently skip. Falling back to `repo-review` (MVP) is the user's call, not the skill's.
-- Each parallel agent is a *general-purpose* sub-agent that itself invokes a plugin skill via the Skill tool. The two-level structure is intentional: the parallel fan-out is the orchestrator's contribution; each plugin skill's authoritative checklist is the source of truth for its domain.
+- The structure is three-level and intentional: the main agent spawns one orchestrator agent (you), which fans out one *general-purpose* review sub-agent per skill; each review sub-agent invokes its plugin skill via the Skill tool. The orchestration is your contribution; each plugin skill's authoritative checklist is the source of truth for its domain.
 - For the concrete invocation pattern (parallel Agent tool calls in a single message, expected per-agent prompt shape), see the example trace recorded in PR #777's review history — that's the workflow this pipeline packages.

--- a/agent/skills/_shared/repo-review-full-analysis.md
+++ b/agent/skills/_shared/repo-review-full-analysis.md
@@ -1,9 +1,11 @@
 # repo-review-full analysis steps
 
 Shared analysis pipeline for `repo-review-full` and `repo-review-full-no-comments`.
-Both skills run the same Steps 1–6 below; only the final delivery step (post inline
+`repo-review-full` runs all of Steps 1–6 below. `repo-review-full-no-comments`
+owns its own Steps 1–2 (so it can also review a local branch with no PR open) and
+delegates only Steps 3–6 here. The final delivery step (Step 7 — post inline
 comments vs. print the report to the user) differs and lives in each skill's
-orchestrator brief (Step 7 in the calling skill's SKILL.md).
+orchestrator brief.
 
 "You" below is the **orchestrator agent** the calling skill spawned to run this
 whole pipeline — not the main agent, which only launches you and relays your

--- a/agent/skills/_shared/repo-review-full-analysis.md
+++ b/agent/skills/_shared/repo-review-full-analysis.md
@@ -77,7 +77,7 @@ Always run `code-health` and `synth-setter-project-standards`. Other skills opt 
 
 Launch one `general-purpose` Agent per selected skill. **All agents in a single message** so they run concurrently (one message with N tool calls = N parallel agents). You are an orchestrator agent yourself, so these review agents are your sub-agents.
 
-If your harness does not let a sub-agent spawn its own sub-agents, fall back to running each selected skill sequentially in your own context — invoke each `tinaudio-synth-setter-skills:<skill-name>` via the Skill tool one at a time and collect its findings. Parallel fan-out is preferred; the sequential fallback preserves correctness when nesting is unavailable.
+If your harness does not let a sub-agent spawn its own sub-agents, fall back to running each selected skill sequentially in your own context — invoke each `tinaudio-synth-setter-skills:<skill-name>` via the Skill tool one at a time. The fallback must produce the *same* per-skill result as the parallel path: feed each skill the same inputs the sub-agent prompt would carry (PR number, repo, base/head SHA, file list) and capture its findings in the per-agent output contract below (BLOCK/WARN sections, each finding citing `<path>:<line>`), so Step 5 aggregation parses sequential and parallel output identically. Parallel fan-out is preferred; the sequential fallback preserves correctness when nesting is unavailable.
 
 Each agent's prompt MUST include:
 

--- a/agent/skills/repo-review-full-no-comments/SKILL.md
+++ b/agent/skills/repo-review-full-no-comments/SKILL.md
@@ -29,9 +29,10 @@ agent you launch that agent and relay its result.
 2. Spawn exactly **one** `general-purpose` agent. Its prompt is the entire
    "## Orchestrator agent brief" section below, with `<N>` substituted (or the
    "resolve the target yourself" instruction when no number was passed).
-3. The agent returns the **full rendered Markdown report** plus the sentinel
-   path it wrote. Print the report to the user verbatim (it is the human
-   deliverable) and note the sentinel path. Do not re-run the pipeline.
+3. The agent returns the **full rendered Markdown report** ending in a final
+   `Sentinel: <path>` line. Print exactly what the orchestrator returned,
+   verbatim — that trailing line already surfaces the sentinel path, so do not
+   append any narration of your own. Do not re-run the pipeline.
 
 Spawn only this one orchestrator. It launches its own parallel per-skill review
 sub-agents; you never launch those directly.
@@ -49,7 +50,10 @@ sub-agents; you never launch those directly.
 > hand.
 >
 > **PR mode.** Use this when an explicit `<N>` was passed, or when
-> `gh pr view --json number` resolves a PR for the current branch:
+> `gh pr view --json number` resolves a PR for the current branch. If no `<N>`
+> was passed, first resolve it from the current branch
+> (`N=$(gh pr view --json number -q .number)`) and use that value wherever `<N>`
+> appears below — never run the command with the literal `<N>` placeholder:
 >
 > ```bash
 > gh pr view <N> --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \

--- a/agent/skills/repo-review-full-no-comments/SKILL.md
+++ b/agent/skills/repo-review-full-no-comments/SKILL.md
@@ -89,8 +89,11 @@ sub-agents; you never launch those directly.
 > - `mergeable`, `mergeStateStatus`, `statusCheckRollup`: **not available** —
 >   Step 2 handles this.
 >
-> If there are zero changed files between `base_sha` and `head_sha`, stop and
-> return `PASS — no diff vs ${base_ref}`.
+> If there are zero changed files between `base_sha` and `head_sha`, skip Steps
+> 2–6 and go straight to Step 7's **PASS short form**: write the sentinel file
+> and return the rendered PASS report ending in `Sentinel: <path>` (note
+> `PASS — no diff vs ${base_ref}` in the report body). Do not early-return a
+> bare string — the pre-PR gate needs the sentinel on disk.
 >
 > ### Step 2: Inspect PR health
 >

--- a/agent/skills/repo-review-full-no-comments/SKILL.md
+++ b/agent/skills/repo-review-full-no-comments/SKILL.md
@@ -3,196 +3,220 @@ name: repo-review-full-no-comments
 description: |-
   Multi-skill review (same fan-out as `/repo-review-full`) that prints the
   aggregated BLOCK/WARN report to the user instead of posting inline comments
-  on GitHub. Works against either an open PR or a local branch that has not
-  been pushed yet — use it as a pre-PR gate or whenever GitHub side effects
-  are undesirable. Requires the tinaudio-synth-setter-skills plugin.
+  on GitHub. Spawns one orchestrator agent that runs the pipeline and returns
+  the rendered report. Works against either an open PR or a local branch that
+  has not been pushed yet — use it as a pre-PR gate or whenever GitHub side
+  effects are undesirable. Requires the tinaudio-synth-setter-skills plugin.
 ---
 
 # repo-review-full-no-comments — Multi-Skill Review Without Posting
 
 Same analysis as `/repo-review-full`, with two differences:
 
-1. The final delivery step renders findings inline in chat instead of
-   submitting a GitHub review.
-2. A PR is **not** required. If no PR exists for the current branch, this skill
-   reviews the local branch vs. the default branch.
+1. The final delivery step renders findings in chat instead of submitting a
+   GitHub review.
+2. A PR is **not** required. If no PR exists for the current branch, the
+   orchestrator reviews the local branch vs. the default branch.
 
-You MUST complete every step in order.
+The entire pipeline runs inside **one** spawned orchestrator agent. As the main
+agent you launch that agent and relay its result.
 
-## Step 1: Resolve the target (PR or local branch)
+## What you (the main agent) do
 
-Pick whichever mode applies. Steps 3–6 work the same once the metadata is in
-hand.
+1. Capture the target argument: if the command was invoked with an explicit
+   `<N>`, keep it; otherwise the orchestrator resolves PR-or-local-branch mode
+   itself.
+2. Spawn exactly **one** `general-purpose` agent. Its prompt is the entire
+   "## Orchestrator agent brief" section below, with `<N>` substituted (or the
+   "resolve the target yourself" instruction when no number was passed).
+3. The agent returns the **full rendered Markdown report** plus the sentinel
+   path it wrote. Print the report to the user verbatim (it is the human
+   deliverable) and note the sentinel path. Do not re-run the pipeline.
 
-**PR mode.** Use this when the caller passed an explicit `<N>`, or when
-`gh pr view --json number` resolves a PR for the current branch:
+Spawn only this one orchestrator. It launches its own parallel per-skill review
+sub-agents; you never launch those directly.
 
-```bash
-gh pr view <N> --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \
-  --json number,headRefOid,baseRefOid,files,title,headRefName,mergeable,mergeStateStatus,statusCheckRollup
-```
+## Orchestrator agent brief
 
-This is the exact call from `agent/skills/_shared/repo-review-full-analysis.md`
-Step 1 — use that file's guidance for parsing it.
-
-**Local-branch mode.** Use this when no `<N>` was passed AND
-`gh pr view --json number` fails / returns nothing for the current branch.
-Derive the same fields from local git:
-
-```bash
-base_ref=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
-base_sha=$(git merge-base HEAD "origin/${base_ref}")
-head_sha=$(git rev-parse HEAD)
-head_ref=$(git rev-parse --abbrev-ref HEAD)
-# File list with status (for tdd-refactor R-detection in Step 3)
-git diff --name-status "${base_sha}..${head_sha}"
-```
-
-Build a synthetic metadata object equivalent to the `gh pr view` JSON:
-
-- `number`: `null` — no PR yet; use the branch name in any user-facing text.
-- `headRefOid`: `head_sha`
-- `baseRefOid`: `base_sha`
-- `headRefName`: `head_ref`
-- `title`: `git log -1 --pretty=%s` (informational only).
-- `files`: parsed `git diff --name-status` output.
-- `mergeable`, `mergeStateStatus`, `statusCheckRollup`: **not available** — Step
-  2 handles this.
-
-If there are zero changed files between `base_sha` and `head_sha`, stop and
-reply `PASS — no diff vs ${base_ref}`.
-
-## Step 2: Inspect PR health
-
-**PR mode.** Follow `agent/skills/_shared/repo-review-full-analysis.md` Step 2
-exactly as written (merge conflicts + failing checks).
-
-**Local-branch mode.** Skip the GitHub-side `mergeable` and `statusCheckRollup`
-checks — they don't exist pre-PR. Do not synthesize PR-health BLOCKs and do not
-emit a `## PR health` section in Step 6's JSON. Instead, Step 6 prepends a
-one-line caveat to the `review_body` so the user knows merge/CI health was not
-verified.
-
-## Steps 3–6: Run the shared analysis pipeline
-
-Read and follow `agent/skills/_shared/repo-review-full-analysis.md` Steps 3
-through 6 using the metadata from Step 1 above. The shared file owns skill
-selection, the parallel fan-out, finding aggregation, and the findings-JSON
-construction; it is mode-agnostic.
-
-When the shared file says "the calling skill," that's this skill:
-
-- Use `repo-review-full-no-comments` as the calling-skill name in any
-  `[<calling-skill>:block]` prefixes inside the `## PR health` bullets (PR mode
-  only — local-branch mode has no PR-health bullets).
-
-- Write the findings JSON to `/tmp/repo-review-full-no-comments-findings.json`.
-
-- For `pr_number` in the JSON: use the resolved PR number in PR mode, or
-  `null` in local-branch mode. Do not place branch names in `pr_number`; keep
-  branch/target details in `review_body` and, if the shared JSON builder
-  supports it, a separate metadata field such as `target`.
-
-- Phrase the `review_body` lead-in to reflect what was reviewed and that
-  nothing was posted. In PR mode, write:
-
-  > Multi-skill dry-run review of PR #\<N> — \<K> parallel passes (\<list of skills>). Findings below; no inline comments posted.
-
-  In local-branch mode, write:
-
-  > Multi-skill dry-run review of branch \<head_ref> vs \<base_ref> (no PR yet) — \<K> parallel passes (\<list of skills>). Findings below; no inline comments posted. Merge/CI health not checked — rerun after opening the PR for that.
-
-Return here once Step 6 has produced the JSON payload on disk.
-
-## Step 7: Render the findings — write the sentinel file **and** print to chat
-
-Do NOT invoke `post_review.py`. Do NOT call any `gh api .../reviews` or
-`gh pr review` command. This skill has zero GitHub side effects.
-
-Transform the JSON payload at `/tmp/repo-review-full-no-comments-findings.json`
-into a Markdown report. The report is **both** printed to chat (human
-delivery surface) **and** written to a sentinel file. The
-`pre-pr-review-gate.sh` PreToolUse hook validates the path supplied via
-`REVIEW_FULL=<path>` on `gh pr create` by parsing this filename.
-
-**Compute the sentinel path** — the format is owned by
-`agent/_shared/review_sentinel.py` (single source of truth shared with the
-gate hook):
-
-```bash
-REVIEW_PATH=$(python3 agent/_shared/review_sentinel.py path "$(git rev-parse HEAD)")
-mkdir -p "$(dirname "$REVIEW_PATH")"
-```
-
-The result is of the form
-`.agent-reviews/repo-review-full-no-comments.<40-char-sha>.md`. **Do not
-hand-write the filename** — always go through the helper.
-
-**Write the report to `$REVIEW_PATH` and print the same content to chat**,
-using this layout:
-
-```markdown
-# repo-review-full-no-comments — <target>
-
-<review_body verbatim, including the `## PR health` section if present>
-
-## Inline findings (would be posted by `/repo-review-full`)
-
-### `<path>`
-- **L<line>** — <body>
-- **L<line>** — <body>
-
-### `<other path>`
-- **L<line>** — <body>
-
-## Summary
-
-- B BLOCK, W WARN across K skills
-- PR-health flags: <M merge-conflict / F failing-check>  (omit if zero or in local-branch mode)
-- Reviewed at: <full-sha-from-git-rev-parse-HEAD>
-- <next-step tip>
-```
-
-For `<target>` in the header, use `PR #<N>` in PR mode or
-`branch <head_ref>` in local-branch mode.
-
-For `<next-step tip>` in the Summary section, use (substitute
-`<REVIEW_PATH>` with the actual path computed above before printing — do
-not emit the literal placeholder):
-
-- PR mode: `Run /repo-review-full <N> to post these as inline review comments.`
-- Local-branch mode: `Open a PR with REVIEW_FULL=<REVIEW_PATH> in the command. Then run /repo-review-full to post these as inline review comments if desired.`
-
-Rules for the rendering:
-
-- Group inline findings by `path`, then list each finding as `**L<line>** — <body>`.
-  Use the same `body` text you put into the JSON (`**[<short-tag>:<severity>]** <description>`).
-
-- Preserve the PR-health bullets from `review_body` verbatim — they are
-  important for human reviewers and easy to lose if you re-summarize.
-
-- **PASS short form.** If the JSON has no findings AND no PR-health flags,
-  still write the sentinel file. The gate's size guard rejects files under
-  200 bytes, and the header + `PASS` line + `Reviewed at:` line are
-  ~130 bytes — pad with a one-line context summary so the total is ≥200
-  bytes. Use this exact template (substitute `<target>` and `<sha>`):
-
-  ```markdown
-  # repo-review-full-no-comments — <target>
-
-  PASS — no findings across all skills (code-health, comment-hygiene,
-  python-style, shell-style, synth-setter, tdd-impl, ml-test).
-
-  ## Summary
-
-  - 0 BLOCK, 0 WARN
-  - Reviewed at: <sha>
-  ```
-
-  Print the same content to chat.
-
-- The sentinel file is the gate's contract; the chat output is the human
-  deliverable. Always produce both.
+> You are the orchestrator for a multi-skill dry-run PR review that posts
+> nothing to GitHub. Complete every step in order and do not stop early. "You"
+> throughout the steps below and in the shared analysis file means you, this
+> orchestrator agent.
+>
+> ### Step 1: Resolve the target (PR or local branch)
+>
+> Pick whichever mode applies. Steps 3–6 work the same once the metadata is in
+> hand.
+>
+> **PR mode.** Use this when an explicit `<N>` was passed, or when
+> `gh pr view --json number` resolves a PR for the current branch:
+>
+> ```bash
+> gh pr view <N> --repo "$(gh repo view --json nameWithOwner -q .nameWithOwner)" \
+>   --json number,headRefOid,baseRefOid,files,title,headRefName,mergeable,mergeStateStatus,statusCheckRollup
+> ```
+>
+> This is the exact call from `agent/skills/_shared/repo-review-full-analysis.md`
+> Step 1 — use that file's guidance for parsing it.
+>
+> **Local-branch mode.** Use this when no `<N>` was passed AND
+> `gh pr view --json number` fails / returns nothing for the current branch.
+> Derive the same fields from local git:
+>
+> ```bash
+> base_ref=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+> base_sha=$(git merge-base HEAD "origin/${base_ref}")
+> head_sha=$(git rev-parse HEAD)
+> head_ref=$(git rev-parse --abbrev-ref HEAD)
+> # File list with status (for tdd-refactor R-detection in Step 3)
+> git diff --name-status "${base_sha}..${head_sha}"
+> ```
+>
+> Build a synthetic metadata object equivalent to the `gh pr view` JSON:
+>
+> - `number`: `null` — no PR yet; use the branch name in any user-facing text.
+> - `headRefOid`: `head_sha`
+> - `baseRefOid`: `base_sha`
+> - `headRefName`: `head_ref`
+> - `title`: `git log -1 --pretty=%s` (informational only).
+> - `files`: parsed `git diff --name-status` output.
+> - `mergeable`, `mergeStateStatus`, `statusCheckRollup`: **not available** —
+>   Step 2 handles this.
+>
+> If there are zero changed files between `base_sha` and `head_sha`, stop and
+> return `PASS — no diff vs ${base_ref}`.
+>
+> ### Step 2: Inspect PR health
+>
+> **PR mode.** Follow `agent/skills/_shared/repo-review-full-analysis.md` Step 2
+> exactly as written (merge conflicts + failing checks).
+>
+> **Local-branch mode.** Skip the GitHub-side `mergeable` and
+> `statusCheckRollup` checks — they don't exist pre-PR. Do not synthesize
+> PR-health BLOCKs and do not emit a `## PR health` section in Step 6's JSON.
+> Instead, Step 6 prepends a one-line caveat to the `review_body` so the user
+> knows merge/CI health was not verified.
+>
+> ### Steps 3–6: Run the shared analysis pipeline
+>
+> Read and follow `agent/skills/_shared/repo-review-full-analysis.md` Steps 3
+> through 6 using the metadata from Step 1 above. The shared file owns skill
+> selection, the parallel fan-out, finding aggregation, and the findings-JSON
+> construction; it is mode-agnostic. When it says "the calling skill," that is
+> `repo-review-full-no-comments`:
+>
+> - Use `repo-review-full-no-comments` as the calling-skill name in any
+>   `[<calling-skill>:block]` prefixes inside the `## PR health` bullets (PR mode
+>   only — local-branch mode has no PR-health bullets).
+>
+> - Write the findings JSON to `/tmp/repo-review-full-no-comments-findings.json`.
+>
+> - For `pr_number` in the JSON: use the resolved PR number in PR mode, or
+>   `null` in local-branch mode. Do not place branch names in `pr_number`; keep
+>   branch/target details in `review_body` and, if the shared JSON builder
+>   supports it, a separate metadata field such as `target`.
+>
+> - Phrase the `review_body` lead-in to reflect what was reviewed and that
+>   nothing was posted. In PR mode, write:
+>
+>   > Multi-skill dry-run review of PR #\<N> — \<K> parallel passes (\<list of skills>). Findings below; no inline comments posted.
+>
+>   In local-branch mode, write:
+>
+>   > Multi-skill dry-run review of branch \<head_ref> vs \<base_ref> (no PR yet) — \<K> parallel passes (\<list of skills>). Findings below; no inline comments posted. Merge/CI health not checked — rerun after opening the PR for that.
+>
+> ### Step 7: Render the findings — write the sentinel file **and** return the report
+>
+> Do NOT invoke `post_review.py`. Do NOT call any `gh api .../reviews` or
+> `gh pr review` command. This step has zero GitHub side effects.
+>
+> Transform the JSON payload at
+> `/tmp/repo-review-full-no-comments-findings.json` into a Markdown report. The
+> report is **both** written to a sentinel file **and** returned as your final
+> message (the main agent prints it for the user). The `pre-pr-review-gate.sh`
+> PreToolUse hook validates the path supplied via `REVIEW_FULL=<path>` on
+> `gh pr create` by parsing this filename.
+>
+> **Compute the sentinel path** — the format is owned by
+> `agent/_shared/review_sentinel.py` (single source of truth shared with the
+> gate hook):
+>
+> ```bash
+> REVIEW_PATH=$(python3 agent/_shared/review_sentinel.py path "$(git rev-parse HEAD)")
+> mkdir -p "$(dirname "$REVIEW_PATH")"
+> ```
+>
+> The result is of the form
+> `.agent-reviews/repo-review-full-no-comments.<40-char-sha>.md`. **Do not
+> hand-write the filename** — always go through the helper.
+>
+> **Write the report to `$REVIEW_PATH`** using this layout:
+>
+> ```markdown
+> # repo-review-full-no-comments — <target>
+>
+> <review_body verbatim, including the `## PR health` section if present>
+>
+> ## Inline findings (would be posted by `/repo-review-full`)
+>
+> ### `<path>`
+> - **L<line>** — <body>
+> - **L<line>** — <body>
+>
+> ### `<other path>`
+> - **L<line>** — <body>
+>
+> ## Summary
+>
+> - B BLOCK, W WARN across K skills
+> - PR-health flags: <M merge-conflict / F failing-check>  (omit if zero or in local-branch mode)
+> - Reviewed at: <full-sha-from-git-rev-parse-HEAD>
+> - <next-step tip>
+> ```
+>
+> For `<target>` in the header, use `PR #<N>` in PR mode or
+> `branch <head_ref>` in local-branch mode.
+>
+> For `<next-step tip>` in the Summary section, use (substitute
+> `<REVIEW_PATH>` with the actual path computed above — do not emit the literal
+> placeholder):
+>
+> - PR mode: `Run /repo-review-full <N> to post these as inline review comments.`
+> - Local-branch mode: `Open a PR with REVIEW_FULL=<REVIEW_PATH> in the command. Then run /repo-review-full to post these as inline review comments if desired.`
+>
+> Rules for the rendering:
+>
+> - Group inline findings by `path`, then list each finding as `**L<line>** — <body>`.
+>   Use the same `body` text you put into the JSON (`**[<short-tag>:<severity>]** <description>`).
+>
+> - Preserve the PR-health bullets from `review_body` verbatim — they are
+>   important for human reviewers and easy to lose if you re-summarize.
+>
+> - **PASS short form.** If the JSON has no findings AND no PR-health flags,
+>   still write the sentinel file. The gate's size guard rejects files under
+>   200 bytes, and the header + `PASS` line + `Reviewed at:` line are
+>   ~130 bytes — pad with a one-line context summary so the total is ≥200
+>   bytes. Use this exact template (substitute `<target>` and `<sha>`):
+>
+>   ```markdown
+>   # repo-review-full-no-comments — <target>
+>
+>   PASS — no findings across all skills (code-health, comment-hygiene,
+>   python-style, shell-style, synth-setter, tdd-impl, ml-test).
+>
+>   ## Summary
+>
+>   - 0 BLOCK, 0 WARN
+>   - Reviewed at: <sha>
+>   ```
+>
+> - The sentinel file is the gate's contract; your returned report is the human
+>   deliverable. Always produce both.
+>
+> **Return value.** Reply with the full Markdown report (the exact content you
+> wrote to the sentinel) followed by a final line: `Sentinel: <REVIEW_PATH>`.
+> The main agent prints the report and surfaces the path. Return the rendered
+> report as data — do not summarize or re-narrate it.
 
 ## Notes
 

--- a/agent/skills/repo-review-full-no-comments/SKILL.md
+++ b/agent/skills/repo-review-full-no-comments/SKILL.md
@@ -27,8 +27,10 @@ agent you launch that agent and relay its result.
    `<N>`, keep it; otherwise the orchestrator resolves PR-or-local-branch mode
    itself.
 2. Spawn exactly **one** `general-purpose` agent. Its prompt is the entire
-   "## Orchestrator agent brief" section below, with `<N>` substituted (or the
-   "resolve the target yourself" instruction when no number was passed).
+   "## Orchestrator agent brief" section below. Only substitute when an explicit
+   `<N>` was passed — replace `<N>` with that number; otherwise pass the brief
+   verbatim (Step 1 of the brief already resolves PR-or-local-branch mode). Do
+   not otherwise edit the brief.
 3. The agent returns the **full rendered Markdown report** ending in a final
    `Sentinel: <path>` line. Print exactly what the orchestrator returned,
    verbatim — that trailing line already surfaces the sentinel path, so do not

--- a/agent/skills/repo-review-full/SKILL.md
+++ b/agent/skills/repo-review-full/SKILL.md
@@ -1,60 +1,81 @@
 ---
 name: repo-review-full
 description: |-
-  Full multi-skill PR review. Fans out one parallel agent per applicable plugin
-  checklist (selection rules in the shared analysis file) and posts every
-  diff-anchored BLOCK/WARN as an individual unresolved inline PR review comment;
-  non-diff findings (merge conflicts, failing checks) go in a `## PR health`
-  section in the review body. Requires the tinaudio-synth-setter-skills plugin.
+  Full multi-skill PR review. Spawns one orchestrator agent that fans out a
+  parallel agent per applicable plugin checklist (selection rules in the shared
+  analysis file) and posts every diff-anchored BLOCK/WARN as an individual
+  unresolved inline PR review comment; non-diff findings (merge conflicts,
+  failing checks) go in a `## PR health` section in the review body. Requires
+  the tinaudio-synth-setter-skills plugin.
 ---
 
 # repo-review-full — Multi-Skill Parallel PR Review
 
-You MUST complete every step in order.
+The entire pipeline runs inside **one** spawned orchestrator agent. As the main
+agent you launch that agent and relay its result — you do NOT resolve the PR,
+fan out the reviews, aggregate findings, or call `post_review.py` yourself.
 
-## Steps 1–6: Run the shared analysis pipeline
+## What you (the main agent) do
 
-Read and follow `agent/skills/_shared/repo-review-full-analysis.md` Steps 1
-through 6. That file owns PR resolution, PR-health inspection, skill selection,
-the parallel fan-out, finding aggregation, and the findings-JSON construction.
+1. Capture the PR argument: if the command was invoked with an explicit `<N>`,
+   keep it; otherwise the orchestrator resolves the PR from the current branch.
+2. Spawn exactly **one** `general-purpose` agent. Its prompt is the entire
+   "## Orchestrator agent brief" section below, with `<N>` substituted (or the
+   "resolve from the current branch" instruction when no number was passed).
+3. Relay the agent's returned `html_url` and one-line summary to the user
+   verbatim. Do not re-run or second-guess the pipeline.
 
-When the shared file says "the calling skill," that's this skill:
+Spawn only this one orchestrator. It launches its own parallel per-skill review
+sub-agents; you never launch those directly.
 
-- Use `repo-review-full` as the calling-skill name in any `[<calling-skill>:block]`
-  prefixes inside the `## PR health` bullets.
-- Write the findings JSON to `/tmp/repo-review-full-findings.json`.
-- Phrase the `review_body` lead-in to reflect that every BLOCK/WARN is being
-  posted as an unresolved inline thread (sample wording is already in the
-  shared file).
-- Set the top-level `"event"` field in the JSON payload: `REQUEST_CHANGES` if
-  any finding is a BLOCK (any `[*:block]`, including the folded PR-health
-  BLOCKs), else `COMMENT` if any WARN exists, else `APPROVE`. The self-review
-  COMMENT fallback (when the bot is the PR author) is automatic in
-  `post_review.py`.
+## Orchestrator agent brief
 
-Return here once Step 6 has produced the JSON payload on disk.
-
-## Step 7: Submit the review
-
-```bash
-python3 agent/skills/_shared/post_review.py < /tmp/repo-review-full-findings.json
-```
-
-`post_review.py`:
-
-- Anchors each finding to its target line if that line falls inside a diff hunk.
-- Falls back to the nearest in-hunk line on the same file with a cross-ref note prepended to the body.
-- Rolls orphan findings (file outside the diff) into the review body under `## Findings on files outside the diff`.
-- Submits with the payload's `event` (REQUEST_CHANGES / COMMENT / APPROVE). On a self-review 422 (the bot is the PR author) it retries once as `event=COMMENT` with an event-aware intent banner prepended — `⛔ N BLOCKING finding(s) — changes required` for a REQUEST_CHANGES downgrade, `✅ No findings` for an APPROVE downgrade — so the original intent stays visible. Threads stay unresolved.
-
-Report the helper's `html_url` back to the user along with a one-line summary (`Posted N findings: B BLOCK + W WARN across K skills; PR-health flags: <M merge-conflict / F failing-check>`). If PR-health found nothing, drop the trailing `; PR-health flags: ...` clause.
+> You are the orchestrator for a full multi-skill PR review. Complete every step
+> in order and do not stop early. "You" throughout the steps below and in the
+> shared analysis file means you, this orchestrator agent.
+>
+> **Steps 1–6 — run the shared analysis pipeline.** Read and follow
+> `agent/skills/_shared/repo-review-full-analysis.md` Steps 1 through 6. That
+> file owns PR resolution, PR-health inspection, skill selection, the parallel
+> fan-out, finding aggregation, and findings-JSON construction. When it says
+> "the calling skill," that is `repo-review-full`:
+>
+> - PR number: `<N>` (or resolve via `gh pr view --json number`).
+> - Use `repo-review-full` as the calling-skill name in any
+>   `[<calling-skill>:block]` prefixes inside the `## PR health` bullets.
+> - Write the findings JSON to `/tmp/repo-review-full-findings.json`.
+> - Phrase the `review_body` lead-in so every BLOCK/WARN reads as being posted
+>   as an unresolved inline thread (sample wording is in the shared file).
+> - Set the top-level `"event"` field: `REQUEST_CHANGES` if any finding is a
+>   BLOCK (any `[*:block]`, including folded PR-health BLOCKs), else `COMMENT`
+>   if any WARN exists, else `APPROVE`. The self-review COMMENT fallback (when
+>   the bot is the PR author) is automatic in `post_review.py`.
+>
+> **Step 7 — submit the review.**
+>
+> ```bash
+> python3 agent/skills/_shared/post_review.py < /tmp/repo-review-full-findings.json
+> ```
+>
+> `post_review.py`:
+>
+> - Anchors each finding to its target line if that line falls inside a diff hunk.
+> - Falls back to the nearest in-hunk line on the same file with a cross-ref note prepended to the body.
+> - Rolls orphan findings (file outside the diff) into the review body under `## Findings on files outside the diff`.
+> - Submits with the payload's `event` (REQUEST_CHANGES / COMMENT / APPROVE). On a self-review 422 (the bot is the PR author) it retries once as `event=COMMENT` with an event-aware intent banner prepended — `⛔ N BLOCKING finding(s) — changes required` for a REQUEST_CHANGES downgrade, `✅ No findings` for an APPROVE downgrade — so the original intent stays visible. Threads stay unresolved.
+>
+> **Return value.** Reply with ONLY the helper's `html_url` and a one-line
+> summary: `Posted N findings: B BLOCK + W WARN across K skills; PR-health flags: <M merge-conflict / F failing-check>`. If PR-health found nothing,
+> drop the trailing `; PR-health flags: ...` clause. This text is the main
+> agent's deliverable — return data, not narration.
 
 ## When to use the no-comments sibling instead
 
-`/repo-review-full-no-comments` runs the same analysis pipeline (delegating
-Steps 3–6 to the shared file; it owns Steps 1–2 itself so it can also run
-against a local branch with no PR open) but prints the aggregated report to
-the user instead of posting inline comments. Reach for it when you want a
-local dry-run of the review (no GitHub side effects), as a pre-PR gate before
-the branch is pushed, when you're iterating on a PR before it's ready for
-reviewers, or when posting publicly is undesirable for any reason.
+`/repo-review-full-no-comments` runs the same analysis pipeline through its own
+orchestrator agent (delegating Steps 3–6 to the shared file; it owns Steps 1–2
+itself so it can also run against a local branch with no PR open) but prints the
+aggregated report to the user instead of posting inline comments. Reach for it
+when you want a local dry-run of the review (no GitHub side effects), as a
+pre-PR gate before the branch is pushed, when you're iterating on a PR before
+it's ready for reviewers, or when posting publicly is undesirable for any
+reason.

--- a/agent/skills/repo-review-full/SKILL.md
+++ b/agent/skills/repo-review-full/SKILL.md
@@ -20,8 +20,10 @@ fan out the reviews, aggregate findings, or call `post_review.py` yourself.
 1. Capture the PR argument: if the command was invoked with an explicit `<N>`,
    keep it; otherwise the orchestrator resolves the PR from the current branch.
 2. Spawn exactly **one** `general-purpose` agent. Its prompt is the entire
-   "## Orchestrator agent brief" section below, with `<N>` substituted (or the
-   "resolve from the current branch" instruction when no number was passed).
+   "## Orchestrator agent brief" section below. Only substitute when an explicit
+   `<N>` was passed — replace `<N>` with that number; otherwise pass the brief
+   verbatim (it already tells the orchestrator to resolve the PR from the
+   current branch). Do not otherwise edit the brief.
 3. Relay the agent's returned `html_url` and one-line summary to the user
    verbatim. Do not re-run or second-guess the pipeline.
 
@@ -40,7 +42,11 @@ sub-agents; you never launch those directly.
 > fan-out, finding aggregation, and findings-JSON construction. When it says
 > "the calling skill," that is `repo-review-full`:
 >
-> - PR number: `<N>` (or resolve via `gh pr view --json number`).
+> - PR number: `<N>`. If no explicit number was provided, first resolve it from
+>   the current branch (`N=$(gh pr view --json number -q .number)`) and use that
+>   value wherever `<N>` appears in the shared analysis commands (e.g.
+>   `gh pr view <N> ...`) — never run a command with the literal `<N>`
+>   placeholder.
 > - Use `repo-review-full` as the calling-skill name in any
 >   `[<calling-skill>:block]` prefixes inside the `## PR health` bullets.
 > - Write the findings JSON to `/tmp/repo-review-full-findings.json`.


### PR DESCRIPTION
## What

Restructure the `repo-review-full` and `repo-review-full-no-comments` skills so the **main agent spawns exactly one `general-purpose` orchestrator agent** that runs the end-to-end review pipeline — PR resolution, PR-health inspection, skill selection, the parallel per-skill review fan-out, finding aggregation, findings-JSON construction, and posting/rendering — then relays the orchestrator's result.

Previously the main agent ran all of that inline and only delegated the per-skill checklist reviews to parallel agents. The orchestration, assembly, and posting consumed the main agent's context; now the main agent just launches one agent and reports its result.

## Why

Keeps the main agent's context clean: for `repo-review-full` it relays the posted review's `html_url` + one-line summary; for `repo-review-full-no-comments` it prints the report the orchestrator returns. The whole "orchestrate the reviews and assemble/post" responsibility moves into agent calls.

## Changes

- `agent/skills/repo-review-full/SKILL.md` — thin launcher + an "Orchestrator agent brief" (Steps 1–6 via the shared file, Step 7 = `post_review.py`) handed to the spawned agent verbatim.
- `agent/skills/repo-review-full-no-comments/SKILL.md` — same launcher shape; the orchestrator writes the sentinel file and returns the full rendered report for the main agent to print. Keeps PR-mode and local-branch mode.
- `agent/skills/_shared/repo-review-full-analysis.md` — reframed so "you" is the orchestrator agent; Step 4 gains a sequential fallback for harnesses that disallow nested agents; the three-level structure (main → orchestrator → review sub-agents) is documented.

## Unchanged contracts

The sentinel format (`agent/_shared/review_sentinel.py`), `post_review.py`, the findings-JSON shape, skill-selection rules, and the BLOCK-inline / WARN-collapsed routing are all unchanged.

## Validation

Dogfooded the new design: ran `/repo-review-full-no-comments` against this branch by spawning a single orchestrator agent per the new brief. It successfully fanned out two parallel review sub-agents (code-health + synth-setter-project-standards), confirming nested agents work in this harness, wrote a valid gate sentinel, and returned 0 BLOCK / 3 advisory WARN (all deliberate design choices).

Refs #1615
Part of #372