### PR TITLE
test(data-pipeline): run finalize-artifact oracle on lance splits

### DIFF
--- a/.github/workflows/test-dataset-finalization.yml
+++ b/.github/workflows/test-dataset-finalization.yml
@@ -206,20 +206,12 @@ jobs:
           fi
           echo "all required artifacts present at ${PREFIX}"
 
-      # Exercises the operator's stated invariant — the fake_oracle predicts
-      # `batch["params"]` verbatim, so audio metrics on the finalized dataset
-      # stay inside the same bounds `tests/test_train.py::test_train_eval_surge_xt`
-      # pins for the oracle leg. Helper auto-skips when R2 is unreachable.
-      # Heavy runtime lives in PEP 735 groups since #1139; `--group dev`
-      # transitively includes `runtime`. No cpu/cu128 extra (which
-      # [tool.uv.sources] keys torch routing on) is active, so torch resolves
-      # from PyPI — runs on the CPU runner, as before.
+      # Param-fidelity invariant against the finalized dataset; auto-skips when
+      # R2 is unreachable. `--group dev` pulls the PEP 735 runtime group → CPU runner (see #1139).
       - name: Install project deps for oracle helper
-        if: ${{ matrix.output_format != 'lance' }}
         run: uv pip install --system --group dev -e .
 
       - name: Run finalize-artifact oracle helper
-        if: ${{ matrix.output_format != 'lance' }}
         env:
           R2_BUCKET: ${{ steps.bucket.outputs.r2_bucket }}
           FINALIZE_RUN_PREFIX: r2:${{ steps.bucket.outputs.r2_bucket }}/data/${{ matrix.task_name }}/${{ steps.run_id.outputs.run_id }}/

--- a/tests/integration/test_finalize_artifact_oracle.py
+++ b/tests/integration/test_finalize_artifact_oracle.py
@@ -30,8 +30,10 @@ from __future__ import annotations
 
 import io
 import os
+import subprocess
 import tarfile
 import tempfile
+from contextlib import closing
 from pathlib import Path
 
 import numpy as np
@@ -107,6 +109,22 @@ def _load_param_array_from_hdf5(local_h5: Path) -> np.ndarray:
         return np.asarray(dataset[...], dtype=np.float32)  # type: ignore[index]
 
 
+def _load_param_array_from_lance(local_lance: Path) -> np.ndarray:
+    """Read the ``param_array`` column out of a finalized single-file Lance split.
+
+    Reads through ``LanceShardFile`` — the adapter the train/eval dataloader
+    uses — so the bytes match what a model would consume.
+
+    :param local_lance: Single-file ``train.lance`` split (not a Lance dataset dir).
+    :returns: Float32 ``param_array`` of shape ``(N, P)``, rows in shard order.
+    """
+    from synth_setter.data.lance_datamodule import LanceShardFile
+    from synth_setter.data.vst.shapes import PARAM_ARRAY_FIELD
+
+    with closing(LanceShardFile(local_lance)) as shard:
+        return np.asarray(shard[PARAM_ARRAY_FIELD][:], dtype=np.float32)
+
+
 def _load_param_array_from_wds_tar(local_tar: Path) -> np.ndarray:
     """Concatenate every ``param_array.npy`` member of a wds shard into a single array.
 
@@ -136,24 +154,26 @@ def _load_param_array_from_wds_tar(local_tar: Path) -> np.ndarray:
 
 
 def _download_first_train_artifact(prefix: str, work_dir: Path) -> tuple[Path, str]:
-    """Probe the finalized prefix for ``train.h5`` (hdf5) or the lowest-shard tar (wds).
+    """Probe the finalized prefix for a ``train`` split file or the lowest-shard tar.
 
-    Tries ``train.h5`` first — that's the hdf5 layout finalize writes. When
-    absent, falls back to listing the prefix and grabbing the first
-    ``shard-*.tar`` (wds layout). Either way returns the local download path
-    plus the format tag so the caller can branch on how to read params.
+    Tries the per-split files finalize writes — ``train.h5`` (hdf5) then
+    ``train.lance`` (lance) — and falls back to listing the prefix for the first
+    ``shard-*.tar`` (wds, which leaves shards in place). Returns the local
+    download path plus the format tag so the caller can branch on how to read
+    params.
 
     :param prefix: Rclone-form prefix; must end with ``/``.
     :param work_dir: Local scratch dir for the download.
-    :returns: ``(local_path, format)`` where ``format`` is ``"hdf5"`` or ``"wds"``.
+    :returns: ``(local_path, format)`` where ``format`` is ``"hdf5"``,
+        ``"lance"``, or ``"wds"``.
     :raises FileNotFoundError: No recognized finalize artifact under ``prefix``.
     """
