### PR TITLE
internal-fix(review): post WARN as unresolved inline threads

### DIFF
--- a/agent/skills/_shared/repo-review-full-analysis.md
+++ b/agent/skills/_shared/repo-review-full-analysis.md
@@ -134,12 +134,9 @@ Aim each agent at a 1500-word ceiling so reports stay scannable. The orchestrato
 
 ## Step 5: Aggregate findings
 
-Once every parallel agent returns, parse each report's BLOCK and WARN findings. **BLOCK and WARN are routed differently** so a flood of low-severity WARNs can't bury the BLOCKs:
+Once every parallel agent returns, parse each report's BLOCK and WARN findings. **Both severities become entries in the `findings` JSON array** (Step 6) — each posts as its own inline unresolved thread. Posting WARNs inline (rather than collapsing them into a body bullet list) is deliberate: a bullet inside a long review body is easy to scroll past, while an unresolved inline thread forces an explicit reply or resolution before the PR ships. The severity tag on the comment body lets reviewers filter or batch-resolve, and `post_review.py` already keeps every thread unresolved.
 
-- **BLOCK findings** become entries in the `findings` JSON array (Step 6) — each posts as its own inline unresolved thread.
-- **WARN findings** are *not* added to `findings`. They collapse into a single `## Advisory (WARN) findings` section appended to `review_body` (Step 6), one bullet each. This keeps the inline-thread list short enough that BLOCKs stay visible.
-
-Prefix each finding body (BLOCK comment or WARN bullet) with the `[<skill>:<severity>]` scheme so reviewers can see which checklist surfaced it — using the short-tag form from the table below (`[<short-tag>:block]` / `[<short-tag>:warn]`), not the full skill name.
+Prefix each finding body with the `[<skill>:<severity>]` scheme so reviewers can see which checklist surfaced it — using the short-tag form from the table below (`[<short-tag>:block]` / `[<short-tag>:warn]`), not the full skill name.
 
 Severity → severity tag:
 
@@ -162,48 +159,43 @@ Skill → tag (short form for comment body):
 | `ml-test`                        | `ml-test`         |
 | `lance-review`                   | `lance`           |
 
-A BLOCK finding becomes one entry in the `findings` array:
+Each finding (BLOCK or WARN) becomes one entry in the `findings` array, with `<severity>` set to `block` or `warn`:
 
 ```json
 {
   "path": "<path>",
   "line": <line>,
-  "body": "**[<short-tag>:block]** <description>"
+  "body": "**[<short-tag>:<severity>]** <description>"
 }
 ```
 
-A WARN finding becomes one bullet in the `## Advisory (WARN) findings` section of `review_body` (built in Step 6), grouped by skill then by `path:line`:
+The shape is identical for both severities — only the tag changes. `post_review.py` anchors the entry, posts it as an inline review comment on the GitHub review, and leaves the thread unresolved.
 
-```
-- **[<short-tag>:warn]** <path>:<line> — <description>
-```
-
-Do NOT dedupe BLOCKs across skills (e.g. shell-style and synth-setter-project-standards both flagging a `[ ]` vs `[[ ]]` issue) — keep each BLOCK's signal independent, as its own inline thread.
-
-**Dedupe WARNs only.** WARNs are collapsed into one advisory list, so near-duplicates are pure noise there. If the same `path:line` plus a near-identical description is flagged by multiple skills, keep one bullet and append `(also: <other-tags>)` listing the other skills' short tags. For example, if both `shell-style` and `synth-setter` flag the same `[ ]` vs `[[ ]]` at `scripts/run.sh:42`, emit a single bullet `- **[shell-style:warn]** scripts/run.sh:42 — Use [[ ]] for the test (also: synth-setter)`. This dedupe applies to WARNs only; never collapse BLOCKs.
+Do NOT dedupe findings across skills (e.g. `shell-style` and `synth-setter-project-standards` both flagging the same `[ ]` vs `[[ ]]` issue at `scripts/run.sh:42`) — keep each finding's signal independent, as its own inline thread. Two short threads from two checklists tell the reviewer more than one merged thread that hides which checklist surfaced it; the cost of a near-duplicate inline comment is much smaller than the cost of misattributing a finding.
 
 ## Step 6: Build the findings JSON
 
-Same shape `post_review.py` consumes. The `findings` array holds **only BLOCK findings** (from Step 5) plus, indirectly, the PR-health BLOCKs folded into `review_body` below. **WARN findings do not appear in `findings`** — they live in the `## Advisory (WARN) findings` section of `review_body`.
+Same shape `post_review.py` consumes. The `findings` array holds **every BLOCK and every WARN** from Step 5; the PR-health BLOCKs from Step 2 are folded into `review_body` separately because they aren't anchored to diff lines.
 
