### PR TITLE
feat(data-pipeline): CLAP embeddings on Lance splits at finalize

### DIFF
--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -225,10 +225,11 @@ The pipeline has two stages. Each is an independent command with well-defined in
 
 Finalize output depends on `output_format` in the spec:
 
-| `output_format` | Finalize outputs                                                                 | Training access pattern            |
-| --------------- | -------------------------------------------------------------------------------- | ---------------------------------- |
-| `hdf5`          | `train.h5`, `val.h5`, `test.h5` (HDF5 virtual datasets)                          | Local random access                |
-| `wds`           | `train-{shard}.tar`, `val-{shard}.tar`, `test-{shard}.tar` (WebDataset archives) | Sequential streaming (local or R2) |
+| `output_format` | Finalize outputs                                                                                                                       | Training access pattern            |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `hdf5`          | `train.h5`, `val.h5`, `test.h5` (HDF5 virtual datasets)                                                                                | Local random access                |
+| `wds`           | `train-{shard}.tar`, `val-{shard}.tar`, `test-{shard}.tar` (WebDataset archives)                                                       | Sequential streaming (local or R2) |
+| `lance`         | `train.lance`, `val.lance`, `test.lance` (Lance files; optional trailing `clap` audio-embedding column when `compute_clap_embeddings`) | Columnar random access             |
 
 Each worker container runs with `MODE=generate-shards` — the entrypoint mode IS the worker. Scoped and validated on the `experiment` branch; pending port to main ([#407](https://github.com/tinaudio/synth-setter/issues/407)).
 

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -85,7 +85,7 @@ docs:
       - pattern: "src/synth_setter/configs/finalize_dataset.yaml"
         covers: "Finalize @hydra.main entry config; required `dataset_root_uri` (run prefix) loads the persisted DatasetSpec from `input_spec.json` under it (file://, r2://, or bare path); overrides `hydra.run.dir` (task_name/run_name absent here); composes `logger: wandb` for best-effort dataset-artifact logging"
       - pattern: "src/synth_setter/cli/finalize_dataset.py"
-        covers: "Finalize entrypoint: loads the frozen DatasetSpec, dispatches by `spec.output_format` across hdf5/wds/lance, writes `dataset.complete` last, and logs the canonical dataset W&B artifact."
+        covers: "Finalize entrypoint: loads the frozen DatasetSpec, dispatches by `spec.output_format` across hdf5/wds/lance, writes `dataset.complete` last, and logs the canonical dataset W&B artifact. The lance branch optionally appends a `clap` audio-embedding column per split when `spec.compute_clap_embeddings` is set."
       - pattern: ".github/workflows/generate-dataset-shards.yaml"
         covers: "Reusable launcher fan-out across providers (skypilot-local kind, runpod, oci); per-provider artifact upload; emits a `spec_uri` workflow output (the materialized spec's canonical under-prefix `input_spec.json` URI, computed by the `synth-setter-spec-uri` console script — see `src/synth_setter/pipeline/ci/spec_uri.py`) consumed by validate-dataset-shards"
       - pattern: ".github/workflows/validate-dataset-shards.yaml"
@@ -105,15 +105,17 @@ docs:
       - pattern: "src/synth_setter/pipeline/schemas/r2_location.py"
         covers: "`R2Location` nested R2-storage model (bucket + prefix_root + prefix) plus `uri()` / `rclone_prefix()` / `shard_uri()` helpers — the single source of R2 URI construction"
       - pattern: "src/synth_setter/pipeline/schemas/spec.py"
-        covers: "DatasetSpec, RenderConfig, ShardSpec, and `OutputFormat` suffix dispatch (`.extension` / `.from_extension()`) consumed by the renderer CLI for hdf5/wds/lance writer selection."
+        covers: "DatasetSpec, RenderConfig, ShardSpec, and `OutputFormat` suffix dispatch (`.extension` / `.from_extension()`) consumed by the renderer CLI for hdf5/wds/lance writer selection. DatasetSpec carries the lance-only `compute_clap_embeddings` flag (rejected for non-lance output by a model validator)."
       - pattern: "src/synth_setter/pipeline/schemas/shard_metadata.py"
         covers: "ShardMetadata — strict pydantic sidecar payload written into wds tar shards as metadata.json, into HDF5 shards as audio.attrs, and into Lance schema metadata; mirrored across shard formats by make_hdf5_dataset / make_wds_dataset / make_lance_dataset in writers.py."
       - pattern: "src/synth_setter/data/vst/writers.py"
         covers: "make_hdf5_dataset + make_wds_dataset + make_lance_dataset entrypoints; per-batch sample-save helpers; ShardMetadata sidecar wiring; CLI suffix dispatch via OutputFormat.from_extension."
       - pattern: "src/synth_setter/data/vst/shapes.py"
-        covers: "Shared shape primitives consumed by the writers, the shard validator, and the test shard seeders — DATASET_FIELD_NAMES / DATASET_FIELD_DTYPES, mel-front-end constants, per-field shape helpers, and dataset_field_shapes (the single field→shape contract)."
+        covers: "Shared shape primitives consumed by the writers, the shard validator, and the test shard seeders — DATASET_FIELD_NAMES / DATASET_FIELD_DTYPES, mel-front-end constants, per-field shape helpers, and dataset_field_shapes (the single field→shape contract). Also hosts the optional `clap` side-column constants CLAP_FIELD / CLAP_EMBEDDING_DIM."
       - pattern: "src/synth_setter/pipeline/data/lance_shard.py"
         covers: "Lance single-file shard codec — lance_schema / tensor_array / record_batch_from_arrays / write_lance_file on the encode side, read_shard_metadata / tensor_chunk_to_numpy / iter_lance_column_rows on the decode side; shared by the Lance writer, validator, and finalize."
+      - pattern: "src/synth_setter/pipeline/data/clap_lance.py"
+        covers: "Optional LAION-CLAP audio-embedding column appended to Lance splits during finalize — clap_augmented_schema / clap_augment_split (injectable-encoder functional core, mono downmix + shape-guarded encode) plus load_clap_audio_encoder (lazy transformers/torch shell); gated by DatasetSpec.compute_clap_embeddings."
 
   # ── SkyPilot compute integration design doc ─────────────────────
   - doc: docs/design/skypilot-compute-integration.md

--- a/docs/reference/configuration-reference.md
+++ b/docs/reference/configuration-reference.md
@@ -61,13 +61,15 @@ synth-setter-finalize-dataset dataset_root_uri=r2://…/<task_name>/<run_id>/
       → r2_io.object_size(spec.r2.dataset_complete_marker_uri()) probe (idempotency short-circuit)
       → assert_r2_prefix_matches(…) (advisory: warns on a non-canonical prefix, never aborts — custom prefixes like the oracle-eval e2e's test-runs/ are legitimate)
       → branch on spec.output_format:
-          ├─ wds:  finalize_wds  — Welford-stream stats over train shards → upload stats.npz
-          └─ hdf5: finalize_hdf5 — download every shard → reshard into {train,val,test}.h5 → stats.npz
+          ├─ wds:   finalize_wds   — Welford-stream stats over train shards → upload stats.npz
+          ├─ hdf5:  finalize_hdf5  — download every shard → reshard into {train,val,test}.h5 → stats.npz
+          └─ lance: finalize_lance — download every shard → concatenate into {train,val,test}.lance → stats.npz
+                                     (optionally append a `clap` audio-embedding column per split when spec.compute_clap_embeddings)
       → upload dataset.complete marker LAST (R2 source-of-truth resumability invariant)
 ```
 
 - Single required input: `dataset_root_uri` (the run prefix `.../<task_name>/<run_id>/`). `load_spec_from_root` joins `input_spec.json` under it; the URI scheme is dispatched by `load_spec_from_uri` (`file://`, `r2://`, or bare path)
-- `cfg.paths.output_dir` (Hydra's per-run dir under `${paths.log_dir}/finalize_dataset/<timestamp>`) is the scratch work_dir for both branches
+- `cfg.paths.output_dir` (Hydra's per-run dir under `${paths.log_dir}/finalize_dataset/<timestamp>`) is the scratch work_dir for all branches
 - Idempotency: a re-run against a prefix that already has `dataset.complete` exits cleanly without downloads or uploads. R2 is the source of truth (see `pipeline/CLAUDE.md`)
 - Marker-last invariant: `dataset.complete` is uploaded strictly after every artifact a downstream consumer expects, so an interrupted run never leaves a marker without its splits / stats
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ torch = [
   "torchaudio>=2.0.0",
   "lightning>=2.6.0",
   "torchmetrics>=0.11.4",
+  "transformers>=4.40.0",
 ]
 config = [
   "hydra-core==1.3.2",

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -208,18 +208,14 @@ def _append_clap_column(parts: LanceSplitBatches, encode: ClapEncodeFn) -> Lance
     :param parts: ``(schema, batches)`` from :func:`_lance_split_batches`.
     :param encode: Mono-batch CLAP encoder built by ``load_clap_audio_encoder``.
     :returns: ``(augmented_schema, augmented_batches)`` for :func:`write_lance_file`.
-    :rtype: LanceSplitBatches
     """
     from synth_setter.data.vst.shapes import CLAP_EMBEDDING_DIM
-    from synth_setter.pipeline.data.clap_lance import clap_augmented_schema, iter_clap_batches
+    from synth_setter.pipeline.data.clap_lance import clap_augment_split
     from synth_setter.pipeline.data.lance_shard import read_shard_metadata
 
     schema, batches = parts
     sample_rate = read_shard_metadata(schema).sample_rate
-    augmented = clap_augmented_schema(schema, CLAP_EMBEDDING_DIM)
-    return augmented, iter_clap_batches(
-        schema, batches, encode, sample_rate, dim=CLAP_EMBEDDING_DIM
-    )
+    return clap_augment_split(schema, batches, encode, sample_rate, dim=CLAP_EMBEDDING_DIM)
 
 
 def finalize_lance(spec: DatasetSpec, work_dir: Path) -> None:

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -247,7 +247,7 @@ def finalize_lance(spec: DatasetSpec, work_dir: Path) -> None:
     stats_npz = work_dir / STATS_NPZ_FILENAME
     np.savez(stats_npz, mean=mean, std=std)
 
-    encode = None
+    encode: ClapEncodeFn | None = None
     if spec.compute_clap_embeddings:
         from synth_setter.pipeline.data.clap_lance import load_clap_audio_encoder
 
@@ -260,6 +260,7 @@ def finalize_lance(spec: DatasetSpec, work_dir: Path) -> None:
         shard_paths = [work_dir / shard.filename for shard in spec.shards[lo:hi]]
         schema, batches = _lance_split_batches(shard_paths)
         if encode is not None:
+            logger.info("appending clap embeddings to {}", split)
             schema, batches = _append_clap_column((schema, batches), encode)
         write_lance_file(split_path, schema, batches)
         split_uri = spec.r2.split_lance_uri(split)

--- a/src/synth_setter/cli/finalize_dataset.py
+++ b/src/synth_setter/cli/finalize_dataset.py
@@ -15,7 +15,7 @@ Welford for ``stats.npz``, and concatenates each split's shards into
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeAlias
 
@@ -49,6 +49,10 @@ if TYPE_CHECKING:
     LanceSplitBatches: TypeAlias = tuple[pa.Schema, LanceBatchIterator]
 else:
     LanceSplitBatches: TypeAlias = tuple[object, Iterator[object]]
+
+# Mono ``(B, T)`` batch + sample rate → ``(B, D)`` CLAP embedding batch; mirrors
+# ``clap_lance.EncodeFn`` without importing it (keeps pyarrow off the import path).
+ClapEncodeFn: TypeAlias = Callable[[np.ndarray, int], np.ndarray]
 
 # Resolve workspace at import so ``${oc.env:PROJECT_ROOT}`` in
 # ``configs/paths/default.yaml`` interpolates under any install layout.
@@ -194,8 +198,36 @@ def _lance_split_batches(shard_paths: list[Path]) -> LanceSplitBatches:
     return schema, _batches()
 
 
+def _append_clap_column(parts: LanceSplitBatches, encode: ClapEncodeFn) -> LanceSplitBatches:
+    """Augment a split's ``(schema, batches)`` with a CLAP embedding column.
+
+    The split's sample rate is read from the shard schema metadata and threaded
+    to ``encode``; the embedding width is pinned to ``CLAP_EMBEDDING_DIM`` (the
+    default checkpoint's projection).
+
+    :param parts: ``(schema, batches)`` from :func:`_lance_split_batches`.
+    :param encode: Mono-batch CLAP encoder built by ``load_clap_audio_encoder``.
+    :returns: ``(augmented_schema, augmented_batches)`` for :func:`write_lance_file`.
+    :rtype: LanceSplitBatches
+    """
+    from synth_setter.data.vst.shapes import CLAP_EMBEDDING_DIM
+    from synth_setter.pipeline.data.clap_lance import clap_augmented_schema, iter_clap_batches
+    from synth_setter.pipeline.data.lance_shard import read_shard_metadata
+
+    schema, batches = parts
+    sample_rate = read_shard_metadata(schema).sample_rate
+    augmented = clap_augmented_schema(schema, CLAP_EMBEDDING_DIM)
+    return augmented, iter_clap_batches(
+        schema, batches, encode, sample_rate, dim=CLAP_EMBEDDING_DIM
+    )
+
+
 def finalize_lance(spec: DatasetSpec, work_dir: Path) -> None:
     """Download Lance shards, write split Lance files, compute stats, and upload artifacts.
+
+    When ``spec.compute_clap_embeddings`` is set, each split file gains a ``clap``
+    audio-embedding column: finalize loads a CLAP encoder once and appends the
+    embedding per row as the splits are written.
 
     :param spec: Validated dataset spec (``output_format == "lance"``).
     :param work_dir: Scratch directory for downloaded shards and finalized outputs.
@@ -219,12 +251,20 @@ def finalize_lance(spec: DatasetSpec, work_dir: Path) -> None:
     stats_npz = work_dir / STATS_NPZ_FILENAME
     np.savez(stats_npz, mean=mean, std=std)
 
+    encode = None
+    if spec.compute_clap_embeddings:
+        from synth_setter.pipeline.data.clap_lance import load_clap_audio_encoder
+
+        encode = load_clap_audio_encoder()
+
     for split, (lo, hi) in spec.split_shard_ranges.items():
         if lo >= hi:
             continue
         split_path = work_dir / f"{split}.lance"
         shard_paths = [work_dir / shard.filename for shard in spec.shards[lo:hi]]
         schema, batches = _lance_split_batches(shard_paths)
+        if encode is not None:
+            schema, batches = _append_clap_column((schema, batches), encode)
         write_lance_file(split_path, schema, batches)
         split_uri = spec.r2.split_lance_uri(split)
         r2_io.upload(split_path, split_uri)

--- a/src/synth_setter/data/vst/shapes.py
+++ b/src/synth_setter/data/vst/shapes.py
@@ -24,10 +24,9 @@ PARAM_ARRAY_FIELD: str = "param_array"
 CLAP_FIELD: str = "clap"
 DATASET_FIELD_NAMES: tuple[str, ...] = (AUDIO_FIELD, MEL_SPEC_FIELD, PARAM_ARRAY_FIELD)
 
-# Pooled-projection width of the LAION CLAP HTSAT audio tower; the row dimension
-# of the optional ``clap`` side column finalize can append to Lance split files.
-# ``CLAP_FIELD`` stays outside ``DATASET_FIELD_NAMES`` because it is an opt-in
-# embedding, not a core field the writers and validator require on every shard.
+# Row width of the optional ``clap`` Lance column (LAION CLAP HTSAT projection).
+# ``CLAP_FIELD`` is outside ``DATASET_FIELD_NAMES``: an opt-in embedding, not a
+# core field the writers and validator require on every shard.
 CLAP_EMBEDDING_DIM: int = 512
 
 # Per-field on-disk dtype, matching what the HDF5 / wds writers emit. Audio is

--- a/src/synth_setter/data/vst/shapes.py
+++ b/src/synth_setter/data/vst/shapes.py
@@ -21,7 +21,14 @@ if TYPE_CHECKING:
 AUDIO_FIELD: str = "audio"
 MEL_SPEC_FIELD: str = "mel_spec"
 PARAM_ARRAY_FIELD: str = "param_array"
+CLAP_FIELD: str = "clap"
 DATASET_FIELD_NAMES: tuple[str, ...] = (AUDIO_FIELD, MEL_SPEC_FIELD, PARAM_ARRAY_FIELD)
+
+# Pooled-projection width of the LAION CLAP HTSAT audio tower; the row dimension
+# of the optional ``clap`` side column finalize can append to Lance split files.
+# ``CLAP_FIELD`` stays outside ``DATASET_FIELD_NAMES`` because it is an opt-in
+# embedding, not a core field the writers and validator require on every shard.
+CLAP_EMBEDDING_DIM: int = 512
 
 # Per-field on-disk dtype, matching what the HDF5 / wds writers emit. Audio is
 # stored as ``float16`` for compressed storage efficiency; mel and params stay

--- a/src/synth_setter/data/vst/shapes.py
+++ b/src/synth_setter/data/vst/shapes.py
@@ -24,9 +24,8 @@ PARAM_ARRAY_FIELD: str = "param_array"
 CLAP_FIELD: str = "clap"
 DATASET_FIELD_NAMES: tuple[str, ...] = (AUDIO_FIELD, MEL_SPEC_FIELD, PARAM_ARRAY_FIELD)
 
-# Row width of the optional ``clap`` Lance column (LAION CLAP HTSAT projection).
-# ``CLAP_FIELD`` is outside ``DATASET_FIELD_NAMES``: an opt-in embedding, not a
-# core field the writers and validator require on every shard.
+# Row width of the optional ``clap`` Lance column; must track DEFAULT_CLAP_CHECKPOINT's
+# projection. Kept out of DATASET_FIELD_NAMES: opt-in, not a per-shard core field.
 CLAP_EMBEDDING_DIM: int = 512
 
 # Per-field on-disk dtype, matching what the HDF5 / wds writers emit. Audio is

--- a/src/synth_setter/pipeline/data/clap_lance.py
+++ b/src/synth_setter/pipeline/data/clap_lance.py
@@ -1,0 +1,132 @@
+"""Append LAION CLAP audio embeddings to Lance split files during finalize.
+
+The functional core (:func:`clap_augmented_schema`, :func:`iter_clap_batches`)
+maps a finalized Lance split's ``(schema, batches)`` to the same stream with an
+extra ``clap`` fixed-shape-tensor column, reading each batch's ``audio`` rows,
+downmixing them to mono, and running an *injected* ``encode`` callable — so it
+is exercised without loading a CLAP checkpoint. :func:`load_clap_audio_encoder`
+is the thin shell that builds the real encoder behind a lazy ``transformers``
+import; its only test is a manual run (see the project test plan).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Iterator
+from typing import Any
+
+import numpy as np
+import pyarrow as pa
+
+from synth_setter.data.vst.shapes import AUDIO_FIELD, CLAP_FIELD
+from synth_setter.pipeline.data.lance_shard import tensor_array, tensor_chunk_to_numpy
+
+# HuggingFace CLAP checkpoint whose audio tower projects to ``CLAP_EMBEDDING_DIM``.
+DEFAULT_CLAP_CHECKPOINT = "laion/clap-htsat-unfused"
+# CLAP's feature extractor rejects any other input rate, so audio is resampled to
+# this before encoding.
+CLAP_SAMPLE_RATE = 48000
+
+# Maps a mono ``(B, T)`` batch and its sample rate to a ``(B, D)`` embedding batch.
+EncodeFn = Callable[[np.ndarray, int], np.ndarray]
+
+
+def clap_augmented_schema(schema: pa.Schema, dim: int) -> pa.Schema:
+    """Append a ``clap`` ``(dim,)`` float32 tensor column to a Lance shard schema.
+
+    :param schema: Schema of a finalized Lance split (core dataset columns).
+    :param dim: Embedding width; the appended column's per-row tensor shape.
+    :returns: ``schema`` with the trailing ``clap`` column, metadata preserved.
+    :rtype: pa.Schema
+    """
+    clap_type = pa.fixed_shape_tensor(pa.from_numpy_dtype(np.dtype("float32")), (dim,))
+    return schema.append(pa.field(CLAP_FIELD, clap_type, nullable=False))
+
+
+def _downmix_to_mono(audio: np.ndarray) -> np.ndarray:
+    """Average the channel axis of an ``(B, C, T)`` batch into ``(B, T)`` mono float32.
+
+    :param audio: Audio batch shaped ``(B, C, T)``.
+    :returns: Mono batch shaped ``(B, T)`` as float32.
+    :rtype: np.ndarray
+    """
+    return audio.mean(axis=1, dtype=np.float32)
+
+
+def iter_clap_batches(
+    schema: pa.Schema,
+    batches: Iterable[pa.RecordBatch],
+    encode: EncodeFn,
+    sample_rate: int,
+    *,
+    dim: int,
+) -> Iterator[pa.RecordBatch]:
+    """Yield each input batch with a ``clap`` embedding column appended.
+
+    Reads every batch's ``audio`` rows, downmixes to mono, calls ``encode``, and
+    appends the result as a ``clap`` column under :func:`clap_augmented_schema`.
+
+    :param schema: Schema of the incoming batches (must carry ``audio``).
+    :param batches: Record batches of one finalized Lance split, in row order.
+    :param encode: Maps a mono ``(B, T)`` batch and ``sample_rate`` to a
+        ``(B, dim)`` float32 embedding batch.
+    :param sample_rate: Audio sample rate passed through to ``encode``.
+    :param dim: Expected embedding width; ``encode`` output is asserted to match.
+    :yields: Each batch with the trailing ``clap`` column.
+    :ytype: pa.RecordBatch
+    :raises ValueError: ``encode`` returns a width other than ``dim``.
+    """
+    out_schema = clap_augmented_schema(schema, dim)
+    audio_inner = tuple(schema.field(AUDIO_FIELD).type.shape)
+    audio_index = schema.get_field_index(AUDIO_FIELD)
+    for batch in batches:
+        audio = tensor_chunk_to_numpy(batch.column(audio_index), audio_inner)
+        embeddings = np.asarray(encode(_downmix_to_mono(audio), sample_rate))
+        if embeddings.shape[1] != dim:
+            raise ValueError(f"CLAP encoder produced width {embeddings.shape[1]}, expected {dim}")
+        clap_column = tensor_array(embeddings, np.dtype("float32"), (dim,))
+        yield pa.record_batch([*batch.columns, clap_column], schema=out_schema)
+
+
+def load_clap_audio_encoder(
+    checkpoint: str = DEFAULT_CLAP_CHECKPOINT,
+    device: str | None = None,
+) -> EncodeFn:
+    """Load a CLAP checkpoint and return a mono-batch encode callable.
+
+    The ``transformers`` and ``torch`` imports are deferred so this module stays
+    importable (and its core testable with a fake encoder) without the heavy
+    dependency or a model download.
+
+    :param checkpoint: HuggingFace CLAP model id.
+    :param device: Torch device string; defaults to cuda when available, else cpu.
+    :returns: Encode callable mapping a mono ``(B, T)`` batch and sample rate to a
+        ``(B, D)`` float32 embedding batch.
+    :rtype: EncodeFn
+    """
+    import torch
+    import torchaudio.functional as audio_fn
+    from transformers import ClapModel, ClapProcessor
+
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+    # transformers' processor/model call surface is dynamically typed; Any at this
+    # external boundary keeps the type checker honest about what it cannot verify.
+    model: Any = ClapModel.from_pretrained(checkpoint)
+    model = model.to(device).eval()
+    processor: Any = ClapProcessor.from_pretrained(checkpoint)
+
+    @torch.no_grad()
+    def encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+        wav = torch.from_numpy(np.ascontiguousarray(mono))
+        if sample_rate != CLAP_SAMPLE_RATE:
+            wav = audio_fn.resample(wav, sample_rate, CLAP_SAMPLE_RATE)
+        inputs = processor(
+            audio=list(wav.numpy()), sampling_rate=CLAP_SAMPLE_RATE, return_tensors="pt"
+        )
+        inputs = {key: value.to(device) for key, value in inputs.items()}
+        # get_audio_features returns the audio-tower output whose pooler_output
+        # holds the projected, L2-normalized joint-space embedding (B, D).
+        features = model.get_audio_features(**inputs)
+        return features.pooler_output.cpu().numpy()
+
+    return encode

--- a/src/synth_setter/pipeline/data/clap_lance.py
+++ b/src/synth_setter/pipeline/data/clap_lance.py
@@ -12,13 +12,16 @@ import; its only test is a manual run (see the project test plan).
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator
-from typing import Any
+from typing import Any, TypeAlias
 
 import numpy as np
 import pyarrow as pa
+import structlog
 
 from synth_setter.data.vst.shapes import AUDIO_FIELD, CLAP_FIELD
 from synth_setter.pipeline.data.lance_shard import tensor_array, tensor_chunk_to_numpy
+
+logger = structlog.get_logger(__name__)
 
 # HuggingFace CLAP checkpoint whose audio tower projects to ``CLAP_EMBEDDING_DIM``.
 DEFAULT_CLAP_CHECKPOINT = "laion/clap-htsat-unfused"
@@ -27,7 +30,7 @@ DEFAULT_CLAP_CHECKPOINT = "laion/clap-htsat-unfused"
 CLAP_SAMPLE_RATE = 48000
 
 # Maps a mono ``(B, T)`` batch and its sample rate to a ``(B, D)`` embedding batch.
-EncodeFn = Callable[[np.ndarray, int], np.ndarray]
+EncodeFn: TypeAlias = Callable[[np.ndarray, int], np.ndarray]
 
 
 def clap_augmented_schema(schema: pa.Schema, dim: int) -> pa.Schema:
@@ -45,7 +48,10 @@ def clap_augmented_schema(schema: pa.Schema, dim: int) -> pa.Schema:
 def _downmix_to_mono(audio: np.ndarray) -> np.ndarray:
     """Average the channel axis of an ``(B, C, T)`` batch into ``(B, T)`` mono float32.
 
-    :param audio: Audio batch shaped ``(B, C, T)``.
+    ``dtype=np.float32`` upcasts the stored float16 audio in the reduction, so the
+    encoder never sees half-precision.
+
+    :param audio: Audio batch shaped ``(B, C, T)`` (on-disk float16).
     :returns: Mono batch shaped ``(B, T)`` as float32.
     :rtype: np.ndarray
     """
@@ -73,7 +79,7 @@ def iter_clap_batches(
     :param dim: Expected embedding width; ``encode`` output is asserted to match.
     :yields: Each batch with the trailing ``clap`` column.
     :ytype: pa.RecordBatch
-    :raises ValueError: ``encode`` returns a width other than ``dim``.
+    :raises ValueError: ``encode`` returns anything other than a ``(B, dim)`` batch.
     """
     out_schema = clap_augmented_schema(schema, dim)
     audio_inner = tuple(schema.field(AUDIO_FIELD).type.shape)
@@ -81,8 +87,10 @@ def iter_clap_batches(
     for batch in batches:
         audio = tensor_chunk_to_numpy(batch.column(audio_index), audio_inner)
         embeddings = np.asarray(encode(_downmix_to_mono(audio), sample_rate))
-        if embeddings.shape[1] != dim:
-            raise ValueError(f"CLAP encoder produced width {embeddings.shape[1]}, expected {dim}")
+        if embeddings.ndim != 2 or embeddings.shape[1] != dim:
+            raise ValueError(
+                f"CLAP encoder produced shape {embeddings.shape}, expected (B, {dim})"
+            )
         clap_column = tensor_array(embeddings, np.dtype("float32"), (dim,))
         yield pa.record_batch([*batch.columns, clap_column], schema=out_schema)
 
@@ -109,6 +117,7 @@ def load_clap_audio_encoder(
 
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
+    logger.info("loading_clap_checkpoint", checkpoint=checkpoint, device=device)
     # transformers' processor/model call surface is dynamically typed; Any at this
     # external boundary keeps the type checker honest about what it cannot verify.
     model: Any = ClapModel.from_pretrained(checkpoint)

--- a/src/synth_setter/pipeline/data/clap_lance.py
+++ b/src/synth_setter/pipeline/data/clap_lance.py
@@ -80,16 +80,20 @@ def _iter_clap_record_batches(
     :param dim: Expected embedding width; ``encode`` output is asserted to match.
     :yields: Each batch with the trailing ``clap`` column.
     :ytype: pa.RecordBatch
-    :raises ValueError: ``encode`` returns anything other than a ``(B, dim)`` batch.
+    :raises ValueError: ``encode`` returns anything other than a ``(num_rows, dim)``
+        batch, where ``num_rows`` is the input batch's row count.
     """
     audio_inner = tuple(in_schema.field(AUDIO_FIELD).type.shape)
     audio_index = in_schema.get_field_index(AUDIO_FIELD)
     for batch in batches:
         audio = tensor_chunk_to_numpy(batch.column(audio_index), audio_inner)
         embeddings = np.asarray(encode(_downmix_to_mono(audio), sample_rate))
-        if embeddings.ndim != 2 or embeddings.shape[1] != dim:
+        # Pin both axes: a wrong row count would otherwise surface only as a cryptic
+        # Arrow "arrays must have the same length" error at record_batch assembly.
+        if embeddings.shape != (batch.num_rows, dim):
             raise ValueError(
-                f"CLAP encoder produced shape {embeddings.shape}, expected (B, {dim})"
+                f"CLAP encoder produced shape {embeddings.shape}, "
+                f"expected ({batch.num_rows}, {dim})"
             )
         clap_column = tensor_array(embeddings, _CLAP_DTYPE, (dim,))
         yield pa.record_batch([*batch.columns, clap_column], schema=out_schema)
@@ -161,8 +165,7 @@ def load_clap_audio_encoder(
             audio=list(wav.numpy()), sampling_rate=CLAP_SAMPLE_RATE, return_tensors="pt"
         )
         inputs = {key: value.to(device) for key, value in inputs.items()}
-        # get_audio_features returns a pooled output whose pooler_output holds the
-        # projected, L2-normalized joint-space audio embedding (B, D).
+        # pooler_output holds the projected, L2-normalized embedding (B, D).
         features = model.get_audio_features(**inputs)
         return features.pooler_output.cpu().numpy()
 

--- a/src/synth_setter/pipeline/data/clap_lance.py
+++ b/src/synth_setter/pipeline/data/clap_lance.py
@@ -1,12 +1,12 @@
 """Append LAION CLAP audio embeddings to Lance split files during finalize.
 
-The functional core (:func:`clap_augmented_schema`, :func:`iter_clap_batches`)
+The functional core (:func:`clap_augmented_schema`, :func:`clap_augment_split`)
 maps a finalized Lance split's ``(schema, batches)`` to the same stream with an
 extra ``clap`` fixed-shape-tensor column, reading each batch's ``audio`` rows,
 downmixing them to mono, and running an *injected* ``encode`` callable — so it
 is exercised without loading a CLAP checkpoint. :func:`load_clap_audio_encoder`
 is the thin shell that builds the real encoder behind a lazy ``transformers``
-import; its only test is a manual run (see the project test plan).
+import; its only test is a manual run (see the PR's "Verification" checklist).
 """
 
 from __future__ import annotations
@@ -24,10 +24,10 @@ from synth_setter.pipeline.data.lance_shard import tensor_array, tensor_chunk_to
 logger = structlog.get_logger(__name__)
 
 # HuggingFace CLAP checkpoint whose audio tower projects to ``CLAP_EMBEDDING_DIM``.
-DEFAULT_CLAP_CHECKPOINT = "laion/clap-htsat-unfused"
+DEFAULT_CLAP_CHECKPOINT: str = "laion/clap-htsat-unfused"
 # CLAP's feature extractor rejects any other input rate, so audio is resampled to
 # this before encoding.
-CLAP_SAMPLE_RATE = 48000
+CLAP_SAMPLE_RATE: int = 48000
 
 # Maps a mono ``(B, T)`` batch and its sample rate to a ``(B, D)`` embedding batch.
 EncodeFn: TypeAlias = Callable[[np.ndarray, int], np.ndarray]
@@ -39,7 +39,6 @@ def clap_augmented_schema(schema: pa.Schema, dim: int) -> pa.Schema:
     :param schema: Schema of a finalized Lance split (core dataset columns).
     :param dim: Embedding width; the appended column's per-row tensor shape.
     :returns: ``schema`` with the trailing ``clap`` column, metadata preserved.
-    :rtype: pa.Schema
     """
     clap_type = pa.fixed_shape_tensor(pa.from_numpy_dtype(np.dtype("float32")), (dim,))
     return schema.append(pa.field(CLAP_FIELD, clap_type, nullable=False))
@@ -51,27 +50,25 @@ def _downmix_to_mono(audio: np.ndarray) -> np.ndarray:
     ``dtype=np.float32`` upcasts the stored float16 audio in the reduction, so the
     encoder never sees half-precision.
 
-    :param audio: Audio batch shaped ``(B, C, T)`` (on-disk float16).
+    :param audio: Audio batch shaped ``(B, C, T)`` with ``C >= 1`` (on-disk float16).
     :returns: Mono batch shaped ``(B, T)`` as float32.
-    :rtype: np.ndarray
     """
     return audio.mean(axis=1, dtype=np.float32)
 
 
-def iter_clap_batches(
-    schema: pa.Schema,
+def _iter_clap_record_batches(
+    in_schema: pa.Schema,
+    out_schema: pa.Schema,
     batches: Iterable[pa.RecordBatch],
     encode: EncodeFn,
     sample_rate: int,
     *,
     dim: int,
 ) -> Iterator[pa.RecordBatch]:
-    """Yield each input batch with a ``clap`` embedding column appended.
+    """Yield each input batch with a ``clap`` column appended under ``out_schema``.
 
-    Reads every batch's ``audio`` rows, downmixes to mono, calls ``encode``, and
-    appends the result as a ``clap`` column under :func:`clap_augmented_schema`.
-
-    :param schema: Schema of the incoming batches (must carry ``audio``).
+    :param in_schema: Schema of the incoming batches (must carry ``audio``).
+    :param out_schema: ``in_schema`` extended with the ``clap`` column.
     :param batches: Record batches of one finalized Lance split, in row order.
     :param encode: Maps a mono ``(B, T)`` batch and ``sample_rate`` to a
         ``(B, dim)`` float32 embedding batch.
@@ -81,9 +78,8 @@ def iter_clap_batches(
     :ytype: pa.RecordBatch
     :raises ValueError: ``encode`` returns anything other than a ``(B, dim)`` batch.
     """
-    out_schema = clap_augmented_schema(schema, dim)
-    audio_inner = tuple(schema.field(AUDIO_FIELD).type.shape)
-    audio_index = schema.get_field_index(AUDIO_FIELD)
+    audio_inner = tuple(in_schema.field(AUDIO_FIELD).type.shape)
+    audio_index = in_schema.get_field_index(AUDIO_FIELD)
     for batch in batches:
         audio = tensor_chunk_to_numpy(batch.column(audio_index), audio_inner)
         embeddings = np.asarray(encode(_downmix_to_mono(audio), sample_rate))
@@ -93,6 +89,35 @@ def iter_clap_batches(
             )
         clap_column = tensor_array(embeddings, np.dtype("float32"), (dim,))
         yield pa.record_batch([*batch.columns, clap_column], schema=out_schema)
+
+
+def clap_augment_split(
+    schema: pa.Schema,
+    batches: Iterable[pa.RecordBatch],
+    encode: EncodeFn,
+    sample_rate: int,
+    *,
+    dim: int,
+) -> tuple[pa.Schema, Iterator[pa.RecordBatch]]:
+    """Augment one Lance split's ``(schema, batches)`` with a ``clap`` embedding column.
+
+    Builds the extended schema once and returns it alongside a generator that
+    appends each row's embedding, so the schema is available to the writer before
+    the batches are consumed.
+
+    :param schema: Schema of the incoming batches (must carry ``audio``).
+    :param batches: Record batches of one finalized Lance split, in row order.
+    :param encode: Maps a mono ``(B, T)`` batch and ``sample_rate`` to a
+        ``(B, dim)`` float32 embedding batch.
+    :param sample_rate: Audio sample rate passed through to ``encode``.
+    :param dim: Embedding width of the appended column.
+    :returns: The extended schema and the ``clap``-augmented batch iterator.
+    """
+    out_schema = clap_augmented_schema(schema, dim)
+    augmented = _iter_clap_record_batches(
+        schema, out_schema, batches, encode, sample_rate, dim=dim
+    )
+    return out_schema, augmented
 
 
 def load_clap_audio_encoder(
@@ -109,7 +134,6 @@ def load_clap_audio_encoder(
     :param device: Torch device string; defaults to cuda when available, else cpu.
     :returns: Encode callable mapping a mono ``(B, T)`` batch and sample rate to a
         ``(B, D)`` float32 embedding batch.
-    :rtype: EncodeFn
     """
     import torch
     import torchaudio.functional as audio_fn
@@ -118,10 +142,11 @@ def load_clap_audio_encoder(
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
     logger.info("loading_clap_checkpoint", checkpoint=checkpoint, device=device)
-    # transformers' processor/model call surface is dynamically typed; Any at this
-    # external boundary keeps the type checker honest about what it cannot verify.
-    model: Any = ClapModel.from_pretrained(checkpoint)
-    model = model.to(device).eval()
+    # ``Any`` at this external boundary is deliberate: ``from_pretrained`` and the
+    # processor call are dynamically typed, and ``@can_return_tuple`` makes
+    # ``get_audio_features`` return a union that would defeat the ``.pooler_output``
+    # access below under concrete annotations.
+    model: Any = ClapModel.from_pretrained(checkpoint).to(device).eval()
     processor: Any = ClapProcessor.from_pretrained(checkpoint)
 
     @torch.no_grad()
@@ -130,11 +155,11 @@ def load_clap_audio_encoder(
         if sample_rate != CLAP_SAMPLE_RATE:
             wav = audio_fn.resample(wav, sample_rate, CLAP_SAMPLE_RATE)
         inputs = processor(
-            audio=list(wav.numpy()), sampling_rate=CLAP_SAMPLE_RATE, return_tensors="pt"
+            audio=list(wav.cpu().numpy()), sampling_rate=CLAP_SAMPLE_RATE, return_tensors="pt"
         )
         inputs = {key: value.to(device) for key, value in inputs.items()}
-        # get_audio_features returns the audio-tower output whose pooler_output
-        # holds the projected, L2-normalized joint-space embedding (B, D).
+        # get_audio_features returns a pooled output whose pooler_output holds the
+        # projected, L2-normalized joint-space audio embedding (B, D).
         features = model.get_audio_features(**inputs)
         return features.pooler_output.cpu().numpy()
 

--- a/src/synth_setter/pipeline/data/clap_lance.py
+++ b/src/synth_setter/pipeline/data/clap_lance.py
@@ -6,7 +6,8 @@ extra ``clap`` fixed-shape-tensor column, reading each batch's ``audio`` rows,
 downmixing them to mono, and running an *injected* ``encode`` callable — so it
 is exercised without loading a CLAP checkpoint. :func:`load_clap_audio_encoder`
 is the thin shell that builds the real encoder behind a lazy ``transformers``
-import; its only test is a manual run (see the PR's "Verification" checklist).
+import; its wiring is unit-tested against fake ``transformers``/``torchaudio``
+stand-ins, and a real checkpoint is exercised by the PR's "Verification" checklist.
 """
 
 from __future__ import annotations

--- a/src/synth_setter/pipeline/data/clap_lance.py
+++ b/src/synth_setter/pipeline/data/clap_lance.py
@@ -29,6 +29,10 @@ DEFAULT_CLAP_CHECKPOINT: str = "laion/clap-htsat-unfused"
 # this before encoding.
 CLAP_SAMPLE_RATE: int = 48000
 
+# On-disk dtype of the ``clap`` column. float32 keeps the projected embedding at
+# full precision (unlike the float16 audio it is derived from).
+_CLAP_DTYPE = np.dtype("float32")
+
 # Maps a mono ``(B, T)`` batch and its sample rate to a ``(B, D)`` embedding batch.
 EncodeFn: TypeAlias = Callable[[np.ndarray, int], np.ndarray]
 
@@ -40,7 +44,7 @@ def clap_augmented_schema(schema: pa.Schema, dim: int) -> pa.Schema:
     :param dim: Embedding width; the appended column's per-row tensor shape.
     :returns: ``schema`` with the trailing ``clap`` column, metadata preserved.
     """
-    clap_type = pa.fixed_shape_tensor(pa.from_numpy_dtype(np.dtype("float32")), (dim,))
+    clap_type = pa.fixed_shape_tensor(pa.from_numpy_dtype(_CLAP_DTYPE), (dim,))
     return schema.append(pa.field(CLAP_FIELD, clap_type, nullable=False))
 
 
@@ -87,7 +91,7 @@ def _iter_clap_record_batches(
             raise ValueError(
                 f"CLAP encoder produced shape {embeddings.shape}, expected (B, {dim})"
             )
-        clap_column = tensor_array(embeddings, np.dtype("float32"), (dim,))
+        clap_column = tensor_array(embeddings, _CLAP_DTYPE, (dim,))
         yield pa.record_batch([*batch.columns, clap_column], schema=out_schema)
 
 
@@ -142,11 +146,10 @@ def load_clap_audio_encoder(
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
     logger.info("loading_clap_checkpoint", checkpoint=checkpoint, device=device)
-    # ``Any`` at this external boundary is deliberate: ``from_pretrained`` and the
-    # processor call are dynamically typed, and ``@can_return_tuple`` makes
-    # ``get_audio_features`` return a union that would defeat the ``.pooler_output``
-    # access below under concrete annotations.
-    model: Any = ClapModel.from_pretrained(checkpoint).to(device).eval()
+    # ``Any``: ``@can_return_tuple`` makes ``get_audio_features`` return a union that
+    # would defeat the ``.pooler_output`` access below under concrete annotations.
+    model: Any = ClapModel.from_pretrained(checkpoint)
+    model = model.to(device).eval()
     processor: Any = ClapProcessor.from_pretrained(checkpoint)
 
     @torch.no_grad()
@@ -155,7 +158,7 @@ def load_clap_audio_encoder(
         if sample_rate != CLAP_SAMPLE_RATE:
             wav = audio_fn.resample(wav, sample_rate, CLAP_SAMPLE_RATE)
         inputs = processor(
-            audio=list(wav.cpu().numpy()), sampling_rate=CLAP_SAMPLE_RATE, return_tensors="pt"
+            audio=list(wav.numpy()), sampling_rate=CLAP_SAMPLE_RATE, return_tensors="pt"
         )
         inputs = {key: value.to(device) for key, value in inputs.items()}
         # get_audio_features returns a pooled output whose pooler_output holds the

--- a/src/synth_setter/pipeline/schemas/spec.py
+++ b/src/synth_setter/pipeline/schemas/spec.py
@@ -559,6 +559,12 @@ class DatasetSpec(BaseModel):
         Whether finalize substitutes ``std=1.0`` at zero-variance mel bins
         instead of raising; ``False`` is the strict production default.
 
+    .. attribute :: compute_clap_embeddings
+
+        Whether finalize appends a ``clap`` audio-embedding column to each Lance
+        split file; ``False`` is the default and the only value allowed for
+        non-lance output.
+
     .. attribute :: git_sha
 
         Commit SHA of the launcher's working tree at construction.
@@ -639,6 +645,15 @@ class DatasetSpec(BaseModel):
             "mel bins instead of raising; ``False`` is the strict production default. "
             "Smoke configs override to ``True`` because tiny renders have constant "
             "attack-time frames and channels below the source's active bandwidth."
+        ),
+    )
+
+    compute_clap_embeddings: bool = Field(
+        default=False,
+        description=(
+            "Whether finalize appends a ``clap`` LAION-CLAP audio-embedding column to each "
+            "Lance split file (``lance`` output only; ``False`` is the default). Enabling it "
+            "makes finalize load a CLAP checkpoint and encode every row's audio."
         ),
     )
 
@@ -982,6 +997,25 @@ class DatasetSpec(BaseModel):
                 "copy_dataset_root_uri (dataset copy) supports output_format='hdf5' only; got "
                 f"output_format={self.output_format!r}. The source is read as an HDF5 "
                 "param_array of the same shard filename."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _reject_clap_embeddings_for_non_lance(self) -> DatasetSpec:
+        """Reject ``compute_clap_embeddings`` paired with non-lance output.
+
+        The CLAP column is appended only on the Lance finalize branch, so pairing
+        the flag with an hdf5/wds output would be silently ignored. Failing at spec
+        construction surfaces the misconfig at launch instead.
+
+        :returns: ``self`` when the flag is unset or output is lance.
+        :raises ValueError: ``compute_clap_embeddings`` is set with ``output_format != "lance"``.
+        """
+        if self.compute_clap_embeddings and self.output_format != "lance":
+            raise ValueError(
+                "compute_clap_embeddings supports output_format='lance' only; got "
+                f"output_format={self.output_format!r}. The CLAP column is appended on the "
+                "Lance finalize branch."
             )
         return self
 

--- a/tests/helpers/finalize_shards.py
+++ b/tests/helpers/finalize_shards.py
@@ -111,6 +111,7 @@ def build_lance_smoke_spec(
     train_val_test_sizes: tuple[int, int, int] = (4, 0, 0),
     mask_degenerate_bins: bool = False,
     render: RenderConfig | None = None,
+    compute_clap_embeddings: bool = False,
 ) -> DatasetSpec:
     """Construct a lance ``DatasetSpec`` directly (no Hydra compose).
 
@@ -120,6 +121,7 @@ def build_lance_smoke_spec(
     :param mask_degenerate_bins: Threaded onto the spec for stats-fold tests.
     :param render: Optional render config replacing the smoke default — used by
         e2e tests that must wrap the exact config a writer rendered with.
+    :param compute_clap_embeddings: Threaded onto the spec for the CLAP finalize lane.
     :returns: A frozen lance ``DatasetSpec`` whose shards are deterministic.
     """
     kwargs: dict[str, Any] = {
@@ -128,6 +130,7 @@ def build_lance_smoke_spec(
         "train_val_test_sizes": list(train_val_test_sizes),
         "base_seed": 42,
         "mask_degenerate_bins": mask_degenerate_bins,
+        "compute_clap_embeddings": compute_clap_embeddings,
         "r2": {"bucket": "intermediate-data"},
         "render": render if render is not None else dict(_LANCE_SMOKE_RENDER),
     }

--- a/tests/pipeline/ci_validate/test_validate_spec.py
+++ b/tests/pipeline/ci_validate/test_validate_spec.py
@@ -26,6 +26,7 @@ def _make_valid_spec(*, output_format: str = "hdf5", **overrides: object) -> dic
         "base_seed": 42,
         "copy_dataset_root_uri": None,
         "mask_degenerate_bins": False,
+        "compute_clap_embeddings": False,
         "num_params": 92,
         "num_shards": 3,
         "r2": {

--- a/tests/pipeline/data/test_clap_lance.py
+++ b/tests/pipeline/data/test_clap_lance.py
@@ -1,0 +1,244 @@
+"""Tests for the Lance CLAP-embedding augmentation core.
+
+The encoder is injected as a plain callable, so every path here runs without
+loading a CLAP checkpoint; :func:`load_clap_audio_encoder` (the real model
+shell) is exercised manually — see the module docstring of ``clap_lance``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pyarrow as pa
+import pytest
+from lance.file import LanceFileReader
+
+from synth_setter.data.vst.shapes import (
+    AUDIO_FIELD,
+    CLAP_FIELD,
+    MEL_SPEC_FIELD,
+    PARAM_ARRAY_FIELD,
+)
+from synth_setter.pipeline.data.clap_lance import (
+    EncodeFn,
+    clap_augmented_schema,
+    iter_clap_batches,
+)
+from synth_setter.pipeline.data.lance_shard import iter_lance_column_rows, write_lance_file
+
+# Small embedding width so fixtures stay tiny; unrelated to the real 512-d model.
+_TEST_DIM = 4
+_SAMPLE_RATE = 16000
+
+
+def _write_shard(path: Path, audio: np.ndarray, mel: np.ndarray, params: np.ndarray) -> None:
+    """Write a single-file Lance shard carrying the three core dataset columns.
+
+    :param path: Output ``.lance`` shard file.
+    :param audio: ``(N, C, T)`` audio rows.
+    :param mel: ``(N, ...)`` mel-spectrogram rows.
+    :param params: ``(N, P)`` parameter rows.
+    """
+    from tests.helpers.lance_fixtures import write_lance_shard
+
+    write_lance_shard(
+        path,
+        {AUDIO_FIELD: audio, MEL_SPEC_FIELD: mel, PARAM_ARRAY_FIELD: params},
+    )
+
+
+def _read_schema_and_batches(path: Path) -> tuple[pa.Schema, list[pa.RecordBatch]]:
+    """Read a Lance file's schema and all record batches, as finalize does.
+
+    :param path: Lance shard file to read.
+    :returns: The file's schema and its record batches.
+    :rtype: tuple[pa.Schema, list[pa.RecordBatch]]
+    """
+    reader = LanceFileReader(str(path))
+    return reader.metadata().schema, reader.read_all().to_batches()
+
+
+def _constant_audio(num_rows: int, channels: int, time: int) -> np.ndarray:
+    """Build an audio batch whose channel ``c`` is filled with ``c + 1``.
+
+    :param num_rows: Row count ``N``.
+    :param channels: Channel count ``C``.
+    :param time: Sample count ``T``.
+    :returns: ``(N, C, T)`` float16 audio.
+    :rtype: np.ndarray
+    """
+    rows = np.empty((num_rows, channels, time), dtype=np.float16)
+    for channel in range(channels):
+        rows[:, channel, :] = channel + 1
+    return rows
+
+
+def _row_indexed_encoder(dim: int) -> EncodeFn:
+    """Build a deterministic encoder mapping a mono batch to ``mean(row) + arange(dim)``.
+
+    :param dim: Embedding width the encoder emits.
+    :returns: An encode callable producing distinct, reproducible rows.
+    :rtype: EncodeFn
+    """
+
+    def encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:  # noqa: ARG001
+        return (mono.mean(axis=1, keepdims=True) + np.arange(dim)[None, :]).astype(np.float32)
+
+    return encode
+
+
+def test_clap_augmented_schema_appends_fixed_shape_tensor_clap_column(tmp_path: Path) -> None:
+    """The augmented schema keeps every original column and adds a ``(dim,)`` float32 ``clap``.
+
+    :param tmp_path: Pytest tmp dir hosting the fixture shard.
+    """
+    _write_shard(
+        tmp_path / "shard.lance",
+        audio=_constant_audio(2, 2, 8),
+        mel=np.zeros((2, 2, 3), dtype=np.float32),
+        params=np.zeros((2, 5), dtype=np.float32),
+    )
+    schema, _ = _read_schema_and_batches(tmp_path / "shard.lance")
+
+    augmented = clap_augmented_schema(schema, _TEST_DIM)
+
+    assert augmented.names == [AUDIO_FIELD, MEL_SPEC_FIELD, PARAM_ARRAY_FIELD, CLAP_FIELD]
+    clap_type = augmented.field(CLAP_FIELD).type
+    assert tuple(clap_type.shape) == (_TEST_DIM,)
+    assert clap_type.value_type == pa.float32()
+
+
+def test_clap_augmented_schema_preserves_shard_metadata() -> None:
+    """Schema-level metadata (ShardMetadata payload) survives the column append."""
+    base = pa.schema(
+        [pa.field(AUDIO_FIELD, pa.fixed_shape_tensor(pa.float16(), (2, 8)), nullable=False)],
+        metadata={b"synth_setter.shard_metadata": b'{"sample_rate": 16000}'},
+    )
+
+    augmented = clap_augmented_schema(base, _TEST_DIM)
+
+    assert augmented.metadata == base.metadata
+
+
+def test_iter_clap_batches_writes_encoder_output_as_clap_column(tmp_path: Path) -> None:
+    """Each row's ``clap`` column equals the injected encoder's output for that row's audio.
+
+    :param tmp_path: Pytest tmp dir hosting the input and output shards.
+    """
+    audio = _constant_audio(num_rows=3, channels=2, time=8)
+    _write_shard(
+        tmp_path / "in.lance",
+        audio=audio,
+        mel=np.zeros((3, 2, 3), dtype=np.float32),
+        params=np.zeros((3, 5), dtype=np.float32),
+    )
+    schema, batches = _read_schema_and_batches(tmp_path / "in.lance")
+
+    out_schema = clap_augmented_schema(schema, _TEST_DIM)
+    out_batches = iter_clap_batches(
+        schema, batches, _row_indexed_encoder(_TEST_DIM), _SAMPLE_RATE, dim=_TEST_DIM
+    )
+    write_lance_file(tmp_path / "out.lance", out_schema, out_batches)
+
+    clap_rows = list(iter_lance_column_rows(tmp_path / "out.lance", CLAP_FIELD))
+    # Every channel mean is (1+2)/2 = 1.5, so each row is 1.5 + arange(dim).
+    expected_row = (1.5 + np.arange(_TEST_DIM)).astype(np.float32)
+    assert len(clap_rows) == 3
+    for row in clap_rows:
+        np.testing.assert_array_equal(row, expected_row)
+
+
+def test_iter_clap_batches_downmixes_channels_to_mono_before_encoding(tmp_path: Path) -> None:
+    """The encoder receives a mono ``(B, T)`` batch averaged across the channel axis.
+
+    :param tmp_path: Pytest tmp dir hosting the input shard.
+    """
+    audio = _constant_audio(num_rows=2, channels=2, time=4)
+    _write_shard(
+        tmp_path / "in.lance",
+        audio=audio,
+        mel=np.zeros((2, 2, 3), dtype=np.float32),
+        params=np.zeros((2, 5), dtype=np.float32),
+    )
+    schema, batches = _read_schema_and_batches(tmp_path / "in.lance")
+    seen: list[np.ndarray] = []
+
+    def recording_encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:  # noqa: ARG001
+        seen.append(mono.copy())
+        return np.zeros((mono.shape[0], _TEST_DIM), dtype=np.float32)
+
+    list(iter_clap_batches(schema, batches, recording_encode, _SAMPLE_RATE, dim=_TEST_DIM))
+
+    assert seen[0].shape == (2, 4)
+    np.testing.assert_array_equal(seen[0], np.full((2, 4), 1.5, dtype=np.float32))
+
+
+def test_iter_clap_batches_passes_sample_rate_to_encoder(tmp_path: Path) -> None:
+    """The sample rate threaded into the iterator reaches the encoder unchanged.
+
+    :param tmp_path: Pytest tmp dir hosting the input shard.
+    """
+    _write_shard(
+        tmp_path / "in.lance",
+        audio=_constant_audio(1, 2, 4),
+        mel=np.zeros((1, 2, 3), dtype=np.float32),
+        params=np.zeros((1, 5), dtype=np.float32),
+    )
+    schema, batches = _read_schema_and_batches(tmp_path / "in.lance")
+    seen_rates: list[int] = []
+
+    def recording_encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+        seen_rates.append(sample_rate)
+        return np.zeros((mono.shape[0], _TEST_DIM), dtype=np.float32)
+
+    list(iter_clap_batches(schema, batches, recording_encode, 22050, dim=_TEST_DIM))
+
+    assert seen_rates == [22050]
+
+
+def test_iter_clap_batches_raises_when_encoder_width_differs_from_dim(tmp_path: Path) -> None:
+    """A width guard rejects an encoder whose output dimension is not the declared ``dim``.
+
+    :param tmp_path: Pytest tmp dir hosting the input shard.
+    """
+    _write_shard(
+        tmp_path / "in.lance",
+        audio=_constant_audio(2, 2, 4),
+        mel=np.zeros((2, 2, 3), dtype=np.float32),
+        params=np.zeros((2, 5), dtype=np.float32),
+    )
+    schema, batches = _read_schema_and_batches(tmp_path / "in.lance")
+
+    def wrong_width_encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:  # noqa: ARG001
+        return np.zeros((mono.shape[0], _TEST_DIM + 1), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="width"):
+        list(iter_clap_batches(schema, batches, wrong_width_encode, _SAMPLE_RATE, dim=_TEST_DIM))
+
+
+def test_iter_clap_batches_preserves_existing_columns(tmp_path: Path) -> None:
+    """Augmentation is additive: the original audio/mel/param rows round-trip unchanged.
+
+    :param tmp_path: Pytest tmp dir hosting the input and output shards.
+    """
+    mel = np.arange(2 * 2 * 3, dtype=np.float32).reshape(2, 2, 3)
+    params = np.arange(2 * 5, dtype=np.float32).reshape(2, 5)
+    _write_shard(
+        tmp_path / "in.lance",
+        audio=_constant_audio(2, 2, 4),
+        mel=mel,
+        params=params,
+    )
+    schema, batches = _read_schema_and_batches(tmp_path / "in.lance")
+
+    out_schema = clap_augmented_schema(schema, _TEST_DIM)
+    out_batches = iter_clap_batches(
+        schema, batches, _row_indexed_encoder(_TEST_DIM), _SAMPLE_RATE, dim=_TEST_DIM
+    )
+    write_lance_file(tmp_path / "out.lance", out_schema, out_batches)
+
+    mel_rows = list(iter_lance_column_rows(tmp_path / "out.lance", MEL_SPEC_FIELD))
+    param_rows = list(iter_lance_column_rows(tmp_path / "out.lance", PARAM_ARRAY_FIELD))
+    np.testing.assert_array_equal(np.stack(mel_rows), mel)
+    np.testing.assert_array_equal(np.stack(param_rows), params)

--- a/tests/pipeline/data/test_clap_lance.py
+++ b/tests/pipeline/data/test_clap_lance.py
@@ -267,7 +267,35 @@ def test_clap_augment_split_raises_when_encoder_width_differs_from_dim(
     _, out_batches = clap_augment_split(
         schema, batches, wrong_width_encode, _SAMPLE_RATE, dim=_TEST_DIM
     )
-    with pytest.raises(ValueError, match=r"expected \(B, 4\)"):
+    with pytest.raises(ValueError, match=r"expected \(2, 4\)"):
+        list(out_batches)
+
+
+def test_clap_augment_split_raises_when_encoder_row_count_differs_from_batch(
+    tmp_path: Path,
+) -> None:
+    """The guard rejects an encoder that returns a different row count than the input batch.
+
+    Without it a row-count mismatch would surface only as a cryptic Arrow length error when the
+    batch is reassembled.
+
+    :param tmp_path: Pytest tmp dir hosting the input shard.
+    """
+    _write_shard(
+        tmp_path / "in.lance",
+        audio=_constant_audio(2, 2, 4),
+        mel=np.zeros((2, 2, 3), dtype=np.float32),
+        params=np.zeros((2, 5), dtype=np.float32),
+    )
+    schema, batches = _read_schema_and_batches(tmp_path / "in.lance")
+
+    def dropped_row_encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:  # noqa: ARG001
+        return np.zeros((mono.shape[0] - 1, _TEST_DIM), dtype=np.float32)
+
+    _, out_batches = clap_augment_split(
+        schema, batches, dropped_row_encode, _SAMPLE_RATE, dim=_TEST_DIM
+    )
+    with pytest.raises(ValueError, match=r"expected \(2, 4\)"):
         list(out_batches)
 
 

--- a/tests/pipeline/data/test_clap_lance.py
+++ b/tests/pipeline/data/test_clap_lance.py
@@ -366,15 +366,13 @@ def _install_fake_clap_stack(monkeypatch: pytest.MonkeyPatch) -> list[tuple[int,
     def fake_processor(*, audio: list[Any], sampling_rate: int, return_tensors: str) -> dict:  # noqa: ARG001
         return {"input_features": torch.zeros((len(audio), 3), dtype=torch.float32)}
 
+    # Patch ``from_pretrained`` on the real classes rather than swapping the classes
+    # on the lazy ``transformers`` module: ``from transformers import ClapModel`` inside
+    # the loader resolves the real class object, so only a method patch on that object
+    # is seen — a module-attribute swap is bypassed and the real checkpoint downloads.
+    monkeypatch.setattr(transformers.ClapModel, "from_pretrained", lambda checkpoint: fake_model)
     monkeypatch.setattr(
-        transformers,
-        "ClapModel",
-        SimpleNamespace(from_pretrained=lambda checkpoint: fake_model),  # noqa: ARG005
-    )
-    monkeypatch.setattr(
-        transformers,
-        "ClapProcessor",
-        SimpleNamespace(from_pretrained=lambda checkpoint: fake_processor),  # noqa: ARG005
+        transformers.ClapProcessor, "from_pretrained", lambda checkpoint: fake_processor
     )
     monkeypatch.setattr(audio_fn, "resample", fake_resample)
     return resample_calls

--- a/tests/pipeline/data/test_clap_lance.py
+++ b/tests/pipeline/data/test_clap_lance.py
@@ -49,22 +49,25 @@ def _write_shard(path: Path, audio: np.ndarray, mel: np.ndarray, params: np.ndar
 
 
 def _read_schema_and_batches(path: Path) -> tuple[pa.Schema, list[pa.RecordBatch]]:
-    """Read a Lance file's schema and all record batches, as finalize does.
+    """Open a Lance shard the way finalize does, returning its schema and batches.
 
     :param path: Lance shard file to read.
-    :returns: The file's schema and its record batches.
+    :returns: The shard's Arrow schema paired with every record batch in it.
     :rtype: tuple[pa.Schema, list[pa.RecordBatch]]
     """
     reader = LanceFileReader(str(path))
-    return reader.metadata().schema, reader.read_all().to_batches()
+    return reader.metadata().schema, list(reader.read_all().to_batches())
 
 
 def _constant_audio(num_rows: int, channels: int, time: int) -> np.ndarray:
-    """Build an audio batch whose channel ``c`` is filled with ``c + 1``.
+    """Build float16 audio whose channel ``c`` is filled with ``c + 1`` (distinct per channel).
 
-    :param num_rows: Row count ``N``.
-    :param channels: Channel count ``C``.
-    :param time: Sample count ``T``.
+    The per-channel constant makes the mono downmix a known value, so downmix
+    tests can assert the exact averaged input.
+
+    :param num_rows: Leading row axis ``N``.
+    :param channels: Channel axis ``C`` whose distinct fills drive the downmix.
+    :param time: Sample axis ``T``.
     :returns: ``(N, C, T)`` float16 audio.
     :rtype: np.ndarray
     """
@@ -146,7 +149,39 @@ def test_iter_clap_batches_writes_encoder_output_as_clap_column(tmp_path: Path) 
     expected_row = (1.5 + np.arange(_TEST_DIM)).astype(np.float32)
     assert len(clap_rows) == 3
     for row in clap_rows:
+        assert row.shape == (_TEST_DIM,)
+        assert row.dtype == np.float32
         np.testing.assert_array_equal(row, expected_row)
+
+
+def test_iter_clap_batches_appends_clap_to_every_input_batch(tmp_path: Path) -> None:
+    """Multi-batch input: each incoming batch is yielded with its own ``clap`` column.
+
+    Exercises the ``for batch in batches`` boundary that the single-batch
+    Lance-reader fixtures do not reach.
+
+    :param tmp_path: Pytest tmp dir hosting the output shard.
+    """
+    _write_shard(
+        tmp_path / "seed.lance",
+        audio=_constant_audio(1, 2, 4),
+        mel=np.zeros((1, 2, 3), dtype=np.float32),
+        params=np.zeros((1, 5), dtype=np.float32),
+    )
+    schema, one_batch = _read_schema_and_batches(tmp_path / "seed.lance")
+    two_batches = [one_batch[0], one_batch[0]]
+
+    out_schema = clap_augmented_schema(schema, _TEST_DIM)
+    out_batches = list(
+        iter_clap_batches(
+            schema, two_batches, _row_indexed_encoder(_TEST_DIM), _SAMPLE_RATE, dim=_TEST_DIM
+        )
+    )
+
+    assert len(out_batches) == 2
+    for batch in out_batches:
+        assert batch.num_rows == 1
+        assert batch.schema.names == out_schema.names
 
 
 def test_iter_clap_batches_downmixes_channels_to_mono_before_encoding(tmp_path: Path) -> None:
@@ -213,7 +248,7 @@ def test_iter_clap_batches_raises_when_encoder_width_differs_from_dim(tmp_path: 
     def wrong_width_encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:  # noqa: ARG001
         return np.zeros((mono.shape[0], _TEST_DIM + 1), dtype=np.float32)
 
-    with pytest.raises(ValueError, match="width"):
+    with pytest.raises(ValueError, match=r"expected \(B, 4\)"):
         list(iter_clap_batches(schema, batches, wrong_width_encode, _SAMPLE_RATE, dim=_TEST_DIM))
 
 

--- a/tests/pipeline/data/test_clap_lance.py
+++ b/tests/pipeline/data/test_clap_lance.py
@@ -346,6 +346,12 @@ def _install_fake_clap_stack(monkeypatch: pytest.MonkeyPatch) -> list[tuple[int,
     import torchaudio.functional as audio_fn
     import transformers
 
+    # Belt-and-suspenders: even though from_pretrained is faked below, force
+    # HuggingFace offline so any unintercepted call fails fast instead of hanging
+    # on the Hub's 429-retry backoff (which has stalled the conda CI lane).
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    monkeypatch.setenv("TRANSFORMERS_OFFLINE", "1")
+
     resample_calls: list[tuple[int, int]] = []
 
     def fake_resample(wav: Any, orig_freq: int, new_freq: int) -> Any:

--- a/tests/pipeline/data/test_clap_lance.py
+++ b/tests/pipeline/data/test_clap_lance.py
@@ -1,13 +1,16 @@
 """Tests for the Lance CLAP-embedding augmentation core.
 
-The encoder is injected as a plain callable, so every path here runs without
-loading a CLAP checkpoint; :func:`load_clap_audio_encoder` (the real model
-shell) is exercised manually — see the PR's "Verification" checklist.
+The augmentation core injects the encoder as a plain callable, so those paths
+run without a CLAP checkpoint; :func:`load_clap_audio_encoder` is tested against
+fake ``transformers``/``torchaudio`` stand-ins (a real checkpoint is exercised
+manually — see the PR's "Verification" checklist).
 """
 
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
 
 import numpy as np
 import pyarrow as pa
@@ -16,14 +19,17 @@ from lance.file import LanceFileReader
 
 from synth_setter.data.vst.shapes import (
     AUDIO_FIELD,
+    CLAP_EMBEDDING_DIM,
     CLAP_FIELD,
     MEL_SPEC_FIELD,
     PARAM_ARRAY_FIELD,
 )
 from synth_setter.pipeline.data.clap_lance import (
+    CLAP_SAMPLE_RATE,
     EncodeFn,
     clap_augment_split,
     clap_augmented_schema,
+    load_clap_audio_encoder,
 )
 from synth_setter.pipeline.data.lance_shard import iter_lance_column_rows, write_lance_file
 
@@ -323,3 +329,89 @@ def test_clap_augment_split_preserves_existing_columns(tmp_path: Path) -> None:
     param_rows = list(iter_lance_column_rows(tmp_path / "out.lance", PARAM_ARRAY_FIELD))
     np.testing.assert_array_equal(np.stack(mel_rows), mel)
     np.testing.assert_array_equal(np.stack(param_rows), params)
+
+
+def _install_fake_clap_stack(monkeypatch: pytest.MonkeyPatch) -> list[tuple[int, int]]:
+    """Swap the lazily-imported CLAP stack for fakes; return a resample-call log.
+
+    Replaces ``transformers.ClapModel`` / ``ClapProcessor`` and
+    ``torchaudio.functional.resample`` with in-memory fakes so the wiring inside
+    :func:`load_clap_audio_encoder` runs without a checkpoint download. The fake
+    model projects any batch to zeros ``(B, CLAP_EMBEDDING_DIM)`` float32.
+
+    :param monkeypatch: Pytest monkeypatch fixture.
+    :returns: List that records ``(orig_freq, new_freq)`` for each ``resample`` call.
+    """
+    import torch
+    import torchaudio.functional as audio_fn
+    import transformers
+
+    resample_calls: list[tuple[int, int]] = []
+
+    def fake_resample(wav: Any, orig_freq: int, new_freq: int) -> Any:
+        resample_calls.append((orig_freq, new_freq))
+        return wav
+
+    def get_audio_features(**inputs: Any) -> SimpleNamespace:
+        (batch,) = {value.shape[0] for value in inputs.values()}
+        pooled = torch.zeros((batch, CLAP_EMBEDDING_DIM), dtype=torch.float32)
+        return SimpleNamespace(pooler_output=pooled)
+
+    fake_model = SimpleNamespace(
+        to=lambda device: fake_model,  # noqa: ARG005
+        eval=lambda: fake_model,
+        get_audio_features=get_audio_features,
+    )
+
+    def fake_processor(*, audio: list[Any], sampling_rate: int, return_tensors: str) -> dict:  # noqa: ARG001
+        return {"input_features": torch.zeros((len(audio), 3), dtype=torch.float32)}
+
+    monkeypatch.setattr(
+        transformers,
+        "ClapModel",
+        SimpleNamespace(from_pretrained=lambda checkpoint: fake_model),  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        transformers,
+        "ClapProcessor",
+        SimpleNamespace(from_pretrained=lambda checkpoint: fake_processor),  # noqa: ARG005
+    )
+    monkeypatch.setattr(audio_fn, "resample", fake_resample)
+    return resample_calls
+
+
+def test_load_clap_audio_encoder_maps_mono_batch_to_embedding_dim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The loaded encoder maps a mono ``(B, T)`` batch to ``(B, CLAP_EMBEDDING_DIM)`` float32.
+
+    The transformers/torchaudio stack is faked so the wiring inside
+    :func:`load_clap_audio_encoder` runs without a checkpoint download.
+
+    :param monkeypatch: Pytest monkeypatch fixture swapping in the fake CLAP stack.
+    """
+    resample_calls = _install_fake_clap_stack(monkeypatch)
+    encode = load_clap_audio_encoder(device="cpu")
+
+    embeddings = encode(np.zeros((2, 8), dtype=np.float32), CLAP_SAMPLE_RATE)
+
+    assert embeddings.shape == (2, CLAP_EMBEDDING_DIM)
+    assert embeddings.dtype == np.float32
+    # At the native rate the encoder must not resample.
+    assert resample_calls == []
+
+
+def test_load_clap_audio_encoder_resamples_when_sample_rate_differs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-native sample rate is resampled to ``CLAP_SAMPLE_RATE`` before encoding.
+
+    :param monkeypatch: Pytest monkeypatch fixture swapping in the fake CLAP stack.
+    """
+    resample_calls = _install_fake_clap_stack(monkeypatch)
+    encode = load_clap_audio_encoder(device="cpu")
+
+    embeddings = encode(np.zeros((1, 8), dtype=np.float32), _SAMPLE_RATE)
+
+    assert embeddings.shape == (1, CLAP_EMBEDDING_DIM)
+    assert resample_calls == [(_SAMPLE_RATE, CLAP_SAMPLE_RATE)]

--- a/tests/pipeline/data/test_clap_lance.py
+++ b/tests/pipeline/data/test_clap_lance.py
@@ -2,7 +2,7 @@
 
 The encoder is injected as a plain callable, so every path here runs without
 loading a CLAP checkpoint; :func:`load_clap_audio_encoder` (the real model
-shell) is exercised manually — see the module docstring of ``clap_lance``.
+shell) is exercised manually — see the PR's "Verification" checklist.
 """
 
 from __future__ import annotations
@@ -22,8 +22,8 @@ from synth_setter.data.vst.shapes import (
 )
 from synth_setter.pipeline.data.clap_lance import (
     EncodeFn,
+    clap_augment_split,
     clap_augmented_schema,
-    iter_clap_batches,
 )
 from synth_setter.pipeline.data.lance_shard import iter_lance_column_rows, write_lance_file
 
@@ -53,7 +53,6 @@ def _read_schema_and_batches(path: Path) -> tuple[pa.Schema, list[pa.RecordBatch
 
     :param path: Lance shard file to read.
     :returns: The shard's Arrow schema paired with every record batch in it.
-    :rtype: tuple[pa.Schema, list[pa.RecordBatch]]
     """
     reader = LanceFileReader(str(path))
     return reader.metadata().schema, list(reader.read_all().to_batches())
@@ -69,7 +68,6 @@ def _constant_audio(num_rows: int, channels: int, time: int) -> np.ndarray:
     :param channels: Channel axis ``C`` whose distinct fills drive the downmix.
     :param time: Sample axis ``T``.
     :returns: ``(N, C, T)`` float16 audio.
-    :rtype: np.ndarray
     """
     rows = np.empty((num_rows, channels, time), dtype=np.float16)
     for channel in range(channels):
@@ -82,7 +80,6 @@ def _row_indexed_encoder(dim: int) -> EncodeFn:
 
     :param dim: Embedding width the encoder emits.
     :returns: An encode callable producing distinct, reproducible rows.
-    :rtype: EncodeFn
     """
 
     def encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:  # noqa: ARG001
@@ -124,7 +121,7 @@ def test_clap_augmented_schema_preserves_shard_metadata() -> None:
     assert augmented.metadata == base.metadata
 
 
-def test_iter_clap_batches_writes_encoder_output_as_clap_column(tmp_path: Path) -> None:
+def test_clap_augment_split_writes_encoder_output_as_clap_column(tmp_path: Path) -> None:
     """Each row's ``clap`` column equals the injected encoder's output for that row's audio.
 
     :param tmp_path: Pytest tmp dir hosting the input and output shards.
@@ -138,8 +135,7 @@ def test_iter_clap_batches_writes_encoder_output_as_clap_column(tmp_path: Path) 
     )
     schema, batches = _read_schema_and_batches(tmp_path / "in.lance")
 
-    out_schema = clap_augmented_schema(schema, _TEST_DIM)
-    out_batches = iter_clap_batches(
+    out_schema, out_batches = clap_augment_split(
         schema, batches, _row_indexed_encoder(_TEST_DIM), _SAMPLE_RATE, dim=_TEST_DIM
     )
     write_lance_file(tmp_path / "out.lance", out_schema, out_batches)
@@ -154,37 +150,47 @@ def test_iter_clap_batches_writes_encoder_output_as_clap_column(tmp_path: Path) 
         np.testing.assert_array_equal(row, expected_row)
 
 
-def test_iter_clap_batches_appends_clap_to_every_input_batch(tmp_path: Path) -> None:
-    """Multi-batch input: each incoming batch is yielded with its own ``clap`` column.
+def test_clap_augment_split_appends_clap_to_every_input_batch(tmp_path: Path) -> None:
+    """Multi-batch input: each incoming batch is yielded with its own ``clap`` values.
 
-    Exercises the ``for batch in batches`` boundary that the single-batch
-    Lance-reader fixtures do not reach.
+    Exercises the per-batch boundary that the single-batch Lance-reader fixtures
+    do not reach, and pins that each batch is encoded from its own audio.
 
-    :param tmp_path: Pytest tmp dir hosting the output shard.
+    :param tmp_path: Pytest tmp dir hosting the seed shard.
     """
     _write_shard(
-        tmp_path / "seed.lance",
-        audio=_constant_audio(1, 2, 4),
+        tmp_path / "a.lance",
+        audio=_constant_audio(1, 2, 4),  # channel mean 1.5
         mel=np.zeros((1, 2, 3), dtype=np.float32),
         params=np.zeros((1, 5), dtype=np.float32),
     )
-    schema, one_batch = _read_schema_and_batches(tmp_path / "seed.lance")
-    two_batches = [one_batch[0], one_batch[0]]
-
-    out_schema = clap_augmented_schema(schema, _TEST_DIM)
-    out_batches = list(
-        iter_clap_batches(
-            schema, two_batches, _row_indexed_encoder(_TEST_DIM), _SAMPLE_RATE, dim=_TEST_DIM
-        )
+    _write_shard(
+        tmp_path / "b.lance",
+        audio=_constant_audio(1, 2, 4) + 2,  # channel mean 3.5
+        mel=np.zeros((1, 2, 3), dtype=np.float32),
+        params=np.zeros((1, 5), dtype=np.float32),
     )
+    schema, batch_a = _read_schema_and_batches(tmp_path / "a.lance")
+    _, batch_b = _read_schema_and_batches(tmp_path / "b.lance")
 
-    assert len(out_batches) == 2
-    for batch in out_batches:
-        assert batch.num_rows == 1
-        assert batch.schema.names == out_schema.names
+    out_schema, out_batches = clap_augment_split(
+        schema,
+        [batch_a[0], batch_b[0]],
+        _row_indexed_encoder(_TEST_DIM),
+        _SAMPLE_RATE,
+        dim=_TEST_DIM,
+    )
+    materialized = list(out_batches)
+
+    assert len(materialized) == 2
+    clap_index = out_schema.get_field_index(CLAP_FIELD)
+    first = materialized[0].column(clap_index).to_pylist()[0]
+    second = materialized[1].column(clap_index).to_pylist()[0]
+    np.testing.assert_array_equal(first, (1.5 + np.arange(_TEST_DIM)).astype(np.float32))
+    np.testing.assert_array_equal(second, (3.5 + np.arange(_TEST_DIM)).astype(np.float32))
 
 
-def test_iter_clap_batches_downmixes_channels_to_mono_before_encoding(tmp_path: Path) -> None:
+def test_clap_augment_split_downmixes_channels_to_mono_before_encoding(tmp_path: Path) -> None:
     """The encoder receives a mono ``(B, T)`` batch averaged across the channel axis.
 
     :param tmp_path: Pytest tmp dir hosting the input shard.
@@ -203,13 +209,18 @@ def test_iter_clap_batches_downmixes_channels_to_mono_before_encoding(tmp_path: 
         seen.append(mono.copy())
         return np.zeros((mono.shape[0], _TEST_DIM), dtype=np.float32)
 
-    list(iter_clap_batches(schema, batches, recording_encode, _SAMPLE_RATE, dim=_TEST_DIM))
+    _, out_batches = clap_augment_split(
+        schema, batches, recording_encode, _SAMPLE_RATE, dim=_TEST_DIM
+    )
+    list(out_batches)
 
+    assert len(seen) == 1
     assert seen[0].shape == (2, 4)
+    assert seen[0].dtype == np.float32
     np.testing.assert_array_equal(seen[0], np.full((2, 4), 1.5, dtype=np.float32))
 
 
-def test_iter_clap_batches_passes_sample_rate_to_encoder(tmp_path: Path) -> None:
+def test_clap_augment_split_passes_sample_rate_to_encoder(tmp_path: Path) -> None:
     """The sample rate threaded into the iterator reaches the encoder unchanged.
 
     :param tmp_path: Pytest tmp dir hosting the input shard.
@@ -227,15 +238,20 @@ def test_iter_clap_batches_passes_sample_rate_to_encoder(tmp_path: Path) -> None
         seen_rates.append(sample_rate)
         return np.zeros((mono.shape[0], _TEST_DIM), dtype=np.float32)
 
-    list(iter_clap_batches(schema, batches, recording_encode, 22050, dim=_TEST_DIM))
+    _, out_batches = clap_augment_split(schema, batches, recording_encode, 22050, dim=_TEST_DIM)
+    list(out_batches)
 
     assert seen_rates == [22050]
 
 
-def test_iter_clap_batches_raises_when_encoder_width_differs_from_dim(tmp_path: Path) -> None:
+@pytest.mark.parametrize("bad_width", [_TEST_DIM - 1, _TEST_DIM + 1])
+def test_clap_augment_split_raises_when_encoder_width_differs_from_dim(
+    tmp_path: Path, bad_width: int
+) -> None:
     """A width guard rejects an encoder whose output dimension is not the declared ``dim``.
 
     :param tmp_path: Pytest tmp dir hosting the input shard.
+    :param bad_width: A wrong embedding width the encoder emits.
     """
     _write_shard(
         tmp_path / "in.lance",
@@ -246,13 +262,16 @@ def test_iter_clap_batches_raises_when_encoder_width_differs_from_dim(tmp_path: 
     schema, batches = _read_schema_and_batches(tmp_path / "in.lance")
 
     def wrong_width_encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:  # noqa: ARG001
-        return np.zeros((mono.shape[0], _TEST_DIM + 1), dtype=np.float32)
+        return np.zeros((mono.shape[0], bad_width), dtype=np.float32)
 
+    _, out_batches = clap_augment_split(
+        schema, batches, wrong_width_encode, _SAMPLE_RATE, dim=_TEST_DIM
+    )
     with pytest.raises(ValueError, match=r"expected \(B, 4\)"):
-        list(iter_clap_batches(schema, batches, wrong_width_encode, _SAMPLE_RATE, dim=_TEST_DIM))
+        list(out_batches)
 
 
-def test_iter_clap_batches_preserves_existing_columns(tmp_path: Path) -> None:
+def test_clap_augment_split_preserves_existing_columns(tmp_path: Path) -> None:
     """Augmentation is additive: the original audio/mel/param rows round-trip unchanged.
 
     :param tmp_path: Pytest tmp dir hosting the input and output shards.
@@ -267,8 +286,7 @@ def test_iter_clap_batches_preserves_existing_columns(tmp_path: Path) -> None:
     )
     schema, batches = _read_schema_and_batches(tmp_path / "in.lance")
 
-    out_schema = clap_augmented_schema(schema, _TEST_DIM)
-    out_batches = iter_clap_batches(
+    out_schema, out_batches = clap_augment_split(
         schema, batches, _row_indexed_encoder(_TEST_DIM), _SAMPLE_RATE, dim=_TEST_DIM
     )
     write_lance_file(tmp_path / "out.lance", out_schema, out_batches)

--- a/tests/pipeline/entrypoints/test_finalize_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_finalize_dataset_unit.py
@@ -597,6 +597,8 @@ def _stub_clap_encoder(monkeypatch: pytest.MonkeyPatch, fill_value: float) -> No
     def fake_encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:  # noqa: ARG001
         return np.full((mono.shape[0], CLAP_EMBEDDING_DIM), fill_value, dtype=np.float32)
 
+    # Patch the source-module attribute, not a finalize_dataset alias: finalize_lance
+    # imports load_clap_audio_encoder lazily from clap_lance at call time.
     monkeypatch.setattr(
         "synth_setter.pipeline.data.clap_lance.load_clap_audio_encoder",
         lambda *args, **kwargs: fake_encode,

--- a/tests/pipeline/entrypoints/test_finalize_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_finalize_dataset_unit.py
@@ -584,7 +584,9 @@ def test_finalize_lance_writes_split_files_stats_and_marker_last(
     )
 
 
-def _stub_clap_encoder(monkeypatch: pytest.MonkeyPatch, fill_value: float) -> None:
+def _stub_clap_encoder(
+    monkeypatch: pytest.MonkeyPatch, fill_value: float, seen_rates: list[int] | None = None
+) -> None:
     """Replace the CLAP model loader with a fake returning constant ``CLAP_EMBEDDING_DIM`` rows.
 
     Keeps the finalize path real (Lance read/encode-loop/write/upload) while faking only the model
@@ -592,9 +594,12 @@ def _stub_clap_encoder(monkeypatch: pytest.MonkeyPatch, fill_value: float) -> No
 
     :param monkeypatch: Pytest fixture used to swap the loader.
     :param fill_value: Constant value every embedding element is set to.
+    :param seen_rates: When given, every sample rate the encoder is called with is appended to it.
     """
 
-    def fake_encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:  # noqa: ARG001
+    def fake_encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+        if seen_rates is not None:
+            seen_rates.append(sample_rate)
         return np.full((mono.shape[0], CLAP_EMBEDDING_DIM), fill_value, dtype=np.float32)
 
     # Patch the source-module attribute, not a finalize_dataset alias: finalize_lance
@@ -605,37 +610,91 @@ def _stub_clap_encoder(monkeypatch: pytest.MonkeyPatch, fill_value: float) -> No
     )
 
 
-def test_finalize_lance_appends_clap_column_when_enabled(
+def test_finalize_lance_appends_clap_column_to_every_split_when_enabled(
     fake_r2_remote: Path,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     stub_finalize_setup: Callable[[int | None], None],  # noqa: ARG001
 ) -> None:
-    """With the flag set, every split row carries the encoder's ``clap`` embedding.
+    """With the flag set, every split's rows carry the encoder's ``clap`` embedding.
 
-    :param fake_r2_remote: Local-typed rclone remote where the shard is seeded.
+    Uses a non-empty val split so a regression that augments only the train split would fail here.
+
+    :param fake_r2_remote: Local-typed rclone remote where the shards are seeded.
     :param tmp_path: Pytest tmp dir hosting finalize scratch files.
     :param monkeypatch: Installs the fake CLAP encoder.
     :param stub_finalize_setup: Fixture-activation only.
     """
     spec = build_lance_smoke_spec(
         task_name="finalize-lance-clap-on",
-        train_val_test_sizes=(4, 0, 0),
+        train_val_test_sizes=(4, 4, 0),
         compute_clap_embeddings=True,
     )
     seed_train_shards(fake_r2_remote, spec)
+    for shard in spec.shards[1:2]:
+        write_minimal_lance_shard(
+            uri_to_local_path(fake_r2_remote, spec.r2.shard_uri(shard)), spec
+        )
     _stub_clap_encoder(monkeypatch, fill_value=0.25)
     work_dir = tmp_path / "work"
     work_dir.mkdir()
 
     finalize_dataset.finalize_from_spec(spec, work_dir)
 
-    train_lance = uri_to_local_path(fake_r2_remote, spec.r2.split_lance_uri("train"))
-    clap_rows = list(iter_lance_column_rows(train_lance, CLAP_FIELD))
-    assert len(clap_rows) == 4
-    for row in clap_rows:
-        assert row.shape == (CLAP_EMBEDDING_DIM,)
-        np.testing.assert_array_equal(row, np.full(CLAP_EMBEDDING_DIM, 0.25, dtype=np.float32))
+    for split in ("train", "val"):
+        split_lance = uri_to_local_path(fake_r2_remote, spec.r2.split_lance_uri(split))
+        clap_rows = list(iter_lance_column_rows(split_lance, CLAP_FIELD))
+        assert len(clap_rows) == 4, split
+        for row in clap_rows:
+            assert row.shape == (CLAP_EMBEDDING_DIM,)
+            np.testing.assert_array_equal(row, np.full(CLAP_EMBEDDING_DIM, 0.25, dtype=np.float32))
+
+
+def test_finalize_lance_encodes_at_the_shard_metadata_sample_rate(
+    fake_r2_remote: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_finalize_setup: Callable[[int | None], None],  # noqa: ARG001
+) -> None:
+    """The encoder is called with the sample rate read from the shard metadata, not a constant.
+
+    Pins the ``read_shard_metadata(schema).sample_rate`` derivation: a regression
+    hardcoding the rate would diverge from the smoke render's value.
+
+    :param fake_r2_remote: Local-typed rclone remote where the shard is seeded.
+    :param tmp_path: Pytest tmp dir hosting finalize scratch files.
+    :param monkeypatch: Installs the rate-recording fake CLAP encoder.
+    :param stub_finalize_setup: Fixture-activation only.
+    """
+    spec = build_lance_smoke_spec(
+        task_name="finalize-lance-clap-rate",
+        train_val_test_sizes=(4, 0, 0),
+        compute_clap_embeddings=True,
+    )
+    seen_rates: list[int] = []
+    seed_train_shards(fake_r2_remote, spec)
+    _stub_clap_encoder(monkeypatch, fill_value=0.0, seen_rates=seen_rates)
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+
+    finalize_dataset.finalize_from_spec(spec, work_dir)
+
+    assert seen_rates == [spec.render.sample_rate]
+
+
+def test_finalize_lance_raises_on_empty_train_split(fake_r2_remote: Path, tmp_path: Path) -> None:
+    """An empty train split surfaces as a clear ValueError before any download.
+
+    :param fake_r2_remote: Local-typed rclone remote — asserted untouched because the guard
+        short-circuits before any I/O.
+    :param tmp_path: Pytest tmp dir used as finalize's local work_dir.
+    """
+    spec = build_lance_smoke_spec(task_name="empty-train-lance", train_val_test_sizes=(0, 4, 0))
+
+    with pytest.raises(ValueError, match="train split is empty"):
+        finalize_dataset.finalize_lance(spec, tmp_path)
+
+    assert [p for p in fake_r2_remote.rglob("*") if p.is_file()] == []
 
 
 def test_finalize_lance_omits_clap_column_by_default(

--- a/tests/pipeline/entrypoints/test_finalize_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_finalize_dataset_unit.py
@@ -26,9 +26,12 @@ from unittest.mock import MagicMock
 import h5py
 import numpy as np
 import pytest
+from lance.file import LanceFileReader
 
 from synth_setter.cli import finalize_dataset
+from synth_setter.data.vst.shapes import CLAP_EMBEDDING_DIM, CLAP_FIELD
 from synth_setter.pipeline import r2_io
+from synth_setter.pipeline.data.lance_shard import iter_lance_column_rows
 from synth_setter.pipeline.data.stats import get_stats_hdf5 as real_get_stats_hdf5
 from synth_setter.pipeline.data.stats import stream_stats_wds as real_stream_stats_wds
 from tests.helpers.finalize_shards import (
@@ -579,6 +582,93 @@ def test_finalize_lance_writes_split_files_stats_and_marker_last(
     assert upload_order.index(spec.r2.stats_uri()) < upload_order.index(
         spec.r2.dataset_complete_marker_uri()
     )
+
+
+def _stub_clap_encoder(monkeypatch: pytest.MonkeyPatch, fill_value: float) -> None:
+    """Replace the CLAP model loader with a fake returning constant ``CLAP_EMBEDDING_DIM`` rows.
+
+    Keeps the finalize path real (Lance read/encode-loop/write/upload) while faking only the model
+    boundary, so the test needs no checkpoint download.
+
+    :param monkeypatch: Pytest fixture used to swap the loader.
+    :param fill_value: Constant value every embedding element is set to.
+    """
+
+    def fake_encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:  # noqa: ARG001
+        return np.full((mono.shape[0], CLAP_EMBEDDING_DIM), fill_value, dtype=np.float32)
+
+    monkeypatch.setattr(
+        "synth_setter.pipeline.data.clap_lance.load_clap_audio_encoder",
+        lambda *args, **kwargs: fake_encode,
+    )
+
+
+def test_finalize_lance_appends_clap_column_when_enabled(
+    fake_r2_remote: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_finalize_setup: Callable[[int | None], None],  # noqa: ARG001
+) -> None:
+    """With the flag set, every split row carries the encoder's ``clap`` embedding.
+
+    :param fake_r2_remote: Local-typed rclone remote where the shard is seeded.
+    :param tmp_path: Pytest tmp dir hosting finalize scratch files.
+    :param monkeypatch: Installs the fake CLAP encoder.
+    :param stub_finalize_setup: Fixture-activation only.
+    """
+    spec = build_lance_smoke_spec(
+        task_name="finalize-lance-clap-on",
+        train_val_test_sizes=(4, 0, 0),
+        compute_clap_embeddings=True,
+    )
+    seed_train_shards(fake_r2_remote, spec)
+    _stub_clap_encoder(monkeypatch, fill_value=0.25)
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+
+    finalize_dataset.finalize_from_spec(spec, work_dir)
+
+    train_lance = uri_to_local_path(fake_r2_remote, spec.r2.split_lance_uri("train"))
+    clap_rows = list(iter_lance_column_rows(train_lance, CLAP_FIELD))
+    assert len(clap_rows) == 4
+    for row in clap_rows:
+        assert row.shape == (CLAP_EMBEDDING_DIM,)
+        np.testing.assert_array_equal(row, np.full(CLAP_EMBEDDING_DIM, 0.25, dtype=np.float32))
+
+
+def test_finalize_lance_omits_clap_column_by_default(
+    fake_r2_remote: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_finalize_setup: Callable[[int | None], None],  # noqa: ARG001
+) -> None:
+    """The default (flag off) preserves the legacy schema — no ``clap`` column, no model load.
+
+    :param fake_r2_remote: Local-typed rclone remote where the shard is seeded.
+    :param tmp_path: Pytest tmp dir hosting finalize scratch files.
+    :param monkeypatch: Installs a loader that fails if finalize touches the model boundary.
+    :param stub_finalize_setup: Fixture-activation only.
+    """
+    spec = build_lance_smoke_spec(
+        task_name="finalize-lance-clap-off",
+        train_val_test_sizes=(4, 0, 0),
+    )
+    seed_train_shards(fake_r2_remote, spec)
+
+    def fail_if_loaded(*args: object, **kwargs: object) -> NoReturn:
+        raise AssertionError("CLAP encoder loaded despite compute_clap_embeddings=False")
+
+    monkeypatch.setattr(
+        "synth_setter.pipeline.data.clap_lance.load_clap_audio_encoder", fail_if_loaded
+    )
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+
+    finalize_dataset.finalize_from_spec(spec, work_dir)
+
+    train_lance = uri_to_local_path(fake_r2_remote, spec.r2.split_lance_uri("train"))
+    reader = LanceFileReader(str(train_lance))
+    assert CLAP_FIELD not in reader.metadata().schema.names
 
 
 def test_finalize_wds_raises_on_empty_train_split(fake_r2_remote: Path, tmp_path: Path) -> None:

--- a/tests/pipeline/schemas/test_dataset_spec.py
+++ b/tests/pipeline/schemas/test_dataset_spec.py
@@ -1190,17 +1190,23 @@ class TestCopyDatasetRootUri:
         assert spec.compute_clap_embeddings is False
 
     def test_compute_clap_embeddings_with_lance_constructs(self) -> None:
-        """``compute_clap_embeddings=True`` is accepted on a lance spec."""
+        """Lance is the one output the CLAP flag is allowed on, so the spec builds."""
         spec = DatasetSpec(
             **_valid_spec_kwargs(output_format="lance", compute_clap_embeddings=True)
         )
 
         assert spec.compute_clap_embeddings is True
 
-    def test_compute_clap_embeddings_with_hdf5_is_rejected(self) -> None:
-        """CLAP embeddings are a Lance-only finalize step; pairing with hdf5 fails at build."""
+    @pytest.mark.parametrize("output_format", ["hdf5", "wds"])
+    def test_compute_clap_embeddings_with_non_lance_is_rejected(self, output_format: str) -> None:
+        """CLAP embeddings are a Lance-only finalize step; any non-lance output fails at build.
+
+        :param output_format: A non-lance output the flag must be rejected against.
+        """
         with pytest.raises(ValidationError, match="output_format='lance' only"):
-            DatasetSpec(**_valid_spec_kwargs(output_format="hdf5", compute_clap_embeddings=True))
+            DatasetSpec(
+                **_valid_spec_kwargs(output_format=output_format, compute_clap_embeddings=True)
+            )
 
     def test_compute_clap_embeddings_survives_json_round_trip(self) -> None:
         """A worker reconstructing the spec from JSON sees the same CLAP flag."""

--- a/tests/pipeline/schemas/test_dataset_spec.py
+++ b/tests/pipeline/schemas/test_dataset_spec.py
@@ -1183,6 +1183,35 @@ class TestCopyDatasetRootUri:
 
         assert restored.copy_dataset_root_uri == spec.copy_dataset_root_uri
 
+    def test_compute_clap_embeddings_defaults_to_false(self) -> None:
+        """The flag is opt-in, so a spec that omits it does not request CLAP embeddings."""
+        spec = DatasetSpec(**_valid_spec_kwargs(output_format="lance"))
+
+        assert spec.compute_clap_embeddings is False
+
+    def test_compute_clap_embeddings_with_lance_constructs(self) -> None:
+        """``compute_clap_embeddings=True`` is accepted on a lance spec."""
+        spec = DatasetSpec(
+            **_valid_spec_kwargs(output_format="lance", compute_clap_embeddings=True)
+        )
+
+        assert spec.compute_clap_embeddings is True
+
+    def test_compute_clap_embeddings_with_hdf5_is_rejected(self) -> None:
+        """CLAP embeddings are a Lance-only finalize step; pairing with hdf5 fails at build."""
+        with pytest.raises(ValidationError, match="output_format='lance' only"):
+            DatasetSpec(**_valid_spec_kwargs(output_format="hdf5", compute_clap_embeddings=True))
+
+    def test_compute_clap_embeddings_survives_json_round_trip(self) -> None:
+        """A worker reconstructing the spec from JSON sees the same CLAP flag."""
+        spec = DatasetSpec(
+            **_valid_spec_kwargs(output_format="lance", compute_clap_embeddings=True)
+        )
+
+        restored = DatasetSpec.model_validate_json(spec.model_dump_json())
+
+        assert restored.compute_clap_embeddings is True
+
     def test_legacy_flat_copy_dataset_root_is_promoted(self) -> None:
         """A pre-rename flat ``copy_dataset_root`` promotes to ``copy_dataset_root_uri``."""
         spec = DatasetSpec(**_valid_spec_kwargs(copy_dataset_root="/data/source-dataset"))

--- a/tests/test_finalize_dataset.py
+++ b/tests/test_finalize_dataset.py
@@ -37,16 +37,20 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import NoReturn, cast
 
+import numpy as np
 import pytest
 import wandb
 from omegaconf import DictConfig, OmegaConf
 
 from synth_setter.cli import finalize_dataset
+from synth_setter.data.vst.shapes import CLAP_EMBEDDING_DIM, CLAP_FIELD
 from synth_setter.pipeline import r2_io
+from synth_setter.pipeline.data.lance_shard import iter_lance_column_rows
 from synth_setter.pipeline.schemas.spec import DatasetSpec
 from tests.helpers.finalize_shards import (
     build_finalize_cfg,
     build_hdf5_smoke_spec,
+    build_lance_smoke_spec,
     build_wds_smoke_spec,
     copy_shard_for_download,
     install_finalize_setup_stubs,
@@ -592,3 +596,50 @@ def test_finalize_forces_wandb_resume_allow_when_wandb_cfg_present(
 
     assert OmegaConf.select(cfg, "logger.wandb.resume") == "allow"
     assert OmegaConf.select(captured_logger_cfg["cfg"], "wandb.resume") == "allow"
+
+
+def test_finalize_lance_entrypoint_writes_clap_column_when_enabled(
+    tmp_path: Path,
+    fake_r2_remote: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    stub_finalize_setup: Callable[[int | None], None],  # noqa: ARG001 — installs stubs only
+) -> None:
+    """``finalize(cfg)`` end-to-end appends the ``clap`` column to the uploaded Lance split.
+
+    Drives the real entrypoint (cfg compose → spec load → lance dispatch → real
+    rclone upload) with ``compute_clap_embeddings=True``, stubbing only the CLAP
+    model loader so no checkpoint download is needed, and reads the ``clap`` column
+    back from the materialized ``train.lance``.
+
+    :param tmp_path: Hosts the on-disk spec JSON + Hydra-style output_dir.
+    :param fake_r2_remote: Local-typed rclone remote; the seeded shard + split land here.
+    :param monkeypatch: Installs the fake CLAP encoder at the source-module attribute.
+    :param stub_finalize_setup: Installs the auth + marker-probe stubs.
+    """
+
+    def fake_encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:  # noqa: ARG001
+        return np.full((mono.shape[0], CLAP_EMBEDDING_DIM), 0.5, dtype=np.float32)
+
+    monkeypatch.setattr(
+        "synth_setter.pipeline.data.clap_lance.load_clap_audio_encoder",
+        lambda *args, **kwargs: fake_encode,
+    )
+
+    spec = build_lance_smoke_spec(
+        task_name="finalize-lance-clap-entrypoint",
+        train_val_test_sizes=(4, 0, 0),
+        compute_clap_embeddings=True,
+    )
+    seed_train_shards(fake_r2_remote, spec)
+    output_dir = tmp_path / "hydra_output"
+    output_dir.mkdir()
+    cfg = build_finalize_cfg(write_spec_to_root(spec, tmp_path), output_dir)
+
+    finalize_dataset.finalize(cfg)
+
+    train_lance = uri_to_local_path(fake_r2_remote, spec.r2.split_lance_uri("train"))
+    clap_rows = list(iter_lance_column_rows(train_lance, CLAP_FIELD))
+    assert len(clap_rows) == 4
+    for row in clap_rows:
+        assert row.shape == (CLAP_EMBEDDING_DIM,)
+        np.testing.assert_array_equal(row, np.full(CLAP_EMBEDDING_DIM, 0.5, dtype=np.float32))

--- a/uv.lock
+++ b/uv.lock
@@ -2210,6 +2210,30 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -2271,6 +2295,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
 ]
 
 [[package]]
@@ -5326,6 +5370,95 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/ed/0ad2c8edf634918eb4484365d3819fa7bd7f58daf807fe7fb21812c316e5/regex-2026.5.9-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a9e1328e17c84c1a5d22ec9f785ecef4a967fab9a42b6a8dc3bcbebd0a0c9e44", size = 489438, upload-time = "2026-05-09T23:11:29.374Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a9/4ed972ad263963b860b7c3e86e0e1bcc791def47b43b8c8efe57e710f139/regex-2026.5.9-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bfe1ce50cbfb569d74e1e4337da6468961f31dbea55fd85aa5de59c0947a805a", size = 291270, upload-time = "2026-05-09T23:11:33.254Z" },
+    { url = "https://files.pythonhosted.org/packages/16/81/075930d9fa28c4ea1f53398dd015ee7c882f623539759113cda1257f4b82/regex-2026.5.9-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:15ee42209947f4ca045412eae98416317238163618ace2a8e54f99586a466733", size = 289198, upload-time = "2026-05-09T23:11:35.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/c8/5cdfbf0b5dc6599e1b6131eff43262e5275d4ec3469ce10216061659aadb/regex-2026.5.9-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4bb445ff3f725f59df8f6014edb547ee928ec7023a774f6a39a3f953038cbb2", size = 784765, upload-time = "2026-05-09T23:11:37.689Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ca/ae5fd6edc59b7f84b904b31d6ec39a860cbcecd10f64bd5a062ca83a4864/regex-2026.5.9-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:446ddd671e43ab535810c4b21cff7104945c701d4a14d1e6d1cd6f4e445a8bea", size = 852115, upload-time = "2026-05-09T23:11:39.973Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/ce/a91cf555afb51f3b74a182e24ba073b91ea7bb64592fc4b315c111bb19fd/regex-2026.5.9-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b92817338591505f282cf3864c145244b1edcf5381d237038df955001091538", size = 899503, upload-time = "2026-05-09T23:11:42.48Z" },
+    { url = "https://files.pythonhosted.org/packages/55/7f/725a0a2b245a4cf0c4bab29d0e97c74285d94136a65d1b55a6459a583502/regex-2026.5.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6b8a143aca6c39b446ea8092cde25cc8fe9304d4f5fecfbc1a9dbb0282703c2", size = 794093, upload-time = "2026-05-09T23:11:44.681Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/2a/996efbd59ce6b5d4a09e3af6180ceb62af171f4a9a6fb557d2f0ae0d462b/regex-2026.5.9-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0f03aa6898aaaac4592479821df16e68e8d0e29e903e65d8f2dfb2f19028a989", size = 786234, upload-time = "2026-05-09T23:11:46.882Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/0a/8731e8b8806174c9cdd5903f80a14990331c1f42fc4209b540952e9e010d/regex-2026.5.9-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ed457d8e98ae812ed7732bef7bf78de78e834eae0372a74e23ca90ef21d910f9", size = 769895, upload-time = "2026-05-09T23:11:49.324Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/0b/932473194bd563f342a412ae2ffbbd6da608306a2bc4e99249a41c2b0b92/regex-2026.5.9-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:71b61c5bfe1c806332defc42ad6c780b3c55f661986d7f40283a3a88274b4c00", size = 774991, upload-time = "2026-05-09T23:11:51.261Z" },
+    { url = "https://files.pythonhosted.org/packages/98/80/9523d196010031df25f7177ee0a467efbee436324038e5d99def17a57515/regex-2026.5.9-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:3b1e39888c5e0c7d92cea4fc777396c4a90363b05de75d02eb459a4752200808", size = 848790, upload-time = "2026-05-09T23:11:53.232Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/07/56987b35e89edf47e4a38cf2845aeee476bfa688a6bdbd3e820cda461dc1/regex-2026.5.9-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:6ba42b2e7e7f46cf68cc6a5ca36fa07959f9bbd9c6bdcc47b6ee76549a590248", size = 757679, upload-time = "2026-05-09T23:11:55.82Z" },
+    { url = "https://files.pythonhosted.org/packages/04/2a/ff713fff0c566507c06a4ce2dc0ae8e7eeebc88811a95fc81cf1e7d534dd/regex-2026.5.9-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:c010eb8caca74bdb40c07498d7ece26b4428fd3f04aa8a72c9ac6f79e8faaac6", size = 837116, upload-time = "2026-05-09T23:11:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/77/90/df6d982b03e3614785c6937ba51b57f6733d97d2ee1c9bc7531dbfab3a54/regex-2026.5.9-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a6a563446a41adc451393dc6b8e6ad87979efaee3c8738690a8d1b08ebead1b4", size = 782081, upload-time = "2026-05-09T23:11:59.607Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/8a/4e88a5f7c3e98489aac4dd23142723d907b2a595b4a6abcbacabefeded09/regex-2026.5.9-cp310-cp310-win32.whl", hash = "sha256:954cc214c04663ee6d266fc61739cad83054683048de65c5bd1d640ad28098ac", size = 266247, upload-time = "2026-05-09T23:12:01.116Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/40/4b224cb0582b2dca1786726e6cdabe26abbf757d7f6718332f186da155d2/regex-2026.5.9-cp310-cp310-win_amd64.whl", hash = "sha256:b310768746dd314ea6e2ff4cc89ef215426813396ff4e94ee8e6f7096c8b6e03", size = 278416, upload-time = "2026-05-09T23:12:03.2Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4d/014fbe803204cab0947ee428f09f658a29632053dde1d3c6176bb4f0fd4c/regex-2026.5.9-cp310-cp310-win_arm64.whl", hash = "sha256:19c16ceb4a267a8789e25733e583983eeab9f0f8664e66b0bd1c5d21f14c2d4b", size = 270413, upload-time = "2026-05-09T23:12:04.649Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/dc/c1f2df4027e82fc54b5a473e4b250f5139faca49a0fbe29a48668d228f34/regex-2026.5.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccf5249114cc3e772ecdd88a98a86eca0fd74c61ce32a94743758c083fc05d48", size = 489445, upload-time = "2026-05-09T23:12:06.111Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/59f01110660081cce9c0bc30ebd0b5ee250dacf658e3248ed92f01e0e8ee/regex-2026.5.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46f1326ca6e65b0879d23ca302c0f2415aad42ff0309b9c818e7949fe19a41d8", size = 291271, upload-time = "2026-05-09T23:12:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b6/14b2c84ff90ddb370c81d27503f4a0fcf071496416f4855f6cc8c5d81c35/regex-2026.5.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef31cbfe458e21c6122ba8150ff060e0c7789ed0d26eb423f25472584920b555", size = 289212, upload-time = "2026-05-09T23:12:09.266Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d0/4db86529117320de0c84afd90e70bb47434625875e34fcef9d8c127c5b16/regex-2026.5.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:992604d02e6d9c6d786c24a706a71ecffe1020fc1ef264044474cd81fa2c3919", size = 792310, upload-time = "2026-05-09T23:12:11.416Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/fe4800cd322f862ecffd2d553409b20d80650e5ed71b9d178f853d020b82/regex-2026.5.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9411dd64ca95477225734a93dfc8583b51916b8d5942f99d6cac21e09965451", size = 861721, upload-time = "2026-05-09T23:12:13.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d0/b3618a895dd8feb897c61bb2954edd265e1767d82a01d53065d5871127a3/regex-2026.5.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4a3ff360dfb836fecdb93a4598f9d6e2ac81e3e397125145c6221bf58cf4c", size = 906460, upload-time = "2026-05-09T23:12:15.443Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6f/1481597e859ef19508b345eec4afd1416ed6e6b459c75a64026ef193aecf/regex-2026.5.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a661a7d270a61f7cf460caee8b9fa2d5ef9e5c681234bcb9e0fe14f488e7dfc", size = 799843, upload-time = "2026-05-09T23:12:16.892Z" },
+    { url = "https://files.pythonhosted.org/packages/73/59/955734c803f59108deccba3597ae440c76b62a652733c0006e6243758420/regex-2026.5.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f079e50a0d3cc3cd5091fa9ff45869a2e6b2cd35895731edafb0327901a8d86d", size = 773610, upload-time = "2026-05-09T23:12:19.127Z" },
+    { url = "https://files.pythonhosted.org/packages/68/8f/70c04a236d651c81881dac42ef8538bddda6121434509d0a22d9e601503b/regex-2026.5.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4ebe8f0b5ec5a5024dc4a4c59f444c4e9afc5f2abdbb8962065b75d27fb971f9", size = 781645, upload-time = "2026-05-09T23:12:20.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/96/05c7434d88185e5d27fe54aeb74df86bd77cd79f52f0b4eae54faa8fea70/regex-2026.5.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:97cf3bc1b7d7d2306772ec07366c80d9df00ff79e79cea32898883a646d2fae2", size = 854473, upload-time = "2026-05-09T23:12:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/6e3d8202d981f3117004bf341ee74893ba4ba8a9fbaf4b94615846550a08/regex-2026.5.9-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0f9eede6a5cbdc02d4978090186390936e1776a7d1359b21e41014c609880bcf", size = 763311, upload-time = "2026-05-09T23:12:24.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c7/e7737f1526b3fb32bd4c337fd6c71c3ebb5c8296fc34d11197e0955d2e35/regex-2026.5.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:01f0f5f55f4b64dacec85dc116d3c05fd23ad3ff037bbc73a2085775953c2611", size = 844593, upload-time = "2026-05-09T23:12:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/0daffb1a535bb39f422c3d200f4ab023c71110ad66a32b366bee708baba0/regex-2026.5.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1268eddd8486dc561d08eee1156e40aa3a8fe10f4bdec8fa653b455fcbffd12c", size = 789167, upload-time = "2026-05-09T23:12:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fc/294fe4fac4f2ed67207b17471815870c1c45b3a489e08e0ac96daea16ef6/regex-2026.5.9-cp311-cp311-win32.whl", hash = "sha256:8676474c07469d6f33dd1085ca2cd45f65785f32518f2b20e36d9953ca07f994", size = 266249, upload-time = "2026-05-09T23:12:30.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b0/8dce459f6245bcf8f6e9f23ac9569f1a0f15c131cc0745e82b43226204cf/regex-2026.5.9-cp311-cp311-win_amd64.whl", hash = "sha256:246de9d60aa3f8538b519834dd95cbf276ea263d6a7bd5a3666dc3fa0230505b", size = 278423, upload-time = "2026-05-09T23:12:31.676Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/f9aeff6ad63a3ef720386f2907e6d34a35a510a6e498ebad28b0fb3f6ab6/regex-2026.5.9-cp311-cp311-win_arm64.whl", hash = "sha256:d726ca3f0d76969bf1e8e477d160d3d666bbf999f6860bd314889e5345782046", size = 270420, upload-time = "2026-05-09T23:12:33.194Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -5755,6 +5888,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
 ]
 
 [[package]]
@@ -6320,7 +6477,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.33.0"
+version = "8.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },
@@ -6442,6 +6599,7 @@ dev = [
     { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "transformers" },
     { name = "wandb" },
     { name = "webdataset" },
 ]
@@ -6506,6 +6664,7 @@ runtime = [
     { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "transformers" },
     { name = "wandb" },
     { name = "webdataset" },
 ]
@@ -6521,6 +6680,7 @@ torch = [
     { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "transformers" },
 ]
 util = [
     { name = "click" },
@@ -6643,6 +6803,7 @@ dev = [
     { name = "torchaudio", specifier = ">=2.0.0" },
     { name = "torchmetrics", specifier = ">=0.11.4" },
     { name = "torchvision", specifier = ">=0.15.0" },
+    { name = "transformers", specifier = ">=4.40.0" },
     { name = "wandb" },
     { name = "webdataset" },
 ]
@@ -6700,6 +6861,7 @@ runtime = [
     { name = "torchaudio", specifier = ">=2.0.0" },
     { name = "torchmetrics", specifier = ">=0.11.4" },
     { name = "torchvision", specifier = ">=0.15.0" },
+    { name = "transformers", specifier = ">=4.40.0" },
     { name = "wandb" },
     { name = "webdataset" },
 ]
@@ -6709,6 +6871,7 @@ torch = [
     { name = "torchaudio", specifier = ">=2.0.0" },
     { name = "torchmetrics", specifier = ">=0.11.4" },
     { name = "torchvision", specifier = ">=0.15.0" },
+    { name = "transformers", specifier = ">=4.40.0" },
 ]
 util = [
     { name = "click", specifier = "<8.2" },
@@ -6804,6 +6967,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
+    { url = "https://files.pythonhosted.org/packages/84/04/655b79dbcc9b3ac5f1479f18e931a344af67e5b7d3b251d2dcdcd7558592/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:753d47ebd4542742ef9261d9da92cd545b2cacbb48349a1225466745bb866ec4", size = 3282301, upload-time = "2026-01-05T10:40:34.858Z" },
+    { url = "https://files.pythonhosted.org/packages/46/cd/e4851401f3d8f6f45d8480262ab6a5c8cb9c4302a790a35aa14eeed6d2fd/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e10bf9113d209be7cd046d40fbabbaf3278ff6d18eb4da4c500443185dc1896c", size = 3161308, upload-time = "2026-01-05T10:40:40.737Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6e/55553992a89982cd12d4a66dddb5e02126c58677ea3931efcbe601d419db/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64d94e84f6660764e64e7e0b22baa72f6cd942279fdbb21d46abd70d179f0195", size = 3718964, upload-time = "2026-01-05T10:40:46.56Z" },
+    { url = "https://files.pythonhosted.org/packages/59/8c/b1c87148aa15e099243ec9f0cf9d0e970cc2234c3257d558c25a2c5304e6/tokenizers-0.22.2-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f01a9c019878532f98927d2bacb79bbb404b43d3437455522a00a30718cdedb5", size = 3373542, upload-time = "2026-01-05T10:40:52.803Z" },
 ]
 
 [[package]]
@@ -7281,6 +7474,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/c1/bd361c24a76e7c0d137e299ca1e86bbe188e4c08e3e46674a285aa762051/tqdm_loggable-0.4.1.tar.gz", hash = "sha256:49123ffcb2deb948edb7121d7e09a6008914e0d0333154f060e435deba9e547a", size = 8170, upload-time = "2026-03-16T18:38:50.774Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/24/303708f276f2a81bd0551f5e93b5dd51201ca0d73aed0dc50be6976a3443/tqdm_loggable-0.4.1-py3-none-any.whl", hash = "sha256:e3b394a6fc85a1b1b0dad52a63ac926ecb3b478acf4f4bae570d9189f00ab91d", size = 10527, upload-time = "2026-03-16T18:38:49.808Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/f9/4552e2ba55db1c943aea0d4c09a32e9cbe5445b9eabe9856900de503dc8f/transformers-5.12.0.tar.gz", hash = "sha256:f0cf42ae1464c2eb41e7e0e66d7fd4b66145f48af17093b4cc0b2e9781faa7f4", size = 8923020, upload-time = "2026-06-12T14:39:20.43Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/1f/d385913c38e900d23b728a4188fee625f2fccb306aeebc59be9d91404a5a/transformers-5.12.0-py3-none-any.whl", hash = "sha256:500be9eb644ede81c3103eee7687fc36d05dd75d1c76686c3820b26396fe7c7c", size = 11150246, upload-time = "2026-06-12T14:39:17.009Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds an **opt-in finalize step that writes a 512-d LAION-CLAP audio-embedding column into each `{train,val,test}.lance` split file**, so downstream sound-matching / preset-exploration work can condition on a pretrained audio embedding space. This is the Lance-native counterpart of the h5/wds producer tracked in #1570.

- **New flag** `DatasetSpec.compute_clap_embeddings` (default `False`, **lance-only** — a validator rejects it for hdf5/wds). It serializes into `input_spec.json`, so enabling it is a generate-side config override that finalize reads.
- **New module** `pipeline/data/clap_lance.py` — a functional core that maps a split's `(schema, batches)` to the same stream with a trailing `clap` column:
  - `clap_augmented_schema` appends the `(512,)` float32 tensor field (metadata preserved).
  - `clap_augment_split` / `_iter_clap_record_batches` read each batch's `audio`, downmix to mono (float16→float32), run an **injected** encoder, and guard the output shape to exactly `(num_rows, dim)`.
  - `load_clap_audio_encoder` is the thin shell that builds the real encoder behind a lazy `transformers` import (HF `ClapModel`, resample to CLAP's 48 kHz).
- **`finalize_lance`** loads the encoder once (only when the flag is set) and threads each split's batches through it as the split files are written. When the flag is off, the schema and behavior are byte-for-byte unchanged.
- `transformers>=4.40.0` added to the `torch` dependency group (locked at 5.12.0).

### Why a side column on the split file

The `clap` field lives on the finalized split files (which the datamodule opens directly) rather than the shards: the resharder's virtual layout only carries the core `DATASET_FIELD_NAMES`, and the embedding is additive, so existing Lance readers that project specific columns are unaffected.

## Out of scope (follow-ups)

- Wiring the `clap` column into datamodules / training.
- Text embeddings (audio only).
- A `clap_checkpoint` config field — the checkpoint is a pinned constant, reproducible via the spec's `git_sha`; declined as YAGNI for now.

## Test plan

- `uv run pytest tests/pipeline/data/test_clap_lance.py tests/pipeline/entrypoints/test_finalize_dataset_unit.py tests/pipeline/schemas/test_dataset_spec.py tests/test_finalize_dataset.py` → all green.
- Functional core exercised end-to-end against **real Lance I/O** with an injected fake encoder (no model download): schema append + metadata preservation, mono downmix, sample-rate passthrough, width **and** row-count guards, multi-batch, additive round-trip.
- Finalize branch: flag-on appends `clap` to **every** split (train + val), flag-off loads no model and leaves the legacy schema, the encoder is called at the **shard-metadata sample rate**, and the empty-train guard raises. An e2e leg drives the real `finalize(cfg)` entrypoint and reads the `clap` column back from the uploaded `train.lance`.
- `make format` clean (ruff, ruff-format, pyright, pydoclint, docformatter, codespell, …).

## Verification — real CLAP encoder (manual; needs a model download)

`load_clap_audio_encoder` is the one path not covered by automated tests (checkpoint download + GPU). Manual check:

```bash
uv run python -c "
import numpy as np
from synth_setter.pipeline.data.clap_lance import load_clap_audio_encoder
enc = load_clap_audio_encoder()
out = enc(np.zeros((2, 48000), dtype=np.float32), 48000)
print(out.shape, out.dtype)  # expect (2, 512) float32
"
```

End-to-end against a small finalized Lance dataset: set `compute_clap_embeddings=true` on the generate config, run `synth-setter-finalize-dataset`, and confirm `train.lance` carries a `clap` column.

Closes #1683
