### PR TITLE
internal-fix(pipeline): SIGTERM subprocess group before SIGKILL fallback

### DIFF
--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -74,6 +74,11 @@ _WORKER_REPO_ROOT = "/home/build/synth-setter"
 # Smoke-shard-sized; longer eval runs belong on the dispatch path, not inline.
 _ORACLE_EVAL_TIMEOUT_SECONDS = 600
 
+# Grace between the group SIGTERM and the SIGKILL fallback: long enough for the
+# headless-VST wrapper's ``trap cleanup`` to reap its Xvfb/dbus tree and remove
+# the X socket, short enough to keep the timeout's tail bounded.
+_GROUP_KILL_GRACE_SECONDS = 5.0
+
 # Finalized artifacts the eval datamodule opens; all must sit in dataset_root.
 _ORACLE_EVAL_REQUIRED_ARTIFACTS = ("train.h5", "val.h5", "test.h5", STATS_NPZ_FILENAME)
 
@@ -89,11 +94,11 @@ def _check_call_streamed(args: Sequence[str], *, timeout: float | None = None) -
 
     :param args: Child argv, run unquoted with no shell, so callers pre-validate it.
     :param timeout: Hard wall-clock bound in seconds; once it elapses the
-        child's process group is killed and the call raises regardless of the
-        direct child's own exit. ``None`` means no limit.
+        child's process group is terminated and the call raises regardless of
+        the direct child's own exit. ``None`` means no limit.
     :raises subprocess.CalledProcessError: Child exited non-zero.
     :raises subprocess.TimeoutExpired: ``timeout`` elapsed before the read loop
-        drained, so the process group was killed.
+        drained, so the process group was terminated.
     """
     with subprocess.Popen(  # noqa: S603 — argv built from validated specs by callers
         args,
@@ -108,19 +113,36 @@ def _check_call_streamed(args: Sequence[str], *, timeout: float | None = None) -
     ) as proc:
         timed_out = threading.Event()
 
-        def _kill_group() -> None:
+        def _terminate_group() -> None:
+            """SIGTERM the child's group, escalating to SIGKILL after a grace period.
+
+            SIGTERM lets the headless-VST wrapper's ``trap cleanup`` run — reaping
+            its Xvfb/dbus/openbox tree and removing the X socket; a bare SIGKILL
+            orphans that tree and leaks the socket, corrupting the shared display
+            for later renders. SIGKILL is the fallback for a group that ignores
+            SIGTERM, so a wedged child still cannot outlive the kill.
+            """
             if proc.returncode is not None:
                 # Already reaped — killpg here could hit a recycled pgid.
                 return
             try:
-                os.killpg(proc.pid, signal.SIGKILL)
+                os.killpg(proc.pid, signal.SIGTERM)
             except ProcessLookupError:
                 # Group already gone — nothing left to reap.
+                return
+            deadline = time.monotonic() + _GROUP_KILL_GRACE_SECONDS
+            while time.monotonic() < deadline:
+                if proc.poll() is not None:
+                    return
+                time.sleep(0.1)
+            try:
+                os.killpg(proc.pid, signal.SIGKILL)
+            except ProcessLookupError:
                 pass
 
         def _kill_on_timeout() -> None:
             timed_out.set()
-            _kill_group()
+            _terminate_group()
 
         timer = threading.Timer(timeout, _kill_on_timeout) if timeout is not None else None
         if timer is not None:
@@ -134,10 +156,10 @@ def _check_call_streamed(args: Sequence[str], *, timeout: float | None = None) -
         finally:
             if timer is not None:
                 timer.cancel()
-            # Kill the group if the direct child is still alive on an abrupt exit
-            # (KeyboardInterrupt, write failure); ``__exit__`` then reaps it.
+            # Terminate the group if the direct child is still alive on an abrupt
+            # exit (KeyboardInterrupt, write failure); ``__exit__`` then reaps it.
             if proc.poll() is None:
-                _kill_group()
+                _terminate_group()
     # Any timer fire means the wall-clock budget was exceeded — surface it as a
     # timeout even when the direct child already exited 0 but a pipe-holding
     # grandchild kept the read loop blocked until the group kill.

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -74,9 +74,8 @@ _WORKER_REPO_ROOT = "/home/build/synth-setter"
 # Smoke-shard-sized; longer eval runs belong on the dispatch path, not inline.
 _ORACLE_EVAL_TIMEOUT_SECONDS = 600
 
-# Grace between the group SIGTERM and the SIGKILL fallback: long enough for the
-# headless-VST wrapper's ``trap cleanup`` to reap its Xvfb/dbus tree and remove
-# the X socket, short enough to keep the timeout's tail bounded.
+# SIGTERM→SIGKILL grace: lets the headless-VST wrapper's ``trap cleanup`` reap
+# its Xvfb/dbus tree and drop the X socket before the hard kill.
 _GROUP_KILL_GRACE_SECONDS = 5.0
 
 # Finalized artifacts the eval datamodule opens; all must sit in dataset_root.
@@ -116,11 +115,9 @@ def _check_call_streamed(args: Sequence[str], *, timeout: float | None = None) -
         def _terminate_group() -> None:
             """SIGTERM the child's group, escalating to SIGKILL after a grace period.
 
