### PR TITLE
test: deflake clean-exit sweep test via heartbeat liveness

### DIFF
--- a/tests/pipeline/test_subprocess_stream.py
+++ b/tests/pipeline/test_subprocess_stream.py
@@ -52,6 +52,9 @@ _PROMPT_SECONDS = 10.0
 # the child interpreter startup margin on loaded CI runners.
 _POLICY_TIMEOUT_SECONDS = 2.0
 
+# Per-phase heartbeat-sweep window (seconds); must exceed the grandchild's write cadence.
+_SWEEP_SETTLE_SECONDS = 1.0
+
 
 def _streamed(
     cmd: list[str], *, timeout: float | None = None, env: dict[str, str] | None = None
@@ -611,9 +614,9 @@ class TestTimeoutEscalation:
             _streamed(_child(script, leak_marker), timeout=_POLICY_TIMEOUT_SECONDS)
 
         _wait_for_file(heartbeat)
-        time.sleep(1.0)
+        time.sleep(_SWEEP_SETTLE_SECONDS)
         size_after_kill = heartbeat.stat().st_size
-        time.sleep(1.0)
+        time.sleep(_SWEEP_SETTLE_SECONDS)
         assert heartbeat.stat().st_size == size_after_kill, "grandchild still heartbeating"
 
 
@@ -644,35 +647,38 @@ def test_pid_alive_unreaped_zombie_reports_dead() -> None:
 class TestPostExitSweep:
     """Problem 4b: the unconditional post-exit in-group SIGTERM sweep."""
 
+    @pytest.mark.slow
     def test_clean_exit_sweep_reaps_ingroup_grandchild(
         self, tmp_path: Path, leak_marker: str
     ) -> None:
         """An in-group grandchild outliving a *successful* child is swept.
 
-        Nothing on the timeout path exercises this: the sweep after a clean
-        exit is the only thing standing between a daemonized descendant and
-        an infinite leak.
+        The post-exit sweep is the only guard against a daemonized in-group descendant leaking
+        forever — no timeout path exercises it.
 
-        :param tmp_path: Holds the grandchild pidfile.
+        :param tmp_path: Holds the grandchild heartbeat file.
         :param leak_marker: argv stamp from the autouse sweep fixture.
         """
-        pidfile = tmp_path / "grandchild.pid"
+        heartbeat = tmp_path / "heartbeat"
         script = (
             "import os, time\n"
             "if os.fork() == 0:\n"
-            f"    with open({str(pidfile)!r}, 'w') as f:\n"
-            "        f.write(str(os.getpid()))\n"
-            "    time.sleep(60)\n"
-            "    os._exit(0)\n"
+            "    while True:\n"
+            f"        with open({str(heartbeat)!r}, 'a') as f:\n"
+            "            f.write('x')\n"
+            "        time.sleep(0.2)\n"
         )
 
         _streamed(_child(script, leak_marker))
 
-        grandchild_pid = int(_wait_for_file(pidfile))
-        deadline = time.monotonic() + 3.0
-        while time.monotonic() < deadline and _pid_alive(grandchild_pid):
-            time.sleep(0.05)
-        assert not _pid_alive(grandchild_pid), "post-exit sweep missed the in-group grandchild"
+        # _streamed returns only after the SUT's finally runs, so the sweep has been dispatched.
+        _wait_for_file(heartbeat)
+        time.sleep(_SWEEP_SETTLE_SECONDS)
+        size_after_sweep = heartbeat.stat().st_size
+        time.sleep(_SWEEP_SETTLE_SECONDS)
+        assert heartbeat.stat().st_size == size_after_sweep, (
+            "post-exit sweep missed the in-group grandchild"
+        )
 
     @pytest.mark.slow
     @pytest.mark.xfail(


### PR DESCRIPTION
## Problem

`tests/pipeline/test_subprocess_stream.py::TestPostExitSweep::test_clean_exit_sweep_reaps_ingroup_grandchild` flakes intermittently on CI (`post-exit sweep missed the in-group grandchild`) while staying green locally.

## Root cause

The test confirmed the swept grandchild was dead via a **bare-PID liveness probe** (`_pid_alive(grandchild_pid)` on a pid read from a pidfile). The SUT is correct — `check_call_streamed_async`'s `finally` unconditionally `os.killpg(pgid, SIGTERM)`, and the grandchild (no `setsid`, no SIGTERM handler) is always an in-group member, so it always dies. The flake is a **false positive in the probe**: after the grandchild is SIGTERM'd and reaped, its PID can be **recycled** by an unrelated process inside the 3 s poll window, so `_pid_alive` reports a stranger as alive.

This is load-correlated — green on hosts with `pid_max=4194304` (sequential allocation can't recycle within 3 s), intermittent on busy CI with smaller `pid_max` and `-n auto` fork churn.

## Fix

Read death from a **heartbeat file only the grandchild writes**, mirroring the sibling `test_timeout_group_kill_stops_ingroup_grandchild_heartbeat`: assert the file stops growing. A recycled PID is a different process that won't grow our file, so the check is identity-bound and immune to PID reuse. The clean-exit trigger (parent forks, exits 0) is unchanged, so the post-exit sweep remains the only thing that can stop the heartbeat. The two heartbeat tests now share a named `_SWEEP_SETTLE_SECONDS` window, and the now-~4 s test gains `@pytest.mark.slow` to match its sibling.

## Verification

- Local reproduction could not surface it (this host has `pid_max=4194304`): **2640/2640** passed under `-n auto` + 120× repeat, plus 90+ isolated/loaded/parallel runs — consistent with the PID-reuse mechanism being container-`pid_max`-dependent.
- Converted test green in isolation, 20/20 under 32-way CPU load, and full module **27 passed, 1 xfailed**.

## Deliberately not addressed (advisory review WARNs)

- **First-write race on `_wait_for_file`**: the SUT's 2 s post-exit pipe drain (the grandchild holds the inherited pipe open) gates the SIGTERM, so the grandchild writes its first heartbeat ~2 s before the sweep — the race cannot fire in practice.
- **DRY of the heartbeat-freeze idiom** across the two tests: only two occurrences; extracting a helper is out of scope for a deflake.

Fixes #1700
