### PR TITLE
automation: keep the edit hook from deleting unused imports (F401)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,9 +42,11 @@ Architecture: [docs/architecture.md](docs/architecture.md).
   from R2, worker reports). Dataclasses for internal typed containers.
 - `structlog` in pipeline code; stdlib `logging` elsewhere.
 - All `rclone` operations use `--checksum`.
-- Add an import in the same edit as its first use, or add imports last —
-  ruff's `F401` autofix deletes an import that is momentarily unused if
-  `make format` runs before the using code lands, costing a re-add cycle.
+- Save-time tooling — the VS Code ruff LSP and the Claude edit hook
+  (`agent/hooks/edit-write.sh`) — won't auto-delete an unused import (`F401`),
+  so one typed an edit before its first use survives. CLI `ruff check --fix`,
+  `make format`, and pre-commit still strip genuinely-dead imports. CI enforces
+  `F401`, so none ever ship.
 - Run `make format` before committing. Pre-commit (ruff, ruff-format,
   pydoclint, prettier, mdformat, gitlint) is authoritative; suppressing
   rules to make CI green is forbidden — see

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,8 @@ Architecture: [docs/architecture.md](docs/architecture.md).
 - `structlog` in pipeline code; stdlib `logging` elsewhere.
 - All `rclone` operations use `--checksum`.
 - Save-time tooling — the VS Code ruff LSP and the Claude edit hook
-  (`agent/hooks/edit-write.sh`) — won't auto-delete an unused import (`F401`),
-  so one typed an edit before its first use survives. CLI `ruff check --fix`,
+  (`agent/hooks/edit-write.sh`) — won't auto-delete an unused import (`F401`)
+  written one edit before its first use. CLI `ruff check --fix`,
   `make format`, and pre-commit still strip genuinely-dead imports. CI enforces
   `F401`, so none ever ship.
 - Run `make format` before committing. Pre-commit (ruff, ruff-format,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,11 +42,6 @@ Architecture: [docs/architecture.md](docs/architecture.md).
   from R2, worker reports). Dataclasses for internal typed containers.
 - `structlog` in pipeline code; stdlib `logging` elsewhere.
 - All `rclone` operations use `--checksum`.
-- Save-time tooling — the VS Code ruff LSP and the Claude edit hook
-  (`agent/hooks/edit-write.sh`) — won't auto-delete an unused import (`F401`)
-  written one edit before its first use. CLI `ruff check --fix`,
-  `make format`, and pre-commit still strip genuinely-dead imports. CI enforces
-  `F401`, so none ever ship.
 - Run `make format` before committing. Pre-commit (ruff, ruff-format,
   pydoclint, prettier, mdformat, gitlint) is authoritative; suppressing
   rules to make CI green is forbidden — see

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,6 @@ Never run `make docker-*` or RunPod commands without asking — they spend money
 - Pydantic `BaseModel(strict=True)` at trust boundaries (config parsing, JSON from R2, worker reports); dataclasses for internal typed containers.
 - `structlog` in pipeline code; stdlib `logging` elsewhere.
 - All `rclone` operations use `--checksum`.
-- Save-time tooling — the VS Code ruff LSP and the Claude edit hook (`agent/hooks/edit-write.sh`) — won't auto-delete an unused import (`F401`) written one edit before its first use. CLI `ruff check --fix`, `make format`, and pre-commit still strip genuinely-dead imports. CI enforces `F401`, so none ever ship.
 
 </important>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Never run `make docker-*` or RunPod commands without asking — they spend money
 - Pydantic `BaseModel(strict=True)` at trust boundaries (config parsing, JSON from R2, worker reports); dataclasses for internal typed containers.
 - `structlog` in pipeline code; stdlib `logging` elsewhere.
 - All `rclone` operations use `--checksum`.
-- Add an import in the same edit as its first use, or add imports last — ruff's `F401` autofix deletes an import that is momentarily unused if `make format` runs before the using code lands, costing a re-add cycle.
+- Save-time tooling — the VS Code ruff LSP and the Claude edit hook (`agent/hooks/edit-write.sh`) — won't auto-delete an unused import (`F401`), so one typed an edit before its first use survives. CLI `ruff check --fix`, `make format`, and pre-commit still strip genuinely-dead imports. CI enforces `F401`, so none ever ship.
 
 </important>
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@ Never run `make docker-*` or RunPod commands without asking — they spend money
 - Pydantic `BaseModel(strict=True)` at trust boundaries (config parsing, JSON from R2, worker reports); dataclasses for internal typed containers.
 - `structlog` in pipeline code; stdlib `logging` elsewhere.
 - All `rclone` operations use `--checksum`.
