### PR TITLE
internal-fix(data-pipeline): launch all cadence sweeps independently

### DIFF
--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -527,14 +527,15 @@ def run_investigation(
     :param count: Per-experiment cell cap (``None`` runs every grid cell).
     :param max_parallel: Maximum wandb agents running at once (ignored by ``local``).
     :raises ValueError: ``launcher`` is not ``"wandb"``/``"local"``, ``only`` names
-        an unknown experiment, ``count`` is set below 1, or ``max_parallel`` is below 1
-        (caps that would silently run nothing).
+        an unknown experiment, ``count`` is set below 1, or the wandb launcher gets a
+        ``max_parallel`` below 1 (caps that would silently run nothing).
     """
     if launcher not in ("wandb", "local"):
         raise ValueError(f"launcher must be 'wandb' or 'local', got {launcher!r}")
     if count is not None and count < 1:
         raise ValueError(f"count must be >= 1 when set, got {count}")
-    if max_parallel < 1:
+    # max_parallel only governs the wandb agent pool; the local launcher ignores it.
+    if launcher == "wandb" and max_parallel < 1:
         raise ValueError(f"max_parallel must be >= 1, got {max_parallel}")
     experiments = build_experiments(scale)
     by_name = {e.name: e for e in experiments}

--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -11,6 +11,12 @@ One :class:`Scale` feeds both the source generation and the copy probes, so the
 copy-preflight match set (``param_spec_name`` / ``samples_per_shard`` /
 ``train_val_test_sizes``) cannot drift between producer and consumer.
 
+On the wandb launcher every selected sweep is created before any agent runs, then
+agents run concurrently as ``wandb agent`` subprocesses under a ``--max-parallel``
+cap — so all sweeps land in the UI even if an agent stalls, and one stalled agent
+never blocks the others. The orchestrator stays alive supervising the pool; run it
+under ``tmux``/``nohup`` so a disconnect does not orphan in-flight agents.
+
 Run the whole investigation::
 
     python -m synth_setter.tools.cadence_investigation_489               # wandb sweeps + agents
@@ -25,6 +31,8 @@ import itertools
 import os
 import subprocess
 import sys
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Any
 
@@ -105,6 +113,10 @@ class Scale:
 # CLI default dataset size: the full #489 run (40 samples per split). The cadence
 # workflow's ``cadence_size`` input overrides it (and defaults smaller) per run.
 DEFAULT_SIZE = 40
+
+# Concurrent agents default low: each renders VST audio through one shared Xvfb
+# display, so over-subscribing the box contends on CPU and the display.
+DEFAULT_MAX_PARALLEL = 2
 
 
 @dataclass(frozen=True)
@@ -406,33 +418,89 @@ def _launch_local(
         _run_generate(cell)
 
 
-def _launch_wandb(
+def _create_sweep(
     experiment: Experiment,
     copy_uri: str,
     prefix_root: str,
     *,
     dry_run: bool,
-    count: int | None,
-) -> None:
-    """Create one wandb sweep for the experiment and run an agent over it.
+) -> str | None:
+    """Create the wandb sweep for one experiment and return its id.
 
     :param experiment: Experiment whose grid drives the sweep.
     :param copy_uri: Copy-source URI injected into copy probes.
     :param prefix_root: R2 prefix root every cell writes under.
     :param dry_run: When true, log the sweep config and create nothing.
-    :param count: Agent run cap (``None`` runs every grid cell).
+    :returns: The created sweep id, or ``None`` under ``dry_run``.
     """
     config = build_sweep_config(experiment, copy_uri, prefix_root)
     if dry_run:
         logger.info(f"[dry-run] wandb sweep {experiment.name}: {config}")
-        return
+        return None
     sweep_id = wandb.sweep(config, entity=ENTITY, project=PROJECT)
     logger.info(f"created sweep {experiment.name} -> {ENTITY}/{PROJECT}/{sweep_id}")
