### PR TITLE
refactor(data-pipeline): unify VST renderer command construction

### DIFF
--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -254,6 +254,25 @@ def build_generate_args(spec: DatasetSpec, shard: ShardSpec, output_dir: Path) -
     return args
 
 
+def _build_renderer_command(
+    spec: DatasetSpec, shard: ShardSpec, work_dir: Path, stack: ExitStack
+) -> list[str]:
+    """Build subprocess argv, materializing the Linux wrapper for stack lifetime.
+
+    :param spec: Dataset spec whose render config becomes CLI flags.
+    :param shard: Shard whose filename becomes the renderer's positional output.
+    :param work_dir: Directory joined with ``shard.filename`` for renderer output.
+    :param stack: Lifetime owner for package resources returned by ``as_file``.
+    :returns: Renderer argv, with the Linux headless wrapper prepended when needed.
+    """
+    args = build_generate_args(spec, shard, work_dir)
+    if sys.platform != "linux":
+        return args
+
+    wrapper_path = stack.enter_context(as_file(vst_headless_wrapper()))
+    return [str(wrapper_path), *args]
+
+
 def _validate_copy_source(spec: DatasetSpec) -> None:
     """Preflight a dataset-copy run against the source's persisted spec.
 
@@ -673,12 +692,7 @@ def _render_and_upload_shard(
     # ``as_file()`` is open; ``ExitStack`` keeps it on disk across the retry
     # loop, and skips materialization on non-Linux.
     with ExitStack() as stack:
-        if sys.platform == "linux":
-            wrapper_path = stack.enter_context(as_file(vst_headless_wrapper()))
-            args = [str(wrapper_path)]
-        else:
-            args = []
-        args += build_generate_args(spec, shard, work_dir)
+        args = _build_renderer_command(spec, shard, work_dir, stack)
         logger.info(f"rendering shard {shard.shard_id} -> {shard.filename}")
         max_attempts = spec.render.max_retries + 1
         for attempt in range(max_attempts):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig, open_dict
 
 from synth_setter.data.vst import core, param_specs, preset_paths
-from synth_setter.pipeline.schemas.spec import DatasetSpec, RenderConfig
+from synth_setter.pipeline.schemas.spec import DatasetSpec, RenderConfig, ShardSpec
 from synth_setter.resources import vst_headless_wrapper
 from synth_setter.utils.utils import register_resolvers
 from synth_setter.workspace import operator_workspace
@@ -669,26 +669,22 @@ def _render_smoke_train_h5_subprocess(train_h5: Path, param_spec_name: str) -> N
     :param param_spec_name: Key into :data:`synth_setter.data.vst.param_specs` and
         :data:`synth_setter.data.vst.preset_paths` selecting spec and preset.
     """
-    generate_dataset_args = []
-    if sys.platform == "linux":
-        generate_dataset_args.append(VST_HEADLESS_WRAPPER)
+    from synth_setter.cli.generate_dataset import build_generate_args
 
-    generate_dataset_args += [
-        sys.executable,
-        "src/synth_setter/data/vst/generate_vst_dataset.py",
-        str(train_h5),
-        f"--plugin_path={PLUGIN_PATH}",
-        f"--preset_path={preset_paths[param_spec_name]}",
-        f"--param_spec_name={param_spec_name}",
-        f"--renderer_version={_SURGE_FIXTURE_RENDERER_VERSION}",
-        f"--sample_rate={_SURGE_FIXTURE_SAMPLE_RATE}",
-        f"--channels={_SURGE_FIXTURE_CHANNELS}",
-        f"--velocity={_SURGE_FIXTURE_VELOCITY}",
-        f"--signal_duration_seconds={_SURGE_FIXTURE_DURATION_SECONDS}",
-        f"--min_loudness={_SURGE_FIXTURE_MIN_LOUDNESS}",
-        f"--samples_per_render_batch={NUM_FIXTURE_SAMPLES}",
-        f"--samples_per_shard={NUM_FIXTURE_SAMPLES}",
-    ]
+    spec = DatasetSpec(
+        task_name="surge-smoke-fixture",
+        git_sha="0" * 40,
+        is_repo_dirty=False,
+        output_format="hdf5",
+        train_val_test_sizes=(NUM_FIXTURE_SAMPLES, 0, 0),
+        base_seed=42,
+        r2={"bucket": "fixture-only"},  # type: ignore[arg-type]
+        render=_smoke_fake_render_cfg(param_spec_name),
+    )
+    shard = ShardSpec(shard_id=0, filename=train_h5.name, seed=spec.base_seed)
+    generate_dataset_args = build_generate_args(spec, shard, train_h5.parent)
+    if sys.platform == "linux":
+        generate_dataset_args = [VST_HEADLESS_WRAPPER, *generate_dataset_args]
 
     # capture_output=False (default): child inherits parent's stdout/stderr, no pipe is
     # created. Avoids the `capture_output=True` deadlock where fork-inherited fds in

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ from hydra.core.global_hydra import GlobalHydra
 from hydra.core.hydra_config import HydraConfig
 from omegaconf import DictConfig, open_dict
 