-            SIGTERM lets the headless-VST wrapper's ``trap cleanup`` run — reaping
-            its Xvfb/dbus/openbox tree and removing the X socket; a bare SIGKILL
-            orphans that tree and leaks the socket, corrupting the shared display
-            for later renders. SIGKILL is the fallback for a group that ignores
-            SIGTERM, so a wedged child still cannot outlive the kill.
+            A bare SIGKILL bypasses the headless-VST wrapper's ``trap cleanup``,
+            orphaning its Xvfb/dbus tree and leaking the X socket; SIGTERM lets
+            that trap run. SIGKILL is the fallback for a group that ignores it.
             """
             if proc.returncode is not None:
                 # Already reaped — killpg here could hit a recycled pgid.

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -127,11 +127,18 @@ def _check_call_streamed(args: Sequence[str], *, timeout: float | None = None) -
             except ProcessLookupError:
                 # Group already gone — nothing left to reap.
                 return
+            # Escalate to SIGKILL unless the read-loop thread reaps the leader
+            # first, which happens only once the pipe drains — i.e. no group
+            # member (e.g. a SIGTERM-ignoring grandchild) is left holding it.
+            # Read ``returncode`` rather than calling ``proc.poll()``: poll would
+            # reap the leader here and free its pgid for reuse before the SIGKILL.
             deadline = time.monotonic() + _GROUP_KILL_GRACE_SECONDS
             while time.monotonic() < deadline:
-                if proc.poll() is not None:
+                if proc.returncode is not None:
                     return
                 time.sleep(0.1)
+            if proc.returncode is not None:
+                return
             try:
                 os.killpg(proc.pid, signal.SIGKILL)
             except ProcessLookupError:

--- a/tests/pipeline/entrypoints/test_check_call_streamed.py
+++ b/tests/pipeline/entrypoints/test_check_call_streamed.py
@@ -198,7 +198,9 @@ class TestCheckCallStreamed:
             _check_call_streamed(argv, timeout=2.0)
         elapsed = time.monotonic() - start
 
-        assert elapsed < 30, f"SIGKILL fallback did not unblock the read loop ({elapsed:.1f}s)"
+        # Worst case is timeout(2) + grace(5) + kill ≈ 7s; 15s catches a grace
+        # regression without risking flakiness on a loaded runner.
+        assert elapsed < 15, f"SIGKILL fallback did not unblock the read loop ({elapsed:.1f}s)"
 
     def test_non_utf8_child_output_does_not_crash(
         self, capsys: pytest.CaptureFixture[str]

--- a/tests/pipeline/entrypoints/test_check_call_streamed.py
+++ b/tests/pipeline/entrypoints/test_check_call_streamed.py
@@ -202,6 +202,33 @@ class TestCheckCallStreamed:
         # regression without risking flakiness on a loaded runner.
         assert elapsed < 15, f"SIGKILL fallback did not unblock the read loop ({elapsed:.1f}s)"
 
+    @pytest.mark.skipif(not hasattr(os, "fork"), reason="needs os.fork (POSIX)")
+    def test_timeout_sigkills_pipe_holding_grandchild_that_ignores_sigterm(self) -> None:
+        """A SIGTERM-ignoring grandchild holding the pipe is still SIGKILLed within the bound.
+
+        The direct child (group leader) exits at once; a forked grandchild ignores SIGTERM and
+        keeps the inherited pipe open. Only the group SIGKILL fallback unblocks the read loop —
+        gating escalation on the leader's exit alone would hang until the grandchild's own 60s
+        sleep ends.
+        """
+        argv = [
+            sys.executable,
+            "-c",
+            "import os, signal, time, sys\n"
+            "if os.fork() == 0:\n"
+            "    signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+            "    time.sleep(60)\n"  # grandchild ignores SIGTERM, keeps the pipe open
+            "else:\n"
+            "    sys.exit(0)\n",  # leader exits at once
+        ]
+
+        start = time.monotonic()
+        with pytest.raises(subprocess.TimeoutExpired):
+            _check_call_streamed(argv, timeout=2.0)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 20, f"group SIGKILL did not unblock the read loop ({elapsed:.1f}s)"
+
     def test_non_utf8_child_output_does_not_crash(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:

--- a/tests/pipeline/entrypoints/test_check_call_streamed.py
+++ b/tests/pipeline/entrypoints/test_check_call_streamed.py
@@ -147,6 +147,59 @@ class TestCheckCallStreamed:
 
         assert elapsed < 30, f"group kill did not unblock the read loop ({elapsed:.1f}s)"
 
+    def test_timeout_sigterms_group_so_child_can_clean_up_before_kill(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The timeout kill sends SIGTERM first so a child cleanup handler runs.
+
+        The headless-VST wrapper reaps its Xvfb/dbus tree and removes the X
+        socket from a ``trap cleanup`` that only fires on SIGTERM (not SIGKILL);
+        a bare SIGKILL would orphan that tree and leak the socket. A child that
+        traps SIGTERM, emits a sentinel, and exits stands in for that wrapper.
+
+        :param capsys: Captures the parent-process ``sys.stderr`` writes.
+        """
+        argv = [
+            sys.executable,
+            "-c",
+            "import signal, sys, time\n"
+            "def _bye(*_):\n"
+            "    print('GRACEFUL_CLEANUP', flush=True)\n"
+            "    sys.exit(0)\n"
+            "signal.signal(signal.SIGTERM, _bye)\n"
+            "print('READY', flush=True)\n"
+            "time.sleep(60)\n",
+        ]
+
+        with pytest.raises(subprocess.TimeoutExpired):
+            _check_call_streamed(argv, timeout=2.0)
+
+        assert "GRACEFUL_CLEANUP" in capsys.readouterr().err
+
+    def test_timeout_sigkills_group_that_ignores_sigterm(self) -> None:
+        """A SIGTERM-ignoring child is still hard-killed within the grace bound.
+
+        The escalation is what keeps the timeout real: without the SIGKILL
+        fallback a child that ignores SIGTERM would block the read loop until
+        its own 60s sleep ends. The elapsed bound turns a missing fallback into
+        a failure rather than a 60s stall.
+        """
+        argv = [
+            sys.executable,
+            "-c",
+            "import signal, time\n"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+            "print('IGNORING_SIGTERM', flush=True)\n"
+            "time.sleep(60)\n",
+        ]
+
+        start = time.monotonic()
+        with pytest.raises(subprocess.TimeoutExpired):
+            _check_call_streamed(argv, timeout=2.0)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 30, f"SIGKILL fallback did not unblock the read loop ({elapsed:.1f}s)"
+
     def test_non_utf8_child_output_does_not_crash(
         self, capsys: pytest.CaptureFixture[str]
     ) -> None:


