### PR TITLE
refactor(data-pipeline): preset-path tidy and VST-rename test pins

### DIFF
--- a/src/synth_setter/evaluation/predict_vst_audio.py
+++ b/src/synth_setter/evaluation/predict_vst_audio.py
@@ -108,7 +108,7 @@ def resolve_preset_path(preset_path: str | None, param_spec: str) -> str:
     :param param_spec: Registry key naming the spec whose default preset to use.
     :returns: Resolved preset path.
     """
-    return preset_paths[param_spec] if preset_path is None else preset_path
+    return preset_path if preset_path is not None else preset_paths[param_spec]
 
 
 @click.command()
@@ -137,7 +137,7 @@ def main(
     rerender_target: bool = False,
     no_params: bool = False,
     skip_spectrogram: bool = False,
-):
+) -> None:
     preset_path = resolve_preset_path(preset_path, param_spec)
     spec = param_specs[param_spec]
     os.makedirs(output_dir, exist_ok=True)

--- a/tests/models/test_surge_fake_oracle_module.py
+++ b/tests/models/test_surge_fake_oracle_module.py
@@ -60,7 +60,6 @@ def _make_module() -> VSTFakeOracleModule:
     """Build a fresh :class:`VSTFakeOracleModule` with a partial Adam optimizer.
 
     :return: Module ready for direct step-method calls (no Trainer attached).
