### PR TITLE
internal-feat(evaluation): log render-order probe permutation as a wandb metric

### DIFF
--- a/docs/design/eval-pipeline.md
+++ b/docs/design/eval-pipeline.md
@@ -260,7 +260,7 @@ When `cfg.mode == "predict"`, `cli/eval.py` invokes `_run_predict_postprocessing
 
 On Linux the render subprocess is prefixed with the headless wrapper materialised via `synth_setter.resources.vst_headless_wrapper()` so the VST3 plugin sees an Xvfb display before pedalboard imports it; the metrics subprocess is CPU-only and runs unwrapped. Both default-off so `mode: test` and `mode: validate` paths are unchanged.
 
-When `evaluation.compute_metrics` runs, the aggregated values from `aggregated_metrics.csv` are surfaced to the active wandb run (as `audio/<name>_{mean,std}` scalars) and, when the auto-shuffle probe ran, `shuffled_audio/<name>_{mean,std}` from `aggregated_metrics_shuffled.csv` — and merged into the dict returned by `evaluate()` alongside Lightning's `trainer.callback_metrics`. Separately, `metrics.csv` is uploaded as `audio/per_sample_metrics` (a `wandb.Table`) — logged to W&B only, not included in the returned dict — so the same wandb run that holds `test/param_mse` can carry the aggregated, shuffled, and per-sample audio metrics too.
+When `evaluation.compute_metrics` runs, the aggregated values from `aggregated_metrics.csv` are surfaced to the active wandb run (as `audio/<name>_{mean,std}` scalars) and, when the auto-shuffle probe ran, `shuffled_audio/<name>_{mean,std}` from `aggregated_metrics_shuffled.csv` — and merged into the dict returned by `evaluate()` alongside Lightning's `trainer.callback_metrics`. Separately, `metrics.csv` is uploaded as `audio/per_sample_metrics` (a `wandb.Table`) — logged to W&B only, not included in the returned dict — so the same wandb run that holds `test/param_mse` can carry the aggregated, shuffled, and per-sample audio metrics too. When the auto-shuffle probe ran, the drawn permutation is also logged as a `shuffle/permutation` `wandb.Table` (from `shuffle_permutation.csv`) — W&B-only, not in the returned dict — so the render-order mapping behind the shuffled metrics is reproducible.
 
 ### 5.2 Render
 
@@ -285,12 +285,12 @@ The render stage loads each predicted parameter tensor, decodes it using the `Pa
 
 ### 5.3 Metrics
 
-| Property    | Value                                                                                                                                                                |
-| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Command** | `python -m synth_setter.evaluation.compute_audio_metrics {audio_dir} {output_dir}`                                                                                   |
-| **Input**   | Directory of `sample_{N}/` subdirectories, each containing `pred.wav` and `target.wav`                                                                               |
-| **Output**  | `metrics.csv` (per-sample), `aggregated_metrics.csv` (mean/std), `aggregated_metrics_shuffled.csv` (mean/std of shuffled pass — present when auto-shuffle probe ran) |
-| **Compute** | CPU — spectral analysis, DTW, optimal transport (parallelized with `ProcessPoolExecutor`)                                                                            |
+| Property    | Value                                                                                                                                                                                                                                                                   |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Command** | `python -m synth_setter.evaluation.compute_audio_metrics {audio_dir} {output_dir}`                                                                                                                                                                                      |
+| **Input**   | Directory of `sample_{N}/` subdirectories, each containing `pred.wav` and `target.wav`                                                                                                                                                                                  |
+| **Output**  | `metrics.csv` (per-sample), `aggregated_metrics.csv` (mean/std), `aggregated_metrics_shuffled.csv` (mean/std of shuffled pass — present when auto-shuffle probe ran), `shuffle_permutation.csv` (`dest_idx`→`src_idx` permutation, written alongside the shuffled pass) |
+| **Compute** | CPU — spectral analysis, DTW, optimal transport (parallelized with `ProcessPoolExecutor`)                                                                                                                                                                               |
 
 Four metrics are computed for each (predicted, target) audio pair:
 

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -204,7 +204,7 @@ docs:
       - pattern: "src/synth_setter/evaluation/predict_vst_audio.py"
         covers: "Audio prediction script, VST rendering, parameter-to-audio pipeline"
       - pattern: "src/synth_setter/evaluation/compute_audio_metrics.py"
