### PR TITLE
refactor(code-health): use Python 3.11 UTC and TimeoutError

### DIFF
--- a/src/synth_setter/pipeline/schemas/prefix.py
+++ b/src/synth_setter/pipeline/schemas/prefix.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import NewType
 
 from synth_setter.run_id import make_wandb_run_id
@@ -19,7 +19,7 @@ def _utc_now() -> datetime:
 
     :returns: A timezone-aware ``datetime`` in UTC.
     """
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 def make_dataset_wandb_run_id(

--- a/src/synth_setter/pipeline/subprocess_stream.py
+++ b/src/synth_setter/pipeline/subprocess_stream.py
@@ -181,7 +181,7 @@ async def check_call_streamed_async(
     try:
         try:
             returncode = await asyncio.wait_for(_wait_exit(proc), timeout=timeout)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             # wait_for(timeout=None) cannot time out, so timeout is a float here.
             timed_out_after = cast(float, timeout)
             _signal_group(pgid, signal.SIGTERM)
@@ -189,7 +189,7 @@ async def check_call_streamed_async(
                 returncode = await asyncio.wait_for(
                     _wait_exit(proc), timeout=_TERM_TO_KILL_GRACE_SECONDS
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 _LOG.warning(
                     "subprocess_term_to_kill_escalation",
                     cmd=cmd[0],
@@ -200,7 +200,7 @@ async def check_call_streamed_async(
 
         try:
             await asyncio.wait_for(pump_task, timeout=_POST_EXIT_DRAIN_SECONDS)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             # A pipe-holding survivor must not stall completion; abandon the tail.
             _LOG.warning(
                 "subprocess_output_drain_abandoned",

--- a/src/synth_setter/run_id.py
+++ b/src/synth_setter/run_id.py
@@ -6,7 +6,7 @@ pulling ``omegaconf``/``hydra`` (see ``test_bare_spec_import_does_not_pull_omega
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 
 def make_wandb_run_id(config_id: str, timestamp: datetime | None = None) -> str:
@@ -22,7 +22,7 @@ def make_wandb_run_id(config_id: str, timestamp: datetime | None = None) -> str:
     :raises ValueError: If ``timestamp`` is naive or not UTC.
     """
     if timestamp is None:
-        timestamp = datetime.now(timezone.utc)
+        timestamp = datetime.now(UTC)
     if timestamp.tzinfo is None:
         raise ValueError("timestamp must be timezone-aware (got naive datetime)")
     offset = timestamp.utcoffset()

