### PR TITLE
internal-fix(data): tighten Lance dataloader types and read assertions

### DIFF
--- a/src/synth_setter/data/lance_datamodule.py
+++ b/src/synth_setter/data/lance_datamodule.py
@@ -90,13 +90,14 @@ class LanceShardFile:
             writes) — a stable contract independent of which exception
             ``LanceFileReader`` raises.
         """
+        path = Path(path)
         self._path = str(path)
-        if Path(path).is_dir():
+        if path.is_dir():
             raise ValueError(
                 f"expected a single-file Lance shard, got a directory "
                 f"(legacy Lance dataset layout?): {self._path}"
             )
-        if not Path(path).is_file():
+        if not path.is_file():
             raise ValueError(f"Lance shard file was not found: {self._path}")
         metadata = LanceFileReader(self._path).metadata()
         # The shard is immutable, so row count and per-column tensor shapes are

--- a/src/synth_setter/data/surge_datamodule.py
+++ b/src/synth_setter/data/surge_datamodule.py
@@ -170,7 +170,7 @@ class VSTDataset(torch.utils.data.Dataset):
 
         return ds[idx]
 
-    def __getitem__(self, idx: int | Sequence[int] | np.ndarray):
+    def __getitem__(self, idx: int | Sequence[int] | np.ndarray) -> dict[str, torch.Tensor | None]:
         if self.fake:
             return self._get_fake_item()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -696,7 +696,6 @@ def _smoke_fake_render_cfg(param_spec_name: str) -> RenderConfig:
     :param param_spec_name: Key into :data:`synth_setter.data.vst.param_specs` and
         :data:`synth_setter.data.vst.preset_paths` selecting spec and preset.
     :returns: A CPU ``RenderConfig`` with the GUI toggle disabled.
-    :rtype: RenderConfig
     """
     return RenderConfig(
         plugin_path=PLUGIN_PATH,

--- a/tests/data/test_lance_datamodule.py
+++ b/tests/data/test_lance_datamodule.py
@@ -192,7 +192,7 @@ class TestLanceShardFile:
         out = shard["mel_spec"][2:5]
         assert out.shape == (3, _MEL_CHANNELS, _MEL_N_MELS, _MEL_N_FRAMES)
         assert out.dtype == columns["mel_spec"].dtype
-        np.testing.assert_allclose(out, columns["mel_spec"][2:5])
+        np.testing.assert_array_equal(out, columns["mel_spec"][2:5])
 
     def test_column_reads_return_writable_arrays(self, tmp_path: Path) -> None:
         """Reads are copied out of Arrow's read-only buffer before reaching torch.
@@ -210,7 +210,7 @@ class TestLanceShardFile:
         """
         columns = _write_seeded_lance_shard(tmp_path / "train.lance", num_rows=8)
         shard = LanceShardFile(tmp_path / "train.lance")
-        np.testing.assert_allclose(shard["param_array"][:3], columns["param_array"][:3])
+        np.testing.assert_array_equal(shard["param_array"][:3], columns["param_array"][:3])
 
     def test_column_fancy_index_read_selects_rows(self, tmp_path: Path) -> None:
         """``file[name][[i, j, k]]`` gathers exactly those rows.
@@ -219,7 +219,7 @@ class TestLanceShardFile:
         """
         columns = _write_seeded_lance_shard(tmp_path / "train.lance", num_rows=8)
         shard = LanceShardFile(tmp_path / "train.lance")
-        np.testing.assert_allclose(shard["audio"][[0, 3, 6]], columns["audio"][[0, 3, 6]])
+        np.testing.assert_array_equal(shard["audio"][[0, 3, 6]], columns["audio"][[0, 3, 6]])
 
     def test_column_numpy_int_indices_are_accepted(self, tmp_path: Path) -> None:
         """Samplers yield numpy integer arrays — the column accepts them directly.
@@ -229,7 +229,7 @@ class TestLanceShardFile:
         columns = _write_seeded_lance_shard(tmp_path / "train.lance", num_rows=8)
         shard = LanceShardFile(tmp_path / "train.lance")
         idx = np.array([1, 2, 4], dtype=np.int64)
-        np.testing.assert_allclose(shard["param_array"][idx], columns["param_array"][idx])
+        np.testing.assert_array_equal(shard["param_array"][idx], columns["param_array"][idx])
 
     def test_column_shape_reports_rows_and_tensor_dims(self, tmp_path: Path) -> None:
         """``file[name].shape`` mirrors h5py: ``(num_rows, *tensor_shape)``.
@@ -310,7 +310,7 @@ class TestLanceShardFile:
         """
         columns = _write_seeded_lance_shard(tmp_path / "train.lance", num_rows=8)
         shard = LanceShardFile(tmp_path / "train.lance")
-        np.testing.assert_allclose(shard["param_array"][1:8:3], columns["param_array"][1:8:3])
+        np.testing.assert_array_equal(shard["param_array"][1:8:3], columns["param_array"][1:8:3])
 
     def test_column_negative_step_slice_raises_value_error(self, tmp_path: Path) -> None:
         """A negative-step slice is rejected — the same contract h5py enforces.
@@ -374,7 +374,7 @@ class TestLanceVSTDataset:
             use_saved_mean_and_variance=False,
             rescale_params=False,
         )
