### PR TITLE
refactor(data-pipeline): decode Lance tensors via pyarrow built-in

### DIFF
--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -113,7 +113,7 @@ docs:
       - pattern: "src/synth_setter/data/vst/shapes.py"
         covers: "Shared shape primitives consumed by the writers, the shard validator, and the test shard seeders — DATASET_FIELD_NAMES / DATASET_FIELD_DTYPES, mel-front-end constants, per-field shape helpers, and dataset_field_shapes (the single field→shape contract)."
       - pattern: "src/synth_setter/pipeline/data/lance_shard.py"
-        covers: "Lance single-file shard codec — lance_schema / tensor_array / record_batch_from_arrays / write_lance_file on the encode side, read_shard_metadata / tensor_chunk_to_numpy / iter_lance_column_rows on the decode side; shared by the Lance writer, validator, and finalize."
+        covers: "Lance single-file shard codec — lance_schema / tensor_array / record_batch_from_arrays / write_lance_file on the encode side, read_shard_metadata / iter_lance_column_rows on the decode side; shared by the Lance writer, validator, and finalize."
 
   # ── SkyPilot compute integration design doc ─────────────────────
   - doc: docs/design/skypilot-compute-integration.md

--- a/src/synth_setter/data/lance_datamodule.py
+++ b/src/synth_setter/data/lance_datamodule.py
@@ -19,7 +19,6 @@ import pyarrow as pa
 from lance.file import LanceFileReader
 
 from synth_setter.data.surge_datamodule import VSTDataModule, VSTDataset
-from synth_setter.pipeline.data.lance_shard import tensor_chunk_to_numpy
 
 
 class LanceColumn:
@@ -34,6 +33,8 @@ class LanceColumn:
         """
         self._shard = shard
         self._name = name
+        # Backs the h5py-like ``shape`` property; decode reads the shape from
+        # Arrow's tensor type, so reads don't consult this.
         self._inner_shape = inner_shape
 
     @property
@@ -72,7 +73,7 @@ class LanceColumn:
                 raise ValueError(f"fancy indices must be in ascending order, got {indices}")
             results = reader.take_rows(indices)
         chunk = results.to_table().column(self._name).combine_chunks()
-        array = tensor_chunk_to_numpy(chunk, self._inner_shape)
+        array = chunk.to_numpy_ndarray()
         # Copy out of Arrow's read-only buffer: h5py reads return writable arrays,
         # and torch.from_numpy over a read-only view is undefined behavior on write.
         return array if array.flags.writeable else array.copy()

--- a/src/synth_setter/pipeline/data/lance_shard.py
+++ b/src/synth_setter/pipeline/data/lance_shard.py
@@ -48,11 +48,15 @@ def tensor_array(values: np.ndarray, dtype: np.dtype, inner_shape: tuple[int, ..
     :param dtype: Scalar dtype the values are cast to — the column's on-disk type.
     :param inner_shape: Schema per-row tensor shape, without the leading row axis.
     :returns: Arrow extension array compatible with :func:`lance_schema`.
-    :raises ValueError: ``values`` is not shaped ``(N, *inner_shape)`` for some ``N >= 1``.
+    :raises ValueError: ``values`` inner axes differ from ``inner_shape``, or the batch is empty.
     """
     rows = np.ascontiguousarray(values, dtype=dtype)
     if rows.shape[1:] != inner_shape:
         raise ValueError(f"tensor rows have inner shape {rows.shape[1:]}, expected {inner_shape}")
+    # Enforce N >= 1 with a clear message; the extension builder otherwise
+    # rejects an empty batch with an opaque "non-empty ndarray" error.
+    if rows.shape[0] == 0:
+        raise ValueError(f"expected a non-empty batch of {inner_shape} tensors, got 0 rows")
     return pa.FixedShapeTensorArray.from_numpy_ndarray(rows)
 
 

