### PR TITLE
test(training): cover Lance datamodule smoke parity

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import sys
 from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, NamedTuple
 
 import h5py
 import hdf5plugin  # noqa: F401   side-effect import: registers HDF5_PLUGIN_PATH so h5py can load Blosc2 filters in fixtures
@@ -667,10 +667,15 @@ def cfg_surge_xt_global(
     )
 
 
-def _render_smoke_train_h5_subprocess(train_h5: Path, param_spec_name: str) -> None:
-    """Render the smoke ``train.h5`` via the ``generate_vst_dataset`` subprocess (real VST), failing loud on timeout/non-zero exit/missing output.
+def _render_smoke_train_subprocess(output_path: Path, param_spec_name: str) -> None:
+    """Render the smoke ``train`` shard via the ``generate_vst_dataset`` subprocess (real VST), failing loud on timeout/non-zero exit/missing output.
 
-    :param train_h5: Destination ``train.h5`` path; its parent must already exist.
+    The writer is dispatched on ``output_path``'s suffix by ``generate_vst_dataset``
+    (``.h5`` -> HDF5, ``.lance`` -> Lance), so this one renderer backs both the h5
+    and Lance real-VST smoke fixtures.
+
+    :param output_path: Destination shard path (``train.h5`` or ``train.lance``); its
+        parent must already exist.
     :param param_spec_name: Key into :data:`synth_setter.data.vst.param_specs` and
         :data:`synth_setter.data.vst.preset_paths` selecting spec and preset.
     """
@@ -681,7 +686,7 @@ def _render_smoke_train_h5_subprocess(train_h5: Path, param_spec_name: str) -> N
     generate_dataset_args += [
         sys.executable,
         "src/synth_setter/data/vst/generate_vst_dataset.py",
-        str(train_h5),
+        str(output_path),
         f"--plugin_path={PLUGIN_PATH}",
         f"--preset_path={preset_paths[param_spec_name]}",
         f"--param_spec_name={param_spec_name}",
@@ -722,7 +727,7 @@ def _render_smoke_train_h5_subprocess(train_h5: Path, param_spec_name: str) -> N
             f"(child stdout/stderr printed above; rerun with `pytest -s` if captured)",
             pytrace=False,
         )
-    assert train_h5.exists(), "Dataset generation failed to produce train.h5 fixture"
+    assert output_path.exists(), "Dataset generation failed to produce train fixture"
 
 
 def _smoke_fake_render_cfg(param_spec_name: str) -> RenderConfig:
@@ -803,12 +808,17 @@ def _build_surge_smoke_datasets(
     return smoke_dataset_dir
 
 
-def _build_surge_smoke_lance_datasets(tmp_path: Path, param_spec_name: str) -> Path:
+def _build_surge_smoke_lance_datasets(
+    tmp_path: Path,
+    param_spec_name: str,
+    render_train_lance: Callable[[Path, str], None],
+) -> Path:
     """Render the N-sample Surge smoke dataset natively as single-file Lance shards.
 
-    The Lance counterpart to :func:`_build_surge_smoke_datasets`: renders
-    ``train.lance`` through the production :func:`make_lance_dataset` writer, folds
-    its mel rows into ``stats.npz`` via :func:`stream_stats_lance`, and clones the
+    The Lance counterpart to :func:`_build_surge_smoke_datasets`: ``render_train_lance``
+    is the only difference between the real-VST and fake fixtures. It renders
+    ``train.lance`` through the production :func:`make_lance_dataset` writer, then this
+    folds the mel rows into ``stats.npz`` via :func:`stream_stats_lance` and clones the
     split into ``val``/``test``. No HDF5 file is produced — every shard carries the
     exact on-disk format the pipeline's Lance finalize emits.
 
@@ -816,6 +826,7 @@ def _build_surge_smoke_lance_datasets(tmp_path: Path, param_spec_name: str) -> P
         ``tmp_path / "data" / "smoke-lance"``.
     :param param_spec_name: Key into :data:`synth_setter.data.vst.param_specs` and
         :data:`synth_setter.data.vst.preset_paths` selecting spec and preset.
+    :param render_train_lance: Renders ``train.lance`` given ``(train_lance, param_spec_name)``.
 
     :return: Path to the directory holding ``{train,val,test}.lance`` and ``stats.npz``.
     """
@@ -825,7 +836,7 @@ def _build_surge_smoke_lance_datasets(tmp_path: Path, param_spec_name: str) -> P
     smoke_dataset_dir.mkdir(parents=True, exist_ok=True)
     train_lance = smoke_dataset_dir / "train.lance"
 
-    _render_smoke_train_lance_fake(train_lance, param_spec_name)
+    render_train_lance(train_lance, param_spec_name)
 
     # Sibling stats.npz folded straight from the Lance mel rows; mask degenerate
     # bins as the h5 path's --mask-degenerate-bins flag does for fake-plugin data.
@@ -850,8 +861,28 @@ def surge_xt_smoke_datasets(tmp_path: Path, param_spec_name: str) -> Path:
     :return: A Path object pointing at the directory containing the N-sample Surge XT smoke-test
         dataset.
     """
