### PR TITLE
chore: add ffn_smoke experiment on the R2 surge_xt fixture

### DIFF
--- a/src/synth_setter/configs/experiment/surge/ffn_smoke.yaml
+++ b/src/synth_setter/configs/experiment/surge/ffn_smoke.yaml
@@ -1,0 +1,25 @@
+# @package _global_
+
+# GPU smoke-test for surge_ffn against the immutable surge_xt fixture in R2
+# (fixtures/smoke-shard-surge-xt-v1, a 20/20/20-sample shard). prepare_data()
+# no-clobber-copies the fixture into dataset_root before fit, so no local data
+# needs staging. Inherits ffn_full for the surge_xt wiring (d_out=300,
+# LogPerParamMSE on surge_xt).
+
+defaults:
+  - /experiment/surge/ffn_full
+  - _self_
+
+experiment_name: surge-smoke-fixture
+run_name: ffn
+
+datamodule:
+  # No-clobber-copied by prepare_data() before fit; opt-in R2 source.
+  download_dataset_root_uri: r2://intermediate-data/fixtures/smoke-shard-surge-xt-v1/
+  # The fixture's train split holds 20 samples; a larger batch yields zero batches.
+  batch_size: 4
+
+trainer:
+  max_steps: 10
+  # Smoke run: drop the surge-default 1M floor so the run stops at max_steps.
+  min_steps: null

--- a/src/synth_setter/configs/experiment/surge/ffn_smoke.yaml
+++ b/src/synth_setter/configs/experiment/surge/ffn_smoke.yaml
@@ -23,6 +23,8 @@ datamodule:
   download_dataset_root_uri: r2://intermediate-data/fixtures/smoke-shard-surge-xt-v1/
   # The fixture's train split holds 20 samples; a larger batch yields zero batches.
   batch_size: 4
+  # Single-process loading for the 20-sample fixture, matching surge/test*.yaml.
+  num_workers: 0
 
 trainer:
   max_steps: 10

--- a/src/synth_setter/configs/experiment/surge/ffn_smoke.yaml
+++ b/src/synth_setter/configs/experiment/surge/ffn_smoke.yaml
@@ -13,6 +13,11 @@ defaults:
 experiment_name: surge-smoke-fixture
 run_name: ffn
 
+model:
+  # surge_ff_module.setup() recompiles net on every stage; with fit + test that
+  # double-compiles and raises. Smoke runs don't need the compiled path anyway.
+  compile: false
+
 datamodule:
   # No-clobber-copied by prepare_data() before fit; opt-in R2 source.
   download_dataset_root_uri: r2://intermediate-data/fixtures/smoke-shard-surge-xt-v1/

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -187,11 +187,12 @@ def test_ffn_smoke_experiment_wires_surge_xt_fixture_source() -> None:
     """``experiment=surge/ffn_smoke`` bakes in the R2 surge_xt fixture and smoke caps.
 
     Pins the contract that lets the experiment run end-to-end with no pre-staged
-    local data: the opt-in R2 download URI, the batch size and single-process loading
-    the 20-sample train split forces, the 10-step cap with the surge-default 1M
-    ``min_steps`` floor dropped, the surge_xt spec wiring (datamodule param spec +
-    LogPerParamMSE callback) and output width inherited from ``ffn_full``, and the
-    disabled ``compile`` that keeps the fit + test setup from double-compiling.
+    local data: the opt-in R2 download URI; the batch size and single-process
+    loading that the 20-sample train split forces; the 10-step cap with the
+    surge-default 1M ``min_steps`` floor dropped; the surge_xt spec wiring
+    (datamodule param spec + LogPerParamMSE callback) and the output width
+    inherited from ``ffn_full``; and the disabled ``compile`` that keeps the
+    fit + test setup from double-compiling.
     """
     GlobalHydra.instance().clear()
     with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -181,3 +181,27 @@ def test_test_mps_yaml_matches_cfg_surge_xt_global(experiment: str, test_mps_yam
         f"{test_mps_yaml}.yaml drifted from "
         f"cfg_surge_xt_global(mps, surge_4, {experiment!r}):\n" + "\n".join(diffs)
     )