-        np.testing.assert_allclose(
+        np.testing.assert_array_equal(
             _unwrap(dataset[1]["params"]).numpy(), columns["param_array"][2:4]
         )
 
@@ -395,7 +395,7 @@ class TestLanceVSTDataset:
             rescale_params=False,
         )
         item = dataset[(1, 5)]
-        np.testing.assert_allclose(_unwrap(item["params"]).numpy(), columns["param_array"][1:5])
+        np.testing.assert_array_equal(_unwrap(item["params"]).numpy(), columns["param_array"][1:5])
 
     def test_getitem_sequence_falls_through_to_fancy_indexing(self, single_shard: Path) -> None:
         """A non-int / non-2-tuple index gathers exactly those rows.


### PR DESCRIPTION
## Summary

Follow-up to the multi-skill review of #1601 (the now-merged Lance dataloader backend). Applies the advisory findings I agreed with — **no behavior changes**, just types, a small readability dedup, and stricter test assertions.

- **`surge_datamodule.py`** — annotate `VSTDataset.__getitem__` return as `dict[str, torch.Tensor | None]`. The `idx` param type was widened in #1601 but the return stayed bare; sibling readers (`LanceColumn.__getitem__`, `_index_dataset`) already carry explicit returns.
- **`lance_datamodule.py`** — build `Path(path)` once in `LanceShardFile.__init__` and reuse it for the directory / missing-file boundary checks instead of reconstructing it twice.
- **`tests/data/test_lance_datamodule.py`** — use `np.testing.assert_array_equal` for the bit-exact read-fidelity assertions (float16 `audio` / float32 columns round-trip losslessly through Lance). Expresses the no-tolerance intent that `assert_allclose` (default `rtol=1e-7`) obscured, matching the writer-compatibility test.
- **`tests/conftest.py`** — drop the redundant `:rtype: RenderConfig` from `_smoke_fake_render_cfg` (pydoclint `check-return-types` is off, so the `->` annotation is the single source).

## Considered but deferred

- **m2l column not emitted by the production Lance writer** (`conditioning="m2l"` would `KeyError` on a real shard) — a real gap, but it belongs in the pipeline writer (#1642), not this dataloader cleanup. Worth a tracked follow-up on #1599.
- **Pre-existing missing annotations** on `_get_fake_item` / `_load_dataset_statistics` / `__len__` — out of scope (not introduced by #1601).
- **`Mapping` vs `dict` return type** — kept `dict`; the value is a freshly-constructed mapping callers consume directly, consistent with `_get_fake_item`'s `dict(...)`.

## Review gate note

Opened with `REVIEW_COMMENT_GATE=warn`. The pre-PR review's only comment-hygiene finding is the pre-existing `:param tmp_path:` boilerplate shared by every test in the file — my diff does not touch those docstring lines, and pydoclint (`DOC101`) requires them, so the suggested removal is not applicable here.

## Testing

- `tests/data/test_lance_datamodule.py` + `tests/data/test_surge_datamodule.py`: 113 passed.
- `make format`: all hooks pass (ruff, pyright, pydoclint, interrogate).

Refs #1599