-        covers: "Audio metric computation, MSS/wMFCC/SOT/RMS distance metrics, parallel workers, automatic render-order probe (auto-shuffles when params are uniform, writes aggregated_metrics_shuffled.csv)"
+        covers: "Audio metric computation, MSS/wMFCC/SOT/RMS distance metrics, parallel workers, automatic render-order probe (auto-shuffles when params are uniform, writes aggregated_metrics_shuffled.csv + shuffle_permutation.csv)"
       - pattern: "src/synth_setter/evaluation/shuffle_pred_audio.py"
         covers: "Render-order probe (#489) — builds a symlink view permuting pred.wav across sample dirs; auto-invoked by compute_audio_metrics.main() when params_are_uniform returns True. params_are_uniform is also the gating predicate imported by compute_audio_metrics."
       - pattern: "renderscript.sh"

--- a/docs/reference/wandb-integration.md
+++ b/docs/reference/wandb-integration.md
@@ -164,7 +164,7 @@ When `synth-setter-eval mode=predict evaluation.compute_metrics=true` runs and a
 | `audio/rms_std`            | Same, standard deviation                                                                                                    |
 | `audio/per_sample_metrics` | Per-sample metrics from `metrics.csv` as a `wandb.Table`; columns match `compute_audio_metrics` output (one row per sample) |
 
-When the auto-shuffle probe ran (uniform params, ≥ 2 sample dirs), a parallel set of `shuffled_audio/<metric>_{mean,std}` keys is also logged from `aggregated_metrics_shuffled.csv`. `_log_metrics_csv_to_wandb` (`src/synth_setter/cli/eval.py`) is a no-op when `metrics.csv` is absent or `wandb.run` is unset; wandb errors are swallowed so a logging failure never aborts the run.
+When the auto-shuffle probe ran (uniform params, ≥ 2 sample dirs), a parallel set of `shuffled_audio/<metric>_{mean,std}` keys is also logged from `aggregated_metrics_shuffled.csv`, and the drawn permutation is logged as a `shuffle/permutation` `wandb.Table` from `shuffle_permutation.csv` via `_log_shuffle_permutation_to_wandb` (`src/synth_setter/cli/eval.py`) — skipped when `shuffle_permutation.csv` is absent or `wandb.run` is unset, with wandb errors swallowed. `_log_metrics_csv_to_wandb` (`src/synth_setter/cli/eval.py`) is a no-op when `metrics.csv` is absent or `wandb.run` is unset; wandb errors are swallowed so a logging failure never aborts the run.
 
 The aggregated scalar metrics dict is also merged into the dict returned by `evaluate()` alongside Lightning's `trainer.callback_metrics`; the `audio/per_sample_metrics` Table is W&B-only and is not included in that dict. See [eval-pipeline.md §5.1](../design/eval-pipeline.md) for the surrounding subprocess chain.
 
@@ -280,7 +280,7 @@ split so they don't overwrite each other's run summary: `test` keeps the bare
 `audio/*` key, while `train`/`val` are logged under `train/audio/*` and
 `val/audio/*` (via `+evaluation.metric_prefix=<split>/`). The prefix applies to
 every metric key, so the `shuffled_audio/*` keys (§2) become `train/shuffled_audio/*`
-etc. too. The eval subprocess
+and the `shuffle/permutation` Table becomes `train/shuffle/permutation`, etc. too. The eval subprocess
 inherits `WANDB_MODE` from the launcher, so its offline/online posture follows
 the parent's. Console logs survive the split-by-split resumes via
 `console_multipart=True`: each session uploads its own `logs/output_*.log`

--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -40,6 +40,7 @@ _SUBPROCESS_TIMEOUT_SECONDS = 600
 _AGGREGATED_METRICS_FILENAME = "aggregated_metrics.csv"
 _METRICS_FILENAME = "metrics.csv"
 _AGGREGATED_METRICS_SHUFFLED_FILENAME = "aggregated_metrics_shuffled.csv"
+_SHUFFLE_PERMUTATION_FILENAME = "shuffle_permutation.csv"
 _AGGREGATED_METRICS_STATS: tuple[str, ...] = ("mean", "std")
 
 # Resolve workspace at import so ``${oc.env:PROJECT_ROOT}`` in
