### PR TITLE
ci(data-pipeline): run VST slow suite for OB-Xf and Surge in matrix

### DIFF
--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -85,11 +85,10 @@ jobs:
     permissions:
       contents: write
 
-    # One cell per registered synth so the render/round-trip suite proves more
-    # than one VST3 renders end-to-end. ``fail-fast: false`` keeps one synth's
-    # failure from masking the other. ``surge_xt`` runs the full Surge-specific
-    # suite and is the only cell that publishes benchmark metrics (Issue #703);
-    # ``obxf`` runs just the synth-agnostic render test as the OB-Xf proof.
+    # One cell per synth proves more than one VST3 renders end-to-end;
+    # ``fail-fast: false`` so one synth's failure doesn't mask the other.
+    # ``surge_xt`` runs the full Surge suite and alone publishes benchmarks
+    # (see #703); ``obxf`` runs only the synth-agnostic render as its proof.
     strategy:
       fail-fast: false
       matrix:
@@ -149,6 +148,10 @@ jobs:
         # imports load the VST host which needs a live X display, so the
         # headless wrapper has to apply at the pytest level (not the
         # entire container).
+        #
+        # ``matrix.pytest_targets`` is a space-separated node list; the
+        # container splits it into a bash array (``read -ra``) so each target is
+        # a distinct pytest arg. Node IDs here carry no spaces or glob chars.
         env:
           PLUGIN_PATH: ${{ matrix.plugin_path }}
           TEST_SYNTH: ${{ matrix.synth }}
@@ -168,10 +171,11 @@ jobs:
               set -euo pipefail
               cd /home/build/synth-setter
               git config --global --add safe.directory /home/build/synth-setter
+              read -ra targets <<< "$PYTEST_TARGETS"
               src/synth_setter/scripts/run-linux-vst-headless.sh \
                 pytest -vv -s \
                   --cov=src --cov-branch --cov-report=xml --cov-report=term \
-                  $PYTEST_TARGETS
+                  "${targets[@]}"
             '
 
       # coverage.xml is written inside the container at the workspace mount,

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -122,7 +122,7 @@ jobs:
           PLUGIN_PATH: ${{ matrix.plugin_path }}
         run: |
           docker run --rm \
-            -v ${{ github.workspace }}:/home/build/synth-setter \
+            -v "${{ github.workspace }}:/home/build/synth-setter" \
             -e "PLUGIN_PATH=$PLUGIN_PATH" \
             "$IMAGE" \
             bash -c '
@@ -156,7 +156,7 @@ jobs:
         run: |
           mkdir -p /tmp/bench
           docker run --rm \
-            -v ${{ github.workspace }}:/home/build/synth-setter \
+            -v "${{ github.workspace }}:/home/build/synth-setter" \
             -v /tmp/bench:/bench \
             -e BENCHMARK_OUTPUT_DIR=/bench \
             -e HYDRA_FULL_ERROR=1 \

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -181,7 +181,7 @@ jobs:
         if: always() && hashFiles('coverage.xml') != ''
         uses: ./.github/actions/upload-coverage
         with:
-          flags: vst
+          flags: vst-${{ matrix.synth }}
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Surface per-bucket bench JSON files on the runner

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -85,10 +85,8 @@ jobs:
     permissions:
       contents: write
 
-    # One cell per synth proves more than one VST3 renders end-to-end;
-    # ``fail-fast: false`` so one synth's failure doesn't mask the other.
-    # ``surge_xt`` runs the full Surge suite and alone publishes benchmarks
-    # (see #703); ``obxf`` runs only the synth-agnostic render as its proof.
+    # One cell per synth (``fail-fast: false`` so neither masks the other);
+    # only ``surge_xt`` runs the full suite and publishes benchmarks (see #703).
     strategy:
       fail-fast: false
       matrix:
@@ -149,9 +147,8 @@ jobs:
         # headless wrapper has to apply at the pytest level (not the
         # entire container).
         #
-        # ``matrix.pytest_targets`` is a space-separated node list; the
-        # container splits it into a bash array (``read -ra``) so each target is
-        # a distinct pytest arg. Node IDs here carry no spaces or glob chars.
+        # ``matrix.pytest_targets`` is a space-separated node list split into a
+        # bash array (``read -ra``); node IDs here carry no spaces or globs.
         env:
           PLUGIN_PATH: ${{ matrix.plugin_path }}
           TEST_SYNTH: ${{ matrix.synth }}

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -76,7 +76,7 @@ permissions:
 
 jobs:
   run_vst_slow_tests:
-    name: VST slow tests (Docker)
+    name: VST slow tests (Docker, ${{ matrix.synth }})
     runs-on: ubuntu-latest-4core
     timeout-minutes: 120
 
@@ -84,6 +84,27 @@ jobs:
     # benchmark history. Workflow-level default is ``contents: read``.
     permissions:
       contents: write
+
+    # One cell per registered synth so the render/round-trip suite proves more
+    # than one VST3 renders end-to-end. ``fail-fast: false`` keeps one synth's
+    # failure from masking the other. ``surge_xt`` runs the full Surge-specific
+    # suite and is the only cell that publishes benchmark metrics (Issue #703);
+    # ``obxf`` runs just the synth-agnostic render test as the OB-Xf proof.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - synth: surge_xt
+            plugin_path: /usr/lib/vst3/Surge XT.vst3
+            pytest_targets: >-
+              tests/data/vst/test_generate_vst_dataset.py
+              tests/data/vst/test_always_on_integration.py
+              tests/data/vst/test_run_with_editor_held_open_real_plugin.py
+              tests/data/vst/test_pedalboard_threading_contract.py
+              tests/integration/test_parallel_shard_render_linux.py
+          - synth: obxf
+            plugin_path: /usr/lib/vst3/OB-Xf.vst3
+            pytest_targets: tests/data/vst/test_generate_vst_dataset.py::test_make_dataset
 
     env:
       IMAGE: tinaudio/synth-setter:${{ inputs.image_tag || 'dev-snapshot' }}
@@ -96,20 +117,23 @@ jobs:
         run: docker pull "$IMAGE"
 
       # Mirrors the headless plugin-load smoke check in
-      # ``docker/ubuntu22_04/Dockerfile:312-314`` (and the local-runner version
+      # ``docker/ubuntu22_04/Dockerfile`` (and the local-runner version
       # in ``cpu-slow.yml``) — fails fast if the plugin / image / mount layout
       # is broken before the much-longer pytest run.