-    return _build_surge_smoke_datasets(
-        tmp_path, param_spec_name, _render_smoke_train_h5_subprocess
+    return _build_surge_smoke_datasets(tmp_path, param_spec_name, _render_smoke_train_subprocess)
+
+
+@pytest.fixture(scope="function")
+def surge_xt_smoke_lance_datasets(tmp_path: Path, param_spec_name: str) -> Path:
+    """Generate the N-sample Surge XT smoke dataset as native Lance shards via the real VST.
+
+    The Lance counterpart to :func:`surge_xt_smoke_datasets`: ``generate_vst_dataset``
+    dispatches the ``.lance`` suffix to :func:`make_lance_dataset`, so the real Surge XT
+    subprocess writes ``train.lance`` directly. Backs the real-VST half of the h5<->Lance
+    train/eval parity matrix.
+
+    :param tmp_path: Per-test temporary directory; the dataset is written under
+        ``tmp_path / "data" / "smoke-lance"``.
+    :param param_spec_name: Param spec name (key into :data:`synth_setter.data.vst.param_specs`
+        and :data:`synth_setter.data.vst.preset_paths`) — selects the matching ``--param_spec_name``
+        and ``--preset_path`` for ``generate_vst_dataset``.
+
+    :return: Path to the directory holding ``{train,val,test}.lance`` and ``stats.npz``.
+    """
+    return _build_surge_smoke_lance_datasets(
+        tmp_path, param_spec_name, _render_smoke_train_subprocess
     )
 
 
@@ -899,7 +930,9 @@ def fake_surge_smoke_lance_datasets(
 
     :return: Path to the directory holding ``{train,val,test}.lance`` and ``stats.npz``.
     """
-    return _build_surge_smoke_lance_datasets(tmp_path, param_spec_name)
+    return _build_surge_smoke_lance_datasets(
+        tmp_path, param_spec_name, _render_smoke_train_lance_fake
+    )
 
 
 @pytest.fixture(scope="function")
@@ -926,43 +959,136 @@ def cfg_surge_xt(
     GlobalHydra.instance().clear()
 
 
+# One dataset-format arm of the Surge XT smoke train/eval parity matrix. Private NamedTuple
+# (no public docstring) matching the sibling ``_FakeOracleDataset`` in test_eval.py.
+class _SurgeSmokeVariant(NamedTuple):
+    dataset_fixture: str  # conftest fixture yielding the dataset root dir
+    datamodule_group: str  # Hydra ``datamodule=`` group: "surge" (h5) | "surge_lance"
+    split_ext: str  # split file suffix: ".h5" | ".lance"
+    plugin_path: str  # render plugin for eval postprocessing: real PLUGIN_PATH | fake.vst3
+
+
+# Dataset-format arms of the h5<->Lance smoke parity matrix, shared by the train and eval
+# entrypoint tests as ``surge_smoke_variant`` parametrize values. The real-VST arms render
+# through the Surge XT subprocess (slow); the fake arms render in-process via the fake
+# plugin (CPU inner loop). Both feed the same test bodies so a Lance-datamodule regression
+# cannot hide behind h5-only coverage.
+REAL_VST_VARIANTS = [
+    pytest.param(
+        _SurgeSmokeVariant("surge_xt_smoke_datasets", "surge", ".h5", PLUGIN_PATH), id="h5"
+    ),
+    pytest.param(
+        _SurgeSmokeVariant("surge_xt_smoke_lance_datasets", "surge_lance", ".lance", PLUGIN_PATH),
+        id="lance",
+    ),
+]
+FAKE_VST_VARIANTS = [
+    pytest.param(
+        _SurgeSmokeVariant("fake_surge_smoke_datasets", "surge", ".h5", "plugins/fake.vst3"),
+        id="h5",
+    ),
+    pytest.param(
+        _SurgeSmokeVariant(
+            "fake_surge_smoke_lance_datasets", "surge_lance", ".lance", "plugins/fake.vst3"
+        ),
+        id="lance",
+    ),
+]
+
+
 @pytest.fixture(scope="function")
-def cfg_surge_xt_lance_global(param_spec_name: str, experiment_name: str) -> DictConfig:
-    """Build a one-step Surge training config over the Lance datamodule.
+def surge_smoke_variant(request: pytest.FixtureRequest) -> _SurgeSmokeVariant:
+    """Indirect-parametrized dataset-format arm for the Surge smoke train/eval cfgs.
 
-    :param param_spec_name: Param spec name for model width and callbacks.
-    :param experiment_name: Hydra ``experiment=...`` override.
-    :return: Resolved CPU ``datamodule=surge_lance`` smoke config.
+    :param request: Carries the the :class:`_SurgeSmokeVariant` arm under ``request.param``.
+    :return: The dataset-format arm under test.
     """
-    return _build_surge_xt_smoke_cfg(
-        accelerator="cpu",
-        param_spec_name=param_spec_name,
-        experiment=experiment_name,
-        datamodule_group="surge_lance",
-    )
+    return request.param
 
 
-@pytest.fixture(scope="function")
-def cfg_surge_xt_lance(
-    cfg_surge_xt_lance_global: DictConfig,
-    tmp_path: Path,
-    fake_surge_smoke_lance_datasets: Path,
-) -> Iterator[DictConfig]:
-    """Per-test Lance wrapper matching :func:`cfg_surge_xt`'s train config shape.
+def _apply_smoke_train_paths(
+    cfg: DictConfig, dataset_root: Path, variant: _SurgeSmokeVariant, tmp_path: Path
+) -> None:
+    """Pin a smoke train cfg's output dirs and dataset/predict paths to a variant.
 
-    :param cfg_surge_xt_lance_global: CPU training config composed with
-        ``datamodule=surge_lance``.
-    :param tmp_path: The temporary logging path.
-    :param fake_surge_smoke_lance_datasets: Native Lance smoke splits.
-    :yields DictConfig: Config pointing at ``{train,val/test}.lance`` splits.
+    :param cfg: Config composed by :func:`_build_surge_xt_smoke_cfg`.
+    :param dataset_root: Directory holding the variant's ``{train,val,test}`` splits.
+    :param variant: Dataset-format arm selecting the predict-split suffix.
+    :param tmp_path: Shared output/log directory (and checkpoint parent for eval).
     """
-    cfg = cfg_surge_xt_lance_global.copy()
-
     with open_dict(cfg):
         cfg.paths.output_dir = str(tmp_path)
         cfg.paths.log_dir = str(tmp_path)
-        cfg.datamodule.dataset_root = str(fake_surge_smoke_lance_datasets)
-        cfg.datamodule.predict_file = str(fake_surge_smoke_lance_datasets / "test.lance")
+        cfg.datamodule.dataset_root = str(dataset_root)
+        cfg.datamodule.predict_file = str(dataset_root / f"test{variant.split_ext}")
+
+
+@pytest.fixture(scope="function")
+def cfg_surge_real_train(
+    surge_smoke_variant: _SurgeSmokeVariant,
+    request: pytest.FixtureRequest,
+    accelerator: str,
+    param_spec_name: str,
+    experiment_name: str,
+    tmp_path: Path,
+) -> Iterator[DictConfig]:
+    """Real-VST Surge smoke train cfg for the requested dataset-format arm.
+
+    Composes over the ``accelerator`` fixture so the h5 and Lance arms each inherit the
+    cpu/mps/gpu matrix. The dataset fixture named by the variant renders through the real
+    Surge XT subprocess.
+
+    :param surge_smoke_variant: Dataset-format arm (h5 or Lance) under test.
+    :param request: Resolves the variant's dataset fixture via ``getfixturevalue``.
+    :param accelerator: Parametrized accelerator driving ``trainer.accelerator``.
+    :param param_spec_name: Param spec the cfg is wired for.
+    :param experiment_name: Hydra ``experiment=...`` override.
+    :param tmp_path: The temporary logging path.
+    :yields DictConfig: One-step train cfg pinned to the variant's splits.
+    """
+    dataset_root = request.getfixturevalue(surge_smoke_variant.dataset_fixture)
+    cfg = _build_surge_xt_smoke_cfg(
+        accelerator=accelerator,
+        param_spec_name=param_spec_name,
+        experiment=experiment_name,
+        datamodule_group=surge_smoke_variant.datamodule_group,
+    )
+    _apply_smoke_train_paths(cfg, dataset_root, surge_smoke_variant, tmp_path)
+
+    yield cfg
+
+    GlobalHydra.instance().clear()
+
+
+@pytest.fixture(scope="function")
+def cfg_surge_fake_train(
+    surge_smoke_variant: _SurgeSmokeVariant,
+    request: pytest.FixtureRequest,
+    param_spec_name: str,
+    experiment_name: str,
+    tmp_path: Path,
+) -> Iterator[DictConfig]:
+    """Fake-plugin CPU Surge smoke train cfg for the requested dataset-format arm.
+
+    The CPU-fast counterpart to :func:`cfg_surge_real_train`: pins ``accelerator="cpu"``
+    and resolves a fake-plugin dataset fixture, so the h5 and Lance arms run in the
+    inner test loop with no real VST host.
+
+    :param surge_smoke_variant: Dataset-format arm (h5 or Lance) under test.
+    :param request: Resolves the variant's dataset fixture via ``getfixturevalue``.
+    :param param_spec_name: Param spec the cfg is wired for.
+    :param experiment_name: Hydra ``experiment=...`` override.
+    :param tmp_path: The temporary logging path.
+    :yields DictConfig: One-step CPU train cfg pinned to the variant's splits.
+    """
+    dataset_root = request.getfixturevalue(surge_smoke_variant.dataset_fixture)
+    cfg = _build_surge_xt_smoke_cfg(
+        accelerator="cpu",
+        param_spec_name=param_spec_name,
+        experiment=experiment_name,
+        datamodule_group=surge_smoke_variant.datamodule_group,
+    )
+    _apply_smoke_train_paths(cfg, dataset_root, surge_smoke_variant, tmp_path)
 
     yield cfg
 
@@ -1047,28 +1173,85 @@ def _configure_surge_xt_eval_cfg(
 
 
 @pytest.fixture(scope="function")
-def cfg_surge_xt_lance_eval(
-    cfg_surge_xt_lance_global: DictConfig,
-    tmp_path: Path,
-    fake_surge_smoke_lance_datasets: Path,
+def cfg_surge_real_eval(
+    surge_smoke_variant: _SurgeSmokeVariant,
+    request: pytest.FixtureRequest,
+    accelerator: str,
     param_spec_name: str,
+    experiment_name: str,
+    tmp_path: Path,
 ) -> Iterator[DictConfig]:
-    """Eval config for the Lance train->predict checkpoint smoke test.
+    """Real-VST predict-mode eval cfg matching :func:`cfg_surge_real_train`.
 
-    :param cfg_surge_xt_lance_global: Matching ``datamodule=surge_lance`` train cfg.
-    :param tmp_path: The temporary logging path shared with training.
-    :param fake_surge_smoke_lance_datasets: Native Lance smoke splits.
+    Shares ``tmp_path`` (and so the checkpoint), ``accelerator``, ``experiment_name`` and
+    ``surge_smoke_variant`` with the train fixture, so the train->eval roundtrip reads the
+    checkpoint training writes for the same dataset-format arm.
+
+    :param surge_smoke_variant: Dataset-format arm (h5 or Lance) under test.
+    :param request: Resolves the variant's dataset fixture via ``getfixturevalue``.
+    :param accelerator: Parametrized accelerator driving ``trainer.accelerator``.
     :param param_spec_name: Param spec used by the rendered fixture.
-    :yields DictConfig: Config that predicts from ``last.ckpt`` over Lance splits.
+    :param experiment_name: Hydra ``experiment=...`` override.
+    :param tmp_path: The temporary logging path shared with training.
+    :yields DictConfig: Config that predicts from ``last.ckpt`` over the variant's splits.
     """
-    cfg = cfg_surge_xt_lance_global.copy()
+    dataset_root = request.getfixturevalue(surge_smoke_variant.dataset_fixture)
+    cfg = _build_surge_xt_smoke_cfg(
+        accelerator=accelerator,
+        param_spec_name=param_spec_name,
+        experiment=experiment_name,
+        datamodule_group=surge_smoke_variant.datamodule_group,
+    )
     _configure_surge_xt_eval_cfg(
         cfg,
         tmp_path=tmp_path,
-        dataset_root=fake_surge_smoke_lance_datasets,
-        predict_file=fake_surge_smoke_lance_datasets / "test.lance",
+        dataset_root=dataset_root,
+        predict_file=dataset_root / f"test{surge_smoke_variant.split_ext}",
         param_spec_name=param_spec_name,
-        plugin_path="plugins/fake.vst3",
+        plugin_path=surge_smoke_variant.plugin_path,
+        rerender_target=True,
+    )
+
+    yield cfg
+
+    GlobalHydra.instance().clear()
+
+
+@pytest.fixture(scope="function")
+def cfg_surge_fake_eval(
+    surge_smoke_variant: _SurgeSmokeVariant,
+    request: pytest.FixtureRequest,
+    param_spec_name: str,
+    experiment_name: str,
+    tmp_path: Path,
+) -> Iterator[DictConfig]:
+    """Fake-plugin CPU predict-mode eval cfg matching :func:`cfg_surge_fake_train`.
+
+    The CPU-fast counterpart to :func:`cfg_surge_real_eval`: the postprocessing subprocess
+    is stubbed by the test body, so this only needs to point ``trainer.predict`` at the
+    variant's fake-plugin splits.
+
+    :param surge_smoke_variant: Dataset-format arm (h5 or Lance) under test.
+    :param request: Resolves the variant's dataset fixture via ``getfixturevalue``.
+    :param param_spec_name: Param spec used by the rendered fixture.
+    :param experiment_name: Hydra ``experiment=...`` override.
+    :param tmp_path: The temporary logging path shared with training.
+    :yields DictConfig: Config that predicts from ``last.ckpt`` over the variant's splits.
+    """
+    dataset_root = request.getfixturevalue(surge_smoke_variant.dataset_fixture)
+    cfg = _build_surge_xt_smoke_cfg(
+        accelerator="cpu",
+        param_spec_name=param_spec_name,
+        experiment=experiment_name,
+        datamodule_group=surge_smoke_variant.datamodule_group,
+    )
+    _configure_surge_xt_eval_cfg(
+        cfg,
+        tmp_path=tmp_path,
+        dataset_root=dataset_root,
+        predict_file=dataset_root / f"test{surge_smoke_variant.split_ext}",
+        param_spec_name=param_spec_name,
+        plugin_path=surge_smoke_variant.plugin_path,
         rerender_target=True,
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import sys
 from collections.abc import Callable, Iterator
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import h5py
 import hdf5plugin  # noqa: F401   side-effect import: registers HDF5_PLUGIN_PATH so h5py can load Blosc2 filters in fixtures
@@ -514,7 +514,7 @@ def _build_surge_xt_smoke_cfg(
     accelerator: str,
     param_spec_name: str,
     experiment: str,
-    datamodule: str | None = None,
+    datamodule_group: Literal["surge", "surge_lance"] = "surge",
 ) -> DictConfig:
     """Construct the Surge XT smoke-test config without the accelerator availability gate.
 
@@ -534,8 +534,7 @@ def _build_surge_xt_smoke_cfg(
         ``model.net.d_out`` and ``callbacks.log_per_param_mse.param_spec``.
     :param experiment: Hydra ``experiment=...`` override (e.g. ``"surge/fake_oracle"``,
         ``"surge/ffn_full"``); selects which model the smoke cfg wires up.
-    :param datamodule: Optional Hydra datamodule group override; ``None`` keeps
-        the experiment's HDF5 ``surge`` datamodule.
+    :param datamodule_group: Hydra datamodule group override.
 
     :return: Resolved DictConfig with the smoke-test bake-ins applied.
     """
@@ -543,8 +542,11 @@ def _build_surge_xt_smoke_cfg(
         cfg = compose(
             config_name="train.yaml",
             return_hydra_config=True,
-            overrides=[f"experiment={experiment}", "callbacks=[default_surge,eval_surge]"]
-            + ([f"datamodule={datamodule}"] if datamodule else []),
+            overrides=[
+                f"experiment={experiment}",
+                f"datamodule={datamodule_group}",
+                "callbacks=[default_surge,eval_surge]",
+            ],
         )
         TRAINING_STEPS = 1
         with open_dict(cfg):
@@ -936,7 +938,7 @@ def cfg_surge_xt_lance_global(param_spec_name: str, experiment_name: str) -> Dic
         accelerator="cpu",
         param_spec_name=param_spec_name,
         experiment=experiment_name,
-        datamodule="surge_lance",
+        datamodule_group="surge_lance",
     )
 
 
@@ -988,29 +990,60 @@ def cfg_surge_xt_eval(
         dataset.
     """
     cfg = cfg_surge_xt_global.copy()
+    _configure_surge_xt_eval_cfg(
+        cfg,
+        tmp_path=tmp_path,
+        dataset_root=surge_xt_smoke_datasets,
+        predict_file=surge_xt_smoke_datasets / "test.h5",
+        param_spec_name=param_spec_name,
+        plugin_path=PLUGIN_PATH,
+        rerender_target=True,
+    )
+
+    yield cfg
+
+    GlobalHydra.instance().clear()
+
+
+def _configure_surge_xt_eval_cfg(
+    cfg: DictConfig,
+    *,
+    tmp_path: Path,
+    dataset_root: Path,
+    predict_file: Path,
+    param_spec_name: str,
+    plugin_path: str,
+    rerender_target: bool,
+) -> None:
+    """Apply shared train-to-predict eval overrides to a Surge smoke config.
+
+    :param cfg: Config copied from the matching train fixture.
+    :param tmp_path: Shared output/log directory and checkpoint parent.
+    :param dataset_root: Directory holding the eval split and stats.
+    :param predict_file: Split consumed by ``trainer.predict``.
+    :param param_spec_name: Param spec used by the rendered fixture.
+    :param plugin_path: Plugin path forwarded to render postprocessing.
+    :param rerender_target: Whether postprocessing should render target audio.
+    """
     with open_dict(cfg):
         cfg.paths.output_dir = str(tmp_path)
         cfg.paths.log_dir = str(tmp_path)
         cfg.datamodule.batch_size = 1
-        cfg.datamodule.dataset_root = str(surge_xt_smoke_datasets)
-        cfg.datamodule.predict_file = str(surge_xt_smoke_datasets / "test.h5")
+        cfg.datamodule.dataset_root = str(dataset_root)
+        cfg.datamodule.predict_file = str(predict_file)
         cfg.ckpt_path = str(tmp_path / "checkpoints" / "last.ckpt")
         cfg.mode = "predict"
         cfg.evaluation = {
             "render_vst": True,
             "compute_metrics": True,
-            "rerender_target": True,
+            "rerender_target": rerender_target,
             "num_workers": 1,
         }
         cfg.render = {
             "param_spec_name": param_spec_name,
             "preset_path": preset_paths[param_spec_name],
-            "plugin_path": PLUGIN_PATH,
+            "plugin_path": plugin_path,
         }
-
-    yield cfg
-
-    GlobalHydra.instance().clear()
 
 
 @pytest.fixture(scope="function")
@@ -1029,25 +1062,15 @@ def cfg_surge_xt_lance_eval(
     :yields DictConfig: Config that predicts from ``last.ckpt`` over Lance splits.
     """
     cfg = cfg_surge_xt_lance_global.copy()
-    with open_dict(cfg):
-        cfg.paths.output_dir = str(tmp_path)
-        cfg.paths.log_dir = str(tmp_path)
-        cfg.datamodule.batch_size = 1
-        cfg.datamodule.dataset_root = str(fake_surge_smoke_lance_datasets)
-        cfg.datamodule.predict_file = str(fake_surge_smoke_lance_datasets / "test.lance")
-        cfg.ckpt_path = str(tmp_path / "checkpoints" / "last.ckpt")
-        cfg.mode = "predict"
-        cfg.evaluation = {
-            "render_vst": True,
-            "compute_metrics": True,
-            "rerender_target": False,
-            "num_workers": 1,
-        }
-        cfg.render = {
-            "param_spec_name": param_spec_name,
-            "preset_path": preset_paths[param_spec_name],
-            "plugin_path": "plugins/fake.vst3",
-        }
+    _configure_surge_xt_eval_cfg(
+        cfg,
+        tmp_path=tmp_path,
+        dataset_root=fake_surge_smoke_lance_datasets,
+        predict_file=fake_surge_smoke_lance_datasets / "test.lance",
+        param_spec_name=param_spec_name,
+        plugin_path="plugins/fake.vst3",
+        rerender_target=True,
+    )
 
     yield cfg
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -511,7 +511,10 @@ def experiment_name(request: pytest.FixtureRequest) -> str:
 
 
 def _build_surge_xt_smoke_cfg(
-    accelerator: str, param_spec_name: str, experiment: str
+    accelerator: str,
+    param_spec_name: str,
+    experiment: str,
+    datamodule: str | None = None,
 ) -> DictConfig:
     """Construct the Surge XT smoke-test config without the accelerator availability gate.
 
@@ -531,6 +534,8 @@ def _build_surge_xt_smoke_cfg(
         ``model.net.d_out`` and ``callbacks.log_per_param_mse.param_spec``.
     :param experiment: Hydra ``experiment=...`` override (e.g. ``"surge/fake_oracle"``,
         ``"surge/ffn_full"``); selects which model the smoke cfg wires up.
+    :param datamodule: Optional Hydra datamodule group override; ``None`` keeps
+        the experiment's HDF5 ``surge`` datamodule.
 
     :return: Resolved DictConfig with the smoke-test bake-ins applied.
     """
@@ -538,10 +543,8 @@ def _build_surge_xt_smoke_cfg(
         cfg = compose(
             config_name="train.yaml",
             return_hydra_config=True,
-            overrides=[
-                f"experiment={experiment}",
-                "callbacks=[default_surge,eval_surge]",
-            ],
+            overrides=[f"experiment={experiment}", "callbacks=[default_surge,eval_surge]"]
+            + ([f"datamodule={datamodule}"] if datamodule else []),
         )
         TRAINING_STEPS = 1
         with open_dict(cfg):
@@ -922,6 +925,49 @@ def cfg_surge_xt(
 
 
 @pytest.fixture(scope="function")
+def cfg_surge_xt_lance_global(param_spec_name: str, experiment_name: str) -> DictConfig:
+    """Build a one-step Surge training config over the Lance datamodule.
+
+    :param param_spec_name: Param spec name for model width and callbacks.
+    :param experiment_name: Hydra ``experiment=...`` override.
+    :return: Resolved CPU ``datamodule=surge_lance`` smoke config.
+    """
+    return _build_surge_xt_smoke_cfg(
+        accelerator="cpu",
+        param_spec_name=param_spec_name,
+        experiment=experiment_name,
+        datamodule="surge_lance",
+    )
+
+
+@pytest.fixture(scope="function")
+def cfg_surge_xt_lance(
+    cfg_surge_xt_lance_global: DictConfig,
+    tmp_path: Path,
+    fake_surge_smoke_lance_datasets: Path,
+) -> Iterator[DictConfig]:
+    """Per-test Lance wrapper matching :func:`cfg_surge_xt`'s train config shape.
+
+    :param cfg_surge_xt_lance_global: CPU training config composed with
+        ``datamodule=surge_lance``.
+    :param tmp_path: The temporary logging path.
+    :param fake_surge_smoke_lance_datasets: Native Lance smoke splits.
+    :yields DictConfig: Config pointing at ``{train,val/test}.lance`` splits.
+    """
+    cfg = cfg_surge_xt_lance_global.copy()
+
+    with open_dict(cfg):
+        cfg.paths.output_dir = str(tmp_path)
+        cfg.paths.log_dir = str(tmp_path)
+        cfg.datamodule.dataset_root = str(fake_surge_smoke_lance_datasets)
+        cfg.datamodule.predict_file = str(fake_surge_smoke_lance_datasets / "test.lance")
+
+    yield cfg
+
+    GlobalHydra.instance().clear()
+
+
+@pytest.fixture(scope="function")
 def cfg_surge_xt_eval(
     cfg_surge_xt_global: DictConfig,
     tmp_path: Path,
@@ -960,6 +1006,47 @@ def cfg_surge_xt_eval(
             "param_spec_name": param_spec_name,
             "preset_path": preset_paths[param_spec_name],
             "plugin_path": PLUGIN_PATH,
+        }
+
+    yield cfg
+
+    GlobalHydra.instance().clear()
+
+
+@pytest.fixture(scope="function")
+def cfg_surge_xt_lance_eval(
+    cfg_surge_xt_lance_global: DictConfig,
+    tmp_path: Path,
+    fake_surge_smoke_lance_datasets: Path,
+    param_spec_name: str,
+) -> Iterator[DictConfig]:
+    """Eval config for the Lance train->predict checkpoint smoke test.
+
+    :param cfg_surge_xt_lance_global: Matching ``datamodule=surge_lance`` train cfg.
+    :param tmp_path: The temporary logging path shared with training.
+    :param fake_surge_smoke_lance_datasets: Native Lance smoke splits.
+    :param param_spec_name: Param spec used by the rendered fixture.
+    :yields DictConfig: Config that predicts from ``last.ckpt`` over Lance splits.
+    """
+    cfg = cfg_surge_xt_lance_global.copy()
+    with open_dict(cfg):
+        cfg.paths.output_dir = str(tmp_path)
+        cfg.paths.log_dir = str(tmp_path)
+        cfg.datamodule.batch_size = 1
+        cfg.datamodule.dataset_root = str(fake_surge_smoke_lance_datasets)
+        cfg.datamodule.predict_file = str(fake_surge_smoke_lance_datasets / "test.lance")
+        cfg.ckpt_path = str(tmp_path / "checkpoints" / "last.ckpt")
+        cfg.mode = "predict"
+        cfg.evaluation = {
+            "render_vst": True,
+            "compute_metrics": True,
+            "rerender_target": False,
+            "num_workers": 1,
+        }
+        cfg.render = {
+            "param_spec_name": param_spec_name,
+            "preset_path": preset_paths[param_spec_name],
+            "plugin_path": "plugins/fake.vst3",
         }
 
     yield cfg

--- a/tests/helpers/eval_fakes.py
+++ b/tests/helpers/eval_fakes.py
@@ -1,0 +1,102 @@
+"""Shared fakes for eval-entrypoint postprocessing tests."""
+
+from collections.abc import Callable
+from pathlib import Path
+
+PREDICT_VST_AUDIO_FRAGMENT = "predict_vst_audio"
+COMPUTE_AUDIO_METRICS_FRAGMENT = "compute_audio_metrics"
+
+FAKE_AGGREGATED_METRICS_CSV = (
+    ",mean,std\nmss,0.5,0.1\nwmfcc,0.3,0.05\nsot,0.2,0.02\nrms,0.9,0.01\n"
+)
+
+
+def fake_metrics_csv(num_samples: int = 2) -> str:
+    """Build a per-sample metrics CSV with ``num_samples`` rows.
+
+    :param num_samples: Number of sample rows to emit.
+    :returns: CSV body matching ``compute_audio_metrics``'s per-sample output shape.
+    """
+    rows = [f"{idx},0.1,0.2,0.3,0.4" for idx in range(num_samples)]
+    return ",mss,wmfcc,sot,rms\n" + "\n".join(rows) + "\n"
+
+
+FAKE_METRICS_CSV = fake_metrics_csv()
+
+
+def fake_postprocessing_subprocess(
+    *,
+    audio_metrics_csv: str = FAKE_AGGREGATED_METRICS_CSV,
+    per_sample_metrics_csv: str | None = None,
+    shuffled_metrics_csv: str | None = None,
+    shuffle_permutation_csv: str | None = None,
+    render_sample_count: int = 0,
+) -> Callable[[list[str]], None]:
+    """Build a ``subprocess.run`` fake that materializes eval postprocessing outputs.
+
+    :param audio_metrics_csv: Body written to ``aggregated_metrics.csv``.
+    :param per_sample_metrics_csv: Optional body written to ``metrics.csv``.
+    :param shuffled_metrics_csv: Optional body written to ``aggregated_metrics_shuffled.csv``.
+    :param shuffle_permutation_csv: Optional body written to ``shuffle_permutation.csv``.
+    :param render_sample_count: Number of fake ``sample_N`` render directories to create.
+    :returns: Callable compatible with ``subprocess.run``.
+    """
+
+    def _fake_run(args: list[str], **_kwargs: object) -> None:
+        is_render = any(PREDICT_VST_AUDIO_FRAGMENT in arg for arg in args)
+        is_metrics = any(COMPUTE_AUDIO_METRICS_FRAGMENT in arg for arg in args)
+        if not (is_render or is_metrics):
+            return
+
+        output_dir = Path(args[args.index("-m") + 3])
+        output_dir.mkdir(parents=True, exist_ok=True)
+        if is_render:
+            _write_render_outputs(output_dir, render_sample_count)
+        if is_metrics:
+            _write_metrics_outputs(
+                output_dir,
+                audio_metrics_csv=audio_metrics_csv,
+                per_sample_metrics_csv=per_sample_metrics_csv,
+                shuffled_metrics_csv=shuffled_metrics_csv,
+                shuffle_permutation_csv=shuffle_permutation_csv,
+            )
+
+    return _fake_run
+
+
+def _write_render_outputs(output_dir: Path, sample_count: int) -> None:
+    """Write the fake render tree consumed by metrics postprocessing tests.
+
+    :param output_dir: Render output directory.
+    :param sample_count: Number of sample directories to create.
+    """
+    for sample_idx in range(sample_count):
+        sample_dir = output_dir / f"sample_{sample_idx}"
+        sample_dir.mkdir()
+        for name in ("target.wav", "pred.wav", "spec.png", "params.csv"):
+            (sample_dir / name).write_text("fake")
+
+
+def _write_metrics_outputs(
+    output_dir: Path,
+    *,
+    audio_metrics_csv: str,
+    per_sample_metrics_csv: str | None,
+    shuffled_metrics_csv: str | None,
+    shuffle_permutation_csv: str | None,
+) -> None:
+    """Write the fake metrics files requested by a test.
+
+    :param output_dir: Metrics output directory.
+    :param audio_metrics_csv: Body written to ``aggregated_metrics.csv``.
+    :param per_sample_metrics_csv: Optional body written to ``metrics.csv``.
+    :param shuffled_metrics_csv: Optional body written to ``aggregated_metrics_shuffled.csv``.
+    :param shuffle_permutation_csv: Optional body written to ``shuffle_permutation.csv``.
+    """
+    (output_dir / "aggregated_metrics.csv").write_text(audio_metrics_csv)
+    if per_sample_metrics_csv is not None:
+        (output_dir / "metrics.csv").write_text(per_sample_metrics_csv)
+    if shuffled_metrics_csv is not None:
+        (output_dir / "aggregated_metrics_shuffled.csv").write_text(shuffled_metrics_csv)
+    if shuffle_permutation_csv is not None:
+        (output_dir / "shuffle_permutation.csv").write_text(shuffle_permutation_csv)

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -37,6 +37,10 @@ from tests.helpers.wandb_artifacts import publish_checkpoint_artifact
 # ``tests/_meta/test_entrypoint_test_modules.py``).
 _PREDICT_VST_AUDIO_FRAGMENT = "predict_vst_audio"
 _COMPUTE_AUDIO_METRICS_FRAGMENT = "compute_audio_metrics"
+_FAKE_ORACLE_DATASETS = [
+    pytest.param("fake_surge_smoke_datasets", None, id="h5"),
+    pytest.param("fake_surge_smoke_lance_datasets", "surge_lance", id="lance"),
+]
 
 # Aggregated audio-metrics CSV the fake metrics subprocess writes; one row per
 # metric, columns mean/std — the shape ``_load_audio_metrics`` flattens.
@@ -266,6 +270,27 @@ def _compose_fake_oracle_eval_cfg(
     return cfg
 
 
+def _compose_parametrized_fake_oracle_eval_cfg(
+    tmp_path: Path,
+    request: pytest.FixtureRequest,
+    dataset_fixture: str,
+    datamodule: str | None,
+    *,
+    mode: str,
+) -> DictConfig:
+    """Compose the fake-oracle eval cfg for the parametrized H5/Lance dataset.
+
+    :param tmp_path: Pinned as ``paths.output_dir`` / ``paths.log_dir``.
+    :param request: Fetches the parametrized dataset fixture.
+    :param dataset_fixture: Fixture name for the dataset root under test.
+    :param datamodule: Optional datamodule group override.
+    :param mode: Eval mode to compose.
+    :returns: Composed eval ``DictConfig`` ready for ``evaluate``.
+    """
+    dataset_root = request.getfixturevalue(dataset_fixture)
+    return _compose_fake_oracle_eval_cfg(tmp_path, dataset_root, mode=mode, datamodule=datamodule)
+
+
 def _fake_postprocessing_subprocess(
     audio_metrics_csv: str,
 ) -> Callable[[list[str]], None]:
@@ -297,9 +322,12 @@ def _fake_postprocessing_subprocess(
 
 
 @pytest.mark.fake_vst
+@pytest.mark.parametrize(("dataset_fixture", "datamodule"), _FAKE_ORACLE_DATASETS)
 def test_evaluate_predict_mode_merges_audio_metrics_into_metric_dict(
     tmp_path: Path,
-    fake_surge_smoke_datasets: Path,
+    request: pytest.FixtureRequest,
+    dataset_fixture: str,
+    datamodule: str | None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``mode=predict`` runs the oracle's predict + postprocessing and merges audio metrics.
@@ -313,11 +341,15 @@ def test_evaluate_predict_mode_merges_audio_metrics_into_metric_dict(
 
     :param tmp_path: Hydra ``output_dir``; ``predictions/`` / ``audio/`` / ``metrics/``
         are derived beneath it.
-    :param fake_surge_smoke_datasets: CPU-fast surge_4 dataset (no real VST).
+    :param request: Fetches the parametrized dataset fixture.
+    :param dataset_fixture: Fixture name for the dataset root under test.
+    :param datamodule: Optional datamodule group override.
     :param monkeypatch: Stubs the render/metrics subprocesses and the headless
         wrapper extraction so no real VST host or Python subprocess launches.
     """
-    cfg = _compose_fake_oracle_eval_cfg(tmp_path, fake_surge_smoke_datasets, mode="predict")
+    cfg = _compose_parametrized_fake_oracle_eval_cfg(
+        tmp_path, request, dataset_fixture, datamodule, mode="predict"
+    )
     monkeypatch.setattr(
         "synth_setter.cli.eval.subprocess.run",
         _fake_postprocessing_subprocess(_FAKE_AGGREGATED_METRICS_CSV),
@@ -343,9 +375,12 @@ def test_evaluate_predict_mode_merges_audio_metrics_into_metric_dict(
 
 
 @pytest.mark.fake_vst
+@pytest.mark.parametrize(("dataset_fixture", "datamodule"), _FAKE_ORACLE_DATASETS)
 def test_evaluate_predict_mode_logs_per_sample_metrics_table_to_wandb(
     tmp_path: Path,
-    fake_surge_smoke_datasets: Path,
+    request: pytest.FixtureRequest,
+    dataset_fixture: str,
+    datamodule: str | None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``mode=predict`` with an active wandb run uploads ``metrics.csv`` as a wandb.Table.
@@ -356,7 +391,9 @@ def test_evaluate_predict_mode_logs_per_sample_metrics_table_to_wandb(
     verifies the per-sample Table arrives under ``audio/per_sample_metrics``.
 
     :param tmp_path: Hydra ``output_dir``; the fake subprocess writes CSVs beneath it.
-    :param fake_surge_smoke_datasets: CPU-fast surge_4 dataset (no real VST).
+    :param request: Fetches the parametrized dataset fixture.
+    :param dataset_fixture: Fixture name for the dataset root under test.
+    :param datamodule: Optional datamodule group override.
     :param monkeypatch: Stubs subprocesses, headless wrapper, and ``wandb.run``.
     """
     logged: list[dict[str, object]] = []
@@ -395,7 +432,9 @@ def test_evaluate_predict_mode_logs_per_sample_metrics_table_to_wandb(
             (out_dir / "aggregated_metrics.csv").write_text(_FAKE_AGGREGATED_METRICS_CSV)
             (out_dir / "metrics.csv").write_text(_FAKE_METRICS_CSV)
 
-    cfg = _compose_fake_oracle_eval_cfg(tmp_path, fake_surge_smoke_datasets, mode="predict")
+    cfg = _compose_parametrized_fake_oracle_eval_cfg(
+        tmp_path, request, dataset_fixture, datamodule, mode="predict"
+    )
     monkeypatch.setattr("synth_setter.cli.eval.subprocess.run", _fake_run_with_metrics)
     monkeypatch.setattr("synth_setter.cli.eval.vst_headless_wrapper", lambda: object())
     monkeypatch.setattr(
@@ -419,9 +458,12 @@ def test_evaluate_predict_mode_logs_per_sample_metrics_table_to_wandb(
 
 
 @pytest.mark.fake_vst
+@pytest.mark.parametrize(("dataset_fixture", "datamodule"), _FAKE_ORACLE_DATASETS)
 def test_evaluate_predict_mode_logs_shuffle_permutation_table_to_wandb(
     tmp_path: Path,
-    fake_surge_smoke_datasets: Path,
+    request: pytest.FixtureRequest,
+    dataset_fixture: str,
+    datamodule: str | None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``mode=predict`` uploads the render-order probe permutation as a ``shuffle/permutation`` Table.
@@ -432,7 +474,9 @@ def test_evaluate_predict_mode_logs_shuffle_permutation_table_to_wandb(
     Table arrives under ``shuffle/permutation`` (#1669).
 
     :param tmp_path: Hydra ``output_dir``; the fake subprocess writes CSVs beneath it.
-    :param fake_surge_smoke_datasets: CPU-fast surge_4 dataset (no real VST).
+    :param request: Fetches the parametrized dataset fixture.
+    :param dataset_fixture: Fixture name for the dataset root under test.
+    :param datamodule: Optional datamodule group override.
     :param monkeypatch: Stubs subprocesses, headless wrapper, and ``wandb.run``.
     """
     permutation_csv = "dest_idx,src_idx\n0,1\n1,0\n"
@@ -472,7 +516,9 @@ def test_evaluate_predict_mode_logs_shuffle_permutation_table_to_wandb(
             (out_dir / "aggregated_metrics.csv").write_text(_FAKE_AGGREGATED_METRICS_CSV)
             (out_dir / "shuffle_permutation.csv").write_text(permutation_csv)
 
-    cfg = _compose_fake_oracle_eval_cfg(tmp_path, fake_surge_smoke_datasets, mode="predict")
+    cfg = _compose_parametrized_fake_oracle_eval_cfg(
+        tmp_path, request, dataset_fixture, datamodule, mode="predict"
+    )
     monkeypatch.setattr("synth_setter.cli.eval.subprocess.run", _fake_run_with_permutation)
     monkeypatch.setattr("synth_setter.cli.eval.vst_headless_wrapper", lambda: object())
     monkeypatch.setattr(
@@ -497,9 +543,12 @@ def test_evaluate_predict_mode_logs_shuffle_permutation_table_to_wandb(
 
 
 @pytest.mark.fake_vst
+@pytest.mark.parametrize(("dataset_fixture", "datamodule"), _FAKE_ORACLE_DATASETS)
 def test_evaluate_validate_mode_legacy_val_spelling_runs_oracle(
     tmp_path: Path,
-    fake_surge_smoke_datasets: Path,
+    request: pytest.FixtureRequest,
+    dataset_fixture: str,
+    datamodule: str | None,
 ) -> None:
     """``mode=val`` (legacy spelling) routes to ``trainer.validate`` and logs zero MSE.
 
@@ -509,9 +558,13 @@ def test_evaluate_validate_mode_legacy_val_spelling_runs_oracle(
     verbatim, so ``val/param_mse`` is exactly zero.
 
     :param tmp_path: Pinned as Hydra ``output_dir`` / ``log_dir``.
-    :param fake_surge_smoke_datasets: CPU-fast surge_4 dataset (no real VST).
+    :param request: Fetches the parametrized dataset fixture.
+    :param dataset_fixture: Fixture name for the dataset root under test.
+    :param datamodule: Optional datamodule group override.
     """
-    cfg = _compose_fake_oracle_eval_cfg(tmp_path, fake_surge_smoke_datasets, mode="val")
+    cfg = _compose_parametrized_fake_oracle_eval_cfg(
+        tmp_path, request, dataset_fixture, datamodule, mode="val"
+    )
 
     HydraConfig().set_config(cfg)
     try:
@@ -577,9 +630,12 @@ def test_evaluate_unknown_mode_returns_only_callback_metrics(
 
 
 @pytest.mark.fake_vst
+@pytest.mark.parametrize(("dataset_fixture", "datamodule"), _FAKE_ORACLE_DATASETS)
 def test_evaluate_predict_mode_includes_shuffled_audio_metrics_when_subprocess_writes_shuffled_csv(
     tmp_path: Path,
-    fake_surge_smoke_datasets: Path,
+    request: pytest.FixtureRequest,
+    dataset_fixture: str,
+    datamodule: str | None,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Merges ``shuffled_audio/*`` keys when the metrics subprocess also writes the shuffled CSV.
@@ -592,7 +648,9 @@ def test_evaluate_predict_mode_includes_shuffled_audio_metrics_when_subprocess_w
     is wired through the real ``evaluate()`` entrypoint (#489).
 
     :param tmp_path: Hydra ``output_dir``; output files are derived beneath it.
-    :param fake_surge_smoke_datasets: CPU-fast surge_4 dataset (no real VST).
+    :param request: Fetches the parametrized dataset fixture.
+    :param dataset_fixture: Fixture name for the dataset root under test.
+    :param datamodule: Optional datamodule group override.
     :param monkeypatch: Stubs render/metrics subprocesses; no real VST launches.
     """
     _SHUFFLED_CSV = ",mean,std\nmss,0.8,0.05\nwmfcc,0.4,0.03\nsot,0.3,0.02\nrms,0.7,0.01\n"
@@ -608,7 +666,9 @@ def test_evaluate_predict_mode_includes_shuffled_audio_metrics_when_subprocess_w
             (out_dir / "aggregated_metrics.csv").write_text(_FAKE_AGGREGATED_METRICS_CSV)
             (out_dir / "aggregated_metrics_shuffled.csv").write_text(_SHUFFLED_CSV)
 
-    cfg = _compose_fake_oracle_eval_cfg(tmp_path, fake_surge_smoke_datasets, mode="predict")
+    cfg = _compose_parametrized_fake_oracle_eval_cfg(
+        tmp_path, request, dataset_fixture, datamodule, mode="predict"
+    )
     monkeypatch.setattr("synth_setter.cli.eval.subprocess.run", _fake_run_with_shuffled)
     monkeypatch.setattr("synth_setter.cli.eval.vst_headless_wrapper", lambda: object())
     monkeypatch.setattr(

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -28,6 +28,7 @@ from synth_setter.cli.train import train
 from synth_setter.data.vst import param_specs, preset_paths
 from synth_setter.utils.utils import register_resolvers
 from synth_setter.workspace import operator_workspace
+from tests.conftest import REAL_VST_VARIANTS
 from tests.helpers.eval_fakes import (
     FAKE_METRICS_CSV,
     fake_postprocessing_subprocess,
@@ -106,11 +107,12 @@ def test_evaluate_runs_oracle_with_null_ckpt_path(
 
 @pytest.mark.requires_vst
 @pytest.mark.slow
+@pytest.mark.parametrize("surge_smoke_variant", REAL_VST_VARIANTS, indirect=True)
 def test_evaluate_predict_explicit_shuffle_seed_rejects_nonuniform_params_via_subprocess(
-    cfg_surge_xt: DictConfig,
-    cfg_surge_xt_eval: DictConfig,
+    cfg_surge_real_train: DictConfig,
+    cfg_surge_real_eval: DictConfig,
 ) -> None:
-    """Non-zero ``shuffle_seed`` with non-uniform params causes the metrics subprocess to fail.
+    """Non-zero ``shuffle_seed`` with non-uniform params causes the metrics subprocess to fail, for both dataset formats.
 
     Drives the real train→eval roundtrip end-to-end with ``shuffle_seed=7``,
     exercising the ``evaluate()`` → ``_run_predict_postprocessing`` →
@@ -121,20 +123,20 @@ def test_evaluate_predict_explicit_shuffle_seed_rejects_nonuniform_params_via_su
     ``evaluate()`` boundary — confirming the gate is wired through the real
     entrypoint (#489).
 
-    :param cfg_surge_xt: Surge XT smoke-test training config.
-    :param cfg_surge_xt_eval: Matching predict-mode eval config (render + metrics on),
+    :param cfg_surge_real_train: Surge XT smoke-test training config (h5 or Lance arm).
+    :param cfg_surge_real_eval: Matching predict-mode eval config (render + metrics on),
         sharing ``tmp_path`` so eval reads the checkpoint training writes.
     """
-    HydraConfig().set_config(cfg_surge_xt)
-    train(cfg_surge_xt)
-    assert Path(cfg_surge_xt_eval.ckpt_path).exists()
+    HydraConfig().set_config(cfg_surge_real_train)
+    train(cfg_surge_real_train)
+    assert Path(cfg_surge_real_eval.ckpt_path).exists()
 
-    with open_dict(cfg_surge_xt_eval):
-        cfg_surge_xt_eval.evaluation.shuffle_seed = 7
+    with open_dict(cfg_surge_real_eval):
+        cfg_surge_real_eval.evaluation.shuffle_seed = 7
 
-    HydraConfig().set_config(cfg_surge_xt_eval)
+    HydraConfig().set_config(cfg_surge_real_eval)
     with pytest.raises(subprocess.CalledProcessError):
-        evaluate(cfg_surge_xt_eval)
+        evaluate(cfg_surge_real_eval)
 
 
 @pytest.mark.gpu

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -11,9 +11,9 @@ postprocessing argv in ``test_eval_postprocessing``, metric IO in
 import math
 import os
 import subprocess
-from collections.abc import Callable
 from contextlib import nullcontext
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 import torch
@@ -28,28 +28,27 @@ from synth_setter.cli.train import train
 from synth_setter.data.vst import param_specs, preset_paths
 from synth_setter.utils.utils import register_resolvers
 from synth_setter.workspace import operator_workspace
+from tests.helpers.eval_fakes import (
+    FAKE_METRICS_CSV,
+    fake_postprocessing_subprocess,
+)
 from tests.helpers.run_if import RunIf
 from tests.helpers.wandb_artifacts import publish_checkpoint_artifact
 
-# Public worker module names the predict-postprocessing subprocesses run; matched
-# as argv substrings so the fake ``subprocess.run`` can route render vs metrics
-# without importing eval.py's private ``_*_MODULE`` constants (forbidden here by
-# ``tests/_meta/test_entrypoint_test_modules.py``).
-_PREDICT_VST_AUDIO_FRAGMENT = "predict_vst_audio"
-_COMPUTE_AUDIO_METRICS_FRAGMENT = "compute_audio_metrics"
-_FAKE_ORACLE_DATASETS = [
-    pytest.param("fake_surge_smoke_datasets", None, id="h5"),
-    pytest.param("fake_surge_smoke_lance_datasets", "surge_lance", id="lance"),
-]
 
-# Aggregated audio-metrics CSV the fake metrics subprocess writes; one row per
-# metric, columns mean/std — the shape ``_load_audio_metrics`` flattens.
-_FAKE_AGGREGATED_METRICS_CSV = (
-    ",mean,std\nmss,0.5,0.1\nwmfcc,0.3,0.05\nsot,0.2,0.02\nrms,0.9,0.01\n"
-)
-# Per-sample metrics CSV the fake metrics subprocess writes alongside the aggregated
-# CSV; one row per sample, columns matching ``compute_audio_metrics`` output.
-_FAKE_METRICS_CSV = ",mss,wmfcc,sot,rms\n0,0.1,0.2,0.3,0.4\n1,0.5,0.6,0.7,0.8\n"
+class _FakeOracleDataset(NamedTuple):
+    name: str
+    fixture: str
+    datamodule_group: str | None
+
+
+_FAKE_ORACLE_DATASETS = [
+    pytest.param(_FakeOracleDataset("h5", "fake_surge_smoke_datasets", None), id="h5"),
+    pytest.param(
+        _FakeOracleDataset("lance", "fake_surge_smoke_lance_datasets", "surge_lance"),
+        id="lance",
+    ),
+]
 
 
 @pytest.mark.requires_vst
@@ -273,8 +272,7 @@ def _compose_fake_oracle_eval_cfg(
 def _compose_parametrized_fake_oracle_eval_cfg(
     tmp_path: Path,
     request: pytest.FixtureRequest,
-    dataset_fixture: str,
-    datamodule: str | None,
+    dataset_variant: _FakeOracleDataset,
     *,
     mode: str,
 ) -> DictConfig:
@@ -282,52 +280,25 @@ def _compose_parametrized_fake_oracle_eval_cfg(
 
     :param tmp_path: Pinned as ``paths.output_dir`` / ``paths.log_dir``.
     :param request: Fetches the parametrized dataset fixture.
-    :param dataset_fixture: Fixture name for the dataset root under test.
-    :param datamodule: Optional datamodule group override.
+    :param dataset_variant: Dataset fixture and datamodule override under test.
     :param mode: Eval mode to compose.
     :returns: Composed eval ``DictConfig`` ready for ``evaluate``.
     """
-    dataset_root = request.getfixturevalue(dataset_fixture)
-    return _compose_fake_oracle_eval_cfg(tmp_path, dataset_root, mode=mode, datamodule=datamodule)
-
-
-def _fake_postprocessing_subprocess(
-    audio_metrics_csv: str,
-) -> Callable[[list[str]], None]:
-    """Build a fake ``subprocess.run`` that materializes the render/metrics outputs.
-
-    Routes on the worker module name in argv: the render call creates the ``audio/``
-    output dir (its second positional) so the metrics branch's existence check
-    passes; the metrics call writes ``aggregated_metrics.csv`` under its output dir.
-    No real VST or Python subprocess is launched.
-
-    :param audio_metrics_csv: CSV body the fake metrics subprocess writes.
-    :returns: A ``subprocess.run``-compatible callable for ``monkeypatch.setattr``.
-    """
-
-    def _fake_run(args: list[str], **_kwargs: object) -> None:
-        is_render = any(_PREDICT_VST_AUDIO_FRAGMENT in a for a in args)
-        is_metrics = any(_COMPUTE_AUDIO_METRICS_FRAGMENT in a for a in args)
-        if not (is_render or is_metrics):
-            return
-        # Both worker argvs are ``[... -m <module> <in_dir> <out_dir> ...]``; the
-        # output dir is 3 past ``-m`` (module, in_dir, out_dir), robust to the
-        # Linux headless-wrapper prefix that shifts the leading entries.
-        out_dir = Path(args[args.index("-m") + 3])
-        out_dir.mkdir(parents=True, exist_ok=True)
-        if is_metrics:
-            (out_dir / "aggregated_metrics.csv").write_text(audio_metrics_csv)
-
-    return _fake_run
+    dataset_root = request.getfixturevalue(dataset_variant.fixture)
+    return _compose_fake_oracle_eval_cfg(
+        tmp_path,
+        dataset_root,
+        mode=mode,
+        datamodule=dataset_variant.datamodule_group,
+    )
 
 
 @pytest.mark.fake_vst
-@pytest.mark.parametrize(("dataset_fixture", "datamodule"), _FAKE_ORACLE_DATASETS)
+@pytest.mark.parametrize("dataset_variant", _FAKE_ORACLE_DATASETS)
 def test_evaluate_predict_mode_merges_audio_metrics_into_metric_dict(
     tmp_path: Path,
     request: pytest.FixtureRequest,
-    dataset_fixture: str,
-    datamodule: str | None,
+    dataset_variant: _FakeOracleDataset,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``mode=predict`` runs the oracle's predict + postprocessing and merges audio metrics.
@@ -342,17 +313,16 @@ def test_evaluate_predict_mode_merges_audio_metrics_into_metric_dict(
     :param tmp_path: Hydra ``output_dir``; ``predictions/`` / ``audio/`` / ``metrics/``
         are derived beneath it.
     :param request: Fetches the parametrized dataset fixture.
-    :param dataset_fixture: Fixture name for the dataset root under test.
-    :param datamodule: Optional datamodule group override.
+    :param dataset_variant: Dataset fixture and datamodule override under test.
     :param monkeypatch: Stubs the render/metrics subprocesses and the headless
         wrapper extraction so no real VST host or Python subprocess launches.
     """
     cfg = _compose_parametrized_fake_oracle_eval_cfg(
-        tmp_path, request, dataset_fixture, datamodule, mode="predict"
+        tmp_path, request, dataset_variant, mode="predict"
     )
     monkeypatch.setattr(
         "synth_setter.cli.eval.subprocess.run",
-        _fake_postprocessing_subprocess(_FAKE_AGGREGATED_METRICS_CSV),
+        fake_postprocessing_subprocess(),
     )
     monkeypatch.setattr("synth_setter.cli.eval.vst_headless_wrapper", lambda: object())
     monkeypatch.setattr(
@@ -375,12 +345,11 @@ def test_evaluate_predict_mode_merges_audio_metrics_into_metric_dict(
 
 
 @pytest.mark.fake_vst
-@pytest.mark.parametrize(("dataset_fixture", "datamodule"), _FAKE_ORACLE_DATASETS)
+@pytest.mark.parametrize("dataset_variant", _FAKE_ORACLE_DATASETS)
 def test_evaluate_predict_mode_logs_per_sample_metrics_table_to_wandb(
     tmp_path: Path,
     request: pytest.FixtureRequest,
-    dataset_fixture: str,
-    datamodule: str | None,
+    dataset_variant: _FakeOracleDataset,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``mode=predict`` with an active wandb run uploads ``metrics.csv`` as a wandb.Table.
@@ -392,8 +361,7 @@ def test_evaluate_predict_mode_logs_per_sample_metrics_table_to_wandb(
 
     :param tmp_path: Hydra ``output_dir``; the fake subprocess writes CSVs beneath it.
     :param request: Fetches the parametrized dataset fixture.
-    :param dataset_fixture: Fixture name for the dataset root under test.
-    :param datamodule: Optional datamodule group override.
+    :param dataset_variant: Dataset fixture and datamodule override under test.
     :param monkeypatch: Stubs subprocesses, headless wrapper, and ``wandb.run``.
     """
     logged: list[dict[str, object]] = []
@@ -421,21 +389,13 @@ def test_evaluate_predict_mode_logs_per_sample_metrics_table_to_wandb(
             """
             return lambda *_args, **_kwargs: None
 
-    def _fake_run_with_metrics(args: list[str], **_kwargs: object) -> None:
-        is_render = any(_PREDICT_VST_AUDIO_FRAGMENT in a for a in args)
-        is_metrics = any(_COMPUTE_AUDIO_METRICS_FRAGMENT in a for a in args)
-        if not (is_render or is_metrics):
-            return
-        out_dir = Path(args[args.index("-m") + 3])
-        out_dir.mkdir(parents=True, exist_ok=True)
-        if is_metrics:
-            (out_dir / "aggregated_metrics.csv").write_text(_FAKE_AGGREGATED_METRICS_CSV)
-            (out_dir / "metrics.csv").write_text(_FAKE_METRICS_CSV)
-
     cfg = _compose_parametrized_fake_oracle_eval_cfg(
-        tmp_path, request, dataset_fixture, datamodule, mode="predict"
+        tmp_path, request, dataset_variant, mode="predict"
     )
-    monkeypatch.setattr("synth_setter.cli.eval.subprocess.run", _fake_run_with_metrics)
+    monkeypatch.setattr(
+        "synth_setter.cli.eval.subprocess.run",
+        fake_postprocessing_subprocess(per_sample_metrics_csv=FAKE_METRICS_CSV),
+    )
     monkeypatch.setattr("synth_setter.cli.eval.vst_headless_wrapper", lambda: object())
     monkeypatch.setattr(
         "synth_setter.cli.eval.as_file",
@@ -458,12 +418,11 @@ def test_evaluate_predict_mode_logs_per_sample_metrics_table_to_wandb(
 
 
 @pytest.mark.fake_vst
-@pytest.mark.parametrize(("dataset_fixture", "datamodule"), _FAKE_ORACLE_DATASETS)
+@pytest.mark.parametrize("dataset_variant", _FAKE_ORACLE_DATASETS)
 def test_evaluate_predict_mode_logs_shuffle_permutation_table_to_wandb(
     tmp_path: Path,
     request: pytest.FixtureRequest,
-    dataset_fixture: str,
-    datamodule: str | None,
+    dataset_variant: _FakeOracleDataset,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """``mode=predict`` uploads the render-order probe permutation as a ``shuffle/permutation`` Table.
@@ -475,8 +434,7 @@ def test_evaluate_predict_mode_logs_shuffle_permutation_table_to_wandb(
 
     :param tmp_path: Hydra ``output_dir``; the fake subprocess writes CSVs beneath it.
     :param request: Fetches the parametrized dataset fixture.
-    :param dataset_fixture: Fixture name for the dataset root under test.
-    :param datamodule: Optional datamodule group override.
+    :param dataset_variant: Dataset fixture and datamodule override under test.
     :param monkeypatch: Stubs subprocesses, headless wrapper, and ``wandb.run``.
     """
     permutation_csv = "dest_idx,src_idx\n0,1\n1,0\n"
@@ -505,21 +463,13 @@ def test_evaluate_predict_mode_logs_shuffle_permutation_table_to_wandb(
             """
             return lambda *_args, **_kwargs: None
 
-    def _fake_run_with_permutation(args: list[str], **_kwargs: object) -> None:
-        is_render = any(_PREDICT_VST_AUDIO_FRAGMENT in a for a in args)
-        is_metrics = any(_COMPUTE_AUDIO_METRICS_FRAGMENT in a for a in args)
-        if not (is_render or is_metrics):
-            return
-        out_dir = Path(args[args.index("-m") + 3])
-        out_dir.mkdir(parents=True, exist_ok=True)
-        if is_metrics:
-            (out_dir / "aggregated_metrics.csv").write_text(_FAKE_AGGREGATED_METRICS_CSV)
-            (out_dir / "shuffle_permutation.csv").write_text(permutation_csv)
-
     cfg = _compose_parametrized_fake_oracle_eval_cfg(
-        tmp_path, request, dataset_fixture, datamodule, mode="predict"
+        tmp_path, request, dataset_variant, mode="predict"
     )
-    monkeypatch.setattr("synth_setter.cli.eval.subprocess.run", _fake_run_with_permutation)
+    monkeypatch.setattr(
+        "synth_setter.cli.eval.subprocess.run",
+        fake_postprocessing_subprocess(shuffle_permutation_csv=permutation_csv),
+    )
     monkeypatch.setattr("synth_setter.cli.eval.vst_headless_wrapper", lambda: object())
     monkeypatch.setattr(
         "synth_setter.cli.eval.as_file",
@@ -543,12 +493,11 @@ def test_evaluate_predict_mode_logs_shuffle_permutation_table_to_wandb(
 
 
 @pytest.mark.fake_vst
-@pytest.mark.parametrize(("dataset_fixture", "datamodule"), _FAKE_ORACLE_DATASETS)
+@pytest.mark.parametrize("dataset_variant", _FAKE_ORACLE_DATASETS)
 def test_evaluate_validate_mode_legacy_val_spelling_runs_oracle(
     tmp_path: Path,
     request: pytest.FixtureRequest,
-    dataset_fixture: str,
-    datamodule: str | None,
+    dataset_variant: _FakeOracleDataset,
 ) -> None:
     """``mode=val`` (legacy spelling) routes to ``trainer.validate`` and logs zero MSE.
 
@@ -559,11 +508,10 @@ def test_evaluate_validate_mode_legacy_val_spelling_runs_oracle(
 
     :param tmp_path: Pinned as Hydra ``output_dir`` / ``log_dir``.
     :param request: Fetches the parametrized dataset fixture.
-    :param dataset_fixture: Fixture name for the dataset root under test.
-    :param datamodule: Optional datamodule group override.
+    :param dataset_variant: Dataset fixture and datamodule override under test.
     """
     cfg = _compose_parametrized_fake_oracle_eval_cfg(
-        tmp_path, request, dataset_fixture, datamodule, mode="val"
+        tmp_path, request, dataset_variant, mode="val"
     )
 
     HydraConfig().set_config(cfg)
@@ -630,12 +578,11 @@ def test_evaluate_unknown_mode_returns_only_callback_metrics(
 
 
 @pytest.mark.fake_vst
-@pytest.mark.parametrize(("dataset_fixture", "datamodule"), _FAKE_ORACLE_DATASETS)
+@pytest.mark.parametrize("dataset_variant", _FAKE_ORACLE_DATASETS)
 def test_evaluate_predict_mode_includes_shuffled_audio_metrics_when_subprocess_writes_shuffled_csv(
     tmp_path: Path,
     request: pytest.FixtureRequest,
-    dataset_fixture: str,
-    datamodule: str | None,
+    dataset_variant: _FakeOracleDataset,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Merges ``shuffled_audio/*`` keys when the metrics subprocess also writes the shuffled CSV.
@@ -649,27 +596,18 @@ def test_evaluate_predict_mode_includes_shuffled_audio_metrics_when_subprocess_w
 
     :param tmp_path: Hydra ``output_dir``; output files are derived beneath it.
     :param request: Fetches the parametrized dataset fixture.
-    :param dataset_fixture: Fixture name for the dataset root under test.
-    :param datamodule: Optional datamodule group override.
+    :param dataset_variant: Dataset fixture and datamodule override under test.
     :param monkeypatch: Stubs render/metrics subprocesses; no real VST launches.
     """
     _SHUFFLED_CSV = ",mean,std\nmss,0.8,0.05\nwmfcc,0.4,0.03\nsot,0.3,0.02\nrms,0.7,0.01\n"
 
-    def _fake_run_with_shuffled(args: list[str], **_kwargs: object) -> None:
-        is_render = any(_PREDICT_VST_AUDIO_FRAGMENT in a for a in args)
-        is_metrics = any(_COMPUTE_AUDIO_METRICS_FRAGMENT in a for a in args)
-        if not (is_render or is_metrics):
-            return
-        out_dir = Path(args[args.index("-m") + 3])
-        out_dir.mkdir(parents=True, exist_ok=True)
-        if is_metrics:
-            (out_dir / "aggregated_metrics.csv").write_text(_FAKE_AGGREGATED_METRICS_CSV)
-            (out_dir / "aggregated_metrics_shuffled.csv").write_text(_SHUFFLED_CSV)
-
     cfg = _compose_parametrized_fake_oracle_eval_cfg(
-        tmp_path, request, dataset_fixture, datamodule, mode="predict"
+        tmp_path, request, dataset_variant, mode="predict"
     )
-    monkeypatch.setattr("synth_setter.cli.eval.subprocess.run", _fake_run_with_shuffled)
+    monkeypatch.setattr(
+        "synth_setter.cli.eval.subprocess.run",
+        fake_postprocessing_subprocess(shuffled_metrics_csv=_SHUFFLED_CSV),
+    )
     monkeypatch.setattr("synth_setter.cli.eval.vst_headless_wrapper", lambda: object())
     monkeypatch.setattr(
         "synth_setter.cli.eval.as_file",

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -8,6 +8,7 @@ that no private ``synth_setter.cli`` helper is imported here.
 """
 
 import os
+from collections.abc import Callable
 from contextlib import nullcontext
 from pathlib import Path
 
@@ -29,6 +30,11 @@ from tests.conftest import (
     build_fake_train_cfg,
 )
 from tests.evaluation._oracle_helpers import ORACLE_AUDIO_METRIC_BOUNDS
+from tests.helpers.eval_fakes import (
+    FAKE_AGGREGATED_METRICS_CSV,
+    fake_metrics_csv,
+    fake_postprocessing_subprocess,
+)
 from tests.helpers.run_if import RunIf
 from tests.helpers.wandb_artifacts import publish_checkpoint_artifact
 
@@ -36,40 +42,22 @@ from tests.helpers.wandb_artifacts import publish_checkpoint_artifact
 # the parametrize lists on the two ``test_train_*_surge_xt`` tests cannot drift apart.
 _ORACLE_EXPERIMENT = "surge/fake_oracle"
 _SURGE_SMOKE_EXPERIMENTS = (_ORACLE_EXPERIMENT, "surge/ffn_full")
-_PREDICT_VST_AUDIO_FRAGMENT = "predict_vst_audio"
-_COMPUTE_AUDIO_METRICS_FRAGMENT = "compute_audio_metrics"
-_FAKE_AGGREGATED_METRICS_CSV = (
-    ",mean,std\nmss,0.5,0.02\nwmfcc,0.25,0.01\nsot,0.1,0.005\nrms,0.9,0.01\n"
-)
-_FAKE_METRICS_CSV = "mss,wmfcc,sot,rms\n" + "\n".join(
-    "0.5,0.25,0.1,0.9" for _ in range(NUM_FIXTURE_SAMPLES)
-)
+_PREDICTION_PT_PREFIXES = ("pred", "target-audio", "target-params")
+_FAKE_METRICS_CSV = fake_metrics_csv(NUM_FIXTURE_SAMPLES)
 
 # TODO(#40): add @pytest.mark.ram gate for memory-intensive CPU tests test_train_fast_dev_run
 
 
-def _fake_predict_postprocessing_subprocess(args: list[str], **_kwargs: object) -> None:
-    """Materialize the render and metrics outputs the Lance smoke test asserts.
+def _lance_eval_postprocessing_fake() -> Callable[[list[str]], None]:
+    """Return fake eval postprocessing that materializes Lance smoke outputs.
 
-    :param args: Subprocess argv from the eval postprocessing step.
-    :param **_kwargs: Ignored ``subprocess.run`` keyword arguments.
+    :returns: ``subprocess.run``-compatible callable.
     """
-    is_render = any(_PREDICT_VST_AUDIO_FRAGMENT in arg for arg in args)
-    is_metrics = any(_COMPUTE_AUDIO_METRICS_FRAGMENT in arg for arg in args)
-    if not (is_render or is_metrics):
-        return
-
-    output_dir = Path(args[args.index("-m") + 3])
-    output_dir.mkdir(parents=True, exist_ok=True)
-    if is_render:
-        for sample_idx in range(NUM_FIXTURE_SAMPLES):
-            sample_dir = output_dir / f"sample_{sample_idx}"
-            sample_dir.mkdir()
-            for name in ("target.wav", "pred.wav", "spec.png", "params.csv"):
-                (sample_dir / name).write_text("fake")
-    if is_metrics:
-        (output_dir / "aggregated_metrics.csv").write_text(_FAKE_AGGREGATED_METRICS_CSV)
-        (output_dir / "metrics.csv").write_text(_FAKE_METRICS_CSV)
+    return fake_postprocessing_subprocess(
+        audio_metrics_csv=FAKE_AGGREGATED_METRICS_CSV,
+        per_sample_metrics_csv=_FAKE_METRICS_CSV,
+        render_sample_count=NUM_FIXTURE_SAMPLES,
+    )
 
 
 def test_train_fast_dev_run_tiny_model_tiny_data(cfg_train: DictConfig) -> None:
@@ -544,7 +532,7 @@ def test_train_eval_surge_lance(
     monkeypatch: pytest.MonkeyPatch,
     experiment_name: str,
 ) -> None:
-    """Train on Lance splits, then predict from the saved checkpoint over Lance splits.
+    """Train on Lance splits, then verify prediction tensors from checkpoint eval.
 
     :param tmp_path: The temporary logging path.
     :param cfg_surge_xt_lance: CPU training config using ``datamodule=surge_lance``.
@@ -552,37 +540,15 @@ def test_train_eval_surge_lance(
     :param monkeypatch: Stubs render/metrics subprocesses so no real VST host launches.
     :param experiment_name: Hydra experiment override the cfg was built from.
     """
-    HydraConfig().set_config(cfg_surge_xt_lance)
-    train(cfg_surge_xt_lance)
-
-    assert Path(cfg_surge_xt_lance_eval.ckpt_path).exists()
-
-    monkeypatch.setattr(
-        "synth_setter.cli.eval.subprocess.run", _fake_predict_postprocessing_subprocess
-    )
-    monkeypatch.setattr("synth_setter.cli.eval.vst_headless_wrapper", lambda: object())
-    monkeypatch.setattr(
-        "synth_setter.cli.eval.as_file",
-        lambda _traversable: nullcontext(Path("/fake/headless-wrapper")),
+    metric_dict, object_dict = _evaluate_surge_lance_checkpoint(
+        cfg_surge_xt_lance, cfg_surge_xt_lance_eval, monkeypatch
     )
 
-    HydraConfig().set_config(cfg_surge_xt_lance_eval)
-    metric_dict, object_dict = evaluate(cfg_surge_xt_lance_eval)
-
-    assert metric_dict["audio/mss_mean"] == pytest.approx(0.5)
-    assert metric_dict["audio/rms_std"] == pytest.approx(0.01)
-
-    test_split = Path(object_dict["datamodule"].dataset_root) / "test.lance"
-    assert test_split.is_dir()
+    _assert_surge_lance_eval_basics(metric_dict, object_dict)
 
     predictions_dir = tmp_path / "predictions"
     assert predictions_dir.is_dir()
-    expected_names = sorted(
-        f"{prefix}-{sample_idx}.pt"
-        for prefix in ("pred", "target-audio", "target-params")
-        for sample_idx in range(NUM_FIXTURE_SAMPLES)
-    )
-    assert sorted(path.name for path in predictions_dir.iterdir()) == expected_names
+    assert sorted(path.name for path in predictions_dir.iterdir()) == _prediction_file_names()
 
     for sample_idx in range(NUM_FIXTURE_SAMPLES):
         pred = torch.load(predictions_dir / f"pred-{sample_idx}.pt", weights_only=True)
@@ -595,6 +561,30 @@ def test_train_eval_surge_lance(
             assert torch.equal(pred, target_params), (
                 f"oracle pred-{sample_idx}.pt != target-params-{sample_idx}.pt"
             )
+
+
+@pytest.mark.fake_vst
+@pytest.mark.parametrize("experiment_name", _SURGE_SMOKE_EXPERIMENTS, indirect=True)
+def test_train_eval_surge_lance_writes_audio_and_metrics_outputs(
+    tmp_path: Path,
+    cfg_surge_xt_lance: DictConfig,
+    cfg_surge_xt_lance_eval: DictConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    experiment_name: str,
+) -> None:
+    """Train on Lance splits, then verify fake render and metrics outputs.
+
+    :param tmp_path: The temporary logging path.
+    :param cfg_surge_xt_lance: CPU training config using ``datamodule=surge_lance``.
+    :param cfg_surge_xt_lance_eval: Matching eval config pinned to ``last.ckpt``.
+    :param monkeypatch: Stubs render/metrics subprocesses so no real VST host launches.
+    :param experiment_name: Hydra experiment override; parametrizes the train/eval run.
+    """
+    metric_dict, object_dict = _evaluate_surge_lance_checkpoint(
+        cfg_surge_xt_lance, cfg_surge_xt_lance_eval, monkeypatch
+    )
+
+    _assert_surge_lance_eval_basics(metric_dict, object_dict)
 
     audio_dir = tmp_path / "audio"
     sample_dirs = sorted(path for path in audio_dir.iterdir() if path.is_dir())
@@ -617,3 +607,62 @@ def test_train_eval_surge_lance(
         assert len(metrics_df) == expected_rows
         numeric = metrics_df.select_dtypes(include=[np.number]).to_numpy()
         assert np.isfinite(numeric).all(), f"{metrics_file} contains NaN/Inf:\n{metrics_df}"
+
+
+def _evaluate_surge_lance_checkpoint(
+    cfg_surge_xt_lance: DictConfig,
+    cfg_surge_xt_lance_eval: DictConfig,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[dict[str, object], dict[str, object]]:
+    """Run the Lance train-to-predict smoke path with faked postprocessing.
+
+    :param cfg_surge_xt_lance: CPU training config using ``datamodule=surge_lance``.
+    :param cfg_surge_xt_lance_eval: Matching eval config pinned to ``last.ckpt``.
+    :param monkeypatch: Stubs postprocessing subprocess dependencies.
+    :returns: ``evaluate`` metric and object dictionaries.
+    """
+    HydraConfig().set_config(cfg_surge_xt_lance)
+    train(cfg_surge_xt_lance)
+
+    assert Path(cfg_surge_xt_lance_eval.ckpt_path).exists()
+
+    monkeypatch.setattr("synth_setter.cli.eval.subprocess.run", _lance_eval_postprocessing_fake())
+    monkeypatch.setattr("synth_setter.cli.eval.vst_headless_wrapper", lambda: object())
+    monkeypatch.setattr(
+        "synth_setter.cli.eval.as_file",
+        lambda _traversable: nullcontext(Path("/fake/headless-wrapper")),
+    )
+
+    HydraConfig().set_config(cfg_surge_xt_lance_eval)
+    return evaluate(cfg_surge_xt_lance_eval)
+
+
+def _assert_surge_lance_eval_basics(
+    metric_dict: dict[str, object],
+    object_dict: dict[str, object],
+) -> None:
+    """Assert the shared Lance predict-mode eval invariants.
+
+    :param metric_dict: Metrics returned by ``evaluate``.
+    :param object_dict: Objects returned by ``evaluate``.
+    """
+    assert metric_dict["audio/mss_mean"] == pytest.approx(0.5)
+    assert metric_dict["audio/rms_std"] == pytest.approx(0.01)
+
+    dataset_root = getattr(object_dict["datamodule"], "dataset_root")
+    assert isinstance(dataset_root, str | os.PathLike)
+
+    test_split = Path(dataset_root) / "test.lance"
+    assert test_split.is_dir()
+
+
+def _prediction_file_names() -> list[str]:
+    """Return the per-batch files ``PredictionWriter`` writes for the smoke split.
+
+    :returns: Sorted expected prediction filenames.
+    """
+    return sorted(
+        f"{prefix}-{sample_idx}.pt"
+        for prefix in _PREDICTION_PT_PREFIXES
+        for sample_idx in range(NUM_FIXTURE_SAMPLES)
+    )

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -8,6 +8,7 @@ that no private ``synth_setter.cli`` helper is imported here.
 """
 
 import os
+from contextlib import nullcontext
 from pathlib import Path
 
 import numpy as np
@@ -35,8 +36,40 @@ from tests.helpers.wandb_artifacts import publish_checkpoint_artifact
 # the parametrize lists on the two ``test_train_*_surge_xt`` tests cannot drift apart.
 _ORACLE_EXPERIMENT = "surge/fake_oracle"
 _SURGE_SMOKE_EXPERIMENTS = (_ORACLE_EXPERIMENT, "surge/ffn_full")
+_PREDICT_VST_AUDIO_FRAGMENT = "predict_vst_audio"
+_COMPUTE_AUDIO_METRICS_FRAGMENT = "compute_audio_metrics"
+_FAKE_AGGREGATED_METRICS_CSV = (
+    ",mean,std\nmss,0.5,0.02\nwmfcc,0.25,0.01\nsot,0.1,0.005\nrms,0.9,0.01\n"
+)
+_FAKE_METRICS_CSV = "mss,wmfcc,sot,rms\n" + "\n".join(
+    "0.5,0.25,0.1,0.9" for _ in range(NUM_FIXTURE_SAMPLES)
+)
 
 # TODO(#40): add @pytest.mark.ram gate for memory-intensive CPU tests test_train_fast_dev_run
+
+
+def _fake_predict_postprocessing_subprocess(args: list[str], **_kwargs: object) -> None:
+    """Materialize the render and metrics outputs the Lance smoke test asserts.
+
+    :param args: Subprocess argv from the eval postprocessing step.
+    :param **_kwargs: Ignored ``subprocess.run`` keyword arguments.
+    """
+    is_render = any(_PREDICT_VST_AUDIO_FRAGMENT in arg for arg in args)
+    is_metrics = any(_COMPUTE_AUDIO_METRICS_FRAGMENT in arg for arg in args)
+    if not (is_render or is_metrics):
+        return
+
+    output_dir = Path(args[args.index("-m") + 3])
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if is_render:
+        for sample_idx in range(NUM_FIXTURE_SAMPLES):
+            sample_dir = output_dir / f"sample_{sample_idx}"
+            sample_dir.mkdir()
+            for name in ("target.wav", "pred.wav", "spec.png", "params.csv"):
+                (sample_dir / name).write_text("fake")
+    if is_metrics:
+        (output_dir / "aggregated_metrics.csv").write_text(_FAKE_AGGREGATED_METRICS_CSV)
+        (output_dir / "metrics.csv").write_text(_FAKE_METRICS_CSV)
 
 
 def test_train_fast_dev_run_tiny_model_tiny_data(cfg_train: DictConfig) -> None:
@@ -471,3 +504,116 @@ def test_train_fast_dev_run_lance_datamodule(cfg_train_lance: DictConfig) -> Non
     # is a Lance dataset directory, not the legacy single ``.lance`` file.
     train_split = Path(object_dict["datamodule"].dataset_root) / "train.lance"
     assert train_split.is_dir()
+
+
+@pytest.mark.fake_vst
+@pytest.mark.parametrize("experiment_name", _SURGE_SMOKE_EXPERIMENTS, indirect=True)
+def test_train_surge_lance(cfg_surge_xt_lance: DictConfig, experiment_name: str) -> None:
+    """Run the Surge smoke training matrix over native Lance splits.
+
+    :param cfg_surge_xt_lance: CPU training config using ``datamodule=surge_lance``.
+    :param experiment_name: Hydra experiment override the cfg was built from.
+    """
+    HydraConfig().set_config(cfg_surge_xt_lance)
+    metric_dict, object_dict = train(cfg_surge_xt_lance)
+
+    trainer = object_dict["trainer"]
+    assert trainer.global_step >= 1, f"trainer did not advance: global_step={trainer.global_step}"
+
+    train_split = Path(object_dict["datamodule"].dataset_root) / "train.lance"
+    assert train_split.is_dir()
+
+    loss_keys = [key for key in metric_dict if key.startswith("train/loss")]
+    assert loss_keys, f"no train/loss* key in metric_dict: {sorted(metric_dict)}"
+    for key in loss_keys:
+        loss = metric_dict[key]
+        assert torch.isfinite(loss).all(), f"{key} is not finite: {loss}"
+
+    if experiment_name == _ORACLE_EXPERIMENT:
+        for key in loss_keys:
+            loss_value = metric_dict[key].item()
+            assert loss_value == 0.0, f"oracle {key} not exactly zero: {loss_value}"
+
+
+@pytest.mark.fake_vst
+@pytest.mark.parametrize("experiment_name", _SURGE_SMOKE_EXPERIMENTS, indirect=True)
+def test_train_eval_surge_lance(
+    tmp_path: Path,
+    cfg_surge_xt_lance: DictConfig,
+    cfg_surge_xt_lance_eval: DictConfig,
+    monkeypatch: pytest.MonkeyPatch,
+    experiment_name: str,
+) -> None:
+    """Train on Lance splits, then predict from the saved checkpoint over Lance splits.
+
+    :param tmp_path: The temporary logging path.
+    :param cfg_surge_xt_lance: CPU training config using ``datamodule=surge_lance``.
+    :param cfg_surge_xt_lance_eval: Matching eval config pinned to ``last.ckpt``.
+    :param monkeypatch: Stubs render/metrics subprocesses so no real VST host launches.
+    :param experiment_name: Hydra experiment override the cfg was built from.
+    """
+    HydraConfig().set_config(cfg_surge_xt_lance)
+    train(cfg_surge_xt_lance)
+
+    assert Path(cfg_surge_xt_lance_eval.ckpt_path).exists()
+
+    monkeypatch.setattr(
+        "synth_setter.cli.eval.subprocess.run", _fake_predict_postprocessing_subprocess
+    )
+    monkeypatch.setattr("synth_setter.cli.eval.vst_headless_wrapper", lambda: object())
+    monkeypatch.setattr(
+        "synth_setter.cli.eval.as_file",
+        lambda _traversable: nullcontext(Path("/fake/headless-wrapper")),
+    )
+
+    HydraConfig().set_config(cfg_surge_xt_lance_eval)
+    metric_dict, object_dict = evaluate(cfg_surge_xt_lance_eval)
+
+    assert metric_dict["audio/mss_mean"] == pytest.approx(0.5)
+    assert metric_dict["audio/rms_std"] == pytest.approx(0.01)
+
+    test_split = Path(object_dict["datamodule"].dataset_root) / "test.lance"
+    assert test_split.is_dir()
+
+    predictions_dir = tmp_path / "predictions"
+    assert predictions_dir.is_dir()
+    expected_names = sorted(
+        f"{prefix}-{sample_idx}.pt"
+        for prefix in ("pred", "target-audio", "target-params")
+        for sample_idx in range(NUM_FIXTURE_SAMPLES)
+    )
+    assert sorted(path.name for path in predictions_dir.iterdir()) == expected_names
+
+    for sample_idx in range(NUM_FIXTURE_SAMPLES):
+        pred = torch.load(predictions_dir / f"pred-{sample_idx}.pt", weights_only=True)
+        assert torch.isfinite(pred).all(), f"pred-{sample_idx}.pt contains NaN/Inf"
+
+        if experiment_name == _ORACLE_EXPERIMENT:
+            target_params = torch.load(
+                predictions_dir / f"target-params-{sample_idx}.pt", weights_only=True
+            )
+            assert torch.equal(pred, target_params), (
+                f"oracle pred-{sample_idx}.pt != target-params-{sample_idx}.pt"
+            )
+
+    audio_dir = tmp_path / "audio"
+    sample_dirs = sorted(path for path in audio_dir.iterdir() if path.is_dir())
+    assert [path.name for path in sample_dirs] == [
+        f"sample_{sample_idx}" for sample_idx in range(NUM_FIXTURE_SAMPLES)
+    ]
+    for sample_dir in sample_dirs:
+        assert (sample_dir / "target.wav").is_file()
+        assert (sample_dir / "pred.wav").is_file()
+        assert (sample_dir / "spec.png").is_file()
+        assert (sample_dir / "params.csv").is_file()
+
+    metrics_dir = tmp_path / "metrics"
+    for metrics_file, expected_rows in {
+        "aggregated_metrics.csv": 4,
+        "metrics.csv": NUM_FIXTURE_SAMPLES,
+    }.items():
+        assert (metrics_dir / metrics_file).is_file(), f"{metrics_file} not found"
+        metrics_df = pd.read_csv(metrics_dir / metrics_file)
+        assert len(metrics_df) == expected_rows
+        numeric = metrics_df.select_dtypes(include=[np.number]).to_numpy()
+        assert np.isfinite(numeric).all(), f"{metrics_file} contains NaN/Inf:\n{metrics_df}"

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -25,8 +25,11 @@ from synth_setter.data.vst import param_specs
 from synth_setter.utils.utils import register_resolvers
 from synth_setter.workspace import operator_workspace
 from tests.conftest import (
+    FAKE_VST_VARIANTS,
     NUM_FIXTURE_SAMPLES,
+    REAL_VST_VARIANTS,
     _build_surge_xt_smoke_cfg,
+    _SurgeSmokeVariant,
     build_fake_train_cfg,
 )
 from tests.evaluation._oracle_helpers import ORACLE_AUDIO_METRIC_BOUNDS
@@ -48,8 +51,8 @@ _FAKE_METRICS_CSV = fake_metrics_csv(NUM_FIXTURE_SAMPLES)
 # TODO(#40): add @pytest.mark.ram gate for memory-intensive CPU tests test_train_fast_dev_run
 
 
-def _lance_eval_postprocessing_fake() -> Callable[[list[str]], None]:
-    """Return fake eval postprocessing that materializes Lance smoke outputs.
+def _smoke_eval_postprocessing_fake() -> Callable[[list[str]], None]:
+    """Return fake eval postprocessing that materializes the fake-plugin smoke outputs.
 
     :returns: ``subprocess.run``-compatible callable.
     """
@@ -258,22 +261,25 @@ def test_train_fake_mode_nondefault_spec_sizes_batches_from_registry(tmp_path: P
 @pytest.mark.requires_vst
 @pytest.mark.slow
 @pytest.mark.parametrize("experiment_name", _SURGE_SMOKE_EXPERIMENTS, indirect=True)
-def test_train_surge_xt(cfg_surge_xt: DictConfig, experiment_name: str) -> None:
-    """Run training of the Surge XT model on the smoke test fixture, across both experiments.
+@pytest.mark.parametrize("surge_smoke_variant", REAL_VST_VARIANTS, indirect=True)
+def test_train_surge_xt(cfg_surge_real_train: DictConfig, experiment_name: str) -> None:
+    """Run training of the Surge XT model on the smoke test fixture, across both experiments and dataset formats.
 
     Asserts the trainer advanced and produced a finite ``train/loss`` — catches silent
     no-op trainers and NaN/Inf regressions that a bare ``train()`` call would not. The
     ``surge/fake_oracle`` leg additionally pins ``train/loss`` to exactly zero (the
     oracle constructs its loss as ``0.0 * net(mel_spec).sum()`` — any drift means the
     oracle stopped being an oracle); meaningful loss-progression coverage comes from
-    the ``surge/ffn_full`` leg.
+    the ``surge/ffn_full`` leg. Parametrized over h5 and Lance so both datamodules train
+    through the real Surge XT render.
 
-    :param cfg_surge_xt: Surge XT training config (parametrized over experiment).
+    :param cfg_surge_real_train: Surge XT training config (parametrized over experiment and
+        dataset format).
     :param experiment_name: Hydra experiment override the cfg was built from — drives
         the oracle-specific tight bound below.
     """
-    HydraConfig().set_config(cfg_surge_xt)
-    metric_dict, object_dict = train(cfg_surge_xt)
+    HydraConfig().set_config(cfg_surge_real_train)
+    metric_dict, object_dict = train(cfg_surge_real_train)
 
     trainer = object_dict["trainer"]
     assert trainer.global_step >= 1, f"trainer did not advance: global_step={trainer.global_step}"
@@ -297,18 +303,19 @@ def test_train_surge_xt(cfg_surge_xt: DictConfig, experiment_name: str) -> None:
 @pytest.mark.requires_vst
 @pytest.mark.slow
 @pytest.mark.parametrize("experiment_name", _SURGE_SMOKE_EXPERIMENTS, indirect=True)
+@pytest.mark.parametrize("surge_smoke_variant", REAL_VST_VARIANTS, indirect=True)
 def test_train_eval_surge_xt(
     tmp_path: Path,
-    cfg_surge_xt: DictConfig,
-    cfg_surge_xt_eval: DictConfig,
+    cfg_surge_real_train: DictConfig,
+    cfg_surge_real_eval: DictConfig,
     param_spec_name: str,
     experiment_name: str,
 ) -> None:
-    """End-to-end smoke test: train Surge XT briefly on a small fixture dataset, then run standalone eval on the saved checkpoint.
+    """End-to-end smoke test: train Surge XT briefly on a small fixture dataset, then run standalone eval on the saved checkpoint, for both dataset formats.
 
     :param tmp_path: The temporary logging path.
-    :param cfg_surge_xt: Surge XT smoke-test training config.
-    :param cfg_surge_xt_eval: Matching smoke-test eval config (ckpt_path set by this test).
+    :param cfg_surge_real_train: Surge XT smoke-test training config (h5 or Lance arm).
+    :param cfg_surge_real_eval: Matching smoke-test eval config (ckpt_path set by this test).
     :param param_spec_name: Param spec the fixtures (and therefore the trained model) are
         wired for — passed to ``predict_vst_audio.py`` so the script's decode layout matches
         the predicted tensor's encoding (mismatched specs go off-the-end and crash with
@@ -330,15 +337,15 @@ def test_train_eval_surge_xt(
         },
     }
 
-    HydraConfig().set_config(cfg_surge_xt)
-    train(cfg_surge_xt)
+    HydraConfig().set_config(cfg_surge_real_train)
+    train(cfg_surge_real_train)
 
-    # `cfg_surge_xt_eval.ckpt_path` is pre-pointed at this same `tmp_path` by the
+    # `cfg_surge_real_eval.ckpt_path` is pre-pointed at this same `tmp_path` by the
     # fixture; assert the train step actually produced the file before eval reads it.
-    assert Path(cfg_surge_xt_eval.ckpt_path).exists()
+    assert Path(cfg_surge_real_eval.ckpt_path).exists()
 
-    HydraConfig().set_config(cfg_surge_xt_eval)
-    evaluate(cfg_surge_xt_eval)
+    HydraConfig().set_config(cfg_surge_real_eval)
+    evaluate(cfg_surge_real_eval)
 
     # `PredictionWriter` (in `src/synth_setter/utils/callbacks.py`) with `write_interval=batch` saves three
     # tensors per predict batch: `pred-{i}.pt`, `target-audio-{i}.pt`, `target-params-{i}.pt`.
@@ -496,20 +503,28 @@ def test_train_fast_dev_run_lance_datamodule(cfg_train_lance: DictConfig) -> Non
 
 @pytest.mark.fake_vst
 @pytest.mark.parametrize("experiment_name", _SURGE_SMOKE_EXPERIMENTS, indirect=True)
-def test_train_surge_lance(cfg_surge_xt_lance: DictConfig, experiment_name: str) -> None:
-    """Run the Surge smoke training matrix over native Lance splits.
+@pytest.mark.parametrize("surge_smoke_variant", FAKE_VST_VARIANTS, indirect=True)
+def test_train_surge_fake(
+    cfg_surge_fake_train: DictConfig,
+    surge_smoke_variant: _SurgeSmokeVariant,
+    experiment_name: str,
+) -> None:
+    """Run the Surge smoke training matrix over fake-plugin h5 and Lance splits.
 
-    :param cfg_surge_xt_lance: CPU training config using ``datamodule=surge_lance``.
+    :param cfg_surge_fake_train: CPU training config for the dataset-format arm under test.
+    :param surge_smoke_variant: Dataset-format arm (h5 or Lance) the cfg was built from.
     :param experiment_name: Hydra experiment override the cfg was built from.
     """
-    HydraConfig().set_config(cfg_surge_xt_lance)
-    metric_dict, object_dict = train(cfg_surge_xt_lance)
+    HydraConfig().set_config(cfg_surge_fake_train)
+    metric_dict, object_dict = train(cfg_surge_fake_train)
 
     trainer = object_dict["trainer"]
     assert trainer.global_step >= 1, f"trainer did not advance: global_step={trainer.global_step}"
 
-    train_split = Path(object_dict["datamodule"].dataset_root) / "train.lance"
-    assert train_split.is_dir()
+    train_split = (
+        Path(object_dict["datamodule"].dataset_root) / f"train{surge_smoke_variant.split_ext}"
+    )
+    assert train_split.exists()
 
     loss_keys = [key for key in metric_dict if key.startswith("train/loss")]
     assert loss_keys, f"no train/loss* key in metric_dict: {sorted(metric_dict)}"
@@ -525,26 +540,29 @@ def test_train_surge_lance(cfg_surge_xt_lance: DictConfig, experiment_name: str)
 
 @pytest.mark.fake_vst
 @pytest.mark.parametrize("experiment_name", _SURGE_SMOKE_EXPERIMENTS, indirect=True)
-def test_train_eval_surge_lance(
+@pytest.mark.parametrize("surge_smoke_variant", FAKE_VST_VARIANTS, indirect=True)
+def test_train_eval_surge_fake(
     tmp_path: Path,
-    cfg_surge_xt_lance: DictConfig,
-    cfg_surge_xt_lance_eval: DictConfig,
+    cfg_surge_fake_train: DictConfig,
+    cfg_surge_fake_eval: DictConfig,
+    surge_smoke_variant: _SurgeSmokeVariant,
     monkeypatch: pytest.MonkeyPatch,
     experiment_name: str,
 ) -> None:
-    """Train on Lance splits, then verify prediction tensors from checkpoint eval.
+    """Train on a fake-plugin arm, then verify prediction tensors from checkpoint eval.
 
     :param tmp_path: The temporary logging path.
-    :param cfg_surge_xt_lance: CPU training config using ``datamodule=surge_lance``.
-    :param cfg_surge_xt_lance_eval: Matching eval config pinned to ``last.ckpt``.
+    :param cfg_surge_fake_train: CPU training config for the dataset-format arm under test.
+    :param cfg_surge_fake_eval: Matching eval config pinned to ``last.ckpt``.
+    :param surge_smoke_variant: Dataset-format arm (h5 or Lance) under test.
     :param monkeypatch: Stubs render/metrics subprocesses so no real VST host launches.
     :param experiment_name: Hydra experiment override the cfg was built from.
     """
-    metric_dict, object_dict = _evaluate_surge_lance_checkpoint(
-        cfg_surge_xt_lance, cfg_surge_xt_lance_eval, monkeypatch
+    metric_dict, object_dict = _evaluate_surge_fake_checkpoint(
+        cfg_surge_fake_train, cfg_surge_fake_eval, monkeypatch
     )
 
-    _assert_surge_lance_eval_basics(metric_dict, object_dict)
+    _assert_surge_fake_eval_basics(metric_dict, object_dict, surge_smoke_variant)
 
     predictions_dir = tmp_path / "predictions"
     assert predictions_dir.is_dir()
@@ -565,26 +583,29 @@ def test_train_eval_surge_lance(
 
 @pytest.mark.fake_vst
 @pytest.mark.parametrize("experiment_name", _SURGE_SMOKE_EXPERIMENTS, indirect=True)
-def test_train_eval_surge_lance_writes_audio_and_metrics_outputs(
+@pytest.mark.parametrize("surge_smoke_variant", FAKE_VST_VARIANTS, indirect=True)
+def test_train_eval_surge_fake_writes_audio_and_metrics_outputs(
     tmp_path: Path,
-    cfg_surge_xt_lance: DictConfig,
-    cfg_surge_xt_lance_eval: DictConfig,
+    cfg_surge_fake_train: DictConfig,
+    cfg_surge_fake_eval: DictConfig,
+    surge_smoke_variant: _SurgeSmokeVariant,
     monkeypatch: pytest.MonkeyPatch,
     experiment_name: str,
 ) -> None:
-    """Train on Lance splits, then verify fake render and metrics outputs.
+    """Train on a fake-plugin arm, then verify fake render and metrics outputs.
 
     :param tmp_path: The temporary logging path.
-    :param cfg_surge_xt_lance: CPU training config using ``datamodule=surge_lance``.
-    :param cfg_surge_xt_lance_eval: Matching eval config pinned to ``last.ckpt``.
+    :param cfg_surge_fake_train: CPU training config for the dataset-format arm under test.
+    :param cfg_surge_fake_eval: Matching eval config pinned to ``last.ckpt``.
+    :param surge_smoke_variant: Dataset-format arm (h5 or Lance) under test.
     :param monkeypatch: Stubs render/metrics subprocesses so no real VST host launches.
     :param experiment_name: Hydra experiment override; parametrizes the train/eval run.
     """
-    metric_dict, object_dict = _evaluate_surge_lance_checkpoint(
-        cfg_surge_xt_lance, cfg_surge_xt_lance_eval, monkeypatch
+    metric_dict, object_dict = _evaluate_surge_fake_checkpoint(
+        cfg_surge_fake_train, cfg_surge_fake_eval, monkeypatch
     )
 
-    _assert_surge_lance_eval_basics(metric_dict, object_dict)
+    _assert_surge_fake_eval_basics(metric_dict, object_dict, surge_smoke_variant)
 
     audio_dir = tmp_path / "audio"
     sample_dirs = sorted(path for path in audio_dir.iterdir() if path.is_dir())
@@ -609,42 +630,44 @@ def test_train_eval_surge_lance_writes_audio_and_metrics_outputs(
         assert np.isfinite(numeric).all(), f"{metrics_file} contains NaN/Inf:\n{metrics_df}"
 
 
-def _evaluate_surge_lance_checkpoint(
-    cfg_surge_xt_lance: DictConfig,
-    cfg_surge_xt_lance_eval: DictConfig,
+def _evaluate_surge_fake_checkpoint(
+    cfg_train: DictConfig,
+    cfg_eval: DictConfig,
     monkeypatch: pytest.MonkeyPatch,
 ) -> tuple[dict[str, object], dict[str, object]]:
-    """Run the Lance train-to-predict smoke path with faked postprocessing.
+    """Run the fake-plugin train-to-predict smoke path with faked postprocessing.
 
-    :param cfg_surge_xt_lance: CPU training config using ``datamodule=surge_lance``.
-    :param cfg_surge_xt_lance_eval: Matching eval config pinned to ``last.ckpt``.
+    :param cfg_train: CPU training config for the dataset-format arm under test.
+    :param cfg_eval: Matching eval config pinned to ``last.ckpt``.
     :param monkeypatch: Stubs postprocessing subprocess dependencies.
     :returns: ``evaluate`` metric and object dictionaries.
     """
-    HydraConfig().set_config(cfg_surge_xt_lance)
-    train(cfg_surge_xt_lance)
+    HydraConfig().set_config(cfg_train)
+    train(cfg_train)
 
-    assert Path(cfg_surge_xt_lance_eval.ckpt_path).exists()
+    assert Path(cfg_eval.ckpt_path).exists()
 
-    monkeypatch.setattr("synth_setter.cli.eval.subprocess.run", _lance_eval_postprocessing_fake())
+    monkeypatch.setattr("synth_setter.cli.eval.subprocess.run", _smoke_eval_postprocessing_fake())
     monkeypatch.setattr("synth_setter.cli.eval.vst_headless_wrapper", lambda: object())
     monkeypatch.setattr(
         "synth_setter.cli.eval.as_file",
         lambda _traversable: nullcontext(Path("/fake/headless-wrapper")),
     )
 
-    HydraConfig().set_config(cfg_surge_xt_lance_eval)
-    return evaluate(cfg_surge_xt_lance_eval)
+    HydraConfig().set_config(cfg_eval)
+    return evaluate(cfg_eval)
 
 
-def _assert_surge_lance_eval_basics(
+def _assert_surge_fake_eval_basics(
     metric_dict: dict[str, object],
     object_dict: dict[str, object],
+    variant: _SurgeSmokeVariant,
 ) -> None:
-    """Assert the shared Lance predict-mode eval invariants.
+    """Assert the shared fake-plugin predict-mode eval invariants.
 
     :param metric_dict: Metrics returned by ``evaluate``.
     :param object_dict: Objects returned by ``evaluate``.
+    :param variant: Dataset-format arm selecting the predicted split's suffix.
     """
     assert metric_dict["audio/mss_mean"] == pytest.approx(0.5)
     assert metric_dict["audio/rms_std"] == pytest.approx(0.01)
@@ -652,8 +675,8 @@ def _assert_surge_lance_eval_basics(
     dataset_root = getattr(object_dict["datamodule"], "dataset_root")
     assert isinstance(dataset_root, str | os.PathLike)
 
-    test_split = Path(dataset_root) / "test.lance"
-    assert test_split.is_dir()
+    test_split = Path(dataset_root) / f"test{variant.split_ext}"
+    assert test_split.exists()
 
 
 def _prediction_file_names() -> list[str]:


### PR DESCRIPTION
## Summary

- add Lance counterparts for the Surge smoke train and train->predict fixtures
- run the Surge smoke experiment matrix over `datamodule=surge_lance`
- parametrize fast eval entrypoint coverage across H5 and Lance datasets

## Validation

- `pre-commit run --files tests/conftest.py tests/test_eval.py tests/test_train.py`
- `uv run pytest tests/test_train.py::test_train_surge_lance tests/test_train.py::test_train_eval_surge_lance tests/test_eval.py::test_evaluate_predict_mode_merges_audio_metrics_into_metric_dict tests/test_eval.py::test_evaluate_predict_mode_logs_per_sample_metrics_table_to_wandb tests/test_eval.py::test_evaluate_predict_mode_logs_shuffle_permutation_table_to_wandb tests/test_eval.py::test_evaluate_validate_mode_legacy_val_spelling_runs_oracle tests/test_eval.py::test_evaluate_predict_mode_includes_shuffled_audio_metrics_when_subprocess_writes_shuffled_csv tests/test_eval.py::test_evaluate_validate_mode_lance_datamodule_runs_oracle -q`
- `/repo-review-full-no-comments`: PASS, 0 BLOCK / 0 WARN

Fixes #1719
