### PR TITLE
refactor(pipeline): centralize rclone reliability flags in one builder

### DIFF
--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -203,28 +203,17 @@ def _unsupported_cadence_reason(render_cfg: DictConfig) -> str | None:
 
 
 def _rclone_copy(src: str, dest: str) -> None:
-    """Upload a file to R2 via rclone with checksum verification.
+    """Upload a file to R2 via ``rclone copy`` with the shared reliability flags.
 
-    Connection-level timeouts and retries are rclone's job, not ours:
-      --contimeout=30s   bound the TCP connect phase
-      --timeout=300s     bound any single HTTP request (PUT, list, etc.)
-      --retries=3        retry the whole copy on transient failure
-      -vv                emit per-request debug log so a failure leaves
-                         actionable evidence in the worker stdout
-    A non-zero rclone exit raises CalledProcessError and the run fails — we
-    do not silently accept partial uploads behind a Python wall-clock.
+    Connect/IO timeouts and retries come from :func:`r2_io._rclone_argv`, so a
+    transient blip retries instead of leaving a partial upload behind a Python
+    wall-clock. A non-zero rclone exit raises ``CalledProcessError`` and the run
+    fails.
+
+    :param src: Local source path passed to rclone verbatim.
+    :param dest: R2 destination passed to rclone verbatim.
     """
-    args = [  # noqa: S607 — rclone resolved by the image's PATH
-        "rclone",
-        "copy",
-        "-vv",
-        "--checksum",
-        "--contimeout=30s",
-        "--timeout=300s",
-        "--retries=3",
-        src,
-        dest,
-    ]
+    args = r2_io._rclone_argv("copy", src, dest)
     subprocess.check_call(args)  # noqa: S603 — args from validated spec
     # Distinct sentinel so we can grep CI logs for "rclone returned" and tell
     # at a glance whether the rclone subprocess actually exited (vs. hanging

--- a/src/synth_setter/pipeline/r2_io.py
+++ b/src/synth_setter/pipeline/r2_io.py
@@ -66,6 +66,31 @@ _R2_STRUCTURAL_DEFAULTS: dict[str, str] = {
 _UPLOAD_DIR_TIMEOUT = "3h"
 
 
+def _rclone_argv(verb: str, *operands: str, timeout: str = "300s") -> list[str]:
+    """Build an rclone argv with the shared reliability-flag block, then operands.
+
+    Centralizes ``-vv --checksum --contimeout=30s --timeout=<timeout> --retries=3``
+    so every transfer helper retries transient blips identically. ``--timeout`` is
+    the IO idle timeout, not a wall-clock cap; only directory uploads widen it past
+    the 300s single-file default.
+
+    :param verb: rclone subcommand (``copy`` / ``copyto``).
+    :param *operands: Source/destination args appended verbatim after the flags.
+    :param timeout: Value for ``--timeout`` (IO idle timeout).
+    :returns: The full ``["rclone", verb, ...flags, *operands]`` argv list.
+    """
+    return [
+        "rclone",
+        verb,
+        "-vv",
+        "--checksum",
+        "--contimeout=30s",
+        f"--timeout={timeout}",
+        "--retries=3",
+        *operands,
+    ]
+
+
 def ensure_r2_env_loaded(env_file: Path | None = None) -> None:
     """Load ``RCLONE_CONFIG_R2_*`` from ``env_file`` into ``os.environ``; validate.
 
@@ -225,18 +250,7 @@ def download_dir_no_overwrite(r2_uri: str, dest_path: Path) -> None:
     :param r2_uri: ``r2://`` directory prefix; every object beneath it is copied.
     :param dest_path: Local destination directory, created by rclone if absent.
     """
-    args = [  # noqa: S607 — rclone resolved by image's PATH
-        "rclone",
-        "copy",
-        "-vv",
-        "--immutable",
-        "--checksum",
-        "--contimeout=30s",
-        "--timeout=300s",
-        "--retries=3",
-        _to_rclone_path(r2_uri),
-        str(dest_path),
-    ]
+    args = _rclone_argv("copy", "--immutable", _to_rclone_path(r2_uri), str(dest_path))
     subprocess.check_call(args)  # noqa: S603 — args from validated URI
 
 
@@ -249,17 +263,7 @@ def download_to_path(r2_uri: str, dest_path: Path) -> None:
     helpers so a transient blip on the per-shard copy-source fetch retries
     instead of failing the render outright.
     """
-    args = [  # noqa: S607 — rclone resolved by image's PATH
-        "rclone",
-        "copyto",
-        "-vv",
-        "--checksum",
-        "--contimeout=30s",
-        "--timeout=300s",
-        "--retries=3",
-        _to_rclone_path(r2_uri),
-        str(dest_path),
-    ]
+    args = _rclone_argv("copyto", _to_rclone_path(r2_uri), str(dest_path))
     subprocess.check_call(args)  # noqa: S603 — args from validated URI
 
 