-      - name: Smoke-test Surge XT plugin load
+      - name: Smoke-test ${{ matrix.synth }} plugin load
+        env:
+          PLUGIN_PATH: ${{ matrix.plugin_path }}
         run: |
           docker run --rm \
             -v ${{ github.workspace }}:/home/build/synth-setter \
+            -e "PLUGIN_PATH=$PLUGIN_PATH" \
             "$IMAGE" \
             bash -c '
               set -euo pipefail
               cd /home/build/synth-setter
               git config --global --add safe.directory /home/build/synth-setter
               src/synth_setter/scripts/run-linux-vst-headless.sh \
-                python -X faulthandler -c "from synth_setter.data.vst.core import load_plugin; load_plugin(\"/usr/lib/vst3/Surge XT.vst3\")"
+                python -X faulthandler -c "import os; from synth_setter.data.vst.core import load_plugin; load_plugin(os.environ[\"PLUGIN_PATH\"])"
             '
 
       - name: Run VST slow tests in Docker
@@ -125,6 +149,10 @@ jobs:
         # imports load the VST host which needs a live X display, so the
         # headless wrapper has to apply at the pytest level (not the
         # entire container).
+        env:
+          PLUGIN_PATH: ${{ matrix.plugin_path }}
+          TEST_SYNTH: ${{ matrix.synth }}
+          PYTEST_TARGETS: ${{ matrix.pytest_targets }}
         run: |
           mkdir -p /tmp/bench
           docker run --rm \
@@ -132,7 +160,9 @@ jobs:
             -v /tmp/bench:/bench \
             -e BENCHMARK_OUTPUT_DIR=/bench \
             -e HYDRA_FULL_ERROR=1 \
-            -e "SYNTH_SETTER_PLUGIN_PATH=/usr/lib/vst3/Surge XT.vst3" \
+            -e "SYNTH_SETTER_PLUGIN_PATH=$PLUGIN_PATH" \
+            -e "SYNTH_SETTER_TEST_SYNTH=$TEST_SYNTH" \
+            -e "PYTEST_TARGETS=$PYTEST_TARGETS" \
             "$IMAGE" \
             bash -c '
               set -euo pipefail
@@ -141,11 +171,7 @@ jobs:
               src/synth_setter/scripts/run-linux-vst-headless.sh \
                 pytest -vv -s \
                   --cov=src --cov-branch --cov-report=xml --cov-report=term \
-                  tests/data/vst/test_generate_vst_dataset.py \
-                  tests/data/vst/test_always_on_integration.py \
-                  tests/data/vst/test_run_with_editor_held_open_real_plugin.py \
-                  tests/data/vst/test_pedalboard_threading_contract.py \
-                  tests/integration/test_parallel_shard_render_linux.py
+                  $PYTEST_TARGETS
             '
 
       # coverage.xml is written inside the container at the workspace mount,
@@ -163,8 +189,9 @@ jobs:
         # ``<prefix>.json`` out of the host-mounted volume to where the
         # publish steps expect it. Each prefix maps 1:1 to a chart bucket.
         # Skipped cleanly if a file is missing (test deselected, xfailed
-        # before emit, etc).
-        if: always()
+        # before emit, etc). Surge-only: the benchmark buckets (Issue #703)
+        # track Surge's noise floor; the obxf cell renders but never publishes.
+        if: always() && matrix.synth == 'surge_xt'
         run: |
           for f in vst-noise-floor-1-preset-n-renders.json vst-noise-floor-random-preset-replay.json; do
             if [ -f "/tmp/bench/$f" ]; then
@@ -183,6 +210,7 @@ jobs:
         # ``publish_metrics`` opt-in. ``hashFiles`` skips the step cleanly if
         # the file is missing.
         if: |
