### PR TITLE
chore(data-pipeline): real Lance writer tests, one shape contract

### DIFF
--- a/.github/workflows/test-dataset-finalization.yml
+++ b/.github/workflows/test-dataset-finalization.yml
@@ -29,6 +29,8 @@ on:
     paths:
       - "src/synth_setter/cli/finalize_dataset.py"
       - "src/synth_setter/cli/generate_dataset.py"
+      - "src/synth_setter/data/vst/writers.py"
+      - "src/synth_setter/pipeline/data/lance_shard.py"
       - "src/synth_setter/pipeline/data/reshard.py"
       - "src/synth_setter/pipeline/schemas/r2_location.py"
       - "src/synth_setter/pipeline/schemas/spec.py"

--- a/.github/workflows/test-dataset-finalization.yml
+++ b/.github/workflows/test-dataset-finalization.yml
@@ -29,7 +29,9 @@ on:
     paths:
       - "src/synth_setter/cli/finalize_dataset.py"
       - "src/synth_setter/cli/generate_dataset.py"
+      - "src/synth_setter/data/vst/shapes.py"
       - "src/synth_setter/data/vst/writers.py"
+      - "src/synth_setter/pipeline/ci/validate_shard.py"
       - "src/synth_setter/pipeline/data/lance_shard.py"
       - "src/synth_setter/pipeline/data/reshard.py"
       - "src/synth_setter/pipeline/schemas/r2_location.py"

--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -1432,7 +1432,7 @@ src/
     ci/                 # CI validation scripts (implemented)
       materialize_spec.py # Compose a DatasetSpec from a Hydra experiment and write it to disk as JSON
       validate_spec.py  # Spec structural validation (required fields, git_sha format, etc.)
-      validate_shard.py # Shard validation (valid HDF5, full per-dataset shapes via synth_setter.data.vst.shapes — not just row count); iterates spec.shards via R2
+      validate_shard.py # Shard validation (suffix-dispatched hdf5/wds/lance, full per-dataset shapes via synth_setter.data.vst.shapes — not just row count); iterates spec.shards via R2
       load_image_config.py # Resolve Docker image configuration for the launcher
 
     constants.py        # Well-known filenames (INPUT_SPEC_FILENAME)

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -109,7 +109,9 @@ docs:
       - pattern: "src/synth_setter/data/vst/writers.py"
         covers: "make_hdf5_dataset + make_wds_dataset + make_lance_dataset entrypoints; per-batch sample-save helpers; ShardMetadata sidecar wiring; CLI suffix dispatch via OutputFormat.from_extension."
       - pattern: "src/synth_setter/data/vst/shapes.py"
-        covers: "Shared shape primitives consumed by writers + (planned) shard validator — DATASET_FIELD_NAMES, mel-front-end constants, audio_dataset_shape / mel_dataset_shape / param_array_dataset_shape."
+        covers: "Shared shape primitives consumed by the writers, the shard validator, and the test shard seeders — DATASET_FIELD_NAMES / DATASET_FIELD_DTYPES, mel-front-end constants, per-field shape helpers, and dataset_field_shapes (the single field→shape contract)."
+      - pattern: "src/synth_setter/pipeline/data/lance_shard.py"
+        covers: "Lance single-file shard codec — lance_schema / tensor_array / record_batch_from_arrays / write_lance_file on the encode side, read_shard_metadata / tensor_chunk_to_numpy / iter_lance_column_rows on the decode side; shared by the Lance writer, validator, and finalize."
 
   # ── SkyPilot compute integration design doc ─────────────────────
   - doc: docs/design/skypilot-compute-integration.md

--- a/src/synth_setter/data/vst/shapes.py
+++ b/src/synth_setter/data/vst/shapes.py
@@ -147,7 +147,7 @@ def param_array_dataset_shape(num_samples: int, num_params: int) -> tuple[int, i
 
 
 def dataset_field_shapes(render: RenderConfig, num_params: int) -> dict[str, tuple[int, ...]]:
-    """Full per-field shapes (leading row axis included) the writers emit for one shard.
+    """Return the full per-field shapes (leading row axis included) the writers emit per shard.
 
     Single source of the field→shape contract — keyed by
     ``DATASET_FIELD_NAMES`` with ``N = render.samples_per_shard``.

--- a/src/synth_setter/data/vst/shapes.py
+++ b/src/synth_setter/data/vst/shapes.py
@@ -2,8 +2,9 @@
 
 Hosts the per-row array names (``DATASET_FIELD_NAMES``), the per-field
 on-disk dtypes (``DATASET_FIELD_DTYPES``), the mel-spectrogram constants the
-writer's ``make_spectrogram`` uses, and the audio / mel-spec / param-array
-dataset-shape calculators. Kept as a thin sibling module so that the shard
+writer's ``make_spectrogram`` uses, the audio / mel-spec / param-array
+dataset-shape calculators, and the per-field aggregate
+(``dataset_field_shapes``). Kept as a thin sibling module so that the shard
 validator and the wds writer can import these primitives without pulling in
 the rest of ``generate_vst_dataset.py``'s import surface (h5py, pedalboard,
 the VST renderer).
@@ -11,7 +12,12 @@ the VST renderer).
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import numpy as np
+
+if TYPE_CHECKING:
+    from synth_setter.pipeline.schemas.spec import RenderConfig
 
 AUDIO_FIELD: str = "audio"
 MEL_SPEC_FIELD: str = "mel_spec"
