### PR TITLE
feat(data-pipeline): add_embeddings CLI for m2l + CLAP Lance columns

### DIFF
--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -1152,12 +1152,17 @@ The following are of interest for next steps but are out of scope for this docum
 
 Additional stages could follow the same contract (§5) without modifying existing stages:
 
-| Stage              | Input        | Output                 | Compute |
-| ------------------ | ------------ | ---------------------- | ------- |
-| **augment-reverb** | raw shards   | augmented shards       | CPU     |
-| **add-captions**   | audio shards | shards + text column   | GPU     |
-| **add-embeddings** | audio shards | shards + latent column | GPU     |
-| **render-presets** | preset bank  | audio shards           | CPU     |
+| Stage              | Input        | Output               | Compute |
+| ------------------ | ------------ | -------------------- | ------- |
+| **augment-reverb** | raw shards   | augmented shards     | CPU     |
+| **add-captions**   | audio shards | shards + text column | GPU     |
+| **render-presets** | preset bank  | audio shards         | CPU     |
+
+`add-embeddings` is now implemented as the `synth-setter-add-embeddings` CLI: it
+augments a finalized Lance dataset in place with a `clap` (LAION-CLAP)
+`FixedSizeList<float32, 512>` vector column — optionally IVF_PQ-indexed for
+`nearest=` vector search — and an `m2l` (music2latent) fixed-shape-tensor
+latent column, both derived from the audio column.
 
 Stage order would remain static and explicit — user runs commands in sequence. If the number of stages grows to 4-6 and manual commands become unwieldy, adopt Prefect rather than building a homegrown orchestrator.
 

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -114,6 +114,10 @@ docs:
         covers: "Shared shape primitives consumed by the writers, the shard validator, and the test shard seeders — DATASET_FIELD_NAMES / DATASET_FIELD_DTYPES, mel-front-end constants, per-field shape helpers, and dataset_field_shapes (the single field→shape contract)."
       - pattern: "src/synth_setter/pipeline/data/lance_shard.py"
         covers: "Lance dataset-shard codec — lance_schema / tensor_array / record_batch_from_arrays / write_lance_dataset / lance_fragment / commit_lance_dataset on the encode side, read_shard_metadata / iter_lance_column_rows on the decode side; shared by the Lance writer, validator, and finalize."
+      - pattern: "src/synth_setter/pipeline/data/add_embeddings.py"
+        covers: "`synth-setter-add-embeddings` CLI — appends a `clap` (LAION-CLAP) `FixedSizeList<float32,512>` vector column (with an optional IVF_PQ index for `nearest=` search) and an `m2l` (music2latent) fixed-shape-tensor column to a finalized Lance dataset via `lance.batch_udf`, with injected/lazy-loaded encoders and row-count + dim + finiteness validation (post-finalize augmenter)."
+      - pattern: "src/synth_setter/pipeline/data/add_music2latent.py"
+        covers: "`python -m synth_setter.pipeline.data.add_music2latent` CLI — adds a `music2latent` dataset to HDF5 shards via reader/writer multiprocessing around a GPU encode loop."
 
   # ── SkyPilot compute integration design doc ─────────────────────
   - doc: docs/design/skypilot-compute-integration.md

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -212,7 +212,7 @@ Available console scripts (declared in `pyproject.toml`'s
 `[project.scripts]`): `synth-setter-train`, `synth-setter-eval`,
 `synth-setter-generate-dataset`, `synth-setter-generate-dataset-from-hydra`,
 `synth-setter-finalize-dataset`, `synth-setter-introspect-plugin`,
-`synth-setter-spec-uri`.
+`synth-setter-spec-uri`, `synth-setter-add-embeddings`.
 
 Prefer `docker run --env-file .env` over `set -a && source .env` to avoid
 polluting your host shell.

