### PR TITLE
chore(tools): fix #489 sweep names and surge_simple control

### DIFF
--- a/src/synth_setter/tools/cadence_sweep_489.py
+++ b/src/synth_setter/tools/cadence_sweep_489.py
@@ -26,12 +26,13 @@ import argparse
 import os
 import subprocess
 import sys
+import uuid
 from typing import Any
 
-import wandb
 import wandb.env
 from loguru import logger
 
+import wandb
 from synth_setter.data.vst import preset_paths
 from synth_setter.pipeline.schemas.prefix import DEFAULT_R2_PREFIX_ROOT, make_r2_prefix
 
@@ -52,11 +53,12 @@ SURGE_SIMPLE = "surge_simple"
 SURGE_XT_PRESET = preset_paths[SURGE_XT]
 SURGE_SIMPLE_PRESET = preset_paths[SURGE_SIMPLE]
 
+UUID_SIFFIX = f"-{uuid.uuid4().hex[:4]}"
 # Fixed reference run identity -> stable copy-source URI the copy probes replay.
 SURGE_XT_REFERENCE_TASK = "ref-surge-xt-489"
-SURGE_XT_REFERENCE_RUN_ID = "paired-surge-xt-ref-v1"
+SURGE_XT_REFERENCE_RUN_ID = "paired-surge-xt-ref-v1" + UUID_SIFFIX
 SURGE_SIMPLE_REFERENCE_TASK = "ref-surge-simple-489"
-SURGE_SIMPLE_REFERENCE_RUN_ID = "paired-surge-simple-ref-v1"
+SURGE_SIMPLE_REFERENCE_RUN_ID = "paired-surge-simple-ref-v1" + UUID_SIFFIX
 
 # The probes run the with-oracle-eval finalize/eval; the source donates raw param
 # shards only (copy reads same-named shards at the run root), so it skips the eval.

--- a/src/synth_setter/tools/cadence_sweep_489.py
+++ b/src/synth_setter/tools/cadence_sweep_489.py
@@ -1,4 +1,4 @@
-"""One-command runner for the #489 surge_xt cadence investigation.
+"""One-command runner for the #489 cadence investigation.
 
 Generates the fixed surge_xt and surge_simple copy-source datasets, then creates
 the W&B grid sweeps and runs an agent for each. Copy and shuffle probes replay

