### PR TITLE
test(data-pipeline): absorb param_spec_name in baseline config compare

### DIFF
--- a/tests/test_compare_baseline_configs.py
+++ b/tests/test_compare_baseline_configs.py
@@ -325,6 +325,9 @@ ACCEPTED_DIFFS: tuple[str, ...] = (
     "datamodule.stats_file",
     # Optional R2-download URI added in #1338; absent in v0.0.0 — locality, not a model knob.
     "datamodule.download_dataset_root_uri",
+    # Param-spec selection key added in #1602; absent in v0.0.0 — selects the spec,
+    # doesn't size the model (d_out/num_params are pinned separately).
+    "datamodule.param_spec_name",
     "evaluation",  # eval CLI predict-mode post-processing block; not a model knob
     "r2",  # checkpoint-artifact bucket/prefix added to train.yaml; storage locality, not a model knob
     # Opt-in W&B artifact-lineage block (#1508/#1509); absent in v0.0.0 — provenance,


### PR DESCRIPTION
## What

Adds `"datamodule.param_spec_name"` to the `ACCEPTED_DIFFS` tuple in `tests/test_compare_baseline_configs.py`, next to the other post-baseline `datamodule.*` additions.

## Why

Open PR #1602 (`refactor(data-pipeline): rename Surge* model/data classes to VST*`) restructures the Hydra datamodule configs: a new `vst.yaml` base sets `param_spec_name: surge_xt`, and the `surge*.yaml` overlays compose through it. As a result, the resolved surge train config gains a `datamodule.param_spec_name` key.

The guardrail test `test_surge_train_configs_are_equal` resolves `jobs/train/surge/train.sh`'s Hydra config at the `v0.0.0` `MODEL_BASELINE` and asserts equality with the live tree, modulo keys stripped via `ACCEPTED_DIFFS` / `ACCEPTED_DIFF_LEAVES`. `datamodule.param_spec_name` is absent at `v0.0.0` and not currently in `ACCEPTED_DIFFS`, so once #1602 merges the test would flag it as drift for all 8 surge cases. This PR pre-absorbs the key.

It's a param-spec selection key (which spec to encode), not a model-sizing knob — `d_out` / `num_params` are pinned separately in the `model` group, so a stray flip that also changed output dims is still caught by the unstripped literal keys.

## Safe to land in either order

`_strip_dotted_keys` no-ops on absent keys (pinned by `TestStripDottedKeys::test_absent_path_is_no_op`), so on `main` — where the key doesn't yet exist — this entry is a no-op until #1602 merges.

## Validation

- `uv run pytest tests/test_compare_baseline_configs.py -m "not slow and not network" -q` -> 23 passed (includes the `TestStripDottedKeys` / `TestStripLeafKeys` / slug unit tests).
- The slow/network surge baseline test (`test_surge_train_configs_are_equal`) needs the `v0.0.0` worktree and ~10min; it runs in `make test-ci-slow` and exercises this entry post-#1602.

Refs #1595