--- a/notebooks/add_embeddings_smoke.ipynb
+++ b/notebooks/add_embeddings_smoke.ipynb
@@ -1,0 +1,239 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "intro-md",
+   "metadata": {},
+   "source": [
+    "# `add_embeddings` smoke walkthrough\n",
+    "\n",
+    "End-to-end demo of `synth_setter.pipeline.data.add_embeddings`:\n",
+    "\n",
+    "1. Build a tiny in-memory **Lance** dataset shaped like a `generate_dataset` /\n",
+    "   `finalize_dataset` shard (an `audio` tensor column plus `mel_spec` /\n",
+    "   `param_array`, with `ShardMetadata` embedded in the schema).\n",
+    "2. Run the **m2l + CLAP** add step. It appends:\n",
+    "   - `clap` — a `FixedSizeList<float32, 512>` LAION-CLAP embedding, **vector-\n",
+    "     searchable** (Lance builds an IVF_PQ index on it for large datasets).\n",
+    "   - `m2l` — a `fixed_shape_tensor<float32, (C*D, T)>` music2latent latent\n",
+    "     (retrievable, not a search vector).\n",
+    "3. Read the dataset back into a pandas `DataFrame` holding **just the params and\n",
+    "   the two new embedding columns**.\n",
+    "4. Run a **vector search** over the `clap` column with `nearest=`.\n",
+    "\n",
+    "> Loading the real encoders downloads the music2latent and\n",
+    "> `laion/clap-htsat-unfused` checkpoints, so step 2 needs `music2latent`,\n",
+    "> `transformers`, and `torchaudio` installed and will pull weights on first run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "imports",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import lance\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from synth_setter.data.vst.shapes import (\n",
+    "    AUDIO_FIELD,\n",
+    "    DATASET_FIELD_DTYPES,\n",
+    "    MEL_SPEC_FIELD,\n",
+    "    PARAM_ARRAY_FIELD,\n",
+    "    audio_dataset_shape,\n",
+    "    mel_dataset_shape,\n",
+    "    param_array_dataset_shape,\n",
+    ")\n",
+    "from synth_setter.pipeline.data.lance_shard import (\n",
+    "    lance_schema,\n",
+    "    read_shard_metadata,\n",
+    "    record_batch_from_arrays,\n",
+    "    write_lance_dataset,\n",
+    ")\n",
+    "from synth_setter.pipeline.schemas.shard_metadata import ShardMetadata"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "build-md",
+   "metadata": {},
+   "source": [
+    "## 1. Build a smoke Lance dataset\n",
+    "\n",
+    "Four rows of 1 s, 44.1 kHz stereo noise — the same on-disk layout a real shard\n",
+    "carries, including the `ShardMetadata` the add step reads the sample rate from."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "build",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows, channels, sample_rate, duration, num_params = 4, 2, 44_100, 1.0, 56\n",
+    "shapes = {\n",
+    "    AUDIO_FIELD: audio_dataset_shape(rows, channels, sample_rate, duration),\n",
+    "    MEL_SPEC_FIELD: mel_dataset_shape(rows, channels, sample_rate, duration),\n",
+    "    PARAM_ARRAY_FIELD: param_array_dataset_shape(rows, num_params),\n",
+    "}\n",
+    "metadata = ShardMetadata(\n",
+    "    velocity=100,\n",
+    "    signal_duration_seconds=duration,\n",
+    "    sample_rate=sample_rate,\n",
+    "    channels=channels,\n",
+    "    min_loudness=-55.0,\n",
+    ")\n",
+    "schema = lance_schema(shapes, metadata)\n",
+    "\n",
+    "rng = np.random.default_rng(0)\n",
+    "arrays = {\n",
+    "    AUDIO_FIELD: (0.1 * rng.standard_normal(shapes[AUDIO_FIELD])).astype(\n",
+    "        DATASET_FIELD_DTYPES[AUDIO_FIELD]\n",
+    "    ),\n",
+    "    MEL_SPEC_FIELD: np.zeros(shapes[MEL_SPEC_FIELD], DATASET_FIELD_DTYPES[MEL_SPEC_FIELD]),\n",
+    "    PARAM_ARRAY_FIELD: rng.random((rows, num_params)).astype(\n",
+    "        DATASET_FIELD_DTYPES[PARAM_ARRAY_FIELD]\n",
+    "    ),\n",
+    "}\n",
+    "\n",
+    "uri = str(Path(tempfile.mkdtemp()) / \"smoke.lance\")\n",
+    "write_lance_dataset(uri, schema, [record_batch_from_arrays(arrays, schema)])\n",
+    "lance.dataset(uri).schema.names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "add-md",
+   "metadata": {},
+   "source": [
+    "## 2. Run the m2l + CLAP add step\n",
+    "\n",
+    "`add_embeddings` reads only the `audio` column per batch and appends the `m2l`\n",
+    "tensor and `clap` vector columns. The sample rate comes from the shard metadata,\n",
+    "exactly as the `python -m synth_setter.pipeline.data.add_embeddings <uri>` CLI\n",
+    "does it.\n",
+    "\n",
+    "We pass `build_index=False` here because IVF_PQ needs ~256 rows to train; on a\n",
+    "real (large) dataset keep the default so `clap` gets an ANN index. Exact\n",
+    "`nearest` search (step 4) works either way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "add",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from synth_setter.pipeline.data.add_embeddings import (\n",
+    "    CLAP_FIELD,\n",
+    "    M2L_FIELD,\n",
+    "    add_embeddings,\n",
+    "    load_clap_audio_encoder,\n",
+    "    load_m2l_audio_encoder,\n",
+    ")\n",
+    "\n",
+    "dataset = lance.dataset(uri)\n",
+    "sample_rate = int(read_shard_metadata(dataset.schema).sample_rate)\n",
+    "\n",
+    "# First call downloads the music2latent + CLAP checkpoints.\n",
+    "m2l_encode = load_m2l_audio_encoder()\n",
+    "clap_encode = load_clap_audio_encoder()\n",
+    "\n",
+    "add_embeddings(dataset, m2l_encode, clap_encode, sample_rate, build_index=False)\n",
+    "lance.dataset(uri).schema.to_string()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df-md",
+   "metadata": {},
+   "source": [
+    "## 3. DataFrame of params + new embeddings\n",
+    "\n",
+    "Project only `param_array`, `m2l`, and `clap`. `clap` rows come back as\n",
+    "fixed-size lists; `m2l` as a fixed-shape tensor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "table = lance.dataset(uri).to_table(columns=[PARAM_ARRAY_FIELD, M2L_FIELD, CLAP_FIELD])\n",
+    "\n",
+    "frame = pd.DataFrame(\n",
+    "    {\n",
+    "        PARAM_ARRAY_FIELD: list(\n",
+    "            table.column(PARAM_ARRAY_FIELD).combine_chunks().to_numpy_ndarray()\n",
+    "        ),\n",
+    "        M2L_FIELD: list(table.column(M2L_FIELD).combine_chunks().to_numpy_ndarray()),\n",
+    "        CLAP_FIELD: [\n",
+    "            np.asarray(row, dtype=np.float32) for row in table.column(CLAP_FIELD).to_pylist()\n",
+    "        ],\n",
+    "    }\n",
+    ")\n",
+    "frame[\"m2l_shape\"] = frame[M2L_FIELD].map(np.shape)\n",
+    "frame[\"clap_shape\"] = frame[CLAP_FIELD].map(np.shape)\n",
+    "frame[[\"m2l_shape\", \"clap_shape\"]]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "search-md",
+   "metadata": {},
+   "source": [
+    "## 4. Vector search over `clap`\n",
+    "\n",
+    "Query the `clap` column with `nearest=`. Using row 0's own embedding as the\n",
+    "query, it should come back first (distance ~0). On a dataset with an IVF_PQ\n",
+    "index this is ANN; here (4 rows, no index) Lance falls back to an exact scan —\n",
+    "same API either way."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "search",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = np.asarray(frame[CLAP_FIELD].iloc[0], dtype=np.float32)\n",
+    "neighbors = lance.dataset(uri).to_table(\n",
+    "    columns=[PARAM_ARRAY_FIELD],\n",
+    "    nearest={\"column\": CLAP_FIELD, \"q\": query, \"k\": 3},\n",
+    ")\n",
+    "neighbors.select([\"_distance\"]).to_pandas()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ synth-setter-eval = "synth_setter.cli.eval:main"
 synth-setter-generate-dataset = "synth_setter.cli.generate_dataset:main"
 synth-setter-generate-dataset-from-hydra = "synth_setter.cli.generate_dataset:from_hydra"
 synth-setter-finalize-dataset = "synth_setter.cli.finalize_dataset:main"
+synth-setter-add-embeddings = "synth_setter.pipeline.data.add_embeddings:main"
 synth-setter-introspect-plugin = "synth_setter.cli.introspect_plugin:main"
 synth-setter-spec-uri = "synth_setter.pipeline.ci.spec_uri:main"
 
@@ -126,6 +127,10 @@ torch = [
   "torchaudio>=2.0.0",
   "lightning>=2.6.0",
   "torchmetrics>=0.11.4",
+  # Audio-embedding encoders for the add_embeddings CLI (lazy-imported). CLAP
+  # rides on transformers; music2latent ships its own torch-backed encoder.
+  "transformers>=4.40.0",
+  "music2latent>=0.1.8",
 ]
 config = [
   "hydra-core==1.3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,8 +128,9 @@ torch = [
   "lightning>=2.6.0",
   "torchmetrics>=0.11.4",
   # Audio-embedding encoders for the add_embeddings CLI (lazy-imported). CLAP
-  # rides on transformers; music2latent ships its own torch-backed encoder.
-  "transformers>=4.40.0",
+  # rides on transformers (>=5: ClapProcessor takes `audio=`, not `audios=`);
+  # music2latent ships its own torch-backed encoder.
+  "transformers>=5.0.0",
   "music2latent>=0.1.8",
 ]
 config = [

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,7 +22,7 @@ The Python utilities live inside the `synth_setter` package and are invoked as `
 | ---------------------------- | ------------------------------------------------------------------------------------------------------------------- |
 | `synth_setter.evaluation`    | `predict_vst_audio`, `compute_audio_metrics`                                                                        |
 | `synth_setter.tools`         | `surge_xt_interactive`, `model_from_wandb`, `plot_param2tok`, `paramspec_to_table`, `sig_perf`, `cadence_sweep_489` |
-| `synth_setter.pipeline.data` | `reshard`, `rewrite_to_latest`, `stats`, `r2_report`, `add_music2latent`                                            |
+| `synth_setter.pipeline.data` | `reshard`, `rewrite_to_latest`, `stats`, `r2_report`, `add_music2latent`, `add_embeddings`                          |
 | `synth_setter.scripts`       | `load_vst3_check`                                                                                                   |
 
 The `synth-setter-train`, `synth-setter-eval`, and `synth-setter-generate-dataset` console scripts (declared in `pyproject.toml`'s `[project.scripts]`) remain the canonical entrypoints for the train / eval / dataset-generation workflows.

--- a/src/synth_setter/data/vst/shapes.py
+++ b/src/synth_setter/data/vst/shapes.py
@@ -23,6 +23,11 @@ MEL_SPEC_FIELD: str = "mel_spec"
 PARAM_ARRAY_FIELD: str = "param_array"
 DATASET_FIELD_NAMES: tuple[str, ...] = (AUDIO_FIELD, MEL_SPEC_FIELD, PARAM_ARRAY_FIELD)
 
+# Optional audio-embedding columns appended post-hoc by the add_embeddings CLI;
+# not in DATASET_FIELD_NAMES because the writers never emit them.
+M2L_FIELD: str = "m2l"
+CLAP_FIELD: str = "clap"
+
 # Per-field on-disk dtype, matching what the HDF5 / wds writers emit. Audio is
 # stored as ``float16`` for compressed storage efficiency; mel and params stay
 # ``float32``. Consumers upcast as needed; this map is the single source of

--- a/src/synth_setter/pipeline/data/add_embeddings.py
+++ b/src/synth_setter/pipeline/data/add_embeddings.py
@@ -48,9 +48,11 @@ CLAP_SAMPLE_RATE: int = 48000
 # Projected audio-embedding width of the default checkpoint; the ``clap`` column's
 # fixed-size-list length, and the dim a vector query must match.
 CLAP_EMBEDDING_DIM: int = 512
-# Caps the music2latent sub-batch independent of Lance's read batch, so GPU
-# memory stays bounded however large add_columns makes each UDF batch.
-M2L_ENCODE_MAX_BATCH: int = 256
+# Per-forward sub-batch caps for the encoders, independent of Lance's read batch:
+# the batch_udf hands an encoder the whole read batch at once, so without these a
+# large dataset OOMs the GPU (a 256-row CLAP forward alone needs ~5 GiB).
+M2L_ENCODE_MAX_BATCH: int = 64
+CLAP_ENCODE_MAX_BATCH: int = 32
 # IVF_PQ needs ~256 training vectors (256 PQ centroids); below this the index is
 # skipped and callers fall back to Lance's exact (brute-force) ``nearest`` scan.
 MIN_ROWS_FOR_INDEX: int = 256
@@ -273,8 +275,8 @@ def load_clap_audio_encoder(
     processor = ClapProcessor.from_pretrained(checkpoint)
 
     @torch.no_grad()
-    def encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:
-        wav = torch.from_numpy(np.ascontiguousarray(mono, dtype=np.float32))
+    def _encode_chunk(chunk: np.ndarray, sample_rate: int) -> np.ndarray:
+        wav = torch.from_numpy(np.ascontiguousarray(chunk, dtype=np.float32))
         if sample_rate != CLAP_SAMPLE_RATE:
             wav = audio_fn.resample(wav, sample_rate, CLAP_SAMPLE_RATE)
         # `audio=` (singular) per transformers>=5; the splat also hides the stub's
@@ -290,6 +292,15 @@ def load_clap_audio_encoder(
         # (B, CLAP_EMBEDDING_DIM) audio embedding is its pooler_output.
         features = model.get_audio_features(**device_inputs)
         return features.pooler_output.cpu().numpy()  # pyright: ignore
+
+    def encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+        # Sub-batch the forward so the whole UDF read batch never hits the GPU at
+        # once; each chunk's result is pulled to CPU before the next runs.
+        chunks = [
+            _encode_chunk(mono[start : start + CLAP_ENCODE_MAX_BATCH], sample_rate)
+            for start in range(0, len(mono), CLAP_ENCODE_MAX_BATCH)
+        ]
+        return np.concatenate(chunks, axis=0)
 
     return encode
 

--- a/src/synth_setter/pipeline/data/add_embeddings.py
+++ b/src/synth_setter/pipeline/data/add_embeddings.py
@@ -144,7 +144,12 @@ def build_clap_index(
     :param metric: Distance metric for the index.
     :returns: ``True`` if an index was built, ``False`` if skipped (too few rows
         to train PQ — exact ``nearest`` still works without an index).
+    :raises ValueError: ``num_sub_vectors`` does not divide the ``clap`` column's
+        vector width (Lance's own PQ-training failure is opaque).
     """
+    clap_dim = dataset.schema.field(CLAP_FIELD).type.list_size
+    if clap_dim % num_sub_vectors != 0:
+        raise ValueError(f"num_sub_vectors={num_sub_vectors} does not divide clap dim {clap_dim}")
     rows = dataset.count_rows()
     if rows < MIN_ROWS_FOR_INDEX:
         logger.warning("clap_index_skipped_too_few_rows", rows=rows, minimum=MIN_ROWS_FOR_INDEX)
@@ -191,13 +196,16 @@ def add_embeddings(
     :param num_partitions: IVF partition count; ``None`` uses ``round(sqrt(rows))``.
     :param num_sub_vectors: PQ sub-vector count (must divide ``clap_dim``).
     :param metric: Vector-index distance metric.
-    :raises ValueError: ``dataset`` already has an ``m2l`` or ``clap`` column —
-        re-running on an augmented dataset would hit Lance's opaque
-        "column already exists" error.
+    :raises ValueError: ``dataset`` already has an ``m2l`` or ``clap`` column
+        (re-running on an augmented dataset would hit Lance's opaque "column
+        already exists" error), or lacks the ``audio`` column the UDF reads
+        (an absent source column would otherwise fail opaquely mid-transaction).
     """
     existing = {M2L_FIELD, CLAP_FIELD} & set(dataset.schema.names)
     if existing:
         raise ValueError(f"dataset already has embedding column(s): {sorted(existing)}")
+    if AUDIO_FIELD not in dataset.schema.names:
+        raise ValueError(f"dataset has no {AUDIO_FIELD!r} column to embed")
 
     @lance.batch_udf()
     def udf(batch: pa.RecordBatch) -> pa.RecordBatch:
@@ -259,7 +267,7 @@ def load_clap_audio_encoder(
     logger.info("loading_clap_checkpoint", checkpoint=checkpoint, device=device)
     # transformers' own types are too loose for the surface used below, so pyright
     # is scoped off the two offending calls (the from_pretrained `.to()` chain and
-    # the get_audio_features tensor return) rather than widened to Any; the
+    # the get_audio_features output access) rather than widened to Any; the
     # processor's audio kwargs are dict-splatted, which the stub can't object to.
     model = ClapModel.from_pretrained(checkpoint).to(device).eval()  # pyright: ignore
     processor = ClapProcessor.from_pretrained(checkpoint)
@@ -278,7 +286,10 @@ def load_clap_audio_encoder(
         }
         inputs = processor(**clap_kwargs)
         device_inputs = {key: value.to(device) for key, value in inputs.items()}
-        return model.get_audio_features(**device_inputs).cpu().numpy()  # pyright: ignore
+        # transformers>=5 returns a BaseModelOutputWithPooling; the projected
+        # (B, CLAP_EMBEDDING_DIM) audio embedding is its pooler_output.
+        features = model.get_audio_features(**device_inputs)
+        return features.pooler_output.cpu().numpy()  # pyright: ignore
 
     return encode
 
@@ -322,12 +333,34 @@ def _open_lance_dataset(uri: str) -> lance.LanceDataset:
     show_default=True,
     help="Build an IVF_PQ vector index on the clap column.",
 )
+@click.option(
+    "--num-partitions",
+    type=int,
+    default=None,
+    help="IVF partition count; defaults to round(sqrt(rows)).",
+)
+@click.option(
+    "--num-sub-vectors",
+    type=int,
+    default=DEFAULT_NUM_SUB_VECTORS,
+    show_default=True,
+    help="PQ sub-vector count (must divide the clap dim).",
+)
+@click.option(
+    "--metric",
+    default=DEFAULT_INDEX_METRIC,
+    show_default=True,
+    help="Vector-index distance metric.",
+)
 def main(
     lance_uri: str,
     clap_checkpoint: str,
     device: str | None,
     batch_size: int | None,
     build_index: bool,
+    num_partitions: int | None,
+    num_sub_vectors: int,
+    metric: str,
 ) -> None:
     """Add ``m2l`` + ``clap`` embedding columns to the Lance dataset at LANCE_URI.
 
@@ -341,6 +374,9 @@ def main(
     :param device: Torch device for CLAP; ``None`` selects cuda when available, else cpu.
     :param batch_size: Rows per UDF call; ``None`` uses the Lance default.
     :param build_index: Build an IVF_PQ index on the clap column after writing it.
+    :param num_partitions: IVF partition count; ``None`` uses ``round(sqrt(rows))``.
+    :param num_sub_vectors: PQ sub-vector count; must divide the clap dim.
+    :param metric: Vector-index distance metric.
     """
     try:
         dataset = _open_lance_dataset(lance_uri)
@@ -365,6 +401,9 @@ def main(
         sample_rate,
         batch_size=batch_size,
         build_index=build_index,
+        num_partitions=num_partitions,
+        num_sub_vectors=num_sub_vectors,
+        metric=metric,
     )
     logger.info("added_embeddings", uri=lance_uri, columns=[M2L_FIELD, CLAP_FIELD])
 

--- a/src/synth_setter/pipeline/data/add_embeddings.py
+++ b/src/synth_setter/pipeline/data/add_embeddings.py
@@ -268,9 +268,10 @@ def load_clap_audio_encoder(
         wav = torch.from_numpy(np.ascontiguousarray(mono, dtype=np.float32))
         if sample_rate != CLAP_SAMPLE_RATE:
             wav = audio_fn.resample(wav, sample_rate, CLAP_SAMPLE_RATE)
-        # Build kwargs as a dict so the splat hides transformers' too-narrow __call__ stub.
+        # `audio=` (singular) per transformers>=5; the splat also hides the stub's
+        # too-narrow __call__ signature from pyright.
         clap_kwargs = {
-            "audios": list(wav.numpy()),
+            "audio": list(wav.numpy()),
             "sampling_rate": CLAP_SAMPLE_RATE,
             "return_tensors": "pt",
         }

--- a/src/synth_setter/pipeline/data/add_embeddings.py
+++ b/src/synth_setter/pipeline/data/add_embeddings.py
@@ -412,19 +412,25 @@ def main(
     logger.info(
         "adding_embeddings", uri=lance_uri, sample_rate=sample_rate, rows=dataset.count_rows()
     )
-    m2l_encode = load_m2l_audio_encoder()
-    clap_encode = load_clap_audio_encoder(clap_checkpoint, device)
-    add_embeddings(
-        dataset,
-        m2l_encode,
-        clap_encode,
-        sample_rate,
-        batch_size=batch_size,
-        build_index=build_index,
-        num_partitions=num_partitions,
-        num_sub_vectors=num_sub_vectors,
-        metric=metric,
-    )
+    try:
+        m2l_encode = load_m2l_audio_encoder()
+        clap_encode = load_clap_audio_encoder(clap_checkpoint, device)
+        add_embeddings(
+            dataset,
+            m2l_encode,
+            clap_encode,
+            sample_rate,
+            batch_size=batch_size,
+            build_index=build_index,
+            num_partitions=num_partitions,
+            num_sub_vectors=num_sub_vectors,
+            metric=metric,
+        )
+    # Encoder load (missing dep) or the add/index step (validation, Lance, CUDA)
+    # should exit cleanly with a logged cause, not a raw CLI traceback.
+    except (OSError, ValueError, RuntimeError, ImportError) as exc:
+        logger.error("add_embeddings_failed", uri=lance_uri, error=str(exc))
+        sys.exit(1)
     logger.info("added_embeddings", uri=lance_uri, columns=[M2L_FIELD, CLAP_FIELD])
 
 

--- a/src/synth_setter/pipeline/data/add_embeddings.py
+++ b/src/synth_setter/pipeline/data/add_embeddings.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python
+"""Append ``m2l`` + CLAP audio-embedding columns to a finalized Lance dataset.
+
+The functional core (:func:`embeddings_record_batch`, :func:`add_embeddings`)
+maps a Lance dataset's ``audio`` column to two columns:
+
+- ``clap`` — a ``FixedSizeList<float32, CLAP_EMBEDDING_DIM>`` LAION-CLAP audio
+  embedding. Stored as a fixed-size list (not opaque bytes) so Lance can build a
+  vector (IVF_PQ) index over it and serve ``nearest=`` queries.
+- ``m2l`` — a ``fixed_shape_tensor<float32, (C*D, T)>`` music2latent latent. A
+  sequence latent, not a search vector, so it is kept retrievable but
+  un-indexed; this requires a constant ``(channels, latent-dim, time)`` across
+  the dataset.
+
+Both embedders are injected callables, so the core runs without a checkpoint;
+:func:`load_m2l_audio_encoder` / :func:`load_clap_audio_encoder` build the real
+encoders behind lazy ``music2latent`` / ``transformers`` imports.
+
+This is a sanctioned post-finalize augmenter: it commits a new Lance version of
+an existing dataset rather than writing fresh ``data/`` shards, so it does not
+cross the worker/finalize write boundary.
+
+CLI: ``python -m synth_setter.pipeline.data.add_embeddings DATASET.lance``.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Callable
+from typing import Any, TypeAlias
+
+import click
+import lance
+import numpy as np
+import pyarrow as pa
+import structlog
+from einops import rearrange
+
+from synth_setter.data.vst.shapes import AUDIO_FIELD, CLAP_FIELD, M2L_FIELD
+from synth_setter.pipeline import r2_io
+from synth_setter.pipeline.data.lance_shard import read_shard_metadata, tensor_array
+
+logger = structlog.get_logger(__name__)
+
+DEFAULT_CLAP_CHECKPOINT: str = "laion/clap-htsat-unfused"
+# CLAP's feature extractor rejects any other input rate.
+CLAP_SAMPLE_RATE: int = 48000
+# Projected audio-embedding width of the default checkpoint; the ``clap`` column's
+# fixed-size-list length, and the dim a vector query must match.
+CLAP_EMBEDDING_DIM: int = 512
+# Caps the music2latent sub-batch independent of Lance's read batch, so GPU
+# memory stays bounded however large add_columns makes each UDF batch.
+M2L_ENCODE_MAX_BATCH: int = 256
+# IVF_PQ needs ~256 training vectors (256 PQ centroids); below this the index is
+# skipped and callers fall back to Lance's exact (brute-force) ``nearest`` scan.
+MIN_ROWS_FOR_INDEX: int = 256
+# 512 % 16 == 0; each PQ sub-quantizer covers a 32-d slice of the CLAP vector.
+DEFAULT_NUM_SUB_VECTORS: int = 16
+# Cosine matches CLAP's L2-normalized audio embeddings.
+DEFAULT_INDEX_METRIC: str = "cosine"
+
+M2LEncodeFn: TypeAlias = Callable[[np.ndarray], np.ndarray]
+ClapEncodeFn: TypeAlias = Callable[[np.ndarray, int], np.ndarray]
+
+
+def _downmix_to_mono(audio: np.ndarray) -> np.ndarray:
+    """Average an ``(B, C, T)`` batch's channels into ``(B, T)`` mono float32.
+
+    :param audio: ``(B, C, T)`` batch, ``C >= 1`` (on-disk float16). ``float32``
+        upcasts in the reduction so the encoder never sees half-precision.
+    :returns: ``(B, T)`` float32 mono batch.
+    """
+    return audio.mean(axis=1, dtype=np.float32)
+
+
+def _clap_fixed_size_list(clap: np.ndarray, dim: int) -> pa.FixedSizeListArray:
+    """Pack a ``(B, dim)`` float32 batch as a ``FixedSizeList<float32, dim>`` array.
+
+    :param clap: ``(B, dim)`` embedding batch.
+    :param dim: Fixed list length (the vector dimensionality).
+    :returns: A Lance-indexable fixed-size-list array.
+    """
+    flat = pa.array(np.ascontiguousarray(clap, dtype=np.float32).reshape(-1), pa.float32())
+    return pa.FixedSizeListArray.from_arrays(flat, dim)
+
+
+def embeddings_record_batch(
+    audio: np.ndarray,
+    m2l_encode: M2LEncodeFn,
+    clap_encode: ClapEncodeFn,
+    sample_rate: int,
+    *,
+    clap_dim: int = CLAP_EMBEDDING_DIM,
+) -> pa.RecordBatch:
+    """Encode one audio batch into the ``(m2l, clap)`` record batch.
+
+    :param audio: ``(B, C, T)`` audio batch (any float dtype).
+    :param m2l_encode: Maps the batch to a ``(B, C*D, T)`` latent batch.
+    :param clap_encode: Maps a mono ``(B, T)`` batch and ``sample_rate`` to ``(B, clap_dim)``.
+    :param sample_rate: Passed through to ``clap_encode``.
+    :param clap_dim: Expected CLAP width; the ``clap`` fixed-size-list length.
+    :returns: A ``B``-row batch with a ``m2l`` fixed-shape-tensor column and a
+        ``clap`` ``FixedSizeList<float32, clap_dim>`` column.
+    :raises ValueError: An encoder returns the wrong row count, ``clap`` is not
+        ``(B, clap_dim)``, or either embedding is non-finite (the columns are
+        permanent — a NaN/inf row from a degenerate clip must not be written).
+    """
+    rows = len(audio)
+    m2l = np.ascontiguousarray(m2l_encode(audio), dtype=np.float32)
+    clap = np.ascontiguousarray(
+        clap_encode(_downmix_to_mono(audio), sample_rate), dtype=np.float32
+    )
+    if len(m2l) != rows or len(clap) != rows:
+        raise ValueError(
+            f"encoders produced {len(m2l)} m2l and {len(clap)} clap rows, expected {rows}"
+        )
+    if clap.ndim != 2 or clap.shape[1] != clap_dim:
+        raise ValueError(
+            f"clap encoder produced shape {clap.shape}, expected ({rows}, {clap_dim})"
+        )
+    for field, embedding in ((M2L_FIELD, m2l), (CLAP_FIELD, clap)):
+        if not np.isfinite(embedding).all():
+            raise ValueError(f"{field} embeddings contain non-finite values")
+    return pa.record_batch(
+        {
+            M2L_FIELD: tensor_array(m2l, np.dtype("float32"), m2l.shape[1:]),
+            CLAP_FIELD: _clap_fixed_size_list(clap, clap_dim),
+        }
+    )
+
+
+def build_clap_index(
+    dataset: lance.LanceDataset,
+    *,
+    num_partitions: int | None = None,
+    num_sub_vectors: int = DEFAULT_NUM_SUB_VECTORS,
+    metric: str = DEFAULT_INDEX_METRIC,
+) -> bool:
+    """Build an IVF_PQ vector index on the ``clap`` column, if the dataset is large enough.
+
+    :param dataset: Dataset already carrying a ``clap`` fixed-size-list column.
+    :param num_partitions: IVF partition count; ``None`` uses ``round(sqrt(rows))``.
+    :param num_sub_vectors: PQ sub-vector count (must divide the CLAP dim).
+    :param metric: Distance metric for the index.
+    :returns: ``True`` if an index was built, ``False`` if skipped (too few rows
+        to train PQ — exact ``nearest`` still works without an index).
+    """
+    rows = dataset.count_rows()
+    if rows < MIN_ROWS_FOR_INDEX:
+        logger.warning("clap_index_skipped_too_few_rows", rows=rows, minimum=MIN_ROWS_FOR_INDEX)
+        return False
+    partitions = num_partitions or max(1, round(rows**0.5))
+    dataset.create_index(
+        CLAP_FIELD,
+        index_type="IVF_PQ",
+        num_partitions=partitions,
+        num_sub_vectors=num_sub_vectors,
+        metric=metric,
+    )
+    logger.info("clap_index_built", rows=rows, num_partitions=partitions, metric=metric)
+    return True
+
+
+def add_embeddings(
+    dataset: lance.LanceDataset,
+    m2l_encode: M2LEncodeFn,
+    clap_encode: ClapEncodeFn,
+    sample_rate: int,
+    *,
+    clap_dim: int = CLAP_EMBEDDING_DIM,
+    batch_size: int | None = None,
+    build_index: bool = True,
+    num_partitions: int | None = None,
+    num_sub_vectors: int = DEFAULT_NUM_SUB_VECTORS,
+    metric: str = DEFAULT_INDEX_METRIC,
+) -> None:
+    """Append ``m2l`` + ``clap`` columns to ``dataset`` and (optionally) index ``clap``.
+
+    Commits a new dataset version; existing columns are untouched and only
+    ``audio`` is read per batch. When ``build_index`` and the dataset has enough
+    rows, an IVF_PQ index is built on ``clap`` so ``nearest=`` uses ANN.
+
+    :param dataset: Open Lance dataset carrying an ``audio`` column.
+    :param m2l_encode: Maps an ``(B, C, T)`` batch to a ``(B, C*D, T)`` latent batch.
+    :param clap_encode: Maps a mono ``(B, T)`` batch and ``sample_rate`` to ``(B, clap_dim)``.
+    :param sample_rate: Passed through to ``clap_encode``.
+    :param clap_dim: CLAP embedding width; the ``clap`` fixed-size-list length.
+    :param batch_size: Rows per UDF call; ``None`` uses the Lance default. Ignored
+        for legacy (v1) Lance datasets, which Lance rewrites whole.
+    :param build_index: Build an IVF_PQ index on ``clap`` after the column lands.
+    :param num_partitions: IVF partition count; ``None`` uses ``round(sqrt(rows))``.
+    :param num_sub_vectors: PQ sub-vector count (must divide ``clap_dim``).
+    :param metric: Vector-index distance metric.
+    :raises ValueError: ``dataset`` already has an ``m2l`` or ``clap`` column —
+        re-running on an augmented dataset would hit Lance's opaque
+        "column already exists" error.
+    """
+    existing = {M2L_FIELD, CLAP_FIELD} & set(dataset.schema.names)
+    if existing:
+        raise ValueError(f"dataset already has embedding column(s): {sorted(existing)}")
+
+    @lance.batch_udf()
+    def udf(batch: pa.RecordBatch) -> pa.RecordBatch:
+        audio = batch.column(AUDIO_FIELD).to_numpy_ndarray()
+        return embeddings_record_batch(
+            audio, m2l_encode, clap_encode, sample_rate, clap_dim=clap_dim
+        )
+
+    dataset.add_columns(udf, read_columns=[AUDIO_FIELD], batch_size=batch_size)
+    if build_index:
+        build_clap_index(
+            dataset, num_partitions=num_partitions, num_sub_vectors=num_sub_vectors, metric=metric
+        )
+
+
+def load_m2l_audio_encoder() -> M2LEncodeFn:
+    """Build a music2latent encode callable over an ``(B, C, T)`` batch.
+
+    The ``music2latent`` import is deferred so this module stays importable (and
+    its core testable with a fake encoder) without loading a checkpoint. No
+    device knob: music2latent owns its own placement.
+
+    :returns: Encode callable mapping ``(B, C, T)`` to ``(B, C*D, T)`` float32.
+    """
+    from music2latent import EncoderDecoder
+
+    encoder = EncoderDecoder()
+
+    def encode(audio: np.ndarray) -> np.ndarray:
+        batch, channels = audio.shape[0], audio.shape[1]
+        flat = np.ascontiguousarray(rearrange(audio, "b c t -> (b c) t"), dtype=np.float32)
+        latents = encoder.encode(flat, max_batch_size=M2L_ENCODE_MAX_BATCH)
+        latents = rearrange(latents, "(b c) d t -> b (c d) t", b=batch, c=channels)
+        return latents.cpu().numpy()
+
+    return encode
+
+
+def load_clap_audio_encoder(
+    checkpoint: str = DEFAULT_CLAP_CHECKPOINT,
+    device: str | None = None,
+) -> ClapEncodeFn:
+    """Load a CLAP checkpoint and return a mono-batch encode callable.
+
+    The ``torch`` / ``transformers`` imports are deferred so this module stays
+    importable without loading a model.
+
+    :param checkpoint: HuggingFace CLAP model id; its audio tower sets the embedding width.
+    :param device: Torch device; ``None`` selects cuda when available, else cpu.
+    :returns: Encode callable mapping a mono ``(B, T)`` batch and sample rate to
+        a ``(B, D)`` float32 embedding batch.
+    """
+    import torch
+    import torchaudio.functional as audio_fn
+    from transformers import ClapModel, ClapProcessor
+
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+    logger.info("loading_clap_checkpoint", checkpoint=checkpoint, device=device)
+    # ``Any``: transformers' from_pretrained / processor / get_audio_features
+    # carry typing that rejects the kwargs and tensor access used below.
+    model: Any = ClapModel.from_pretrained(checkpoint)
+    model = model.to(device).eval()
+    processor: Any = ClapProcessor.from_pretrained(checkpoint)
+
+    @torch.no_grad()
+    def encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+        wav = torch.from_numpy(np.ascontiguousarray(mono, dtype=np.float32))
+        if sample_rate != CLAP_SAMPLE_RATE:
+            wav = audio_fn.resample(wav, sample_rate, CLAP_SAMPLE_RATE)
+        inputs = processor(
+            audios=list(wav.numpy()), sampling_rate=CLAP_SAMPLE_RATE, return_tensors="pt"
+        )
+        inputs = {key: value.to(device) for key, value in inputs.items()}
+        return model.get_audio_features(**inputs).cpu().numpy()
+
+    return encode
+
+
+def _open_lance_dataset(uri: str) -> lance.LanceDataset:
+    """Open a Lance dataset, attaching R2 ``storage_options`` for cloud URIs.
+
+    :param uri: Local path, ``r2://bucket/key``, or ``s3://bucket/key``.
+    :returns: The opened dataset, credentialed when ``uri`` is on R2.
+    """
+    if r2_io.is_r2_uri(uri):
+        uri = r2_io.to_s3_uri(uri)
+    if uri.startswith("s3://"):
+        r2_io.ensure_r2_env_loaded()
+        return lance.dataset(uri, storage_options=r2_io.r2_storage_options())
+    return lance.dataset(uri)
+
+
+@click.command()
+@click.argument("lance_uri", type=str)
+@click.option(
+    "--clap-checkpoint",
+    default=DEFAULT_CLAP_CHECKPOINT,
+    show_default=True,
+    help="HuggingFace CLAP model id.",
+)
+@click.option(
+    "--device",
+    default=None,
+    help="Torch device for CLAP (defaults to cuda when available, else cpu).",
+)
+@click.option(
+    "--batch-size",
+    type=int,
+    default=None,
+    help="Rows per UDF call; defaults to the Lance default (ignored for v1 datasets).",
+)
+@click.option(
+    "--build-index/--no-build-index",
+    default=True,
+    show_default=True,
+    help="Build an IVF_PQ vector index on the clap column.",
+)
+def main(
+    lance_uri: str,
+    clap_checkpoint: str,
+    device: str | None,
+    batch_size: int | None,
+    build_index: bool,
+) -> None:
+    """Add ``m2l`` + ``clap`` embedding columns to the Lance dataset at LANCE_URI.
+
+    LANCE_URI is a dataset from generate_dataset or finalize_dataset (local path,
+    ``r2://``, or ``s3://``); its audio sample rate is read from the shard
+    metadata in the schema. The ``clap`` column is a vector-searchable
+    fixed-size list; with ``--build-index`` it also gets an IVF_PQ index.
+
+    :param lance_uri: Dataset directory to augment in place.
+    :param clap_checkpoint: HuggingFace CLAP model id.
+    :param device: Torch device for CLAP; ``None`` selects cuda when available, else cpu.
+    :param batch_size: Rows per UDF call; ``None`` uses the Lance default.
+    :param build_index: Build an IVF_PQ index on the clap column after writing it.
+    """
+    try:
+        dataset = _open_lance_dataset(lance_uri)
+        sample_rate = int(read_shard_metadata(dataset.schema).sample_rate)
+    # RuntimeError covers missing R2 creds / rclone from the cloud-URI path.
+    except (OSError, ValueError, RuntimeError) as exc:
+        logger.error("open_dataset_failed", uri=lance_uri, error=str(exc))
+        sys.exit(1)
+    existing = {M2L_FIELD, CLAP_FIELD} & set(dataset.schema.names)
+    if existing:
+        logger.error("embeddings_already_present", uri=lance_uri, columns=sorted(existing))
+        sys.exit(1)
+    logger.info(
+        "adding_embeddings", uri=lance_uri, sample_rate=sample_rate, rows=dataset.count_rows()
+    )
+    m2l_encode = load_m2l_audio_encoder()
+    clap_encode = load_clap_audio_encoder(clap_checkpoint, device)
+    add_embeddings(
+        dataset,
+        m2l_encode,
+        clap_encode,
+        sample_rate,
+        batch_size=batch_size,
+        build_index=build_index,
+    )
+    logger.info("added_embeddings", uri=lance_uri, columns=[M2L_FIELD, CLAP_FIELD])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/synth_setter/pipeline/data/add_embeddings.py
+++ b/src/synth_setter/pipeline/data/add_embeddings.py
@@ -149,7 +149,7 @@ def build_clap_index(
     if rows < MIN_ROWS_FOR_INDEX:
         logger.warning("clap_index_skipped_too_few_rows", rows=rows, minimum=MIN_ROWS_FOR_INDEX)
         return False
-    partitions = num_partitions or max(1, round(rows**0.5))
+    partitions = max(1, round(rows**0.5)) if num_partitions is None else num_partitions
     dataset.create_index(
         CLAP_FIELD,
         index_type="IVF_PQ",
@@ -257,9 +257,10 @@ def load_clap_audio_encoder(
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
     logger.info("loading_clap_checkpoint", checkpoint=checkpoint, device=device)
-    # transformers' own types are too loose for the narrow surface used below
-    # (the processor's audio kwargs, and get_audio_features' tensor return), so
-    # pyright is scoped off the three offending calls rather than widened to Any.
+    # transformers' own types are too loose for the surface used below, so pyright
+    # is scoped off the two offending calls (the from_pretrained `.to()` chain and
+    # the get_audio_features tensor return) rather than widened to Any; the
+    # processor's audio kwargs are dict-splatted, which the stub can't object to.
     model = ClapModel.from_pretrained(checkpoint).to(device).eval()  # pyright: ignore
     processor = ClapProcessor.from_pretrained(checkpoint)
 

--- a/src/synth_setter/pipeline/data/add_embeddings.py
+++ b/src/synth_setter/pipeline/data/add_embeddings.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Callable
-from typing import Any, TypeAlias
+from typing import TypeAlias
 
 import click
 import lance
@@ -257,22 +257,26 @@ def load_clap_audio_encoder(
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
     logger.info("loading_clap_checkpoint", checkpoint=checkpoint, device=device)
-    # ``Any``: transformers' from_pretrained / processor / get_audio_features
-    # carry typing that rejects the kwargs and tensor access used below.
-    model: Any = ClapModel.from_pretrained(checkpoint)
-    model = model.to(device).eval()
-    processor: Any = ClapProcessor.from_pretrained(checkpoint)
+    # transformers' own types are too loose for the narrow surface used below
+    # (the processor's audio kwargs, and get_audio_features' tensor return), so
+    # pyright is scoped off the three offending calls rather than widened to Any.
+    model = ClapModel.from_pretrained(checkpoint).to(device).eval()  # pyright: ignore
+    processor = ClapProcessor.from_pretrained(checkpoint)
 
     @torch.no_grad()
     def encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:
         wav = torch.from_numpy(np.ascontiguousarray(mono, dtype=np.float32))
         if sample_rate != CLAP_SAMPLE_RATE:
             wav = audio_fn.resample(wav, sample_rate, CLAP_SAMPLE_RATE)
-        inputs = processor(
-            audios=list(wav.numpy()), sampling_rate=CLAP_SAMPLE_RATE, return_tensors="pt"
-        )
-        inputs = {key: value.to(device) for key, value in inputs.items()}
-        return model.get_audio_features(**inputs).cpu().numpy()
+        # Build kwargs as a dict so the splat hides transformers' too-narrow __call__ stub.
+        clap_kwargs = {
+            "audios": list(wav.numpy()),
+            "sampling_rate": CLAP_SAMPLE_RATE,
+            "return_tensors": "pt",
+        }
+        inputs = processor(**clap_kwargs)
+        device_inputs = {key: value.to(device) for key, value in inputs.items()}
+        return model.get_audio_features(**device_inputs).cpu().numpy()  # pyright: ignore
 
     return encode
 

--- a/src/synth_setter/pipeline/data/add_embeddings.py
+++ b/src/synth_setter/pipeline/data/add_embeddings.py
@@ -146,9 +146,14 @@ def build_clap_index(
     :param metric: Distance metric for the index.
     :returns: ``True`` if an index was built, ``False`` if skipped (too few rows
         to train PQ — exact ``nearest`` still works without an index).
-    :raises ValueError: ``num_sub_vectors`` does not divide the ``clap`` column's
-        vector width (Lance's own PQ-training failure is opaque).
+    :raises ValueError: ``num_sub_vectors`` or ``num_partitions`` is non-positive,
+        or ``num_sub_vectors`` does not divide the ``clap`` column's vector width
+        (Lance's own failures here are a ``ZeroDivisionError`` / opaque PQ error).
     """
+    if num_sub_vectors < 1:
+        raise ValueError(f"num_sub_vectors must be >= 1, got {num_sub_vectors}")
+    if num_partitions is not None and num_partitions < 1:
+        raise ValueError(f"num_partitions must be >= 1, got {num_partitions}")
     clap_dim = dataset.schema.field(CLAP_FIELD).type.list_size
     if clap_dim % num_sub_vectors != 0:
         raise ValueError(f"num_sub_vectors={num_sub_vectors} does not divide clap dim {clap_dim}")

--- a/src/synth_setter/pipeline/data/add_embeddings.py
+++ b/src/synth_setter/pipeline/data/add_embeddings.py
@@ -313,7 +313,11 @@ def load_clap_audio_encoder(
 def _open_lance_dataset(uri: str) -> lance.LanceDataset:
     """Open a Lance dataset, attaching R2 ``storage_options`` for cloud URIs.
 
-    :param uri: Local path, ``r2://bucket/key``, or ``s3://bucket/key``.
+    Any ``s3://`` URI is treated as the project's R2 (S3-compatible) endpoint and
+    credentialed via :func:`r2_io.r2_storage_options`; generic non-R2 S3 buckets
+    are not a supported input.
+
+    :param uri: Local path, ``r2://bucket/key``, or ``s3://bucket/key`` (R2).
     :returns: The opened dataset, credentialed when ``uri`` is on R2.
     """
     if r2_io.is_r2_uri(uri):

--- a/tests/integration/test_add_embeddings_r2.py
+++ b/tests/integration/test_add_embeddings_r2.py
@@ -1,0 +1,261 @@
+"""End-to-end add-embeddings-against-real-R2 test (no mocks).
+
+Drives the two production CLIs back to back: the real VST renderer
+(``generate_vst_dataset.py``) writes a tiny Lance shard that is uploaded to a
+unique R2 prefix, then ``synth-setter-add-embeddings`` runs the real
+music2latent + LAION-CLAP encoders against that remote URI. The augmented
+dataset is reopened from R2 and its ``m2l`` / ``clap`` columns, indexability,
+and ``nearest=`` query path are asserted. The prefix is purged on teardown
+regardless of pass/fail.
+
+Auto-skips when the VST plugin is absent (``requires_vst``) or R2 credentials
+are missing (``integration_r2``); also skips when R2 is unreachable at runtime.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import uuid
+from collections.abc import Iterator
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Any
+
+import lance
+import numpy as np
+import pyarrow as pa
+import pytest
+
+from synth_setter.cli.generate_dataset import build_generate_args
+from synth_setter.data.vst.shapes import (
+    AUDIO_FIELD,
+    CLAP_FIELD,
+    M2L_FIELD,
+    PARAM_ARRAY_FIELD,
+)
+from synth_setter.pipeline import r2_io
+from synth_setter.pipeline.data.add_embeddings import (
+    CLAP_EMBEDDING_DIM,
+    MIN_ROWS_FOR_INDEX,
+)
+from synth_setter.pipeline.schemas.spec import DatasetSpec, ShardSpec
+from synth_setter.resources import as_file, vst_headless_wrapper
+from tests._vst import (
+    PLUGIN_PATH,
+    TEST_PARAM_SPEC_NAME,
+    TEST_PRESET_PATH,
+    TEST_RENDERER_VERSION,
+    VST_SUBPROCESS_TIMEOUT_SECONDS,
+)
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.requires_vst,
+    pytest.mark.integration_r2,
+    pytest.mark.r2,
+]
+
+# Kept tiny so the real encoders stay fast: one 4-row shard. 4 < MIN_ROWS_FOR_INDEX,
+# so the IVF_PQ build is skipped and the test asserts the exact ``nearest`` fallback.
+_SAMPLES_PER_SHARD = 4
+# Short clips keep both the VST render and the CLAP/m2l forward pass cheap;
+# CLAP resamples to 48 kHz internally, so 1 s still yields a valid embedding.
+_SIGNAL_DURATION_SECONDS = 1.0
+_SAMPLE_RATE = 44100
+_CHANNELS = 2
+
+# The add_embeddings CLI is the system under test; invoke it as the console
+# script the operator runs, against the uploaded ``r2://`` dataset directory.
+_ADD_EMBEDDINGS_CMD = "synth-setter-add-embeddings"
+# Generous: covers a real VST render plus the first-run checkpoint downloads
+# and CPU/GPU forward passes of music2latent + CLAP.
+_EMBED_SUBPROCESS_TIMEOUT_SECONDS = 1800
+
+
+def _unique_test_prefix() -> str:
+    """Build a per-run ``ci-add-embeddings/<run_id>/<attempt>/<uuid>/`` R2 prefix.
+
+    Mirrors the layout in :mod:`tests.integration.test_finalize_dataset_r2` so
+    concurrent CI runs and local dev runs never collide, and the leading
+    ``ci-add-embeddings/`` segment makes a bulk ``rclone purge`` of stale
+    artifacts straightforward.
+
+    :returns: Trailing-slash-terminated R2 prefix string.
+    """
+    run_id = os.environ.get("GITHUB_RUN_ID", "local")
+    run_attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "0")
+    nonce = uuid.uuid4().hex[:8]
+    return f"ci-add-embeddings/{run_id}/{run_attempt}/{nonce}/"
+
+
+def _lance_embed_spec(prefix: str) -> DatasetSpec:
+    """Build a 1-shard Lance ``DatasetSpec`` pinned to the real test synth + R2 prefix.
+
+    :param prefix: Unique R2 prefix the shard is rendered + uploaded under.
+    :returns: A frozen Lance spec whose single train shard is renderable by the
+        real VST and whose ``r2`` layout is safe to ``purge_prefix`` on teardown.
+    """
+    spec_kwargs: dict[str, Any] = {
+        "task_name": "it-add-embeddings",
+        "output_format": "lance",
+        "train_val_test_sizes": [_SAMPLES_PER_SHARD, 0, 0],
+        "base_seed": 42,
+        # Constant mel bins over so few samples; mask so the spec stays valid.
+        "mask_degenerate_bins": True,
+        "r2": {"bucket": "intermediate-data", "prefix": prefix},
+        "render": {
+            "plugin_path": PLUGIN_PATH,
+            "preset_path": TEST_PRESET_PATH,
+            "param_spec_name": TEST_PARAM_SPEC_NAME,
+            "renderer_version": TEST_RENDERER_VERSION,
+            "sample_rate": _SAMPLE_RATE,
+            "channels": _CHANNELS,
+            "velocity": 100,
+            "signal_duration_seconds": _SIGNAL_DURATION_SECONDS,
+            "min_loudness": -55.0,
+            "samples_per_render_batch": _SAMPLES_PER_SHARD,
+            "samples_per_shard": _SAMPLES_PER_SHARD,
+            "gui_toggle_cadence": "never",
+        },
+    }
+    return DatasetSpec(**spec_kwargs)  # type: ignore[arg-type]
+
+
+def _render_shard_locally(spec: DatasetSpec, shard: ShardSpec, work_dir: Path) -> Path:
+    """Render one Lance shard via the real ``generate_vst_dataset.py`` CLI.
+
+    Wraps the renderer in the X11 headless bootstrap (as the production
+    dispatcher does on Linux) and shells out with the repo's own
+    ``build_generate_args`` so the flag set tracks ``RenderConfig`` exactly.
+
+    :param spec: Spec supplying the render config + shard layout.
+    :param shard: The single train shard to render.
+    :param work_dir: Local dir the ``.lance`` dataset directory is written into.
+    :returns: Path to the produced local Lance dataset directory.
+    """
+    with ExitStack() as stack:
+        args: list[str] = []
+        if sys.platform == "linux":
+            wrapper = stack.enter_context(as_file(vst_headless_wrapper()))
+            args.append(str(wrapper))
+        args += build_generate_args(spec, shard, work_dir)
+        subprocess.run(  # noqa: S603 — args from a validated spec + repo wrapper
+            args, check=True, timeout=VST_SUBPROCESS_TIMEOUT_SECONDS
+        )
+    shard_path = work_dir / shard.filename
+    assert shard_path.is_dir(), f"renderer wrote no Lance dataset at {shard_path}"
+    return shard_path
+
+
+@pytest.fixture()
+def remote_lance_dataset_uri() -> Iterator[str]:
+    """Render a tiny Lance shard, upload it to a unique R2 prefix, yield its ``r2://`` URI.
+
+    Exercises the real generate path end-to-end: VST render → local Lance
+    dataset → ``upload_dir`` to R2. The prefix is purged on teardown regardless
+    of pass/fail so a failed assertion never leaks artifacts.
+
+    :yields str: ``r2://bucket/prefix/shard-000000.lance`` of the uploaded dataset.
+    """
+    if not r2_io.is_r2_reachable():
+        pytest.skip("R2 not reachable (rclone not on PATH or rclone lsd r2: failed)")
+    r2_io.ensure_r2_env_loaded()
+
+    prefix = _unique_test_prefix()
+    spec = _lance_embed_spec(prefix)
+    shard = spec.shards[0]
+    shard_uri = spec.r2.shard_uri(shard)
+    try:
+        with tempfile.TemporaryDirectory() as raw_work_dir:
+            local_shard = _render_shard_locally(spec, shard, Path(raw_work_dir))
+            r2_io.upload_dir(local_shard, shard_uri)
+        assert r2_io.r2_directory_exists(shard_uri), f"upload left nothing at {shard_uri}"
+        yield shard_uri
+    finally:
+        # Best-effort teardown; a purge failure must not mask a test assertion.
+        r2_io.purge_prefix(spec.r2.bucket, prefix)
+
+
+def _open_remote_dataset(r2_uri: str) -> lance.LanceDataset:
+    """Open a Lance dataset on R2, mirroring ``add_embeddings._open_lance_dataset``.
+
+    :param r2_uri: Canonical ``r2://bucket/key`` dataset directory URI.
+    :returns: The credentialed, opened dataset.
+    """
+    return lance.dataset(r2_io.to_s3_uri(r2_uri), storage_options=r2_io.r2_storage_options())
+
+
+def test_add_embeddings_cli_against_real_r2_writes_indexable_clap_and_m2l(
+    remote_lance_dataset_uri: str,
+) -> None:
+    """``synth-setter-add-embeddings`` on a real R2 Lance dataset writes searchable columns.
+
+    Runs the two production CLIs back to back with no mocks: the fixture renders
+    + uploads a tiny Lance shard via the VST renderer, then this test invokes the
+    real ``add_embeddings`` CLI (real music2latent + LAION-CLAP encoders) against
+    that ``r2://`` URI. The augmented dataset is reopened from R2 and asserted to
+    carry a ``FixedSizeList<float32, 512>`` ``clap`` column, a
+    ``fixed_shape_tensor<float32, ...>`` ``m2l`` column, finite values, one row
+    per audio row, preserved source columns, and a working exact ``nearest=``
+    query (the 4-row shard is below the IVF_PQ training floor, so no index is
+    expected).
+
+    :param remote_lance_dataset_uri: Fixture-provided ``r2://`` Lance dataset URI.
+    """
+    result = subprocess.run(  # noqa: S603 — literal cmd + a validated r2:// URI
+        [_ADD_EMBEDDINGS_CMD, remote_lance_dataset_uri],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=_EMBED_SUBPROCESS_TIMEOUT_SECONDS,
+    )
+    assert result.returncode == 0, (
+        f"{_ADD_EMBEDDINGS_CMD} exited {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+    dataset = _open_remote_dataset(remote_lance_dataset_uri)
+    names = set(dataset.schema.names)
+    assert {AUDIO_FIELD, PARAM_ARRAY_FIELD} <= names, (
+        f"source columns dropped: schema is {sorted(names)}"
+    )
+    assert {M2L_FIELD, CLAP_FIELD} <= names, f"embedding columns absent: schema is {sorted(names)}"
+
+    rows = dataset.count_rows()
+    assert rows == _SAMPLES_PER_SHARD, f"row count changed to {rows}"
+
+    clap_type = dataset.schema.field(CLAP_FIELD).type
+    assert pa.types.is_fixed_size_list(clap_type), f"clap is {clap_type}, not a fixed-size list"
+    assert clap_type.value_type == pa.float32(), f"clap value type is {clap_type.value_type}"
+    assert clap_type.list_size == CLAP_EMBEDDING_DIM, (
+        f"clap width is {clap_type.list_size}, expected {CLAP_EMBEDDING_DIM}"
+    )
+
+    m2l_type = dataset.schema.field(M2L_FIELD).type
+    assert isinstance(m2l_type, pa.FixedShapeTensorType), (
+        f"m2l is {m2l_type}, not a fixed-shape tensor"
+    )
+    assert m2l_type.value_type == pa.float32(), f"m2l value type is {m2l_type.value_type}"
+
+    table = dataset.to_table(columns=[CLAP_FIELD, M2L_FIELD])
+    clap = np.stack(table.column(CLAP_FIELD).to_numpy(zero_copy_only=False))
+    assert clap.shape == (rows, CLAP_EMBEDDING_DIM), f"clap materialized as {clap.shape}"
+    assert np.isfinite(clap).all(), "clap embeddings contain non-finite values"
+    m2l = table.column(M2L_FIELD).combine_chunks().to_numpy_ndarray()
+    assert len(m2l) == rows, f"m2l has {len(m2l)} rows, expected {rows}"
+    assert np.isfinite(m2l).all(), "m2l embeddings contain non-finite values"
+
+    # 4 rows is below the IVF_PQ training floor, so the CLI skips the index and
+    # exact (brute-force) nearest must still resolve. clap is the only column the
+    # CLI ever indexes, so an empty index list pins the skip directly.
+    assert rows < MIN_ROWS_FOR_INDEX
+    assert dataset.list_indices() == [], (
+        f"unexpected index for a {rows}-row dataset: {dataset.list_indices()}"
+    )
+
+    query = clap[0].astype(np.float32)
+    neighbours = dataset.to_table(nearest={"column": CLAP_FIELD, "q": query, "k": rows})
+    assert neighbours.num_rows >= 1, "nearest query returned no rows"

--- a/tests/integration/test_add_embeddings_r2.py
+++ b/tests/integration/test_add_embeddings_r2.py
@@ -76,9 +76,6 @@ _EMBED_SUBPROCESS_TIMEOUT_SECONDS = 1800
 # Observed real-VST throughput is ~2.5 s/sample (param load + render + flush);
 # 5 s/sample keeps a 256-row render comfortably inside its scaled timeout.
 _RENDER_SECONDS_PER_SAMPLE = 5
-# Rows per add_columns UDF call; bounds the audio fed to the GPU per CLAP/m2l
-# forward pass so a whole-shard batch never exhausts CUDA memory.
-_EMBED_BATCH_SIZE = 16
 
 
 def _unique_test_prefix() -> str:
@@ -312,9 +309,9 @@ def test_add_embeddings_cli_against_real_r2_builds_ivf_pq_index(
         dataset with enough rows to train the index.
     """
     # num_partitions=4 / num_sub_vectors=16 (512 % 16 == 0) train cleanly at 256
-    # rows; the partition count stays well under the row floor PQ needs.
-    # --batch-size bounds the per-UDF read so a whole-shard batch of audio does
-    # not exhaust GPU memory in the real CLAP/m2l forward pass.
+    # rows; the partition count stays well under the row floor PQ needs. No
+    # --batch-size: exercise the default path, since the encoders self-bound their
+    # GPU memory (CLAP_ENCODE_MAX_BATCH / M2L_ENCODE_MAX_BATCH).
     result = subprocess.run(  # noqa: S603 — literal cmd + a validated r2:// URI
         [
             _ADD_EMBEDDINGS_CMD,
@@ -324,8 +321,6 @@ def test_add_embeddings_cli_against_real_r2_builds_ivf_pq_index(
             "4",
             "--num-sub-vectors",
             "16",
-            "--batch-size",
-            str(_EMBED_BATCH_SIZE),
         ],
         check=False,
         capture_output=True,

--- a/tests/integration/test_add_embeddings_r2.py
+++ b/tests/integration/test_add_embeddings_r2.py
@@ -76,6 +76,9 @@ _EMBED_SUBPROCESS_TIMEOUT_SECONDS = 1800
 # Observed real-VST throughput is ~2.5 s/sample (param load + render + flush);
 # 5 s/sample keeps a 256-row render comfortably inside its scaled timeout.
 _RENDER_SECONDS_PER_SAMPLE = 5
+# Rows per add_columns UDF call; bounds the audio fed to the GPU per CLAP/m2l
+# forward pass so a whole-shard batch never exhausts CUDA memory.
+_EMBED_BATCH_SIZE = 16
 
 
 def _unique_test_prefix() -> str:
@@ -310,6 +313,8 @@ def test_add_embeddings_cli_against_real_r2_builds_ivf_pq_index(
     """
     # num_partitions=4 / num_sub_vectors=16 (512 % 16 == 0) train cleanly at 256
     # rows; the partition count stays well under the row floor PQ needs.
+    # --batch-size bounds the per-UDF read so a whole-shard batch of audio does
+    # not exhaust GPU memory in the real CLAP/m2l forward pass.
     result = subprocess.run(  # noqa: S603 — literal cmd + a validated r2:// URI
         [
             _ADD_EMBEDDINGS_CMD,
@@ -319,6 +324,8 @@ def test_add_embeddings_cli_against_real_r2_builds_ivf_pq_index(
             "4",
             "--num-sub-vectors",
             "16",
+            "--batch-size",
+            str(_EMBED_BATCH_SIZE),
         ],
         check=False,
         capture_output=True,

--- a/tests/integration/test_add_embeddings_r2.py
+++ b/tests/integration/test_add_embeddings_r2.py
@@ -22,7 +22,7 @@ import uuid
 from collections.abc import Iterator
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import lance
 import numpy as np
@@ -73,6 +73,9 @@ _ADD_EMBEDDINGS_CMD = "synth-setter-add-embeddings"
 # Generous: covers a real VST render plus the first-run checkpoint downloads
 # and CPU/GPU forward passes of music2latent + CLAP.
 _EMBED_SUBPROCESS_TIMEOUT_SECONDS = 1800
+# Observed real-VST throughput is ~2.5 s/sample (param load + render + flush);
+# 5 s/sample keeps a 256-row render comfortably inside its scaled timeout.
+_RENDER_SECONDS_PER_SAMPLE = 5
 
 
 def _unique_test_prefix() -> str:
@@ -91,17 +94,19 @@ def _unique_test_prefix() -> str:
     return f"ci-add-embeddings/{run_id}/{run_attempt}/{nonce}/"
 
 
-def _lance_embed_spec(prefix: str) -> DatasetSpec:
+def _lance_embed_spec(prefix: str, rows: int = _SAMPLES_PER_SHARD) -> DatasetSpec:
     """Build a 1-shard Lance ``DatasetSpec`` pinned to the real test synth + R2 prefix.
 
     :param prefix: Unique R2 prefix the shard is rendered + uploaded under.
+    :param rows: Samples in the single train shard; ``>= MIN_ROWS_FOR_INDEX`` makes
+        the downstream IVF_PQ build train rather than skip.
     :returns: A frozen Lance spec whose single train shard is renderable by the
         real VST and whose ``r2`` layout is safe to ``purge_prefix`` on teardown.
     """
     spec_kwargs: dict[str, Any] = {
         "task_name": "it-add-embeddings",
         "output_format": "lance",
-        "train_val_test_sizes": [_SAMPLES_PER_SHARD, 0, 0],
+        "train_val_test_sizes": [rows, 0, 0],
         "base_seed": 42,
         # Constant mel bins over so few samples; mask so the spec stays valid.
         "mask_degenerate_bins": True,
@@ -116,8 +121,11 @@ def _lance_embed_spec(prefix: str) -> DatasetSpec:
             "velocity": 100,
             "signal_duration_seconds": _SIGNAL_DURATION_SECONDS,
             "min_loudness": -55.0,
-            "samples_per_render_batch": _SAMPLES_PER_SHARD,
-            "samples_per_shard": _SAMPLES_PER_SHARD,
+            # Render the whole shard in one batch and load the plugin once, so a
+            # 256-row shard does not pay 64 per-batch plugin reloads.
+            "samples_per_render_batch": rows,
+            "samples_per_shard": rows,
+            "plugin_reload_cadence": "once",
             "gui_toggle_cadence": "never",
         },
     }
@@ -136,6 +144,11 @@ def _render_shard_locally(spec: DatasetSpec, shard: ShardSpec, work_dir: Path) -
     :param work_dir: Local dir the ``.lance`` dataset directory is written into.
     :returns: Path to the produced local Lance dataset directory.
     """
+    # The per-sample render cost (param load + render + flush) dominates, so the
+    # timeout scales with shard size atop the fixed base for a 256-row shard.
+    timeout = (
+        VST_SUBPROCESS_TIMEOUT_SECONDS + _RENDER_SECONDS_PER_SAMPLE * spec.render.samples_per_shard
+    )
     with ExitStack() as stack:
         args: list[str] = []
         if sys.platform == "linux":
@@ -143,21 +156,21 @@ def _render_shard_locally(spec: DatasetSpec, shard: ShardSpec, work_dir: Path) -
             args.append(str(wrapper))
         args += build_generate_args(spec, shard, work_dir)
         subprocess.run(  # noqa: S603 — args from a validated spec + repo wrapper
-            args, check=True, timeout=VST_SUBPROCESS_TIMEOUT_SECONDS
+            args, check=True, timeout=timeout
         )
     shard_path = work_dir / shard.filename
     assert shard_path.is_dir(), f"renderer wrote no Lance dataset at {shard_path}"
     return shard_path
 
 
-@pytest.fixture()
-def remote_lance_dataset_uri() -> Iterator[str]:
-    """Render a tiny Lance shard, upload it to a unique R2 prefix, yield its ``r2://`` URI.
+def _render_and_upload(rows: int) -> Iterator[str]:
+    """Render a Lance shard of ``rows`` samples, upload it to a unique R2 prefix, yield its URI.
 
     Exercises the real generate path end-to-end: VST render → local Lance
     dataset → ``upload_dir`` to R2. The prefix is purged on teardown regardless
     of pass/fail so a failed assertion never leaks artifacts.
 
+    :param rows: Samples in the single rendered shard.
     :yields str: ``r2://bucket/prefix/shard-000000.lance`` of the uploaded dataset.
     """
     if not r2_io.is_r2_reachable():
@@ -165,7 +178,7 @@ def remote_lance_dataset_uri() -> Iterator[str]:
     r2_io.ensure_r2_env_loaded()
 
     prefix = _unique_test_prefix()
-    spec = _lance_embed_spec(prefix)
+    spec = _lance_embed_spec(prefix, rows)
     shard = spec.shards[0]
     shard_uri = spec.r2.shard_uri(shard)
     try:
@@ -177,6 +190,26 @@ def remote_lance_dataset_uri() -> Iterator[str]:
     finally:
         # Best-effort teardown; a purge failure must not mask a test assertion.
         r2_io.purge_prefix(spec.r2.bucket, prefix)
+
+
+@pytest.fixture()
+def remote_lance_dataset_uri() -> Iterator[str]:
+    """Yield a tiny (``_SAMPLES_PER_SHARD``-row) uploaded Lance dataset URI.
+
+    :yields str: ``r2://`` URI of the uploaded dataset.
+    """
+    yield from _render_and_upload(_SAMPLES_PER_SHARD)
+
+
+@pytest.fixture()
+def remote_indexed_lance_dataset_uri() -> Iterator[str]:
+    """Yield an uploaded Lance dataset URI with ``>= MIN_ROWS_FOR_INDEX`` rows.
+
+    Enough rows that the downstream IVF_PQ build trains rather than skips.
+
+    :yields str: ``r2://`` URI of the uploaded dataset.
+    """
+    yield from _render_and_upload(MIN_ROWS_FOR_INDEX)
 
 
 def _open_remote_dataset(r2_uri: str) -> lance.LanceDataset:
@@ -259,3 +292,62 @@ def test_add_embeddings_cli_against_real_r2_writes_indexable_clap_and_m2l(
     query = clap[0].astype(np.float32)
     neighbours = dataset.to_table(nearest={"column": CLAP_FIELD, "q": query, "k": rows})
     assert neighbours.num_rows >= 1, "nearest query returned no rows"
+
+
+def test_add_embeddings_cli_against_real_r2_builds_ivf_pq_index(
+    remote_indexed_lance_dataset_uri: str,
+) -> None:
+    """``synth-setter-add-embeddings --build-index`` trains an IVF_PQ index on a real R2 dataset.
+
+    Renders + uploads a ``MIN_ROWS_FOR_INDEX``-row shard via the VST renderer,
+    runs the real ``add_embeddings`` CLI with ``--build-index`` and tuning sized
+    for the row count (so PQ training succeeds rather than skips), then reopens
+    the remote dataset and asserts the IVF_PQ index exists on ``clap`` and an ANN
+    ``nearest=`` query returns a stored row's own vector as the top hit.
+
+    :param remote_indexed_lance_dataset_uri: Fixture-provided ``r2://`` URI of a
+        dataset with enough rows to train the index.
+    """
+    # num_partitions=4 / num_sub_vectors=16 (512 % 16 == 0) train cleanly at 256
+    # rows; the partition count stays well under the row floor PQ needs.
+    result = subprocess.run(  # noqa: S603 — literal cmd + a validated r2:// URI
+        [
+            _ADD_EMBEDDINGS_CMD,
+            remote_indexed_lance_dataset_uri,
+            "--build-index",
+            "--num-partitions",
+            "4",
+            "--num-sub-vectors",
+            "16",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=_EMBED_SUBPROCESS_TIMEOUT_SECONDS,
+    )
+    assert result.returncode == 0, (
+        f"{_ADD_EMBEDDINGS_CMD} exited {result.returncode}\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+    dataset = _open_remote_dataset(remote_indexed_lance_dataset_uri)
+    rows = dataset.count_rows()
+    assert rows == MIN_ROWS_FOR_INDEX, f"row count changed to {rows}"
+
+    indices = cast("list[dict[str, Any]]", dataset.list_indices())
+    assert indices, f"no index built for a {rows}-row dataset"
+    assert [idx["fields"] for idx in indices] == [[CLAP_FIELD]], (
+        f"expected a single clap index, got {indices}"
+    )
+
+    clap_table = dataset.to_table(columns=[CLAP_FIELD])
+    clap = np.stack(clap_table.column(CLAP_FIELD).to_numpy(zero_copy_only=False))
+    target = rows // 2
+    query = clap[target].astype(np.float32)
+    # PQ is lossy, so the ANN top hit need not be the exact stored row; assert a
+    # near-zero cosine distance, which a self-query yields for any close vector.
+    hits = dataset.to_table(nearest={"column": CLAP_FIELD, "q": query, "k": 1})
+    assert hits.num_rows == 1, "ANN query returned no rows"
+    assert hits.column("_distance")[0].as_py() < 1e-2, (
+        f"self-query top hit distance {hits.column('_distance')[0].as_py()} not near zero"
+    )

--- a/tests/pipeline/data/test_add_embeddings.py
+++ b/tests/pipeline/data/test_add_embeddings.py
@@ -459,3 +459,22 @@ def test_main_exits_1_when_open_fails_with_runtime_error(monkeypatch: pytest.Mon
 
     assert result.exit_code == 1
     assert result.exception is None or isinstance(result.exception, SystemExit)
+
+
+@pytest.mark.slow
+def test_main_exits_1_when_add_step_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    spec = build_lance_smoke_spec()
+    uri = tmp_path / "shard.lance"
+    write_minimal_lance_shard(uri, spec)
+
+    def boom() -> M2LEncodeFn:
+        raise RuntimeError("encoder load blew up")
+
+    # Dataset opens fine; a failure in the encode/add step must still exit 1 cleanly.
+    monkeypatch.setattr("synth_setter.pipeline.data.add_embeddings.load_m2l_audio_encoder", boom)
+
+    result = CliRunner().invoke(main, [str(uri)])
+
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)
+    assert {M2L_FIELD, CLAP_FIELD}.isdisjoint(lance.dataset(str(uri)).schema.names)

--- a/tests/pipeline/data/test_add_embeddings.py
+++ b/tests/pipeline/data/test_add_embeddings.py
@@ -133,6 +133,23 @@ def _audio_dataset(uri: str, rows: int, *, with_params: bool = False) -> np.ndar
     return audio
 
 
+def _distinct_clap(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+    """Give every row a unique embedding so each row is its own nearest neighbour.
+
+    Encodes the row's mono mean into channel 0 and the row index into channel 1,
+    leaving the rest zero — distinct per row regardless of duplicate audio.
+
+    :param mono: ``(B, T)`` mono batch.
+    :param sample_rate: Ignored.
+    :returns: ``(B, CLAP_EMBEDDING_DIM)`` embedding batch, distinct per row.
+    """
+    del sample_rate
+    out = np.zeros((mono.shape[0], CLAP_EMBEDDING_DIM), dtype=np.float32)
+    out[:, 0] = mono.mean(axis=1)
+    out[:, 1] = np.arange(mono.shape[0], dtype=np.float32)
+    return out
+
+
 def test_downmix_to_mono_averages_channels_to_float32() -> None:
     """Channel averaging yields float32 mono with the channel axis collapsed."""
     audio = np.array([[[1.0, 3.0], [3.0, 5.0]]], dtype=np.float16)
@@ -241,6 +258,39 @@ def test_add_embeddings_builds_ivf_pq_index_on_clap(tmp_path: Path) -> None:
 
 
 @pytest.mark.slow
+def test_clap_exact_search_returns_queried_row_as_top_hit(tmp_path: Path) -> None:
+    """Exact nearest search over ``clap`` returns the queried row itself at distance ~0.
+
+    Uses Lance's exact (brute-force) scan — deterministic regardless of vector distribution — to
+    pin the *semantic* contract: a stored vector's nearest neighbour is its own row. (IVF_PQ recall
+    on realistic dense embeddings is covered by the real ≥256-row R2 e2e; PQ on synthetic toy
+    vectors is degenerate and not a meaningful correctness signal.)
+
+    :param tmp_path: Pytest-provided scratch directory for the dataset.
+    """
+    uri = str(tmp_path / "semantic.lance")
+    _audio_dataset(uri, 64, with_params=True)
+
+    # _distinct_clap gives every row a unique vector, so the exact nearest of a
+    # stored vector is unambiguously its own row.
+    add_embeddings(lance.dataset(uri), _fake_m2l, _distinct_clap, _SAMPLE_RATE, build_index=False)
+
+    dataset = lance.dataset(uri)
+    stored = dataset.to_table(columns=[CLAP_FIELD, PARAM_ARRAY_FIELD])
+    target_row = 37
+    query = np.array(stored.column(CLAP_FIELD)[target_row].as_py(), dtype=np.float32)
+    expected_params = stored.column(PARAM_ARRAY_FIELD)[target_row].as_py()
+
+    hits = dataset.to_table(
+        nearest={"column": CLAP_FIELD, "q": query, "k": 1}, columns=[PARAM_ARRAY_FIELD]
+    )
+
+    assert hits.num_rows == 1
+    assert hits.column(PARAM_ARRAY_FIELD)[0].as_py() == expected_params
+    np.testing.assert_allclose(hits.column("_distance")[0].as_py(), 0.0, atol=1e-5)
+
+
+@pytest.mark.slow
 def test_build_clap_index_skips_when_too_few_rows(tmp_path: Path) -> None:
     uri = str(tmp_path / "tiny.lance")
     _audio_dataset(uri, 8)
@@ -249,6 +299,37 @@ def test_build_clap_index_skips_when_too_few_rows(tmp_path: Path) -> None:
     built = build_clap_index(lance.dataset(uri))
 
     assert built is False
+    assert lance.dataset(uri).list_indices() == []
+
+
+@pytest.mark.slow
+def test_add_embeddings_rejects_dataset_without_audio_column(tmp_path: Path) -> None:
+    """A dataset lacking the audio column raises before the UDF runs.
+
+    :param tmp_path: Pytest-provided scratch directory for the dataset.
+    """
+    uri = str(tmp_path / "no_audio.lance")
+    rng = np.random.default_rng(0)
+    write_lance_shard(Path(uri), {PARAM_ARRAY_FIELD: rng.random((4, 3)).astype(np.float32)})
+
+    with pytest.raises(ValueError, match="no 'audio' column"):
+        add_embeddings(lance.dataset(uri), _fake_m2l, _fake_clap, _SAMPLE_RATE, build_index=False)
+
+
+@pytest.mark.slow
+def test_build_clap_index_rejects_num_sub_vectors_not_dividing_dim(tmp_path: Path) -> None:
+    """A num_sub_vectors that does not divide the clap dim raises before any index work.
+
+    :param tmp_path: Pytest-provided scratch directory for the dataset.
+    """
+    uri = str(tmp_path / "indivisible.lance")
+    _audio_dataset(uri, 8)
+    add_embeddings(lance.dataset(uri), _fake_m2l, _fake_clap, _SAMPLE_RATE, build_index=False)
+
+    # 7 does not divide 512; reject before any index/training work begins.
+    with pytest.raises(ValueError, match="does not divide clap dim"):
+        build_clap_index(lance.dataset(uri), num_sub_vectors=7)
+
     assert lance.dataset(uri).list_indices() == []
 
 
@@ -292,6 +373,62 @@ def test_main_adds_embeddings_using_sample_rate_from_metadata(
     assert seen_sample_rate
     assert all(sr == int(spec.render.sample_rate) for sr in seen_sample_rate)
     assert {M2L_FIELD, CLAP_FIELD} <= set(lance.dataset(str(uri)).schema.names)
+
+
+def test_main_exposes_index_tuning_options() -> None:
+    """The CLI surfaces the IVF_PQ tuning flags threaded into ``add_embeddings``."""
+    result = CliRunner().invoke(main, ["--help"])
+
+    assert result.exit_code == 0, result.output
+    for flag in ("--num-partitions", "--num-sub-vectors", "--metric"):
+        assert flag in result.output
+
+
+@pytest.mark.slow
+def test_main_threads_index_tuning_options_into_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CLI's index-tuning flags reach ``build_clap_index`` unchanged.
+
+    :param tmp_path: Pytest-provided scratch directory for the dataset.
+    :param monkeypatch: Fixture used to inject fake encoders + a spy index builder.
+    """
+    spec = build_lance_smoke_spec()
+    uri = tmp_path / "tuned.lance"
+    write_minimal_lance_shard(uri, spec)
+
+    captured: dict[str, object] = {}
+
+    def spy_build_clap_index(
+        dataset: object,
+        *,
+        num_partitions: int | None = None,
+        num_sub_vectors: int = 0,
+        metric: str = "",
+    ) -> bool:
+        captured.update(
+            num_partitions=num_partitions, num_sub_vectors=num_sub_vectors, metric=metric
+        )
+        return False
+
+    monkeypatch.setattr(
+        "synth_setter.pipeline.data.add_embeddings.load_m2l_audio_encoder", lambda: _fake_m2l
+    )
+    monkeypatch.setattr(
+        "synth_setter.pipeline.data.add_embeddings.load_clap_audio_encoder",
+        lambda checkpoint, device=None: _fake_clap,
+    )
+    monkeypatch.setattr(
+        "synth_setter.pipeline.data.add_embeddings.build_clap_index", spy_build_clap_index
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [str(uri), "--num-partitions", "4", "--num-sub-vectors", "8", "--metric", "l2"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == {"num_partitions": 4, "num_sub_vectors": 8, "metric": "l2"}
 
 
 def test_main_exits_1_when_open_fails_with_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/pipeline/data/test_add_embeddings.py
+++ b/tests/pipeline/data/test_add_embeddings.py
@@ -333,6 +333,23 @@ def test_build_clap_index_rejects_num_sub_vectors_not_dividing_dim(tmp_path: Pat
     assert lance.dataset(uri).list_indices() == []
 
 
+def test_build_clap_index_rejects_non_positive_index_params(tmp_path: Path) -> None:
+    """Non-positive num_sub_vectors / num_partitions raise instead of ZeroDivision/opaque.
+
+    :param tmp_path: Pytest-provided scratch directory for the dataset.
+    """
+    uri = str(tmp_path / "badparams.lance")
+    _audio_dataset(uri, 8)
+    add_embeddings(lance.dataset(uri), _fake_m2l, _fake_clap, _SAMPLE_RATE, build_index=False)
+
+    with pytest.raises(ValueError, match="num_sub_vectors must be >= 1"):
+        build_clap_index(lance.dataset(uri), num_sub_vectors=0)
+    with pytest.raises(ValueError, match="num_partitions must be >= 1"):
+        build_clap_index(lance.dataset(uri), num_partitions=0)
+
+    assert lance.dataset(uri).list_indices() == []
+
+
 @pytest.mark.slow
 def test_add_embeddings_rejects_rerun_when_columns_already_exist(tmp_path: Path) -> None:
     uri = str(tmp_path / "twice.lance")

--- a/tests/pipeline/data/test_add_embeddings.py
+++ b/tests/pipeline/data/test_add_embeddings.py
@@ -1,0 +1,307 @@
+"""Behavioral tests for :mod:`synth_setter.pipeline.data.add_embeddings`.
+
+The model loaders are exercised through *injected* encode callables so the suite
+never downloads a CLAP or music2latent checkpoint; the functional core, the
+Lance ``add_columns`` wiring, and the vector-index path are what these tests pin.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, cast
+
+import lance
+import numpy as np
+import pyarrow as pa
+import pytest
+from click.testing import CliRunner
+
+from synth_setter.data.vst.shapes import AUDIO_FIELD, CLAP_FIELD, M2L_FIELD, PARAM_ARRAY_FIELD
+from synth_setter.pipeline.data.add_embeddings import (
+    CLAP_EMBEDDING_DIM,
+    ClapEncodeFn,
+    M2LEncodeFn,
+    _downmix_to_mono,
+    add_embeddings,
+    build_clap_index,
+    embeddings_record_batch,
+    main,
+)
+from tests.helpers.finalize_shards import build_lance_smoke_spec, write_minimal_lance_shard
+from tests.helpers.lance_fixtures import write_lance_shard
+
+_SAMPLE_RATE = 44100
+# fake m2l per-row inner shape: (C*4, 3) — constant across rows (tensor contract).
+_M2L_TIME = 3
+
+
+def _fake_m2l(audio: np.ndarray) -> np.ndarray:
+    """Tile the per-channel mean into a constant-shape ``(B, C*4, 3)`` latent.
+
+    :param audio: ``(B, C, T)`` audio batch.
+    :returns: ``(B, C*4, 3)`` stand-in latent batch.
+    """
+    per_channel = np.repeat(audio.mean(axis=2), 4, axis=1)  # (B, C*4)
+    return np.repeat(per_channel[:, :, None], _M2L_TIME, axis=2)
+
+
+def _fake_clap(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+    """Broadcast each row's grand mean into a ``(B, CLAP_EMBEDDING_DIM)`` embedding.
+
+    :param mono: ``(B, T)`` mono batch.
+    :param sample_rate: Ignored.
+    :returns: ``(B, CLAP_EMBEDDING_DIM)`` stand-in embedding batch.
+    """
+    del sample_rate
+    return np.repeat(mono.mean(axis=1, keepdims=True), CLAP_EMBEDDING_DIM, axis=1)
+
+
+def _short_m2l(audio: np.ndarray) -> np.ndarray:
+    """M2l encoder that drops a row, mismatching the input row count.
+
+    :param audio: ``(B, C, T)`` audio batch.
+    :returns: ``(B-1, C*4, 3)`` latent batch.
+    """
+    return _fake_m2l(audio)[:-1]
+
+
+def _short_clap(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+    """CLAP encoder that drops a row, mismatching the input row count.
+
+    :param mono: ``(B, T)`` mono batch.
+    :param sample_rate: Ignored.
+    :returns: ``(B-1, CLAP_EMBEDDING_DIM)`` embedding batch.
+    """
+    return _fake_clap(mono, sample_rate)[:-1]
+
+
+def _wrong_dim_clap(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+    """CLAP encoder with the wrong embedding width.
+
+    :param mono: ``(B, T)`` mono batch.
+    :param sample_rate: Ignored.
+    :returns: ``(B, CLAP_EMBEDDING_DIM // 2)`` embedding batch.
+    """
+    del sample_rate
+    return np.repeat(mono.mean(axis=1, keepdims=True), CLAP_EMBEDDING_DIM // 2, axis=1)
+
+
+def _nonfinite_m2l(value: float) -> M2LEncodeFn:
+    """Build an m2l encoder whose first cell is ``value`` (a NaN/inf injector).
+
+    :param value: Non-finite value to inject at row 0.
+    :returns: An encoder poisoning one cell of its output.
+    """
+
+    def encode(audio: np.ndarray) -> np.ndarray:
+        out = _fake_m2l(audio).astype(np.float32)
+        out[0, 0, 0] = value
+        return out
+
+    return encode
+
+
+def _nonfinite_clap(value: float) -> ClapEncodeFn:
+    """Build a CLAP encoder whose first cell is ``value`` (a NaN/inf injector).
+
+    :param value: Non-finite value to inject at row 0.
+    :returns: An encoder poisoning one cell of its output.
+    """
+
+    def encode(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+        out = _fake_clap(mono, sample_rate).astype(np.float32)
+        out[0, 0] = value
+        return out
+
+    return encode
+
+
+def _audio_dataset(uri: str, rows: int, *, with_params: bool = False) -> np.ndarray:
+    """Write a Lance dataset of ``rows`` random-audio rows; return the audio array.
+
+    :param uri: Output ``.lance`` directory.
+    :param rows: Row count.
+    :param with_params: Also write a ``param_array`` column.
+    :returns: The ``(rows, 2, 16)`` float16 audio written.
+    """
+    rng = np.random.default_rng(rows)
+    audio = rng.random((rows, 2, 16)).astype(np.float16)
+    columns: dict[str, np.ndarray] = {AUDIO_FIELD: audio}
+    if with_params:
+        columns[PARAM_ARRAY_FIELD] = rng.random((rows, 3)).astype(np.float32)
+    write_lance_shard(Path(uri), columns)
+    return audio
+
+
+def test_downmix_to_mono_averages_channels_to_float32() -> None:
+    """Channel averaging yields float32 mono with the channel axis collapsed."""
+    audio = np.array([[[1.0, 3.0], [3.0, 5.0]]], dtype=np.float16)
+    mono = _downmix_to_mono(audio)
+    assert mono.shape == (1, 2)
+    assert mono.dtype == np.float32
+    np.testing.assert_allclose(mono, [[2.0, 4.0]])
+
+
+def test_downmix_to_mono_single_channel_passes_signal_through() -> None:
+    """A mono ``(B, 1, T)`` input is upcast to float32 with values unchanged."""
+    audio = np.array([[[1.0, 2.0, 3.0]]], dtype=np.float16)
+    mono = _downmix_to_mono(audio)
+    assert mono.shape == (1, 3)
+    assert mono.dtype == np.float32
+    np.testing.assert_allclose(mono, [[1.0, 2.0, 3.0]])
+
+
+def test_embeddings_record_batch_builds_tensor_and_fixed_size_list() -> None:
+    """M2l lands as a fixed-shape tensor; clap as a fixed-size-list<float32, dim>."""
+    audio = np.random.default_rng(0).random((5, 2, 8)).astype(np.float16)
+    batch = embeddings_record_batch(audio, _fake_m2l, _fake_clap, _SAMPLE_RATE)
+    table = pa.Table.from_batches([batch])
+
+    assert batch.schema.field(CLAP_FIELD).type == pa.list_(pa.float32(), CLAP_EMBEDDING_DIM)
+    m2l = table.column(M2L_FIELD).combine_chunks().to_numpy_ndarray()
+    clap = np.array(table.column(CLAP_FIELD).to_pylist(), dtype=np.float32)
+    assert m2l.shape == (5, 8, _M2L_TIME)  # (B, C*4, T)
+    assert clap.shape == (5, CLAP_EMBEDDING_DIM)
+    np.testing.assert_allclose(m2l, _fake_m2l(audio))
+    assert np.isfinite(m2l).all()
+    assert np.isfinite(clap).all()
+
+
+def test_embeddings_record_batch_rejects_m2l_row_count_mismatch() -> None:
+    """An m2l encoder returning fewer rows than the input raises."""
+    audio = np.zeros((4, 2, 8), dtype=np.float16)
+    with pytest.raises(ValueError, match="row"):
+        embeddings_record_batch(audio, _short_m2l, _fake_clap, _SAMPLE_RATE)
+
+
+def test_embeddings_record_batch_rejects_clap_row_count_mismatch() -> None:
+    """A CLAP encoder returning fewer rows than the input raises."""
+    audio = np.zeros((4, 2, 8), dtype=np.float16)
+    with pytest.raises(ValueError, match="row"):
+        embeddings_record_batch(audio, _fake_m2l, _short_clap, _SAMPLE_RATE)
+
+
+def test_embeddings_record_batch_rejects_wrong_clap_dim() -> None:
+    """A CLAP embedding of the wrong width raises before the column is built."""
+    audio = np.zeros((4, 2, 8), dtype=np.float16)
+    with pytest.raises(ValueError, match="expected"):
+        embeddings_record_batch(audio, _fake_m2l, _wrong_dim_clap, _SAMPLE_RATE)
+
+
+@pytest.mark.parametrize("value", [np.nan, np.inf])
+@pytest.mark.parametrize("side", ["m2l", "clap"])
+def test_embeddings_record_batch_rejects_non_finite_embeddings(side: str, value: float) -> None:
+    """A NaN/inf from either encoder raises rather than landing in the permanent column.
+
+    :param side: Which encoder (``m2l`` or ``clap``) emits the poisoned cell.
+    :param value: The non-finite value injected (NaN or inf).
+    """
+    audio = np.zeros((3, 2, 8), dtype=np.float16)
+    m2l = _nonfinite_m2l(value) if side == "m2l" else _fake_m2l
+    clap = _nonfinite_clap(value) if side == "clap" else _fake_clap
+    with pytest.raises(ValueError, match="non-finite"):
+        embeddings_record_batch(audio, m2l, clap, _SAMPLE_RATE)
+
+
+@pytest.mark.slow
+def test_add_embeddings_writes_searchable_columns_and_keeps_params(tmp_path: Path) -> None:
+    uri = str(tmp_path / "smoke.lance")
+    audio = _audio_dataset(uri, 6, with_params=True)
+
+    add_embeddings(lance.dataset(uri), _fake_m2l, _fake_clap, _SAMPLE_RATE, build_index=False)
+
+    table = lance.dataset(uri).to_table()
+    assert set(table.column_names) == {AUDIO_FIELD, PARAM_ARRAY_FIELD, M2L_FIELD, CLAP_FIELD}
+    assert table.schema.field(CLAP_FIELD).type == pa.list_(pa.float32(), CLAP_EMBEDDING_DIM)
+    m2l = table.column(M2L_FIELD).combine_chunks().to_numpy_ndarray()
+    np.testing.assert_allclose(m2l, _fake_m2l(audio))
+    # Exact (brute-force) nearest works even without an index.
+    hits = lance.dataset(uri).to_table(
+        nearest={"column": CLAP_FIELD, "q": np.ones(CLAP_EMBEDDING_DIM, np.float32), "k": 3}
+    )
+    assert hits.num_rows == 3
+    assert "_distance" in hits.column_names
+
+
+@pytest.mark.slow
+def test_add_embeddings_builds_ivf_pq_index_on_clap(tmp_path: Path) -> None:
+    uri = str(tmp_path / "indexed.lance")
+    _audio_dataset(uri, 300)
+
+    add_embeddings(
+        lance.dataset(uri), _fake_m2l, _fake_clap, _SAMPLE_RATE, build_index=True, num_partitions=4
+    )
+
+    indices = cast("list[dict[str, Any]]", lance.dataset(uri).list_indices())
+    assert any(idx["fields"] == [CLAP_FIELD] for idx in indices)
+    hits = lance.dataset(uri).to_table(
+        nearest={"column": CLAP_FIELD, "q": np.ones(CLAP_EMBEDDING_DIM, np.float32), "k": 5}
+    )
+    assert hits.num_rows == 5
+
+
+@pytest.mark.slow
+def test_build_clap_index_skips_when_too_few_rows(tmp_path: Path) -> None:
+    uri = str(tmp_path / "tiny.lance")
+    _audio_dataset(uri, 8)
+    add_embeddings(lance.dataset(uri), _fake_m2l, _fake_clap, _SAMPLE_RATE, build_index=False)
+
+    built = build_clap_index(lance.dataset(uri))
+
+    assert built is False
+    assert lance.dataset(uri).list_indices() == []
+
+
+@pytest.mark.slow
+def test_add_embeddings_rejects_rerun_when_columns_already_exist(tmp_path: Path) -> None:
+    uri = str(tmp_path / "twice.lance")
+    _audio_dataset(uri, 6)
+    add_embeddings(lance.dataset(uri), _fake_m2l, _fake_clap, _SAMPLE_RATE, build_index=False)
+
+    with pytest.raises(ValueError, match="already has embedding column"):
+        add_embeddings(lance.dataset(uri), _fake_m2l, _fake_clap, _SAMPLE_RATE, build_index=False)
+
+
+@pytest.mark.slow
+def test_main_adds_embeddings_using_sample_rate_from_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    spec = build_lance_smoke_spec()
+    uri = tmp_path / "shard.lance"
+    write_minimal_lance_shard(uri, spec)
+
+    seen_sample_rate: list[int] = []
+
+    def clap_recording_sr(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+        seen_sample_rate.append(sample_rate)
+        return _fake_clap(mono, sample_rate)
+
+    # Loaders injected: the real encoders need checkpoints + a GPU (see the notebook).
+    monkeypatch.setattr(
+        "synth_setter.pipeline.data.add_embeddings.load_m2l_audio_encoder",
+        lambda: _fake_m2l,
+    )
+    monkeypatch.setattr(
+        "synth_setter.pipeline.data.add_embeddings.load_clap_audio_encoder",
+        lambda checkpoint, device=None: clap_recording_sr,
+    )
+
+    result = CliRunner().invoke(main, [str(uri), "--no-build-index"])
+
+    assert result.exit_code == 0, result.output
+    assert seen_sample_rate
+    assert all(sr == int(spec.render.sample_rate) for sr in seen_sample_rate)
+    assert {M2L_FIELD, CLAP_FIELD} <= set(lance.dataset(str(uri)).schema.names)
+
+
+def test_main_exits_1_when_open_fails_with_runtime_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A cloud-creds RuntimeError from the open path must exit 1 cleanly, not traceback.
+    def boom(uri: str) -> object:
+        raise RuntimeError("missing R2 credentials")
+
+    monkeypatch.setattr("synth_setter.pipeline.data.add_embeddings._open_lance_dataset", boom)
+
+    result = CliRunner().invoke(main, ["s3://bucket/missing.lance"])
+
+    assert result.exit_code == 1
+    assert result.exception is None or isinstance(result.exception, SystemExit)

--- a/uv.lock
+++ b/uv.lock
@@ -5802,7 +5802,7 @@ dev = [
     { name = "torchaudio", specifier = ">=2.0.0" },
     { name = "torchmetrics", specifier = ">=0.11.4" },
     { name = "torchvision", specifier = ">=0.15.0" },
-    { name = "transformers", specifier = ">=4.40.0" },
+    { name = "transformers", specifier = ">=5.0.0" },
     { name = "wandb" },
     { name = "webdataset" },
 ]
@@ -5860,7 +5860,7 @@ runtime = [
     { name = "torchaudio", specifier = ">=2.0.0" },
     { name = "torchmetrics", specifier = ">=0.11.4" },
     { name = "torchvision", specifier = ">=0.15.0" },
-    { name = "transformers", specifier = ">=4.40.0" },
+    { name = "transformers", specifier = ">=5.0.0" },
     { name = "wandb" },
     { name = "webdataset" },
 ]
@@ -5871,7 +5871,7 @@ torch = [
     { name = "torchaudio", specifier = ">=2.0.0" },
     { name = "torchmetrics", specifier = ">=0.11.4" },
     { name = "torchvision", specifier = ">=0.15.0" },
-    { name = "transformers", specifier = ">=4.40.0" },
+    { name = "transformers", specifier = ">=5.0.0" },
 ]
 util = [
     { name = "click", specifier = "<8.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -1812,6 +1812,30 @@ wheels = [
 ]
 
 [[package]]
+name = "hf-xet"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -1866,6 +1890,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.16.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typer" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/0f/ed994dbade67a54407c28cab96ef845e0e6d25500be56aca6394f8bfc9dd/huggingface_hub-1.16.1.tar.gz", hash = "sha256:7f1dc4c5ec21aed69be630ad0c3378616be16f3de1a47b141c0e812965d9c832", size = 792534, upload-time = "2026-05-21T18:40:00.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/79/621a7dbb80c70974f73a597275351ebe03ce5bc65cb5f8f4acb5859252bc/huggingface_hub-1.16.1-py3-none-any.whl", hash = "sha256:64340de934b9ce37857ef85a82de72f5629e8a270f9119eabb12bf495eb53c22", size = 668176, upload-time = "2026-05-21T18:39:58.596Z" },
 ]
 
 [[package]]
@@ -2838,6 +2882,23 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/5b/2d2d1d522e51285bd61b1e20df8f47ae1a9d80839db0b24ea783b3832832/multidict-6.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d54ecf9f301853f2c5e802da559604b3e95bb7a3b01a9c295c6ee591b9882de8", size = 53109, upload-time = "2026-01-26T02:45:08.044Z" },
     { url = "https://files.pythonhosted.org/packages/3d/a3/cc409ba012c83ca024a308516703cf339bdc4b696195644a7215a5164a24/multidict-6.7.1-cp313-cp313t-win_arm64.whl", hash = "sha256:5a37ca18e360377cfda1d62f5f382ff41f2b8c4ccb329ed974cc2e1643440118", size = 45573, upload-time = "2026-01-26T02:45:09.349Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "music2latent"
+version = "0.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "soundfile" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/29/ffd2302eab316e901da3388a0654bfdbb07ffe69551aa80214aab855232f/music2latent-0.1.8.tar.gz", hash = "sha256:86ea42f2390a15ed6a8c12278a81a61ff4580207108a7f088b5017ebc5d23687", size = 19049, upload-time = "2025-11-07T17:28:33.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/ab/6c743722ec838eef125d904dbad78c3cd6fc5a3eec06a1adedf4a5bb9fcc/music2latent-0.1.8-py3-none-any.whl", hash = "sha256:432a32ca7924148ff09a27df9bf86a59d98ffc495154fcc196177fdb4da37faf", size = 19896, upload-time = "2025-11-07T17:28:32.746Z" },
 ]
 
 [[package]]
@@ -4571,6 +4632,78 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/dc/c1f2df4027e82fc54b5a473e4b250f5139faca49a0fbe29a48668d228f34/regex-2026.5.9-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:ccf5249114cc3e772ecdd88a98a86eca0fd74c61ce32a94743758c083fc05d48", size = 489445, upload-time = "2026-05-09T23:12:06.111Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/59f01110660081cce9c0bc30ebd0b5ee250dacf658e3248ed92f01e0e8ee/regex-2026.5.9-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:46f1326ca6e65b0879d23ca302c0f2415aad42ff0309b9c818e7949fe19a41d8", size = 291271, upload-time = "2026-05-09T23:12:07.731Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b6/14b2c84ff90ddb370c81d27503f4a0fcf071496416f4855f6cc8c5d81c35/regex-2026.5.9-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ef31cbfe458e21c6122ba8150ff060e0c7789ed0d26eb423f25472584920b555", size = 289212, upload-time = "2026-05-09T23:12:09.266Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d0/4db86529117320de0c84afd90e70bb47434625875e34fcef9d8c127c5b16/regex-2026.5.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:992604d02e6d9c6d786c24a706a71ecffe1020fc1ef264044474cd81fa2c3919", size = 792310, upload-time = "2026-05-09T23:12:11.416Z" },
+    { url = "https://files.pythonhosted.org/packages/07/78/fe4800cd322f862ecffd2d553409b20d80650e5ed71b9d178f853d020b82/regex-2026.5.9-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c9411dd64ca95477225734a93dfc8583b51916b8d5942f99d6cac21e09965451", size = 861721, upload-time = "2026-05-09T23:12:13.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d0/b3618a895dd8feb897c61bb2954edd265e1767d82a01d53065d5871127a3/regex-2026.5.9-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3dd4a3ff360dfb836fecdb93a4598f9d6e2ac81e3e397125145c6221bf58cf4c", size = 906460, upload-time = "2026-05-09T23:12:15.443Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6f/1481597e859ef19508b345eec4afd1416ed6e6b459c75a64026ef193aecf/regex-2026.5.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2a661a7d270a61f7cf460caee8b9fa2d5ef9e5c681234bcb9e0fe14f488e7dfc", size = 799843, upload-time = "2026-05-09T23:12:16.892Z" },
+    { url = "https://files.pythonhosted.org/packages/73/59/955734c803f59108deccba3597ae440c76b62a652733c0006e6243758420/regex-2026.5.9-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f079e50a0d3cc3cd5091fa9ff45869a2e6b2cd35895731edafb0327901a8d86d", size = 773610, upload-time = "2026-05-09T23:12:19.127Z" },
+    { url = "https://files.pythonhosted.org/packages/68/8f/70c04a236d651c81881dac42ef8538bddda6121434509d0a22d9e601503b/regex-2026.5.9-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4ebe8f0b5ec5a5024dc4a4c59f444c4e9afc5f2abdbb8962065b75d27fb971f9", size = 781645, upload-time = "2026-05-09T23:12:20.806Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/96/05c7434d88185e5d27fe54aeb74df86bd77cd79f52f0b4eae54faa8fea70/regex-2026.5.9-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:97cf3bc1b7d7d2306772ec07366c80d9df00ff79e79cea32898883a646d2fae2", size = 854473, upload-time = "2026-05-09T23:12:22.465Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/6e3d8202d981f3117004bf341ee74893ba4ba8a9fbaf4b94615846550a08/regex-2026.5.9-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:0f9eede6a5cbdc02d4978090186390936e1776a7d1359b21e41014c609880bcf", size = 763311, upload-time = "2026-05-09T23:12:24.351Z" },
+    { url = "https://files.pythonhosted.org/packages/93/c7/e7737f1526b3fb32bd4c337fd6c71c3ebb5c8296fc34d11197e0955d2e35/regex-2026.5.9-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:01f0f5f55f4b64dacec85dc116d3c05fd23ad3ff037bbc73a2085775953c2611", size = 844593, upload-time = "2026-05-09T23:12:26.341Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/27/0daffb1a535bb39f422c3d200f4ab023c71110ad66a32b366bee708baba0/regex-2026.5.9-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1268eddd8486dc561d08eee1156e40aa3a8fe10f4bdec8fa653b455fcbffd12c", size = 789167, upload-time = "2026-05-09T23:12:27.975Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fc/294fe4fac4f2ed67207b17471815870c1c45b3a489e08e0ac96daea16ef6/regex-2026.5.9-cp311-cp311-win32.whl", hash = "sha256:8676474c07469d6f33dd1085ca2cd45f65785f32518f2b20e36d9953ca07f994", size = 266249, upload-time = "2026-05-09T23:12:30.141Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/b0/8dce459f6245bcf8f6e9f23ac9569f1a0f15c131cc0745e82b43226204cf/regex-2026.5.9-cp311-cp311-win_amd64.whl", hash = "sha256:246de9d60aa3f8538b519834dd95cbf276ea263d6a7bd5a3666dc3fa0230505b", size = 278423, upload-time = "2026-05-09T23:12:31.676Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8d/f9aeff6ad63a3ef720386f2907e6d34a35a510a6e498ebad28b0fb3f6ab6/regex-2026.5.9-cp311-cp311-win_arm64.whl", hash = "sha256:d726ca3f0d76969bf1e8e477d160d3d666bbf999f6860bd314889e5345782046", size = 270420, upload-time = "2026-05-09T23:12:33.194Z" },
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4858,6 +4991,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e0/1f/12417f7f493fc45e1f9fd5d4a9b6c125cf8d2cf3f8ddbdfab3e76406e9d6/s3transfer-0.18.0.tar.gz", hash = "sha256:3760b8b7ec1315da54048b2d626276732bee4300d054d492d4e1d43e20d4ecbd", size = 160560, upload-time = "2026-05-28T19:39:09.124Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2b/58/a58fc997655386daa2e25784e30c288aa3e3819e401f77029ee4899fb55a/s3transfer-0.18.0-py3-none-any.whl", hash = "sha256:239c13b09e65ad0346e1be7348b8a202dcad44ac7ea7c6eb858fc881dce739b6", size = 88572, upload-time = "2026-05-28T19:39:07.999Z" },
+]
+
+[[package]]
+name = "safetensors"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/06/f955dbbb1859e3bd23c8ac6141af5106e7ad5fedec4a3a6e3d60f94b7001/safetensors-0.8.0.tar.gz", hash = "sha256:fabaf3e0f18a6618d9b36560682562157f77c2b71fcffc7b432be2baed9d753d", size = 325846, upload-time = "2026-06-09T07:52:25.563Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/a0/f718cda65b05407d228f97602cf60dca269c979867aa5beb25410de26cd3/safetensors-0.8.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c554f85858e05226d3c2828e32395e677434685d6d94594a41643361c5e837f0", size = 473568, upload-time = "2026-06-09T07:52:18.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b1/fa7c600e7dceae12e9606c7578cbc9ff1e1ed55844883ee5c92205e86226/safetensors-0.8.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c80201d22cbf405b80647a60ada77bba06c8fba2da2743ba1e89cdcc39a81f25", size = 484562, upload-time = "2026-06-09T07:52:17.518Z" },
+    { url = "https://files.pythonhosted.org/packages/09/7d/65a7de0af421317bb36a067241e4235fff194eed60b961ed6d3f59a3fc60/safetensors-0.8.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a46e5ff292c356d6991e60942ba7f79817682d3a2cef0702136448cb9c4d235", size = 502844, upload-time = "2026-06-09T07:52:07.624Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4f/3175c9d75634e0e0dda0082794193521035edd7c70a6f212bf33ca06ddf4/safetensors-0.8.0-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4124502b78f03534117c848f87a39b8f31e577b15eff423bf8bfb95f2a8c30d0", size = 511823, upload-time = "2026-06-09T07:52:09.565Z" },
+    { url = "https://files.pythonhosted.org/packages/20/87/846c289e7aa2299eff406335717cf43ce8777194ece8aad75772e0411615/safetensors-0.8.0-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7bc0a787ba8a35be368ee3574edfa2b1ad389eebd0a72e482ae275490e3f6c98", size = 633461, upload-time = "2026-06-09T07:52:11.128Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/8d64d9df2c45d5ded401df889d0ad90882804ca172d79ec4f0df8f727fe0/safetensors-0.8.0-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:040070828e36dc8e122178bbbd5830ff9e97920affb84cbe0f46442497bed358", size = 545148, upload-time = "2026-06-09T07:52:13.603Z" },
+    { url = "https://files.pythonhosted.org/packages/28/50/f203ff3a3ddfe19308efc83c5a3a29ed02bf786732ec35e68bf9162f3365/safetensors-0.8.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd6f3f93c9a0a7cc2788ee63fb763353d4bd2e89b0751bc78fcf7dda00bea774", size = 516040, upload-time = "2026-06-09T07:52:16.29Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fb/cdaed17ceb2948784fd9c36b6fd3e951b608547cea81a48e8ee6f8cfdfcb/safetensors-0.8.0-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:fcdd41ec4628fee5799f807c73c353629130fbd942aa23d83c623dd6c9d52d78", size = 513832, upload-time = "2026-06-09T07:52:12.37Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/49/1e15de264dcc3b77943d2d0c56a95809956883b1c2d6d585c792523f180b/safetensors-0.8.0-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8e9f537aa183a38ace122d27303dcd986b26bd2a7591f9181d7f0c396f4677ca", size = 559930, upload-time = "2026-06-09T07:52:14.743Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/43/bf38443278eab4b1be1fce2931e2b012ad9cb7df52ada751d0aab8f7659a/safetensors-0.8.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87eec7ffed2b809f05a398a8becb7d013f19f7837cd15d9748580d6cf30dbaf4", size = 678670, upload-time = "2026-06-09T07:52:20.032Z" },
+    { url = "https://files.pythonhosted.org/packages/72/e3/68cd3fa5b48488e84add63e04cb12f3bc28ae4638c06d4508c6e88823d0e/safetensors-0.8.0-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:4a95ae2b05d7726d751da4ebf626a2ca782b706e101bd894c95bc2450b1cffcc", size = 786679, upload-time = "2026-06-09T07:52:21.322Z" },
+    { url = "https://files.pythonhosted.org/packages/29/4b/1c19c509d56e01f4fbb3d0a2e597450f6cc04d1d56cf52defb0a62dfd715/safetensors-0.8.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:3ae091f16662658bdc019a4ff6cb4c085bb7d725eb5978b183ffd265863b6d2d", size = 765683, upload-time = "2026-06-09T07:52:22.594Z" },
+    { url = "https://files.pythonhosted.org/packages/27/43/41c1621732edd934d868a00d1b891584c892a7b62a9aab82ea5a0a5623ee/safetensors-0.8.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8e080062fcde23be189565e1c3305d16751a218ecf9412c8601e64204eb6f846", size = 722361, upload-time = "2026-06-09T07:52:23.924Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/3f/73ccf82579412b4a71c4ca673f10b5f1f888d7cf5af7fe24f27d30307be4/safetensors-0.8.0-cp310-abi3-win32.whl", hash = "sha256:2ddf52eac562eda224f99acfa7889d02968c1fd59a5b011ae7d8137c37e9c02d", size = 342401, upload-time = "2026-06-09T07:52:28.895Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/6d/3fba214c1e5e0f69991677ec3bc17023f0421776975e1de0c682dca475e2/safetensors-0.8.0-cp310-abi3-win_amd64.whl", hash = "sha256:096ec1a98435df7beb08853bb5aa9081a84f23d0adc67ed1a0a10550f608373f", size = 355540, upload-time = "2026-06-09T07:52:27.832Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/fc/7eedc3510d97878876e32774eebbeb61c43f148a96e915c84229a3e967aa/safetensors-0.8.0-cp310-abi3-win_arm64.whl", hash = "sha256:f7838e5135a406ad3e02efdcb8cf2e5397d368b0154537c4fec682dbc544d452", size = 340500, upload-time = "2026-06-09T07:52:26.745Z" },
 ]
 
 [[package]]
@@ -5401,6 +5558,7 @@ dev = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "music2latent" },
     { name = "mutmut" },
     { name = "numpy" },
     { name = "oci" },
@@ -5441,6 +5599,7 @@ dev = [
     { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "transformers" },
     { name = "wandb" },
     { name = "webdataset" },
 ]
@@ -5474,6 +5633,7 @@ runtime = [
     { name = "loguru" },
     { name = "matplotlib" },
     { name = "mido" },
+    { name = "music2latent" },
     { name = "numpy" },
     { name = "oci" },
     { name = "omegaconf" },
@@ -5503,11 +5663,13 @@ runtime = [
     { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "transformers" },
     { name = "wandb" },
     { name = "webdataset" },
 ]
 torch = [
     { name = "lightning" },
+    { name = "music2latent" },
     { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torch", version = "2.12.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
@@ -5518,6 +5680,7 @@ torch = [
     { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cu128') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'linux' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128') or (sys_platform == 'win32' and extra != 'extra-12-synth-setter-cpu' and extra != 'extra-12-synth-setter-cu128')" },
     { name = "torchvision", version = "0.27.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(sys_platform == 'linux' and extra == 'extra-12-synth-setter-cpu') or (sys_platform == 'win32' and extra == 'extra-12-synth-setter-cpu') or (extra == 'extra-12-synth-setter-cpu' and extra == 'extra-12-synth-setter-cu128')" },
+    { name = "transformers" },
 ]
 util = [
     { name = "click" },
@@ -5604,6 +5767,7 @@ dev = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extras = ["python"] },
+    { name = "music2latent", specifier = ">=0.1.8" },
     { name = "mutmut", specifier = "==3.5.*" },
     { name = "numpy" },
     { name = "oci" },
@@ -5638,6 +5802,7 @@ dev = [
     { name = "torchaudio", specifier = ">=2.0.0" },
     { name = "torchmetrics", specifier = ">=0.11.4" },
     { name = "torchvision", specifier = ">=0.15.0" },
+    { name = "transformers", specifier = ">=4.40.0" },
     { name = "wandb" },
     { name = "webdataset" },
 ]
@@ -5671,6 +5836,7 @@ runtime = [
     { name = "loguru", specifier = "==0.7.3" },
     { name = "matplotlib" },
     { name = "mido" },
+    { name = "music2latent", specifier = ">=0.1.8" },
     { name = "numpy" },
     { name = "oci" },
     { name = "omegaconf" },
@@ -5694,15 +5860,18 @@ runtime = [
     { name = "torchaudio", specifier = ">=2.0.0" },
     { name = "torchmetrics", specifier = ">=0.11.4" },
     { name = "torchvision", specifier = ">=0.15.0" },
+    { name = "transformers", specifier = ">=4.40.0" },
     { name = "wandb" },
     { name = "webdataset" },
 ]
 torch = [
     { name = "lightning", specifier = ">=2.6.0" },
+    { name = "music2latent", specifier = ">=0.1.8" },
     { name = "torch", specifier = ">=2.0.0" },
     { name = "torchaudio", specifier = ">=2.0.0" },
     { name = "torchmetrics", specifier = ">=0.11.4" },
     { name = "torchvision", specifier = ">=0.15.0" },
+    { name = "transformers", specifier = ">=4.40.0" },
 ]
 util = [
     { name = "click", specifier = "<8.2" },
@@ -5798,6 +5967,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/6f/f80cfef4a312e1fb34baf7d85c72d4411afde10978d4657f8cdd811d3ccc/tokenizers-0.22.2.tar.gz", hash = "sha256:473b83b915e547aa366d1eee11806deaf419e17be16310ac0a14077f1e28f917", size = 372115, upload-time = "2026-01-05T10:45:15.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/97/5dbfabf04c7e348e655e907ed27913e03db0923abb5dfdd120d7b25630e1/tokenizers-0.22.2-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:544dd704ae7238755d790de45ba8da072e9af3eea688f698b137915ae959281c", size = 3100275, upload-time = "2026-01-05T10:41:02.158Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/47/174dca0502ef88b28f1c9e06b73ce33500eedfac7a7692108aec220464e7/tokenizers-0.22.2-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1e418a55456beedca4621dbab65a318981467a2b188e982a23e117f115ce5001", size = 2981472, upload-time = "2026-01-05T10:41:00.276Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/84/7990e799f1309a8b87af6b948f31edaa12a3ed22d11b352eaf4f4b2e5753/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249487018adec45d6e3554c71d46eb39fa8ea67156c640f7513eb26f318cec7", size = 3290736, upload-time = "2026-01-05T10:40:32.165Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/09d0d9ba94dcd5f4f1368d4858d24546b4bdc0231c2354aa31d6199f0399/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:25b85325d0815e86e0bac263506dd114578953b7b53d7de09a6485e4a160a7dd", size = 3168835, upload-time = "2026-01-05T10:40:38.847Z" },
+    { url = "https://files.pythonhosted.org/packages/47/50/b3ebb4243e7160bda8d34b731e54dd8ab8b133e50775872e7a434e524c28/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bfb88f22a209ff7b40a576d5324bf8286b519d7358663db21d6246fb17eea2d5", size = 3521673, upload-time = "2026-01-05T10:40:56.614Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/fa/89f4cb9e08df770b57adb96f8cbb7e22695a4cb6c2bd5f0c4f0ebcf33b66/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1c774b1276f71e1ef716e5486f21e76333464f47bece56bbd554485982a9e03e", size = 3724818, upload-time = "2026-01-05T10:40:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/64/04/ca2363f0bfbe3b3d36e95bf67e56a4c88c8e3362b658e616d1ac185d47f2/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:df6c4265b289083bf710dff49bc51ef252f9d5be33a45ee2bed151114a56207b", size = 3379195, upload-time = "2026-01-05T10:40:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/76/932be4b50ef6ccedf9d3c6639b056a967a86258c6d9200643f01269211ca/tokenizers-0.22.2-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:369cc9fc8cc10cb24143873a0d95438bb8ee257bb80c71989e3ee290e8d72c67", size = 3274982, upload-time = "2026-01-05T10:40:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/28/5f9f5a4cc211b69e89420980e483831bcc29dade307955cc9dc858a40f01/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:29c30b83d8dcd061078b05ae0cb94d3c710555fbb44861139f9f83dcca3dc3e4", size = 9478245, upload-time = "2026-01-05T10:41:04.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/fb/66e2da4704d6aadebf8cb39f1d6d1957df667ab24cff2326b77cda0dcb85/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:37ae80a28c1d3265bb1f22464c856bd23c02a05bb211e56d0c5301a435be6c1a", size = 9560069, upload-time = "2026-01-05T10:45:10.673Z" },
+    { url = "https://files.pythonhosted.org/packages/16/04/fed398b05caa87ce9b1a1bb5166645e38196081b225059a6edaff6440fac/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:791135ee325f2336f498590eb2f11dc5c295232f288e75c99a36c5dbce63088a", size = 9899263, upload-time = "2026-01-05T10:45:12.559Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a1/d62dfe7376beaaf1394917e0f8e93ee5f67fea8fcf4107501db35996586b/tokenizers-0.22.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:38337540fbbddff8e999d59970f3c6f35a82de10053206a7562f1ea02d046fa5", size = 10033429, upload-time = "2026-01-05T10:45:14.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/18/a545c4ea42af3df6effd7d13d250ba77a0a86fb20393143bbb9a92e434d4/tokenizers-0.22.2-cp39-abi3-win32.whl", hash = "sha256:a6bf3f88c554a2b653af81f3204491c818ae2ac6fbc09e76ef4773351292bc92", size = 2502363, upload-time = "2026-01-05T10:45:20.593Z" },
+    { url = "https://files.pythonhosted.org/packages/65/71/0670843133a43d43070abeb1949abfdef12a86d490bea9cd9e18e37c5ff7/tokenizers-0.22.2-cp39-abi3-win_amd64.whl", hash = "sha256:c9ea31edff2968b44a88f97d784c2f16dc0729b8b143ed004699ebca91f05c48", size = 2747786, upload-time = "2026-01-05T10:45:18.411Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f4/0de46cfa12cdcbcd464cc59fde36912af405696f687e53a091fb432f694c/tokenizers-0.22.2-cp39-abi3-win_arm64.whl", hash = "sha256:9ce725d22864a1e965217204946f830c37876eee3b2ba6fc6255e8e903d5fcbc", size = 2612133, upload-time = "2026-01-05T10:45:17.232Z" },
 ]
 
 [[package]]
@@ -6217,6 +6412,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/c1/bd361c24a76e7c0d137e299ca1e86bbe188e4c08e3e46674a285aa762051/tqdm_loggable-0.4.1.tar.gz", hash = "sha256:49123ffcb2deb948edb7121d7e09a6008914e0d0333154f060e435deba9e547a", size = 8170, upload-time = "2026-03-16T18:38:50.774Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/24/303708f276f2a81bd0551f5e93b5dd51201ca0d73aed0dc50be6976a3443/tqdm_loggable-0.4.1-py3-none-any.whl", hash = "sha256:e3b394a6fc85a1b1b0dad52a63ac926ecb3b478acf4f4bae570d9189f00ab91d", size = 10527, upload-time = "2026-03-16T18:38:49.808Z" },
+]
+
+[[package]]
+name = "transformers"
+version = "5.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "huggingface-hub" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "safetensors" },
+    { name = "tokenizers" },
+    { name = "tqdm" },
+    { name = "typer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/7c/8240f612819718100a9346dc28dea6a11370c3ca9c8c6eabadd3dea4ef29/transformers-5.12.1.tar.gz", hash = "sha256:679ee731c8225347889ad4fb3b2c926a62e9da3b7d284e9d12c791da7272466b", size = 8924054, upload-time = "2026-06-15T17:27:50.604Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/56/bbd60dd8668055803bf8ba55a81f9b8a8b31497f620109a9671d26a2076d/transformers-5.12.1-py3-none-any.whl", hash = "sha256:2a5e109d2021265df7098ffbb738295acaf5ad256f12cbc586db2ea4dcbb1a8a", size = 11150587, upload-time = "2026-06-15T17:27:46.679Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds a standalone `add_embeddings` CLI that reads a Lance dataset produced by `generate_dataset` / `finalize_dataset` and appends **two** audio-embedding columns derived from the `audio` column:

- **`clap`** — LAION CLAP audio embedding (`laion/clap-htsat-unfused`), stored as a **`FixedSizeList<float32, 512>`** so it is **vector-searchable**: Lance builds an **IVF_PQ** index over it (in the CLI by default) and serves `to_table(nearest={...})` ANN queries.
- **`m2l`** — music2latent latent, stored as a **`fixed_shape_tensor<float32, (C*D, T)>`** (retrievable, not a search vector; requires constant `(channels, latent-dim, time)` across the dataset).

Run it with `python -m synth_setter.pipeline.data.add_embeddings DATASET.lance` (also registered as `synth-setter-add-embeddings`).

## How it works

- Columns are added through `LanceDataset.add_columns` with a `lance.batch_udf` that reads **only** the `audio` column per batch.
- The functional core (`embeddings_record_batch`, `add_embeddings`) takes **injected** encode callables, so it runs and is unit-tested without a checkpoint; `load_m2l_audio_encoder` / `load_clap_audio_encoder` build the real encoders behind lazy `music2latent` / `transformers` imports (both declared in the `torch` dependency group).
- Audio sample rate is read from the shard `ShardMetadata` in the schema; audio is downmixed to mono and resampled to CLAP's 48 kHz before encoding.
- Validation before write: row count, CLAP dim, and **finiteness** (a NaN/inf row is rejected rather than poisoning a permanent column). A re-run guard refuses to re-add existing columns. Cloud URIs (`r2://` / `s3://`) open with R2 `storage_options`.
- The IVF_PQ index is built by default; it is skipped (with a logged warning) below ~256 rows, where exact `nearest` search still works.

A `notebooks/add_embeddings_smoke.ipynb` walkthrough builds a smoke Lance dataset, runs the add step, builds a DataFrame of params + embeddings, and runs a `clap` vector search.

## Testing

- 20 unit tests + 2 real-R2 integration tests (Lance-I/O and R2 ones `@pytest.mark.slow`): tensor + fixed-size-list construction, row-count/dim/finiteness guards (parametrized NaN/inf), mono downmix, IVF_PQ index build + `nearest`, exact `nearest` without an index, index-skip on tiny data, index-param validation (non-positive partitions/sub-vectors, sub-vectors not dividing the CLAP dim), re-run guard, missing-`audio`-column guard, the CLI sample-rate-from-metadata path, index-tuning options threaded into the build, and `main()` exiting `1` on open/add failure.
- `make format` (ruff, pyright, pydoclint, interrogate, mdformat, codespell, …) passes on all changed files; `uv.lock` resolved with `transformers` + `music2latent`.
- The real CLAP/m2l encoders are **not** exercised in CI (checkpoint downloads + GPU); covered by the notebook and intended for manual verification on a GPU host.

## Verification

- [ ] Real CLAP + music2latent encoders smoke-run end-to-end on a GPU host against a real Lance shard, then confirm `to_table(nearest=...)` over the `clap` column returns sensible neighbors (not run in CI — needs checkpoints + GPU).

Fixes #1716

## Tests

`tests/integration/test_add_embeddings_r2.py` is a real no-mocks end-to-end test (marked `slow` / `requires_vst` / `integration_r2`): it generates a 1-shard Lance dataset via the real VST renderer, uploads it to a unique R2 prefix, runs `synth-setter-add-embeddings` against that `r2://` URI with the real music2latent + LAION-CLAP encoders, then reopens the remote dataset and asserts the `clap` fixed-size-list + `m2l` tensor columns, preserved source columns, finiteness, and an exact `nearest=` query. The R2 prefix is purged on teardown.