-    train_h5_uri = _prefix_to_r2_uri(prefix, "train.h5")
-    if r2_io.object_size(train_h5_uri) is not None:
-        local = work_dir / "train.h5"
-        r2_io.download_to_path(train_h5_uri, local)
-        return local, "hdf5"
-    import subprocess
+    for leaf, fmt in (("train.h5", "hdf5"), ("train.lance", "lance")):
+        split_uri = _prefix_to_r2_uri(prefix, leaf)
+        if r2_io.object_size(split_uri) is not None:
+            local = work_dir / leaf
+            r2_io.download_to_path(split_uri, local)
+            return local, fmt
 
     listing = subprocess.run(  # noqa: S603
         ["rclone", "lsf", prefix, "--include", "shard-*.tar"],  # noqa: S607
@@ -164,7 +184,7 @@ def _download_first_train_artifact(prefix: str, work_dir: Path) -> tuple[Path, s
     candidates = sorted(line.strip() for line in listing.stdout.splitlines() if line.strip())
     if not candidates:
         raise FileNotFoundError(
-            f"no finalize artifact under {prefix}: looked for train.h5 and shard-*.tar"
+            f"no finalize artifact under {prefix}: expected train.h5, train.lance, or shard-*.tar"
         )
     leaf = candidates[0]
     local = work_dir / leaf
@@ -176,10 +196,10 @@ def test_finalize_train_split_passes_fake_oracle_invariants() -> None:
     """``surge/fake_oracle`` predict_step returns finalized params verbatim.
 
     Downloads the first finalize-written train artifact at
-    ``$FINALIZE_RUN_PREFIX`` (``train.h5`` for the hdf5 row, the lowest-index
-    ``shard-*.tar`` for the wds row), runs the oracle's ``predict_step`` /
-    eval step over the loaded ``param_array``, and pins three invariants the
-    oracle leg of ``tests/test_train.py`` already requires:
+    ``$FINALIZE_RUN_PREFIX`` (``train.h5`` for hdf5, ``train.lance`` for lance,
+    the lowest-index ``shard-*.tar`` for wds), runs the oracle's
+    ``predict_step`` / eval step over the loaded ``param_array``, and pins three
+    invariants the oracle leg of ``tests/test_train.py`` already requires:
 
       1. ``predict_step`` returns ``batch["params"]`` bit-identically.
       2. ``per_param_mse`` is exactly zero (no float drift).
@@ -196,14 +216,15 @@ def test_finalize_train_split_passes_fake_oracle_invariants() -> None:
     prefix = _finalize_prefix_from_env()
     assert prefix is not None
 
+    loaders = {
+        "hdf5": _load_param_array_from_hdf5,
+        "lance": _load_param_array_from_lance,
+        "wds": _load_param_array_from_wds_tar,
+    }
     with tempfile.TemporaryDirectory() as raw_work_dir:
         work_dir = Path(raw_work_dir)
         local_artifact, fmt = _download_first_train_artifact(prefix, work_dir)
-
-        if fmt == "hdf5":
-            param_array = _load_param_array_from_hdf5(local_artifact)
-        else:
-            param_array = _load_param_array_from_wds_tar(local_artifact)
+        param_array = loaders[fmt](local_artifact)
 
     assert param_array.size > 0, (
         f"finalized {fmt} artifact at {prefix} carries no param_array rows"

--- a/tests/integration/test_finalize_artifact_oracle_lance_loader.py
+++ b/tests/integration/test_finalize_artifact_oracle_lance_loader.py
@@ -1,0 +1,47 @@
+"""Local decode-contract tests for the Lance param-array loader in the oracle helper.
+
+Pins values, row order, and the float32 cast so a loader regression fails in
+``test-fast`` without R2 creds; the end-to-end path lives in
+``test_finalize_artifact_oracle.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from synth_setter.data.vst.shapes import PARAM_ARRAY_FIELD
+from tests.helpers.lance_fixtures import write_lance_shard
+from tests.integration.test_finalize_artifact_oracle import _load_param_array_from_lance
+
+
+def test_load_param_array_from_lance_preserves_values_and_row_order(tmp_path: Path) -> None:
+    """The loader returns ``param_array`` values unchanged and in shard row order.
+
+    :param tmp_path: Dir hosting the written-then-read ``.lance`` shard fixture.
+    """
+    shard = tmp_path / "train.lance"
+    # Distinct per-row values so a row-order or reshape bug cannot pass.
+    param_array = np.arange(3 * 4, dtype=np.float32).reshape(3, 4)
+    write_lance_shard(shard, {PARAM_ARRAY_FIELD: param_array})
+
+    loaded = _load_param_array_from_lance(shard)
+
+    np.testing.assert_array_equal(loaded, param_array)
+    assert loaded.dtype == np.float32
+
+
+def test_load_param_array_from_lance_casts_non_float32_column_to_float32(tmp_path: Path) -> None:
+    """A wider on-disk dtype is downcast to float32 with values preserved.
+
+    :param tmp_path: Dir hosting the written-then-read ``.lance`` shard fixture.
+    """
+    shard = tmp_path / "train.lance"
+    param_array = np.arange(2 * 3, dtype=np.float64).reshape(2, 3)
+    write_lance_shard(shard, {PARAM_ARRAY_FIELD: param_array})
+
+    loaded = _load_param_array_from_lance(shard)
+
+    assert loaded.dtype == np.float32
+    np.testing.assert_array_equal(loaded, param_array.astype(np.float32))

--- a/uv.lock
+++ b/uv.lock
@@ -6320,7 +6320,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.32.1"
+version = "8.33.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What

The finalize-artifact oracle CI helper read only HDF5 and WDS splits, so the lance row in `test-dataset-finalization.yml` skipped the param-fidelity oracle (`if: output_format != 'lance'`) and verified lance finalize by the `rclone ls` presence pin alone — a corrupt `param_array` in a finalized `train.lance` would have passed CI.

Now that #1601 landed the Lance dataloader, the read path the oracle needs already exists. This PR routes the oracle through it:

- Add `_load_param_array_from_lance`, reading the finalized `train.lance` through the same `LanceShardFile` adapter `VSTDataset` consumes (#1601) — so the oracle validates the exact bytes a model would load, not a parallel decoder.
- Probe `train.lance` alongside `train.h5` in `_download_first_train_artifact` and dispatch the param loader by format.
- Drop the two `if: output_format != 'lance'` guards so the oracle runs for every matrix row.
- Add a CPU unit test pinning the loader's value / row-order / float32-cast contract (runs in `test-fast`, no R2 needed).

## Why

Closes the lance coverage gap left open when #1642 merged — the oracle skip was an untracked workaround. Param fidelity on finalized lance splits is now checked on every finalization run, at the same trust boundary as HDF5 and WDS.

## Test

- `test-fast`: two new loader unit tests pass (round-trip values/order; `float64`→`float32` cast).
- The R2 oracle integration leg auto-skips locally (no creds) and now runs for the lance matrix row in CI.

## Notes

- `uv.lock` carries a single hook-mandated `synth-setter` version sync (`8.32.1` → `8.33.0`); `main`'s lock was left stale by the `chore(release): 8.33.0 [skip ci]` commit. No dependency changes.

Refs #1600
