### PR TITLE
fix(training): handle None vector-field penalty in flow-matching step

### DIFF
--- a/src/synth_setter/models/ksin_flow_matching_module.py
+++ b/src/synth_setter/models/ksin_flow_matching_module.py
@@ -318,8 +318,8 @@ class KSinFlowMatchingModule(LightningModule):
         return target
 
     def _train_step(
-        self, batch: tuple[torch.Tensor, torch.Tensor]
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        self, batch: tuple[torch.Tensor, torch.Tensor, torch.Tensor, Callable[..., torch.Tensor]]
+    ) -> tuple[torch.Tensor, torch.Tensor | float | None]:
         signal, params, noise, _ = batch
 
         # Get conditioning vector
@@ -353,7 +353,9 @@ class KSinFlowMatchingModule(LightningModule):
         return loss, penalty
 
     def training_step(
-        self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int
+        self,
+        batch: tuple[torch.Tensor, torch.Tensor, torch.Tensor, Callable[..., torch.Tensor]],
+        batch_idx: int,
     ) -> torch.Tensor:
         if self.global_step < self.hparams.freeze_for_first_n_steps:
             # freeze vector_field and encoder, leaving only projection active

--- a/src/synth_setter/models/ksin_flow_matching_module.py
+++ b/src/synth_setter/models/ksin_flow_matching_module.py
@@ -317,7 +317,9 @@ class KSinFlowMatchingModule(LightningModule):
 
         return target
 
-    def _train_step(self, batch: tuple[torch.Tensor, torch.Tensor]):
+    def _train_step(
+        self, batch: tuple[torch.Tensor, torch.Tensor]
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         signal, params, noise, _ = batch
 
         # Get conditioning vector
@@ -350,7 +352,9 @@ class KSinFlowMatchingModule(LightningModule):
 
         return loss, penalty
 
-    def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def training_step(
+        self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int
+    ) -> torch.Tensor:
         if self.global_step < self.hparams.freeze_for_first_n_steps:
             # freeze vector_field and encoder, leaving only projection active
             for param in self.vector_field.parameters():
@@ -374,7 +378,7 @@ class KSinFlowMatchingModule(LightningModule):
         if penalty is not None:
             self.log("train/penalty", penalty, on_step=True, on_epoch=True, prog_bar=True)
 
-        return loss + penalty
+        return loss if penalty is None else loss + penalty
 
     def on_train_epoch_end(self) -> None:
         pass

--- a/src/synth_setter/models/surge_flow_matching_module.py
+++ b/src/synth_setter/models/surge_flow_matching_module.py
@@ -142,6 +142,8 @@ class VSTFlowMatchingModule(LightningModule):
         conditioning = self._get_conditioning_from_batch(batch)
         params = batch["params"]
         noise = batch["noise"]
+        # The dataset always populates params and noise (only audio/mel/m2l may be None).
+        assert params is not None and noise is not None
 
         # Get conditioning vector
         conditioning = self.encoder(conditioning)
@@ -223,14 +225,16 @@ class VSTFlowMatchingModule(LightningModule):
         self, batch: dict[str, torch.Tensor | None], batch_idx: int
     ) -> dict[str, torch.Tensor]:
         conditioning = self._get_conditioning_from_batch(batch)
+        params = batch["params"]
+        assert params is not None  # the dataset always populates params
         pred_params = self._sample(
             conditioning,
-            torch.randn_like(batch["params"]),
+            torch.randn_like(params),
             self.hparams.validation_sample_steps,
             self.hparams.validation_cfg_strength,
         )
 
-        per_param_mse = (pred_params - batch["params"]).square().mean(dim=0)
+        per_param_mse = (pred_params - params).square().mean(dim=0)
         param_mse = per_param_mse.mean()
         self.log("val/param_mse", param_mse, on_step=False, on_epoch=True, prog_bar=True)
 
@@ -241,14 +245,16 @@ class VSTFlowMatchingModule(LightningModule):
 
     def test_step(self, batch: dict[str, torch.Tensor | None], batch_idx: int) -> torch.Tensor:
         conditioning = self._get_conditioning_from_batch(batch)
+        params = batch["params"]
+        assert params is not None  # the dataset always populates params
         pred_params = self._sample(
             conditioning,
-            torch.randn_like(batch["params"]),
+            torch.randn_like(params),
             self.hparams.test_sample_steps,
             self.hparams.test_cfg_strength,
         )
 