-`review_body` carries up to two appended sections, in this order: `## PR health` (Step 2 BLOCKs), then `## Advisory (WARN) findings` (the collapsed WARNs from Step 5). Omit either section if it would be empty.
+`review_body` carries one optional appended section, `## PR health` (Step 2 BLOCKs). Omit it if Step 2 produced nothing.
 
 **Fold the Step 2 PR-health BLOCKs into `review_body`** (they aren't anchored to diff lines, so they can't be inline comments). Prepend a `## PR health` section listing every PR-health BLOCK; if Step 2 produced nothing, omit the section entirely.
 
 Transform each Step 2 BLOCK line into one bullet under `## PR health`: strip the `BLOCK: <PR> — ` prefix and prepend `- **[<calling-skill>:block]** `, leaving the `[pr-health] …` body unchanged. Substitute `<calling-skill>` with the calling skill's name (`repo-review-full` or `repo-review-full-no-comments`). For example, `BLOCK: 897 — [pr-health] Failing check: ci/test (FAILURE) — https://…` becomes `- **[repo-review-full:block]** [pr-health] Failing check: ci/test (FAILURE) — https://…` when called from `repo-review-full`.
 
-**Append the collapsed WARNs under `## Advisory (WARN) findings`.** Emit one bullet per (deduped) WARN from Step 5, grouped by skill then by `path:line`, using the `- **[<short-tag>:warn]** <path>:<line> — <description>` shape. If Step 5 produced no WARNs, omit the section entirely.
-
 ```json
 {
   "pr_number": <N>,
   "repo": "<owner>/<repo>",
-  "review_body": "Multi-skill review of PR #<N> — <K> parallel passes (<list of skills>). Each BLOCK posted below as an individual unresolved thread; WARNs are collapsed into the `## Advisory (WARN) findings` section to keep the inline-thread list short. Findings on files outside the diff are anchored to the line in the diff that *causes* the staleness or rolled into the review body.\n\n## PR health\n\n- **[<calling-skill>:block]** [pr-health] Merge conflict with base branch (mergeStateStatus=DIRTY). Rebase or merge base before review.\n- **[<calling-skill>:block]** [pr-health] Failing check: ci/test (FAILURE) — https://github.com/.../runs/123\n\n## Advisory (WARN) findings\n\n- **[code-health:warn]** src/foo.py:42 — Function exceeds the length budget; consider extracting a helper.\n- **[comment-hygiene:warn]** src/foo.py:7 — Docstring restates the signature; tighten to the contract.",
-  "findings": [ ... ]
+  "review_body": "Multi-skill review of PR #<N> — <K> parallel passes (<list of skills>). Each finding below (BLOCK or WARN) is posted as an individual unresolved inline thread so it can't be scrolled past without an explicit reply or resolution. Findings on files outside the diff are anchored to the line in the diff that *causes* the staleness or rolled into the review body.\n\n## PR health\n\n- **[<calling-skill>:block]** [pr-health] Merge conflict with base branch (mergeStateStatus=DIRTY). Rebase or merge base before review.\n- **[<calling-skill>:block]** [pr-health] Failing check: ci/test (FAILURE) — https://github.com/.../runs/123",
+  "findings": [
+    {"path": "src/foo.py", "line": 42, "body": "**[code-health:warn]** Function exceeds the length budget; consider extracting a helper."},
+    {"path": "src/foo.py", "line": 7,  "body": "**[comment-hygiene:warn]** Docstring restates the signature; tighten to the contract."}
+  ]
 }
 ```
 
-The `findings` array now holds only BLOCK items (each posts as its own inline unresolved thread); WARNs live in `review_body`. The exact wording of `review_body` is up to the calling skill — `repo-review-full` writes the "each BLOCK posted below as an individual unresolved thread" phrasing; `repo-review-full-no-comments` writes a variant that says nothing was posted. Both reuse the `## PR health` and `## Advisory (WARN) findings` section formats.
+The `findings` array carries every BLOCK and every WARN (each posts as its own inline unresolved thread). The exact wording of `review_body` is up to the calling skill — `repo-review-full` writes the "each finding posted below as an individual unresolved inline thread" phrasing; `repo-review-full-no-comments` writes a variant that says nothing was posted. Both reuse the same `## PR health` section format.
 
 When the calling skill submits via `post_review.py` (i.e. `repo-review-full`), add a top-level `"event"`: `REQUEST_CHANGES` if any finding is a BLOCK (any `[*:block]`, including the folded PR-health BLOCKs), else `COMMENT` if any WARN exists, else `APPROVE`. `repo-review-full-no-comments` renders to chat and never posts, so it omits `"event"`.
 
@@ -219,7 +211,7 @@ Return to your orchestrator brief's Step 7 for the final delivery step.
 
 ## Notes
 
