### PR TITLE
fix(testing): treat unreaped zombies as dead in _pid_alive probe

### DIFF
--- a/tests/pipeline/test_subprocess_stream.py
+++ b/tests/pipeline/test_subprocess_stream.py
@@ -100,9 +100,14 @@ def _pid_alive(pid: int) -> bool:
         return True
     try:
         stat = Path(f"/proc/{pid}/stat").read_text()
-    except OSError:
+    except FileNotFoundError:
         return False
-    return stat.rsplit(")", 1)[1].split()[0] != "Z"
+    except OSError:
+        return True
+    fields = stat.rsplit(")", 1)
+    if len(fields) < 2 or not fields[1].split():
+        return True
+    return fields[1].split()[0] != "Z"
 
 
 def _wait_for_file(path: Path, deadline_seconds: float = 5.0) -> str:
@@ -623,6 +628,7 @@ def test_pid_alive_unreaped_zombie_reports_dead() -> None:
     if pid == 0:
         os._exit(0)
     try:
+        state = ""
         deadline = time.monotonic() + 3.0
         while time.monotonic() < deadline:
             state = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()[0]

--- a/tests/pipeline/test_subprocess_stream.py
+++ b/tests/pipeline/test_subprocess_stream.py
@@ -81,16 +81,28 @@ def _child(script: str, marker: str) -> list[str]:
 
 
 def _pid_alive(pid: int) -> bool:
-    """Probe liveness via signal 0; a zombie counts as dead once reaped.
+    r"""Probe liveness via signal 0, treating an unreaped zombie as dead.
+
+    Under ``docker build`` the test process is PID 1: swept descendants
+    reparent to it and stay zombies because nothing ``wait()``\ s them, so
+    signal 0 alone reports them alive forever (#1655). Where ``/proc`` is
+    absent (macOS) the signal-0 result stands — there the runner's init
+    reaps orphans, so zombies do not linger.
 
     :param pid: Process id to probe.
-    :returns: True when the pid still exists.
+    :returns: True when the pid still exists and is not a zombie.
     """
     try:
         os.kill(pid, 0)
     except ProcessLookupError:
         return False
-    return True
+    if not Path("/proc").exists():
+        return True
+    try:
+        stat = Path(f"/proc/{pid}/stat").read_text()
+    except OSError:
+        return False
+    return stat.rsplit(")", 1)[1].split()[0] != "Z"
 
 
 def _wait_for_file(path: Path, deadline_seconds: float = 5.0) -> str:
@@ -598,6 +610,31 @@ class TestTimeoutEscalation:
         size_after_kill = heartbeat.stat().st_size
         time.sleep(1.0)
         assert heartbeat.stat().st_size == size_after_kill, "grandchild still heartbeating"
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="zombie-state probe reads /proc")
+def test_pid_alive_unreaped_zombie_reports_dead() -> None:
+    r"""A killed-but-unreaped child (zombie) must not count as alive.
+
+    Inside ``docker build`` the test process is PID 1, so swept grandchildren
+    reparent to it and linger as zombies nothing ``wait()``\ s; probing with
+    signal 0 alone reported them alive forever and failed the sweep tests in
+    every image build (#1655).
+    """
+    pid = os.fork()
+    if pid == 0:
+        os._exit(0)
+    try:
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline:
+            state = Path(f"/proc/{pid}/stat").read_text().rsplit(")", 1)[1].split()[0]
+            if state == "Z":
+                break
+            time.sleep(0.05)
+        assert state == "Z", f"child never became a zombie (state {state})"
+        assert not _pid_alive(pid), "unreaped zombie reported alive"
+    finally:
+        os.waitpid(pid, 0)
 
 
 class TestPostExitSweep:

--- a/tests/pipeline/test_subprocess_stream.py
+++ b/tests/pipeline/test_subprocess_stream.py
@@ -614,12 +614,10 @@ class TestTimeoutEscalation:
 
 @pytest.mark.skipif(sys.platform != "linux", reason="zombie-state probe reads /proc")
 def test_pid_alive_unreaped_zombie_reports_dead() -> None:
-    r"""A killed-but-unreaped child (zombie) must not count as alive.
+    """A killed-but-unreaped child (zombie) must not count as alive.
 
-    Inside ``docker build`` the test process is PID 1, so swept grandchildren
-    reparent to it and linger as zombies nothing ``wait()``\ s; probing with
-    signal 0 alone reported them alive forever and failed the sweep tests in
-    every image build (#1655).
+    Guards the ``/proc`` zombie check in ``_pid_alive`` (rationale documented
+    there): a bare signal-0 probe counts an unreaped zombie as alive (#1655).
     """
     pid = os.fork()
     if pid == 0:


### PR DESCRIPTION
## Summary

Every docker-build-validation run since #1641 merged fails — `main` pushes and PRs alike — in the dev-base `RUN pytest -k "not slow"` step on:

```
FAILED tests/pipeline/test_subprocess_stream.py::TestPostExitSweep::test_clean_exit_sweep_reaps_ingroup_grandchild
AssertionError: post-exit sweep missed the in-group grandchild
```

(Evidence: main runs 27382767031 / 27382035540 / 27376752168; PR #1651 runs 27387846366 / 27388075192 / 27388306096 incl. a rerun. `code-quality-main` on ordinary runners stays green.)

## Root cause

Inside a `docker build` RUN step pytest is **PID 1**. The post-exit sweep's SIGTERM does kill the in-group grandchild, but the corpse reparents to PID 1 — pytest — which never `wait()`s it, so it lingers as a **zombie**. `_pid_alive` probes with `os.kill(pid, 0)`, which succeeds for zombies, so the assertion stays true for the whole 3 s window. On ordinary runners init reaps the orphan, the pid vanishes, and the same probe goes false. The teardown `pgrep -f` leak check matches nothing because a zombie's cmdline is empty — exactly the CI symptom (in-test failure, no teardown leak error).

Reproduced and fix-verified locally under `unshare --pid --fork --mount-proc` (pytest as PID 1, like a docker build): the sweep test fails before this change and passes after, alongside the new regression test.

## Change

- `_pid_alive` now reads `/proc/<pid>/stat` and counts state `Z` as dead; where `/proc` is absent (macOS) the signal-0 result stands. One test-helper file, no production code.
- New linux-only regression test `test_pid_alive_unreaped_zombie_reports_dead` using a forked, deliberately unreaped child.

Unblocks #1651 and every future docker image build.

Fixes #1655