@@ -271,17 +275,7 @@ def upload_to_uri(local_path: Path, r2_uri: str) -> None:
     and the per-request timeout, retries the whole copy on transient failure, and emits per-request
     debug logs so a CI failure leaves actionable evidence in stdout.
     """
-    args = [  # noqa: S607 — rclone resolved by image's PATH
-        "rclone",
-        "copyto",
-        "-vv",
-        "--checksum",
-        "--contimeout=30s",
-        "--timeout=300s",
-        "--retries=3",
-        str(local_path),
-        _to_rclone_path(r2_uri),
-    ]
+    args = _rclone_argv("copyto", str(local_path), _to_rclone_path(r2_uri))
     subprocess.check_call(args)  # noqa: S603 — args from validated URI
 
 
@@ -301,17 +295,9 @@ def upload_dir(local_dir: Path, r2_uri: str) -> None:
         ``r2_uri`` (the directory itself is not nested under its own name).
     :param r2_uri: ``r2://`` destination prefix; created implicitly by rclone.
     """
-    args = [  # noqa: S607 — rclone resolved by image's PATH
-        "rclone",
-        "copy",
-        "-vv",
-        "--checksum",
-        "--contimeout=30s",
-        f"--timeout={_UPLOAD_DIR_TIMEOUT}",
-        "--retries=3",
-        str(local_dir),
-        _to_rclone_path(r2_uri),
-    ]
+    args = _rclone_argv(
+        "copy", str(local_dir), _to_rclone_path(r2_uri), timeout=_UPLOAD_DIR_TIMEOUT
+    )
     subprocess.check_call(args)  # noqa: S603 — args from validated URI
 
 
@@ -337,17 +323,7 @@ def upload(source: str | Path, destination_uri: str) -> None:
             f"so the source-type dispatch is unambiguous."
         )
     if isinstance(source, str) and is_r2_uri(source):
-        args = [  # noqa: S607 — rclone resolved by image's PATH
-            "rclone",
-            "copyto",
-            "-vv",
-            "--checksum",
-            "--contimeout=30s",
-            "--timeout=300s",
-            "--retries=3",
-            _to_rclone_path(source),
-            _to_rclone_path(destination_uri),
-        ]
+        args = _rclone_argv("copyto", _to_rclone_path(source), _to_rclone_path(destination_uri))
         subprocess.check_call(args)  # noqa: S603 — args from validated URIs
         return
     upload_to_uri(Path(source), destination_uri)

--- a/src/synth_setter/pipeline/r2_io.py
+++ b/src/synth_setter/pipeline/r2_io.py
@@ -75,7 +75,8 @@ def _rclone_argv(verb: str, *operands: str, timeout: str = "300s") -> list[str]:
     the 300s single-file default.
 
     :param verb: rclone subcommand (``copy`` / ``copyto``).
-    :param *operands: Source/destination args appended verbatim after the flags.
+    :param \\*operands: Per-call args (extra flags like ``--immutable`` plus the
+        source/destination paths) appended verbatim after the shared flags.
     :param timeout: Value for ``--timeout`` (IO idle timeout).
     :returns: The full ``["rclone", verb, ...flags, *operands]`` argv list.
     """

--- a/tests/pipeline/test_r2_io.py
+++ b/tests/pipeline/test_r2_io.py
@@ -60,6 +60,38 @@ class TestToRclonePath:
             r2_io._to_rclone_path("local-spec.json")
 
 
+class TestRcloneArgv:
+    """Tests for _rclone_argv — the centralized reliability-flag builder."""
+
+    def test_default_timeout_emits_full_reliability_flag_set(self) -> None:
+        """The default builder pins the verb, reliability flags, then operands in order."""
+        assert r2_io._rclone_argv("copyto", "r2:bucket/key", "dest/file") == [
+            "rclone",
+            "copyto",
+            "-vv",
+            "--checksum",
+            "--contimeout=30s",
+            "--timeout=300s",
+            "--retries=3",
+            "r2:bucket/key",
+            "dest/file",
+        ]
+
+    def test_custom_timeout_widens_only_the_io_timeout(self) -> None:
+        """A non-default timeout (the dir-upload 3h) lands on ``--timeout`` alone."""
+        assert r2_io._rclone_argv("copy", "src/dir", "r2:bucket/p", timeout="3h") == [
+            "rclone",
+            "copy",
+            "-vv",
+            "--checksum",
+            "--contimeout=30s",
+            "--timeout=3h",
+            "--retries=3",
+            "src/dir",
+            "r2:bucket/p",
+        ]
+
+
 class TestToS3Uri:
     """Tests for to_s3_uri — r2:// → s3:// scheme rewrite for W&B references."""
 


### PR DESCRIPTION
Centralize the duplicated rclone reliability-flag block (`-vv --checksum --contimeout=30s --timeout=<t> --retries=3`) into one private `_rclone_argv(verb, *operands, timeout="300s")` builder in `r2_io.py`, and route all five transfer helpers plus `generate_dataset._rclone_copy` through it. Behavior-preserving: each call site keeps its verb (copy/copyto), operand order, `download_dir_no_overwrite`'s `--immutable`, and `upload_dir`'s wider 3h `_UPLOAD_DIR_TIMEOUT` (via the `timeout` param).

Refs #1614