@@ -137,6 +138,33 @@ def _log_metrics_csv_to_wandb(metrics_dir: Path, prefix: str = "") -> None:
     except Exception as exc:
         log.warning(
             f"per-sample metrics table logging failed with {type(exc).__name__}: {exc}; skipped."
+        )
+
+
+def _log_shuffle_permutation_to_wandb(metrics_dir: Path, prefix: str = "") -> None:
+    """Log the probe permutation to wandb as a Table; no-op when ``wandb.run`` is unset.
+
+    Silently skips when ``shuffle_permutation.csv`` is absent — the probe writes it only
+    for uniform-params (oracle) datasets, so its absence is the common case. Swallows wandb
+    errors so a logging failure never aborts the evaluation run.
+
+    :param metrics_dir: Directory produced by
+        :mod:`synth_setter.evaluation.compute_audio_metrics`; ``shuffle_permutation.csv``
+        is read from it when present.
+    :param prefix: Prepended to the ``shuffle/permutation`` Table key so per-split runs
+        (one wandb run shared across splits) stay distinct.
+    """
+    if wandb.run is None:
+        return
+    csv_path = metrics_dir / _SHUFFLE_PERMUTATION_FILENAME
+    if not csv_path.is_file():
+        return
+    try:
+        df = pd.read_csv(csv_path)
+        wandb.run.log({f"{prefix}shuffle/permutation": wandb.Table(dataframe=df)})
+    except Exception as exc:
+        log.warning(
+            f"shuffle permutation table logging failed with {type(exc).__name__}: {exc}; skipped."
         )
 
 
@@ -250,6 +278,7 @@ def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: D
             audio_metrics = {f"{prefix}{key}": value for key, value in audio_metrics.items()}
         _log_audio_metrics_to_wandb(audio_metrics)
         _log_metrics_csv_to_wandb(metrics_dir, prefix)
+        _log_shuffle_permutation_to_wandb(metrics_dir, prefix)
         return audio_metrics
 
     return {}

--- a/src/synth_setter/evaluation/compute_audio_metrics.py
+++ b/src/synth_setter/evaluation/compute_audio_metrics.py
@@ -499,11 +499,12 @@ def _run_shuffle_probe(
     shuffle_seed: int,
     num_workers: int,
 ) -> None:
-    """Run the render-order probe and write ``aggregated_metrics_shuffled.csv``.
+    """Run the render-order probe, writing the shuffled-metrics and permutation CSVs.
 
-    Builds a symlink view with permuted ``pred.wav`` files, runs
-    :func:`_aggregate_metrics` over it, and writes the shuffled aggregation.
-    Cleans up the intermediate temp dir in all cases.
+    Builds a symlink view with permuted ``pred.wav`` files, scores it into
+    ``aggregated_metrics_shuffled.csv``, and records the drawn permutation alongside it to
+    ``shuffle_permutation.csv`` (columns ``dest_idx``, ``src_idx``). Cleans up the
+    intermediate temp dir in all cases.
 
     :param audio_dir_path: Root audio directory passed to :func:`shuffle_pred_audio`.
     :param output_dir_path: Destination dir for ``aggregated_metrics_shuffled.csv``.