+    return sweep_id
+
+
+def _run_agent(sweep_id: str, *, count: int | None) -> None:
+    """Run a ``wandb agent`` for one sweep to completion as a subprocess (fail-fast).
+
+    Running each agent as its own process lets the supervisor cap concurrency and
+    keeps one stalled agent from blocking the others — unlike the in-process
+    ``wandb.agent`` loop, which served sweeps strictly one at a time. A non-zero
+    exit raises ``subprocess.CalledProcessError`` (``check=True``).
+
+    :param sweep_id: Sweep the agent pulls grid cells from.
+    :param count: Agent run cap forwarded to ``--count`` (``None`` runs every cell).
+    """
+    argv = ["wandb", "agent"]
+    if count is not None:
+        argv += ["--count", str(count)]
+    argv.append(f"{ENTITY}/{PROJECT}/{sweep_id}")
     # wandb 0.26.1's Agent.is_flapping reads wandb.START_TIME, which only the legacy
     # wandb.old.core sets, so the agent crashes with AttributeError unless flapping
     # is disabled; the grid is already bounded by count, so flapping adds no value.
-    os.environ.setdefault(wandb.env.AGENT_DISABLE_FLAPPING, "true")
-    wandb.agent(sweep_id, entity=ENTITY, project=PROJECT, count=count)
+    env = {**os.environ, wandb.env.AGENT_DISABLE_FLAPPING: "true"}
+    subprocess.run(argv, check=True, env=env)  # noqa: S603 — argv built from validated literals
+
+
+def _supervise_agents(
+    sweep_ids: list[str],
+    *,
+    count: int | None,
+    max_parallel: int,
+    run_agent: Callable[..., None] | None = None,
+) -> list[str]:
+    """Run an agent per sweep concurrently, capping concurrency at ``max_parallel``.
+
+    A stalled agent occupies one pool slot only, so the remaining sweeps keep
+    draining; failures are collected across all agents and raised once every
+    sweep has been attempted.
+
+    :param sweep_ids: Sweeps to run agents for.
+    :param count: Per-agent run cap forwarded to each agent.
+    :param max_parallel: Maximum agents running at once.
+    :param run_agent: Per-agent runner; defaults to :func:`_run_agent` and is
+        injectable so tests avoid real subprocesses.
+    :returns: The sweep ids whose agents exited cleanly.
+    :raises RuntimeError: when one or more agents fail, naming the failed sweeps.
+    """
+    run_agent = run_agent or _run_agent
+    completed: list[str] = []
+    failures: dict[str, str] = {}
+    with ThreadPoolExecutor(max_workers=max_parallel) as pool:
+        futures = {pool.submit(run_agent, sid, count=count): sid for sid in sweep_ids}
+        for future in as_completed(futures):
+            sweep_id = futures[future]
+            try:
+                future.result()
+                completed.append(sweep_id)
+            except Exception as exc:  # noqa: BLE001 — record every failure, raise once below
+                failures[sweep_id] = f"{type(exc).__name__}: {exc}"
+                logger.warning(f"agent for sweep {sweep_id} failed: {failures[sweep_id]}")
+    if failures:
+        raise RuntimeError(f"{len(failures)} sweep agent(s) failed: {failures}")
+    return completed
 
 
 def run_investigation(
@@ -443,23 +511,31 @@ def run_investigation(
     only: list[str] | None,
     dry_run: bool,
     count: int | None,
+    max_parallel: int = DEFAULT_MAX_PARALLEL,
 ) -> None:
     """Generate the copy source, then dispatch each selected experiment.
 
+    On the wandb launcher every selected sweep is created up front, then agents
+    run concurrently under a ``max_parallel`` cap — so all sweeps appear in the
+    UI regardless of agent fate, and no stalled agent blocks the rest.
+
     :param scale: Size knobs shared by the source and copy probes.
-    :param launcher: ``"wandb"`` (sweeps + agents) or ``"local"`` (subprocess loop).
+    :param launcher: ``"wandb"`` (sweeps + supervised agents) or ``"local"`` (subprocess loop).
     :param prefix_root: R2 prefix root for the source run and copy URI.
     :param only: Experiment names to run; ``None`` runs all five.
     :param dry_run: When true, print the plan and execute nothing.
     :param count: Per-experiment cell cap (``None`` runs every grid cell).
+    :param max_parallel: Maximum wandb agents running at once (ignored by ``local``).
     :raises ValueError: ``launcher`` is not ``"wandb"``/``"local"``, ``only`` names
-        an unknown experiment, or ``count`` is set below 1 (a cap that would silently
-        run no cells).
+        an unknown experiment, ``count`` is set below 1, or ``max_parallel`` is below 1
+        (caps that would silently run nothing).
     """
     if launcher not in ("wandb", "local"):
         raise ValueError(f"launcher must be 'wandb' or 'local', got {launcher!r}")
     if count is not None and count < 1:
         raise ValueError(f"count must be >= 1 when set, got {count}")
+    if max_parallel < 1:
+        raise ValueError(f"max_parallel must be >= 1, got {max_parallel}")
     experiments = build_experiments(scale)
     by_name = {e.name: e for e in experiments}
     if only is not None:
@@ -469,16 +545,25 @@ def run_investigation(
         experiments = [by_name[name] for name in only]
 
     # The copy source is only read by copy probes; skip its (real, costly)
-    # generation when the selection is within-run probes alone.
+    # generation when the selection is within-run probes alone. It must finish
+    # before any copy-probe agent runs, so it stays sequential ahead of dispatch.
     if any(experiment.needs_copy_source for experiment in experiments):
         copy_uri = generate_reference_dataset(scale, prefix_root, dry_run=dry_run)
     else:
         copy_uri = reference_copy_uri(prefix_root=prefix_root)
-    for experiment in experiments:
-        if launcher == "local":
+
+    if launcher == "local":
+        for experiment in experiments:
             _launch_local(experiment, copy_uri, prefix_root, dry_run=dry_run, count=count)
-        else:
-            _launch_wandb(experiment, copy_uri, prefix_root, dry_run=dry_run, count=count)
+        return
+
+    sweep_ids: list[str] = []
+    for experiment in experiments:
+        sweep_id = _create_sweep(experiment, copy_uri, prefix_root, dry_run=dry_run)
+        if sweep_id is not None:
+            sweep_ids.append(sweep_id)
+    if sweep_ids:
+        _supervise_agents(sweep_ids, count=count, max_parallel=max_parallel)
 
 
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
@@ -516,6 +601,15 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         help="per-experiment cell cap (wandb agent run cap; default: all cells)",
     )
     parser.add_argument(
+        "--max-parallel",
+        type=int,
+        default=DEFAULT_MAX_PARALLEL,
+        help=(
+            f"max wandb agents running at once (default: {DEFAULT_MAX_PARALLEL}); "
+            "agents share one Xvfb display, so raise with care"
+        ),
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="print the plan and execute nothing",
@@ -538,6 +632,7 @@ def main(argv: list[str] | None = None) -> None:
         else None,
         dry_run=args.dry_run,
         count=args.count,
+        max_parallel=args.max_parallel,
     )
 
 

--- a/src/synth_setter/tools/cadence_investigation_489.py
+++ b/src/synth_setter/tools/cadence_investigation_489.py
@@ -13,9 +13,10 @@ copy-preflight match set (``param_spec_name`` / ``samples_per_shard`` /
 
 On the wandb launcher every selected sweep is created before any agent runs, then
 agents run concurrently as ``wandb agent`` subprocesses under a ``--max-parallel``
-cap — so all sweeps land in the UI even if an agent stalls, and one stalled agent
-never blocks the others. The orchestrator stays alive supervising the pool; run it
-under ``tmux``/``nohup`` so a disconnect does not orphan in-flight agents.
+cap — so all sweeps land in the UI even if an agent stalls, and a stalled agent ties
+up only one slot while the remaining sweeps still run. The orchestrator stays alive
+supervising the pool until every agent returns; run it under ``tmux``/``nohup`` so a
+disconnect does not orphan in-flight agents.
 
 Run the whole investigation::
 
@@ -445,10 +446,8 @@ def _create_sweep(
 def _run_agent(sweep_id: str, *, count: int | None) -> None:
     """Run a ``wandb agent`` for one sweep to completion as a subprocess (fail-fast).
 
-    Running each agent as its own process lets the supervisor cap concurrency and
-    keeps one stalled agent from blocking the others — unlike the in-process
-    ``wandb.agent`` loop, which served sweeps strictly one at a time. A non-zero
-    exit raises ``subprocess.CalledProcessError`` (``check=True``).
+    A separate process per agent lets the supervisor cap concurrency across sweeps.
+    A non-zero exit raises ``subprocess.CalledProcessError`` (``check=True``).
 
     :param sweep_id: Sweep the agent pulls grid cells from.
     :param count: Agent run cap forwarded to ``--count`` (``None`` runs every cell).
@@ -461,7 +460,8 @@ def _run_agent(sweep_id: str, *, count: int | None) -> None:
     # wandb.old.core sets, so the agent crashes with AttributeError unless flapping
     # is disabled; the grid is already bounded by count, so flapping adds no value.
     env = {**os.environ, wandb.env.AGENT_DISABLE_FLAPPING: "true"}
-    subprocess.run(argv, check=True, env=env)  # noqa: S603 — argv built from validated literals
+    # Safe despite S603: list argv runs no shell; tokens are our literals plus the wandb sweep id.
+    subprocess.run(argv, check=True, env=env)  # noqa: S603
 
 
 def _supervise_agents(
@@ -517,7 +517,7 @@ def run_investigation(
 
     On the wandb launcher every selected sweep is created up front, then agents
     run concurrently under a ``max_parallel`` cap — so all sweeps appear in the
-    UI regardless of agent fate, and no stalled agent blocks the rest.
+    UI regardless of agent fate, and a stalled agent ties up only one slot.
 
     :param scale: Size knobs shared by the source and copy probes.
     :param launcher: ``"wandb"`` (sweeps + supervised agents) or ``"local"`` (subprocess loop).

--- a/tests/tools/test_cadence_investigation_489.py
+++ b/tests/tools/test_cadence_investigation_489.py
@@ -356,7 +356,7 @@ def test_copy_source_generated_before_copy_agents(monkeypatch: pytest.MonkeyPatc
 
 
 def test_max_parallel_below_one_raises_value_error() -> None:
-    """A ``--max-parallel`` below 1 fails fast instead of running no agents."""
+    """A ``--max-parallel`` below 1 fails fast on the wandb launcher (it would run no agents)."""
     with pytest.raises(ValueError, match="max_parallel must be >= 1"):
         inv.run_investigation(
             scale=SMOKE,
@@ -367,6 +367,24 @@ def test_max_parallel_below_one_raises_value_error() -> None:
             count=None,
             max_parallel=0,
         )
+
+
+def test_local_launcher_ignores_max_parallel_below_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The local launcher does not use ``max_parallel``, so a sub-1 value is not rejected.
+
+    :param monkeypatch: Stubs generate so the plan runs without spawning subprocesses.
+    """
+    monkeypatch.setattr(inv, "_run_generate", lambda overrides: None)
+
+    inv.run_investigation(
+        scale=SMOKE,
+        launcher="local",
+        prefix_root="data",
+        only=["reuse_depth"],
+        dry_run=False,
+        count=None,
+        max_parallel=0,
+    )
 
 
 def test_main_passes_max_parallel_to_run_investigation(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tools/test_cadence_investigation_489.py
+++ b/tests/tools/test_cadence_investigation_489.py
@@ -203,7 +203,7 @@ def test_main_maps_size_to_scale(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_dry_run_executes_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``--dry-run`` plans only: no generate subprocess, no wandb calls.
+    """``--dry-run`` plans only: no generate subprocess, no sweep creation.
 
     :param monkeypatch: Replaces the subprocess and wandb entry points with a
         sentinel that fails if dry-run ever calls them.
@@ -214,37 +214,145 @@ def test_dry_run_executes_nothing(monkeypatch: pytest.MonkeyPatch) -> None:
 
     monkeypatch.setattr(inv.subprocess, "run", _boom)
     monkeypatch.setattr(inv.wandb, "sweep", _boom)
-    monkeypatch.setattr(inv.wandb, "agent", _boom)
 
     inv.main(["--dry-run", "--size", "2", "--launcher", "wandb"])
 
 
-def test_wandb_launch_disables_agent_flapping(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The agent runs with flapping disabled so wandb 0.26.1 cannot read its unset ``START_TIME``.
+def test_wandb_agents_run_detached_with_flapping_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each sweep's agent runs as a ``wandb agent`` subprocess with flapping disabled.
 
     wandb 0.26.1's ``Agent.is_flapping`` references ``wandb.START_TIME``, which only
-    ``wandb.old.core`` sets, so a plain ``wandb.agent`` call crashes with
-    ``AttributeError`` unless flapping is disabled first.
+    ``wandb.old.core`` sets, so the agent crashes with ``AttributeError`` unless
+    ``WANDB_AGENT_DISABLE_FLAPPING`` is exported into the agent's environment.
 
-    :param monkeypatch: Stubs ``wandb.sweep``/``wandb.agent`` and clears the
-        flapping env var so the launcher's own setting is observed.
+    :param monkeypatch: Stubs ``wandb.sweep`` and captures the ``subprocess.run``
+        argv and environment the supervised agent is launched with.
     """
-    import os
-
     import wandb.env
 
-    monkeypatch.delenv(wandb.env.AGENT_DISABLE_FLAPPING, raising=False)
-    monkeypatch.setattr(inv.wandb, "sweep", lambda *a, **k: "sweep-id")
-    seen: dict[str, str | None] = {}
-    monkeypatch.setattr(
-        inv.wandb,
-        "agent",
-        lambda *a, **k: seen.update(flapping=os.environ.get(wandb.env.AGENT_DISABLE_FLAPPING)),
-    )
+    monkeypatch.setattr(inv.wandb, "sweep", lambda *a, **k: "abc123")
+    argv: list[str] = []
+    env: dict[str, str] = {}
+
+    def _record(call_argv: list[str], **kwargs: object) -> None:
+        argv[:] = call_argv
+        env.update(kwargs["env"])  # type: ignore[arg-type]
+
+    monkeypatch.setattr(inv.subprocess, "run", _record)
 
     inv.main(["--launcher", "wandb", "--size", "2", "--only", "shuffle_probe"])
 
-    assert seen["flapping"] == "true"
+    assert argv[:2] == ["wandb", "agent"]
+    assert argv[-1] == f"{inv.ENTITY}/{inv.PROJECT}/abc123"
+    assert env[wandb.env.AGENT_DISABLE_FLAPPING] == "true"
+
+
+def test_all_wandb_sweeps_created_before_any_agent_runs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every selected sweep is created up front, before any agent is dispatched.
+
+    Sequential create-then-block left only the first sweep visible when an agent stalled; creating
+    all sweeps first guarantees they appear regardless of agent fate.
+
+    :param monkeypatch: Stubs sweep creation and the per-agent runner to record the global order of
+        create vs. run events.
+    """
+    events: list[str] = []
+    ids = iter(("s0", "s1"))
+    monkeypatch.setattr(inv.wandb, "sweep", lambda *a, **k: events.append("create") or next(ids))
+    monkeypatch.setattr(inv, "_run_agent", lambda sweep_id, **k: events.append("run"))
+
+    inv.main(["--launcher", "wandb", "--size", "2", "--only", "shuffle_probe,reuse_depth"])
+
+    assert events == ["create", "create", "run", "run"]
+
+
+def test_max_parallel_caps_concurrent_agents() -> None:
+    """The supervised pool never runs more than ``max_parallel`` agents at once."""
+    import threading
+    import time
+
+    lock = threading.Lock()
+    live = 0
+    peak = 0
+
+    def _fake_agent(sweep_id: str, *, count: int | None) -> None:
+        nonlocal live, peak
+        with lock:
+            live += 1
+            peak = max(peak, live)
+        time.sleep(0.02)
+        with lock:
+            live -= 1
+
+    completed = inv._supervise_agents(
+        ["s0", "s1", "s2", "s3", "s4"], count=None, max_parallel=2, run_agent=_fake_agent
+    )
+
+    assert peak <= 2
+    assert sorted(completed) == ["s0", "s1", "s2", "s3", "s4"]
+
+
+def test_supervise_agents_raises_when_an_agent_fails() -> None:
+    """A non-zero agent exit surfaces as a raised error naming the failed sweep."""
+
+    def _fake_agent(sweep_id: str, *, count: int | None) -> None:
+        if sweep_id == "s1":
+            raise RuntimeError("agent crashed")
+
+    with pytest.raises(RuntimeError, match="s1"):
+        inv._supervise_agents(["s0", "s1"], count=None, max_parallel=2, run_agent=_fake_agent)
+
+
+def test_copy_source_generated_before_copy_agents(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The copy-source dataset is generated before any copy-probe agent runs.
+
+    :param monkeypatch: Stubs generate, sweep creation, and the per-agent runner to record the
+        order of generate vs. agent events without side effects.
+    """
+    events: list[str] = []
+    monkeypatch.setattr(inv, "_run_generate", lambda overrides: events.append("generate"))
+    monkeypatch.setattr(inv.wandb, "sweep", lambda *a, **k: "sweep-id")
+    monkeypatch.setattr(inv, "_run_agent", lambda sweep_id, **k: events.append("agent"))
+
+    inv.main(["--launcher", "wandb", "--size", "2", "--only", "copy_reload"])
+
+    assert events[0] == "generate"
+    assert "agent" in events
+    assert events.index("generate") < events.index("agent")
+
+
+def test_max_parallel_below_one_raises_value_error() -> None:
+    """A ``--max-parallel`` below 1 fails fast instead of running no agents."""
+    with pytest.raises(ValueError, match="max_parallel must be >= 1"):
+        inv.run_investigation(
+            scale=SMOKE,
+            launcher="wandb",
+            prefix_root="data",
+            only=["shuffle_probe"],
+            dry_run=True,
+            count=None,
+            max_parallel=0,
+        )
+
+
+def test_main_passes_max_parallel_to_run_investigation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--max-parallel`` reaches ``run_investigation``; absent, it defaults.
+
+    :param monkeypatch: Replaces ``run_investigation`` with a recorder so the
+        resolved cap is observed without launching any real run.
+    """
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(inv, "run_investigation", lambda **kwargs: captured.update(kwargs))
+
+    inv.main(["--max-parallel", "4"])
+    assert captured["max_parallel"] == 4
+
+    inv.main([])
+    assert captured["max_parallel"] == inv.DEFAULT_MAX_PARALLEL
 
 
 def test_local_count_caps_cells_run_per_experiment(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tools/test_cadence_investigation_489.py
+++ b/tests/tools/test_cadence_investigation_489.py
@@ -10,6 +10,8 @@ R2) in ``tests/integration/test_cadence_investigation_489_e2e.py``.
 
 from __future__ import annotations
 
+import threading
+
 import pytest
 
 from synth_setter.tools import cadence_investigation_489 as inv
@@ -254,8 +256,7 @@ def test_all_wandb_sweeps_created_before_any_agent_runs(
 ) -> None:
     """Every selected sweep is created up front, before any agent is dispatched.
 
-    Sequential create-then-block left only the first sweep visible when an agent stalled; creating
-    all sweeps first guarantees they appear regardless of agent fate.
+    Creating all sweeps before dispatch guarantees they appear in the UI regardless of agent fate.
 
     :param monkeypatch: Stubs sweep creation and the per-agent runner to record the global order of
         create vs. run events.
@@ -271,10 +272,14 @@ def test_all_wandb_sweeps_created_before_any_agent_runs(
 
 
 def test_max_parallel_caps_concurrent_agents() -> None:
-    """The supervised pool never runs more than ``max_parallel`` agents at once."""
-    import threading
-    import time
+    """The supervised pool runs exactly ``max_parallel`` agents at once, never more.
 
+    A ``Barrier(max_parallel)`` makes the overlap deterministic — agents release in
+    full pairs, so the observed peak is exactly the cap with no timing race. Four
+    tasks at cap 2 split into two clean pairs (no lone task to deadlock the barrier).
+    """
+    max_parallel = 2
+    barrier = threading.Barrier(max_parallel)
     lock = threading.Lock()
     live = 0
     peak = 0
@@ -284,27 +289,52 @@ def test_max_parallel_caps_concurrent_agents() -> None:
         with lock:
             live += 1
             peak = max(peak, live)
-        time.sleep(0.02)
+        barrier.wait()  # hold the slot until its partner is also live
         with lock:
             live -= 1
 
     completed = inv._supervise_agents(
-        ["s0", "s1", "s2", "s3", "s4"], count=None, max_parallel=2, run_agent=_fake_agent
+        ["s0", "s1", "s2", "s3"], count=None, max_parallel=max_parallel, run_agent=_fake_agent
     )
 
-    assert peak <= 2
-    assert sorted(completed) == ["s0", "s1", "s2", "s3", "s4"]
+    assert peak == max_parallel
+    assert sorted(completed) == ["s0", "s1", "s2", "s3"]
 
 
-def test_supervise_agents_raises_when_an_agent_fails() -> None:
-    """A non-zero agent exit surfaces as a raised error naming the failed sweep."""
+def test_supervise_agents_attempts_every_sweep_then_raises_all_failures() -> None:
+    """Failures are collected across all agents; the passing one still runs."""
+    ran: list[str] = []
+    ran_lock = threading.Lock()
 
     def _fake_agent(sweep_id: str, *, count: int | None) -> None:
-        if sweep_id == "s1":
-            raise RuntimeError("agent crashed")
+        with ran_lock:
+            ran.append(sweep_id)
+        if sweep_id in ("s1", "s2"):
+            raise RuntimeError(f"agent {sweep_id} crashed")
 
-    with pytest.raises(RuntimeError, match="s1"):
-        inv._supervise_agents(["s0", "s1"], count=None, max_parallel=2, run_agent=_fake_agent)
+    with pytest.raises(RuntimeError, match="2 sweep agent") as excinfo:
+        inv._supervise_agents(
+            ["s0", "s1", "s2"], count=None, max_parallel=3, run_agent=_fake_agent
+        )
+
+    message = str(excinfo.value)
+    assert "s1" in message and "s2" in message
+    assert "s0" in ran  # the passing agent was attempted, not skipped
+
+
+def test_run_agent_forwards_count_to_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``count`` becomes ``--count N`` in the agent argv; it is omitted when ``None``.
+
+    :param monkeypatch: Captures the argv passed to ``subprocess.run``.
+    """
+    calls: list[list[str]] = []
+    monkeypatch.setattr(inv.subprocess, "run", lambda argv, **k: calls.append(argv))
+
+    inv._run_agent("sw1", count=5)
+    inv._run_agent("sw2", count=None)
+
+    assert calls[0][calls[0].index("--count") + 1] == "5"
+    assert "--count" not in calls[1]
 
 
 def test_copy_source_generated_before_copy_agents(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

`python -m synth_setter.tools.cadence_investigation_489` was meant to create five sweeps (one per experiment: `shuffle_probe`, `reuse_depth`, `copy_reload`, `copy_gui`, `copy_repro`). In practice only `shuffle_probe` sweeps ever appeared — the `synth-setter` W&B project has 13+ `generate_dataset_shuffle_probe_*` sweeps and zero `reuse_depth`/`copy_*` sweeps.

**Root cause:** `run_investigation()` looped over experiments calling `_launch_wandb()`, which did `wandb.sweep(...)` immediately followed by a **blocking** `wandb.agent(sweep_id, count=count)`. The loop is sequential — sweep N+1 is not created until experiment N's agent returns. When the first agent stalled or the single foreground process was interrupted, experiments 2–5 never got their sweeps created at all.

## Fix

Restructure the wandb launcher so every selected sweep is **created up front** (before any agent runs), then run agents **concurrently** as `wandb agent` subprocesses under a `--max-parallel` cap:

- `_launch_wandb` is split into `_create_sweep` (register sweep, return id) and `_run_agent` (run one `wandb agent` subprocess, fail-fast).
- `_supervise_agents` runs the agents through a `ThreadPoolExecutor(max_workers=max_parallel)`, collects per-sweep failures, and raises once after every sweep is attempted.
- New `--max-parallel` flag (default 2, since agents share one Xvfb display).
- Copy-source generation stays sequential ahead of dispatch (copy probes depend on it).

All five sweeps now appear in the UI regardless of agent fate, and a stalled agent ties up only one pool slot instead of blocking the rest. The `--launcher local` path is unchanged.

## Verification

- `make test-fast` (CPU) green; `tests/tools/test_cadence_investigation_489.py` — 30 passed.
- New/strengthened tests: all-sweeps-created-before-any-agent-runs, `--max-parallel` cap (deterministic via `threading.Barrier`, asserts `peak == cap`), flapping env exported into the agent subprocess, copy-source-before-copy-agents ordering, collect-all-failures-then-raise, and `--count` argv forwarding.
- `--dry-run` now lists all five sweeps up front.

## Scope notes

Out of scope (possible follow-ups): a per-agent subprocess timeout / cancellation of in-flight agents on failure, and #1605 (sweeps dangling in `RUNNING` after their agent exits — a separate `set_sweep_state` finalization fix).

Fixes #1619