@@ -139,3 +145,33 @@ def param_array_dataset_shape(num_samples: int, num_params: int) -> tuple[int, i
     :rtype: tuple[int, int]
     """
     return (num_samples, num_params)
+
+
+def dataset_field_shapes(render: RenderConfig, num_params: int) -> dict[str, tuple[int, ...]]:
+    """Full per-field shapes (leading row axis included) the writers emit for one shard.
+
+    Single source of the field→shape contract shared by the Lance writer, the
+    shard validator, and the test-side shard seeders — keyed by
+    ``DATASET_FIELD_NAMES`` with ``N = render.samples_per_shard``.
+
+    :param render: Per-shard renderer config supplying row count, channels,
+        sample rate, and duration.
+    :param num_params: Width of the per-row parameter vector.
+    :returns: Mapping with one full ``(N, ...)`` shape tuple per dataset field.
+    :rtype: dict[str, tuple[int, ...]]
+    """
+    return {
+        AUDIO_FIELD: audio_dataset_shape(
+            render.samples_per_shard,
+            render.channels,
+            render.sample_rate,
+            render.signal_duration_seconds,
+        ),
+        MEL_SPEC_FIELD: mel_dataset_shape(
+            render.samples_per_shard,
+            render.channels,
+            render.sample_rate,
+            render.signal_duration_seconds,
+        ),
+        PARAM_ARRAY_FIELD: param_array_dataset_shape(render.samples_per_shard, num_params),
+    }

--- a/src/synth_setter/data/vst/shapes.py
+++ b/src/synth_setter/data/vst/shapes.py
@@ -1,13 +1,10 @@
-"""Shape and mel-front-end primitives shared by writer and validator.
+"""Shape and mel-front-end primitives shared by the writers and the validator.
 
-Hosts the per-row array names (``DATASET_FIELD_NAMES``), the per-field
-on-disk dtypes (``DATASET_FIELD_DTYPES``), the mel-spectrogram constants the
-writer's ``make_spectrogram`` uses, the audio / mel-spec / param-array
-dataset-shape calculators, and the per-field aggregate
-(``dataset_field_shapes``). Kept as a thin sibling module so that the shard
-validator and the wds writer can import these primitives without pulling in
-the rest of ``generate_vst_dataset.py``'s import surface (h5py, pedalboard,
-the VST renderer).
+Hosts the per-row array names, on-disk dtypes, mel-spectrogram constants, and
+dataset-shape calculators. Kept as a thin sibling module so that the shard
+validator and the writers can import these primitives without pulling in the
+rest of ``generate_vst_dataset.py``'s import surface (h5py, pedalboard, the
+VST renderer).
 """
 
 from __future__ import annotations
@@ -150,8 +147,7 @@ def param_array_dataset_shape(num_samples: int, num_params: int) -> tuple[int, i
 def dataset_field_shapes(render: RenderConfig, num_params: int) -> dict[str, tuple[int, ...]]:
     """Full per-field shapes (leading row axis included) the writers emit for one shard.
 
-    Single source of the field→shape contract shared by the Lance writer, the
-    shard validator, and the test-side shard seeders — keyed by
+    Single source of the field→shape contract — keyed by
     ``DATASET_FIELD_NAMES`` with ``N = render.samples_per_shard``.
 
     :param render: Per-shard renderer config supplying row count, channels,

--- a/src/synth_setter/data/vst/shapes.py
+++ b/src/synth_setter/data/vst/shapes.py
@@ -14,6 +14,8 @@ from typing import TYPE_CHECKING
 import numpy as np
 
 if TYPE_CHECKING:
+    # Type-only on purpose: a runtime import would risk a cycle (spec.py lazily
+    # imports the param-spec registry from data.vst).
     from synth_setter.pipeline.schemas.spec import RenderConfig
 
 AUDIO_FIELD: str = "audio"
@@ -79,7 +81,7 @@ def mel_n_fft(sample_rate: float) -> int:
 
 
 def mel_n_frames(sample_rate: float, signal_duration_seconds: float) -> int:
-    """Number of mel-time frames librosa produces (``center=True`` default).
+    """Return the number of mel-time frames librosa produces (``center=True`` default).
 
     Mirrors librosa's ``1 + audio_length // hop_length`` calculation.
 

--- a/src/synth_setter/data/vst/writers.py
+++ b/src/synth_setter/data/vst/writers.py
@@ -472,6 +472,7 @@ def make_lance_dataset(
     :param fixed_note_params_list: Optional pre-set note params; same full-shard
         contract as ``fixed_synth_params_list``.
     """
+    # Function-local so the h5/wds writer paths never pay the pylance import.
     from lance.file import LanceFileWriter
 
     from synth_setter.pipeline.data.lance_shard import lance_schema, record_batch_from_arrays

--- a/src/synth_setter/data/vst/writers.py
+++ b/src/synth_setter/data/vst/writers.py
@@ -306,13 +306,13 @@ def _render_in_batches(
 def _shard_metadata_from_render(render_cfg: RenderConfig) -> ShardMetadata:
     """Project a ``RenderConfig`` onto the per-shard sidecar metadata fields.
 
-    Single source of truth for the five render-derived attrs the HDF5
+    Single source of truth for the render-derived attrs the HDF5
     ``audio.attrs`` sidecar, the wds ``metadata.json`` tar member, and the
     Lance schema metadata expose. Keeping projection here means the writers
     can never drift.
 
     :param render_cfg: Per-shard renderer config from the dataset spec.
-    :returns: Strict ``ShardMetadata`` with the five render-derived fields filled.
+    :returns: Strict ``ShardMetadata`` with every render-derived field filled.
     :rtype: ShardMetadata
     """
     return ShardMetadata(

--- a/src/synth_setter/data/vst/writers.py
+++ b/src/synth_setter/data/vst/writers.py
@@ -306,9 +306,10 @@ def _render_in_batches(
 def _shard_metadata_from_render(render_cfg: RenderConfig) -> ShardMetadata:
     """Project a ``RenderConfig`` onto the per-shard sidecar metadata fields.
 
-    Single source of truth for the five render-derived attrs that both the
-    HDF5 ``audio.attrs`` sidecar and the wds ``metadata.json`` tar member
-    expose. Keeping projection here means the two writers can never drift.
+    Single source of truth for the five render-derived attrs the HDF5
+    ``audio.attrs`` sidecar, the wds ``metadata.json`` tar member, and the
+    Lance schema metadata expose. Keeping projection here means the writers
+    can never drift.
 
     :param render_cfg: Per-shard renderer config from the dataset spec.
     :returns: Strict ``ShardMetadata`` with the five render-derived fields filled.
@@ -472,7 +473,7 @@ def make_lance_dataset(
     :param fixed_note_params_list: Optional pre-set note params; same full-shard
         contract as ``fixed_synth_params_list``.
     """
-    # Function-local so the h5/wds writer paths never pay the pylance import.
+    # Function-local so the h5/wds writer paths never pay the `lance` import cost.
     from lance.file import LanceFileWriter
 
     from synth_setter.pipeline.data.lance_shard import lance_schema, record_batch_from_arrays

--- a/src/synth_setter/data/vst/writers.py
+++ b/src/synth_setter/data/vst/writers.py
@@ -472,12 +472,13 @@ def make_lance_dataset(
     :param fixed_note_params_list: Optional pre-set note params; same full-shard
         contract as ``fixed_synth_params_list``.
     """
-    param_spec = param_specs[render_cfg.param_spec_name]
-    meta = _shard_metadata_from_render(render_cfg)
-    start_idx = 0
     from lance.file import LanceFileWriter
 
     from synth_setter.pipeline.data.lance_shard import lance_schema, record_batch_from_arrays
+
+    param_spec = param_specs[render_cfg.param_spec_name]
+    meta = _shard_metadata_from_render(render_cfg)
+    start_idx = 0
 
     _validate_fixed_params_lengths(
         num_samples=render_cfg.samples_per_shard,

--- a/src/synth_setter/data/vst/writers.py
+++ b/src/synth_setter/data/vst/writers.py
@@ -28,12 +28,7 @@ from synth_setter.data.vst.generate_vst_dataset import (
     generate_sample,
 )
 from synth_setter.data.vst.param_spec import NoteParams, ParamSpec
-from synth_setter.data.vst.shapes import (
-    DATASET_FIELD_NAMES,
-    audio_dataset_shape,
-    mel_dataset_shape,
-    param_array_dataset_shape,
-)
+from synth_setter.data.vst.shapes import DATASET_FIELD_NAMES, dataset_field_shapes
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
 from synth_setter.pipeline.schemas.spec import RenderConfig
 
@@ -481,6 +476,7 @@ def make_lance_dataset(
     meta = _shard_metadata_from_render(render_cfg)
     start_idx = 0
     from lance.file import LanceFileWriter
+
     from synth_setter.pipeline.data.lance_shard import lance_schema, record_batch_from_arrays
 
     _validate_fixed_params_lengths(
@@ -488,27 +484,7 @@ def make_lance_dataset(
         fixed_synth_params_list=fixed_synth_params_list,
         fixed_note_params_list=fixed_note_params_list,
     )
-    schema = lance_schema(
-        {
-            DATASET_FIELD_NAMES[0]: audio_dataset_shape(
-                render_cfg.samples_per_shard,
-                render_cfg.channels,
-                render_cfg.sample_rate,
-                render_cfg.signal_duration_seconds,
-            ),
-            DATASET_FIELD_NAMES[1]: mel_dataset_shape(
-                render_cfg.samples_per_shard,
-                render_cfg.channels,
-                render_cfg.sample_rate,
-                render_cfg.signal_duration_seconds,
-            ),
-            DATASET_FIELD_NAMES[2]: param_array_dataset_shape(
-                render_cfg.samples_per_shard,
-                len(param_spec),
-            ),
-        },
-        meta,
-    )
+    schema = lance_schema(dataset_field_shapes(render_cfg, len(param_spec)), meta)
 
     writer = LanceFileWriter(str(lance_file), schema)
 

--- a/src/synth_setter/pipeline/ci/validate_shard.py
+++ b/src/synth_setter/pipeline/ci/validate_shard.py
@@ -148,7 +148,7 @@ def check_shard_contracts(
 
 
 def _expected_dataset_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
-    """Spec-level adapter for :func:`dataset_field_shapes` (the shape contract's home).
+    """Adapt ``spec`` to :func:`dataset_field_shapes`, the shape contract's home.
 
     :param spec: Dataset spec whose ``render`` config and ``num_params`` parameterize
         the per-field shapes the writer would emit for one shard.

--- a/src/synth_setter/pipeline/ci/validate_shard.py
+++ b/src/synth_setter/pipeline/ci/validate_shard.py
@@ -3,7 +3,8 @@
 
 Performs full per-shard validation. Each shard file is dispatched by its
 filename suffix via ``synth_setter.pipeline.schemas.spec.OutputFormat.from_extension``
-to either the HDF5 path (``.h5``) or the wds tar path (``.tar``):
+to the HDF5 path (``.h5``), the wds tar path (``.tar``), or the Lance path
+(``.lance``):
 
 - HDF5 path: each top-level dataset's full ``.shape`` matches the writer's
   source-of-truth shape helpers in ``synth_setter.data.vst.shapes`` —
@@ -14,6 +15,9 @@ to either the HDF5 path (``.h5``) or the wds tar path (``.tar``):
   as a numpy array whose trailing dims (``arr.shape[1:]``) match the same
   shape helpers; and the summed row count per field equals
   ``spec.render.samples_per_shard``.
+- Lance path: schema metadata parses as a strict ``ShardMetadata``; every
+  field is a fixed-shape tensor column whose dtype and inner shape match the
+  same shape helpers; and ``num_rows`` equals ``spec.render.samples_per_shard``.
 
 CLI usage:
     python3 -m synth_setter.pipeline.ci.validate_shard <spec.json|r2://bucket/spec.json>
@@ -37,14 +41,9 @@ import numpy as np
 from pydantic import ValidationError
 
 from synth_setter.data.vst.shapes import (
-    AUDIO_FIELD,
     DATASET_FIELD_DTYPES,
     DATASET_FIELD_NAMES,
-    MEL_SPEC_FIELD,
-    PARAM_ARRAY_FIELD,
-    audio_dataset_shape,
-    mel_dataset_shape,
-    param_array_dataset_shape,
+    dataset_field_shapes,
 )
 from synth_setter.pipeline.r2_io import downloaded_to_tempfile
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
@@ -149,11 +148,7 @@ def check_shard_contracts(
 
 
 def _expected_dataset_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
-    """Full per-field shapes (N + inner) the writer emits for ``spec``.
-
-    Keys match ``DATASET_FIELD_NAMES``; values come from the writer's own
-    shape helpers in ``synth_setter.data.vst.shapes`` so a future renderer
-    change that drifts the audio / mel / param shapes fails fast here.
+    """Spec-level adapter for :func:`dataset_field_shapes` (the shape contract's home).
 
     :param spec: Dataset spec whose ``render`` config and ``num_params`` parameterize
         the per-field shapes the writer would emit for one shard.
@@ -161,17 +156,7 @@ def _expected_dataset_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
         ``(N, ...)`` shape tuple.
     :rtype: dict[str, tuple[int, ...]]
     """
-    render = spec.render
-    num_samples = render.samples_per_shard
-    return {
-        AUDIO_FIELD: audio_dataset_shape(
-            num_samples, render.channels, render.sample_rate, render.signal_duration_seconds
-        ),
-        MEL_SPEC_FIELD: mel_dataset_shape(
-            num_samples, render.channels, render.sample_rate, render.signal_duration_seconds
-        ),
-        PARAM_ARRAY_FIELD: param_array_dataset_shape(num_samples, spec.num_params),
-    }
+    return dataset_field_shapes(spec.render, spec.num_params)
 
 
 def validate_shard(shard_path: Path, spec: DatasetSpec) -> list[str]:

--- a/tests/data/vst/test_fake_plugin_e2e.py
+++ b/tests/data/vst/test_fake_plugin_e2e.py
@@ -25,6 +25,7 @@ from synth_setter.data.vst.shapes import AUDIO_FIELD, MEL_SPEC_FIELD, PARAM_ARRA
 from synth_setter.data.vst.writers import make_hdf5_dataset, make_lance_dataset, make_wds_dataset
 from synth_setter.pipeline.ci.validate_shard import validate_shard
 from synth_setter.pipeline.data.lance_shard import iter_lance_column_rows, read_shard_metadata
+from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
 from synth_setter.pipeline.schemas.spec import DatasetSpec, RenderConfig
 
 _ = hdf5plugin  # keep type checkers from flagging the side-effect import
@@ -206,7 +207,7 @@ def test_make_lance_dataset_writes_validator_passing_shard_under_fake_plugin(
     Drives ``make_lance_dataset`` end-to-end (batch loop, per-batch flush via
     ``samples_per_render_batch=2``, schema construction, writer close) and
     checks the produced file through the production validator — schema,
-    dtypes, inner shapes, row count — plus a field-level ``ShardMetadata``
+    dtypes, inner shapes, row count — plus a whole-model ``ShardMetadata``
     round-trip against the render config.
 
     :param tmp_path: Destination directory for the Lance shard under test.
@@ -227,11 +228,15 @@ def test_make_lance_dataset_writes_validator_passing_shard_under_fake_plugin(
 
     assert validate_shard(out, spec) == []
     meta = read_shard_metadata(LanceFileReader(str(out)).metadata().schema)
-    assert meta.velocity == render_cfg.velocity
-    assert meta.signal_duration_seconds == render_cfg.signal_duration_seconds
-    assert meta.sample_rate == render_cfg.sample_rate
-    assert meta.channels == render_cfg.channels
-    assert meta.min_loudness == render_cfg.min_loudness
+    # Whole-model equality: a new ShardMetadata field fails construction here,
+    # forcing this round-trip pin to cover it.
+    assert meta == ShardMetadata(
+        velocity=render_cfg.velocity,
+        signal_duration_seconds=render_cfg.signal_duration_seconds,
+        sample_rate=render_cfg.sample_rate,
+        channels=render_cfg.channels,
+        min_loudness=render_cfg.min_loudness,
+    )
 
 
 @pytest.mark.fake_vst
@@ -251,7 +256,7 @@ def test_make_lance_dataset_arrays_match_h5_writer_under_fake_plugin(
         renders run without a real VST3 or X11.
     """
     num_samples = 4
-    render_cfg = _fake_render_cfg(num_samples=num_samples)
+    render_cfg = _fake_render_cfg(num_samples=num_samples, samples_per_render_batch=2)
     fixed_synth = [_HARDCODED_SYNTH_PARAMS] * num_samples
     fixed_note = [_HARDCODED_NOTE_PARAMS] * num_samples
     lance_out = tmp_path / "shard-000000.lance"
@@ -296,12 +301,24 @@ def test_make_lance_dataset_rerun_overwrites_rather_than_appends(
     """
     num_samples = 4
     render_cfg = _fake_render_cfg(num_samples=num_samples, samples_per_render_batch=2)
+    fixed_synth = [_HARDCODED_SYNTH_PARAMS] * num_samples
+    fixed_note = [_HARDCODED_NOTE_PARAMS] * num_samples
     out = tmp_path / "shard-000000.lance"
 
-    make_lance_dataset(lance_file=out, render_cfg=render_cfg)
+    make_lance_dataset(
+        lance_file=out,
+        render_cfg=render_cfg,
+        fixed_synth_params_list=fixed_synth,
+        fixed_note_params_list=fixed_note,
+    )
     assert LanceFileReader(str(out)).num_rows() == num_samples
 
-    make_lance_dataset(lance_file=out, render_cfg=render_cfg)
+    make_lance_dataset(
+        lance_file=out,
+        render_cfg=render_cfg,
+        fixed_synth_params_list=fixed_synth,
+        fixed_note_params_list=fixed_note,
+    )
     assert LanceFileReader(str(out)).num_rows() == num_samples, (
         "lance re-run appended instead of overwriting the shard"
     )

--- a/tests/data/vst/test_fake_plugin_e2e.py
+++ b/tests/data/vst/test_fake_plugin_e2e.py
@@ -312,6 +312,7 @@ def test_make_lance_dataset_rerun_overwrites_rather_than_appends(
         fixed_note_params_list=fixed_note,
     )
     assert LanceFileReader(str(out)).num_rows() == num_samples
+    first_run_params = np.stack(list(iter_lance_column_rows(out, PARAM_ARRAY_FIELD)), axis=0)
 
     make_lance_dataset(
         lance_file=out,
@@ -322,6 +323,8 @@ def test_make_lance_dataset_rerun_overwrites_rather_than_appends(
     assert LanceFileReader(str(out)).num_rows() == num_samples, (
         "lance re-run appended instead of overwriting the shard"
     )
+    rerun_params = np.stack(list(iter_lance_column_rows(out, PARAM_ARRAY_FIELD)), axis=0)
+    np.testing.assert_array_equal(rerun_params, first_run_params)
 
 
 @pytest.mark.fake_vst

--- a/tests/data/vst/test_fake_plugin_e2e.py
+++ b/tests/data/vst/test_fake_plugin_e2e.py
@@ -18,11 +18,14 @@ import h5py
 import hdf5plugin  # noqa: F401  side-effect: registers Blosc2 filter for h5py reads
 import numpy as np
 import pytest
+from lance.file import LanceFileReader
 
 from synth_setter.data.vst import core
-from synth_setter.data.vst.shapes import AUDIO_FIELD
-from synth_setter.data.vst.writers import make_hdf5_dataset, make_wds_dataset
-from synth_setter.pipeline.schemas.spec import RenderConfig
+from synth_setter.data.vst.shapes import AUDIO_FIELD, MEL_SPEC_FIELD, PARAM_ARRAY_FIELD
+from synth_setter.data.vst.writers import make_hdf5_dataset, make_lance_dataset, make_wds_dataset
+from synth_setter.pipeline.ci.validate_shard import validate_shard
+from synth_setter.pipeline.data.lance_shard import iter_lance_column_rows, read_shard_metadata
+from synth_setter.pipeline.schemas.spec import DatasetSpec, RenderConfig
 
 _ = hdf5plugin  # keep type checkers from flagging the side-effect import
 
@@ -32,6 +35,7 @@ from tests.data.vst.test_generate_vst_dataset import (  # noqa: E402  pinned can
     _HARDCODED_SYNTH_PARAMS,
     _render_cfg,
 )
+from tests.helpers.finalize_shards import build_lance_smoke_spec  # noqa: E402
 from tests.helpers.logger_assertions import assert_no_logger_exceptions  # noqa: E402
 
 _PLUGIN_PATH = "plugins/fake.vst3"  # never touched on disk — load_plugin is patched
@@ -61,6 +65,22 @@ def _fake_render_cfg(**overrides: object) -> RenderConfig:
     if cadence is not None:
         update["param_sample_cadence"] = cadence
     return cfg.model_copy(update=update)
+
+
+def _lance_spec_for(render_cfg: RenderConfig) -> DatasetSpec:
+    """Build a one-shard lance ``DatasetSpec`` around ``render_cfg``.
+
+    Gives ``validate_shard`` a spec whose render config matches what the
+    writer under test actually rendered.
+
+    :param render_cfg: The fake-plugin render config driving the writer.
+    :returns: A frozen lance ``DatasetSpec`` with a single train shard.
+    """
+    return build_lance_smoke_spec(
+        task_name="fake-plugin-lance-e2e",
+        train_val_test_sizes=(render_cfg.samples_per_shard, 0, 0),
+        render=render_cfg,
+    )
 
 
 def _count_wds_audio_rows(tar_path: Path) -> int:
@@ -173,6 +193,117 @@ def test_make_hdf5_dataset_shard_cadence_writes_one_identical_patch_per_shard(
     assert params.shape[0] == num_samples
     assert np.array_equal(params, np.broadcast_to(params[0], params.shape)), (
         "shard-cadence shard has non-identical param rows"
+    )
+
+
+@pytest.mark.fake_vst
+def test_make_lance_dataset_writes_validator_passing_shard_under_fake_plugin(
+    tmp_path: Path,
+    install_fake_plugin: FakeVST3Plugin,
+) -> None:
+    """The real Lance writer produces a shard ``validate_shard`` accepts.
+
+    Drives ``make_lance_dataset`` end-to-end (batch loop, per-batch flush via
+    ``samples_per_render_batch=2``, schema construction, writer close) and
+    checks the produced file through the production validator — schema,
+    dtypes, inner shapes, row count — plus a field-level ``ShardMetadata``
+    round-trip against the render config.
+
+    :param tmp_path: Destination directory for the Lance shard under test.
+    :param install_fake_plugin: Swaps the plugin loader for the fake so the
+        render runs without a real VST3 or X11.
+    """
+    num_samples = 4
+    render_cfg = _fake_render_cfg(num_samples=num_samples, samples_per_render_batch=2)
+    spec = _lance_spec_for(render_cfg)
+    out = tmp_path / spec.shards[0].filename
+
+    make_lance_dataset(
+        lance_file=out,
+        render_cfg=render_cfg,
+        fixed_synth_params_list=[_HARDCODED_SYNTH_PARAMS] * num_samples,
+        fixed_note_params_list=[_HARDCODED_NOTE_PARAMS] * num_samples,
+    )
+
+    assert validate_shard(out, spec) == []
+    meta = read_shard_metadata(LanceFileReader(str(out)).metadata().schema)
+    assert meta.velocity == render_cfg.velocity
+    assert meta.signal_duration_seconds == render_cfg.signal_duration_seconds
+    assert meta.sample_rate == render_cfg.sample_rate
+    assert meta.channels == render_cfg.channels
+    assert meta.min_loudness == render_cfg.min_loudness
+
+
+@pytest.mark.fake_vst
+def test_make_lance_dataset_arrays_match_h5_writer_under_fake_plugin(
+    tmp_path: Path,
+    install_fake_plugin: FakeVST3Plugin,
+) -> None:
+    """Same fixed params through the Lance and h5 writers yield equal on-disk arrays.
+
+    The lance counterpart of the h5↔wds parity pin: the fake plugin renders
+    deterministically (fixed sine, no phase jitter), so all three fields —
+    including the ``s.audio.T`` transpose + ``float16`` cast in
+    ``_sample_batch_arrays`` — must be byte-equal across writers.
+
+    :param tmp_path: Destination directory for both shards under test.
+    :param install_fake_plugin: Swaps the plugin loader for the fake so both
+        renders run without a real VST3 or X11.
+    """
+    num_samples = 4
+    render_cfg = _fake_render_cfg(num_samples=num_samples)
+    fixed_synth = [_HARDCODED_SYNTH_PARAMS] * num_samples
+    fixed_note = [_HARDCODED_NOTE_PARAMS] * num_samples
+    lance_out = tmp_path / "shard-000000.lance"
+    h5_out = tmp_path / "shard-000000.h5"
+
+    make_lance_dataset(
+        lance_file=lance_out,
+        render_cfg=render_cfg,
+        fixed_synth_params_list=fixed_synth,
+        fixed_note_params_list=fixed_note,
+    )
+    make_hdf5_dataset(
+        hdf5_file=h5_out,
+        render_cfg=render_cfg,
+        fixed_synth_params_list=fixed_synth,
+        fixed_note_params_list=fixed_note,
+    )
+
+    with h5py.File(h5_out, "r") as f:
+        for field in (AUDIO_FIELD, MEL_SPEC_FIELD, PARAM_ARRAY_FIELD):
+            h5_ds = f[field]
+            assert isinstance(h5_ds, h5py.Dataset)
+            lance_arr = np.stack(list(iter_lance_column_rows(lance_out, field)), axis=0)
+            assert lance_arr.dtype == h5_ds.dtype
+            np.testing.assert_array_equal(lance_arr, h5_ds[...], err_msg=field)
+
+
+@pytest.mark.fake_vst
+def test_make_lance_dataset_rerun_overwrites_rather_than_appends(
+    tmp_path: Path,
+    install_fake_plugin: FakeVST3Plugin,
+) -> None:
+    """Re-running the Lance writer on an existing path overwrites it (non-resumable).
+
+    ``make_lance_dataset`` pins ``start_idx=0`` and reopens the path with
+    ``LanceFileWriter``, so a second pass yields exactly ``samples_per_shard``
+    rows, not double — the lance counterpart of the wds pin below.
+
+    :param tmp_path: Destination directory for the Lance shard under test.
+    :param install_fake_plugin: Swaps the plugin loader for the fake so the
+        render runs without a real VST3 or X11.
+    """
+    num_samples = 4
+    render_cfg = _fake_render_cfg(num_samples=num_samples, samples_per_render_batch=2)
+    out = tmp_path / "shard-000000.lance"
+
+    make_lance_dataset(lance_file=out, render_cfg=render_cfg)
+    assert LanceFileReader(str(out)).num_rows() == num_samples
+
+    make_lance_dataset(lance_file=out, render_cfg=render_cfg)
+    assert LanceFileReader(str(out)).num_rows() == num_samples, (
+        "lance re-run appended instead of overwriting the shard"
     )
 
 

--- a/tests/data/vst/test_fake_plugin_e2e.py
+++ b/tests/data/vst/test_fake_plugin_e2e.py
@@ -204,8 +204,9 @@ def test_make_lance_dataset_writes_validator_passing_shard_under_fake_plugin(
 ) -> None:
     """The real Lance writer produces a shard ``validate_shard`` accepts.
 
-    Drives ``make_lance_dataset`` end-to-end (batch loop, per-batch flush via
-    ``samples_per_render_batch=2``, schema construction, writer close) and
+    Drives ``make_lance_dataset`` end-to-end (batch loop, per-batch flushes via
+    a ``samples_per_render_batch`` below ``num_samples``, schema construction,
+    writer close) and
     checks the produced file through the production validator — schema,
     dtypes, inner shapes, row count — plus a whole-model ``ShardMetadata``
     round-trip against the render config.

--- a/tests/data/vst/test_shape_helpers.py
+++ b/tests/data/vst/test_shape_helpers.py
@@ -21,12 +21,14 @@ from synth_setter.data.vst.shapes import (
     MEL_WINDOW,
     PARAM_ARRAY_FIELD,
     audio_dataset_shape,
+    dataset_field_shapes,
     mel_dataset_shape,
     mel_hop_length,
     mel_n_fft,
     mel_n_frames,
     param_array_dataset_shape,
 )
+from synth_setter.pipeline.schemas.spec import RenderConfig
 
 
 def test_dataset_field_names_match_writer_emissions() -> None:
@@ -104,6 +106,30 @@ def test_param_array_dataset_shape_matches_legacy_inline_calc() -> None:
     """Pins ``(num_samples, num_params)``."""
     assert param_array_dataset_shape(2, 175) == (2, 175)
     assert param_array_dataset_shape(0, 0) == (0, 0)
+
+
+def test_dataset_field_shapes_maps_every_field_to_full_writer_shape() -> None:
+    """``dataset_field_shapes`` returns the three per-field shapes the writers emit."""
+    render = RenderConfig(
+        plugin_path="/fake/Plugin.vst3",
+        preset_path="presets/fake.vstpreset",
+        param_spec_name="surge_simple",
+        renderer_version="1.0.0-test",
+        sample_rate=44100,
+        channels=2,
+        velocity=100,
+        signal_duration_seconds=4.0,
+        min_loudness=-55.0,
+        samples_per_render_batch=4,
+        samples_per_shard=4,
+        gui_toggle_cadence="never",
+    )
+
+    assert dataset_field_shapes(render, num_params=7) == {
+        AUDIO_FIELD: (4, 2, 176400),
+        MEL_SPEC_FIELD: (4, 2, 128, 401),
+        PARAM_ARRAY_FIELD: (4, 7),
+    }
 
 
 def test_make_spectrogram_output_shape_matches_mel_dataset_shape_helper() -> None:

--- a/tests/data/vst/test_shape_helpers.py
+++ b/tests/data/vst/test_shape_helpers.py
@@ -109,7 +109,7 @@ def test_param_array_dataset_shape_matches_legacy_inline_calc() -> None:
 
 
 def test_dataset_field_shapes_maps_every_field_to_full_writer_shape() -> None:
-    """``dataset_field_shapes`` returns the three per-field shapes the writers emit."""
+    """``dataset_field_shapes`` returns the full writer-emitted shape for every dataset field."""
     render = RenderConfig(
         plugin_path="/fake/Plugin.vst3",
         preset_path="presets/fake.vstpreset",

--- a/tests/helpers/dummy_shards.py
+++ b/tests/helpers/dummy_shards.py
@@ -103,10 +103,9 @@ def stub_renderer(spec: DatasetSpec) -> Callable[[list[str]], None]:
     """Return a ``_check_call_streamed`` side effect that writes dummy shards.
 
     Dispatches on the renderer output path's suffix via ``OutputFormat.from_extension``,
-    so the same factory backs hdf5, wds, and lance runs (the lance writer is
-    shared with the finalize lanes). ``rclone`` invocations fall
-    through to the real binary so the R2 upload, the skip-existing probe, and any
-    purge hit the configured remote (real R2, or a local-backed fake remote).
+    so the same factory backs hdf5, wds, and lance runs. ``rclone`` invocations
+    fall through to the real binary so the R2 upload, the skip-existing probe, and
+    any purge hit the configured remote (real R2, or a local-backed fake remote).
 
     :param spec: Dataset spec the launcher will materialize; threaded into the
         dummy-shard writers so shapes match the validator's expectations.

--- a/tests/helpers/dummy_shards.py
+++ b/tests/helpers/dummy_shards.py
@@ -5,7 +5,8 @@ and the fast fake-R2 orchestrator test (``tests/test_generate_dataset.py``) driv
 ``cli.generate_dataset`` with the Surge VST3 subprocess replaced by a deterministic
 stub that writes a validation-passing shard of the right shape. Centralizing the
 writers + stub here keeps the two lanes from drifting: a change to the writer's
-shard layout updates both at once.
+shard layout updates both at once. The lance writer is imported from
+``tests.helpers.finalize_shards``, which owns it for the finalize lanes.
 """
 
 from __future__ import annotations

--- a/tests/helpers/dummy_shards.py
+++ b/tests/helpers/dummy_shards.py
@@ -27,10 +27,9 @@ from synth_setter.data.vst.shapes import (
     PARAM_ARRAY_FIELD,
     dataset_field_shapes,
 )
-from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
 from synth_setter.pipeline.schemas.spec import DatasetSpec, OutputFormat
 from synth_setter.pipeline.subprocess_stream import check_call_streamed
-from tests.helpers.finalize_shards import write_minimal_lance_shard
+from tests.helpers.finalize_shards import smoke_shard_metadata, write_minimal_lance_shard
 from tests.helpers.subprocess_args import find_script_index
 
 # rclone passthrough: bound from the pipeline module, so it bypasses the patched
@@ -72,13 +71,7 @@ def write_dummy_tar_shard(output_path: Path, spec: DatasetSpec) -> None:
     audio = np.zeros(shapes[AUDIO_FIELD], dtype=DATASET_FIELD_DTYPES[AUDIO_FIELD])
     mel = np.zeros(shapes[MEL_SPEC_FIELD], dtype=DATASET_FIELD_DTYPES[MEL_SPEC_FIELD])
     params = np.zeros(shapes[PARAM_ARRAY_FIELD], dtype=DATASET_FIELD_DTYPES[PARAM_ARRAY_FIELD])
-    metadata = ShardMetadata(
-        velocity=render.velocity,
-        signal_duration_seconds=render.signal_duration_seconds,
-        sample_rate=render.sample_rate,
-        channels=render.channels,
-        min_loudness=render.min_loudness,
-    )
+    metadata = smoke_shard_metadata(render)
     with tarfile.open(output_path, mode="w") as tar:
         for field_name, arr in (
             (AUDIO_FIELD, audio),

--- a/tests/helpers/dummy_shards.py
+++ b/tests/helpers/dummy_shards.py
@@ -20,16 +20,16 @@ import numpy as np
 
 from synth_setter.data.vst.shapes import (
     AUDIO_FIELD,
+    DATASET_FIELD_DTYPES,
     DATASET_FIELD_NAMES,
     MEL_SPEC_FIELD,
     PARAM_ARRAY_FIELD,
-    audio_dataset_shape,
-    mel_dataset_shape,
-    param_array_dataset_shape,
+    dataset_field_shapes,
 )
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
 from synth_setter.pipeline.schemas.spec import DatasetSpec, OutputFormat
 from synth_setter.pipeline.subprocess_stream import check_call_streamed
+from tests.helpers.finalize_shards import write_minimal_lance_shard
 from tests.helpers.subprocess_args import find_script_index
 
 # rclone passthrough: bound from the pipeline module, so it bypasses the patched
@@ -48,19 +48,10 @@ def write_dummy_h5_shard(output_path: Path, spec: DatasetSpec) -> None:
     :param spec: Dataset spec whose ``render`` config and ``num_params`` drive the
         per-field array shapes.
     """
-    render = spec.render
-    n = render.samples_per_shard
-    audio_shape = audio_dataset_shape(
-        n, render.channels, render.sample_rate, render.signal_duration_seconds
-    )
-    mel_shape = mel_dataset_shape(
-        n, render.channels, render.sample_rate, render.signal_duration_seconds
-    )
-    param_shape = param_array_dataset_shape(n, spec.num_params)
+    shapes = dataset_field_shapes(spec.render, spec.num_params)
     with h5py.File(output_path, "w") as f:
-        f.create_dataset(AUDIO_FIELD, data=np.zeros(audio_shape, dtype=np.float16))
-        f.create_dataset(MEL_SPEC_FIELD, data=np.zeros(mel_shape, dtype=np.float32))
-        f.create_dataset(PARAM_ARRAY_FIELD, data=np.zeros(param_shape, dtype=np.float32))
+        for field, shape in shapes.items():
+            f.create_dataset(field, data=np.zeros(shape, dtype=DATASET_FIELD_DTYPES[field]))
 
 
 def write_dummy_tar_shard(output_path: Path, spec: DatasetSpec) -> None:
@@ -76,18 +67,10 @@ def write_dummy_tar_shard(output_path: Path, spec: DatasetSpec) -> None:
     :raises ValueError: If a field name is not in ``DATASET_FIELD_NAMES``.
     """
     render = spec.render
-    n = render.samples_per_shard
-    audio = np.zeros(
-        audio_dataset_shape(
-            n, render.channels, render.sample_rate, render.signal_duration_seconds
-        ),
-        dtype=np.float16,
-    )
-    mel = np.zeros(
-        mel_dataset_shape(n, render.channels, render.sample_rate, render.signal_duration_seconds),
-        dtype=np.float32,
-    )
-    params = np.zeros(param_array_dataset_shape(n, spec.num_params), dtype=np.float32)
+    shapes = dataset_field_shapes(render, spec.num_params)
+    audio = np.zeros(shapes[AUDIO_FIELD], dtype=DATASET_FIELD_DTYPES[AUDIO_FIELD])
+    mel = np.zeros(shapes[MEL_SPEC_FIELD], dtype=DATASET_FIELD_DTYPES[MEL_SPEC_FIELD])
+    params = np.zeros(shapes[PARAM_ARRAY_FIELD], dtype=DATASET_FIELD_DTYPES[PARAM_ARRAY_FIELD])
     metadata = ShardMetadata(
         velocity=render.velocity,
         signal_duration_seconds=render.signal_duration_seconds,
@@ -119,7 +102,8 @@ def stub_renderer(spec: DatasetSpec) -> Callable[[list[str]], None]:
     """Return a ``_check_call_streamed`` side effect that writes dummy shards.
 
     Dispatches on the renderer output path's suffix via ``OutputFormat.from_extension``,
-    so the same factory backs both hdf5 and wds runs. ``rclone`` invocations fall
+    so the same factory backs hdf5, wds, and lance runs (the lance writer is
+    shared with the finalize lanes). ``rclone`` invocations fall
     through to the real binary so the R2 upload, the skip-existing probe, and any
     purge hit the configured remote (real R2, or a local-backed fake remote).
 
@@ -140,6 +124,8 @@ def stub_renderer(spec: DatasetSpec) -> Callable[[list[str]], None]:
             write_dummy_h5_shard(output_file, spec)
         elif fmt is OutputFormat.WDS:
             write_dummy_tar_shard(output_file, spec)
+        elif fmt is OutputFormat.LANCE:
+            write_minimal_lance_shard(output_file, spec)
         else:
             raise AssertionError(
                 f"stubbed renderer cannot write output with suffix {output_file.suffix!r}"

--- a/tests/helpers/finalize_shards.py
+++ b/tests/helpers/finalize_shards.py
@@ -89,6 +89,24 @@ def build_wds_smoke_spec(
     return DatasetSpec(**kwargs)  # type: ignore[arg-type]
 
 
+# Default render for the lance smoke spec; sample_rate=100 keeps the mel front
+# end at its minimum hop so shards stay tiny.
+_LANCE_SMOKE_RENDER: dict[str, Any] = {
+    "plugin_path": "/fake/Plugin.vst3",
+    "preset_path": "presets/surge-base.vstpreset",
+    "param_spec_name": "surge_simple",
+    "renderer_version": "1.0.0-test",
+    "sample_rate": 100,
+    "channels": 2,
+    "velocity": 100,
+    "signal_duration_seconds": 1.0,
+    "min_loudness": -55.0,
+    "samples_per_render_batch": 4,
+    "samples_per_shard": 4,
+    "gui_toggle_cadence": "never",
+}
+
+
 def build_lance_smoke_spec(
     task_name: str = "finalize-lance-unit",
     train_val_test_sizes: tuple[int, int, int] = (4, 0, 0),
@@ -112,22 +130,7 @@ def build_lance_smoke_spec(
         "base_seed": 42,
         "mask_degenerate_bins": mask_degenerate_bins,
         "r2": {"bucket": "intermediate-data"},
-        "render": render
-        if render is not None
-        else {
-            "plugin_path": "/fake/Plugin.vst3",
-            "preset_path": "presets/surge-base.vstpreset",
-            "param_spec_name": "surge_simple",
-            "renderer_version": "1.0.0-test",
-            "sample_rate": 100,
-            "channels": 2,
-            "velocity": 100,
-            "signal_duration_seconds": 1.0,
-            "min_loudness": -55.0,
-            "samples_per_render_batch": 4,
-            "samples_per_shard": 4,
-            "gui_toggle_cadence": "never",
-        },
+        "render": render if render is not None else dict(_LANCE_SMOKE_RENDER),
     }
     return DatasetSpec(**kwargs)  # type: ignore[arg-type]
 

--- a/tests/helpers/finalize_shards.py
+++ b/tests/helpers/finalize_shards.py
@@ -175,6 +175,24 @@ def build_hdf5_smoke_spec(
     return DatasetSpec(**kwargs)  # type: ignore[arg-type]
 
 
+def smoke_shard_metadata(render: RenderConfig) -> ShardMetadata:
+    """Project ``render`` onto the ``ShardMetadata`` fields the writers embed.
+
+    Test-side twin of the writers' projection so shard seeders and validator
+    tests build the sidecar payload one way.
+
+    :param render: Render config supplying the sidecar field values.
+    :returns: Strict ``ShardMetadata`` with the five render-derived fields filled.
+    """
+    return ShardMetadata(
+        velocity=render.velocity,
+        signal_duration_seconds=render.signal_duration_seconds,
+        sample_rate=render.sample_rate,
+        channels=render.channels,
+        min_loudness=render.min_loudness,
+    )
+
+
 def write_minimal_lance_shard(dest: Path, spec: DatasetSpec) -> None:
     """Write a structurally valid Lance shard for ``spec`` at ``dest``.
 
@@ -190,14 +208,7 @@ def write_minimal_lance_shard(dest: Path, spec: DatasetSpec) -> None:
     dest.parent.mkdir(parents=True, exist_ok=True)
     render = spec.render
     shapes = dataset_field_shapes(render, spec.num_params)
-    metadata = ShardMetadata(
-        velocity=render.velocity,
-        signal_duration_seconds=render.signal_duration_seconds,
-        sample_rate=render.sample_rate,
-        channels=render.channels,
-        min_loudness=render.min_loudness,
-    )
-    schema = lance_schema(shapes, metadata)
+    schema = lance_schema(shapes, smoke_shard_metadata(render))
     arrays = {
         AUDIO_FIELD: np.zeros(shapes[AUDIO_FIELD], dtype=DATASET_FIELD_DTYPES[AUDIO_FIELD]),
         MEL_SPEC_FIELD: np.arange(

--- a/tests/helpers/finalize_shards.py
+++ b/tests/helpers/finalize_shards.py
@@ -27,12 +27,10 @@ from synth_setter.data.vst.shapes import (
     DATASET_FIELD_DTYPES,
     MEL_SPEC_FIELD,
     PARAM_ARRAY_FIELD,
-    audio_dataset_shape,
-    mel_dataset_shape,
-    param_array_dataset_shape,
+    dataset_field_shapes,
 )
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
-from synth_setter.pipeline.schemas.spec import DatasetSpec
+from synth_setter.pipeline.schemas.spec import DatasetSpec, RenderConfig
 
 
 def write_minimal_wds_shard(dest: Path) -> None:
@@ -95,6 +93,7 @@ def build_lance_smoke_spec(
     task_name: str = "finalize-lance-unit",
     train_val_test_sizes: tuple[int, int, int] = (4, 0, 0),
     mask_degenerate_bins: bool = False,
+    render: RenderConfig | None = None,
 ) -> DatasetSpec:
     """Construct a lance ``DatasetSpec`` directly (no Hydra compose).
 
@@ -102,6 +101,8 @@ def build_lance_smoke_spec(
     :param train_val_test_sizes: Three-tuple of sample counts; default is one
         4-sample shard.
     :param mask_degenerate_bins: Threaded onto the spec for stats-fold tests.
+    :param render: Optional render config replacing the smoke default — used by
+        e2e tests that must wrap the exact config a writer rendered with.
     :returns: A frozen lance ``DatasetSpec`` whose shards are deterministic.
     """
     kwargs: dict[str, Any] = {
@@ -111,7 +112,9 @@ def build_lance_smoke_spec(
         "base_seed": 42,
         "mask_degenerate_bins": mask_degenerate_bins,
         "r2": {"bucket": "intermediate-data"},
-        "render": {
+        "render": render
+        if render is not None
+        else {
             "plugin_path": "/fake/Plugin.vst3",
             "preset_path": "presets/surge-base.vstpreset",
             "param_spec_name": "surge_simple",
@@ -184,21 +187,7 @@ def write_minimal_lance_shard(dest: Path, spec: DatasetSpec) -> None:
 
     dest.parent.mkdir(parents=True, exist_ok=True)
     render = spec.render
-    shapes = {
-        AUDIO_FIELD: audio_dataset_shape(
-            render.samples_per_shard,
-            render.channels,
-            render.sample_rate,
-            render.signal_duration_seconds,
-        ),
-        MEL_SPEC_FIELD: mel_dataset_shape(
-            render.samples_per_shard,
-            render.channels,
-            render.sample_rate,
-            render.signal_duration_seconds,
-        ),
-        PARAM_ARRAY_FIELD: param_array_dataset_shape(render.samples_per_shard, spec.num_params),
-    }
+    shapes = dataset_field_shapes(render, spec.num_params)
     metadata = ShardMetadata(
         velocity=render.velocity,
         signal_duration_seconds=render.signal_duration_seconds,
@@ -275,33 +264,11 @@ def seed_shard_files(remote_root: Path, spec: DatasetSpec) -> None:
     :param spec: Spec whose ``shards`` define the filenames to seed.
     """
     remote_root.mkdir(parents=True, exist_ok=True)
-    render = spec.render
-    audio_shape = audio_dataset_shape(
-        render.samples_per_shard,
-        render.channels,
-        render.sample_rate,
-        render.signal_duration_seconds,
-    )
-    mel_shape = mel_dataset_shape(
-        render.samples_per_shard,
-        render.channels,
-        render.sample_rate,
-        render.signal_duration_seconds,
-    )
-    param_shape = param_array_dataset_shape(render.samples_per_shard, spec.num_params)
+    shapes = dataset_field_shapes(spec.render, spec.num_params)
     for shard in spec.shards:
         with h5py.File(remote_root / shard.filename, "w") as f:
-            f.create_dataset(
-                AUDIO_FIELD, shape=audio_shape, dtype=DATASET_FIELD_DTYPES[AUDIO_FIELD]
-            )
-            f.create_dataset(
-                MEL_SPEC_FIELD, shape=mel_shape, dtype=DATASET_FIELD_DTYPES[MEL_SPEC_FIELD]
-            )
-            f.create_dataset(
-                PARAM_ARRAY_FIELD,
-                shape=param_shape,
-                dtype=DATASET_FIELD_DTYPES[PARAM_ARRAY_FIELD],
-            )
+            for field, shape in shapes.items():
+                f.create_dataset(field, shape=shape, dtype=DATASET_FIELD_DTYPES[field])
 
 
 def write_spec_to_root(spec: DatasetSpec, tmp_path: Path) -> str:

--- a/tests/helpers/finalize_shards.py
+++ b/tests/helpers/finalize_shards.py
@@ -89,9 +89,8 @@ def build_wds_smoke_spec(
     return DatasetSpec(**kwargs)  # type: ignore[arg-type]
 
 
-# Default render for the lance smoke spec; sample_rate=100 keeps the mel front
-# end at its minimum hop so shards stay tiny.
-_LANCE_SMOKE_RENDER: dict[str, Any] = {
+# sample_rate=100 keeps the mel front end at its minimum hop so shards stay tiny.
+_LANCE_SMOKE_RENDER: dict[str, str | int | float] = {
     "plugin_path": "/fake/Plugin.vst3",
     "preset_path": "presets/surge-base.vstpreset",
     "param_spec_name": "surge_simple",

--- a/tests/helpers/finalize_shards.py
+++ b/tests/helpers/finalize_shards.py
@@ -182,7 +182,7 @@ def smoke_shard_metadata(render: RenderConfig) -> ShardMetadata:
     tests build the sidecar payload one way.
 
     :param render: Render config supplying the sidecar field values.
-    :returns: Strict ``ShardMetadata`` with the five render-derived fields filled.
+    :returns: Strict ``ShardMetadata`` with every render-derived field filled.
     """
     return ShardMetadata(
         velocity=render.velocity,

--- a/tests/pipeline/ci_validate/test_validate_shard_lance.py
+++ b/tests/pipeline/ci_validate/test_validate_shard_lance.py
@@ -5,19 +5,42 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import pyarrow as pa
 from lance.file import LanceFileReader
 
-from synth_setter.data.vst.shapes import DATASET_FIELD_DTYPES, dataset_field_shapes
+from synth_setter.data.vst.shapes import (
+    AUDIO_FIELD,
+    DATASET_FIELD_DTYPES,
+    MEL_SPEC_FIELD,
+    PARAM_ARRAY_FIELD,
+    dataset_field_shapes,
+)
 from synth_setter.pipeline.ci.validate_shard import validate_shard
 from synth_setter.pipeline.data.lance_shard import (
     lance_schema,
     record_batch_from_arrays,
+    tensor_array,
     tensor_chunk_to_numpy,
     write_lance_file,
 )
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
-from synth_setter.pipeline.schemas.spec import DatasetSpec
+from synth_setter.pipeline.schemas.spec import DatasetSpec, RenderConfig
 from tests.helpers.finalize_shards import build_lance_smoke_spec, write_minimal_lance_shard
+
+
+def _smoke_metadata(render: RenderConfig) -> ShardMetadata:
+    """Project ``render`` onto the ``ShardMetadata`` fields the writer embeds.
+
+    :param render: Render config supplying the sidecar field values.
+    :returns: Metadata payload for ``lance_schema``.
+    """
+    return ShardMetadata(
+        velocity=render.velocity,
+        signal_duration_seconds=render.signal_duration_seconds,
+        sample_rate=render.sample_rate,
+        channels=render.channels,
+        min_loudness=render.min_loudness,
+    )
 
 
 def _one_row_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
@@ -29,6 +52,18 @@ def _one_row_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
     return {
         field: (1, *shape[1:])
         for field, shape in dataset_field_shapes(spec.render, spec.num_params).items()
+    }
+
+
+def _zero_arrays(shapes: dict[str, tuple[int, ...]]) -> dict[str, np.ndarray]:
+    """Build all-zero per-field arrays with the writer's on-disk dtypes.
+
+    :param shapes: Full per-field shapes including the leading row axis.
+    :returns: Mapping ready for ``record_batch_from_arrays``.
+    """
+    return {
+        field: np.zeros(shape, dtype=DATASET_FIELD_DTYPES[field])
+        for field, shape in shapes.items()
     }
 
 
@@ -50,36 +85,23 @@ def test_lance_record_batch_preserves_transposed_tensor_shape(tmp_path: Path) ->
     :param tmp_path: Pytest fixture providing a fresh test directory.
     """
     spec = build_lance_smoke_spec()
-    render = spec.render
     shapes = _one_row_shapes(spec)
-    schema = lance_schema(
-        shapes,
-        ShardMetadata(
-            velocity=render.velocity,
-            signal_duration_seconds=render.signal_duration_seconds,
-            sample_rate=render.sample_rate,
-            channels=render.channels,
-            min_loudness=render.min_loudness,
-        ),
+    schema = lance_schema(shapes, _smoke_metadata(spec.render))
+    n, channels, n_mels, n_frames = shapes[MEL_SPEC_FIELD]
+    arrays = _zero_arrays(shapes)
+    arrays[MEL_SPEC_FIELD] = np.zeros((n, n_mels, channels, n_frames), dtype=np.float32).transpose(
+        0, 2, 1, 3
     )
-    n, channels, n_mels, n_frames = shapes["mel_spec"]
-    arrays = {
-        "audio": np.zeros(shapes["audio"], dtype=np.float16),
-        "mel_spec": np.zeros((n, n_mels, channels, n_frames), dtype=np.float32).transpose(
-            0, 2, 1, 3
-        ),
-        "param_array": np.zeros(shapes["param_array"], dtype=np.float32),
-    }
     shard = tmp_path / spec.shards[0].filename
 
     write_lance_file(shard, schema, [record_batch_from_arrays(arrays, schema)])
 
-    reader = LanceFileReader(str(shard), columns=["mel_spec"])
-    field = reader.metadata().schema.field("mel_spec")
-    assert tuple(field.type.shape) == shapes["mel_spec"][1:]
+    reader = LanceFileReader(str(shard), columns=[MEL_SPEC_FIELD])
+    field = reader.metadata().schema.field(MEL_SPEC_FIELD)
+    assert tuple(field.type.shape) == shapes[MEL_SPEC_FIELD][1:]
     batch = next(reader.read_all().to_batches())
-    decoded = tensor_chunk_to_numpy(batch.column(0), shapes["mel_spec"][1:])
-    assert decoded.shape == shapes["mel_spec"]
+    decoded = tensor_chunk_to_numpy(batch.column(0), shapes[MEL_SPEC_FIELD][1:])
+    assert decoded.shape == shapes[MEL_SPEC_FIELD]
 
 
 def test_validate_lance_shard_rejects_bad_suffix_payload(tmp_path: Path) -> None:
@@ -103,26 +125,11 @@ def test_validate_lance_shard_reports_row_count_mismatch(tmp_path: Path) -> None
     :param tmp_path: Pytest fixture providing a fresh test directory.
     """
     spec = build_lance_smoke_spec()
-    render = spec.render
     # A one-row shard disagrees with the spec's samples_per_shard.
     shapes = _one_row_shapes(spec)
-    schema = lance_schema(
-        shapes,
-        ShardMetadata(
-            velocity=render.velocity,
-            signal_duration_seconds=render.signal_duration_seconds,
-            sample_rate=render.sample_rate,
-            channels=render.channels,
-            min_loudness=render.min_loudness,
-        ),
-    )
-    arrays = {
-        "audio": np.zeros(shapes["audio"], dtype=np.float16),
-        "mel_spec": np.zeros(shapes["mel_spec"], dtype=np.float32),
-        "param_array": np.zeros(shapes["param_array"], dtype=np.float32),
-    }
+    schema = lance_schema(shapes, _smoke_metadata(spec.render))
     shard = tmp_path / spec.shards[0].filename
-    write_lance_file(shard, schema, [record_batch_from_arrays(arrays, schema)])
+    write_lance_file(shard, schema, [record_batch_from_arrays(_zero_arrays(shapes), schema)])
 
     errors = validate_shard(shard, spec)
 
@@ -136,32 +143,44 @@ def test_validate_lance_shard_reports_inner_shape_mismatch(tmp_path: Path) -> No
     :param tmp_path: Pytest fixture providing a fresh test directory.
     """
     spec = build_lance_smoke_spec()
-    render = spec.render
-    shapes = dataset_field_shapes(render, spec.num_params)
-    n, channels, n_mels, n_frames = shapes["mel_spec"]
-    shapes["mel_spec"] = (n, channels, n_mels + 1, n_frames)
-    schema = lance_schema(
-        shapes,
-        ShardMetadata(
-            velocity=render.velocity,
-            signal_duration_seconds=render.signal_duration_seconds,
-            sample_rate=render.sample_rate,
-            channels=render.channels,
-            min_loudness=render.min_loudness,
-        ),
-    )
-    arrays = {
-        field: np.zeros(shape, dtype=DATASET_FIELD_DTYPES[field])
-        for field, shape in shapes.items()
-    }
+    expected_shapes = dataset_field_shapes(spec.render, spec.num_params)
+    n, channels, n_mels, n_frames = expected_shapes[MEL_SPEC_FIELD]
+    shapes = {**expected_shapes, MEL_SPEC_FIELD: (n, channels, n_mels + 1, n_frames)}
+    schema = lance_schema(shapes, _smoke_metadata(spec.render))
     shard = tmp_path / spec.shards[0].filename
-    write_lance_file(shard, schema, [record_batch_from_arrays(arrays, schema)])
+    write_lance_file(shard, schema, [record_batch_from_arrays(_zero_arrays(shapes), schema)])
 
     errors = validate_shard(shard, spec)
 
     expected_inner = (channels, n_mels, n_frames)
     actual_inner = (channels, n_mels + 1, n_frames)
     assert any(
-        f"column 'mel_spec' has inner shape {actual_inner}, expected {expected_inner}" in error
+        f"column {MEL_SPEC_FIELD!r} has inner shape {actual_inner}, expected {expected_inner}"
+        in error
         for error in errors
     )
+
+
+def test_validate_lance_shard_reports_missing_column(tmp_path: Path) -> None:
+    """A Lance shard missing one writer field reports the absent column.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    spec = build_lance_smoke_spec()
+    shapes = dataset_field_shapes(spec.render, spec.num_params)
+    full_schema = lance_schema(shapes, _smoke_metadata(spec.render))
+    schema = full_schema.remove(full_schema.get_field_index(PARAM_ARRAY_FIELD))
+    columns = [
+        tensor_array(
+            np.zeros(shapes[field], dtype=DATASET_FIELD_DTYPES[field]),
+            DATASET_FIELD_DTYPES[field],
+            shapes[field][1:],
+        )
+        for field in (AUDIO_FIELD, MEL_SPEC_FIELD)
+    ]
+    shard = tmp_path / spec.shards[0].filename
+    write_lance_file(shard, schema, [pa.record_batch(columns, schema=schema)])
+
+    errors = validate_shard(shard, spec)
+
+    assert any(f"missing column: {PARAM_ARRAY_FIELD!r}" in error for error in errors)

--- a/tests/pipeline/ci_validate/test_validate_shard_lance.py
+++ b/tests/pipeline/ci_validate/test_validate_shard_lance.py
@@ -12,6 +12,7 @@ from lance.file import LanceFileReader
 from synth_setter.data.vst.shapes import (
     AUDIO_FIELD,
     DATASET_FIELD_DTYPES,
+    DATASET_FIELD_NAMES,
     MEL_SPEC_FIELD,
     PARAM_ARRAY_FIELD,
     dataset_field_shapes,
@@ -148,6 +149,54 @@ def test_validate_lance_shard_reports_inner_shape_mismatch(tmp_path: Path) -> No
         in error
         for error in errors
     )
+
+
+def test_validate_lance_shard_reports_value_dtype_mismatch(tmp_path: Path) -> None:
+    """A Lance shard whose audio column is float32 reports the dtype contract.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    spec = build_lance_smoke_spec()
+    shapes = dataset_field_shapes(spec.render, spec.num_params)
+    schema = lance_schema(shapes, smoke_shard_metadata(spec.render))
+    float32_audio = pa.field(
+        AUDIO_FIELD,
+        pa.fixed_shape_tensor(pa.float32(), shapes[AUDIO_FIELD][1:]),
+        nullable=False,
+    )
+    schema = schema.set(schema.get_field_index(AUDIO_FIELD), float32_audio)
+    dtypes = {**DATASET_FIELD_DTYPES, AUDIO_FIELD: np.dtype("float32")}
+    columns = [
+        tensor_array(
+            np.zeros(shapes[field], dtype=dtypes[field]), dtypes[field], shapes[field][1:]
+        )
+        for field in DATASET_FIELD_NAMES
+    ]
+    shard = tmp_path / spec.shards[0].filename
+    write_lance_file(shard, schema, [pa.record_batch(columns, schema=schema)])
+
+    errors = validate_shard(shard, spec)
+
+    assert any(
+        f"column {AUDIO_FIELD!r} has value type float, expected halffloat" in error
+        for error in errors
+    )
+
+
+def test_validate_lance_shard_reports_missing_schema_metadata(tmp_path: Path) -> None:
+    """A Lance shard without embedded ``ShardMetadata`` reports the missing key.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    spec = build_lance_smoke_spec()
+    shapes = dataset_field_shapes(spec.render, spec.num_params)
+    schema = lance_schema(shapes, smoke_shard_metadata(spec.render)).remove_metadata()
+    shard = tmp_path / spec.shards[0].filename
+    write_lance_file(shard, schema, [record_batch_from_arrays(_zero_arrays(shapes), schema)])
+
+    errors = validate_shard(shard, spec)
+
+    assert any("missing schema metadata key" in error for error in errors)
 
 
 def test_validate_lance_shard_reports_missing_column(tmp_path: Path) -> None:

--- a/tests/pipeline/ci_validate/test_validate_shard_lance.py
+++ b/tests/pipeline/ci_validate/test_validate_shard_lance.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import numpy as np
 from lance.file import LanceFileReader
 
-from synth_setter.data.vst.shapes import dataset_field_shapes
+from synth_setter.data.vst.shapes import DATASET_FIELD_DTYPES, dataset_field_shapes
 from synth_setter.pipeline.ci.validate_shard import validate_shard
 from synth_setter.pipeline.data.lance_shard import (
     lance_schema,
@@ -104,7 +104,7 @@ def test_validate_lance_shard_reports_row_count_mismatch(tmp_path: Path) -> None
     """
     spec = build_lance_smoke_spec()
     render = spec.render
-    # A one-row shard disagrees with the spec's samples_per_shard=4.
+    # A one-row shard disagrees with the spec's samples_per_shard.
     shapes = _one_row_shapes(spec)
     schema = lance_schema(
         shapes,
@@ -126,4 +126,42 @@ def test_validate_lance_shard_reports_row_count_mismatch(tmp_path: Path) -> None
 
     errors = validate_shard(shard, spec)
 
-    assert any("expected 4" in error for error in errors)
+    row_count_error = f"file has 1 rows, expected {spec.render.samples_per_shard}"
+    assert any(row_count_error in error for error in errors)
+
+
+def test_validate_lance_shard_reports_inner_shape_mismatch(tmp_path: Path) -> None:
+    """A Lance shard whose mel column has a wrong inner shape names both shapes.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    spec = build_lance_smoke_spec()
+    render = spec.render
+    shapes = dataset_field_shapes(render, spec.num_params)
+    n, channels, n_mels, n_frames = shapes["mel_spec"]
+    shapes["mel_spec"] = (n, channels, n_mels + 1, n_frames)
+    schema = lance_schema(
+        shapes,
+        ShardMetadata(
+            velocity=render.velocity,
+            signal_duration_seconds=render.signal_duration_seconds,
+            sample_rate=render.sample_rate,
+            channels=render.channels,
+            min_loudness=render.min_loudness,
+        ),
+    )
+    arrays = {
+        field: np.zeros(shape, dtype=DATASET_FIELD_DTYPES[field])
+        for field, shape in shapes.items()
+    }
+    shard = tmp_path / spec.shards[0].filename
+    write_lance_file(shard, schema, [record_batch_from_arrays(arrays, schema)])
+
+    errors = validate_shard(shard, spec)
+
+    expected_inner = (channels, n_mels, n_frames)
+    actual_inner = (channels, n_mels + 1, n_frames)
+    assert any(
+        f"column 'mel_spec' has inner shape {actual_inner}, expected {expected_inner}" in error
+        for error in errors
+    )

--- a/tests/pipeline/ci_validate/test_validate_shard_lance.py
+++ b/tests/pipeline/ci_validate/test_validate_shard_lance.py
@@ -4,13 +4,32 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
+from lance.file import LanceFileReader
+
+from synth_setter.data.vst.shapes import dataset_field_shapes
 from synth_setter.pipeline.ci.validate_shard import validate_shard
 from synth_setter.pipeline.data.lance_shard import (
     lance_schema,
     record_batch_from_arrays,
+    tensor_chunk_to_numpy,
     write_lance_file,
 )
+from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
+from synth_setter.pipeline.schemas.spec import DatasetSpec
 from tests.helpers.finalize_shards import build_lance_smoke_spec, write_minimal_lance_shard
+
+
+def _one_row_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
+    """One-row variant of the writer's shapes: same inner dims, leading axis 1.
+
+    :param spec: Lance spec whose render config defines the inner dims.
+    :returns: Per-field shapes with the leading row axis pinned to 1.
+    """
+    return {
+        field: (1, *shape[1:])
+        for field, shape in dataset_field_shapes(spec.render, spec.num_params).items()
+    }
 
 
 def test_validate_lance_shard_accepts_valid_file(tmp_path: Path) -> None:
@@ -32,17 +51,7 @@ def test_lance_record_batch_preserves_transposed_tensor_shape(tmp_path: Path) ->
     """
     spec = build_lance_smoke_spec()
     render = spec.render
-    shapes = {
-        "audio": (1, render.channels, int(render.sample_rate * render.signal_duration_seconds)),
-        "mel_spec": (1, render.channels, 128, 101),
-        "param_array": (1, spec.num_params),
-    }
-    import numpy as np
-    from lance.file import LanceFileReader
-
-    from synth_setter.pipeline.data.lance_shard import tensor_chunk_to_numpy
-    from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
-
+    shapes = _one_row_shapes(spec)
     schema = lance_schema(
         shapes,
         ShardMetadata(
@@ -53,9 +62,10 @@ def test_lance_record_batch_preserves_transposed_tensor_shape(tmp_path: Path) ->
             min_loudness=render.min_loudness,
         ),
     )
+    n, channels, n_mels, n_frames = shapes["mel_spec"]
     arrays = {
         "audio": np.zeros(shapes["audio"], dtype=np.float16),
-        "mel_spec": np.zeros((1, 128, render.channels, 101), dtype=np.float32).transpose(
+        "mel_spec": np.zeros((n, n_mels, channels, n_frames), dtype=np.float32).transpose(
             0, 2, 1, 3
         ),
         "param_array": np.zeros(shapes["param_array"], dtype=np.float32),
@@ -94,15 +104,8 @@ def test_validate_lance_shard_reports_row_count_mismatch(tmp_path: Path) -> None
     """
     spec = build_lance_smoke_spec()
     render = spec.render
-    shapes = {
-        "audio": (1, render.channels, int(render.sample_rate * render.signal_duration_seconds)),
-        "mel_spec": (1, render.channels, 128, 101),
-        "param_array": (1, spec.num_params),
-    }
-    import numpy as np
-
-    from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
-
+    # A one-row shard disagrees with the spec's samples_per_shard=4.
+    shapes = _one_row_shapes(spec)
     schema = lance_schema(
         shapes,
         ShardMetadata(

--- a/tests/pipeline/ci_validate/test_validate_shard_lance.py
+++ b/tests/pipeline/ci_validate/test_validate_shard_lance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from pathlib import Path
 
 import numpy as np
@@ -23,24 +24,12 @@ from synth_setter.pipeline.data.lance_shard import (
     tensor_chunk_to_numpy,
     write_lance_file,
 )
-from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
-from synth_setter.pipeline.schemas.spec import DatasetSpec, RenderConfig
-from tests.helpers.finalize_shards import build_lance_smoke_spec, write_minimal_lance_shard
-
-
-def _smoke_metadata(render: RenderConfig) -> ShardMetadata:
-    """Project ``render`` onto the ``ShardMetadata`` fields the writer embeds.
-
-    :param render: Render config supplying the sidecar field values.
-    :returns: Metadata payload for ``lance_schema``.
-    """
-    return ShardMetadata(
-        velocity=render.velocity,
-        signal_duration_seconds=render.signal_duration_seconds,
-        sample_rate=render.sample_rate,
-        channels=render.channels,
-        min_loudness=render.min_loudness,
-    )
+from synth_setter.pipeline.schemas.spec import DatasetSpec
+from tests.helpers.finalize_shards import (
+    build_lance_smoke_spec,
+    smoke_shard_metadata,
+    write_minimal_lance_shard,
+)
 
 
 def _one_row_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
@@ -55,7 +44,7 @@ def _one_row_shapes(spec: DatasetSpec) -> dict[str, tuple[int, ...]]:
     }
 
 
-def _zero_arrays(shapes: dict[str, tuple[int, ...]]) -> dict[str, np.ndarray]:
+def _zero_arrays(shapes: Mapping[str, tuple[int, ...]]) -> dict[str, np.ndarray]:
     """Build all-zero per-field arrays with the writer's on-disk dtypes.
 
     :param shapes: Full per-field shapes including the leading row axis.
@@ -86,7 +75,7 @@ def test_lance_record_batch_preserves_transposed_tensor_shape(tmp_path: Path) ->
     """
     spec = build_lance_smoke_spec()
     shapes = _one_row_shapes(spec)
-    schema = lance_schema(shapes, _smoke_metadata(spec.render))
+    schema = lance_schema(shapes, smoke_shard_metadata(spec.render))
     n, channels, n_mels, n_frames = shapes[MEL_SPEC_FIELD]
     arrays = _zero_arrays(shapes)
     arrays[MEL_SPEC_FIELD] = np.zeros((n, n_mels, channels, n_frames), dtype=np.float32).transpose(
@@ -127,7 +116,7 @@ def test_validate_lance_shard_reports_row_count_mismatch(tmp_path: Path) -> None
     spec = build_lance_smoke_spec()
     # A one-row shard disagrees with the spec's samples_per_shard.
     shapes = _one_row_shapes(spec)
-    schema = lance_schema(shapes, _smoke_metadata(spec.render))
+    schema = lance_schema(shapes, smoke_shard_metadata(spec.render))
     shard = tmp_path / spec.shards[0].filename
     write_lance_file(shard, schema, [record_batch_from_arrays(_zero_arrays(shapes), schema)])
 
@@ -146,7 +135,7 @@ def test_validate_lance_shard_reports_inner_shape_mismatch(tmp_path: Path) -> No
     expected_shapes = dataset_field_shapes(spec.render, spec.num_params)
     n, channels, n_mels, n_frames = expected_shapes[MEL_SPEC_FIELD]
     shapes = {**expected_shapes, MEL_SPEC_FIELD: (n, channels, n_mels + 1, n_frames)}
-    schema = lance_schema(shapes, _smoke_metadata(spec.render))
+    schema = lance_schema(shapes, smoke_shard_metadata(spec.render))
     shard = tmp_path / spec.shards[0].filename
     write_lance_file(shard, schema, [record_batch_from_arrays(_zero_arrays(shapes), schema)])
 
@@ -168,7 +157,7 @@ def test_validate_lance_shard_reports_missing_column(tmp_path: Path) -> None:
     """
     spec = build_lance_smoke_spec()
     shapes = dataset_field_shapes(spec.render, spec.num_params)
-    full_schema = lance_schema(shapes, _smoke_metadata(spec.render))
+    full_schema = lance_schema(shapes, smoke_shard_metadata(spec.render))
     schema = full_schema.remove(full_schema.get_field_index(PARAM_ARRAY_FIELD))
     columns = [
         tensor_array(

--- a/tests/pipeline/data/test_lance_shard.py
+++ b/tests/pipeline/data/test_lance_shard.py
@@ -35,8 +35,8 @@ _FIELD_SHAPES: dict[str, tuple[int, ...]] = {
     PARAM_ARRAY_FIELD: (2, 7),
 }
 
-# Carried opaquely by the codec — its values intentionally don't derive
-# _FIELD_SHAPES, which the schema takes directly.
+# Opaque payload to the codec — its values needn't match _FIELD_SHAPES, which
+# the schema takes directly.
 _METADATA = ShardMetadata(
     velocity=100,
     signal_duration_seconds=1.0,

--- a/tests/pipeline/data/test_lance_shard.py
+++ b/tests/pipeline/data/test_lance_shard.py
@@ -35,6 +35,8 @@ _FIELD_SHAPES: dict[str, tuple[int, ...]] = {
     PARAM_ARRAY_FIELD: (2, 7),
 }
 
+# Carried opaquely by the codec — its values intentionally don't derive
+# _FIELD_SHAPES, which the schema takes directly.
 _METADATA = ShardMetadata(
     velocity=100,
     signal_duration_seconds=1.0,

--- a/tests/pipeline/data/test_lance_shard.py
+++ b/tests/pipeline/data/test_lance_shard.py
@@ -1,0 +1,115 @@
+"""Write→read value-fidelity tests for the Lance shard codec.
+
+The expected arrays are constructed directly in numpy — never through the
+decoder under test — so a row-ordering or reshape bug in ``tensor_array`` /
+``tensor_chunk_to_numpy`` cannot corrupt both sides identically and pass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from synth_setter.data.vst.shapes import (
+    AUDIO_FIELD,
+    DATASET_FIELD_DTYPES,
+    DATASET_FIELD_NAMES,
+    MEL_SPEC_FIELD,
+    PARAM_ARRAY_FIELD,
+)
+from synth_setter.pipeline.data.lance_shard import (
+    iter_lance_column_rows,
+    lance_schema,
+    record_batch_from_arrays,
+    write_lance_file,
+)
+from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
+
+# Small distinct inner shapes so every element has a unique, exactly
+# representable value (float16 is exact for integers up to 2048).
+_FIELD_SHAPES: dict[str, tuple[int, ...]] = {
+    AUDIO_FIELD: (2, 2, 5),
+    MEL_SPEC_FIELD: (2, 2, 3, 4),
+    PARAM_ARRAY_FIELD: (2, 7),
+}
+
+_METADATA = ShardMetadata(
+    velocity=100,
+    signal_duration_seconds=1.0,
+    sample_rate=100,
+    channels=2,
+    min_loudness=-55.0,
+)
+
+
+def _arange_arrays(offset: int) -> dict[str, np.ndarray]:
+    """Build one batch of distinct per-field arrays starting at ``offset``.
+
+    :param offset: First value of every field's ``arange`` so two batches
+        never share element values.
+    :returns: Mapping keyed by ``DATASET_FIELD_NAMES`` with writer dtypes.
+    """
+    return {
+        field: np.arange(
+            offset, offset + np.prod(shape), dtype=DATASET_FIELD_DTYPES[field]
+        ).reshape(shape)
+        for field, shape in _FIELD_SHAPES.items()
+    }
+
+
+@pytest.mark.parametrize("field", DATASET_FIELD_NAMES)
+def test_lance_round_trip_two_batches_preserves_values_and_row_order(
+    field: str, tmp_path: Path
+) -> None:
+    """Distinct known values written in two batches read back exactly, in order.
+
+    :param field: Writer dataset field whose column is decoded and compared.
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    first = _arange_arrays(offset=0)
+    second = _arange_arrays(offset=1000)
+    schema = lance_schema(_FIELD_SHAPES, _METADATA)
+    shard = tmp_path / "shard-000000.lance"
+
+    write_lance_file(
+        shard,
+        schema,
+        [record_batch_from_arrays(first, schema), record_batch_from_arrays(second, schema)],
+    )
+
+    decoded = np.stack(list(iter_lance_column_rows(shard, field)), axis=0)
+    expected = np.concatenate([first[field], second[field]], axis=0)
+    np.testing.assert_array_equal(decoded, expected)
+    assert decoded.dtype == DATASET_FIELD_DTYPES[field]
+
+
+def test_lance_round_trip_noncontiguous_transposed_input_preserves_values(
+    tmp_path: Path,
+) -> None:
+    """A transposed (non-contiguous) mel input decodes to its logical values.
+
+    The writer receives ``mel_spec`` rows transposed from their allocation
+    order — the layout ``_sample_batch_arrays`` produces — so a codec that
+    serialized raw buffer order instead of logical order would scramble
+    values while keeping shapes intact.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    n, channels, n_mels, n_frames = _FIELD_SHAPES[MEL_SPEC_FIELD]
+    transposed_mel = (
+        np.arange(n * channels * n_mels * n_frames, dtype=np.float32)
+        .reshape(n, n_mels, channels, n_frames)
+        .transpose(0, 2, 1, 3)
+    )
+    assert not transposed_mel.flags["C_CONTIGUOUS"]
+    arrays = _arange_arrays(offset=0)
+    arrays[MEL_SPEC_FIELD] = transposed_mel
+    schema = lance_schema(_FIELD_SHAPES, _METADATA)
+    shard = tmp_path / "shard-000000.lance"
+
+    write_lance_file(shard, schema, [record_batch_from_arrays(arrays, schema)])
+
+    decoded = np.stack(list(iter_lance_column_rows(shard, MEL_SPEC_FIELD)), axis=0)
+    np.testing.assert_array_equal(decoded, transposed_mel)

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -137,12 +137,11 @@ def test_from_hydra_renders_every_shard_to_fake_r2_then_resume_skips(
     ``fake_r2_remote``, so the partition → render → ``rclone copy`` upload →
     skip-existing probe loop (#750) runs with no real plugin and no real R2.
     Parametrized over ``output_format`` so every format's config surface
-    (lance per #1600) runs the same loop with its own shard suffix.
-    Asserts (1) ``smoke-shard``
-    partitions into one shard per split, (2) every shard lands under its
-    spec-derived R2 URI with the format's suffix, and (3) a second
-    ``from_hydra`` pass renders nothing because the probe finds all shards
-    already present.
+    (lance per #1600) runs the same loop with its own shard suffix. Asserts
+    (1) ``smoke-shard`` partitions into one shard per split, (2) every shard
+    lands under its spec-derived R2 URI with the format's suffix, and (3) a
+    second ``from_hydra`` pass renders nothing because the probe finds all
+    shards already present.
 
     :param output_format: Dataset output format the run is pinned to.
     :param shard_suffix: File suffix the format's shards must carry.

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -137,7 +137,7 @@ def test_from_hydra_renders_every_shard_to_fake_r2_then_resume_skips(
     ``fake_r2_remote``, so the partition → render → ``rclone copy`` upload →
     skip-existing probe loop (#750) runs with no real plugin and no real R2.
     Parametrized over ``output_format`` so every format's config surface
-    (lance per #1600) runs the same loop with its own shard suffix. Asserts
+    runs the same loop with its own shard suffix (#1600). Asserts
     (1) ``smoke-shard`` partitions into one shard per split, (2) every shard
     lands under its spec-derived R2 URI with the format's suffix, and (3) a
     second ``from_hydra`` pass renders nothing because the probe finds all

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -118,7 +118,10 @@ def test_cfg_dataset_copy_dataset_root_uri_with_wds_output_is_rejected(
 
 
 @pytest.mark.fake_vst
+@pytest.mark.parametrize(("output_format", "shard_suffix"), [("hdf5", ".h5"), ("lance", ".lance")])
 def test_from_hydra_renders_every_shard_to_fake_r2_then_resume_skips(
+    output_format: str,
+    shard_suffix: str,
     cfg_dataset: DictConfig,
     fake_r2_remote: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -130,10 +133,15 @@ def test_from_hydra_renders_every_shard_to_fake_r2_then_resume_skips(
     validation-shaped shard) and ``r2:`` is a local-filesystem rclone remote via
     ``fake_r2_remote``, so the partition → render → ``rclone copy`` upload →
     skip-existing probe loop (#750) runs with no real plugin and no real R2.
-    Asserts (1) ``smoke-shard`` partitions into one shard per split, (2) every
-    shard lands under its spec-derived R2 URI, and (3) a second ``from_hydra``
-    pass renders nothing because the probe finds all shards already present.
+    Parametrized over ``output_format`` so the lance config surface (P31) runs
+    the same loop with ``.lance`` shard names. Asserts (1) ``smoke-shard``
+    partitions into one shard per split, (2) every shard lands under its
+    spec-derived R2 URI with the format's suffix, and (3) a second
+    ``from_hydra`` pass renders nothing because the probe finds all shards
+    already present.
 
+    :param output_format: Dataset output format the run is pinned to.
+    :param shard_suffix: File suffix the format's shards must carry.
     :param cfg_dataset: Hydra cfg composed with ``generate_dataset/smoke-shard``
         and ``tmp_path``-pinned paths (the same ``tmp_path`` ``fake_r2_remote``
         backs ``r2:`` against).
@@ -144,6 +152,7 @@ def test_from_hydra_renders_every_shard_to_fake_r2_then_resume_skips(
     monkeypatch.setenv("SYNTH_SETTER_WORKER_RANK", "0")
     monkeypatch.setenv("SYNTH_SETTER_NUM_WORKERS", "1")
     with open_dict(cfg_dataset):
+        cfg_dataset.output_format = output_format
         cfg_dataset.render.plugin_path = str(_TEST_PLUGIN_VST3)
         cfg_dataset.render.renderer_version = _TEST_PLUGIN_VERSION
         # Pin r2.prefix so the spec built here for assertions and the one
@@ -177,6 +186,7 @@ def test_from_hydra_renders_every_shard_to_fake_r2_then_resume_skips(
         from_hydra(cfg_dataset)
 
     for shard in spec.shards:
+        assert shard.filename.endswith(shard_suffix)
         size = r2_io.object_size(spec.r2.shard_uri(shard))
         assert size is not None and size > 0, f"shard missing in fake R2: {shard.filename}"
 

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -118,7 +118,10 @@ def test_cfg_dataset_copy_dataset_root_uri_with_wds_output_is_rejected(
 
 
 @pytest.mark.fake_vst
-@pytest.mark.parametrize(("output_format", "shard_suffix"), [("hdf5", ".h5"), ("lance", ".lance")])
+@pytest.mark.parametrize(
+    ("output_format", "shard_suffix"),
+    [("hdf5", ".h5"), ("wds", ".tar"), ("lance", ".lance")],
+)
 def test_from_hydra_renders_every_shard_to_fake_r2_then_resume_skips(
     output_format: str,
     shard_suffix: str,
@@ -133,8 +136,9 @@ def test_from_hydra_renders_every_shard_to_fake_r2_then_resume_skips(
     validation-shaped shard) and ``r2:`` is a local-filesystem rclone remote via
     ``fake_r2_remote``, so the partition → render → ``rclone copy`` upload →
     skip-existing probe loop (#750) runs with no real plugin and no real R2.
-    Parametrized over ``output_format`` so the lance config surface (P31) runs
-    the same loop with ``.lance`` shard names. Asserts (1) ``smoke-shard``
+    Parametrized over ``output_format`` so every format's config surface
+    (lance per #1600) runs the same loop with its own shard suffix.
+    Asserts (1) ``smoke-shard``
     partitions into one shard per split, (2) every shard lands under its
     spec-derived R2 URI with the format's suffix, and (3) a second
     ``from_hydra`` pass renders nothing because the probe finds all shards


### PR DESCRIPTION
Refs #1600

Addresses the five unresolved `[skill:block]` review findings posted on PR #1642 shortly before it merged.

## Summary

- **code-health** — extract `dataset_field_shapes(render, num_params)` into `synth_setter.data.vst.shapes` as the single source of the field→shape contract; the Lance writer, `validate_shard`, and the test-side shard seeders all delegate to it (five duplicated copies removed)
- **tdd-impl / ml-test** — `make_lance_dataset` now runs for real in pytest: fake-plugin e2e proves the shard passes `validate_shard`, round-trips `ShardMetadata`, is byte-equal to the h5 writer's arrays for the same fixed params, and that a rerun overwrites rather than appends
- **ml-test** — write→read value-fidelity round-trips for the Lance tensor codec with distinct `arange` values, two batches, and a non-contiguous transposed input; expected arrays are built directly in numpy so a codec bug cannot corrupt both sides identically
- **synth-setter (P31)** — the `from_hydra` fake-R2 e2e in `tests/test_generate_dataset.py` is parametrized over `hdf5`/`wds`/`lance`, so the lance config surface drives the render→upload→resume loop on every PR
- **ci** — `test-dataset-finalization.yml` paths now include `writers.py`, `lance_shard.py`, `shapes.py`, and `validate_shard.py`, so writer/codec changes fire the lance finalize smoke
- negative validator tests for the Lance row-count, inner-shape, missing-column, value-dtype, and missing-schema-metadata branches

## Verification

- `make format`
- `. .venv/bin/activate && make test-fast` — 2196 passed
- decoder mutation check: reversing row order in `tensor_chunk_to_numpy` fails all four codec round-trip tests
- `/repo-review-full-no-comments` — 0 BLOCK, sentinel: `.agent-reviews/repo-review-full-no-comments.ae338cd4fa0c7e8532750f2f8b9a4ddee7de7f82.md`