-- Save-time tooling — the VS Code ruff LSP and the Claude edit hook (`agent/hooks/edit-write.sh`) — won't auto-delete an unused import (`F401`), so one typed an edit before its first use survives. CLI `ruff check --fix`, `make format`, and pre-commit still strip genuinely-dead imports. CI enforces `F401`, so none ever ship.
+- Save-time tooling — the VS Code ruff LSP and the Claude edit hook (`agent/hooks/edit-write.sh`) — won't auto-delete an unused import (`F401`) written one edit before its first use. CLI `ruff check --fix`, `make format`, and pre-commit still strip genuinely-dead imports. CI enforces `F401`, so none ever ship.
 
 </important>
 

--- a/agent/hooks/edit-write.sh
+++ b/agent/hooks/edit-write.sh
@@ -21,7 +21,9 @@ case "$MODE" in
   format)
     case "$FILE_PATH" in
       *.py)
-        ruff check --fix --quiet "$FILE_PATH" 2>/dev/null || true
+        # Guard mid-edit imports: an import often lands one tool call before its
+        # use, so the save-time fix must not delete it. CLI/pre-commit strip dead ones.
+        ruff check --fix --unfixable F401 --quiet "$FILE_PATH" 2>/dev/null || true
         ruff format --quiet "$FILE_PATH" 2>/dev/null || true
         ;;
       *.md)

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -762,22 +762,25 @@ PYEOF
 it "edit-write: test mode falls back to flat layout tests/test_<base>.py when mirror missing" T_edit_write_test_mode_falls_back_to_flat_layout
 
 T_edit_write_format_preserves_unused_import() {
-  # Regression: --unfixable F401 in format mode keeps an import typed before its
-  # first use. Plain --fix would delete it; the PATH guard avoids a vacuous pass.
-  command -v ruff >/dev/null 2>&1 \
-    || { echo "ruff not on PATH — cannot exercise the format hook"; return 1; }
+  # Regression: --unfixable F401 in format mode keeps an unused import written
+  # one edit before its first use. The `x=1` reformat is the executed-signal:
+  # `ruff format` rewrites it to `x = 1` regardless of lint config, so a no-op
+  # hook (missing jq/ruff, unparsed path) fails the reformat check instead of
+  # passing this vacuously.
   local scratch
   scratch=$(mktemp -d "$TEST_DIR/scratch-XXXX")
   local py="$scratch/probe.py"
-  printf 'import os\n\nprint("x")\n' > "${py}" \
+  printf 'import os\nx=1\n' > "${py}" \
     || { echo "could not write probe file"; rm -rf "$scratch"; return 1; }
   echo "{\"tool_input\":{\"file_path\":\"${py}\"}}" \
     | bash "$REPO_ROOT/agent/hooks/edit-write.sh" format >/dev/null 2>&1 || true
   [[ -f "${py}" ]] || { echo "probe file vanished — hook errored"; rm -rf "$scratch"; return 1; }
-  local import_present=no
-  grep -q '^import os$' "${py}" && import_present=yes
+  local out
+  out=$(cat "${py}")
   rm -rf "$scratch"
-  [[ "${import_present}" == yes ]] \
+  [[ "${out}" == *"x = 1"* ]] \
+    || { echo "hook did not reformat probe — jq/ruff missing or path unparsed; test would be vacuous: ${out}"; return 1; }
+  grep -q '^import os$' <<<"${out}" \
     || { echo "format mode deleted the unused import (F401 should be unfixable)"; return 1; }
 }
 it "edit-write: format mode keeps an unused import (F401 unfixable)" T_edit_write_format_preserves_unused_import

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -761,6 +761,27 @@ PYEOF
 }
 it "edit-write: test mode falls back to flat layout tests/test_<base>.py when mirror missing" T_edit_write_test_mode_falls_back_to_flat_layout
 
