### PR TITLE
internal-fix(tools): lower #489 probe-7 loudness floor so it clears

### DIFF
--- a/src/synth_setter/tools/cadence_sweep_489.py
+++ b/src/synth_setter/tools/cadence_sweep_489.py
@@ -71,6 +71,10 @@ _SOURCE_EXPERIMENT = "generate_dataset/smoke-shard"
 # CLI default dataset size: the full #489 run.
 DEFAULT_SIZE = 40
 
+# surge_simple params under the surge-base (xt) preset render deterministically to ~-55.6 dB, just
+# under the default -55.0 floor; probe 7 alone drops its floor so its fixed-param cells clear (#489).
+SIMPLE_XT_PRESET_MIN_LOUDNESS_DB = -60.0
+
 
 def surge_xt_reference_copy_uri() -> str:
     """Return the R2 run-root URI of the copy-source dataset under the current ``PREFIX_ROOT``.
@@ -248,6 +252,7 @@ def sweeps(n: int) -> list[dict[str, Any]]:
                 simple_spec,
                 xt_preset,
                 simple_copy_uri,
+                f"render.min_loudness={SIMPLE_XT_PRESET_MIN_LOUDNESS_DB}",
             ),
             grid={
                 "render.plugin_reload_cadence": ["once", "render"],

--- a/tests/tools/test_cadence_sweep_489.py
+++ b/tests/tools/test_cadence_sweep_489.py
@@ -64,6 +64,24 @@ def test_simple_control_omits_the_copy_uri_so_it_regenerates_fresh() -> None:
     assert any("copy_dataset_root_uri=" in t for t in copy_probe["command"])
 
 
+def test_simple_xt_preset_probe_sets_a_lower_loudness_floor() -> None:
+    """Probe 7 pins a sub-default ``render.min_loudness`` so its quiet cross-render clears it (#489)."""
+    probe = _config_by_label(sweep.sweeps(2), "cadence_probe_surge_simple_xt_preset")
+    floor_tokens = [t for t in probe["command"] if t.startswith("render.min_loudness=")]
+    assert floor_tokens == ["render.min_loudness=-60.0"]
+
+
+def test_no_other_sweep_pins_a_min_loudness_floor() -> None:
+    """Only probe 7 lowers the loudness floor; every other probe keeps the project default (#489)."""
+    others = [
+        config["name"]
+        for config in sweep.sweeps(2)
+        if config["name"] != "generate_dataset_cadence_probe_surge_simple_xt_preset"
+        and any(t.startswith("render.min_loudness=") for t in config["command"])
+    ]
+    assert others == []
+
+
 def test_swept_args_macro_is_last_so_grid_values_win_over_fixed_pins() -> None:
     """``${args_no_hyphens}`` must be the final command token in every sweep.
 


### PR DESCRIPTION
## What

Probe 7 of the #489 cadence sweep (`cadence_probe_surge_simple_xt_preset`) replays surge_simple copied params under the surge-base (xt) preset. That cross-render is deterministically ~-55.6 dB — just under the default -55.0 `min_loudness` floor — so every fixed-param copy cell raised `ValueError`, the wandb agent shut down after 5 consecutive failures, and the sequential launcher exited non-zero on its final sweep.

## Fix

Pin `render.min_loudness=-60.0` on this probe alone (new `SIMPLE_XT_PRESET_MIN_LOUDNESS_DB` constant), so the quiet cross-render clears the floor without relaxing the quality gate on the other six sweeps.

## Testing

- `test_simple_xt_preset_probe_sets_a_lower_loudness_floor` — probe 7 carries the lowered floor token.
- `test_no_other_sweep_pins_a_min_loudness_floor` — the other six sweeps keep the project default.
- Surfaced by a live `python -m synth_setter.tools.cadence_sweep_489 --size 3` run: sweeps 1–6 (48 cells) all passed; sweep 7 failed 5/5 at exactly -55.60 dB before the agent gave up.

Refs #489