-- Collapsing WARNs into a single advisory section (instead of one inline thread each) is intentional signal-preservation: posting every finding as its own thread trains reviewers to ignore the whole list, which buries the rare BLOCK that actually gates the merge.
+- WARN findings are posted inline (as their own unresolved threads) rather than collapsed into a body bullet list. The earlier collapse design optimized for keeping BLOCKs visible, but in practice body bullets were silently ignored — every review converged on `event=COMMENT` with zero inline threads, and the WARNs never got addressed. The inline form forces an explicit reply or resolution before merge under "Conversations must be resolved" branch protection, and the `[<short-tag>:<severity>]` prefix lets reviewers filter or batch-resolve.
 - This pipeline depends on the `tinaudio-synth-setter-skills` plugin being enabled. If a sub-skill invocation fails, surface the error — don't silently skip. Falling back to `repo-review` (MVP) is the user's call, not the skill's.
 - The structure is three-level and intentional: the main agent spawns one orchestrator agent (you), which fans out one *general-purpose* review sub-agent per skill; each review sub-agent invokes its plugin skill via the Skill tool. The orchestration is your contribution; each plugin skill's authoritative checklist is the source of truth for its domain.
 - For the concrete invocation pattern (parallel Agent tool calls in a single message, expected per-agent prompt shape), see the example trace recorded in PR #777's review history — that's the workflow this pipeline packages.


### PR DESCRIPTION
## Summary

- Removes the WARN-collapse path from the `repo-review-full` shared analysis pipeline so every BLOCK **and** every WARN is routed through the `findings` JSON array and posts as its own unresolved inline review comment, instead of being collapsed into a `## Advisory (WARN) findings` bullet list inside the review body. PR-health BLOCKs still fold into `review_body` because they aren't anchored to diff lines.
- `post_review.py` already leaves every thread unresolved, so under "Conversations must be resolved" branch protection a WARN now forces an explicit reply or resolution before the PR can merge. The `[<short-tag>:<severity>]` body prefix lets reviewers filter or batch-resolve.
- Triggering evidence: of the four most recent `/repo-review-full` reviews, both that posted (PR #1720, PR #1713) submitted `event=COMMENT` with **zero inline threads** — every finding lived in a collapsed body bullet that reviewers can scroll past without action.

## Why

`agent/skills/_shared/repo-review-full-analysis.md` previously sorted findings into two routes:

| Severity | Where it landed                                              | Could be ignored?                                                |
| -------- | ------------------------------------------------------------ | ---------------------------------------------------------------- |
| `BLOCK`  | `findings[]` → inline unresolved thread on the diff line     | Branch protection forces an explicit reply / resolution.         |
| `WARN`   | Bullet under `## Advisory (WARN) findings` in `review_body`  | Yes — body bullets don't create threads and are easy to scroll past. |

The collapse design optimized for keeping the rare BLOCK visible, but in practice WARN-only reviews (the common case) became zero-thread `COMMENT` reviews that the bot was never asked to follow up on. Posting WARNs inline restores symmetry: every finding earns a thread, and the severity tag carries the urgency.

Refs #1406 (this change replaces the collapse-WARN remedy that issue originally proposed; both share the goal of making review signal actionable, but inline-WARN-with-resolution-required beats body-bullet-collapse on observed reviewer behavior).

## Changes

`agent/skills/_shared/repo-review-full-analysis.md`:

- **Step 5** — replace the "BLOCK and WARN are routed differently" two-route framing with a single rule: both severities become `findings[]` entries; the `[<short-tag>:<severity>]` prefix carries the routing signal.
- **Step 5** — drop the WARN-only dedupe with `(also: <other-tags>)` cross-references; reviewers are better served by independent threads per skill.
- **Step 6** — remove the `## Advisory (WARN) findings` section from the `review_body` shape; `review_body` carries only the `## PR health` section.
- **Step 6** — update the sample JSON payload and the `review_body` lead-in text to match.
- **Notes** — rewrite the rationale bullet to explain why the inline-WARN form replaces the collapse design.

No code change to `post_review.py` is needed — its docstring already promises "every finding as an unresolved inline thread," which is now the contract.

## Test plan

- [ ] On a future `/repo-review-full` invocation with WARN-only findings, every WARN appears as its own inline review comment with the `[<short-tag>:warn]` prefix and no `## Advisory (WARN) findings` section appears in the review body.
- [ ] On a `/repo-review-full` invocation with both BLOCK and WARN findings, both severities post as inline threads; the review event remains `REQUEST_CHANGES`.
- [ ] `/repo-review-full-no-comments` still renders findings (BLOCK + WARN) in its "Inline findings (would be posted by `/repo-review-full`)" section. (The rendering instructions were not changed; only the JSON shape they consume.)
- [ ] `tests/claude_hooks/test_post_review_event.py` continues to pass — the event-derivation tests pin payload helpers directly and are independent of the routing change.
- [ ] `tests/claude_hooks/test_pre_pr_review_gate.py` continues to pass — sentinel parsing already counts `[*:warn]` / `[*:block]` tags in inline-findings entries regardless of which severities are present.