+T_edit_write_format_preserves_unused_import() {
+  # Regression: --unfixable F401 in format mode keeps an import typed before its
+  # first use. Plain --fix would delete it; the PATH guard avoids a vacuous pass.
+  command -v ruff >/dev/null 2>&1 \
+    || { echo "ruff not on PATH — cannot exercise the format hook"; return 1; }
+  local scratch
+  scratch=$(mktemp -d "$TEST_DIR/scratch-XXXX")
+  local py="$scratch/probe.py"
+  printf 'import os\n\nprint("x")\n' > "${py}" \
+    || { echo "could not write probe file"; rm -rf "$scratch"; return 1; }
+  echo "{\"tool_input\":{\"file_path\":\"${py}\"}}" \
+    | bash "$REPO_ROOT/agent/hooks/edit-write.sh" format >/dev/null 2>&1 || true
+  [[ -f "${py}" ]] || { echo "probe file vanished — hook errored"; rm -rf "$scratch"; return 1; }
+  local import_present=no
+  grep -q '^import os$' "${py}" && import_present=yes
+  rm -rf "$scratch"
+  [[ "${import_present}" == yes ]] \
+    || { echo "format mode deleted the unused import (F401 should be unfixable)"; return 1; }
+}
+it "edit-write: format mode keeps an unused import (F401 unfixable)" T_edit_write_format_preserves_unused_import
+
 # ===========================================================================
 # verify-gh-taxonomy.sh — smoke tests for early-exit paths
 # (mode_pr / mode_issue / mode_hierarchy require full gh-API stubbing; those

--- a/agent/hooks/test.sh
+++ b/agent/hooks/test.sh
@@ -762,18 +762,17 @@ PYEOF
 it "edit-write: test mode falls back to flat layout tests/test_<base>.py when mirror missing" T_edit_write_test_mode_falls_back_to_flat_layout
 
 T_edit_write_format_preserves_unused_import() {
-  # Regression: --unfixable F401 in format mode keeps an unused import written
-  # one edit before its first use. The `x=1` reformat is the executed-signal:
-  # `ruff format` rewrites it to `x = 1` regardless of lint config, so a no-op
-  # hook (missing jq/ruff, unparsed path) fails the reformat check instead of
-  # passing this vacuously.
+  command -v jq >/dev/null 2>&1 \
+    || { echo "jq not on PATH — cannot parse the hook payload"; return 1; }
+  command -v ruff >/dev/null 2>&1 \
+    || { echo "ruff not on PATH — cannot exercise the format hook"; return 1; }
   local scratch
   scratch=$(mktemp -d "$TEST_DIR/scratch-XXXX")
   local py="$scratch/probe.py"
   printf 'import os\nx=1\n' > "${py}" \
     || { echo "could not write probe file"; rm -rf "$scratch"; return 1; }
   echo "{\"tool_input\":{\"file_path\":\"${py}\"}}" \
-    | bash "$REPO_ROOT/agent/hooks/edit-write.sh" format >/dev/null 2>&1 || true
+    | bash "$REPO_ROOT/agent/hooks/edit-write.sh" format >/dev/null 2>&1
   [[ -f "${py}" ]] || { echo "probe file vanished — hook errored"; rm -rf "$scratch"; return 1; }
   local out
   out=$(cat "${py}")


### PR DESCRIPTION
## What

The `PostToolUse` format hook (`agent/hooks/edit-write.sh`) ran `ruff check
--fix` after every Edit/Write. `--fix` applies the F401 (unused-import) autofix,
so an import added one tool call before the line that uses it was deleted out
from under the agent, forcing a re-add cycle. This passes `--unfixable F401` so
the save-time fix leaves unused imports in place.

## Scope of the behavior change

Only the save-time edit hook is affected:

- CLI `ruff check --fix`, `make format`, and the pre-commit `ruff` hook read
  `pyproject.toml` (no `unfixable`) and **still strip** unused imports.
- CI still enforces F401, so genuinely-dead imports never ship.
- `pyproject.toml` is intentionally unchanged.

Mirrors the editor-only override shipped for the VS Code ruff LSP in #1432,
completing the same fix for the Claude edit hook — which is the half #1432 left
to CLI behavior and the source of the agent-side churn.

## Tests

Adds a regression test in `agent/hooks/test.sh` that runs the hook over a probe
with an unused import and asserts it survives; it guards that `ruff` is on PATH
so it can't pass vacuously, and was mutation-checked (dropping the flag makes it
fail). Full hook suite: 94 passed.

Fixes #1431