+
+
+def test_ffn_smoke_experiment_wires_surge_xt_fixture_source() -> None:
+    """``experiment=surge/ffn_smoke`` bakes in the R2 surge_xt fixture and smoke caps.
+
+    Pins the contract that lets the experiment run with no pre-staged local data:
+    the opt-in R2 download URI, the batch size the 20-sample train split forces, the
+    10-step cap, and the surge_xt output width inherited from ``ffn_full``.
+    """
+    GlobalHydra.instance().clear()
+    with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
+        cfg = compose(
+            config_name="train.yaml",
+            return_hydra_config=False,
+            overrides=["experiment=surge/ffn_smoke"],
+        )
+    GlobalHydra.instance().clear()
+
+    assert cfg.datamodule.download_dataset_root_uri == (
+        "r2://intermediate-data/fixtures/smoke-shard-surge-xt-v1/"
+    )
+    assert cfg.datamodule.batch_size == 4
+    assert cfg.trainer.max_steps == 10
+    assert cfg.model.net.d_out == 300

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -186,9 +186,10 @@ def test_test_mps_yaml_matches_cfg_surge_xt_global(experiment: str, test_mps_yam
 def test_ffn_smoke_experiment_wires_surge_xt_fixture_source() -> None:
     """``experiment=surge/ffn_smoke`` bakes in the R2 surge_xt fixture and smoke caps.
 
-    Pins the contract that lets the experiment run with no pre-staged local data:
-    the opt-in R2 download URI, the batch size the 20-sample train split forces, the
-    10-step cap, and the surge_xt output width inherited from ``ffn_full``.
+    Pins the contract that lets the experiment run end-to-end with no pre-staged
+    local data: the opt-in R2 download URI, the batch size the 20-sample train split
+    forces, the 10-step cap, the surge_xt output width inherited from ``ffn_full``,
+    and the disabled ``compile`` that keeps the fit + test setup from double-compiling.
     """
     GlobalHydra.instance().clear()
     with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
@@ -205,3 +206,4 @@ def test_ffn_smoke_experiment_wires_surge_xt_fixture_source() -> None:
     assert cfg.datamodule.batch_size == 4
     assert cfg.trainer.max_steps == 10
     assert cfg.model.net.d_out == 300
+    assert cfg.model.compile is False

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -187,9 +187,11 @@ def test_ffn_smoke_experiment_wires_surge_xt_fixture_source() -> None:
     """``experiment=surge/ffn_smoke`` bakes in the R2 surge_xt fixture and smoke caps.
 
     Pins the contract that lets the experiment run end-to-end with no pre-staged
-    local data: the opt-in R2 download URI, the batch size the 20-sample train split
-    forces, the 10-step cap, the surge_xt output width inherited from ``ffn_full``,
-    and the disabled ``compile`` that keeps the fit + test setup from double-compiling.
+    local data: the opt-in R2 download URI, the batch size and single-process loading
+    the 20-sample train split forces, the 10-step cap with the surge-default 1M
+    ``min_steps`` floor dropped, the surge_xt spec wiring (datamodule param spec +
+    LogPerParamMSE callback) and output width inherited from ``ffn_full``, and the
+    disabled ``compile`` that keeps the fit + test setup from double-compiling.
     """
     GlobalHydra.instance().clear()
     with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
@@ -204,6 +206,10 @@ def test_ffn_smoke_experiment_wires_surge_xt_fixture_source() -> None:
         "r2://intermediate-data/fixtures/smoke-shard-surge-xt-v1/"
     )
     assert cfg.datamodule.batch_size == 4
+    assert cfg.datamodule.num_workers == 0
+    assert cfg.datamodule.param_spec_name == "surge_xt"
+    assert cfg.callbacks.log_per_param_mse.param_spec == "surge_xt"
     assert cfg.trainer.max_steps == 10
+    assert cfg.trainer.min_steps is None
     assert cfg.model.net.d_out == 300
     assert cfg.model.compile is False


### PR DESCRIPTION
## What

Adds `experiment=surge/ffn_smoke`, a GPU smoke-test experiment that trains `surge_ffn` end-to-end against an immutable `surge_xt` fixture pinned in R2 (`fixtures/smoke-shard-surge-xt-v1`, a 20/20/20-sample shard). It inherits `surge/ffn_full` for the `surge_xt` wiring (`d_out=300`, `LogPerParamMSE` on `surge_xt`) and bakes in the three overrides needed to run without any pre-staged local data:

- `datamodule.download_dataset_root_uri` → `prepare_data()` no-clobber-copies the fixture from R2 before fit.
- `datamodule.batch_size=4` → the fixture's 20-sample train split yields zero batches at the config default of 128.
- `trainer.max_steps=10` + `min_steps=null` → drops the surge-default 1M-step floor so the run stops at the cap.

## Why

Running a real training loop previously required either generating a dataset or hand-passing those three overrides every time (the default `dataset_root` points at the empty per-run output dir, so a bare `synth-setter-train experiment=surge/ffn_full` fails opening `train.h5`). This config makes a no-setup, end-to-end training smoke one command: `synth-setter-train experiment=surge/ffn_smoke`.

## Test

- New `test_ffn_smoke_experiment_wires_surge_xt_fixture_source` in `tests/test_configs.py` pins the load-bearing contract (R2 URI, batch size, step cap, `d_out`).
- `pytest tests/test_configs.py` → 10 passed.
- Verified the composed config resolves: `max_steps=10`, `min_steps=None`, `scheduler.T_max=10`, `param_spec_name=surge_xt`.

Refs #13