-        param_mse = (pred_params - batch["params"]).square().mean()
+        param_mse = (pred_params - params).square().mean()
         self.log("test/param_mse", param_mse, on_step=False, on_epoch=True, prog_bar=True)
 
         return param_mse

--- a/src/synth_setter/models/surge_flow_matching_module.py
+++ b/src/synth_setter/models/surge_flow_matching_module.py
@@ -135,7 +135,7 @@ class VSTFlowMatchingModule(LightningModule):
 
     def _train_step(
         self, batch: dict[str, torch.Tensor]
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+    ) -> tuple[torch.Tensor, torch.Tensor | float | None]:
         conditioning = self._get_conditioning_from_batch(batch)
         params = batch["params"]
         noise = batch["noise"]

--- a/src/synth_setter/models/surge_flow_matching_module.py
+++ b/src/synth_setter/models/surge_flow_matching_module.py
@@ -133,7 +133,9 @@ class VSTFlowMatchingModule(LightningModule):
         else:
             raise ValueError(f"Unknown conditioning {self.hparams.conditioning}")
 
-    def _train_step(self, batch: tuple[torch.Tensor, torch.Tensor]):
+    def _train_step(
+        self, batch: dict[str, torch.Tensor]
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
         conditioning = self._get_conditioning_from_batch(batch)
         params = batch["params"]
         noise = batch["noise"]
@@ -167,14 +169,14 @@ class VSTFlowMatchingModule(LightningModule):
 
         return loss, penalty
 
-    def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def training_step(self, batch: dict[str, torch.Tensor], batch_idx: int) -> torch.Tensor:
         loss, penalty = self._train_step(batch)
         self.log("train/loss", loss, on_step=True, on_epoch=True, prog_bar=True)
 
         if penalty is not None:
             self.log("train/penalty", penalty, on_step=True, on_epoch=True, prog_bar=True)
 
-        return loss + penalty
+        return loss if penalty is None else loss + penalty
 
     def on_train_epoch_end(self) -> None:
         pass
@@ -214,7 +216,9 @@ class VSTFlowMatchingModule(LightningModule):
 
         return sample
 
-    def validation_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def validation_step(
+        self, batch: dict[str, torch.Tensor], batch_idx: int
+    ) -> dict[str, torch.Tensor]:
         conditioning = self._get_conditioning_from_batch(batch)
         pred_params = self._sample(
             conditioning,
@@ -232,7 +236,7 @@ class VSTFlowMatchingModule(LightningModule):
     def on_validation_epoch_end(self):
         pass
 
-    def test_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def test_step(self, batch: dict[str, torch.Tensor], batch_idx: int) -> torch.Tensor:
         conditioning = self._get_conditioning_from_batch(batch)
         pred_params = self._sample(
             conditioning,

--- a/src/synth_setter/models/surge_flow_matching_module.py
+++ b/src/synth_setter/models/surge_flow_matching_module.py
@@ -125,16 +125,19 @@ class VSTFlowMatchingModule(LightningModule):
         target = self._rectified_vector_field(x0, x1)
         return target
 
-    def _get_conditioning_from_batch(self, batch: dict[str, torch.Tensor]) -> torch.Tensor:
+    def _get_conditioning_from_batch(self, batch: dict[str, torch.Tensor | None]) -> torch.Tensor:
         if self.hparams.conditioning == "mel":
-            return batch["mel_spec"]
+            conditioning = batch["mel_spec"]
         elif self.hparams.conditioning == "m2l":
-            return batch["m2l"]
+            conditioning = batch["m2l"]
         else:
             raise ValueError(f"Unknown conditioning {self.hparams.conditioning}")
+        # The dataset leaves unread feature keys as None; the selected one must be present.
+        assert conditioning is not None, f"conditioning {self.hparams.conditioning!r} not read"
+        return conditioning
 
     def _train_step(
-        self, batch: dict[str, torch.Tensor]
+        self, batch: dict[str, torch.Tensor | None]
     ) -> tuple[torch.Tensor, torch.Tensor | float | None]:
         conditioning = self._get_conditioning_from_batch(batch)
         params = batch["params"]
@@ -169,7 +172,7 @@ class VSTFlowMatchingModule(LightningModule):
 
         return loss, penalty
 
-    def training_step(self, batch: dict[str, torch.Tensor], batch_idx: int) -> torch.Tensor:
+    def training_step(self, batch: dict[str, torch.Tensor | None], batch_idx: int) -> torch.Tensor:
         loss, penalty = self._train_step(batch)
         self.log("train/loss", loss, on_step=True, on_epoch=True, prog_bar=True)
 
@@ -217,7 +220,7 @@ class VSTFlowMatchingModule(LightningModule):
         return sample
 
     def validation_step(
-        self, batch: dict[str, torch.Tensor], batch_idx: int
+        self, batch: dict[str, torch.Tensor | None], batch_idx: int
     ) -> dict[str, torch.Tensor]:
         conditioning = self._get_conditioning_from_batch(batch)
         pred_params = self._sample(
@@ -236,7 +239,7 @@ class VSTFlowMatchingModule(LightningModule):
     def on_validation_epoch_end(self):
         pass
 
-    def test_step(self, batch: dict[str, torch.Tensor], batch_idx: int) -> torch.Tensor:
+    def test_step(self, batch: dict[str, torch.Tensor | None], batch_idx: int) -> torch.Tensor:
         conditioning = self._get_conditioning_from_batch(batch)
         pred_params = self._sample(
             conditioning,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -306,6 +306,37 @@ def cfg_train(cfg_train_global: DictConfig, tmp_path: Path) -> DictConfig:
 
 
 @pytest.fixture(scope="function")
+def cfg_train_flow(tmp_path: Path) -> Iterator[DictConfig]:
+    """Compose a CPU ``model=flow`` training config for end-to-end smoke tests.
+
+    Selects ``model=flow`` so a ``fast_dev_run`` step drives the flow-matching
+    ``training_step`` (loss-plus-penalty) through the real ``train`` entrypoint.
+
+    :param tmp_path: Per-test output/log directory.
+    :yields: A ready-to-run flow-matching training config.
+    :ytype: DictConfig
+    """
+    with initialize_config_module(version_base="1.3", config_module="synth_setter.configs"):
+        cfg = compose(
+            config_name="train.yaml",
+            return_hydra_config=True,
+            overrides=["datamodule=ksin", "model=flow", "trainer=cpu"],
+        )
+        with open_dict(cfg):
+            _apply_common_train_eval_overrides(cfg)
+            cfg.datamodule.num_workers = 0
+            callbacks = cfg.get("callbacks")
+            if callbacks is not None and "lr_monitor" in callbacks:
+                del callbacks.lr_monitor
+            cfg.paths.output_dir = str(tmp_path)
+            cfg.paths.log_dir = str(tmp_path)
+
+    yield cfg
+
+    GlobalHydra.instance().clear()
+
+
+@pytest.fixture(scope="function")
 def cfg_eval(cfg_eval_global: DictConfig, tmp_path: Path) -> DictConfig:
     """Build on top of ``cfg_eval_global()`` and redirect logging into ``tmp_path``.
 

--- a/tests/models/test_flow_matching_penalty.py
+++ b/tests/models/test_flow_matching_penalty.py
@@ -1,0 +1,120 @@
+"""Regression tests for the optional penalty path in flow-matching ``training_step`` (#1689)."""
+
+from __future__ import annotations
+
+import functools
+from collections.abc import Callable
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+import torch.nn as nn
+
+from synth_setter.models.components.vector_field import VectorField
+from synth_setter.models.ksin_flow_matching_module import KSinFlowMatchingModule
+from synth_setter.models.surge_flow_matching_module import VSTFlowMatchingModule
+
+_SENTINEL_BATCH = object()
+
+
+@pytest.fixture(autouse=True)
+def _seed() -> None:
+    """Seed PyTorch's global RNG so each test is deterministic."""
+    torch.manual_seed(0)
+
+
+def _opt_partial() -> Callable[..., torch.optim.Optimizer]:  # noqa: DOC201
+    """Return an SGD optimizer partial matching the Hydra ``_partial_`` pattern."""
+    return functools.partial(torch.optim.SGD, lr=1e-2)
+
+
+def _sched_partial() -> Callable[..., torch.optim.lr_scheduler.LRScheduler]:  # noqa: DOC201
+    """Return a StepLR scheduler partial matching the Hydra ``_partial_`` pattern."""
+    return functools.partial(torch.optim.lr_scheduler.StepLR, step_size=1)
+
+
+def _make_surge() -> VSTFlowMatchingModule:  # noqa: DOC201
+    """Build a stand-in-net module (valid only with ``_train_step`` patched)."""
+    return VSTFlowMatchingModule(
+        encoder=nn.Identity(),
+        vector_field=nn.Identity(),
+        optimizer=_opt_partial(),  # type: ignore[arg-type]  # Hydra _partial_ factory
+        scheduler=_sched_partial(),  # type: ignore[arg-type]  # Hydra _partial_ factory
+    )
+
+
+def _make_ksin() -> KSinFlowMatchingModule:  # noqa: DOC201
+    """Build a stand-in-net module (valid only with ``_train_step`` patched)."""
+    return KSinFlowMatchingModule(
+        encoder=nn.Identity(),
+        vector_field=nn.Identity(),
+        optimizer=_opt_partial(),  # type: ignore[arg-type]  # Hydra _partial_ factory
+        scheduler=_sched_partial(),  # type: ignore[arg-type]  # Hydra _partial_ factory
+    )
+
+
+@pytest.mark.parametrize("make_module", [_make_surge, _make_ksin], ids=["surge", "ksin"])
+def test_training_step_returns_loss_when_field_lacks_penalty(  # noqa: DOC101,DOC103
+    make_module: Callable[[], VSTFlowMatchingModule | KSinFlowMatchingModule],
+) -> None:
+    """``training_step`` returns the bare loss when ``_train_step`` yields no penalty."""
+    module = make_module()
+    module.log = MagicMock()  # type: ignore[method-assign]
+    loss = torch.tensor(2.0, requires_grad=True)
+    module._train_step = lambda _batch: (loss, None)  # type: ignore[assignment,method-assign]
+
+    out = module.training_step(_SENTINEL_BATCH, 0)  # type: ignore[arg-type]
+
+    torch.testing.assert_close(out, loss)
+    assert out.requires_grad
+    logged = [call.args[0] for call in module.log.call_args_list]
+    assert "train/penalty" not in logged
+
+
+@pytest.mark.parametrize("make_module", [_make_surge, _make_ksin], ids=["surge", "ksin"])
+def test_training_step_adds_penalty_when_field_provides_it(  # noqa: DOC101,DOC103
+    make_module: Callable[[], VSTFlowMatchingModule | KSinFlowMatchingModule],
+) -> None:
+    """``training_step`` adds the field penalty to the loss when one is reported."""
+    module = make_module()
+    module.log = MagicMock()  # type: ignore[method-assign]
+    loss = torch.tensor(2.0, requires_grad=True)
+    penalty = torch.tensor(0.5, requires_grad=True)
+    module._train_step = lambda _batch: (loss, penalty)  # type: ignore[assignment,method-assign]
+
+    out = module.training_step(_SENTINEL_BATCH, 0)  # type: ignore[arg-type]
+
+    torch.testing.assert_close(out, torch.tensor(2.5))
+    logged = [call.args[0] for call in module.log.call_args_list]
+    assert "train/penalty" in logged
+    # Pin that the penalty itself stays in the graph, not just the loss.
+    out.backward()
+    assert penalty.grad is not None
+
+
+def test_surge_training_step_real_penaltyless_field_returns_finite_scalar() -> None:
+    """A real ``VectorField`` (no ``penalty``) drives ``training_step`` to a finite scalar loss."""
+    num_params, conditioning_dim = 8, 4
+    field = VectorField(
+        field_dim=num_params, hidden_dim=16, conditioning_dim=conditioning_dim, num_blocks=2
+    )
+    module = VSTFlowMatchingModule(
+        encoder=nn.Identity(),
+        vector_field=field,
+        optimizer=_opt_partial(),  # type: ignore[arg-type]  # Hydra _partial_ factory
+        scheduler=_sched_partial(),  # type: ignore[arg-type]  # Hydra _partial_ factory
+        cfg_dropout_rate=0.0,
+        num_params=num_params,
+    )
+    module.log = MagicMock()  # type: ignore[method-assign]
+    batch = {
+        "mel_spec": torch.randn(3, conditioning_dim),
+        "params": torch.rand(3, num_params),
+        "noise": torch.randn(3, num_params),
+    }
+
+    _, penalty = module._train_step(batch)
+    assert penalty is None, "VectorField has no penalty(); this pins the reachable None branch"
+
+    out = module.training_step(batch, 0)
+    assert out.ndim == 0 and out.requires_grad and torch.isfinite(out)

--- a/tests/models/test_flow_matching_penalty.py
+++ b/tests/models/test_flow_matching_penalty.py
@@ -107,7 +107,7 @@ def test_surge_training_step_real_penaltyless_field_returns_finite_scalar() -> N
         num_params=num_params,
     )
     module.log = MagicMock()  # type: ignore[method-assign]
-    batch = {
+    batch: dict[str, torch.Tensor | None] = {
         "mel_spec": torch.randn(3, conditioning_dim),
         "params": torch.rand(3, num_params),
         "noise": torch.randn(3, num_params),

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -54,6 +54,20 @@ def test_train_fast_dev_run_tiny_model_tiny_data(cfg_train: DictConfig) -> None:
     train(cfg_train)
 
 
+@pytest.mark.slow
+def test_train_fast_dev_run_flow_matching_folds_penalty_into_loss(
+    cfg_train_flow: DictConfig,
+) -> None:
+    """``train`` + ``fast_dev_run`` drives flow-matching ``training_step`` end-to-end (#1689).
+
+    :param cfg_train_flow: Training cfg wired with ``model=flow`` and ``trainer=cpu``.
+    """
+    HydraConfig().set_config(cfg_train_flow)
+    with open_dict(cfg_train_flow):
+        cfg_train_flow.trainer.fast_dev_run = True
+    train(cfg_train_flow)
+
+
 @pytest.mark.gpu
 @RunIf(min_gpus=1)
 def test_train_fast_dev_run_gpu(cfg_train: DictConfig) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -6320,7 +6320,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.33.0"
+version = "8.34.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What

Both `VSTFlowMatchingModule` (`surge_flow_matching_module.py`) and `KSinFlowMatchingModule` (`ksin_flow_matching_module.py`) set `penalty = None` in `_train_step` when the vector field has no `penalty()` method, and guard the *logging* with `if penalty is not None`. But `training_step` returned `loss + penalty` unconditionally:

```python
penalty = None
if hasattr(self.vector_field, "penalty"):
    penalty = self.vector_field.penalty()
...
if penalty is not None:
    self.log("train/penalty", penalty, ...)
return loss + penalty   # TypeError when penalty is None
```

`models/components/vector_field.py:VectorField` is a real, wireable field that defines `apply_dropout` but **no** `penalty`, so wiring it raised `TypeError: unsupported operand type(s) for +: 'Tensor' and 'NoneType'` on the first training step. Currently latent because the two shipped flow configs use fields that happen to define `penalty` — the logging guard proves `None` was anticipated, but the return path was not.

This was flagged in review on #1680 and dismissed; the defect predates that rename and sits on `main`.

## Change

- Return `loss` when `penalty is None`, else `loss + penalty`, in both flow-matching modules.
- Add `-> torch.Tensor` / `-> tuple[torch.Tensor, torch.Tensor | None]` return annotations to the touched `training_step` / `_train_step`, and correct the surge `batch` annotations (`dict[str, torch.Tensor]`) plus `validation_step` / `test_step` return types.
- Tests: unit regression for both modules (stubbed `_train_step` for the None and tensor-penalty branches, asserting the log contract + gradient flow) and a real penalty-less `VectorField` driving surge `training_step`; plus a CPU `fast_dev_run` leg through the `train` entrypoint.

## Verification

`make format` clean; `pytest tests/models/test_flow_matching_penalty.py` (5) and the new `tests/test_train.py::test_train_fast_dev_run_flow_matching_folds_penalty_into_loss` pass. Pre-PR `/repo-review-full-no-comments`: 0 BLOCK, 0 comment-hygiene findings.

## Note

Review surfaced a pre-existing, out-of-scope inconsistency: several `penalty()` methods (`residual_mlp.py:129`, `transformer.py:55,346`) return Python `float 0.0` rather than a tensor or `None` (and `transformer.py:55` is annotated `-> torch.Tensor`). No runtime impact here (`tensor + 0.0` is a tensor), but the `penalty()` contract should be normalised in a follow-up — not touched in this bugfix.

Fixes #1689
