### PR TITLE
chore: bound #489 sweep agents with --count to terminate

### DIFF
--- a/src/synth_setter/tools/cadence_sweep_489.py
+++ b/src/synth_setter/tools/cadence_sweep_489.py
@@ -15,24 +15,27 @@ Run it::
     python -m synth_setter.tools.cadence_sweep_489 --size 5
 
 Every sweep is created before any agent runs, so they all appear in the W&B UI
-even if an agent later stalls; agents then run one at a time because they share
-one Xvfb display and would otherwise contend on it. Run under tmux/nohup so a
-disconnect does not orphan an in-flight agent.
+even if an agent later stalls; agents then run one at a time (the loop is
+sequential) so concurrent host renders do not oversubscribe CPU/RAM — each cell's
+render already gets its own ephemeral Xvfb from the headless wrapper, so they do
+not share a display. Run under tmux/nohup so a disconnect does not orphan an
+in-flight agent.
 """
 
 from __future__ import annotations
 
 import argparse
+import math
 import os
 import subprocess
 import sys
 import uuid
 from typing import Any
 
+import wandb
 import wandb.env
 from loguru import logger
 
-import wandb
 from synth_setter.data.vst import preset_paths
 from synth_setter.pipeline.schemas.prefix import DEFAULT_R2_PREFIX_ROOT, make_r2_prefix
 
@@ -267,18 +270,30 @@ def _run_generate(overrides: list[str]) -> None:
     subprocess.run(argv, check=True)  # noqa: S603 — argv built from validated literals
 
 
-def _run_agent(sweep_id: str) -> None:
-    """Run a ``wandb agent`` for one sweep to completion as a subprocess (fail-fast).
+def _grid_cell_count(config: dict[str, Any]) -> int:
+    """Return the grid size: the product of each swept parameter's value count.
+
+    :param config: A ``_sweep`` config whose ``parameters`` map each swept key to its ``values``.
+    :returns: The number of grid cells the sweep enumerates.
+    """
+    return math.prod(len(param["values"]) for param in config["parameters"].values())
+
+
+def _run_agent(sweep_id: str, count: int) -> None:
+    """Run a ``wandb agent`` for one sweep, bounded to ``count`` runs, as a subprocess (fail-fast).
 
     A non-zero exit raises ``subprocess.CalledProcessError`` (``check=True``).
 
     :param sweep_id: Sweep the agent pulls grid cells from.
+    :param count: Run cap (the grid size); the agent exits once it is reached.
     """
     # wandb 0.26.1's Agent.is_flapping reads wandb.START_TIME, which only the legacy
     # wandb.old.core sets, so the agent crashes with AttributeError unless flapping is
     # disabled; the grid is bounded, so flapping adds no value anyway.
     env = {**os.environ, wandb.env.AGENT_DISABLE_FLAPPING: "true"}
-    argv = ["wandb", "agent", f"{ENTITY}/{PROJECT}/{sweep_id}"]
+    # --count bounds the agent to the grid size: unbounded, wandb keeps the agent alive after the
+    # grid is exhausted and re-dispatches an already-finished run, wedging the sequential loop (#489).
+    argv = ["wandb", "agent", "--count", str(count), f"{ENTITY}/{PROJECT}/{sweep_id}"]
     subprocess.run(argv, check=True, env=env)  # noqa: S603 — fixed argv plus our sweep id
 
 
@@ -286,8 +301,8 @@ def run(n: int) -> None:
     """Generate the surge_xt and surge_simple copy sources, then create and drive every #489 sweep.
 
     The sources are generated first because the copy probes read them; then every sweep is created
-    before any agent runs so they all land in the W&B UI; agents run one at a time to avoid
-    contending on the shared Xvfb display.
+    before any agent runs so they all land in the W&B UI; agents run one at a time (sequential
+    loop), each bounded by its grid size so it exits when the grid is exhausted.
 
     :param n: Per-split sample count shared by the sources and the copy probes.
     """
@@ -317,9 +332,10 @@ def run(n: int) -> None:
     logger.info(f"generating copy source -> {surge_simple_reference_copy_uri()}")
     _run_generate(simple_overrides)
     sweep_ids = [wandb.sweep(config, entity=ENTITY, project=PROJECT) for config in sweep_configs]
-    for sweep_id in sweep_ids:
-        logger.info(f"running agent for {ENTITY}/{PROJECT}/{sweep_id}")
-        _run_agent(sweep_id)
+    for config, sweep_id in zip(sweep_configs, sweep_ids, strict=True):
+        count = _grid_cell_count(config)
+        logger.info(f"running agent for {ENTITY}/{PROJECT}/{sweep_id} ({count} cells)")
+        _run_agent(sweep_id, count)
 
 
 def main(argv: list[str] | None = None) -> None:

