### PR TITLE
chore(config): surge_xt Lance generate_dataset config (10k/2k/1k)

### DIFF
--- a/src/synth_setter/configs/experiment/generate_dataset/surge-xt-lance-10k-2k-1k.yaml
+++ b/src/synth_setter/configs/experiment/generate_dataset/surge-xt-lance-10k-2k-1k.yaml
@@ -1,0 +1,19 @@
+# @package _global_
+
+defaults:
+  - override /datamodule: surge
+  - override /render: surge_xt
+  - _self_
+
+task_name: surge-xt-lance-10k-2k-1k
+
+output_format: lance
+
+train_val_test_sizes: [10000, 2000, 1000]
+
+r2:
+  bucket: experiments
+
+render:
+  # Smaller shards than the inherited default for parallelism at experiment scale.
+  samples_per_shard: 1000

--- a/tests/pipeline/configs/test_experiment_yamls.py
+++ b/tests/pipeline/configs/test_experiment_yamls.py
@@ -40,6 +40,7 @@ DATASET_EXPERIMENTS: dict[str, str] = {
     "generate_dataset/smoke-shard-lance": "smoke-shard-lance",
     "generate_dataset/smoke-shard-wds": "smoke-shard-wds",
     "generate_dataset/surge-simple-480k-10k": "surge-simple-480k-10k",
+    "generate_dataset/surge-xt-lance-10k-2k-1k": "surge-xt-lance-10k-2k-1k",
     "generate_dataset/smoke-shard-with-finalize": "smoke-shard",
     "generate_dataset/smoke-shard-with-oracle-eval": "smoke-shard",
 }


### PR DESCRIPTION
## What

Adds `surge-xt-lance-10k-2k-1k`, a datagen experiment config that writes the **Lance** single-file shard format using the full **surge_xt** param spec.

- `output_format: lance`
- `train_val_test_sizes: [10000, 2000, 1000]` (13k samples → **13 shards** at `samples_per_shard: 1000`)
- `override /datamodule: surge` + `override /render: surge_xt` → `param_spec_name: surge_xt` (300 params)
- `r2: { bucket: experiments }` — routes this experiment-scale dataset to the `experiments` bucket, matching the sibling `10-1k-shards.yaml`

## Testing

Registers the config in the `DATASET_EXPERIMENTS` allowlist in `tests/pipeline/configs/test_experiment_yamls.py` (per that module's docstring: "Add a new entry here when landing a new datagen experiment"). The two parametrized legs confirm it composes `dataset.yaml`, validates as `DatasetSpec`, and JSON round-trips without drift.

The Lance writer path is already exercised end-to-end through the real `from_hydra` entrypoint by `test_from_hydra_renders_every_shard_to_fake_r2_then_resume_skips` (parametrized over hdf5/wds/lance); this PR adds no new code path, only a new parameterization.

Refs #1600