+          matrix.synth == 'surge_xt' &&
           hashFiles('vst-noise-floor-1-preset-n-renders.json') != '' && (
             (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test/vst-roundtrip-xfail-tests')) ||
             (github.event_name == 'workflow_dispatch' && inputs.publish_metrics == true)
@@ -209,6 +237,7 @@ jobs:
         # invariant rather than the every-other-render bug. See
         # ``docs/reference/audio-similarity-benchmarks.md``.
         if: |
+          matrix.synth == 'surge_xt' &&
           hashFiles('vst-noise-floor-random-preset-replay.json') != '' && (
             (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test/vst-roundtrip-xfail-tests')) ||
             (github.event_name == 'workflow_dispatch' && inputs.publish_metrics == true)

--- a/.github/workflows/test-vst-slow.yml
+++ b/.github/workflows/test-vst-slow.yml
@@ -80,10 +80,10 @@ jobs:
     runs-on: ubuntu-latest-4core
     timeout-minutes: 120
 
-    # Job-level grant so only this job can push to ``gh-pages`` for the
-    # benchmark history. Workflow-level default is ``contents: read``.
-    permissions:
-      contents: write
+    # No write grant here: both matrix cells stay at the workflow-default
+    # ``contents: read``. Pushing to ``gh-pages`` is scoped to the separate
+    # ``publish_benchmarks`` job, so a compromised test/run step in either
+    # synth cell can't reach the repo's contents (#703).
 
     # One cell per synth (``fail-fast: false`` so neither masks the other);
     # only ``surge_xt`` runs the full suite and publishes benchmarks (see #703).
@@ -203,19 +203,57 @@ jobs:
             fi
           done
 
+      # Hand the bench JSON to the ``publish_benchmarks`` job, which holds the
+      # ``contents: write`` grant. Surge-only: only this cell produces the
+      # benchmark buckets (#703). ``if-no-files-found: ignore`` keeps a
+      # deselected/xfailed run from failing the upload.
+      - name: Upload benchmark JSON for the publish job
+        if: always() && matrix.synth == 'surge_xt'
+        uses: actions/upload-artifact@v4
+        with:
+          name: vst-benchmark-json
+          path: |
+            ${{ github.workspace }}/vst-noise-floor-1-preset-n-renders.json
+            ${{ github.workspace }}/vst-noise-floor-random-preset-replay.json
+          if-no-files-found: ignore
+          retention-days: 1
+
+  publish_benchmarks:
+    name: Publish VST benchmarks to gh-pages
+    needs: run_vst_slow_tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    # The only job that pushes to ``gh-pages`` (Issue #703), so the
+    # ``contents: write`` grant lives here alone — the matrix test cells run
+    # untrusted plugin/render code at ``contents: read``. Push-to-main always
+    # publishes; manual dispatch requires the ``publish_metrics`` opt-in. PRs
+    # never reach this job.
+    permissions:
+      contents: write
+    if: |
+      (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test/vst-roundtrip-xfail-tests')) ||
+      (github.event_name == 'workflow_dispatch' && inputs.publish_metrics == true)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # Pulls the Surge bench JSON surfaced by ``run_vst_slow_tests`` into the
+      # workspace where ``benchmark-action`` and the ``hashFiles`` guards
+      # expect it.
+      - name: Download benchmark JSON
+        uses: actions/download-artifact@v4
+        with:
+          name: vst-benchmark-json
+          path: ${{ github.workspace }}
+
       - name: Publish "1 preset N renders" metrics to benchmark history
         # Bucket 1: same hardcoded patch rendered ``num_samples`` times across
         # both stages, exposing the every-other-render variance described in
         # bug #489. See ``docs/reference/audio-similarity-benchmarks.md``.
-        # Push-to-main always publishes; manual dispatch requires the
-        # ``publish_metrics`` opt-in. ``hashFiles`` skips the step cleanly if
-        # the file is missing.
-        if: |
-          matrix.synth == 'surge_xt' &&
-          hashFiles('vst-noise-floor-1-preset-n-renders.json') != '' && (
-            (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test/vst-roundtrip-xfail-tests')) ||
-            (github.event_name == 'workflow_dispatch' && inputs.publish_metrics == true)
-          )
+        # ``hashFiles`` skips the step cleanly if the file is missing.
+        if: hashFiles('vst-noise-floor-1-preset-n-renders.json') != ''
         uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:
           name: VST noise floor (1 preset N renders)
@@ -237,12 +275,7 @@ jobs:
         # only (no all-pairs), so it tracks the API-level round-trip
         # invariant rather than the every-other-render bug. See
         # ``docs/reference/audio-similarity-benchmarks.md``.
-        if: |
-          matrix.synth == 'surge_xt' &&
-          hashFiles('vst-noise-floor-random-preset-replay.json') != '' && (
-            (github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/test/vst-roundtrip-xfail-tests')) ||
-            (github.event_name == 'workflow_dispatch' && inputs.publish_metrics == true)
-          )
+        if: hashFiles('vst-noise-floor-random-preset-replay.json') != ''
         uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:
           name: VST noise floor (random preset replay)

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -421,10 +421,10 @@ COPY --from=synth-setter-src /home/build/synth-setter/src/synth_setter/scripts/l
 # required on every arch; OB-Xf (and the other fetched synths) are amd64-only, so
 # OB-Xf is asserted only on amd64. The per-synth X11 load-validation follows.
 RUN for bundle in "Surge XT" "OB-Xf"; do \
-      if [ "$bundle" = "OB-Xf" ] && [ "${TARGETARCH:-}" != "amd64" ]; then \
+      if [[ "$bundle" == "OB-Xf" && "${TARGETARCH:-}" != "amd64" ]]; then \
         echo "skipping ${bundle}.vst3 presence check on ${TARGETARCH:-<unset>}" >&2; continue; \
       fi; \
-      test -n "$(ls -A "/usr/lib/vst3/${bundle}.vst3" 2>/dev/null)" \
+      [[ -d "/usr/lib/vst3/${bundle}.vst3" ]] \
         || { echo "ERROR: ${bundle}.vst3 not found in /usr/lib/vst3/" >&2; exit 1; }; \
     done
 

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -330,8 +330,7 @@ RUN python --version && \
 # ==========================================
 FROM python-base AS builder-install-synth-setter-deps
 # Re-declare the predefined platform ARG so ${TARGETARCH} resolves in this
-# stage's RUN steps (the pueue case, the bundle presence gate, and the synth
-# load-validation all read it); buildkit does not inherit ARG across FROM.
+# stage's RUN steps; buildkit does not inherit ARG across FROM.
 ARG TARGETARCH
 # Install Python dependencies via `uv sync --frozen` against the committed
 # lockfile. uv's cache (mounted below) persists torch wheels (~2.5 GB)

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -291,10 +291,9 @@ RUN curl -fsSL \
 # Python base: Python + venv on top of the chosen Surge install.
 # ==========================================
 FROM builder-install-surge-from-${BUILD_MODE} AS python-base
-# Check the surge-stage VST3 install. Surge XT is the only bundle present at this
-# stage; the amd64-only fetched synths (OB-Xf/Dexed/Six Sines) land in
-# /usr/lib/vst3/ after the ``vst3-synths-fetch`` COPY downstream, where each is
-# load-validated under headless X11 (see the "fetched synth" RUN below).
+# Surge XT is the only bundle present at this stage; the amd64-only fetched
+# synths land in /usr/lib/vst3/ after the vst3-synths-fetch COPY downstream,
+# where the presence gate + per-synth X11 load-validation cover them.
 RUN ls /usr/lib/vst3/ && test -n "$(ls -A /usr/lib/vst3/Surge\ XT.vst3 2>/dev/null)" \
     || (echo "ERROR: Surge XT.vst3 not found in /usr/lib/vst3/" >&2; exit 1)
 
@@ -417,9 +416,8 @@ RUN mkdir -p /home/build/synth-setter/plugins && \
 COPY --from=vst3-synths-fetch /plugins-staging/ /usr/lib/vst3/
 COPY --from=synth-setter-src /home/build/synth-setter/src/synth_setter/scripts/load_vst3_check.py /artifacts/
 
-# Synth-neutral presence gate for the bundles the image must ship. Surge XT is
-# required on every arch; OB-Xf (and the other fetched synths) are amd64-only, so
-# OB-Xf is asserted only on amd64. The per-synth X11 load-validation follows.
+# Presence gate for the bundles the image must ship: Surge XT on every arch,
+# OB-Xf on amd64 only (the fetched synths are amd64-only). Load-validation follows.
 RUN for bundle in "Surge XT" "OB-Xf"; do \
       if [[ "$bundle" == "OB-Xf" && "${TARGETARCH:-}" != "amd64" ]]; then \
         echo "skipping ${bundle}.vst3 presence check on ${TARGETARCH:-<unset>}" >&2; continue; \

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -291,7 +291,10 @@ RUN curl -fsSL \
 # Python base: Python + venv on top of the chosen Surge install.
 # ==========================================
 FROM builder-install-surge-from-${BUILD_MODE} AS python-base
-# Check that vst3 was installed.
+# Check the surge-stage VST3 install. Surge XT is the only bundle present at this
+# stage; the amd64-only fetched synths (OB-Xf/Dexed/Six Sines) land in
+# /usr/lib/vst3/ after the ``vst3-synths-fetch`` COPY downstream, where each is
+# load-validated under headless X11 (see the "fetched synth" RUN below).
 RUN ls /usr/lib/vst3/ && test -n "$(ls -A /usr/lib/vst3/Surge\ XT.vst3 2>/dev/null)" \
     || (echo "ERROR: Surge XT.vst3 not found in /usr/lib/vst3/" >&2; exit 1)
 
@@ -413,6 +416,17 @@ RUN mkdir -p /home/build/synth-setter/plugins && \
 
 COPY --from=vst3-synths-fetch /plugins-staging/ /usr/lib/vst3/
 COPY --from=synth-setter-src /home/build/synth-setter/src/synth_setter/scripts/load_vst3_check.py /artifacts/
+
+# Synth-neutral presence gate for the bundles the image must ship. Surge XT is
+# required on every arch; OB-Xf (and the other fetched synths) are amd64-only, so
+# OB-Xf is asserted only on amd64. The per-synth X11 load-validation follows.
+RUN for bundle in "Surge XT" "OB-Xf"; do \
+      if [ "$bundle" = "OB-Xf" ] && [ "${TARGETARCH:-}" != "amd64" ]; then \
+        echo "skipping ${bundle}.vst3 presence check on ${TARGETARCH:-<unset>}" >&2; continue; \
+      fi; \
+      test -n "$(ls -A "/usr/lib/vst3/${bundle}.vst3" 2>/dev/null)" \
+        || { echo "ERROR: ${bundle}.vst3 not found in /usr/lib/vst3/" >&2; exit 1; }; \
+    done
 
 # Validate each fetched synth loads under headless X11 — one wrapper run per
 # plugin, since sequential in-process loads crash order-dependently (#1649) —

--- a/docker/ubuntu22_04/Dockerfile
+++ b/docker/ubuntu22_04/Dockerfile
@@ -291,9 +291,8 @@ RUN curl -fsSL \
 # Python base: Python + venv on top of the chosen Surge install.
 # ==========================================
 FROM builder-install-surge-from-${BUILD_MODE} AS python-base
-# Surge XT is the only bundle present at this stage; the amd64-only fetched
-# synths land in /usr/lib/vst3/ after the vst3-synths-fetch COPY downstream,
-# where the presence gate + per-synth X11 load-validation cover them.
+# Surge XT is the only bundle present here; the amd64-only fetched synths land
+# downstream (vst3-synths-fetch COPY), gated and load-validated there.
 RUN ls /usr/lib/vst3/ && test -n "$(ls -A /usr/lib/vst3/Surge\ XT.vst3 2>/dev/null)" \
     || (echo "ERROR: Surge XT.vst3 not found in /usr/lib/vst3/" >&2; exit 1)
 
@@ -330,6 +329,10 @@ RUN python --version && \
 # Both dev and final-stage inherit from this stage.
 # ==========================================
 FROM python-base AS builder-install-synth-setter-deps
+# Re-declare the predefined platform ARG so ${TARGETARCH} resolves in this
+# stage's RUN steps (the pueue case, the bundle presence gate, and the synth
+# load-validation all read it); buildkit does not inherit ARG across FROM.
+ARG TARGETARCH
 # Install Python dependencies via `uv sync --frozen` against the committed
 # lockfile. uv's cache (mounted below) persists torch wheels (~2.5 GB)
 # across builds. Cache scope: only pyproject.toml + uv.lock + README.md

--- a/tests/_vst.py
+++ b/tests/_vst.py
@@ -1,8 +1,9 @@
 """Single source of truth for VST plugin discovery in tests.
 
 ``SYNTH_SETTER_TEST_SYNTH`` (a ``preset_paths`` key, default ``surge_xt``)
-drives ``TEST_SYNTH`` / ``TEST_PARAM_SPEC_NAME`` / ``TEST_PRESET_PATH`` so a CI
-cell can target a second synth without hardcoding. The plugin binary resolves
+drives ``TEST_SYNTH`` / ``TEST_PARAM_SPEC_NAME`` / ``TEST_PRESET_PATH`` /
+``TEST_RENDERER_VERSION`` so a CI cell can target a second synth without
+hardcoding. The plugin binary resolves
 separately via ``SYNTH_SETTER_PLUGIN_PATH`` (``PLUGIN_PATH`` / ``VST_AVAILABLE``);
 ``conftest.pytest_collection_modifyitems`` consults ``VST_AVAILABLE`` to
 auto-skip ``requires_vst`` tests.
@@ -23,6 +24,17 @@ TEST_PARAM_SPEC_NAME = TEST_SYNTH
 # Eager lookup so an unregistered TEST_SYNTH raises KeyError at import rather
 # than letting a downstream render test skip or fail opaquely.
 TEST_PRESET_PATH = preset_paths[TEST_SYNTH]
+
+# Per-synth renderer pin mirroring ``configs/render/<synth>.yaml`` (the value
+# ``generate_dataset`` cross-checks against the plugin), so the synth-agnostic
+# dataset test labels provenance for the selected synth, not always Surge XT's.
+# The Surge family shares one plugin binary, hence one version.
+TEST_RENDERER_VERSION = {
+    "surge_xt": "1.3.4",
+    "surge_simple": "1.3.4",
+    "surge_4": "1.3.4",
+    "obxf": "1.0.3",
+}[TEST_SYNTH]
 
 PLUGIN_PATH = default_plugin_path()
 

--- a/tests/_vst.py
+++ b/tests/_vst.py
@@ -2,7 +2,7 @@
 
 The target synth defaults to Surge XT and is overridable via
 ``SYNTH_SETTER_TEST_SYNTH`` (a key into
-:data:`synth_setter.data.vst.param_specs`), so a CI cell can point the slow
+:data:`synth_setter.data.vst.preset_paths`), so a CI cell can point the slow
 render/round-trip suite at a second synth without hardcoding. ``TEST_SYNTH``
 drives ``TEST_PARAM_SPEC_NAME`` / ``TEST_PRESET_PATH``; the plugin binary is
 resolved separately via ``SYNTH_SETTER_PLUGIN_PATH`` (set by CI and the
@@ -19,9 +19,8 @@ from pathlib import Path
 
 from synth_setter.data.vst.param_spec_registry import default_plugin_path, preset_paths
 
-# Registry key for the synth under test; doubles as the ``param_specs`` /
-# ``preset_paths`` key and the ``--param_spec_name`` the render CLI takes. ``or``
-# (not a ``get`` default) so an empty override also falls back to Surge XT.
+# ``or`` (not a ``get`` default) so an empty override also falls back to Surge XT.
+# The key doubles as the ``--param_spec_name`` the render CLI takes.
 TEST_SYNTH = os.environ.get("SYNTH_SETTER_TEST_SYNTH") or "surge_xt"
 TEST_PARAM_SPEC_NAME = TEST_SYNTH
 

--- a/tests/_vst.py
+++ b/tests/_vst.py
@@ -1,15 +1,11 @@
 """Single source of truth for VST plugin discovery in tests.
 
-The target synth defaults to Surge XT and is overridable via
-``SYNTH_SETTER_TEST_SYNTH`` (a key into
-:data:`synth_setter.data.vst.preset_paths`), so a CI cell can point the slow
-render/round-trip suite at a second synth without hardcoding. ``TEST_SYNTH``
-drives ``TEST_PARAM_SPEC_NAME`` / ``TEST_PRESET_PATH``; the plugin binary is
-resolved separately via ``SYNTH_SETTER_PLUGIN_PATH`` (set by CI and the
-devcontainer), falling back to the in-repo Surge bundle. Importers use
-``PLUGIN_PATH`` for the path and ``VST_AVAILABLE`` for the presence check that
-``conftest.pytest_collection_modifyitems`` consults when auto-skipping
-``requires_vst`` tests.
+``SYNTH_SETTER_TEST_SYNTH`` (a ``preset_paths`` key, default ``surge_xt``)
+drives ``TEST_SYNTH`` / ``TEST_PARAM_SPEC_NAME`` / ``TEST_PRESET_PATH`` so a CI
+cell can target a second synth without hardcoding. The plugin binary resolves
+separately via ``SYNTH_SETTER_PLUGIN_PATH`` (``PLUGIN_PATH`` / ``VST_AVAILABLE``);
+``conftest.pytest_collection_modifyitems`` consults ``VST_AVAILABLE`` to
+auto-skip ``requires_vst`` tests.
 """
 
 from __future__ import annotations

--- a/tests/_vst.py
+++ b/tests/_vst.py
@@ -16,8 +16,8 @@ from pathlib import Path
 from synth_setter.data.vst.param_spec_registry import default_plugin_path, preset_paths
 
 # ``or`` (not a ``get`` default) so an empty override also falls back to Surge XT.
-# The key doubles as the ``--param_spec_name`` the render CLI takes.
 TEST_SYNTH = os.environ.get("SYNTH_SETTER_TEST_SYNTH") or "surge_xt"
+# Registry key doubles as the render CLI's ``--param_spec_name``.
 TEST_PARAM_SPEC_NAME = TEST_SYNTH
 
 # Eager lookup so an unregistered TEST_SYNTH raises KeyError at import rather

--- a/tests/_vst.py
+++ b/tests/_vst.py
@@ -1,7 +1,12 @@
-"""Single source of truth for Surge XT VST plugin discovery in tests.
+"""Single source of truth for VST plugin discovery in tests.
 
-The plugin path is overridable via ``SYNTH_SETTER_PLUGIN_PATH`` (set by CI and the
-devcontainer); absent or empty, it falls back to the in-repo bundle. Importers use
+The target synth defaults to Surge XT and is overridable via
+``SYNTH_SETTER_TEST_SYNTH`` (a key into
+:data:`synth_setter.data.vst.param_specs`), so a CI cell can point the slow
+render/round-trip suite at a second synth without hardcoding. ``TEST_SYNTH``
+drives ``TEST_PARAM_SPEC_NAME`` / ``TEST_PRESET_PATH``; the plugin binary is
+resolved separately via ``SYNTH_SETTER_PLUGIN_PATH`` (set by CI and the
+devcontainer), falling back to the in-repo Surge bundle. Importers use
 ``PLUGIN_PATH`` for the path and ``VST_AVAILABLE`` for the presence check that
 ``conftest.pytest_collection_modifyitems`` consults when auto-skipping
 ``requires_vst`` tests.
@@ -9,9 +14,20 @@ devcontainer); absent or empty, it falls back to the in-repo bundle. Importers u
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
-from synth_setter.data.vst.param_spec_registry import default_plugin_path
+from synth_setter.data.vst.param_spec_registry import default_plugin_path, preset_paths
+
+# Registry key for the synth under test; doubles as the ``param_specs`` /
+# ``preset_paths`` key and the ``--param_spec_name`` the render CLI takes. ``or``
+# (not a ``get`` default) so an empty override also falls back to Surge XT.
+TEST_SYNTH = os.environ.get("SYNTH_SETTER_TEST_SYNTH") or "surge_xt"
+TEST_PARAM_SPEC_NAME = TEST_SYNTH
+
+# Eager lookup so an unregistered TEST_SYNTH raises KeyError at import rather
+# than letting a downstream render test skip or fail opaquely.
+TEST_PRESET_PATH = preset_paths[TEST_SYNTH]
 
 PLUGIN_PATH = default_plugin_path()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,7 +60,7 @@ def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
     :param items: mutated in-place to insert skip markers for missing resources.
     """
     skip_vst = pytest.mark.skip(
-        reason=f"Surge XT VST not found at {PLUGIN_PATH!r} "
+        reason=f"VST plugin not found at {PLUGIN_PATH!r} "
         f"(set SYNTH_SETTER_PLUGIN_PATH or place plugin at that path)"
     )
     skip_r2 = pytest.mark.skip(

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -33,18 +33,21 @@ from synth_setter.evaluation.compute_audio_metrics import (
     compute_wmfcc,
 )
 from synth_setter.pipeline.schemas.spec import RenderConfig
-from tests._vst import PLUGIN_PATH
+from tests._vst import PLUGIN_PATH, TEST_PARAM_SPEC_NAME, TEST_PRESET_PATH
 
 log = logging.getLogger(__name__)
 
-_PRESET_PATH = "presets/surge-base.vstpreset"
+# Default Surge XT, redirected to the env's synth so the synth-agnostic
+# ``test_make_dataset`` renders a second synth in CI. The Surge-specific tests
+# below (hardcoded param names, tuned audio thresholds) are deselected there.
+_PRESET_PATH = TEST_PRESET_PATH
 _NUM_SAMPLES = 5
 _SAMPLE_RATE = 44100.0
 _CHANNELS = 2
 _DURATION = 4.0
 _VELOCITY = 100
 _MIN_LOUDNESS = -55.0
-_SPEC_NAME = "surge_xt"
+_SPEC_NAME = TEST_PARAM_SPEC_NAME
 _RENDERER_VERSION = "1.3.4"
 _ABSOLUTE_TOLERANCE = 1e-7
 _RELATIVE_TOLERANCE = 1e-9

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -37,9 +37,8 @@ from tests._vst import PLUGIN_PATH, TEST_PARAM_SPEC_NAME, TEST_PRESET_PATH
 
 log = logging.getLogger(__name__)
 
-# Default Surge XT, redirected to the env's synth so the synth-agnostic
-# ``test_make_dataset`` renders a second synth in CI. The Surge-specific tests
-# below (hardcoded param names, tuned audio thresholds) are deselected there.
+# Env-driven (Surge XT default) so the synth-agnostic ``test_make_dataset``
+# renders a second synth in CI; the Surge-specific tests below are deselected there.
 _PRESET_PATH = TEST_PRESET_PATH
 _NUM_SAMPLES = 5
 _SAMPLE_RATE = 44100.0

--- a/tests/data/vst/test_generate_vst_dataset.py
+++ b/tests/data/vst/test_generate_vst_dataset.py
@@ -33,12 +33,19 @@ from synth_setter.evaluation.compute_audio_metrics import (
     compute_wmfcc,
 )
 from synth_setter.pipeline.schemas.spec import RenderConfig
-from tests._vst import PLUGIN_PATH, TEST_PARAM_SPEC_NAME, TEST_PRESET_PATH
+from tests._vst import (
+    PLUGIN_PATH,
+    TEST_PARAM_SPEC_NAME,
+    TEST_PRESET_PATH,
+    TEST_RENDERER_VERSION,
+)
 
 log = logging.getLogger(__name__)
 
 # Env-driven (Surge XT default) so the synth-agnostic ``test_make_dataset``
 # renders a second synth in CI; the Surge-specific tests below are deselected there.
+# Preset, spec name, and renderer version all track the selected synth so the
+# OB-Xf cell pins OB-Xf's version, not Surge XT's.
 _PRESET_PATH = TEST_PRESET_PATH
 _NUM_SAMPLES = 5
 _SAMPLE_RATE = 44100.0
@@ -47,7 +54,7 @@ _DURATION = 4.0
 _VELOCITY = 100
 _MIN_LOUDNESS = -55.0
 _SPEC_NAME = TEST_PARAM_SPEC_NAME
-_RENDERER_VERSION = "1.3.4"
+_RENDERER_VERSION = TEST_RENDERER_VERSION
 _ABSOLUTE_TOLERANCE = 1e-7
 _RELATIVE_TOLERANCE = 1e-9
 

--- a/tests/infra/test_conftest_skip_hooks.py
+++ b/tests/infra/test_conftest_skip_hooks.py
@@ -42,7 +42,7 @@ def test_requires_vst_item_skipped_when_vst_absent(monkeypatch: pytest.MonkeyPat
     item = _FakeItem({"requires_vst": pytest.mark.requires_vst})
     conftest_module.pytest_collection_modifyitems(items=cast(list[pytest.Item], [item]))
     assert len(item.added_markers) == 1
-    assert "Surge XT VST not found" in item.added_markers[0].kwargs["reason"]
+    assert "VST plugin not found" in item.added_markers[0].kwargs["reason"]
 
 
 @pytest.mark.infra

--- a/tests/infra/test_vst_helper.py
+++ b/tests/infra/test_vst_helper.py
@@ -134,6 +134,7 @@ def test_test_synth_defaults_to_surge_xt_when_env_unset(
     assert mod.TEST_SYNTH == "surge_xt"
     assert mod.TEST_PARAM_SPEC_NAME == "surge_xt"
     assert mod.TEST_PRESET_PATH == "presets/surge-base.vstpreset"
+    assert mod.TEST_RENDERER_VERSION == "1.3.4"
 
 
 @pytest.mark.infra
@@ -150,6 +151,7 @@ def test_test_synth_selects_registry_entry_from_env_override(
     assert mod.TEST_SYNTH == "obxf"
     assert mod.TEST_PARAM_SPEC_NAME == "obxf"
     assert mod.TEST_PRESET_PATH == "presets/obxf-base.vstpreset"
+    assert mod.TEST_RENDERER_VERSION == "1.0.3"
 
 
 @pytest.mark.infra

--- a/tests/infra/test_vst_helper.py
+++ b/tests/infra/test_vst_helper.py
@@ -16,31 +16,35 @@ from types import ModuleType
 import pytest
 
 _ENV_VAR = "SYNTH_SETTER_PLUGIN_PATH"
+_SYNTH_ENV_VAR = "SYNTH_SETTER_TEST_SYNTH"
 _DEFAULT_PATH = "plugins/Surge XT.vst3"
+_RESTORED_ENV_VARS = (_ENV_VAR, _SYNTH_ENV_VAR)
 
 
 @pytest.fixture
 def reload_vst(request: pytest.FixtureRequest) -> Callable[[], ModuleType]:
     """Reload ``tests._vst`` on demand, restoring real-env values at teardown.
 
-    The finalizer restores ``SYNTH_SETTER_PLUGIN_PATH`` itself (not via
-    ``monkeypatch``, whose teardown may run after this one) before the final
-    reload, so the module is left resolved against the real environment
-    regardless of fixture-finalization order.
+    The finalizer restores ``SYNTH_SETTER_PLUGIN_PATH`` and
+    ``SYNTH_SETTER_TEST_SYNTH`` itself (not via ``monkeypatch``, whose teardown
+    may run after this one) before the final reload, so the module is left
+    resolved against the real environment regardless of fixture-finalization
+    order.
 
     :param request: registers the teardown that restores env + reloads the module.
     :returns: a callable that reloads and returns the freshly imported module.
     """
-    original = os.environ.get(_ENV_VAR)
+    originals = {name: os.environ.get(name) for name in _RESTORED_ENV_VARS}
 
     def _reload() -> ModuleType:
         return importlib.reload(importlib.import_module("tests._vst"))
 
     def _restore() -> None:
-        if original is None:
-            os.environ.pop(_ENV_VAR, None)
-        else:
-            os.environ[_ENV_VAR] = original
+        for name, value in originals.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
         _reload()
 
     request.addfinalizer(_restore)
@@ -114,3 +118,62 @@ def test_vst_available_false_when_path_absent(
     """
     monkeypatch.setenv("SYNTH_SETTER_PLUGIN_PATH", str(tmp_path / "missing.vst3"))
     assert reload_vst().VST_AVAILABLE is False
+
+
+@pytest.mark.infra
+def test_test_synth_defaults_to_surge_xt_when_env_unset(
+    monkeypatch: pytest.MonkeyPatch, reload_vst: Callable[[], ModuleType]
+) -> None:
+    """The target synth defaults to Surge XT, keeping existing tests synth-stable.
+
+    :param monkeypatch: removes ``SYNTH_SETTER_TEST_SYNTH``.
+    :param reload_vst: re-resolves the module constants under the patched env.
+    """
+    monkeypatch.delenv(_SYNTH_ENV_VAR, raising=False)
+    mod = reload_vst()
+    assert mod.TEST_SYNTH == "surge_xt"
+    assert mod.TEST_PARAM_SPEC_NAME == "surge_xt"
+    assert mod.TEST_PRESET_PATH == "presets/surge-base.vstpreset"
+
+
+@pytest.mark.infra
+def test_test_synth_selects_registry_entry_from_env_override(
+    monkeypatch: pytest.MonkeyPatch, reload_vst: Callable[[], ModuleType]
+) -> None:
+    """A registered synth key resolves its spec name and preset from the registry.
+
+    :param monkeypatch: pins ``SYNTH_SETTER_TEST_SYNTH`` to ``obxf``.
+    :param reload_vst: re-resolves the module constants under the patched env.
+    """
+    monkeypatch.setenv(_SYNTH_ENV_VAR, "obxf")
+    mod = reload_vst()
+    assert mod.TEST_SYNTH == "obxf"
+    assert mod.TEST_PARAM_SPEC_NAME == "obxf"
+    assert mod.TEST_PRESET_PATH == "presets/obxf-base.vstpreset"
+
+
+@pytest.mark.infra
+def test_test_synth_falls_back_to_surge_xt_when_env_empty(
+    monkeypatch: pytest.MonkeyPatch, reload_vst: Callable[[], ModuleType]
+) -> None:
+    """An empty override falls back to Surge XT (the normalized ``or`` semantic).
+
+    :param monkeypatch: sets an empty ``SYNTH_SETTER_TEST_SYNTH``.
+    :param reload_vst: re-resolves the module constants under the patched env.
+    """
+    monkeypatch.setenv(_SYNTH_ENV_VAR, "")
+    assert reload_vst().TEST_SYNTH == "surge_xt"
+
+
+@pytest.mark.infra
+def test_test_synth_rejects_unregistered_key(
+    monkeypatch: pytest.MonkeyPatch, reload_vst: Callable[[], ModuleType]
+) -> None:
+    """An unregistered synth key fails loud at import rather than skipping silently.
+
+    :param monkeypatch: pins ``SYNTH_SETTER_TEST_SYNTH`` to an unknown key.
+    :param reload_vst: re-resolves the module constants under the patched env.
+    """
+    monkeypatch.setenv(_SYNTH_ENV_VAR, "not_a_synth")
+    with pytest.raises(KeyError, match="not_a_synth"):
+        reload_vst()

--- a/tests/infra/test_vst_helper.py
+++ b/tests/infra/test_vst_helper.py
@@ -162,7 +162,10 @@ def test_test_synth_falls_back_to_surge_xt_when_env_empty(
     :param reload_vst: re-resolves the module constants under the patched env.
     """
     monkeypatch.setenv(_SYNTH_ENV_VAR, "")
-    assert reload_vst().TEST_SYNTH == "surge_xt"
+    mod = reload_vst()
+    assert mod.TEST_SYNTH == "surge_xt"
+    assert mod.TEST_PARAM_SPEC_NAME == "surge_xt"
+    assert mod.TEST_PRESET_PATH == "presets/surge-base.vstpreset"
 
 
 @pytest.mark.infra

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -354,7 +354,10 @@ def test_generate_dataset_renders_obxf_shards_to_r2(
     ``rclone copy`` upload. The unique-per-run ``r2.prefix`` keeps concurrent runs
     isolated; a best-effort ``rclone purge`` in ``finally`` removes the prefix even on
     failure so we don't leak shards. Auto-skips when ``rclone`` is missing or
-    ``rclone lsd r2:`` fails (contributor laptops, fork PRs without secrets).
+    ``rclone lsd r2:`` fails (contributor laptops, fork PRs without secrets), and
+    when the OB-Xf bundle is absent: ``requires_vst`` only gates the env-selected
+    synth (``SYNTH_SETTER_PLUGIN_PATH``), so a Surge-only host would otherwise fail
+    here rather than skip when ``render=obxf``'s ``plugin_path`` is missing.
 
     :param cfg_dataset_obxf: ``render=obxf`` cfg composed with the
         ``generate_dataset/smoke-shard`` experiment; carries the real OB-Xf bundle,
@@ -371,6 +374,9 @@ def test_generate_dataset_renders_obxf_shards_to_r2(
 
     spec = spec_from_cfg(cfg_dataset_obxf)
     assert spec.render.param_spec_name == "obxf"
+    obxf_bundle = Path(spec.render.plugin_path)
+    if not obxf_bundle.exists():
+        pytest.skip(f"OB-Xf bundle not found at {obxf_bundle} (render=obxf plugin_path)")
     try:
         from_hydra(cfg_dataset_obxf)
         for shard in spec.shards:

--- a/tests/test_generate_dataset.py
+++ b/tests/test_generate_dataset.py
@@ -344,6 +344,46 @@ def test_generate_dataset_renders_shards_to_r2(
 @pytest.mark.r2
 @pytest.mark.requires_vst
 @pytest.mark.slow
+def test_generate_dataset_renders_obxf_shards_to_r2(
+    cfg_dataset_obxf: DictConfig,
+) -> None:
+    """``from_hydra`` renders every OB-Xf shard with the real plugin and uploads to R2.
+
+    The second-synth counterpart to ``test_generate_dataset_renders_shards_to_r2``,
+    under ``render=obxf`` so the real OB-Xf VST3 renders each shard (no stub) before the
+    ``rclone copy`` upload. The unique-per-run ``r2.prefix`` keeps concurrent runs
+    isolated; a best-effort ``rclone purge`` in ``finally`` removes the prefix even on
+    failure so we don't leak shards. Auto-skips when ``rclone`` is missing or
+    ``rclone lsd r2:`` fails (contributor laptops, fork PRs without secrets).
+
+    :param cfg_dataset_obxf: ``render=obxf`` cfg composed with the
+        ``generate_dataset/smoke-shard`` experiment; carries the real OB-Xf bundle,
+        preset, and pinned renderer version.
+    """
+    if not r2_io.is_r2_reachable():
+        pytest.skip("R2 not reachable (rclone not on PATH or `rclone lsd r2:` failed)")
+
+    unique_prefix = (
+        f"test-runs/test_generate_dataset_renders_obxf_shards_to_r2/{uuid.uuid4().hex[:12]}/"
+    )
+    with open_dict(cfg_dataset_obxf):
+        cfg_dataset_obxf.r2.prefix = unique_prefix
+
+    spec = spec_from_cfg(cfg_dataset_obxf)
+    assert spec.render.param_spec_name == "obxf"
+    try:
+        from_hydra(cfg_dataset_obxf)
+        for shard in spec.shards:
+            size = r2_io.object_size(spec.r2.shard_uri(shard))
+            assert size is not None and size > 0, f"shard missing in R2: {shard.filename}"
+    finally:
+        r2_io.purge_prefix(spec.r2.bucket, spec.r2.prefix)
+
+
+@pytest.mark.integration_r2
+@pytest.mark.r2
+@pytest.mark.requires_vst
+@pytest.mark.slow
 def test_generate_dataset_shard_cadence_renders_one_identical_patch_per_shard(
     cfg_dataset: DictConfig,
 ) -> None:


### PR DESCRIPTION
## Summary

PR2 of Phase 3 (Epic #1582) makes the test fixture, the VST CI matrix, and the Docker image validation **synth-parameterized**, and proves a **second synth (OB-Xf)** renders end-to-end in CI alongside Surge XT.

**Stacked on PR1** (branch `feat/1597-register-obxf`, which registers the `obxf` ParamSpec + preset + `render=obxf` config). This PR's base is set to that branch so GitHub shows only PR2's diff; it must merge **after** PR1. Once PR1 lands on `main`, this branch will be rebased onto `main` and the base retargeted.

## Three deliverables

### A. Synth-parameterize `tests/_vst.py`
- Resolves the target synth from `SYNTH_SETTER_TEST_SYNTH` (a `preset_paths` key, default `surge_xt`) and exposes `TEST_SYNTH` / `TEST_PARAM_SPEC_NAME` / `TEST_PRESET_PATH`. An unregistered key raises `KeyError` at import (fail-loud, no silent skip).
- `PLUGIN_PATH` / `VST_AVAILABLE` and the `conftest.pytest_collection_modifyitems` auto-skip contract are unchanged; the skip reason drops the Surge-specific wording (de-Surged, with the matching `test_conftest_skip_hooks` assertion updated).
- `test_generate_vst_dataset`'s synth-agnostic `test_make_dataset` now renders the env's synth via `_SPEC_NAME` / `_PRESET_PATH`; the Surge-specific tests (hardcoded param names, Surge-tuned audio thresholds) keep their patches and are deselected in the obxf cell. New env-resolution tests cover default / override / empty-fallback / unregistered-key.

### B. OB-Xf as a second cell in the VST CI matrix (`test-vst-slow.yml`)
- Adds a `strategy.matrix` (`fail-fast: false`) over `surge_xt` and `obxf`, parameterizing the smoke plugin-load path, `SYNTH_SETTER_PLUGIN_PATH`, `SYNTH_SETTER_TEST_SYNTH`, and the pytest targets per cell.
- The `surge_xt` cell runs the full Surge slow suite; the `obxf` cell runs only the synth-agnostic `test_make_dataset` as the OB-Xf end-to-end render proof.
- **Scoping decision:** the benchmark / gh-pages publishing steps (buckets `vst-noise-floor-*`, #703) are Surge-specific and gated to the `surge_xt` cell only — the obxf cell renders but never publishes. Codecov uploads under per-cell `flags: vst-<synth>`.

### C. De-Surge the Docker image validation (`docker/ubuntu22_04/Dockerfile`)
- The `python-base` check still validates Surge XT (the only bundle present at that stage). After the `vst3-synths-fetch` COPY, a synth-neutral presence gate asserts the expected baked bundles exist (Surge XT on every arch, OB-Xf on amd64) before the per-synth headless-X11 load validation. `ARG TARGETARCH` is re-declared in that stage so the gate reads the platform arg correctly.
- `SYNTH_SETTER_PLUGIN_PATH` still defaults to Surge XT for backward compat; callers override per synth.

## Verification

- `make test-fast`: 2374 passed, 6 skipped, 0 failed.
- Real-VST `test_make_dataset` rendered locally under the headless wrapper for **both** `obxf` (`SYNTH_SETTER_TEST_SYNTH=obxf`) and `surge_xt` — both pass. The obxf render produced valid, non-silent audio.
- `gha-workflow-validator` passes on `test-vst-slow.yml`; pre-PR `/repo-review-full-no-comments` is clean (0 BLOCK, 0 comment-hygiene).
- The Docker dev-snapshot slow suite is built/run by CI (not buildable locally); the obxf render cell is the end-to-end proof there.

Refs #1597
Part of #1582