--- a/tests/tools/test_cadence_sweep_489.py
+++ b/tests/tools/test_cadence_sweep_489.py
@@ -74,6 +74,51 @@ def test_swept_args_macro_is_last_so_grid_values_win_over_fixed_pins() -> None:
         assert config["command"][-1] == "${args_no_hyphens}"
 
 
+def test_grid_cell_count_is_the_product_of_each_swept_knob() -> None:
+    """The grid size is the product of every swept knob's value count (2 reload x 4 gui = 8)."""
+    config = _config_by_label(sweep.sweeps(2), "cadence_probe_surge_xt")
+    assert sweep._grid_cell_count(config) == 8
+
+
+def test_run_agent_bounds_the_agent_to_the_grid_cell_count(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``_run_agent`` passes ``--count <cells>`` so the agent exits when the grid is exhausted.
+
+    Unbounded, wandb 0.26.1 keeps the agent alive after the grid is exhausted and re-dispatches an
+    already-finished run, so the runner's sequential loop never reaches the next sweep (#489).
+
+    :param monkeypatch: Captures the ``subprocess.run`` argv without spawning a real agent.
+    """
+    captured: list[list[str]] = []
+    monkeypatch.setattr(sweep.subprocess, "run", lambda argv, **kwargs: captured.append(argv))
+
+    sweep._run_agent("sid-123", 8)
+
+    (argv,) = captured
+    assert argv[:2] == ["wandb", "agent"]
+    assert "--count" in argv
+    assert argv[argv.index("--count") + 1] == "8"
+    assert argv[-1].endswith("/sid-123")
+
+
+def test_run_bounds_every_agent_by_its_own_grid_size(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``run`` creates all sweeps, then drives each agent bounded by that sweep's grid size.
+
+    :param monkeypatch: Stubs source generation and ``wandb.sweep``, and records the per-agent count.
+    """
+    monkeypatch.setattr(sweep, "_run_generate", lambda overrides: None)
+    monkeypatch.setattr(sweep.wandb, "sweep", lambda config, **kwargs: "sid")
+    counts: list[int] = []
+    monkeypatch.setattr(sweep, "_run_agent", lambda sweep_id, count: counts.append(count))
+
+    sweep.run(2)
+
+    assert counts == [8] * 7
+
+
 def test_run_rejects_size_below_one_before_generating_any_source(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What

`src/synth_setter/tools/cadence_sweep_489.py` drove each #489 grid sweep with an
**unbounded** `wandb agent`. On wandb 0.26.1 the agent does not terminate when a
grid is exhausted — it stays alive and re-dispatches an already-finished run
(observed re-running the same finished cell once an hour). Because `_run_agent`
blocks on that subprocess via `check=True`, the runner's sequential loop never
returns to start the next sweep.

**Symptom (observed in a live `--size 5` run):** two script instances each wedged
on sweep #2 (`cadence_probe_surge_xt`, which had *succeeded*), re-dispatching its
last finished cell hourly for 3+ hours. Sweeps #3–#7 never started.

## Fix

Bound each agent with `--count <grid cells>` (the product of the swept-knob value
counts, via a new `_grid_cell_count`) so it exits once the grid is enumerated and
the loop advances to the next sweep.

Also correct the module docstring's stale claim that agents serialize "because
they share one Xvfb display": each render already gets its **own** ephemeral Xvfb
from the headless wrapper (`run-linux-vst-headless.sh`, `Xvfb -displayfd`), so the
real reason to run them one at a time is host CPU/RAM, not display contention.

## Tests

`tests/tools/test_cadence_sweep_489.py` (pure, no R2/W&B):

- `_grid_cell_count` returns the product of the swept value counts (8),
- `_run_agent` emits `--count <n>` in its argv,
- `run` drives every agent bounded by its own grid size.

All three fail against the pre-fix code.

## Scope / follow-ups

- The shuffle sweeps' `param_sample_cadence=shard` + copy combination (which fails
  by renderer design) is **out of scope** here — handled in a separate PR that
  relaxes the renderer guard so shard-cadence cells seed their single patch from
  the copy source.
- Separately, a fully-failed sweep's agent still exits 0, so the runner silently
  skips it — a latent robustness gap worth a follow-up guard (not the blocker
  this PR fixes).

Pre-commit hooks pass; `/repo-review-full-no-comments` returned **0 BLOCK** (4
advisory WARNs, all pre-existing-convention / change-detector, noted and accepted).

Refs #489