+from synth_setter.cli.generate_dataset import build_generate_args
 from synth_setter.data.vst import core, param_specs, preset_paths
 from synth_setter.pipeline.schemas.spec import DatasetSpec, RenderConfig, ShardSpec
 from synth_setter.resources import vst_headless_wrapper
@@ -669,8 +670,6 @@ def _render_smoke_train_h5_subprocess(train_h5: Path, param_spec_name: str) -> N
     :param param_spec_name: Key into :data:`synth_setter.data.vst.param_specs` and
         :data:`synth_setter.data.vst.preset_paths` selecting spec and preset.
     """
-    from synth_setter.cli.generate_dataset import build_generate_args
-
     spec = DatasetSpec(
         task_name="surge-smoke-fixture",
         git_sha="0" * 40,

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -67,6 +67,7 @@ from tests.helpers.render_subprocess import (
 from tests.helpers.subprocess_args import find_script_index
 
 VST_HEADLESS_WRAPPER = str(vst_headless_wrapper())
+VST_HEADLESS_WRAPPER_NAME = Path(VST_HEADLESS_WRAPPER).name
 
 # Reusable VST3 bundle with a real Contents/moduleinfo.json so
 # extract_renderer_version (called by generate) returns a deterministic version
@@ -393,7 +394,7 @@ class TestRun:
         assert len(renderer_calls) == 1
         args = renderer_calls[0]
         if sys.platform == "linux":
-            assert args[0] == VST_HEADLESS_WRAPPER
+            assert Path(args[0]).name == VST_HEADLESS_WRAPPER_NAME
             assert args[2] == "src/synth_setter/data/vst/generate_vst_dataset.py"
         else:
             assert VST_HEADLESS_WRAPPER not in args
@@ -1323,7 +1324,8 @@ class TestBuildRendererCommand:
         with ExitStack() as stack:
             args = _build_renderer_command(spec, spec.shards[0], tmp_path, stack)
 
-        assert args[0] == VST_HEADLESS_WRAPPER
+            assert Path(args[0]).name == VST_HEADLESS_WRAPPER_NAME
+            assert Path(args[0]).is_file()
         assert args[1:] == build_generate_args(spec, spec.shards[0], tmp_path)
 
     def test_non_linux_uses_generate_args_directly(

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -36,6 +36,7 @@ import subprocess
 import sys
 import threading
 from collections.abc import Iterator
+from contextlib import ExitStack
 from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
@@ -46,6 +47,7 @@ import numpy as np
 import pytest
 
 from synth_setter.cli.generate_dataset import (
+    _build_renderer_command,
     build_generate_args,
     generate,
 )
@@ -1302,6 +1304,43 @@ class TestBuildGenerateArgs:
 
         flag_idx = args.index("--copy_dataset_root_uri")
         assert args[flag_idx + 1] == "r2://bucket/source"
+
+
+class TestBuildRendererCommand:
+    """Renderer command construction composes environment policy around CLI args."""
+
+    def test_linux_prefixes_headless_wrapper_without_changing_generate_args(
+        self, spec: DatasetSpec, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Linux command wraps the renderer argv while ``build_generate_args`` stays pure.
+
+        :param spec: Source for the unwrapped renderer argv expected after the wrapper.
+        :param tmp_path: Output root used to compare wrapped and unwrapped commands.
+        :param monkeypatch: Forces the Linux-only wrapper branch.
+        """
+        monkeypatch.setattr("synth_setter.cli.generate_dataset.sys.platform", "linux")
+
+        with ExitStack() as stack:
+            args = _build_renderer_command(spec, spec.shards[0], tmp_path, stack)
+
+        assert args[0] == VST_HEADLESS_WRAPPER
+        assert args[1:] == build_generate_args(spec, spec.shards[0], tmp_path)
+
+    def test_non_linux_uses_generate_args_directly(
+        self, spec: DatasetSpec, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-Linux command is exactly the renderer CLI argv.
+
+        :param spec: Source for the canonical renderer argv.
+        :param tmp_path: Output root used for the expected renderer command.
+        :param monkeypatch: Forces the non-Linux branch.
+        """
+        monkeypatch.setattr("synth_setter.cli.generate_dataset.sys.platform", "darwin")
+
+        with ExitStack() as stack:
+            args = _build_renderer_command(spec, spec.shards[0], tmp_path, stack)
+
+        assert args == build_generate_args(spec, spec.shards[0], tmp_path)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test__conftest_cpu.py
+++ b/tests/test__conftest_cpu.py
@@ -2,12 +2,14 @@
 
 import io
 import os
+import subprocess
 from collections.abc import Callable
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from tests.conftest import _cgroup_aware_cpu_count
+from tests.conftest import _cgroup_aware_cpu_count, _render_smoke_train_h5_subprocess
 
 _V2_PATH = "/sys/fs/cgroup/cpu.max"
 _V1_QUOTA_PATH = "/sys/fs/cgroup/cpu/cpu.cfs_quota_us"
@@ -191,3 +193,27 @@ class TestCgroupAwareCpuCount:
 
         with patch("builtins.open", side_effect=_bad_all):
             assert _cgroup_aware_cpu_count() == 3
+
+
+def test_render_smoke_train_h5_subprocess_uses_render_config_flags(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The real-VST smoke subprocess reuses the shared RenderConfig arg mapping.
+
+    :param tmp_path: Output parent captured in the generated renderer argv.
+    :param monkeypatch: Replaces subprocess execution with a writer for the expected file.
+    """
+    train_h5 = tmp_path / "train.h5"
+    captured_args: list[str] = []
+
+    def _fake_run(args: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured_args.extend(args)
+        train_h5.touch()
+        return subprocess.CompletedProcess(args=args, returncode=0)
+
+    monkeypatch.setattr("tests.conftest.subprocess.run", _fake_run)
+
+    _render_smoke_train_h5_subprocess(train_h5, "surge_simple")
+
+    flag_idx = captured_args.index("--gui_toggle_cadence")
+    assert captured_args[flag_idx + 1] == "never"


### PR DESCRIPTION
## Summary

- centralize renderer subprocess command construction while keeping `build_generate_args()` wrapper-free
- reuse `build_generate_args()` for the real-VST smoke fixture argv instead of duplicating `RenderConfig` flags
- add focused coverage for Linux wrapper composition and smoke fixture arg parity

## Verification

- `uv run pre-commit run --files src/synth_setter/cli/generate_dataset.py tests/conftest.py tests/pipeline/entrypoints/test_generate_dataset_unit.py tests/test__conftest_cpu.py`
- `uv run pytest tests/pipeline/entrypoints/test_generate_dataset_unit.py tests/test__conftest_cpu.py -q`
- `make test-fast`

## Review note

Pre-PR dry-run review reported comment-hygiene warnings on pydoclint-required `:param:` docstrings. The docstrings were tightened to include constraints, and scoped hooks pass. PR creation uses `REVIEW_COMMENT_GATE=off` for that intentional lint-vs-comment-hygiene conflict.

Closes #1736
