### PR TITLE
test(testing): raise xdist per-worker mem budget to measured 2 GiB peak

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -949,9 +949,9 @@ def _cgroup_aware_cpu_count() -> int:
     return max(1, int(cpus))
 
 
-# Per-worker resident-memory budget for the -n auto memory clamp, overridable
-# via PYTEST_XDIST_WORKER_MEM_MB. 1 GiB suits a torch+h5py+Hydra worker.
-_DEFAULT_WORKER_MEM_MB = 1024
+# Per-worker resident-memory budget for the -n auto clamp (override via
+# PYTEST_XDIST_WORKER_MEM_MB); 2 GiB = measured peak RSS per worker slot (#1646).
+_DEFAULT_WORKER_MEM_MB = 2048
 
 # A v1 memory.limit_in_bytes at or above this is the kernel's unlimited sentinel.
 _MEM_UNLIMITED_SENTINEL = 1 << 62
@@ -1014,7 +1014,7 @@ def _available_memory_bytes() -> int | None:
 def _memory_aware_worker_count() -> int | None:
     """Cap ``-n auto`` workers by available memory and a per-worker budget.
 
-    Divides available memory by ``PYTEST_XDIST_WORKER_MEM_MB`` (default 1 GiB) so
+    Divides available memory by ``PYTEST_XDIST_WORKER_MEM_MB`` (default 2 GiB) so
     a busy shared host doesn't OOM-kill the run — the failure #1490's CPU clamp
     can't catch, since neither cpu.max nor memory.max is set on a shared host.
 

--- a/tests/test__conftest_mem.py
+++ b/tests/test__conftest_mem.py
@@ -114,17 +114,17 @@ class TestMemoryAwareWorkerCount:
     """Unit tests for _memory_aware_worker_count covering budget division."""
 
     def test_divides_avail_by_default_budget(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """20 GiB avail / 1 GiB default budget → 20 workers.
+        """20 GiB avail / 2 GiB default budget → 10 workers.
 
         :param monkeypatch: Pytest monkeypatch fixture.
         """
         monkeypatch.delenv("PYTEST_XDIST_WORKER_MEM_MB", raising=False)
         files = {_MEMINFO: _meminfo(20 * 1024 * 1024), _V2_MEM: "max\n"}
         with patch("builtins.open", side_effect=_make_open(files)):
-            assert _memory_aware_worker_count() == 20
+            assert _memory_aware_worker_count() == 10
 
     def test_fractional_floors_to_at_least_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """1.5 GiB avail / 1 GiB budget → floored to 1, never 0.
+        """1.5 GiB avail / 2 GiB budget → 0.75 floors to 0, then lifted to 1.
 
         :param monkeypatch: Pytest monkeypatch fixture.
         """
@@ -134,26 +134,29 @@ class TestMemoryAwareWorkerCount:
             assert _memory_aware_worker_count() == 1
 
     def test_env_budget_override_changes_divisor(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """PYTEST_XDIST_WORKER_MEM_MB=2048 → 16 GiB / 2 GiB = 8 workers.
+        """PYTEST_XDIST_WORKER_MEM_MB=4096 → 16 GiB / 4 GiB = 4 workers.
+
+        The override is deliberately distinct from the 2 GiB default so the test fails if the env
+        var is ignored and the default divisor is used instead.
 
         :param monkeypatch: Pytest monkeypatch fixture.
         """
-        monkeypatch.setenv("PYTEST_XDIST_WORKER_MEM_MB", "2048")
+        monkeypatch.setenv("PYTEST_XDIST_WORKER_MEM_MB", "4096")
         files = {_MEMINFO: _meminfo(16 * 1024 * 1024), _V2_MEM: "max\n"}
         with patch("builtins.open", side_effect=_make_open(files)):
-            assert _memory_aware_worker_count() == 8
+            assert _memory_aware_worker_count() == 4
 
     def test_invalid_env_budget_falls_back_to_default(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Non-integer budget env → default 1 GiB divisor, not a crash.
+        """Non-integer budget env → default 2 GiB divisor, not a crash.
 
         :param monkeypatch: Pytest monkeypatch fixture.
         """
         monkeypatch.setenv("PYTEST_XDIST_WORKER_MEM_MB", "not-a-number")
         files = {_MEMINFO: _meminfo(8 * 1024 * 1024), _V2_MEM: "max\n"}
         with patch("builtins.open", side_effect=_make_open(files)):
-            assert _memory_aware_worker_count() == 8
+            assert _memory_aware_worker_count() == 4
 
     def test_no_memory_signal_returns_none(self) -> None:
         """No readable memory signal → None so the caller falls back to CPU count."""
@@ -174,7 +177,7 @@ class TestHookCombinesCpuAndMemory:
         monkeypatch.setattr(os, "sched_getaffinity", lambda _pid: set(range(32)), raising=False)
         files = {_MEMINFO: _meminfo(4 * 1024 * 1024), _V2_MEM: "max\n"}
         with patch("builtins.open", side_effect=_make_open(files)):
-            assert pytest_xdist_auto_num_workers(cast("pytest.Config", None)) == 4
+            assert pytest_xdist_auto_num_workers(cast("pytest.Config", None)) == 2
 
     def test_cpu_clamps_below_memory(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Plenty of memory but few CPUs → cpu count wins the min.


### PR DESCRIPTION
## Problem

`make test-fast` (`pytest -n auto`) still OOM-kills on the shared dev host even after the memory-aware clamp landed in #1524. The clamp divides available memory by a **1 GiB** per-worker budget, but that is roughly half a worker slot's real peak RSS, so it over-provisions ~2x and the kernel OOM-killer reaps the run.

## Measurement

Ran the fast suite (2114 tests) under a per-process RSS monitor at `-n 6`:

- Whole-tree peak RSS = **12,467 MB across 6 worker slots → ~2,080 MB per worker** (worker process + the torch-importing subprocesses some tests spawn).
- A single xdist worker's own RSS peaked at ~1,353 MB.

## Fix

Raise `_DEFAULT_WORKER_MEM_MB` from 1024 → **2048**, grounded in the measured ~2 GiB per-worker-slot peak. On a 31 GiB / 32-core shared host, `-n auto` now resolves to ~7-9 workers instead of ~18. The `PYTEST_XDIST_WORKER_MEM_MB` override is unchanged.

## Verification

- Full fast suite under `-n auto` with the new budget: **2111 passed, 3 skipped, no OOM, no worker crashes** (79s, resolved to 7 workers on this host).
- `tests/test__conftest_mem.py`: 22/22 green. The env-override test now uses 4096 (distinct from the 2 GiB default) so it fails if the override is ignored.

## Follow-up (not in this PR)

`_available_memory_bytes()` trusts `MemAvailable`, which counts reclaimable cache as free — optimistic on a swap-thrashing host. Hardening that estimate is separate; tracked under #1646's follow-up note.

Fixes #1646