### PR DESCRIPTION
## Problem

`python -m synth_setter.tools.cadence_sweep_489 --size 5` (and other `generate_dataset` runs) intermittently die mid-render with:

```
synth_setter.data.vst.core:load_plugin:80 - Loading plugin plugins/Surge XT.vst3
X connection to :0.0 broken (explicit kill or server shutdown).
```

The renderer subprocess exits non-zero, so `generate_dataset` exits 1 and the cadence-sweep runner raises `CalledProcessError`.

## Root cause (regression from #1617)

`_check_call_streamed` puts each child in its own process group (`start_new_session=True`) and, on timeout or abrupt exit, killed it with a bare `os.killpg(pid, signal.SIGKILL)`.

SIGKILL is uncatchable, so the headless-VST wrapper (`run-linux-vst-headless.sh`) never ran its `trap cleanup EXIT`: its `Xvfb`/`openbox`/`xsettingsd`/`dbus` tree was orphaned and the `/tmp/.X11-unix/X*` socket leaked. Across repeated cadence-sweep runs — each probe's inline oracle-eval carries a 600s timeout that can fire `killpg` — orphaned X servers and stale sockets accumulate and corrupt the shared X display, so a later render's connection to `:0` breaks.

## Fix

SIGTERM the process group first — bash runs the wrapper's `EXIT` trap on SIGTERM, so it reaps its X tree and removes the socket — then escalate to SIGKILL only if the group is still alive after a bounded grace period (`_GROUP_KILL_GRACE_SECONDS = 5.0`), keeping the timeout real for a wedged child.

## Verification (direct repro)

- Before: timing out the real wrapper through `_check_call_streamed` (SIGKILL) left a leaked `/tmp/.X11-unix/X0` socket **and** orphaned `Xvfb`/`openbox`/`xsettingsd` processes (cleanup trap never ran).
- After: the same timeout runs the wrapper's `cleanup` (`cleanup: starting … done`), reaps its Xvfb and removes the socket — no orphan added, no socket leaked.

## Tests

- `test_timeout_sigterms_group_so_child_can_clean_up_before_kill` — a child that traps SIGTERM, emits a sentinel, and exits proves SIGTERM is sent first (the sentinel reaches the streamed output); fails against the old SIGKILL-only path.
- `test_timeout_sigkills_group_that_ignores_sigterm` — a SIGTERM-ignoring child is still hard-killed within a bounded `elapsed < 15s`, pinning the escalation.
- The existing grandchild-reap / timeout / non-UTF-8 tests still pass; all drive real subprocesses with no SUT mocking.

Scope note: the change is exercised at the unit level (real subprocesses + signals); the entrypoint e2e (`tests/test_generate_dataset.py`) gains no assertion because triggering a real inline-eval timeout through Hydra is impractical in CI — the kill-path behavior is pinned end-to-end at the `_check_call_streamed` helper boundary instead (flagged as a soft P31 advisory in pre-PR review, left unit-only deliberately).

Fixes #1634