--- a/src/synth_setter/tools/cadence_sweep_489.py
+++ b/src/synth_setter/tools/cadence_sweep_489.py
@@ -105,14 +105,16 @@ def _sweep(
     :param grid: Maps each swept Hydra key to its values; their product is the cells.
     :returns: A ``wandb.sweep``-ready config dict.
     """
+    # ``${args_no_hyphens}`` (the swept grid cell) goes last: Hydra applies later overrides last,
+    # so a fixed pin must never follow a swept key it would otherwise shadow.
     command = [
         "${interpreter}",
         "${program}",
-        "${args_no_hyphens}",
         f"task_name={name}",
         f"r2.prefix_root={PREFIX_ROOT}",
         f"experiment={_PROBE_EXPERIMENT}",
         *fixed,
+        "${args_no_hyphens}",
     ]
     return {
         "program": PROGRAM,

--- a/src/synth_setter/tools/cadence_sweep_489.py
+++ b/src/synth_setter/tools/cadence_sweep_489.py
@@ -289,6 +289,9 @@ def run(n: int) -> None:
 
     :param n: Per-split sample count shared by the sources and the copy probes.
     """
+    # Build (and validate ``n`` via) the sweep configs first, so an invalid size fails fast
+    # before the two expensive source-generation subprocesses run.
+    sweep_configs = sweeps(n)
     copy_src_overrides = [
         f"experiment={_SOURCE_EXPERIMENT}",
         f"r2.prefix_root={PREFIX_ROOT}",
@@ -311,7 +314,7 @@ def run(n: int) -> None:
     _run_generate(xt_overrides)
     logger.info(f"generating copy source -> {surge_simple_reference_copy_uri()}")
     _run_generate(simple_overrides)
-    sweep_ids = [wandb.sweep(config, entity=ENTITY, project=PROJECT) for config in sweeps(n)]
+    sweep_ids = [wandb.sweep(config, entity=ENTITY, project=PROJECT) for config in sweep_configs]
     for sweep_id in sweep_ids:
         logger.info(f"running agent for {ENTITY}/{PROJECT}/{sweep_id}")
         _run_agent(sweep_id)

--- a/src/synth_setter/tools/cadence_sweep_489.py
+++ b/src/synth_setter/tools/cadence_sweep_489.py
@@ -1,9 +1,9 @@
 """One-command runner for the #489 surge_xt cadence investigation.
 
-Generates the fixed surge_xt copy-source dataset, then creates five W&B grid
-sweeps and runs an agent for each: two within-run probes (render-order shuffle,
-reuse-depth) and three paired-copy probes (reload cadence, gui cadence,
-reproducibility) that replay the source via its derived run-root URI.
+Generates the fixed surge_xt and surge_simple copy-source datasets, then creates
+the W&B grid sweeps and runs an agent for each. Copy and shuffle probes replay
+the source via its derived run-root URI; the controls omit the copy URI and
+regenerate fresh. ``sweeps()`` is authoritative on the matrix; see #489.
 
 The dataset size N is the only input; it feeds both the source and the copy
 probes so their copy-preflight match set (param spec, samples-per-shard, split
@@ -14,7 +14,7 @@ Run it::
     python -m synth_setter.tools.cadence_sweep_489            # the full #489 run
     python -m synth_setter.tools.cadence_sweep_489 --size 5
 
-Every sweep is created before any agent runs, so all five appear in the W&B UI
+Every sweep is created before any agent runs, so they all appear in the W&B UI
 even if an agent later stalls; agents then run one at a time because they share
 one Xvfb display and would otherwise contend on it. Run under tmux/nohup so a
 disconnect does not orphan an in-flight agent.
@@ -28,10 +28,10 @@ import subprocess
 import sys
 from typing import Any
 
+import wandb
 import wandb.env
 from loguru import logger
 
-import wandb
 from synth_setter.data.vst import preset_paths
 from synth_setter.pipeline.schemas.prefix import DEFAULT_R2_PREFIX_ROOT, make_r2_prefix
 
@@ -118,7 +118,7 @@ def _sweep(
         "program": PROGRAM,
         "entity": ENTITY,
         "project": PROJECT,
-        "name": f"generate_dataset_{name}_surge_xt",
+        "name": f"generate_dataset_{name}",
         "method": "grid",
         # grid ignores metric at scheduling time; kept for dashboard legibility.
         "metric": {"goal": "minimize", "name": "audio/mss_mean"},
@@ -128,9 +128,10 @@ def _sweep(
 
 
 def sweeps(n: int) -> list[dict[str, Any]]:
-    """Return the five #489 W&B grid sweep configs at dataset size ``n``.
+    """Return the #489 W&B grid sweep configs at dataset size ``n``.
 
-    The derived ``copy_dataset_root_uri`` so every cell replays the source verbatim.
+    The copy and shuffle probes pin the derived ``copy_dataset_root_uri`` so their cells replay the
+    source verbatim; the control sweeps omit it and regenerate fresh.
 
     :param n: Per-split sample count shared with the source generation.
     :returns: ``wandb.sweep``-ready config dicts, in run order.
@@ -226,7 +227,6 @@ def sweeps(n: int) -> list[dict[str, Any]]:
                 samples_per_shard,
                 simple_spec,
                 simple_preset,
-                simple_copy_uri,
             ),
             grid={
                 "render.plugin_reload_cadence": ["once", "render"],
@@ -279,13 +279,13 @@ def _run_agent(sweep_id: str) -> None:
 
 
 def run(n: int) -> None:
-    """Generate the copy source, then create and drive all five #489 sweeps.
+    """Generate the surge_xt and surge_simple copy sources, then create and drive every #489 sweep.
 
-    The source is generated first because the copy probes read it; then every sweep is created
-    before any agent runs so all five land in the W&B UI; agents run one at a time to avoid
+    The sources are generated first because the copy probes read them; then every sweep is created
+    before any agent runs so they all land in the W&B UI; agents run one at a time to avoid
     contending on the shared Xvfb display.
 
-    :param n: Per-split sample count shared by the source and the copy probes;
+    :param n: Per-split sample count shared by the sources and the copy probes.
     """
     copy_src_overrides = [
         f"experiment={_SOURCE_EXPERIMENT}",

--- a/tests/tools/test_cadence_sweep_489.py
+++ b/tests/tools/test_cadence_sweep_489.py
@@ -62,3 +62,13 @@ def test_simple_control_omits_the_copy_uri_so_it_regenerates_fresh() -> None:
 
     assert not any("copy_dataset_root_uri=" in t for t in control["command"])
     assert any("copy_dataset_root_uri=" in t for t in copy_probe["command"])
+
+
+def test_swept_args_macro_is_last_so_grid_values_win_over_fixed_pins() -> None:
+    """``${args_no_hyphens}`` must be the final command token in every sweep.
+
+    Hydra applies later overrides last, so the swept grid macro has to follow the fixed pins;
+    placing it earlier would let a fixed pin silently shadow an overlapping swept key.
+    """
+    for config in sweep.sweeps(2):
+        assert config["command"][-1] == "${args_no_hyphens}"

--- a/tests/tools/test_cadence_sweep_489.py
+++ b/tests/tools/test_cadence_sweep_489.py
@@ -72,3 +72,23 @@ def test_swept_args_macro_is_last_so_grid_values_win_over_fixed_pins() -> None:
     """
     for config in sweep.sweeps(2):
         assert config["command"][-1] == "${args_no_hyphens}"
+
+
+def test_run_rejects_size_below_one_before_generating_any_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``run`` validates ``n`` up front, before launching any ``generate_dataset`` subprocess.
+
+    The ``n >= 1`` guard lives in ``sweeps``; ``run`` must reach it before the expensive source
+    generation, so an invalid size fails fast instead of burning two subprocess runs.
+
+    :param monkeypatch: Replaces ``_run_generate`` with a recorder so the test can assert no
+        source generation was attempted.
+    """
+    generated: list[list[str]] = []
+    monkeypatch.setattr(sweep, "_run_generate", lambda overrides: generated.append(overrides))
+
+    with pytest.raises(ValueError, match="must be >= 1"):
+        sweep.run(0)
+
+    assert generated == []

--- a/tests/tools/test_cadence_sweep_489.py
+++ b/tests/tools/test_cadence_sweep_489.py
@@ -1,0 +1,64 @@
+"""Unit tests for the minimal #489 cadence-sweep runner's plan-building core.
+
+These pin the pure ``sweeps(n)`` plan: every sweep is named for the synth
+variant it actually renders, and the control sweep is a genuine no-copy control
+rather than a duplicate of its copy probe. No real R2 or W&B is touched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from synth_setter.tools import cadence_sweep_489 as sweep
+
+
+def _config_by_label(configs: list[dict], label: str) -> dict:
+    """Return the single sweep config named ``generate_dataset_<label>``.
+
+    :param configs: The ``sweeps(n)`` output.
+    :param label: Experiment label passed to ``_sweep``.
+    :returns: The matching config.
+    """
+    wanted = f"generate_dataset_{label}"
+    matches = [config for config in configs if config["name"] == wanted]
+    assert len(matches) == 1, (
+        f"expected exactly one {wanted!r}, got {[c['name'] for c in configs]}"
+    )
+    return matches[0]
+
+
+def test_sweeps_rejects_size_below_one() -> None:
+    """A sub-1 size leaves every split empty, so it is rejected up front."""
+    with pytest.raises(ValueError, match="must be >= 1"):
+        sweep.sweeps(0)
+
+
+def test_sweep_name_carries_the_variant_it_renders_without_a_stale_suffix() -> None:
+    """Each sweep is named for the synth it renders, with no hardcoded ``surge_xt`` tail.
+
+    The runner builds both surge_xt and surge_simple sweeps; a fixed suffix would mislabel every
+    surge_simple sweep as surge_xt (and double it on surge_xt).
+    """
+    assert {config["name"] for config in sweep.sweeps(2)} == {
+        "generate_dataset_shuffle_cadence_probe_surge_xt",
+        "generate_dataset_cadence_probe_surge_xt",
+        "generate_dataset_control_cadence_probe_surge_xt",
+        "generate_dataset_shuffle_cadence_probe_surge_simple",
+        "generate_dataset_cadence_probe_surge_simple",
+        "generate_dataset_control_cadence_probe_surge_simple",
+        "generate_dataset_cadence_probe_surge_simple_xt_preset",
+    }
+
+
+def test_simple_control_omits_the_copy_uri_so_it_regenerates_fresh() -> None:
+    """The surge_simple control omits the copy URI, mirroring the surge_xt control.
+
+    Without this the control replays the copy source under the same cadence grid as
+    ``cadence_probe_surge_simple`` (differing only in ``task_name``), so it is no control at all.
+    """
+    configs = sweep.sweeps(2)
+    control = _config_by_label(configs, "control_cadence_probe_surge_simple")
+    copy_probe = _config_by_label(configs, "cadence_probe_surge_simple")
+
+    assert not any("copy_dataset_root_uri=" in t for t in control["command"])
+    assert any("copy_dataset_root_uri=" in t for t in copy_probe["command"])


### PR DESCRIPTION
## What

Two bug fixes to `src/synth_setter/tools/cadence_sweep_489.py` (added in #1629),
plus tests pinning them and a docstring refresh.

## Bugs

**1. Sweep names carried a hardcoded `_surge_xt` suffix.** `_sweep` named every
config `f"generate_dataset_{name}_surge_xt"` — a leftover from the surge_xt-only
original where `name` was e.g. `"shuffle_probe"`. Now that each label already
embeds its synth variant, this:

- doubled the suffix on surge_xt sweeps (`..._surge_xt_surge_xt`), and
- mislabeled every surge_simple sweep as surge_xt
  (`..._surge_simple_surge_xt`).

Dropped the suffix → `f"generate_dataset_{name}"`, so each sweep is named for the
variant it actually renders.

**2. The surge_simple control wasn't a control.**
`control_cadence_probe_surge_simple` pinned `simple_copy_uri` in its `fixed`
overrides, so it **replayed the copy source under the same cadence grid** as
`cadence_probe_surge_simple` — the two configs differ only in `task_name`.
Its surge_xt counterpart `control_cadence_probe_surge_xt` correctly *omits* the
copy URI and regenerates fresh; that omission is what makes it a control.
Dropped `simple_copy_uri` so the surge_simple control regenerates fresh too.

## Tests

New `tests/tools/test_cadence_sweep_489.py` (pure, no R2/W&B):

- rejects `n < 1`,
- pins the exact set of seven sweep names (catches the suffix bug),
- asserts the surge_simple control omits the copy URI while its copy probe
  carries it (catches the control bug).

Both regression tests fail against the pre-fix code.

## Docs

Refreshed the now-stale module/function docstrings: they described "five"
sweeps and probes (reuse-depth, reproducibility) that the runner never builds,
and `run()` said "the copy source" (singular) though it generates two — both
corrected to the seven sweeps / two sources it actually creates.

## Scope

`cadence_investigation_489.py` and the workflow are untouched. Pre-commit hooks
and the new tests pass locally; `/repo-review-full-no-comments` returned zero
BLOCK findings.

Refs #489