--- a/src/synth_setter/pipeline/data/lance_shard.py
+++ b/src/synth_setter/pipeline/data/lance_shard.py
@@ -25,7 +25,6 @@ def lance_schema(
     :param field_shapes: Full writer shapes including the leading row axis.
     :param metadata: Per-shard render metadata to embed in schema metadata.
     :returns: Arrow schema with fixed-shape tensor columns and shard metadata.
-    :rtype: pa.Schema
     """
     fields = []
     for field in DATASET_FIELD_NAMES:
@@ -44,19 +43,17 @@ def lance_schema(
 def tensor_array(values: np.ndarray, dtype: np.dtype, inner_shape: tuple[int, ...]) -> pa.Array:
     """Encode an ``(N, *inner_shape)`` ndarray as an Arrow fixed-shape tensor array.
 
-    :param values: Batch values with a leading row axis.
-    :param dtype: On-disk scalar dtype for the tensor values.
-    :param inner_shape: Per-row tensor shape, excluding the leading row axis.
+    :param values: Rows to encode; cast to ``dtype`` and required to have shape
+        ``(N, *inner_shape)`` with ``N >= 1`` (the leading axis is the row axis).
+    :param dtype: Scalar dtype the values are cast to — the column's on-disk type.
+    :param inner_shape: Schema per-row tensor shape, without the leading row axis.
     :returns: Arrow extension array compatible with :func:`lance_schema`.
-    :rtype: pa.Array
-    :raises ValueError: ``values`` has an inner shape different from ``inner_shape``.
+    :raises ValueError: ``values`` is not shaped ``(N, *inner_shape)`` for some ``N >= 1``.
     """
-    rows = np.asarray(values, dtype=dtype)
-    if rows.ndim == len(inner_shape):
-        rows = rows.reshape((1, *inner_shape))
+    rows = np.ascontiguousarray(values, dtype=dtype)
     if rows.shape[1:] != inner_shape:
         raise ValueError(f"tensor rows have inner shape {rows.shape[1:]}, expected {inner_shape}")
-    return pa.FixedShapeTensorArray.from_numpy_ndarray(np.ascontiguousarray(rows))
+    return pa.FixedShapeTensorArray.from_numpy_ndarray(rows)
 
 
 def record_batch_from_arrays(
@@ -68,22 +65,20 @@ def record_batch_from_arrays(
     :param arrays: Mapping with one ``(N, *inner)`` array per dataset field.
     :param schema: Schema returned by :func:`lance_schema`.
     :returns: Arrow record batch ready for ``LanceFileWriter.write_batch``.
-    :rtype: pa.RecordBatch
     """
     columns = []
     for field in DATASET_FIELD_NAMES:
-        schema_field = schema.field(field)
-        columns.append(
-            tensor_array(
-                arrays[field],
-                DATASET_FIELD_DTYPES[field],
-                tuple(schema_field.type.shape),
-            )
-        )
+        # Read dtype and shape from the schema so an overridden field wins over
+        # the global DATASET_FIELD_DTYPES default and the batch matches the file.
+        tensor_type = schema.field(field).type
+        np_dtype = np.dtype(tensor_type.value_type.to_pandas_dtype())
+        columns.append(tensor_array(arrays[field], np_dtype, tuple(tensor_type.shape)))
     return pa.record_batch(columns, schema=schema)
 
 
-def write_lance_file(path: Path | str, schema: pa.Schema, batches: Iterable[pa.RecordBatch]) -> None:
+def write_lance_file(
+    path: Path | str, schema: pa.Schema, batches: Iterable[pa.RecordBatch]
+) -> None:
     """Write a single Lance file from pre-shaped Arrow record batches.
 
     :param path: Destination ``.lance`` file.
@@ -103,7 +98,6 @@ def read_shard_metadata(schema: pa.Schema) -> ShardMetadata:
 
     :param schema: Arrow schema read from a Lance file.
     :returns: Strict shard metadata payload.
-    :rtype: ShardMetadata
     :raises ValueError: Metadata is absent or malformed.
     """
     payload = (schema.metadata or {}).get(SHARD_METADATA_SCHEMA_KEY)
@@ -115,33 +109,14 @@ def read_shard_metadata(schema: pa.Schema) -> ShardMetadata:
         raise ValueError(f"invalid ShardMetadata: {exc}") from exc
 
 
-def tensor_chunk_to_numpy(chunk: pa.Array, inner_shape: tuple[int, ...]) -> np.ndarray:
-    """Decode one fixed-shape tensor Arrow chunk to ``(N, *inner_shape)`` numpy.
-
-    :param chunk: Arrow extension array chunk from a Lance tensor column.
-    :param inner_shape: Per-row tensor shape from the schema.
-    :returns: Decoded numpy array.
-    :rtype: np.ndarray
-    :raises TypeError: ``chunk`` is not backed by fixed-size-list tensor storage.
-    """
-    storage = getattr(chunk, "storage", None)
-    if storage is None or not pa.types.is_fixed_size_list(storage.type):
-        raise TypeError(f"expected fixed-size-list tensor storage, got {chunk.type}")
-    values = storage.values.to_numpy(zero_copy_only=False)
-    return values.reshape(len(chunk), *inner_shape)
-
-
 def iter_lance_column_rows(path: Path, column: str) -> Iterator[np.ndarray]:
     """Yield rows from one projected Lance tensor column.
 
     :param path: Local ``.lance`` shard path.
     :param column: Column to project from the Lance file.
-    :yields: One numpy tensor row at a time.
+    :yields: One ``(*inner_shape,)`` read-only view over Arrow's buffer — copy before mutating.
     :ytype: np.ndarray
     """
     reader = LanceFileReader(str(path), columns=[column])
-    field = reader.metadata().schema.field(column)
-    inner_shape = tuple(field.type.shape)
     for batch in reader.read_all().to_batches():
-        array = tensor_chunk_to_numpy(batch.column(0), inner_shape)
-        yield from array
+        yield from batch.column(0).to_numpy_ndarray()

--- a/tests/data/test_lance_datamodule.py
+++ b/tests/data/test_lance_datamodule.py
@@ -195,13 +195,18 @@ class TestLanceShardFile:
         np.testing.assert_array_equal(out, columns["mel_spec"][2:5])
 
     def test_column_reads_return_writable_arrays(self, tmp_path: Path) -> None:
-        """Reads are copied out of Arrow's read-only buffer before reaching torch.
+        """Every decode path copies out of Arrow's read-only buffer.
+
+        ``to_numpy_ndarray`` returns a read-only view, and torch.from_numpy over
+        one is undefined behavior on write, so every read must hit ``.copy()``.
 
         :param tmp_path: Pytest fixture providing a fresh test directory.
         """
         _write_seeded_lance_shard(tmp_path / "train.lance", num_rows=8)
         shard = LanceShardFile(tmp_path / "train.lance")
         assert shard["audio"][0:2].flags.writeable
+        assert shard["audio"][[0, 3, 5]].flags.writeable
+        assert shard["audio"][0:8:2].flags.writeable
 
     def test_column_open_ended_slice_reads_from_row_zero(self, tmp_path: Path) -> None:
         """``file[name][:k]`` (no explicit start) reads the first ``k`` rows.
@@ -440,6 +445,27 @@ class TestLanceVSTDataset:
         for key in _ALL_TENSOR_KEYS:
             assert _unwrap(item[key]).dtype == torch.float32, key
             assert _unwrap(item[key]).is_contiguous(), f"{key} not contiguous"
+
+    def test_getitem_returns_writable_tensors_through_decode_path(
+        self, single_shard: Path
+    ) -> None:
+        """End-to-end: dataset tensors are writable out of the Lance decode path.
+
+        The column decode yields a read-only Arrow view; only the ``.copy()``
+        guard makes it safe for ``torch.from_numpy`` (writable iff its buffer is).
+
+        :param single_shard: Fixture-provided single-shard Lance path.
+        """
+        dataset = LanceVSTDataset(
+            single_shard,
+            batch_size=2,
+            ot=False,
+            use_saved_mean_and_variance=False,
+            read_audio=True,
+            read_mel=True,
+        )
+        item = dataset[0]
+        assert _unwrap(item["audio"]).numpy().flags.writeable
 
     def test_read_flags_route_modalities(self, single_shard: Path) -> None:
         """``read_audio`` / ``read_mel`` / ``read_m2l`` toggle their dict slots.

--- a/tests/pipeline/ci_validate/test_validate_shard_lance.py
+++ b/tests/pipeline/ci_validate/test_validate_shard_lance.py
@@ -22,7 +22,6 @@ from synth_setter.pipeline.data.lance_shard import (
     lance_schema,
     record_batch_from_arrays,
     tensor_array,
-    tensor_chunk_to_numpy,
     write_lance_file,
 )
 from synth_setter.pipeline.schemas.spec import DatasetSpec
@@ -90,7 +89,7 @@ def test_lance_record_batch_preserves_transposed_tensor_shape(tmp_path: Path) ->
     field = reader.metadata().schema.field(MEL_SPEC_FIELD)
     assert tuple(field.type.shape) == shapes[MEL_SPEC_FIELD][1:]
     batch = next(reader.read_all().to_batches())
-    decoded = tensor_chunk_to_numpy(batch.column(0), shapes[MEL_SPEC_FIELD][1:])
+    decoded = batch.column(0).to_numpy_ndarray()
     assert decoded.shape == shapes[MEL_SPEC_FIELD]
 
 

--- a/tests/pipeline/data/test_lance_shard.py
+++ b/tests/pipeline/data/test_lance_shard.py
@@ -142,6 +142,16 @@ def test_tensor_array_missing_row_axis_raises_value_error() -> None:
         tensor_array(np.zeros((2, 7), dtype=np.float16), np.dtype(np.float16), (2, 7))
 
 
+def test_tensor_array_empty_batch_raises_value_error() -> None:
+    """A correctly-shaped but row-empty batch raises a clear ValueError, not Arrow's.
+
+    ``(0, 2, 7)`` passes the inner-shape check, so the explicit N >= 1 guard —
+    not the opaque extension-builder error — is what must fire.
+    """
+    with pytest.raises(ValueError, match=r"non-empty batch .* got 0 rows"):
+        tensor_array(np.zeros((0, 2, 7), dtype=np.float16), np.dtype(np.float16), (2, 7))
+
+
 def test_record_batch_from_arrays_schema_dtype_wins_over_field_default() -> None:
     """Each column's dtype comes from the schema, not ``DATASET_FIELD_DTYPES``.
 

--- a/tests/pipeline/data/test_lance_shard.py
+++ b/tests/pipeline/data/test_lance_shard.py
@@ -1,8 +1,8 @@
 """Write→read value-fidelity tests for the Lance shard codec.
 
 The expected arrays are constructed directly in numpy — never through the
-decoder under test — so a row-ordering or reshape bug in ``tensor_array`` /
-``tensor_chunk_to_numpy`` cannot corrupt both sides identically and pass.
+codec under test — so a row-ordering or reshape bug in ``tensor_array`` or the
+tensor decode cannot corrupt both sides identically and pass.
 """
 
 from __future__ import annotations
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+import pyarrow as pa
 import pytest
 
 from synth_setter.data.vst.shapes import (
@@ -23,12 +24,12 @@ from synth_setter.pipeline.data.lance_shard import (
     iter_lance_column_rows,
     lance_schema,
     record_batch_from_arrays,
+    tensor_array,
     write_lance_file,
 )
 from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata
 
-# Small distinct inner shapes so every element has a unique, exactly
-# representable value (float16 is exact for integers up to 2048).
+# Small shapes: each element gets a unique value, exactly representable as float16 (<= 2048).
 _FIELD_SHAPES: dict[str, tuple[int, ...]] = {
     AUDIO_FIELD: (2, 2, 5),
     MEL_SPEC_FIELD: (2, 2, 3, 4),
@@ -115,3 +116,53 @@ def test_lance_round_trip_noncontiguous_transposed_input_preserves_values(
 
     decoded = np.stack(list(iter_lance_column_rows(shard, MEL_SPEC_FIELD)), axis=0)
     np.testing.assert_array_equal(decoded, transposed_mel)
+
+
+def test_iter_lance_column_rows_yields_read_only_views(tmp_path: Path) -> None:
+    """Yielded rows share Arrow's read-only buffer, so callers must copy to mutate.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    schema = lance_schema(_FIELD_SHAPES, _METADATA)
+    shard = tmp_path / "shard-000000.lance"
+    write_lance_file(shard, schema, [record_batch_from_arrays(_arange_arrays(offset=0), schema)])
+
+    row = next(iter_lance_column_rows(shard, AUDIO_FIELD))
+
+    assert not row.flags.writeable
+
+
+def test_tensor_array_missing_row_axis_raises_value_error() -> None:
+    """A tensor whose ndim equals ``inner_shape``'s (no row axis) raises ValueError.
+
+    ``(2, 7)`` under inner shape ``(2, 7)`` is rejected, not read as a single
+    row of shape ``(2, 7)``.
+    """
+    with pytest.raises(ValueError, match=r"inner shape .+, expected \(2, 7\)"):
+        tensor_array(np.zeros((2, 7), dtype=np.float16), np.dtype(np.float16), (2, 7))
+
+
+def test_record_batch_from_arrays_schema_dtype_wins_over_field_default() -> None:
+    """Each column's dtype comes from the schema, not ``DATASET_FIELD_DTYPES``.
+
+    ``audio`` defaults to float16, so a schema overriding it to float32 must
+    yield a float32 column; sourcing the dtype from the global dict would emit
+    float16 and fail ``pa.record_batch`` schema validation.
+    """
+    assert (
+        DATASET_FIELD_DTYPES[AUDIO_FIELD] == np.float16
+    )  # guards the override's discriminating power
+    schema = lance_schema(_FIELD_SHAPES, _METADATA)
+    field_index = schema.get_field_index(AUDIO_FIELD)
+    float32_audio = pa.field(
+        AUDIO_FIELD,
+        pa.fixed_shape_tensor(pa.float32(), _FIELD_SHAPES[AUDIO_FIELD][1:]),
+        nullable=False,
+    )
+    schema = schema.set(field_index, float32_audio)
+    arrays = _arange_arrays(offset=0)
+    arrays[AUDIO_FIELD] = arrays[AUDIO_FIELD].astype(np.float32)
+
+    batch = record_batch_from_arrays(arrays, schema)
+
+    assert batch.schema.field(AUDIO_FIELD).type.value_type == pa.float32()

--- a/uv.lock
+++ b/uv.lock
@@ -6320,7 +6320,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.33.0"
+version = "8.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What

Code-health cleanup of the Lance single-file codec (`src/synth_setter/pipeline/data/lance_shard.py`), removing hand-rolled work the pyarrow fixed-shape-tensor extension already provides. Behavior-preserving.

- **Delete `tensor_chunk_to_numpy`; use `FixedShapeTensorArray.to_numpy_ndarray()`.** The old decoder reached into `.storage`, asserted fixed-size-list, copied via `to_numpy(zero_copy_only=False)`, and reshaped by a hand-threaded `inner_shape`. The extension type carries its own shape and decodes itself, so the function — and the `inner_shape` plumbing in `iter_lance_column_rows` and the datamodule — both go away. Applied at every call site (codec iterator, datamodule `LanceColumn`, validator test).
- **Drop the single-row branch in `tensor_array`.** Every caller passes a batched `(N, *inner)` array; the branch served a non-existent caller and made a bare `(k,)` input ambiguous (one row of k, or k mis-shaped rows?). The contract is now single: `(N, *inner_shape)`.
- **Single-source the dtype.** `record_batch_from_arrays` read shape from the schema but dtype from the `DATASET_FIELD_DTYPES` global — two sources that can drift. It now derives the numpy dtype from the schema field's `value_type`, so dtype and shape share one source.

## Why

Removes a function, an argument, and a forced copy; eliminates a drift risk between the schema and a parallel dtype dict; and aligns the codec with pyarrow's documented tensor API instead of reimplementing it.

## Tests

Existing round-trip / value-fidelity / validator / datamodule tests pass unchanged (the safety net for a behavior-preserving refactor). New tests pin the stricter contracts:
- `test_tensor_array_missing_row_axis_raises_value_error` — the dropped auto-promote branch now raises.
- `test_record_batch_from_arrays_schema_dtype_wins_over_field_default` — dtype comes from the schema, not the global dict (overrides `audio` float16→float32 so the assertion discriminates).
- `test_iter_lance_column_rows_yields_read_only_views` and `test_getitem_returns_writable_tensors_through_decode_path` — pin the read-only iter contract and the datamodule's writable-tensor guarantee through the new decode path.

Fixes #1690