### PR TITLE
internal-fix(codex): project Claude skills before doctor checks

### DIFF
--- a/scripts/dev/codex-doctor.sh
+++ b/scripts/dev/codex-doctor.sh
@@ -12,6 +12,8 @@ main() {
   # shellcheck disable=SC1091
   source "$repo_root/agent/hooks/_lib.sh"
 
+  "$repo_root/scripts/dev/link-skills.sh"
+
   if command -v codex >/dev/null 2>&1; then
     printf 'OK: codex CLI found\n'
   else

--- a/scripts/dev/link-skills.sh
+++ b/scripts/dev/link-skills.sh
@@ -1,25 +1,29 @@
 #!/usr/bin/env bash
-# Project the installed tinaudio/skills marketplace into ~/.agents/skills so
-# Agent-Skills-standard CLIs (Gemini, Antigravity) see the full pack. See #1561.
+# Project Claude Code's installed tinaudio/skills marketplace into
+# ~/.agents/skills so Agent-Skills-standard CLIs see the full pack. See #1561.
 set -euo pipefail
 shopt -s nullglob
 
-src="${HOME}/.claude/plugins/marketplaces/tinaudio-skills"
+marketplace="${HOME}/.claude/plugins/marketplaces/tinaudio-skills"
+codex_src="${marketplace}/codex/synth-setter-skills"
 dest="${HOME}/.agents/skills"
 
-if [[ ! -d "${src}" ]]; then
+if [[ ! -d "${marketplace}" ]]; then
   # The cache only exists once Claude has installed the plugin, so a fresh box
   # legitimately has nothing to project — skip rather than fail.
-  echo "link-skills: no skills marketplace at ${src} — install the tinaudio/skills plugin first; skipping." >&2
+  echo "link-skills: no skills marketplace at ${marketplace} — install the tinaudio/skills plugin first; skipping." >&2
   exit 0
 fi
 
 mkdir -p "${dest}"
 linked=0
-for skill_dir in "${src}"/*/; do
-  [[ -f "${skill_dir}SKILL.md" ]] || continue
-  ln -sfn "${skill_dir%/}" "${dest}/$(basename "${skill_dir}")"
-  linked=$((linked + 1))
+for src in "${marketplace}" "${codex_src}"; do
+  [[ -d "${src}" ]] || continue
+  for skill_dir in "${src}"/*/; do
+    [[ -f "${skill_dir}SKILL.md" ]] || continue
+    ln -sfn "${skill_dir%/}" "${dest}/$(basename "${skill_dir}")"
+    linked=$((linked + 1))
+  done
 done
 
-echo "link-skills: projected ${linked} skill(s) from ${src} into ${dest}."
+echo "link-skills: projected ${linked} skill link(s) from ${marketplace} into ${dest}."

--- a/tests/infra/test_codex_doctor.py
+++ b/tests/infra/test_codex_doctor.py
@@ -17,6 +17,7 @@ REQUIRED_PLUGIN_SKILLS = (
     "simplify",
     "tdd-implementation",
 )
+MARKETPLACE_CODEX_REL = ".claude/plugins/marketplaces/tinaudio-skills/codex/synth-setter-skills"
 
 
 def _write_fake_codex(bin_dir: Path) -> None:
@@ -37,6 +38,17 @@ def _write_user_skill(home: Path, name: str) -> None:
     :param name: Skill name.
     """
     skill_dir = home / ".agents" / "skills" / name
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
+
+
+def _write_claude_marketplace_skill(home: Path, name: str) -> None:
+    """Create a fake skill in Claude's installed marketplace Codex projection.
+
+    :param home: Isolated HOME root so the doctor cannot read the real cache.
+    :param name: Required skill identifier that ``codex-doctor`` must discover.
+    """
+    skill_dir = home / MARKETPLACE_CODEX_REL / name
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
 
@@ -80,6 +92,24 @@ def test_codex_doctor_with_required_plugin_skills_passes(tmp_path: Path) -> None
 
     assert result.returncode == 0, result.stdout + result.stderr
     assert "Codex setup looks ready." in result.stdout
+
+
+def test_codex_doctor_projects_claude_marketplace_before_checking(
+    tmp_path: Path,
+) -> None:
+    """Doctor self-heals from Claude's marketplace cache before skill checks.
+
+    :param tmp_path: Isolated filesystem root that starts without ``~/.agents`` links.
+    """
+    home = tmp_path / "home"
+    for skill in REQUIRED_PLUGIN_SKILLS:
+        _write_claude_marketplace_skill(home, skill)
+
+    result = _run_doctor(tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "Codex setup looks ready." in result.stdout
+    assert (home / ".agents" / "skills" / "code-health").is_symlink()
 
 
 def test_codex_doctor_missing_plugin_skills_prints_install_command(

--- a/tests/infra/test_link_skills.py
+++ b/tests/infra/test_link_skills.py
@@ -9,6 +9,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LINK_SKILLS = REPO_ROOT / "scripts" / "dev" / "link-skills.sh"
 MARKETPLACE_REL = ".claude/plugins/marketplaces/tinaudio-skills"
+CODEX_SKILLS_REL = f"{MARKETPLACE_REL}/codex/synth-setter-skills"
 
 
 def _write_marketplace_skill(home: Path, name: str) -> Path:
@@ -19,6 +20,19 @@ def _write_marketplace_skill(home: Path, name: str) -> Path:
     :returns: The created skill directory.
     """
     skill_dir = home / MARKETPLACE_REL / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
+    return skill_dir
+
+
+def _write_codex_marketplace_skill(home: Path, name: str) -> Path:
+    """Create a fake installed skill under the Claude cache's Codex projection.
+
+    :param home: Isolated HOME root so projection never reads the real cache.
+    :param name: Skill identifier expected to become a ``~/.agents`` link.
+    :returns: Directory that the projected link must resolve to.
+    """
+    skill_dir = home / CODEX_SKILLS_REL / name
     skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(f"---\nname: {name}\n---\n")
     return skill_dir
@@ -58,6 +72,56 @@ def test_link_skills_projects_marketplace_skills_into_agents_skills(tmp_path: Pa
         link = dest / name
         assert link.is_symlink()
         assert link.resolve() == source.resolve()
+
+
+def test_link_skills_projects_claude_codex_skill_projection(tmp_path: Path) -> None:
+    """The Claude marketplace's Codex skill path is projected into ``~/.agents``.
+
+    :param tmp_path: Temporary test root.
+    """
+    home = tmp_path / "home"
+    simplify = _write_codex_marketplace_skill(home, "simplify")
+
+    result = _run_link_skills(home)
+
+    assert result.returncode == 0, result.stderr
+    link = home / ".agents" / "skills" / "simplify"
+    assert link.is_symlink()
+    assert link.resolve() == simplify.resolve()
+
+
+def test_link_skills_falls_back_when_codex_projection_is_empty(tmp_path: Path) -> None:
+    """An empty Codex projection does not mask top-level marketplace skills.
+
+    :param tmp_path: Isolated filesystem root for the fake marketplace cache.
+    """
+    home = tmp_path / "home"
+    code_health = _write_marketplace_skill(home, "code-health")
+    (home / CODEX_SKILLS_REL).mkdir(parents=True)
+
+    result = _run_link_skills(home)
+
+    assert result.returncode == 0, result.stderr
+    link = home / ".agents" / "skills" / "code-health"
+    assert link.is_symlink()
+    assert link.resolve() == code_health.resolve()
+
+
+def test_link_skills_projects_codex_and_top_level_only_skills(tmp_path: Path) -> None:
+    """Mixed marketplace layouts project both Codex and top-level-only skills.
+
+    :param tmp_path: Isolated filesystem root for the fake mixed-layout cache.
+    """
+    home = tmp_path / "home"
+    codex_skill = _write_codex_marketplace_skill(home, "code-health")
+    top_level_only = _write_marketplace_skill(home, "wiki-content")
+
+    result = _run_link_skills(home)
+
+    assert result.returncode == 0, result.stderr
+    dest = home / ".agents" / "skills"
+    assert (dest / "code-health").resolve() == codex_skill.resolve()
+    assert (dest / "wiki-content").resolve() == top_level_only.resolve()
 
 
 def test_link_skills_skips_marketplace_dirs_without_a_skill_file(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- project Claude Code's installed tinaudio skills into `~/.agents/skills` before `codex-doctor` checks discoverability
- merge top-level marketplace skills with the Codex symlink projection so top-level-only skills are not dropped
- add regression coverage for Codex projection, empty projection fallback, mixed-layout projection, and doctor self-healing

## Root Cause

`make codex-doctor` checked `has_skill` before projecting the already-installed Claude marketplace cache into `~/.agents/skills`. The fallback instruction also pointed at `codex plugin marketplace add tinaudio/skills`, but that GitHub repository is not accessible from this environment.

## Validation

- `uv run pytest tests/infra/test_link_skills.py tests/infra/test_codex_doctor.py -q`
- `uv run pre-commit run --files scripts/dev/codex-doctor.sh scripts/dev/link-skills.sh tests/infra/test_codex_doctor.py tests/infra/test_link_skills.py`
- `make codex-doctor`
- `/repo-review-full-no-comments`: PASS, 0 BLOCK / 0 WARN (`.agent-reviews/repo-review-full-no-comments.fc5e72d865908d93328156d5d504f2e42b21d0f5.md`)

Refs #1561