--- a/tests/integration/test_parallel_shard_render_linux.py
+++ b/tests/integration/test_parallel_shard_render_linux.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 import os
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import h5py
@@ -130,7 +130,7 @@ def _build_real_surge_spec(
     kwargs: dict[str, object] = {
         "task_name": task_name,
         "run_id": run_id,
-        "created_at": datetime(2026, 5, 20, 0, 0, 0, tzinfo=timezone.utc),
+        "created_at": datetime(2026, 5, 20, 0, 0, 0, tzinfo=UTC),
         "git_sha": "0" * 40,
         "is_repo_dirty": False,
         "output_format": "hdf5",

--- a/tests/pipeline/ci_validate/test_validate_shard.py
+++ b/tests/pipeline/ci_validate/test_validate_shard.py
@@ -9,7 +9,7 @@ shard files it expects ``validate_all_shards_from_r2`` to download.
 from __future__ import annotations
 
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import h5py
@@ -50,7 +50,7 @@ def _create_shard(
 @pytest.fixture()
 def real_spec(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> DatasetSpec:
     """Build a real DatasetSpec with mocked git/timestamp factories."""
-    fixed_now = datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc)
+    fixed_now = datetime(2026, 3, 28, 12, 0, 0, tzinfo=UTC)
     monkeypatch.setattr("synth_setter.pipeline.schemas.spec._get_git_sha", lambda: "a" * 40)
     monkeypatch.setattr("synth_setter.pipeline.schemas.spec._is_repo_dirty", lambda: False)
     monkeypatch.setattr("synth_setter.pipeline.schemas.spec._utc_now", lambda: fixed_now)

--- a/tests/pipeline/ci_validate/test_validate_shard_inner_shapes.py
+++ b/tests/pipeline/ci_validate/test_validate_shard_inner_shapes.py
@@ -13,7 +13,7 @@ helpers get full sphinx-docstring coverage from day one.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import h5py
@@ -79,7 +79,7 @@ def real_spec(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> DatasetSpec:
         signal_duration_seconds match this module's ``_VALID_*`` constants.
     :rtype: DatasetSpec
     """
-    fixed_now = datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc)
+    fixed_now = datetime(2026, 3, 28, 12, 0, 0, tzinfo=UTC)
     monkeypatch.setattr("synth_setter.pipeline.schemas.spec._get_git_sha", lambda: "a" * 40)
     monkeypatch.setattr("synth_setter.pipeline.schemas.spec._is_repo_dirty", lambda: False)
     monkeypatch.setattr("synth_setter.pipeline.schemas.spec._utc_now", lambda: fixed_now)

--- a/tests/pipeline/ci_validate/test_validate_shard_tar.py
+++ b/tests/pipeline/ci_validate/test_validate_shard_tar.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import io
 import json
 import tarfile
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import h5py
@@ -59,7 +59,7 @@ def real_spec(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> DatasetSpec:
     :returns: Spec whose render fields match the ``_VALID_*`` constants in this module.
     :rtype: DatasetSpec
     """
-    fixed_now = datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc)
+    fixed_now = datetime(2026, 3, 28, 12, 0, 0, tzinfo=UTC)
     monkeypatch.setattr("synth_setter.pipeline.schemas.spec._get_git_sha", lambda: "a" * 40)
     monkeypatch.setattr("synth_setter.pipeline.schemas.spec._is_repo_dirty", lambda: False)
     monkeypatch.setattr("synth_setter.pipeline.schemas.spec._utc_now", lambda: fixed_now)

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -36,7 +36,7 @@ import subprocess
 import sys
 import threading
 from collections.abc import Iterator
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -98,7 +98,7 @@ def _base_spec_kwargs(tmp_path: Path, **overrides: object) -> dict[str, object]:
     kwargs: dict[str, object] = {
         "task_name": "test-dataset",
         "run_id": "test-dataset-20260328T120000000Z",
-        "created_at": datetime(2026, 3, 28, 12, 0, 0, tzinfo=timezone.utc),
+        "created_at": datetime(2026, 3, 28, 12, 0, 0, tzinfo=UTC),
         "git_sha": "a" * 40,
         "is_repo_dirty": False,
         "output_format": "hdf5",

--- a/tests/pipeline/schemas/test_prefix.py
+++ b/tests/pipeline/schemas/test_prefix.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pytest
@@ -15,7 +15,7 @@ from synth_setter.pipeline.schemas.prefix import (
     make_r2_prefix,
 )
 
-FIXED_NOW = datetime(2026, 6, 15, 12, 30, 45, tzinfo=timezone.utc)
+FIXED_NOW = datetime(2026, 6, 15, 12, 30, 45, tzinfo=UTC)
 
 
 class TestMakeDatasetWandbRunId:
@@ -23,20 +23,20 @@ class TestMakeDatasetWandbRunId:
 
     def test_make_run_id_fixed_timestamp_format(self):
         """Fixed UTC timestamp (microsecond=0) produces the expected run ID string."""
-        ts = datetime(2026, 3, 13, 10, 0, 0, tzinfo=timezone.utc)
+        ts = datetime(2026, 3, 13, 10, 0, 0, tzinfo=UTC)
         result = make_dataset_wandb_run_id(DatasetConfigId("surge-simple-480k-10k"), timestamp=ts)
         assert result == "surge-simple-480k-10k-20260313T100000000Z"
 
     def test_make_run_id_includes_millisecond_field(self):
         """A timestamp with microseconds produces a 3-digit millisecond suffix."""
-        ts = datetime(2026, 5, 3, 13, 36, 33, 456789, tzinfo=timezone.utc)
+        ts = datetime(2026, 5, 3, 13, 36, 33, 456789, tzinfo=UTC)
         result = make_dataset_wandb_run_id(DatasetConfigId("cfg"), timestamp=ts)
         assert result == "cfg-20260503T133633456Z"
 
     def test_make_run_id_milliseconds_disambiguate_within_same_second(self):
         """Two timestamps within the same wall-clock second produce different IDs."""
-        ts1 = datetime(2026, 3, 13, 10, 0, 0, 100_000, tzinfo=timezone.utc)
-        ts2 = datetime(2026, 3, 13, 10, 0, 0, 900_000, tzinfo=timezone.utc)
+        ts1 = datetime(2026, 3, 13, 10, 0, 0, 100_000, tzinfo=UTC)
+        ts2 = datetime(2026, 3, 13, 10, 0, 0, 900_000, tzinfo=UTC)
         id1 = make_dataset_wandb_run_id(DatasetConfigId("cfg"), timestamp=ts1)
         id2 = make_dataset_wandb_run_id(DatasetConfigId("cfg"), timestamp=ts2)
         assert id1 != id2
@@ -67,15 +67,15 @@ class TestMakeDatasetWandbRunId:
 
     def test_make_run_id_deterministic_same_inputs(self):
         """Same arguments produce the same result."""
-        ts = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        ts = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
         a = make_dataset_wandb_run_id(DatasetConfigId("cfg"), timestamp=ts)
         b = make_dataset_wandb_run_id(DatasetConfigId("cfg"), timestamp=ts)
         assert a == b
 
     def test_make_run_id_seconds_precision(self):
         """Timestamps one second apart produce different IDs."""
-        ts1 = datetime(2026, 3, 13, 10, 0, 0, tzinfo=timezone.utc)
-        ts2 = datetime(2026, 3, 13, 10, 0, 1, tzinfo=timezone.utc)
+        ts1 = datetime(2026, 3, 13, 10, 0, 0, tzinfo=UTC)
+        ts2 = datetime(2026, 3, 13, 10, 0, 1, tzinfo=UTC)
         id1 = make_dataset_wandb_run_id(DatasetConfigId("cfg"), timestamp=ts1)
         id2 = make_dataset_wandb_run_id(DatasetConfigId("cfg"), timestamp=ts2)
         assert id1 != id2

--- a/tests/pipeline/test_spec_io.py
+++ b/tests/pipeline/test_spec_io.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 import subprocess
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import patch
 
@@ -23,7 +23,7 @@ def _spec_kwargs() -> dict[str, object]:
     return {
         "task_name": "test-task",
         "run_id": "test-task-20260519T120000000Z",
-        "created_at": datetime(2026, 5, 19, 12, 0, 0, tzinfo=timezone.utc),
+        "created_at": datetime(2026, 5, 19, 12, 0, 0, tzinfo=UTC),
         "git_sha": "a" * 40,
         "is_repo_dirty": False,
         "output_format": "hdf5",

--- a/tests/test_run_id.py
+++ b/tests/test_run_id.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 
 import pytest
 
@@ -15,12 +15,12 @@ class TestMakeWandbRunId:
 
     def test_fixed_utc_timestamp_produces_expected_id(self) -> None:
         """A whole-second UTC timestamp yields ``<config_id>-YYYYMMDDTHHMMSS000Z``."""
-        ts = datetime(2026, 3, 13, 10, 0, 0, tzinfo=timezone.utc)
+        ts = datetime(2026, 3, 13, 10, 0, 0, tzinfo=UTC)
         assert make_wandb_run_id("flow_simple", timestamp=ts) == "flow_simple-20260313T100000000Z"
 
     def test_microseconds_render_as_three_digit_millis(self) -> None:
         """Sub-second precision is truncated to a 3-digit millisecond field."""
-        ts = datetime(2026, 5, 3, 13, 36, 33, 456789, tzinfo=timezone.utc)
+        ts = datetime(2026, 5, 3, 13, 36, 33, 456789, tzinfo=UTC)
         assert make_wandb_run_id("cfg", timestamp=ts) == "cfg-20260503T133633456Z"
 
     def test_naive_timestamp_raises(self) -> None:


### PR DESCRIPTION
## Summary

- replace `datetime.timezone.utc` with Python 3.11 `datetime.UTC` in run-id and dataset-prefix timestamp code
- replace `asyncio.TimeoutError` catches with the builtin `TimeoutError` alias in subprocess streaming
- update the tests that construct fixed UTC datetimes to use `datetime.UTC`

## Context

These behavior-preserving lint modernizations were accidentally swept into PR #1733 alongside unrelated agent-harness work. This PR isolates the Python 3.11 cleanup on its own branch so PR #1733 can stay focused on Antigravity skill projection.

Fixes #1728

## Validation

- `uv run ruff check src/synth_setter/pipeline/schemas/prefix.py src/synth_setter/pipeline/subprocess_stream.py src/synth_setter/run_id.py tests/integration/test_parallel_shard_render_linux.py tests/pipeline/ci_validate/test_validate_shard.py tests/pipeline/ci_validate/test_validate_shard_inner_shapes.py tests/pipeline/ci_validate/test_validate_shard_tar.py tests/pipeline/entrypoints/test_generate_dataset_unit.py tests/pipeline/schemas/test_prefix.py tests/pipeline/test_spec_io.py tests/test_run_id.py`
- `uv run ruff format --check src/synth_setter/pipeline/schemas/prefix.py src/synth_setter/pipeline/subprocess_stream.py src/synth_setter/run_id.py tests/integration/test_parallel_shard_render_linux.py tests/pipeline/ci_validate/test_validate_shard.py tests/pipeline/ci_validate/test_validate_shard_inner_shapes.py tests/pipeline/ci_validate/test_validate_shard_tar.py tests/pipeline/entrypoints/test_generate_dataset_unit.py tests/pipeline/schemas/test_prefix.py tests/pipeline/test_spec_io.py tests/test_run_id.py`
- `uv run pytest tests/pipeline/schemas/test_prefix.py tests/test_run_id.py tests/pipeline/ci_validate/test_validate_shard.py tests/pipeline/ci_validate/test_validate_shard_inner_shapes.py tests/pipeline/ci_validate/test_validate_shard_tar.py tests/pipeline/entrypoints/test_generate_dataset_unit.py tests/pipeline/test_spec_io.py -q`
- `uv run pytest tests/integration/test_parallel_shard_render_linux.py -q`

## Pre-PR review

- `.agent-reviews/repo-review-full-no-comments.db770f27d7ec0a508e55955ba60e5a41b3a29df3.md`