-    :rtype: VSTFakeOracleModule
     """
     net = FakeOracleNet(d_out=_NUM_PARAMS)
     optimizer = partial(torch.optim.Adam, lr=1e-4)

--- a/tests/models/test_vst_module_aliases.py
+++ b/tests/models/test_vst_module_aliases.py
@@ -42,15 +42,32 @@ def test_deprecated_alias_is_renamed_class(alias: type, renamed: type) -> None:
     assert alias is renamed
 
 
+def _flowvae_module_ast() -> ast.Module:
+    # Parse the source instead of importing it: the module pulls the undeclared optional nflows dep.
+    source = (Path(synth_setter.models.__file__).parent / "surge_flowvae_module.py").read_text()
+    return ast.parse(source)
+
+
+def test_flowvae_renamed_class_defined_in_module_source() -> None:
+    """Pin the renamed ``VSTFlowVAEModule`` class definition via AST.
+
+    Identity import needs the optional ``nflows`` dep, so a typo'd class name would
+    otherwise pass the suite and fail only at launch.
+    """
+    tree = _flowvae_module_ast()
+    assert any(
+        isinstance(node, ast.ClassDef) and node.name == "VSTFlowVAEModule"
+        for node in ast.walk(tree)
+    ), "no `class VSTFlowVAEModule` definition found"
+
+
 def test_flowvae_deprecated_alias_assigned_in_module_source() -> None:
     """``surge_flowvae_module`` binds ``SurgeFlowVAEModule`` to ``VSTFlowVAEModule``.
 
     Importing the module needs the undeclared optional ``nflows`` dependency, so
     the alias assignment is pinned in the module AST rather than by identity.
     """
-    source = (Path(synth_setter.models.__file__).parent / "surge_flowvae_module.py").read_text()
-    tree = ast.parse(source)
-    for node in ast.walk(tree):
+    for node in ast.walk(_flowvae_module_ast()):
         if (
             isinstance(node, ast.Assign)
             and any(isinstance(t, ast.Name) and t.id == "SurgeFlowVAEModule" for t in node.targets)

--- a/tests/schemas/test_datamodule_config.py
+++ b/tests/schemas/test_datamodule_config.py
@@ -71,6 +71,12 @@ class TestSurgeDatamoduleOverlays:
         assert subtree["param_spec_name"] == "surge_simple"
         assert subtree["_target_"].endswith("VSTDataModule")
 
+    def test_surge_inherits_vst_base_with_default_spec(self) -> None:
+        """The plain ``surge`` overlay adds no overrides, so it keeps the ``vst`` base verbatim."""
+        subtree = compose_subtree("datamodule", "surge")
+        assert subtree["param_spec_name"] == "surge_xt"
+        assert subtree["_target_"].endswith("VSTDataModule")
+
     def test_surge_debug_sets_repeat_first_batch_and_keeps_default_spec(self) -> None:
         """``surge_debug`` flips ``repeat_first_batch`` and keeps the ``vst`` default spec."""
         subtree = compose_subtree("datamodule", "surge_debug")

--- a/tests/tools/test_surge_xt_interactive.py
+++ b/tests/tools/test_surge_xt_interactive.py
@@ -1,9 +1,12 @@
 """Tests for src/synth_setter/tools/surge_xt_interactive.py prediction decoding helpers."""
 
 import importlib
+import os
 import queue
 import threading
 from pathlib import Path
+from typing import NoReturn
+from unittest import mock
 
 import click
 import h5py
@@ -11,6 +14,7 @@ import numpy as np
 import pandas as pd
 import pytest
 import torch
+from click.testing import CliRunner
 from pedalboard.io import AudioFile
 
 from synth_setter.data.vst import param_specs
@@ -1652,3 +1656,41 @@ class TestKeyboardLoopE2E:
             assert isinstance(value, float)
             assert np.isfinite(value), f"{name} = {value} is not finite"
         assert stop_event.is_set()
+
+
+class _StopBeforeGuiError(Exception):
+    """Sentinel raised from a patched ``load_plugin``; carries the resolved plugin path."""
+
+
+def _raise_stop(plugin_path: str) -> NoReturn:
+    raise _StopBeforeGuiError(plugin_path)
+
+
+class TestMainPluginPathDefault:
+    """``main``'s ``--plugin-path`` default flows through the env-aware registry resolver.
+
+    ``load_plugin`` is patched to capture its argument and abort: once the guard
+    clauses pass it is the first call that consumes the resolved ``--plugin-path``,
+    so the captured path is exactly what the resolver produced.
+    """
+
+    def test_env_var_overrides_default_plugin_path(self) -> None:
+        """``$SYNTH_SETTER_PLUGIN_PATH`` reaches ``load_plugin`` when no flag is passed."""
+        sxi = importlib.import_module("synth_setter.tools.surge_xt_interactive")
+        with mock.patch.object(sxi, "load_plugin", _raise_stop):
+            result = CliRunner().invoke(
+                sxi.main,
+                ["--param-spec-name", "surge_xt"],
+                env={"SYNTH_SETTER_PLUGIN_PATH": "env-plugin.vst3"},
+            )
+        assert isinstance(result.exception, _StopBeforeGuiError)
+        assert result.exception.args[0] == "env-plugin.vst3"
+
+    def test_unset_env_falls_back_to_bundle(self) -> None:
+        """With no override, ``--plugin-path`` resolves to the in-repo bundle default."""
+        sxi = importlib.import_module("synth_setter.tools.surge_xt_interactive")
+        with mock.patch.dict(os.environ), mock.patch.object(sxi, "load_plugin", _raise_stop):
+            os.environ.pop("SYNTH_SETTER_PLUGIN_PATH", None)
+            result = CliRunner().invoke(sxi.main, ["--param-spec-name", "surge_xt"])
+        assert isinstance(result.exception, _StopBeforeGuiError)
+        assert result.exception.args[0] == "plugins/Surge XT.vst3"


### PR DESCRIPTION
Addresses advisory findings from the #1602 self-review (Phase 1 of the multi-synth generalization Epic), scoped to non-behavioral cleanups and test coverage. No behavior change.

## What changed

- **`predict_vst_audio`** — reorder `resolve_preset_path` to priority order (explicit path first) and annotate `main` with `-> None`.
- **tests** — drop the `:rtype:` echo from `_make_module` (pydoclint `check-return-types` is off, so it was never required), and pin three previously untested seams:
  - the plain `surge` datamodule overlay (`param_spec_name` / `_target_`),
  - the `VSTFlowVAEModule` class definition in the AST test — the one rename with no resolution pin (a typo'd class name would otherwise pass the suite and fail only at launch),
  - the env-aware `surge_xt_interactive --plugin-path` default via `CliRunner` (set + unset `$SYNTH_SETTER_PLUGIN_PATH`).

## Intentionally not applied

Three review suggestions conflict with this repo's pydoclint config and are deferred rather than forced (all verified):

- **Collapse `resolve_preset_path` to one line** / **drop the test `:ytype:` echo** — both introduce new pydoclint violations here (`skip-checking-short-docstrings=false`, `check-yield-types=true`).
- **Extend the registry module docstring** — touching `param_spec_registry.py` pulls the pre-existing `default_plugin_path` into review, whose pydoclint-required `:returns:` then reads as a comment-hygiene echo (removing it breaks `DOC201`). The #1602 review's own alternative — extract `default_plugin_path` to a dedicated plugin-path module — is the right home for that doc; deferred under #1582.

## Related follow-ups

- File renames `surge_*` -> `vst_*` (un-exempt ~155 grandfathered pyright+ruff errors): tracked in #1664.
- Lint-cleanup graduations of the related files (`surge_datamodule.py` D107; stale `surge_ff_module` F821): separate `chore(lint):` PRs.

Pre-PR gate: `/repo-review-full-no-comments` -> 0 BLOCK / 3 WARN, all marked acceptable/defensible by the reviewer.

Refs #1595
