### PR TITLE
test(monitoring): absorb console_multipart in baseline config compare

### DIFF
--- a/tests/test_compare_baseline_configs.py
+++ b/tests/test_compare_baseline_configs.py
@@ -319,6 +319,7 @@ ACCEPTED_DIFFS: tuple[str, ...] = (
     "logger.wandb.log_model",  # changed `true` → False (artifact upload policy, not training)
     "logger.wandb.project",  # env-derived (${oc.env:WANDB_PROJECT,synth-setter})
     "logger.wandb.settings.console",  # `wrap` added in #1506; console capture, no model impact
+    "logger.wandb.settings.console_multipart",  # added in #1641; console capture, no model impact
     # Cleared to `???` (mandatory override) in #809 — dataset locality, not a model knob.
     "datamodule.dataset_root",
     "datamodule.predict_file",


### PR DESCRIPTION
## What

Adds `"logger.wandb.settings.console_multipart"` to the `ACCEPTED_DIFFS` tuple in `tests/test_compare_baseline_configs.py`, directly after the existing `"logger.wandb.settings.console"` entry.

## Why

`cpu-slow.yml` on `main` is red: 52 failures in `tests/test_compare_baseline_configs.py` — `test_kosc_train_configs_are_equal` (all 44 cases) and `test_surge_train_configs_are_equal` (all 8 cases); run [27382766985](https://github.com/tinaudio/synth-setter/actions/runs/27382766985). The predict and fixture comparison tests pass.

Every failure's normalized dict-diff shows exactly one differing subtree: `logger.wandb.settings` — baseline (`v0.0.0`) has `{'code_dir': '.'}`, current has `{'code_dir': '.', 'console_multipart': True}`. Commit `29f20d37` (PR #1641) added `console_multipart: true` to `src/synth_setter/configs/logger/wandb.yaml`, and the key is not yet absorbed.

## Why absorbing is safe

`console_multipart` is a W&B console-log-capture setting (per-session `logs/output_*.log` on resumed runs) — observability only, not a model knob. It is the same category as the existing `"logger.wandb.settings.console"` entry added for #1506, and follows the precedent #1645 established for absorbing post-baseline config keys (`datamodule.param_spec_name`).

## Validation

- `uv run pytest tests/test_compare_baseline_configs.py -m "not slow and not network" -q` → 23 passed.
- Direct check of `_normalize_for_compare`: a baseline-shaped dict without the key and a current-shaped dict with `logger.wandb.settings.console_multipart: True` normalize equal; a control pair differing in `model.d_out` stays unequal.

Fixes #1653
Refs #1604