@@ -547,6 +548,11 @@ def _run_shuffle_probe(
         pd.DataFrame({"mean": shuffled_df.mean(axis=0), "std": shuffled_df.std(axis=0)}).to_csv(
             output_dir_path / "aggregated_metrics_shuffled.csv"
         )
+    # Written only after the shuffled metrics land, so the permutation never
+    # appears without the metrics it explains.
+    pd.DataFrame({"dest_idx": range(len(permutation)), "src_idx": permutation}).to_csv(
+        output_dir_path / "shuffle_permutation.csv", index=False
+    )
 
 
 if __name__ == "__main__":

--- a/tests/evaluation/test_compute_audio_metrics.py
+++ b/tests/evaluation/test_compute_audio_metrics.py
@@ -657,6 +657,87 @@ def test_main_uniform_params_writes_aggregated_metrics_shuffled_csv(tmp_path: Pa
 
 
 @pytest.mark.slow
+def test_main_uniform_params_writes_shuffle_permutation_csv(tmp_path: Path) -> None:
+    """Uniform params → ``shuffle_permutation.csv`` round-trips the ``dest_idx -> src_idx`` mapping.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    audio_root = tmp_path / "audio"
+    audio_root.mkdir()
+    metrics_dir = tmp_path / "metrics"
+    _make_uniform_sample_dir(audio_root, "0", _sine(seconds=0.3), _sine(seconds=0.3))
+    _make_uniform_sample_dir(
+        audio_root, "1", _sine(seconds=0.3, freq=440.0), _sine(seconds=0.3, freq=880.0)
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        compute_audio_metrics_main,
+        [str(audio_root), str(metrics_dir), "-w", "1"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    permutation = pd.read_csv(metrics_dir / "shuffle_permutation.csv")
+    assert list(permutation.columns) == ["dest_idx", "src_idx"]
+    assert permutation["dest_idx"].tolist() == [0, 1]
+    assert sorted(permutation["src_idx"].tolist()) == [0, 1]
+    # _draw_non_identity_permutation guarantees ≥1 pred.wav moves even at the default
+    # seed 0, so for two dirs the only non-identity mapping is the full swap [1, 0].
+    assert permutation["src_idx"].tolist() == [1, 0]
+
+
+def test_run_shuffle_probe_fewer_than_two_sample_dirs_writes_neither_csv(tmp_path: Path) -> None:
+    """A <2 permutation (too few dirs with params) short-circuits before either probe write.
+
+    Pins the ``len(permutation) < 2`` guard, which the CLI cannot reach — its outer
+    ``len(probe_dirs) >= 2`` gate fires first.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    audio_root = tmp_path / "audio"
+    audio_root.mkdir()
+    output_dir = tmp_path / "metrics"
+    output_dir.mkdir()
+    _make_uniform_sample_dir(audio_root, "0", _sine(seconds=0.05), _sine(seconds=0.05))
+
+    cam._run_shuffle_probe(audio_root, output_dir, shuffle_seed=0, num_workers=1)
+
+    assert not (output_dir / "shuffle_permutation.csv").exists()
+    assert not (output_dir / "aggregated_metrics_shuffled.csv").exists()
+
+
+def test_run_shuffle_probe_aggregation_failure_leaves_no_permutation_csv(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed shuffled-metric aggregation leaves no orphaned ``shuffle_permutation.csv``.
+
+    Pins the write ordering: the permutation is recorded only after the shuffled metrics
+    land, so an aggregation that raises must not leave a permutation file behind.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    :param monkeypatch: Patches ``_aggregate_metrics`` to raise during the shuffled pass.
+    """
+    audio_root = tmp_path / "audio"
+    audio_root.mkdir()
+    output_dir = tmp_path / "metrics"
+    output_dir.mkdir()
+    _make_uniform_sample_dir(audio_root, "0", _sine(seconds=0.05), _sine(seconds=0.05))
+    _make_uniform_sample_dir(audio_root, "1", _sine(seconds=0.05), _sine(seconds=0.05))
+
+    def _raise(*_args: object, **_kwargs: object) -> pd.DataFrame:
+        raise RuntimeError("metric aggregation failed")
+
+    monkeypatch.setattr(cam, "_aggregate_metrics", _raise)
+
+    with pytest.raises(RuntimeError, match="metric aggregation failed"):
+        cam._run_shuffle_probe(audio_root, output_dir, shuffle_seed=0, num_workers=1)
+
+    assert not (output_dir / "shuffle_permutation.csv").exists()
+
+
+@pytest.mark.slow
 def test_main_auto_shuffle_does_not_mutate_source(tmp_path: Path) -> None:
     """The original ``audio/`` tree is byte-identical after the auto-shuffle pass.
 
@@ -714,6 +795,7 @@ def test_main_nonuniform_params_default_seed_skips_shuffle_no_shuffled_csv(
 
     assert result.exit_code == 0, result.output
     assert not (metrics_dir / "aggregated_metrics_shuffled.csv").exists()
+    assert not (metrics_dir / "shuffle_permutation.csv").exists()
 
 
 @pytest.mark.slow
@@ -778,9 +860,10 @@ def test_main_num_workers_zero_raises_usage_error(tmp_path: Path) -> None:
 
 @pytest.mark.slow
 def test_main_single_sample_dir_no_shuffled_csv(tmp_path: Path) -> None:
-    """Single sample dir cannot be shuffled → no ``aggregated_metrics_shuffled.csv``.
+    """Single sample dir cannot be shuffled → no shuffled-metrics or permutation CSV.
 
-    Drives ``main`` with one uniform-params dir; assertion is on filesystem state.
+    Drives ``main`` with one uniform-params dir; both probe outputs are written only when a
+    real shuffle ran (≥2 dirs), so neither must appear.
 
     :param tmp_path: Pytest fixture providing a fresh test directory.
     """
@@ -797,6 +880,7 @@ def test_main_single_sample_dir_no_shuffled_csv(tmp_path: Path) -> None:
     )
     assert result.exit_code == 0, result.output
     assert not (metrics_dir / "aggregated_metrics_shuffled.csv").exists()
+    assert not (metrics_dir / "shuffle_permutation.csv").exists()
 
 
 @pytest.mark.slow

--- a/tests/evaluation/test_compute_audio_metrics.py
+++ b/tests/evaluation/test_compute_audio_metrics.py
@@ -907,6 +907,7 @@ def test_main_output_dir_inside_audio_dir_default_seed_skips_shuffle(tmp_path: P
     )
     assert result.exit_code == 0, result.output
     assert not (metrics_dir / "aggregated_metrics_shuffled.csv").exists()
+    assert not (metrics_dir / "shuffle_permutation.csv").exists()
 
 
 @pytest.mark.slow

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -493,6 +493,7 @@ def test_evaluate_predict_mode_logs_shuffle_permutation_table_to_wandb(
     table = table_payloads[0]["shuffle/permutation"]
     assert isinstance(table, wandb.Table)
     assert table.columns == ["dest_idx", "src_idx"]
+    assert table.data == [[0, 1], [1, 0]]
 
 
 @pytest.mark.fake_vst

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -419,6 +419,83 @@ def test_evaluate_predict_mode_logs_per_sample_metrics_table_to_wandb(
 
 
 @pytest.mark.fake_vst
+def test_evaluate_predict_mode_logs_shuffle_permutation_table_to_wandb(
+    tmp_path: Path,
+    fake_surge_smoke_datasets: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``mode=predict`` uploads the render-order probe permutation as a ``shuffle/permutation`` Table.
+
+    Exercises the ``_log_shuffle_permutation_to_wandb`` call-through via the real
+    ``evaluate`` entrypoint: the fake metrics subprocess writes ``aggregated_metrics.csv``
+    and ``shuffle_permutation.csv``; a spy on ``wandb.run.log`` verifies the permutation
+    Table arrives under ``shuffle/permutation`` (#1669).
+
+    :param tmp_path: Hydra ``output_dir``; the fake subprocess writes CSVs beneath it.
+    :param fake_surge_smoke_datasets: CPU-fast surge_4 dataset (no real VST).
+    :param monkeypatch: Stubs subprocesses, headless wrapper, and ``wandb.run``.
+    """
+    permutation_csv = "dest_idx,src_idx\n0,1\n1,0\n"
+    logged: list[dict[str, object]] = []
+
+    class _Spy:
+        """Stand-in for ``wandb.run`` that records ``log`` payloads; no-ops SDK lifecycle calls.
+
+        ``__getattr__`` absorbs wandb SDK cleanup methods (e.g. ``finish``,
+        ``summary``) that Lightning triggers after predict — they are irrelevant to
+        this test's contract.
+        """
+
+        def log(self, payload: dict[str, object]) -> None:
+            """Record one ``wandb.run.log`` call's argument.
+
+            :param payload: The dict passed to ``wandb.run.log``.
+            """
+            logged.append(payload)
+
+        def __getattr__(self, _name: str) -> object:
+            """Return a no-op callable for any undeclared wandb SDK method.
+
+            :param _name: Unused; any undeclared attribute resolves to the no-op.
+            :returns: A callable accepting any args and returning ``None``.
+            """
+            return lambda *_args, **_kwargs: None
+
+    def _fake_run_with_permutation(args: list[str], **_kwargs: object) -> None:
+        is_render = any(_PREDICT_VST_AUDIO_FRAGMENT in a for a in args)
+        is_metrics = any(_COMPUTE_AUDIO_METRICS_FRAGMENT in a for a in args)
+        if not (is_render or is_metrics):
+            return
+        out_dir = Path(args[args.index("-m") + 3])
+        out_dir.mkdir(parents=True, exist_ok=True)
+        if is_metrics:
+            (out_dir / "aggregated_metrics.csv").write_text(_FAKE_AGGREGATED_METRICS_CSV)
+            (out_dir / "shuffle_permutation.csv").write_text(permutation_csv)
+
+    cfg = _compose_fake_oracle_eval_cfg(tmp_path, fake_surge_smoke_datasets, mode="predict")
+    monkeypatch.setattr("synth_setter.cli.eval.subprocess.run", _fake_run_with_permutation)
+    monkeypatch.setattr("synth_setter.cli.eval.vst_headless_wrapper", lambda: object())
+    monkeypatch.setattr(
+        "synth_setter.cli.eval.as_file",
+        lambda _traversable: nullcontext(Path("/fake/headless-wrapper")),
+    )
+    monkeypatch.setattr(wandb, "run", _Spy())
+    monkeypatch.setattr(wandb, "finish", lambda *_args, **_kwargs: None)
+
+    HydraConfig().set_config(cfg)
+    try:
+        evaluate(cfg)
+    finally:
+        GlobalHydra.instance().clear()
+
+    table_payloads = [p for p in logged if "shuffle/permutation" in p]
+    assert len(table_payloads) == 1
+    table = table_payloads[0]["shuffle/permutation"]
+    assert isinstance(table, wandb.Table)
+    assert table.columns == ["dest_idx", "src_idx"]
+
+
+@pytest.mark.fake_vst
 def test_evaluate_validate_mode_legacy_val_spelling_runs_oracle(
     tmp_path: Path,
     fake_surge_smoke_datasets: Path,

--- a/tests/test_eval_postprocessing.py
+++ b/tests/test_eval_postprocessing.py
@@ -22,6 +22,7 @@ from synth_setter.cli.eval import (
     _PREDICT_VST_AUDIO_MODULE,
     _log_audio_metrics_to_wandb,
     _log_metrics_csv_to_wandb,
+    _log_shuffle_permutation_to_wandb,
     _run_predict_postprocessing,
 )
 
@@ -904,3 +905,176 @@ def test_log_metrics_csv_to_wandb_log_exception_is_swallowed(
         _log_metrics_csv_to_wandb(tmp_path)
 
     assert any("RuntimeError" in r.message for r in caplog.records)
+
+
+_SHUFFLE_PERMUTATION_CSV = "dest_idx,src_idx\n0,1\n1,0\n"
+
+
+class _RecordingWandbRun:
+    """Spy stand-in for ``wandb.run`` that appends every ``log`` payload to ``payloads``."""
+
+    def __init__(self) -> None:
+        self.payloads: list[dict[str, object]] = []
+
+    def log(self, payload: dict[str, object]) -> None:
+        """Record one ``wandb.run.log`` call's argument.
+
+        :param payload: The dict passed to ``wandb.run.log``.
+        """
+        self.payloads.append(payload)
+
+
+@pytest.fixture
+def wandb_log_spy(monkeypatch: pytest.MonkeyPatch) -> _RecordingWandbRun:
+    """Pin ``wandb.run`` to a fresh recording spy for the test's duration.
+
+    :param monkeypatch: Applies and reverts the ``eval_mod.wandb.run`` patch.
+    :returns: The installed spy, whose ``payloads`` collects every logged dict.
+    """
+    spy = _RecordingWandbRun()
+    monkeypatch.setattr(eval_mod.wandb, "run", spy)
+    return spy
+
+
+def test_log_shuffle_permutation_to_wandb_logs_table_to_active_run(
+    wandb_log_spy: _RecordingWandbRun,
+    tmp_path: Path,
+) -> None:
+    """An active run plus a present ``shuffle_permutation.csv`` logs exactly one Table.
+
+    :param wandb_log_spy: Recording spy pinned to ``wandb.run``.
+    :param tmp_path: Scratch metrics dir seeded with a minimal ``shuffle_permutation.csv``.
+    """
+    (tmp_path / "shuffle_permutation.csv").write_text(_SHUFFLE_PERMUTATION_CSV)
+
+    _log_shuffle_permutation_to_wandb(tmp_path)
+
+    assert len(wandb_log_spy.payloads) == 1
+    table = wandb_log_spy.payloads[0]["shuffle/permutation"]
+    assert isinstance(table, wandb.Table)
+    assert table.columns == ["dest_idx", "src_idx"]
+    # Rows must round-trip the CSV verbatim, not just carry the right header.
+    assert table.data == [[0, 1], [1, 0]]
+
+
+def test_log_shuffle_permutation_to_wandb_prepends_prefix_to_table_key(
+    wandb_log_spy: _RecordingWandbRun,
+    tmp_path: Path,
+) -> None:
+    """A non-empty ``prefix`` namespaces the Table key so per-split runs stay distinct.
+
+    :param wandb_log_spy: Recording spy pinned to ``wandb.run``.
+    :param tmp_path: Scratch metrics dir seeded with a minimal ``shuffle_permutation.csv``.
+    """
+    (tmp_path / "shuffle_permutation.csv").write_text(_SHUFFLE_PERMUTATION_CSV)
+
+    _log_shuffle_permutation_to_wandb(tmp_path, prefix="train/")
+
+    assert len(wandb_log_spy.payloads) == 1
+    assert isinstance(wandb_log_spy.payloads[0]["train/shuffle/permutation"], wandb.Table)
+
+
+def test_log_shuffle_permutation_to_wandb_noop_when_no_run(
+    wandb_log_spy: _RecordingWandbRun,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """``wandb.run is None`` → returns without raising or logging, even with the CSV present.
+
+    Overriding the spy with ``None`` exercises the early-exit guard: removing it would
+    dereference ``None.log`` and raise instead of logging nothing.
+
+    :param wandb_log_spy: Recording spy whose ``payloads`` must stay empty.
+    :param monkeypatch: Overrides ``wandb.run`` with ``None`` after the fixture installs the spy.
+    :param tmp_path: Scratch dir — ``shuffle_permutation.csv`` is present but must not be read.
+    """
+    (tmp_path / "shuffle_permutation.csv").write_text(_SHUFFLE_PERMUTATION_CSV)
+    monkeypatch.setattr(eval_mod.wandb, "run", None)
+
+    _log_shuffle_permutation_to_wandb(tmp_path)
+
+    assert wandb_log_spy.payloads == []
+
+
+def test_log_shuffle_permutation_to_wandb_missing_file_is_silent(
+    wandb_log_spy: _RecordingWandbRun,
+    tmp_path: Path,
+) -> None:
+    """A missing ``shuffle_permutation.csv`` is skipped; nothing is logged.
+
+    The probe writes the file only for uniform-params datasets, so its absence is the
+    common non-oracle case and must not raise.
+
+    :param wandb_log_spy: Recording spy pinned to ``wandb.run``.
+    :param tmp_path: Empty scratch dir — no ``shuffle_permutation.csv`` present.
+    """
+    _log_shuffle_permutation_to_wandb(tmp_path)
+
+    assert wandb_log_spy.payloads == []
+
+
+def test_log_shuffle_permutation_to_wandb_log_exception_is_swallowed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An exception from ``wandb.run.log`` is swallowed and a warning is emitted.
+
+    :param monkeypatch: Pins ``wandb.run`` to a fake whose ``.log`` raises ``RuntimeError``.
+    :param tmp_path: Scratch metrics dir seeded with a minimal ``shuffle_permutation.csv``.
+    :param caplog: Captures log output to verify the warning is emitted.
+    """
+    (tmp_path / "shuffle_permutation.csv").write_text(_SHUFFLE_PERMUTATION_CSV)
+
+    class _RaisingRun:
+        """Stand-in for ``wandb.run`` whose ``log`` always raises to simulate a backend failure."""
+
+        def log(self, _payload: object) -> None:
+            """Simulate a failing wandb backend.
+
+            :param _payload: The would-be log dict; discarded before raising.
+            :raises RuntimeError: Always, to simulate a wandb backend failure.
+            """
+            raise RuntimeError("wandb backend unavailable")
+
+    monkeypatch.setattr(eval_mod.wandb, "run", _RaisingRun())
+
+    with caplog.at_level(logging.WARNING):
+        _log_shuffle_permutation_to_wandb(tmp_path)
+
+    assert any("RuntimeError" in r.message for r in caplog.records)
+
+
+def test_postprocessing_logs_shuffle_permutation_table_when_subprocess_writes_csv(
+    wandb_log_spy: _RecordingWandbRun,
+    predictions_tree: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The probe permutation Table reaches ``wandb.run.log`` end-to-end through postprocessing.
+
+    Wires the producer→consumer contract: when the metrics subprocess writes
+    ``shuffle_permutation.csv``, ``_run_predict_postprocessing`` logs it as a Table under
+    the ``shuffle/permutation`` key. Deleting the log call would fail this test.
+
+    :param wandb_log_spy: Recording spy pinned to ``wandb.run``.
+    :param predictions_tree: ``tmp_path`` with ``predictions/`` + ``audio/`` pre-created.
+    :param monkeypatch: Replaces ``subprocess.run`` with a fake that writes the aggregated
+        metrics CSV and the permutation CSV.
+    """
+    metrics_dir = predictions_tree / "metrics"
+
+    def _writes_metrics_and_permutation(args: list[str], **_kwargs: object) -> None:
+        if _COMPUTE_AUDIO_METRICS_MODULE not in args:
+            return
+        metrics_dir.mkdir(parents=True, exist_ok=True)
+        (metrics_dir / "aggregated_metrics.csv").write_text(_AGGREGATED_METRICS_CSV)
+        (metrics_dir / "shuffle_permutation.csv").write_text(_SHUFFLE_PERMUTATION_CSV)
+
+    monkeypatch.setattr(eval_mod.subprocess, "run", _writes_metrics_and_permutation)
+    cfg = _build_postprocess_cfg(predictions_tree, render_vst=False, compute_metrics=True)
+
+    _run_predict_postprocessing(cfg)
+
+    permutation_payloads = [p for p in wandb_log_spy.payloads if "shuffle/permutation" in p]
+    assert len(permutation_payloads) == 1
+    assert isinstance(permutation_payloads[0]["shuffle/permutation"], wandb.Table)

--- a/tests/test_eval_postprocessing.py
+++ b/tests/test_eval_postprocessing.py
@@ -1077,4 +1077,6 @@ def test_postprocessing_logs_shuffle_permutation_table_when_subprocess_writes_cs
 
     permutation_payloads = [p for p in wandb_log_spy.payloads if "shuffle/permutation" in p]
     assert len(permutation_payloads) == 1
-    assert isinstance(permutation_payloads[0]["shuffle/permutation"], wandb.Table)
+    table = permutation_payloads[0]["shuffle/permutation"]
+    assert isinstance(table, wandb.Table)
+    assert table.columns == ["dest_idx", "src_idx"]

--- a/uv.lock
+++ b/uv.lock
@@ -6320,7 +6320,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.32.1"
+version = "8.33.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What

The inline oracle eval's render-order probe (#489) draws a `dest_idx -> src_idx` permutation (`shuffle_pred_audio`) to re-score `pred.wav` against a shuffled render order, but discarded it after use — only the aggregate `shuffled_audio/*` metrics reached wandb, with no record of *which* permutation produced them.

This PR persists the drawn permutation and surfaces it in wandb so the render-order mapping is reproducible and inspectable from the run.

## Changes

- **Producer** (`compute_audio_metrics._run_shuffle_probe`): writes `shuffle_permutation.csv` (columns `dest_idx`, `src_idx`) alongside `aggregated_metrics_shuffled.csv`. The write lands *after* the shuffled metrics so a failed aggregation never leaves an orphaned permutation file.
- **Consumer** (`eval._log_shuffle_permutation_to_wandb`): reads that CSV and logs it as a `shuffle/permutation` wandb `Table`, namespaced by the existing per-split `metric_prefix`. Wired into `_run_predict_postprocessing` next to the existing per-sample-metrics table logging. No-ops when `wandb.run` is unset or the CSV is absent (the common non-oracle case).

The inline oracle eval (`surge/fake_oracle`, `compute_metrics: true`) runs the probe automatically when params are uniform, so the mapping now surfaces on the generate run for free.

## Test plan

- Producer: `shuffle_permutation.csv` round-trips the `dest_idx -> src_idx` mapping (uniform params, ≥2 dirs); absent on every probe-skip path (single dir, non-uniform params, nested output dir).
- `_run_shuffle_probe` unit tests pin the `len(permutation) < 2` guard and the write-ordering invariant (aggregation-raises → no permutation CSV) — branches the CLI cannot reach.
- Consumer: logs a `shuffle/permutation` Table with correct columns/rows to an active run; prefixes the key; no-ops on no-run / missing-file; swallows wandb backend errors.
- End-to-end: `_run_predict_postprocessing` and the real `evaluate()` predict entrypoint both log the `shuffle/permutation` Table.

## Notes

- The one-line `uv.lock` change is a version sync (8.32.1 → 8.33.0) that the `uv-lock` pre-commit hook applied to match HEAD's release; not a dependency change.

Fixes #1669