### PR TITLE
internal-feat(data-pipeline): standalone #489 reuse-depth reproducer

### DIFF
--- a/src/synth_setter/tools/repro_489_reuse_depth.py
+++ b/src/synth_setter/tools/repro_489_reuse_depth.py
@@ -1,19 +1,16 @@
 """Standalone #489 reproducer: render one identical patch N times and score all-pairs MSS.
 
-Measures the bug at its source, bypassing the oracle/sweep harness that masks it.
 For each reuse depth N it renders the *same* patch N times against a single cached
 ``VST3Plugin`` (the ``plugin_reload_cadence="once"`` path) and reports the
 **all-pairs worst-case** multi-scale spectral loss across those N renders — the
-exact signal that defined #489 in the PR #706 reproducer. Identical params should
-render identically, so any worst pair above the threshold is render-to-render junk.
+signal that defined #489 in the PR #706 reproducer. Identical params should render
+identically, so any worst pair above the threshold is render-to-render junk.
 
 A control arm re-renders the same patch reloading the plugin per call (the #713
-workaround, now the default), so a run that prints reuse≫threshold while
-reload<threshold confirms the bug is still live and merely worked around.
-
-The harness sweeps (``synth_setter.tools.cadence_sweep_489``) could not surface
-this: they score target-vs-oracle-prediction *means*, never two raw renders of one
-patch against each other.
+workaround, now the default), so reuse>>threshold while reload<threshold pins the
+bug as live and merely worked around. The oracle/sweep harness scores
+target-vs-prediction means, so only a direct render-vs-render comparison like this
+can surface it.
 
 Run it::
 
@@ -24,14 +21,15 @@ Run it::
 from __future__ import annotations
 
 import argparse
+import logging
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from enum import StrEnum
 from itertools import combinations
-from typing import Any
+from typing import TYPE_CHECKING
 
 import numpy as np
-from loguru import logger
 from pyloudnorm import Meter
 
 from synth_setter.data.vst import param_specs, preset_paths
@@ -39,6 +37,12 @@ from synth_setter.data.vst.core import load_plugin, load_preset, render_params
 from synth_setter.data.vst.param_spec import NoteParams
 from synth_setter.data.vst.param_spec_registry import default_plugin_path
 from synth_setter.evaluation.compute_audio_metrics import compute_mss
+
+if TYPE_CHECKING:
+    from pedalboard import VST3Plugin
+    from wandb.sdk.wandb_run import Run
+
+logger = logging.getLogger(__name__)
 
 # Render settings mirror configs/render/surge_xt.yaml so the reproduction matches
 # the production render path the #489 datasets are generated with.
@@ -48,17 +52,60 @@ _VELOCITY = 100
 _DURATION_SECONDS = 4.0
 _MIN_LOUDNESS_DB = -55.0
 
-# PR #706 threshold: the per-pair MSS of identical params sits well under this; the
-# junk render pushed the worst pair to ~21, ~6x the clean per-pair value.
+# PR #706 threshold: identical-param renders sit well under this; the junk render
+# pushed the worst pair to ~21, ~6x the clean per-pair value.
 _MSS_THRESHOLD = 10.0
 _DEFAULT_DEPTHS = (12, 40)
 # Guards the loud-patch search from spinning forever on a silent param spec.
 _MAX_PATCH_DRAWS = 200
 
-# Verdict labels for ``classify``.
-BUG_PRESENT = "BUG_PRESENT"
-NO_REPRO = "NO_REPRO"
-INCONCLUSIVE = "INCONCLUSIVE"
+
+class Verdict(StrEnum):
+    """Outcome of one reuse depth's reuse-vs-reload comparison.
+
+    .. attribute :: BUG_PRESENT
+
+       Reuse arm above threshold while the reload control held — #489 live.
+
+    .. attribute :: NO_REPRO
+
+       Reuse arm within threshold — no junk at this depth.
+
+    .. attribute :: INCONCLUSIVE
+
+       Both arms above threshold — divergence is patch/phase, not reuse.
+    """
+
+    BUG_PRESENT = "BUG_PRESENT"
+    NO_REPRO = "NO_REPRO"
+    INCONCLUSIVE = "INCONCLUSIVE"
+
+
+@dataclass(frozen=True)
+class PatchSpec:
+    """One synth patch plus the plugin and preset that render it.
+
+    .. attribute :: plugin_path
+
+       VST3 bundle path.
+
+    .. attribute :: preset_path
+
+       Preset applied before each render.
+
+    .. attribute :: synth_params
+
+       Synth patch held identical across every render.
+
+    .. attribute :: note_params
+
+       ``pitch`` and ``note_start_and_end`` held identical across every render.
+    """
+
+    plugin_path: str
+    preset_path: str
+    synth_params: dict[str, float]
+    note_params: NoteParams
 
 
 @dataclass(frozen=True)
@@ -67,23 +114,23 @@ class ReuseDepthResult:
 
     .. attribute :: depth
 
-       Number of renders compared (the reuse depth).
+       Render count; equals ``len(renders)``.
 
     .. attribute :: mss_max
 
-       Worst-case multi-scale spectral loss over all unordered pairs.
+       Worst-case multi-scale spectral loss (dB) over all pairs.
 
     .. attribute :: worst_pair
 
-       ``(i, j)`` render indices that produced ``mss_max``.
+       ``(i, j)`` indices of the render pair scoring ``mss_max``.
 
     .. attribute :: pair_count
 
-       Number of unordered pairs scored, ``depth*(depth-1)/2``.
+       ``depth*(depth-1)/2``.
 
     .. attribute :: peaks
 
-       Per-render peak amplitude; a near-zero entry is a silent junk render.
+       Per-render peak amplitude; near-zero marks a silent junk render.
     """
 
     depth: int
@@ -94,20 +141,20 @@ class ReuseDepthResult:
 
 
 def all_pairs_worst_mss(
-    renders: list[np.ndarray],
+    renders: Sequence[np.ndarray],
     metric: Callable[[np.ndarray, np.ndarray], float] = compute_mss,
 ) -> ReuseDepthResult:
     """Score every unordered pair of renders and return the worst-case divergence.
 
     :param renders: Audio clips, each shape ``(C, T)``, all rendered from one patch.
     :param metric: Pairwise distance; defaults to :func:`compute_mss`.
-    :returns: The worst pair, its score, the pair count, and per-render peaks.
+    :returns: A :class:`ReuseDepthResult` for the ``len(renders)`` renders.
     :raises ValueError: Fewer than two renders — no pair to compare.
     """
     n = len(renders)
     if n < 2:
         raise ValueError(f"all-pairs scoring needs at least 2 renders, got {n}")
-    worst_score, worst_i, worst_j = -1.0, -1, -1
+    worst_score, worst_i, worst_j = float("-inf"), -1, -1
     for i, j in combinations(range(n), 2):
         score = metric(renders[i], renders[j])
         if score > worst_score:
@@ -122,18 +169,20 @@ def all_pairs_worst_mss(
     )
 
 
-def classify(reused_max: float, reloaded_max: float, threshold: float) -> str:
+def classify(reused_max: float, reloaded_max: float | None, threshold: float) -> Verdict:
     """Label a depth's outcome from its reuse and reload all-pairs worst scores.
 
     :param reused_max: Worst all-pairs MSS on the cached-plugin (reuse) arm.
-    :param reloaded_max: Worst all-pairs MSS on the per-render-reload control arm.
+    :param reloaded_max: Worst all-pairs MSS on the reload control arm, or ``None``
+        when the control arm was skipped.
     :param threshold: Score above which identical-patch renders count as junk.
-    :returns: ``BUG_PRESENT`` (reuse diverges, reload holds), ``INCONCLUSIVE``
-        (both diverge — patch/phase, not the reuse bug), or ``NO_REPRO``.
+    :returns: One of the :class:`Verdict` members.
     """
     if reused_max <= threshold:
-        return NO_REPRO
-    return INCONCLUSIVE if reloaded_max > threshold else BUG_PRESENT
+        return Verdict.NO_REPRO
+    if reloaded_max is not None and reloaded_max > threshold:
+        return Verdict.INCONCLUSIVE
+    return Verdict.BUG_PRESENT
 
 
 def _integrated_loudness(audio: np.ndarray) -> float:
@@ -145,21 +194,18 @@ def _integrated_loudness(audio: np.ndarray) -> float:
     return float(Meter(_SAMPLE_RATE).integrated_loudness(audio.T))
 
 
-def _sample_loud_patch(
-    spec_name: str, plugin_path: str, preset_path: str
-) -> tuple[dict[str, float], NoteParams]:
-    """Draw one patch that renders above ``_MIN_LOUDNESS_DB``, reused across all depths.
+def resolve_patch(spec_name: str) -> PatchSpec:
+    """Draw one patch that renders above ``_MIN_LOUDNESS_DB`` for the named spec.
 
     Renders each candidate once via the reload path (a fresh plugin) so the gate
-    decision is never itself contaminated by reuse-state. Reuses one patch for the
-    whole run so depths and arms are directly comparable.
+    decision is never itself contaminated by reuse-state.
 
     :param spec_name: Param-spec registry key (e.g. ``"surge_xt"``).
-    :param plugin_path: VST3 bundle path.
-    :param preset_path: Preset applied before each render.
-    :returns: The ``(synth_params, note_params)`` tuple of the first loud draw.
+    :returns: The first loud draw, bound to its plugin and preset.
     :raises RuntimeError: No draw cleared the gate within ``_MAX_PATCH_DRAWS``.
     """
+    plugin_path = default_plugin_path()
+    preset_path = preset_paths[spec_name]
     spec = param_specs[spec_name]
     for draw in range(_MAX_PATCH_DRAWS):
         synth_params, note_params = spec.sample()
@@ -176,96 +222,89 @@ def _sample_loud_patch(
         )
         loudness = _integrated_loudness(audio)
         if loudness >= _MIN_LOUDNESS_DB:
-            logger.info(f"loud patch found on draw {draw} ({loudness:.1f} LUFS)")
-            return synth_params, note_params
-        logger.debug(f"draw {draw}: {loudness:.1f} LUFS below gate, redrawing")
+            logger.info("loud patch found on draw %d (%.1f LUFS)", draw, loudness)
+            return PatchSpec(plugin_path, preset_path, synth_params, note_params)
+        logger.debug("draw %d: %.1f LUFS below gate, redrawing", draw, loudness)
     raise RuntimeError(
         f"no patch cleared {_MIN_LOUDNESS_DB} dB in {_MAX_PATCH_DRAWS} draws for {spec_name!r}"
     )
 
 
-def render_identical_patch(
-    plugin_path: str,
-    preset_path: str,
-    synth_params: dict[str, float],
-    note_params: NoteParams,
-    depth: int,
-    *,
-    reuse_plugin: bool,
+def _render_repeated(
+    patch: PatchSpec, depth: int, cached_plugin: VST3Plugin | None
 ) -> list[np.ndarray]:
-    """Render one patch ``depth`` times, either reusing one instance or reloading per call.
+    """Render ``patch`` ``depth`` times, reusing ``cached_plugin`` when supplied.
 
-    :param plugin_path: VST3 bundle path.
-    :param preset_path: Preset applied to the plugin.
-    :param synth_params: Synth patch held identical across every render.
-    :param note_params: Note params (``pitch``, ``note_start_and_end``) held identical.
+    :param patch: The identical patch and its plugin/preset.
     :param depth: Number of renders (the reuse depth).
-    :param reuse_plugin: When True, load + preset once and reuse the cached instance
-        (the ``plugin_reload_cadence="once"`` bug path); when False, reload per render
-        (the #713 workaround / current default).
+    :param cached_plugin: Reused instance, or ``None`` to reload per render.
     :returns: ``depth`` rendered clips, each shape ``(C, T)``.
     """
-    cached = None
-    if reuse_plugin:
-        cached = load_plugin(plugin_path)
-        load_preset(cached, preset_path)
     return [
         render_params(
-            plugin_path,
-            synth_params,
-            note_params["pitch"],
+            patch.plugin_path,
+            patch.synth_params,
+            patch.note_params["pitch"],
             _VELOCITY,
-            note_params["note_start_and_end"],
+            patch.note_params["note_start_and_end"],
             _DURATION_SECONDS,
             _SAMPLE_RATE,
             _CHANNELS,
-            preset_path=preset_path,
-            plugin=cached,
+            preset_path=patch.preset_path,
+            plugin=cached_plugin,
         )
         for _ in range(depth)
     ]
 
 
+def render_reusing_one_plugin(patch: PatchSpec, depth: int) -> list[np.ndarray]:
+    """Render ``patch`` ``depth`` times against one cached instance (the #489 bug path).
+
+    :param patch: The identical patch and its plugin/preset.
+    :param depth: Number of renders (the reuse depth).
+    :returns: ``depth`` rendered clips, each shape ``(C, T)``.
+    """
+    plugin = load_plugin(patch.plugin_path)
+    load_preset(plugin, patch.preset_path)
+    return _render_repeated(patch, depth, cached_plugin=plugin)
+
+
+def render_reloading_each_call(patch: PatchSpec, depth: int) -> list[np.ndarray]:
+    """Render ``patch`` ``depth`` times reloading per call (the #713 workaround / default).
+
+    :param patch: The identical patch and its plugin/preset.
+    :param depth: Number of renders (the reuse depth).
+    :returns: ``depth`` rendered clips, each shape ``(C, T)``.
+    """
+    return _render_repeated(patch, depth, cached_plugin=None)
+
+
 def run(
-    depths: tuple[int, ...],
+    depths: Sequence[int],
     *,
     spec_name: str,
     control: bool,
     wandb_enabled: bool,
-) -> dict[int, str]:
+) -> dict[int, Verdict]:
     """Reproduce #489 at each depth and report all-pairs worst MSS for reuse vs reload.
 
     :param depths: Reuse depths to probe, in order.
     :param spec_name: Param-spec registry key selecting synth + preset.
     :param control: Also render the per-render-reload control arm at each depth.
     :param wandb_enabled: Log per-depth all-pairs metrics to W&B.
-    :returns: Map of depth to its :data:`classify` verdict.
+    :returns: Map of depth to its :func:`classify` verdict.
     """
-    plugin_path = default_plugin_path()
-    preset_path = preset_paths[spec_name]
-    synth_params, note_params = _sample_loud_patch(spec_name, plugin_path, preset_path)
-
+    patch = resolve_patch(spec_name)
     wandb_run = _init_wandb(spec_name, depths) if wandb_enabled else None
-    verdicts: dict[int, str] = {}
+    verdicts: dict[int, Verdict] = {}
     for depth in depths:
-        reused = all_pairs_worst_mss(
-            render_identical_patch(
-                plugin_path, preset_path, synth_params, note_params, depth, reuse_plugin=True
-            )
-        )
-        reloaded_max = float("nan")
-        if control:
-            reloaded = all_pairs_worst_mss(
-                render_identical_patch(
-                    plugin_path, preset_path, synth_params, note_params, depth, reuse_plugin=False
-                )
-            )
-            reloaded_max = reloaded.mss_max
-        verdict = (
-            classify(reused.mss_max, reloaded_max, _MSS_THRESHOLD)
+        reused = all_pairs_worst_mss(render_reusing_one_plugin(patch, depth))
+        reloaded_max = (
+            all_pairs_worst_mss(render_reloading_each_call(patch, depth)).mss_max
             if control
-            else (BUG_PRESENT if reused.mss_max > _MSS_THRESHOLD else NO_REPRO)
+            else None
         )
+        verdict = classify(reused.mss_max, reloaded_max, _MSS_THRESHOLD)
         verdicts[depth] = verdict
         _report_depth(depth, reused, reloaded_max, verdict)
         if wandb_run is not None:
@@ -275,27 +314,34 @@ def run(
     return verdicts
 
 
-def _report_depth(depth: int, reused: ReuseDepthResult, reloaded_max: float, verdict: str) -> None:
-    """Print one depth's reuse/reload worst-pair scores, peaks, and verdict.
+def _report_depth(
+    depth: int, reused: ReuseDepthResult, reloaded_max: float | None, verdict: Verdict
+) -> None:
+    """Log one depth's reuse/reload worst-pair scores, peaks, and verdict.
 
     :param depth: Reuse depth being reported.
     :param reused: All-pairs result of the cached-plugin arm.
-    :param reloaded_max: Worst all-pairs MSS of the reload control (``nan`` when skipped).
+    :param reloaded_max: Worst all-pairs MSS of the reload control, or ``None`` if skipped.
     :param verdict: This depth's :func:`classify` label.
     """
+    reload_str = "    N/A" if reloaded_max is None else f"{reloaded_max:7.3f}"
     logger.info(
-        f"depth={depth:>3} | reuse worst mss={reused.mss_max:7.3f} @ {reused.worst_pair} "
-        f"| reload worst mss={reloaded_max:7.3f} | {verdict}"
+        "depth=%3d | reuse worst mss=%7.3f @ %s | reload worst mss=%s | %s",
+        depth,
+        reused.mss_max,
+        reused.worst_pair,
+        reload_str,
+        verdict,
     )
-    logger.info(f"depth={depth:>3} | reuse peaks={[round(p, 4) for p in reused.peaks]}")
+    logger.info("depth=%3d | reuse peaks=%s", depth, [round(p, 4) for p in reused.peaks])
 
 
-def _init_wandb(spec_name: str, depths: tuple[int, ...]) -> Any:
+def _init_wandb(spec_name: str, depths: Sequence[int]) -> Run:
     """Start a W&B run for the reproduction; import is local so non-W&B runs stay light.
 
-    :param spec_name: Param-spec registry key, logged to the run config.
-    :param depths: Reuse depths probed, logged to the run config.
-    :returns: The initialised ``wandb`` run handle.
+    :param spec_name: Param-spec registry key.
+    :param depths: Reuse depths probed.
+    :returns: The initialised W&B run handle.
     """
     import wandb
 
@@ -312,23 +358,23 @@ def _init_wandb(spec_name: str, depths: tuple[int, ...]) -> Any:
 
 
 def _log_depth_to_wandb(
-    wandb_run: Any, depth: int, reused: ReuseDepthResult, reloaded_max: float
+    wandb_run: Run, depth: int, reused: ReuseDepthResult, reloaded_max: float | None
 ) -> None:
-    """Log a depth's all-pairs worst MSS (reuse and reload) and min peak to W&B.
+    """Log a depth's all-pairs worst MSS (reuse, and reload when run) and min peak to W&B.
 
     :param wandb_run: Active W&B run handle from :func:`_init_wandb`.
     :param depth: Reuse depth being logged (the x-axis).
     :param reused: All-pairs result of the cached-plugin arm.
-    :param reloaded_max: Worst all-pairs MSS of the reload control (``nan`` when skipped).
+    :param reloaded_max: Worst all-pairs MSS of the reload control, or ``None`` if skipped.
     """
-    wandb_run.log(
-        {
-            "depth": depth,
-            "reuse-once/all-pairs-mss-max": reused.mss_max,
-            "reload-render/all-pairs-mss-max": reloaded_max,
-            "reuse-once/min-peak-amplitude": min(reused.peaks),
-        }
-    )
+    metrics: dict[str, float] = {
+        "depth": depth,
+        "reuse-once/all-pairs-mss-max": reused.mss_max,
+        "reuse-once/min-peak-amplitude": min(reused.peaks),
+    }
+    if reloaded_max is not None:
+        metrics["reload-render/all-pairs-mss-max"] = reloaded_max
+    wandb_run.log(metrics)
 
 
 def main(argv: list[str] | None = None) -> None:
@@ -355,15 +401,16 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--wandb", action="store_true", help="log per-depth metrics to W&B")
     args = parser.parse_args(argv)
 
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     verdicts = run(
-        tuple(args.depths),
+        args.depths,
         spec_name=args.spec,
         control=not args.no_control,
         wandb_enabled=args.wandb,
     )
-    if BUG_PRESENT in verdicts.values():
-        depths = [d for d, v in verdicts.items() if v == BUG_PRESENT]
-        logger.warning(f"#489 reproduced at depths {depths}: reuse junk, reload clean")
+    bug_depths = [depth for depth, verdict in verdicts.items() if verdict is Verdict.BUG_PRESENT]
+    if bug_depths:
+        logger.warning("#489 reproduced at depths %s: reuse junk, reload clean", bug_depths)
         sys.exit(1)
 
 

--- a/src/synth_setter/tools/repro_489_reuse_depth.py
+++ b/src/synth_setter/tools/repro_489_reuse_depth.py
@@ -53,7 +53,7 @@ _DEFAULT_DEPTHS = (12, 40)
 # Guards the loud-patch search from spinning forever on a silent param spec.
 _MAX_PATCH_DRAWS = 200
 _LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
-# configs/render/<spec>.yaml relative to this tools/ module.
+# Two parents climb tools/ -> synth_setter/ package root, then into configs/render/.
 _RENDER_CONFIG_DIR = Path(__file__).resolve().parent.parent / "configs" / "render"
 
 
@@ -203,7 +203,9 @@ def all_pairs_worst_mss(
     )
 
 
-def classify(reused_max: float, reloaded_max: float | None, threshold: float) -> Verdict:
+def classify(
+    reused_max: float, reloaded_max: float | None, threshold: float = _MSS_THRESHOLD
+) -> Verdict:
     """Label a depth's outcome from its reuse and reload all-pairs worst scores.
 
     :param reused_max: Worst all-pairs MSS on the cached-plugin (reuse) arm.
@@ -346,7 +348,7 @@ def run(
                 if control
                 else None
             )
-            verdict = classify(reused.mss_max, reloaded_max, _MSS_THRESHOLD)
+            verdict = classify(reused.mss_max, reloaded_max)
             verdicts[depth] = verdict
             _report_depth(depth, reused, reloaded_max, verdict)
             if wandb_run is not None:

--- a/src/synth_setter/tools/repro_489_reuse_depth.py
+++ b/src/synth_setter/tools/repro_489_reuse_depth.py
@@ -237,7 +237,8 @@ def _render_repeated(
 
     :param patch: The identical patch and its plugin/preset.
     :param depth: Number of renders (the reuse depth).
-    :param cached_plugin: Reused instance, or ``None`` to reload per render.
+    :param cached_plugin: Reused instance for the #489 ``once`` arm, or ``None`` to
+        reload a fresh plugin per render (the #713 reload arm / current default).
     :returns: ``depth`` rendered clips, each shape ``(C, T)``.
     """
     return [
@@ -257,26 +258,16 @@ def _render_repeated(
     ]
 
 
-def render_reusing_one_plugin(patch: PatchSpec, depth: int) -> list[np.ndarray]:
-    """Render ``patch`` ``depth`` times against one cached instance (the #489 bug path).
+def _render_reusing_one_plugin(patch: PatchSpec, depth: int) -> list[np.ndarray]:
+    """Render ``patch`` ``depth`` times against one cached instance (the #489 ``once`` arm).
 
     :param patch: The identical patch and its plugin/preset.
-    :param depth: Number of renders (the reuse depth).
+    :param depth: Number of renders sharing the cached instance.
     :returns: ``depth`` rendered clips, each shape ``(C, T)``.
     """
     plugin = load_plugin(patch.plugin_path)
     load_preset(plugin, patch.preset_path)
     return _render_repeated(patch, depth, cached_plugin=plugin)
-
-
-def render_reloading_each_call(patch: PatchSpec, depth: int) -> list[np.ndarray]:
-    """Render ``patch`` ``depth`` times reloading per call (the #713 workaround / default).
-
-    :param patch: The identical patch and its plugin/preset.
-    :param depth: Number of renders (the reuse depth).
-    :returns: ``depth`` rendered clips, each shape ``(C, T)``.
-    """
-    return _render_repeated(patch, depth, cached_plugin=None)
 
 
 def run(
@@ -298,9 +289,11 @@ def run(
     wandb_run = _init_wandb(spec_name, depths) if wandb_enabled else None
     verdicts: dict[int, Verdict] = {}
     for depth in depths:
-        reused = all_pairs_worst_mss(render_reusing_one_plugin(patch, depth))
+        reused = all_pairs_worst_mss(_render_reusing_one_plugin(patch, depth))
+        # Control arm reloads a fresh plugin per render (cached_plugin=None) — the #713
+        # workaround / current default; skipped under --no-control.
         reloaded_max = (
-            all_pairs_worst_mss(render_reloading_each_call(patch, depth)).mss_max
+            all_pairs_worst_mss(_render_repeated(patch, depth, cached_plugin=None)).mss_max
             if control
             else None
         )
@@ -321,7 +314,8 @@ def _report_depth(
 
     :param depth: Reuse depth being reported.
     :param reused: All-pairs result of the cached-plugin arm.
-    :param reloaded_max: Worst all-pairs MSS of the reload control, or ``None`` if skipped.
+    :param reloaded_max: Worst all-pairs MSS of the reload control, or ``None`` if skipped
+        (rendered as ``N/A`` to keep columns aligned).
     :param verdict: This depth's :func:`classify` label.
     """
     reload_str = "    N/A" if reloaded_max is None else f"{reloaded_max:7.3f}"

--- a/src/synth_setter/tools/repro_489_reuse_depth.py
+++ b/src/synth_setter/tools/repro_489_reuse_depth.py
@@ -27,9 +27,11 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
 from itertools import combinations
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
+from omegaconf import OmegaConf
 from pyloudnorm import Meter
 
 from synth_setter.data.vst import param_specs, preset_paths
@@ -44,20 +46,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Render settings mirror configs/render/surge_xt.yaml so the reproduction matches
-# the production render path the #489 datasets are generated with.
-_SAMPLE_RATE = 44100
-_CHANNELS = 2
-_VELOCITY = 100
-_DURATION_SECONDS = 4.0
-_MIN_LOUDNESS_DB = -55.0
-
 # PR #706 threshold: identical-param renders sit well under this; the junk render
 # pushed the worst pair to ~21, ~6x the clean per-pair value.
 _MSS_THRESHOLD = 10.0
 _DEFAULT_DEPTHS = (12, 40)
 # Guards the loud-patch search from spinning forever on a silent param spec.
 _MAX_PATCH_DRAWS = 200
+_LOG_FORMAT = "%(asctime)s %(levelname)s %(message)s"
+# configs/render/<spec>.yaml relative to this tools/ module.
+_RENDER_CONFIG_DIR = Path(__file__).resolve().parent.parent / "configs" / "render"
 
 
 class Verdict(StrEnum):
@@ -82,8 +79,40 @@ class Verdict(StrEnum):
 
 
 @dataclass(frozen=True)
+class RenderSettings:
+    """Render knobs sourced from ``configs/render/<spec>.yaml`` (single source of truth).
+
+    .. attribute :: sample_rate
+
+       Audio sample rate in Hz.
+
+    .. attribute :: channels
+
+       Audio channel count.
+
+    .. attribute :: velocity
+
+       MIDI velocity for every render.
+
+    .. attribute :: duration_seconds
+
+       Render length in seconds.
+
+    .. attribute :: min_loudness_db
+
+       Loudness floor (LUFS) the seed patch must clear.
+    """
+
+    sample_rate: int
+    channels: int
+    velocity: int
+    duration_seconds: float
+    min_loudness_db: float
+
+
+@dataclass(frozen=True)
 class PatchSpec:
-    """One synth patch plus the plugin and preset that render it.
+    """One synth patch plus everything needed to render it identically.
 
     .. attribute :: plugin_path
 
@@ -100,12 +129,17 @@ class PatchSpec:
     .. attribute :: note_params
 
        ``pitch`` and ``note_start_and_end`` held identical across every render.
+
+    .. attribute :: settings
+
+       Render knobs (sample rate, channels, velocity, duration, loudness floor).
     """
 
     plugin_path: str
     preset_path: str
     synth_params: dict[str, float]
     note_params: NoteParams
+    settings: RenderSettings
 
 
 @dataclass(frozen=True)
@@ -146,7 +180,7 @@ def all_pairs_worst_mss(
 ) -> ReuseDepthResult:
     """Score every unordered pair of renders and return the worst-case divergence.
 
-    :param renders: Audio clips, each shape ``(C, T)``, all rendered from one patch.
+    :param renders: Audio clips, each shape ``(C, T)`` float32, all from one patch.
     :param metric: Pairwise distance; defaults to :func:`compute_mss`.
     :returns: A :class:`ReuseDepthResult` for the ``len(renders)`` renders.
     :raises ValueError: Fewer than two renders — no pair to compare.
@@ -185,89 +219,105 @@ def classify(reused_max: float, reloaded_max: float | None, threshold: float) ->
     return Verdict.BUG_PRESENT
 
 
-def _integrated_loudness(audio: np.ndarray) -> float:
-    """Return ITU integrated loudness (LUFS) of a ``(C, T)`` clip.
+def load_render_settings(spec_name: str) -> RenderSettings:
+    """Read render knobs from ``configs/render/<spec_name>.yaml``.
 
-    :param audio: Rendered clip, shape ``(C, T)``.
-    :returns: Integrated loudness in LUFS.
+    :param spec_name: Param-spec registry key, also the render config stem.
+    :returns: The render settings the production pipeline uses for this spec.
+    :raises FileNotFoundError: No render config exists for ``spec_name``.
     """
-    return float(Meter(_SAMPLE_RATE).integrated_loudness(audio.T))
-
-
-def resolve_patch(spec_name: str) -> PatchSpec:
-    """Draw one patch that renders above ``_MIN_LOUDNESS_DB`` for the named spec.
-
-    Renders each candidate once via the reload path (a fresh plugin) so the gate
-    decision is never itself contaminated by reuse-state.
-
-    :param spec_name: Param-spec registry key (e.g. ``"surge_xt"``).
-    :returns: The first loud draw, bound to its plugin and preset.
-    :raises RuntimeError: No draw cleared the gate within ``_MAX_PATCH_DRAWS``.
-    """
-    plugin_path = default_plugin_path()
-    preset_path = preset_paths[spec_name]
-    spec = param_specs[spec_name]
-    for draw in range(_MAX_PATCH_DRAWS):
-        synth_params, note_params = spec.sample()
-        audio = render_params(
-            plugin_path,
-            synth_params,
-            note_params["pitch"],
-            _VELOCITY,
-            note_params["note_start_and_end"],
-            _DURATION_SECONDS,
-            _SAMPLE_RATE,
-            _CHANNELS,
-            preset_path=preset_path,
-        )
-        loudness = _integrated_loudness(audio)
-        if loudness >= _MIN_LOUDNESS_DB:
-            logger.info("loud patch found on draw %d (%.1f LUFS)", draw, loudness)
-            return PatchSpec(plugin_path, preset_path, synth_params, note_params)
-        logger.debug("draw %d: %.1f LUFS below gate, redrawing", draw, loudness)
-    raise RuntimeError(
-        f"no patch cleared {_MIN_LOUDNESS_DB} dB in {_MAX_PATCH_DRAWS} draws for {spec_name!r}"
+    config_path = _RENDER_CONFIG_DIR / f"{spec_name}.yaml"
+    if not config_path.is_file():
+        raise FileNotFoundError(f"no render config for spec {spec_name!r} at {config_path}")
+    cfg = OmegaConf.load(config_path)
+    return RenderSettings(
+        sample_rate=int(cfg.sample_rate),
+        channels=int(cfg.channels),
+        velocity=int(cfg.velocity),
+        duration_seconds=float(cfg.signal_duration_seconds),
+        min_loudness_db=float(cfg.min_loudness),
     )
 
 
-def _render_repeated(
-    patch: PatchSpec, depth: int, cached_plugin: VST3Plugin | None
-) -> list[np.ndarray]:
-    """Render ``patch`` ``depth`` times, reusing ``cached_plugin`` when supplied.
+def integrated_loudness(audio: np.ndarray, sample_rate: int) -> float:
+    """Return ITU integrated loudness (LUFS) of a ``(C, T)`` clip.
 
-    :param patch: The identical patch and its plugin/preset.
-    :param depth: Number of renders (the reuse depth).
-    :param cached_plugin: Reused instance for the #489 ``once`` arm, or ``None`` to
-        reload a fresh plugin per render (the #713 reload arm / current default).
-    :returns: ``depth`` rendered clips, each shape ``(C, T)``.
+    :param audio: Rendered clip, shape ``(C, T)`` float32.
+    :param sample_rate: Sample rate of ``audio`` in Hz.
+    :returns: Integrated loudness in LUFS.
     """
-    return [
-        render_params(
-            patch.plugin_path,
-            patch.synth_params,
-            patch.note_params["pitch"],
-            _VELOCITY,
-            patch.note_params["note_start_and_end"],
-            _DURATION_SECONDS,
-            _SAMPLE_RATE,
-            _CHANNELS,
-            preset_path=patch.preset_path,
-            plugin=cached_plugin,
-        )
-        for _ in range(depth)
-    ]
+    return float(Meter(sample_rate).integrated_loudness(audio.T))
 
 
-def _render_reusing_one_plugin(patch: PatchSpec, depth: int) -> list[np.ndarray]:
+def _render_once(patch: PatchSpec, cached_plugin: VST3Plugin | None) -> np.ndarray:
+    """Render ``patch`` once, on ``cached_plugin`` if given else a freshly loaded plugin.
+
+    :param patch: The patch and its plugin/preset/settings.
+    :param cached_plugin: Injected instance to reuse, or ``None`` to load fresh.
+    :returns: One rendered clip, shape ``(C, T)``.
+    """
+    return render_params(
+        patch.plugin_path,
+        patch.synth_params,
+        patch.note_params["pitch"],
+        patch.settings.velocity,
+        patch.note_params["note_start_and_end"],
+        patch.settings.duration_seconds,
+        patch.settings.sample_rate,
+        patch.settings.channels,
+        preset_path=patch.preset_path,
+        plugin=cached_plugin,
+    )
+
+
+def render_reusing_one_plugin(patch: PatchSpec, depth: int) -> list[np.ndarray]:
     """Render ``patch`` ``depth`` times against one cached instance (the #489 ``once`` arm).
 
-    :param patch: The identical patch and its plugin/preset.
+    :param patch: The patch and its plugin/preset/settings.
     :param depth: Number of renders sharing the cached instance.
     :returns: ``depth`` rendered clips, each shape ``(C, T)``.
     """
     plugin = load_plugin(patch.plugin_path)
     load_preset(plugin, patch.preset_path)
-    return _render_repeated(patch, depth, cached_plugin=plugin)
+    return [_render_once(patch, plugin) for _ in range(depth)]
+
+
+def render_reloading_each_render(patch: PatchSpec, depth: int) -> list[np.ndarray]:
+    """Render ``patch`` ``depth`` times, reloading a fresh plugin per render (#713 default arm).
+
+    :param patch: The patch and its plugin/preset/settings.
+    :param depth: Number of independent reload-and-render cycles.
+    :returns: ``depth`` rendered clips, each shape ``(C, T)``.
+    """
+    return [_render_once(patch, None) for _ in range(depth)]
+
+
+def resolve_patch(spec_name: str) -> PatchSpec:
+    """Draw one patch that renders above the spec's loudness floor.
+
+    Renders each candidate once via a fresh plugin so the gate decision is never
+    itself contaminated by reuse-state.
+
+    :param spec_name: Param-spec registry key (e.g. ``"surge_xt"``).
+    :returns: The first loud draw, bound to its plugin, preset, and settings.
+    :raises RuntimeError: No draw cleared the floor within ``_MAX_PATCH_DRAWS``.
+    """
+    plugin_path = default_plugin_path()
+    preset_path = preset_paths[spec_name]
+    settings = load_render_settings(spec_name)
+    spec = param_specs[spec_name]
+    for draw in range(_MAX_PATCH_DRAWS):
+        synth_params, note_params = spec.sample()
+        patch = PatchSpec(plugin_path, preset_path, synth_params, note_params, settings)
+        loudness = integrated_loudness(_render_once(patch, None), settings.sample_rate)
+        if loudness >= settings.min_loudness_db:
+            logger.info("loud patch found on draw %d (%.1f LUFS)", draw, loudness)
+            return patch
+        logger.debug("draw %d: %.1f LUFS below floor, redrawing", draw, loudness)
+    raise RuntimeError(
+        f"no patch cleared {settings.min_loudness_db} dB in {_MAX_PATCH_DRAWS} draws "
+        f"for {spec_name!r}"
+    )
 
 
 def run(
@@ -288,22 +338,22 @@ def run(
     patch = resolve_patch(spec_name)
     wandb_run = _init_wandb(spec_name, depths) if wandb_enabled else None
     verdicts: dict[int, Verdict] = {}
-    for depth in depths:
-        reused = all_pairs_worst_mss(_render_reusing_one_plugin(patch, depth))
-        # Control arm reloads a fresh plugin per render (cached_plugin=None) — the #713
-        # workaround / current default; skipped under --no-control.
-        reloaded_max = (
-            all_pairs_worst_mss(_render_repeated(patch, depth, cached_plugin=None)).mss_max
-            if control
-            else None
-        )
-        verdict = classify(reused.mss_max, reloaded_max, _MSS_THRESHOLD)
-        verdicts[depth] = verdict
-        _report_depth(depth, reused, reloaded_max, verdict)
+    try:
+        for depth in depths:
+            reused = all_pairs_worst_mss(render_reusing_one_plugin(patch, depth))
+            reloaded_max = (
+                all_pairs_worst_mss(render_reloading_each_render(patch, depth)).mss_max
+                if control
+                else None
+            )
+            verdict = classify(reused.mss_max, reloaded_max, _MSS_THRESHOLD)
+            verdicts[depth] = verdict
+            _report_depth(depth, reused, reloaded_max, verdict)
+            if wandb_run is not None:
+                _log_depth_to_wandb(wandb_run, depth, reused, reloaded_max)
+    finally:
         if wandb_run is not None:
-            _log_depth_to_wandb(wandb_run, depth, reused, reloaded_max)
-    if wandb_run is not None:
-        wandb_run.finish()
+            wandb_run.finish()
     return verdicts
 
 
@@ -333,8 +383,8 @@ def _report_depth(
 def _init_wandb(spec_name: str, depths: Sequence[int]) -> Run:
     """Start a W&B run for the reproduction; import is local so non-W&B runs stay light.
 
-    :param spec_name: Param-spec registry key.
-    :param depths: Reuse depths probed.
+    :param spec_name: Param-spec registry key, recorded so a run ties to its synth.
+    :param depths: Reuse depths probed, recorded for the depth axis.
     :returns: The initialised W&B run handle.
     """
     import wandb
@@ -346,7 +396,6 @@ def _init_wandb(spec_name: str, depths: Sequence[int]) -> Run:
             "spec_name": spec_name,
             "depths": list(depths),
             "mss_threshold": _MSS_THRESHOLD,
-            "min_loudness_db": _MIN_LOUDNESS_DB,
         },
     )
 
@@ -395,7 +444,7 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument("--wandb", action="store_true", help="log per-depth metrics to W&B")
     args = parser.parse_args(argv)
 
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    logging.basicConfig(level=logging.INFO, format=_LOG_FORMAT)
     verdicts = run(
         args.depths,
         spec_name=args.spec,

--- a/src/synth_setter/tools/repro_489_reuse_depth.py
+++ b/src/synth_setter/tools/repro_489_reuse_depth.py
@@ -1,0 +1,371 @@
+"""Standalone #489 reproducer: render one identical patch N times and score all-pairs MSS.
+
+Measures the bug at its source, bypassing the oracle/sweep harness that masks it.
+For each reuse depth N it renders the *same* patch N times against a single cached
+``VST3Plugin`` (the ``plugin_reload_cadence="once"`` path) and reports the
+**all-pairs worst-case** multi-scale spectral loss across those N renders — the
+exact signal that defined #489 in the PR #706 reproducer. Identical params should
+render identically, so any worst pair above the threshold is render-to-render junk.
+
+A control arm re-renders the same patch reloading the plugin per call (the #713
+workaround, now the default), so a run that prints reuse≫threshold while
+reload<threshold confirms the bug is still live and merely worked around.
+
+The harness sweeps (``synth_setter.tools.cadence_sweep_489``) could not surface
+this: they score target-vs-oracle-prediction *means*, never two raw renders of one
+patch against each other.
+
+Run it::
+
+    python -m synth_setter.tools.repro_489_reuse_depth                 # depths 12,40 + control
+    python -m synth_setter.tools.repro_489_reuse_depth --depths 12 80 --wandb
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Any
+
+import numpy as np
+from loguru import logger
+from pyloudnorm import Meter
+
+from synth_setter.data.vst import param_specs, preset_paths
+from synth_setter.data.vst.core import load_plugin, load_preset, render_params
+from synth_setter.data.vst.param_spec import NoteParams
+from synth_setter.data.vst.param_spec_registry import default_plugin_path
+from synth_setter.evaluation.compute_audio_metrics import compute_mss
+
+# Render settings mirror configs/render/surge_xt.yaml so the reproduction matches
+# the production render path the #489 datasets are generated with.
+_SAMPLE_RATE = 44100
+_CHANNELS = 2
+_VELOCITY = 100
+_DURATION_SECONDS = 4.0
+_MIN_LOUDNESS_DB = -55.0
+
+# PR #706 threshold: the per-pair MSS of identical params sits well under this; the
+# junk render pushed the worst pair to ~21, ~6x the clean per-pair value.
+_MSS_THRESHOLD = 10.0
+_DEFAULT_DEPTHS = (12, 40)
+# Guards the loud-patch search from spinning forever on a silent param spec.
+_MAX_PATCH_DRAWS = 200
+
+# Verdict labels for ``classify``.
+BUG_PRESENT = "BUG_PRESENT"
+NO_REPRO = "NO_REPRO"
+INCONCLUSIVE = "INCONCLUSIVE"
+
+
+@dataclass(frozen=True)
+class ReuseDepthResult:
+    """All-pairs scoring of N renders of one identical patch.
+
+    .. attribute :: depth
+
+       Number of renders compared (the reuse depth).
+
+    .. attribute :: mss_max
+
+       Worst-case multi-scale spectral loss over all unordered pairs.
+
+    .. attribute :: worst_pair
+
+       ``(i, j)`` render indices that produced ``mss_max``.
+
+    .. attribute :: pair_count
+
+       Number of unordered pairs scored, ``depth*(depth-1)/2``.
+
+    .. attribute :: peaks
+
+       Per-render peak amplitude; a near-zero entry is a silent junk render.
+    """
+
+    depth: int
+    mss_max: float
+    worst_pair: tuple[int, int]
+    pair_count: int
+    peaks: list[float]
+
+
+def all_pairs_worst_mss(
+    renders: list[np.ndarray],
+    metric: Callable[[np.ndarray, np.ndarray], float] = compute_mss,
+) -> ReuseDepthResult:
+    """Score every unordered pair of renders and return the worst-case divergence.
+
+    :param renders: Audio clips, each shape ``(C, T)``, all rendered from one patch.
+    :param metric: Pairwise distance; defaults to :func:`compute_mss`.
+    :returns: The worst pair, its score, the pair count, and per-render peaks.
+    :raises ValueError: Fewer than two renders — no pair to compare.
+    """
+    n = len(renders)
+    if n < 2:
+        raise ValueError(f"all-pairs scoring needs at least 2 renders, got {n}")
+    worst_score, worst_i, worst_j = -1.0, -1, -1
+    for i, j in combinations(range(n), 2):
+        score = metric(renders[i], renders[j])
+        if score > worst_score:
+            worst_score, worst_i, worst_j = score, i, j
+    peaks = [float(np.abs(render).max()) for render in renders]
+    return ReuseDepthResult(
+        depth=n,
+        mss_max=float(worst_score),
+        worst_pair=(worst_i, worst_j),
+        pair_count=n * (n - 1) // 2,
+        peaks=peaks,
+    )
+
+
+def classify(reused_max: float, reloaded_max: float, threshold: float) -> str:
+    """Label a depth's outcome from its reuse and reload all-pairs worst scores.
+
+    :param reused_max: Worst all-pairs MSS on the cached-plugin (reuse) arm.
+    :param reloaded_max: Worst all-pairs MSS on the per-render-reload control arm.
+    :param threshold: Score above which identical-patch renders count as junk.
+    :returns: ``BUG_PRESENT`` (reuse diverges, reload holds), ``INCONCLUSIVE``
+        (both diverge — patch/phase, not the reuse bug), or ``NO_REPRO``.
+    """
+    if reused_max <= threshold:
+        return NO_REPRO
+    return INCONCLUSIVE if reloaded_max > threshold else BUG_PRESENT
+
+
+def _integrated_loudness(audio: np.ndarray) -> float:
+    """Return ITU integrated loudness (LUFS) of a ``(C, T)`` clip.
+
+    :param audio: Rendered clip, shape ``(C, T)``.
+    :returns: Integrated loudness in LUFS.
+    """
+    return float(Meter(_SAMPLE_RATE).integrated_loudness(audio.T))
+
+
+def _sample_loud_patch(
+    spec_name: str, plugin_path: str, preset_path: str
+) -> tuple[dict[str, float], NoteParams]:
+    """Draw one patch that renders above ``_MIN_LOUDNESS_DB``, reused across all depths.
+
+    Renders each candidate once via the reload path (a fresh plugin) so the gate
+    decision is never itself contaminated by reuse-state. Reuses one patch for the
+    whole run so depths and arms are directly comparable.
+
+    :param spec_name: Param-spec registry key (e.g. ``"surge_xt"``).
+    :param plugin_path: VST3 bundle path.
+    :param preset_path: Preset applied before each render.
+    :returns: The ``(synth_params, note_params)`` tuple of the first loud draw.
+    :raises RuntimeError: No draw cleared the gate within ``_MAX_PATCH_DRAWS``.
+    """
+    spec = param_specs[spec_name]
+    for draw in range(_MAX_PATCH_DRAWS):
+        synth_params, note_params = spec.sample()
+        audio = render_params(
+            plugin_path,
+            synth_params,
+            note_params["pitch"],
+            _VELOCITY,
+            note_params["note_start_and_end"],
+            _DURATION_SECONDS,
+            _SAMPLE_RATE,
+            _CHANNELS,
+            preset_path=preset_path,
+        )
+        loudness = _integrated_loudness(audio)
+        if loudness >= _MIN_LOUDNESS_DB:
+            logger.info(f"loud patch found on draw {draw} ({loudness:.1f} LUFS)")
+            return synth_params, note_params
+        logger.debug(f"draw {draw}: {loudness:.1f} LUFS below gate, redrawing")
+    raise RuntimeError(
+        f"no patch cleared {_MIN_LOUDNESS_DB} dB in {_MAX_PATCH_DRAWS} draws for {spec_name!r}"
+    )
+
+
+def render_identical_patch(
+    plugin_path: str,
+    preset_path: str,
+    synth_params: dict[str, float],
+    note_params: NoteParams,
+    depth: int,
+    *,
+    reuse_plugin: bool,
+) -> list[np.ndarray]:
+    """Render one patch ``depth`` times, either reusing one instance or reloading per call.
+
+    :param plugin_path: VST3 bundle path.
+    :param preset_path: Preset applied to the plugin.
+    :param synth_params: Synth patch held identical across every render.
+    :param note_params: Note params (``pitch``, ``note_start_and_end``) held identical.
+    :param depth: Number of renders (the reuse depth).
+    :param reuse_plugin: When True, load + preset once and reuse the cached instance
+        (the ``plugin_reload_cadence="once"`` bug path); when False, reload per render
+        (the #713 workaround / current default).
+    :returns: ``depth`` rendered clips, each shape ``(C, T)``.
+    """
+    cached = None
+    if reuse_plugin:
+        cached = load_plugin(plugin_path)
+        load_preset(cached, preset_path)
+    return [
+        render_params(
+            plugin_path,
+            synth_params,
+            note_params["pitch"],
+            _VELOCITY,
+            note_params["note_start_and_end"],
+            _DURATION_SECONDS,
+            _SAMPLE_RATE,
+            _CHANNELS,
+            preset_path=preset_path,
+            plugin=cached,
+        )
+        for _ in range(depth)
+    ]
+
+
+def run(
+    depths: tuple[int, ...],
+    *,
+    spec_name: str,
+    control: bool,
+    wandb_enabled: bool,
+) -> dict[int, str]:
+    """Reproduce #489 at each depth and report all-pairs worst MSS for reuse vs reload.
+
+    :param depths: Reuse depths to probe, in order.
+    :param spec_name: Param-spec registry key selecting synth + preset.
+    :param control: Also render the per-render-reload control arm at each depth.
+    :param wandb_enabled: Log per-depth all-pairs metrics to W&B.
+    :returns: Map of depth to its :data:`classify` verdict.
+    """
+    plugin_path = default_plugin_path()
+    preset_path = preset_paths[spec_name]
+    synth_params, note_params = _sample_loud_patch(spec_name, plugin_path, preset_path)
+
+    wandb_run = _init_wandb(spec_name, depths) if wandb_enabled else None
+    verdicts: dict[int, str] = {}
+    for depth in depths:
+        reused = all_pairs_worst_mss(
+            render_identical_patch(
+                plugin_path, preset_path, synth_params, note_params, depth, reuse_plugin=True
+            )
+        )
+        reloaded_max = float("nan")
+        if control:
+            reloaded = all_pairs_worst_mss(
+                render_identical_patch(
+                    plugin_path, preset_path, synth_params, note_params, depth, reuse_plugin=False
+                )
+            )
+            reloaded_max = reloaded.mss_max
+        verdict = (
+            classify(reused.mss_max, reloaded_max, _MSS_THRESHOLD)
+            if control
+            else (BUG_PRESENT if reused.mss_max > _MSS_THRESHOLD else NO_REPRO)
+        )
+        verdicts[depth] = verdict
+        _report_depth(depth, reused, reloaded_max, verdict)
+        if wandb_run is not None:
+            _log_depth_to_wandb(wandb_run, depth, reused, reloaded_max)
+    if wandb_run is not None:
+        wandb_run.finish()
+    return verdicts
+
+
+def _report_depth(depth: int, reused: ReuseDepthResult, reloaded_max: float, verdict: str) -> None:
+    """Print one depth's reuse/reload worst-pair scores, peaks, and verdict.
+
+    :param depth: Reuse depth being reported.
+    :param reused: All-pairs result of the cached-plugin arm.
+    :param reloaded_max: Worst all-pairs MSS of the reload control (``nan`` when skipped).
+    :param verdict: This depth's :func:`classify` label.
+    """
+    logger.info(
+        f"depth={depth:>3} | reuse worst mss={reused.mss_max:7.3f} @ {reused.worst_pair} "
+        f"| reload worst mss={reloaded_max:7.3f} | {verdict}"
+    )
+    logger.info(f"depth={depth:>3} | reuse peaks={[round(p, 4) for p in reused.peaks]}")
+
+
+def _init_wandb(spec_name: str, depths: tuple[int, ...]) -> Any:
+    """Start a W&B run for the reproduction; import is local so non-W&B runs stay light.
+
+    :param spec_name: Param-spec registry key, logged to the run config.
+    :param depths: Reuse depths probed, logged to the run config.
+    :returns: The initialised ``wandb`` run handle.
+    """
+    import wandb
+
+    return wandb.init(
+        project="synth-setter",
+        job_type="repro-489-reuse-depth",
+        config={
+            "spec_name": spec_name,
+            "depths": list(depths),
+            "mss_threshold": _MSS_THRESHOLD,
+            "min_loudness_db": _MIN_LOUDNESS_DB,
+        },
+    )
+
+
+def _log_depth_to_wandb(
+    wandb_run: Any, depth: int, reused: ReuseDepthResult, reloaded_max: float
+) -> None:
+    """Log a depth's all-pairs worst MSS (reuse and reload) and min peak to W&B.
+
+    :param wandb_run: Active W&B run handle from :func:`_init_wandb`.
+    :param depth: Reuse depth being logged (the x-axis).
+    :param reused: All-pairs result of the cached-plugin arm.
+    :param reloaded_max: Worst all-pairs MSS of the reload control (``nan`` when skipped).
+    """
+    wandb_run.log(
+        {
+            "depth": depth,
+            "reuse-once/all-pairs-mss-max": reused.mss_max,
+            "reload-render/all-pairs-mss-max": reloaded_max,
+            "reuse-once/min-peak-amplitude": min(reused.peaks),
+        }
+    )
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI: reproduce #489 at the chosen depths and exit non-zero if the bug is present.
+
+    :param argv: Argument list (defaults to ``sys.argv[1:]``).
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--depths",
+        type=int,
+        nargs="+",
+        default=list(_DEFAULT_DEPTHS),
+        help=f"reuse depths to probe (default: {' '.join(map(str, _DEFAULT_DEPTHS))})",
+    )
+    parser.add_argument(
+        "--spec", default="surge_xt", help="param-spec registry key (default: surge_xt)"
+    )
+    parser.add_argument(
+        "--no-control",
+        action="store_true",
+        help="skip the per-render-reload control arm (reuse arm only)",
+    )
+    parser.add_argument("--wandb", action="store_true", help="log per-depth metrics to W&B")
+    args = parser.parse_args(argv)
+
+    verdicts = run(
+        tuple(args.depths),
+        spec_name=args.spec,
+        control=not args.no_control,
+        wandb_enabled=args.wandb,
+    )
+    if BUG_PRESENT in verdicts.values():
+        depths = [d for d, v in verdicts.items() if v == BUG_PRESENT]
+        logger.warning(f"#489 reproduced at depths {depths}: reuse junk, reload clean")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/synth_setter/tools/repro_489_reuse_depth.py
+++ b/src/synth_setter/tools/repro_489_reuse_depth.py
@@ -302,7 +302,9 @@ def _render_once(patch: PatchSpec, cached_plugin: VST3Plugin | None) -> np.ndarr
         patch.settings.duration_seconds,
         patch.settings.sample_rate,
         patch.settings.channels,
-        preset_path=patch.preset_path,
+        # render_params ignores preset_path when a plugin is supplied (the caller
+        # already applied the preset), so only pass it on the reload arm.
+        preset_path=None if cached_plugin is not None else patch.preset_path,
         plugin=cached_plugin,
     )
 

--- a/src/synth_setter/tools/repro_489_reuse_depth.py
+++ b/src/synth_setter/tools/repro_489_reuse_depth.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
+from loguru import logger as loguru_logger
 from omegaconf import DictConfig, OmegaConf
 from pyloudnorm import Meter
 
@@ -45,6 +46,10 @@ if TYPE_CHECKING:
     from wandb.sdk.wandb_run import Run
 
 logger = logging.getLogger(__name__)
+
+# stdlib logging is this tool's own logger (project rule); the loguru handle is
+# only used to mute the shared compute_mss INFO line during the pairwise loop.
+_MSS_LOGGER = "synth_setter.evaluation.compute_audio_metrics"
 
 # PR #706 threshold: identical-param renders sit well under this; the junk render
 # pushed the worst pair to ~21, ~6x the clean per-pair value.
@@ -236,19 +241,22 @@ def _load_render_config(spec_name: str) -> DictConfig:
     :param spec_name: Param-spec registry key, also the render config stem.
     :returns: The merged render config (bases first, spec overrides last).
     :raises FileNotFoundError: No render config exists for ``spec_name``.
+    :raises TypeError: The config (or a base) is a sequence, not a mapping.
     """
     config_path = _RENDER_CONFIG_DIR / f"{spec_name}.yaml"
     if not config_path.is_file():
         raise FileNotFoundError(f"no render config for spec {spec_name!r} at {config_path}")
     cfg = OmegaConf.load(config_path)
-    assert isinstance(cfg, DictConfig)
+    if not isinstance(cfg, DictConfig):
+        raise TypeError(f"render config {config_path} must be a mapping, got {type(cfg).__name__}")
     bases = cfg.pop("defaults", [])
     merged = OmegaConf.create({})
     for base in bases:
         if isinstance(base, str):
             merged = OmegaConf.merge(merged, _load_render_config(base))
     merged = OmegaConf.merge(merged, cfg)
-    assert isinstance(merged, DictConfig)
+    if not isinstance(merged, DictConfig):
+        raise TypeError(f"merged render config for {config_path} is not a mapping")
     return merged
 
 
@@ -345,7 +353,7 @@ def resolve_patch(spec_name: str) -> PatchSpec:
             return patch
         logger.debug("draw %d: %.1f LUFS below floor, redrawing", draw, loudness)
     raise RuntimeError(
-        f"no patch cleared {settings.min_loudness_db} dB in {_MAX_PATCH_DRAWS} draws "
+        f"no patch cleared {settings.min_loudness_db} LUFS in {_MAX_PATCH_DRAWS} draws "
         f"for {spec_name!r}"
     )
 
@@ -368,6 +376,9 @@ def run(
     patch = resolve_patch(spec_name)
     wandb_run = _init_wandb(spec_name, depths) if wandb_enabled else None
     verdicts: dict[int, Verdict] = {}
+    # compute_mss emits an INFO line per call; mute it around the O(depth^2)
+    # pairwise loop so the verdict table isn't buried, then restore.
+    loguru_logger.disable(_MSS_LOGGER)
     try:
         for depth in depths:
             reused = all_pairs_worst_mss(render_reusing_one_plugin(patch, depth))
@@ -382,6 +393,7 @@ def run(
             if wandb_run is not None:
                 _log_depth_to_wandb(wandb_run, depth, reused, reloaded_max)
     finally:
+        loguru_logger.enable(_MSS_LOGGER)
         if wandb_run is not None:
             wandb_run.finish()
     return verdicts

--- a/src/synth_setter/tools/repro_489_reuse_depth.py
+++ b/src/synth_setter/tools/repro_489_reuse_depth.py
@@ -260,13 +260,12 @@ def _load_render_config(spec_name: str) -> DictConfig:
     return merged
 
 
-def load_render_settings(spec_name: str) -> RenderSettings:
-    """Read render knobs from the merged ``configs/render/<spec_name>.yaml``.
+def _settings_from_cfg(cfg: DictConfig) -> RenderSettings:
+    """Project a merged render config onto the render knobs this tool needs.
 
-    :param spec_name: Param-spec registry key, also the render config stem.
+    :param cfg: A merged render config from :func:`_load_render_config`.
     :returns: The render settings the production pipeline uses for this spec.
     """
-    cfg = _load_render_config(spec_name)
     return RenderSettings(
         sample_rate=int(cfg.sample_rate),
         channels=int(cfg.channels),
@@ -274,6 +273,15 @@ def load_render_settings(spec_name: str) -> RenderSettings:
         duration_seconds=float(cfg.signal_duration_seconds),
         min_loudness_db=float(cfg.min_loudness),
     )
+
+
+def load_render_settings(spec_name: str) -> RenderSettings:
+    """Read render knobs from the merged ``configs/render/<spec_name>.yaml``.
+
+    :param spec_name: Param-spec registry key, also the render config stem.
+    :returns: The render settings the production pipeline uses for this spec.
+    """
+    return _settings_from_cfg(_load_render_config(spec_name))
 
 
 def integrated_loudness(audio: np.ndarray, sample_rate: int) -> float:
@@ -344,7 +352,7 @@ def resolve_patch(spec_name: str) -> PatchSpec:
     cfg = _load_render_config(spec_name)
     plugin_path = str(cfg.plugin_path)
     preset_path = str(cfg.preset_path)
-    settings = load_render_settings(spec_name)
+    settings = _settings_from_cfg(cfg)
     spec = param_specs[spec_name]
     for draw in range(_MAX_PATCH_DRAWS):
         synth_params, note_params = spec.sample()

--- a/src/synth_setter/tools/repro_489_reuse_depth.py
+++ b/src/synth_setter/tools/repro_489_reuse_depth.py
@@ -473,6 +473,8 @@ def main(argv: list[str] | None = None) -> None:
     )
     parser.add_argument("--wandb", action="store_true", help="log per-depth metrics to W&B")
     args = parser.parse_args(argv)
+    if any(depth < 2 for depth in args.depths):
+        parser.error("--depths values must be >= 2 (a pair needs at least two renders)")
 
     logging.basicConfig(level=logging.INFO, format=_LOG_FORMAT)
     verdicts = run(

--- a/src/synth_setter/tools/repro_489_reuse_depth.py
+++ b/src/synth_setter/tools/repro_489_reuse_depth.py
@@ -464,6 +464,19 @@ def _log_depth_to_wandb(
     wandb_run.log(metrics)
 
 
+def available_specs() -> list[str]:
+    """Return specs valid for ``--spec``: those with both a param spec and a render config.
+
+    ``param_specs`` can hold specs (e.g. ``surge_4``) that have no
+    ``configs/render/<spec>.yaml``; offering them would crash in
+    :func:`_load_render_config`, so they are excluded from the CLI choices.
+
+    :returns: Sorted spec names that both render-configure and resolve a param spec.
+    """
+    stems = {path.stem for path in _RENDER_CONFIG_DIR.glob("*.yaml")}
+    return sorted(set(param_specs) & stems)
+
+
 def main(argv: list[str] | None = None) -> None:
     """CLI: reproduce #489 at the chosen depths and exit non-zero if the bug is present.
 
@@ -478,7 +491,10 @@ def main(argv: list[str] | None = None) -> None:
         help=f"reuse depths to probe (default: {' '.join(map(str, _DEFAULT_DEPTHS))})",
     )
     parser.add_argument(
-        "--spec", default="surge_xt", help="param-spec registry key (default: surge_xt)"
+        "--spec",
+        default="surge_xt",
+        choices=available_specs(),
+        help="param-spec registry key (default: surge_xt)",
     )
     parser.add_argument(
         "--no-control",

--- a/src/synth_setter/tools/repro_489_reuse_depth.py
+++ b/src/synth_setter/tools/repro_489_reuse_depth.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import math
 import sys
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -31,13 +32,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import numpy as np
-from omegaconf import OmegaConf
+from omegaconf import DictConfig, OmegaConf
 from pyloudnorm import Meter
 
-from synth_setter.data.vst import param_specs, preset_paths
+from synth_setter.data.vst import param_specs
 from synth_setter.data.vst.core import load_plugin, load_preset, render_params
 from synth_setter.data.vst.param_spec import NoteParams
-from synth_setter.data.vst.param_spec_registry import default_plugin_path
 from synth_setter.evaluation.compute_audio_metrics import compute_mss
 
 if TYPE_CHECKING:
@@ -191,6 +191,10 @@ def all_pairs_worst_mss(
     worst_score, worst_i, worst_j = float("-inf"), -1, -1
     for i, j in combinations(range(n), 2):
         score = metric(renders[i], renders[j])
+        # A non-finite score (e.g. NaN MSS from a silent junk render) is the #489
+        # symptom itself; treat it as maximal divergence so it can't read as clean.
+        if not math.isfinite(score):
+            score = float("inf")
         if score > worst_score:
             worst_score, worst_i, worst_j = score, i, j
     peaks = [float(np.abs(render).max()) for render in renders]
@@ -221,17 +225,40 @@ def classify(
     return Verdict.BUG_PRESENT
 
 
-def load_render_settings(spec_name: str) -> RenderSettings:
-    """Read render knobs from ``configs/render/<spec_name>.yaml``.
+def _load_render_config(spec_name: str) -> DictConfig:
+    """Load ``configs/render/<spec_name>.yaml`` with its ``defaults:`` chain merged.
+
+    ``OmegaConf.load`` does not resolve Hydra ``defaults:``, so specs that inherit
+    generic knobs (``surge_simple``, ``obxf`` declare ``defaults: - surge_xt``)
+    would be missing ``sample_rate`` etc. Each listed base is merged under the
+    spec's own overrides, recursively.
 
     :param spec_name: Param-spec registry key, also the render config stem.
-    :returns: The render settings the production pipeline uses for this spec.
+    :returns: The merged render config (bases first, spec overrides last).
     :raises FileNotFoundError: No render config exists for ``spec_name``.
     """
     config_path = _RENDER_CONFIG_DIR / f"{spec_name}.yaml"
     if not config_path.is_file():
         raise FileNotFoundError(f"no render config for spec {spec_name!r} at {config_path}")
     cfg = OmegaConf.load(config_path)
+    assert isinstance(cfg, DictConfig)
+    bases = cfg.pop("defaults", [])
+    merged = OmegaConf.create({})
+    for base in bases:
+        if isinstance(base, str):
+            merged = OmegaConf.merge(merged, _load_render_config(base))
+    merged = OmegaConf.merge(merged, cfg)
+    assert isinstance(merged, DictConfig)
+    return merged
+
+
+def load_render_settings(spec_name: str) -> RenderSettings:
+    """Read render knobs from the merged ``configs/render/<spec_name>.yaml``.
+
+    :param spec_name: Param-spec registry key, also the render config stem.
+    :returns: The render settings the production pipeline uses for this spec.
+    """
+    cfg = _load_render_config(spec_name)
     return RenderSettings(
         sample_rate=int(cfg.sample_rate),
         channels=int(cfg.channels),
@@ -304,8 +331,9 @@ def resolve_patch(spec_name: str) -> PatchSpec:
     :returns: The first loud draw, bound to its plugin, preset, and settings.
     :raises RuntimeError: No draw cleared the floor within ``_MAX_PATCH_DRAWS``.
     """
-    plugin_path = default_plugin_path()
-    preset_path = preset_paths[spec_name]
+    cfg = _load_render_config(spec_name)
+    plugin_path = str(cfg.plugin_path)
+    preset_path = str(cfg.preset_path)
     settings = load_render_settings(spec_name)
     spec = param_specs[spec_name]
     for draw in range(_MAX_PATCH_DRAWS):

--- a/tests/tools/test_repro_489_reuse_depth.py
+++ b/tests/tools/test_repro_489_reuse_depth.py
@@ -32,7 +32,6 @@ def test_all_pairs_worst_mss_selects_the_first_most_divergent_pair() -> None:
     )
     assert result.worst_pair == (0, 1)
     assert result.mss_max == pytest.approx(5.0)
-    assert result.mss_max >= 0.0
 
 
 def test_all_pairs_worst_mss_scores_and_counts_every_unordered_pair() -> None:
@@ -40,12 +39,14 @@ def test_all_pairs_worst_mss_scores_and_counts_every_unordered_pair() -> None:
     calls: list[tuple[int, int]] = []
 
     def counting_metric(a: np.ndarray, b: np.ndarray) -> float:
+        # _const(i) fills the clip with i, so a[0, 0] recovers each render's index.
         calls.append((int(a[0, 0]), int(b[0, 0])))
         return 0.0
 
     renders = [_const(float(i)) for i in range(4)]
     result = repro.all_pairs_worst_mss(renders, metric=counting_metric)
-    assert calls == [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
+    # Contract: every unordered pair scored exactly once (order-independent).
+    assert sorted(calls) == [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
     assert result.pair_count == 6
     # A worst pair is recorded even when every score ties at 0.0 (sentinel is -inf).
     assert result.worst_pair == (0, 1)
@@ -115,3 +116,15 @@ def test_main_exits_zero_when_no_depth_reproduces_the_bug(
     monkeypatch.setattr(repro, "run", fake_run)
     repro.main(["--depths", "12", "40"])
     assert captured["depths"] == [12, 40]
+
+
+@pytest.mark.slow
+@pytest.mark.requires_vst
+def test_main_drives_the_real_render_chain_end_to_end() -> None:
+    """``main`` renders through resolve_patch -> all_pairs_worst_mss -> classify on a real VST.
+
+    Exercises the integration the stubbed CLI tests cannot: at depth 2 with no control
+    the run completes without raising and stays NO_REPRO (no #489 SystemExit) on the
+    current, flush-everything render path.
+    """
+    repro.main(["--depths", "2", "--no-control"])

--- a/tests/tools/test_repro_489_reuse_depth.py
+++ b/tests/tools/test_repro_489_reuse_depth.py
@@ -51,8 +51,7 @@ def test_all_pairs_worst_mss_scores_and_counts_every_unordered_pair() -> None:
     calls: list[tuple[int, int]] = []
 
     def counting_metric(a: np.ndarray, b: np.ndarray) -> float:
-        # Encode each render's index in its fill value so the closure can record
-        # which pairs were scored without sharing mutable index state.
+        # Fill value encodes render index; avoids shared mutable index state.
         calls.append((int(a[0, 0]), int(b[0, 0])))
         return 0.0
 
@@ -151,5 +150,5 @@ def test_main_passes_parsed_depths_through_to_run(monkeypatch: pytest.MonkeyPatc
 @pytest.mark.slow
 @pytest.mark.requires_vst
 def test_main_drives_the_real_render_chain_end_to_end() -> None:
-    """``main`` completes at depth 2 on a real VST with no #489 SystemExit (see #489)."""
+    """Real VST smoke test: depth-2 run must not raise SystemExit (regression for #489)."""
     assert repro.main(["--depths", "2", "--no-control"]) is None

--- a/tests/tools/test_repro_489_reuse_depth.py
+++ b/tests/tools/test_repro_489_reuse_depth.py
@@ -103,7 +103,7 @@ def test_classify_labels_each_reuse_reload_combination(
     :param reloaded_max: Reload-arm worst all-pairs MSS, or ``None`` when skipped.
     :param expected: The verdict ``classify`` must return.
     """
-    assert repro.classify(reused_max, reloaded_max, repro._MSS_THRESHOLD) == expected
+    assert repro.classify(reused_max, reloaded_max) == expected
 
 
 @pytest.mark.parametrize(
@@ -151,10 +151,5 @@ def test_main_passes_parsed_depths_through_to_run(monkeypatch: pytest.MonkeyPatc
 @pytest.mark.slow
 @pytest.mark.requires_vst
 def test_main_drives_the_real_render_chain_end_to_end() -> None:
-    """``main`` renders through resolve_patch -> all_pairs_worst_mss -> classify on a real VST.
-
-    Exercises the integration the stubbed CLI tests cannot: at depth 2 with no control
-    the run completes without raising and stays NO_REPRO (no #489 SystemExit) on the
-    current, flush-everything render path.
-    """
-    repro.main(["--depths", "2", "--no-control"])
+    """``main`` completes at depth 2 on a real VST with no #489 SystemExit (see #489)."""
+    assert repro.main(["--depths", "2", "--no-control"]) is None

--- a/tests/tools/test_repro_489_reuse_depth.py
+++ b/tests/tools/test_repro_489_reuse_depth.py
@@ -1,8 +1,9 @@
 """Unit tests for the #489 reuse-depth reproducer's pure scoring core.
 
-These pin the all-pairs worst-MSS reducer and the bug verdict without touching a
-VST: the metric is injected so the enumeration, worst-pair selection, peak trace,
-and verdict logic are exercised on plain arrays.
+These pin the all-pairs worst-MSS reducer, the bug verdict, and the CLI exit path
+without touching a VST: the metric is injected and the render layer is stubbed, so
+enumeration, worst-pair selection, peak trace, verdict logic, and ``main``'s
+non-zero exit are exercised on plain data.
 """
 
 from __future__ import annotations
@@ -14,37 +15,45 @@ from synth_setter.tools import repro_489_reuse_depth as repro
 
 
 def _const(value: float) -> np.ndarray:
-    """Return a 1-row clip whose every sample equals ``value`` (peak == ``|value|``).
+    """Return a 1-row clip filled with ``value``.
 
-    :param value: Constant amplitude filling the clip.
+    :param value: Fill value; also the clip's peak amplitude.
     :returns: A ``(1, 8)`` float32 array of ``value``.
     """
     return np.full((1, 8), value, dtype=np.float32)
 
 
-def test_all_pairs_worst_mss_selects_the_most_divergent_pair() -> None:
-    """The worst pair is the (i, j) maximising the injected metric, not the first tripped."""
-    renders = [_const(0.0), _const(1.0), _const(5.0)]
-    # L1-of-means stand-in: distance grows with the value gap, so (0, 2) is worst.
+def test_all_pairs_worst_mss_selects_the_first_most_divergent_pair() -> None:
+    """The worst pair is the earliest (i, j) maximising the metric (``>``, not ``>=``)."""
+    # means [0, 5, 0, 5]: pairs (0,1),(0,3),(1,2),(2,3) all gap 5; (0,1) is earliest.
+    renders = [_const(0.0), _const(5.0), _const(0.0), _const(5.0)]
     result = repro.all_pairs_worst_mss(
         renders, metric=lambda a, b: abs(float(a.mean()) - float(b.mean()))
     )
-    assert result.worst_pair == (0, 2)
+    assert result.worst_pair == (0, 1)
     assert result.mss_max == pytest.approx(5.0)
+    assert result.mss_max >= 0.0
 
 
-def test_all_pairs_worst_mss_counts_every_unordered_pair() -> None:
-    """``pair_count`` is n*(n-1)/2 — every unordered pair, the #489 all-pairs surface."""
+def test_all_pairs_worst_mss_scores_and_counts_every_unordered_pair() -> None:
+    """Every unordered pair is scored once and ``pair_count`` matches the calls made."""
+    calls: list[tuple[int, int]] = []
+
+    def counting_metric(a: np.ndarray, b: np.ndarray) -> float:
+        calls.append((int(a[0, 0]), int(b[0, 0])))
+        return 0.0
+
     renders = [_const(float(i)) for i in range(4)]
-    result = repro.all_pairs_worst_mss(renders, metric=lambda a, b: 0.0)
+    result = repro.all_pairs_worst_mss(renders, metric=counting_metric)
+    assert calls == [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
     assert result.pair_count == 6
-    assert result.depth == 4
+    # A worst pair is recorded even when every score ties at 0.0 (sentinel is -inf).
+    assert result.worst_pair == (0, 1)
 
 
 def test_all_pairs_worst_mss_traces_peak_amplitude_per_render() -> None:
     """Per-render peak amplitude is reported so silent (junk) renders are visible."""
-    renders = [_const(0.001), _const(0.5)]
-    result = repro.all_pairs_worst_mss(renders, metric=lambda a, b: 0.0)
+    result = repro.all_pairs_worst_mss([_const(0.001), _const(0.5)], metric=lambda a, b: 0.0)
     assert result.peaks == pytest.approx([0.001, 0.5])
 
 
@@ -54,16 +63,55 @@ def test_all_pairs_worst_mss_rejects_fewer_than_two_renders() -> None:
         repro.all_pairs_worst_mss([_const(0.1)], metric=lambda a, b: 0.0)
 
 
-def test_classify_flags_bug_when_reuse_diverges_but_reload_holds() -> None:
-    """Reuse over threshold while reload stays under it is the #489 signature."""
-    assert repro.classify(reused_max=21.0, reloaded_max=3.0, threshold=10.0) == repro.BUG_PRESENT
+@pytest.mark.parametrize(
+    ("reused_max", "reloaded_max", "expected"),
+    [
+        (21.0, 3.0, repro.Verdict.BUG_PRESENT),  # reuse diverges, reload holds
+        (2.0, 3.0, repro.Verdict.NO_REPRO),  # both clean
+        (21.0, 15.0, repro.Verdict.INCONCLUSIVE),  # both diverge -> not the reuse bug
+        (10.0, 3.0, repro.Verdict.NO_REPRO),  # boundary: == threshold is clean
+        (21.0, None, repro.Verdict.BUG_PRESENT),  # control skipped, reuse diverges
+        (2.0, None, repro.Verdict.NO_REPRO),  # control skipped, reuse clean
+    ],
+)
+def test_classify_labels_each_reuse_reload_combination(
+    reused_max: float, reloaded_max: float | None, expected: repro.Verdict
+) -> None:
+    """``classify`` maps reuse/reload worst scores to the right verdict at every case.
+
+    :param reused_max: Reuse-arm worst all-pairs MSS.
+    :param reloaded_max: Reload-arm worst all-pairs MSS, or ``None`` when skipped.
+    :param expected: The verdict ``classify`` must return.
+    """
+    assert repro.classify(reused_max, reloaded_max, threshold=10.0) == expected
 
 
-def test_classify_reports_clean_when_both_arms_hold() -> None:
-    """Both arms under threshold means no reproduction at this depth."""
-    assert repro.classify(reused_max=2.0, reloaded_max=3.0, threshold=10.0) == repro.NO_REPRO
+def test_main_exits_nonzero_when_any_depth_reproduces_the_bug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``main`` exits 1 when ``run`` reports BUG_PRESENT at any depth (CI signal).
+
+    :param monkeypatch: Stubs ``run`` so no VST is rendered.
+    """
+    monkeypatch.setattr(repro, "run", lambda *a, **k: {12: repro.Verdict.BUG_PRESENT})
+    with pytest.raises(SystemExit) as exc:
+        repro.main(["--depths", "12", "--no-control"])
+    assert exc.value.code == 1
 
 
-def test_classify_reports_inconclusive_when_reload_also_diverges() -> None:
-    """Reload over threshold too means the divergence is not the reuse bug (patch/phase)."""
-    assert repro.classify(reused_max=21.0, reloaded_max=15.0, threshold=10.0) == repro.INCONCLUSIVE
+def test_main_exits_zero_when_no_depth_reproduces_the_bug(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``main`` returns normally (exit 0) when no depth is BUG_PRESENT.
+
+    :param monkeypatch: Stubs ``run`` and captures the parsed depths.
+    """
+    captured: dict[str, object] = {}
+
+    def fake_run(depths: object, **kwargs: object) -> dict[int, repro.Verdict]:
+        captured["depths"] = depths
+        return {12: repro.Verdict.NO_REPRO, 40: repro.Verdict.NO_REPRO}
+
+    monkeypatch.setattr(repro, "run", fake_run)
+    repro.main(["--depths", "12", "40"])
+    assert captured["depths"] == [12, 40]

--- a/tests/tools/test_repro_489_reuse_depth.py
+++ b/tests/tools/test_repro_489_reuse_depth.py
@@ -1,9 +1,8 @@
 """Unit tests for the #489 reuse-depth reproducer's pure scoring core.
 
-These pin the all-pairs worst-MSS reducer, the bug verdict, and the CLI exit path
-without touching a VST: the metric is injected and the render layer is stubbed, so
-enumeration, worst-pair selection, peak trace, verdict logic, and ``main``'s
-non-zero exit are exercised on plain data.
+These pin the all-pairs worst-MSS reducer, the loudness gate, the bug verdict, and
+the CLI exit path without rendering a VST: the metric is injected and the render
+layer is stubbed. One ``@slow @requires_vst`` test drives the real render chain.
 """
 
 from __future__ import annotations
@@ -23,6 +22,19 @@ def _const(value: float) -> np.ndarray:
     return np.full((1, 8), value, dtype=np.float32)
 
 
+def _sine(amplitude: float, sample_rate: int = 44100, seconds: float = 1.0) -> np.ndarray:
+    """Return a 2-channel 440 Hz sine at ``amplitude``.
+
+    :param amplitude: Peak amplitude of the tone.
+    :param sample_rate: Samples per second.
+    :param seconds: Tone length (≥0.4 s so the loudness meter has a full block).
+    :returns: A ``(2, T)`` float32 sine.
+    """
+    t = np.arange(int(sample_rate * seconds)) / sample_rate
+    wave = (amplitude * np.sin(2 * np.pi * 440.0 * t)).astype(np.float32)
+    return np.stack([wave, wave])
+
+
 def test_all_pairs_worst_mss_selects_the_first_most_divergent_pair() -> None:
     """The worst pair is the earliest (i, j) maximising the metric (``>``, not ``>=``)."""
     # means [0, 5, 0, 5]: pairs (0,1),(0,3),(1,2),(2,3) all gap 5; (0,1) is earliest.
@@ -39,16 +51,15 @@ def test_all_pairs_worst_mss_scores_and_counts_every_unordered_pair() -> None:
     calls: list[tuple[int, int]] = []
 
     def counting_metric(a: np.ndarray, b: np.ndarray) -> float:
-        # _const(i) fills the clip with i, so a[0, 0] recovers each render's index.
+        # Encode each render's index in its fill value so the closure can record
+        # which pairs were scored without sharing mutable index state.
         calls.append((int(a[0, 0]), int(b[0, 0])))
         return 0.0
 
     renders = [_const(float(i)) for i in range(4)]
     result = repro.all_pairs_worst_mss(renders, metric=counting_metric)
-    # Contract: every unordered pair scored exactly once (order-independent).
     assert sorted(calls) == [(0, 1), (0, 2), (0, 3), (1, 2), (1, 3), (2, 3)]
     assert result.pair_count == 6
-    # A worst pair is recorded even when every score ties at 0.0 (sentinel is -inf).
     assert result.worst_pair == (0, 1)
 
 
@@ -62,6 +73,14 @@ def test_all_pairs_worst_mss_rejects_fewer_than_two_renders() -> None:
     """A single render has no pair to compare, so the reducer refuses it."""
     with pytest.raises(ValueError, match="at least 2"):
         repro.all_pairs_worst_mss([_const(0.1)], metric=lambda a, b: 0.0)
+
+
+def test_integrated_loudness_rises_with_amplitude() -> None:
+    """A louder tone reports higher LUFS, pinning axis/sample-rate wiring of the gate."""
+    loud = repro.integrated_loudness(_sine(0.5), 44100)
+    quiet = repro.integrated_loudness(_sine(0.02), 44100)
+    assert np.isfinite(loud)
+    assert loud > quiet
 
 
 @pytest.mark.parametrize(
@@ -84,34 +103,45 @@ def test_classify_labels_each_reuse_reload_combination(
     :param reloaded_max: Reload-arm worst all-pairs MSS, or ``None`` when skipped.
     :param expected: The verdict ``classify`` must return.
     """
-    assert repro.classify(reused_max, reloaded_max, threshold=10.0) == expected
+    assert repro.classify(reused_max, reloaded_max, repro._MSS_THRESHOLD) == expected
 
 
-def test_main_exits_nonzero_when_any_depth_reproduces_the_bug(
-    monkeypatch: pytest.MonkeyPatch,
+@pytest.mark.parametrize(
+    ("verdicts", "exits"),
+    [
+        ({12: repro.Verdict.BUG_PRESENT}, True),
+        ({12: repro.Verdict.NO_REPRO, 40: repro.Verdict.NO_REPRO}, False),
+        ({12: repro.Verdict.INCONCLUSIVE}, False),
+    ],
+)
+def test_main_exits_nonzero_only_when_a_depth_is_bug_present(
+    monkeypatch: pytest.MonkeyPatch, verdicts: dict[int, repro.Verdict], exits: bool
 ) -> None:
-    """``main`` exits 1 when ``run`` reports BUG_PRESENT at any depth (CI signal).
+    """``main`` exits 1 iff some depth is BUG_PRESENT; INCONCLUSIVE/NO_REPRO exit 0.
 
-    :param monkeypatch: Stubs ``run`` so no VST is rendered.
+    :param monkeypatch: Replaces ``run`` with a stub returning ``verdicts``.
+    :param verdicts: Stubbed per-depth verdicts ``run`` returns.
+    :param exits: Whether ``main`` should raise ``SystemExit(1)``.
     """
-    monkeypatch.setattr(repro, "run", lambda *a, **k: {12: repro.Verdict.BUG_PRESENT})
-    with pytest.raises(SystemExit) as exc:
+    monkeypatch.setattr(repro, "run", lambda *a, **k: verdicts)
+    if exits:
+        with pytest.raises(SystemExit) as exc:
+            repro.main(["--depths", "12", "--no-control"])
+        assert exc.value.code == 1
+    else:
         repro.main(["--depths", "12", "--no-control"])
-    assert exc.value.code == 1
 
 
-def test_main_exits_zero_when_no_depth_reproduces_the_bug(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """``main`` returns normally (exit 0) when no depth is BUG_PRESENT.
+def test_main_passes_parsed_depths_through_to_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``main`` forwards the parsed ``--depths`` list to ``run``.
 
-    :param monkeypatch: Stubs ``run`` and captures the parsed depths.
+    :param monkeypatch: Captures the depths ``run`` is called with.
     """
     captured: dict[str, object] = {}
 
     def fake_run(depths: object, **kwargs: object) -> dict[int, repro.Verdict]:
         captured["depths"] = depths
-        return {12: repro.Verdict.NO_REPRO, 40: repro.Verdict.NO_REPRO}
+        return {12: repro.Verdict.NO_REPRO}
 
     monkeypatch.setattr(repro, "run", fake_run)
     repro.main(["--depths", "12", "40"])

--- a/tests/tools/test_repro_489_reuse_depth.py
+++ b/tests/tools/test_repro_489_reuse_depth.py
@@ -1,0 +1,69 @@
+"""Unit tests for the #489 reuse-depth reproducer's pure scoring core.
+
+These pin the all-pairs worst-MSS reducer and the bug verdict without touching a
+VST: the metric is injected so the enumeration, worst-pair selection, peak trace,
+and verdict logic are exercised on plain arrays.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from synth_setter.tools import repro_489_reuse_depth as repro
+
+
+def _const(value: float) -> np.ndarray:
+    """Return a 1-row clip whose every sample equals ``value`` (peak == ``|value|``).
+
+    :param value: Constant amplitude filling the clip.
+    :returns: A ``(1, 8)`` float32 array of ``value``.
+    """
+    return np.full((1, 8), value, dtype=np.float32)
+
+
+def test_all_pairs_worst_mss_selects_the_most_divergent_pair() -> None:
+    """The worst pair is the (i, j) maximising the injected metric, not the first tripped."""
+    renders = [_const(0.0), _const(1.0), _const(5.0)]
+    # L1-of-means stand-in: distance grows with the value gap, so (0, 2) is worst.
+    result = repro.all_pairs_worst_mss(
+        renders, metric=lambda a, b: abs(float(a.mean()) - float(b.mean()))
+    )
+    assert result.worst_pair == (0, 2)
+    assert result.mss_max == pytest.approx(5.0)
+
+
+def test_all_pairs_worst_mss_counts_every_unordered_pair() -> None:
+    """``pair_count`` is n*(n-1)/2 — every unordered pair, the #489 all-pairs surface."""
+    renders = [_const(float(i)) for i in range(4)]
+    result = repro.all_pairs_worst_mss(renders, metric=lambda a, b: 0.0)
+    assert result.pair_count == 6
+    assert result.depth == 4
+
+
+def test_all_pairs_worst_mss_traces_peak_amplitude_per_render() -> None:
+    """Per-render peak amplitude is reported so silent (junk) renders are visible."""
+    renders = [_const(0.001), _const(0.5)]
+    result = repro.all_pairs_worst_mss(renders, metric=lambda a, b: 0.0)
+    assert result.peaks == pytest.approx([0.001, 0.5])
+
+
+def test_all_pairs_worst_mss_rejects_fewer_than_two_renders() -> None:
+    """A single render has no pair to compare, so the reducer refuses it."""
+    with pytest.raises(ValueError, match="at least 2"):
+        repro.all_pairs_worst_mss([_const(0.1)], metric=lambda a, b: 0.0)
+
+
+def test_classify_flags_bug_when_reuse_diverges_but_reload_holds() -> None:
+    """Reuse over threshold while reload stays under it is the #489 signature."""
+    assert repro.classify(reused_max=21.0, reloaded_max=3.0, threshold=10.0) == repro.BUG_PRESENT
+
+
+def test_classify_reports_clean_when_both_arms_hold() -> None:
+    """Both arms under threshold means no reproduction at this depth."""
+    assert repro.classify(reused_max=2.0, reloaded_max=3.0, threshold=10.0) == repro.NO_REPRO
+
+
+def test_classify_reports_inconclusive_when_reload_also_diverges() -> None:
+    """Reload over threshold too means the divergence is not the reuse bug (patch/phase)."""
+    assert repro.classify(reused_max=21.0, reloaded_max=15.0, threshold=10.0) == repro.INCONCLUSIVE

--- a/tests/tools/test_repro_489_reuse_depth.py
+++ b/tests/tools/test_repro_489_reuse_depth.py
@@ -170,6 +170,17 @@ def test_main_rejects_depths_below_two(monkeypatch: pytest.MonkeyPatch) -> None:
     assert exc.value.code == 2  # argparse parser.error exit code
 
 
+def test_main_rejects_spec_without_a_render_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A spec lacking ``configs/render/<spec>.yaml`` is rejected by argparse choices.
+
+    :param monkeypatch: Stubs ``run`` so a regression that skips validation can't render.
+    """
+    monkeypatch.setattr(repro, "run", lambda *a, **k: {})
+    with pytest.raises(SystemExit) as exc:
+        repro.main(["--spec", "surge_4", "--depths", "2"])
+    assert exc.value.code == 2  # argparse invalid-choice exit code
+
+
 @pytest.mark.slow
 @pytest.mark.requires_vst
 def test_main_drives_the_real_render_chain_end_to_end() -> None:

--- a/tests/tools/test_repro_489_reuse_depth.py
+++ b/tests/tools/test_repro_489_reuse_depth.py
@@ -159,12 +159,28 @@ def test_main_passes_parsed_depths_through_to_run(monkeypatch: pytest.MonkeyPatc
     assert captured["depths"] == [12, 40]
 
 
+def test_main_rejects_depths_below_two(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``--depths`` below 2 is rejected up front, before any render runs.
+
+    :param monkeypatch: Stubs ``run`` so a regression that skips validation can't render.
+    """
+    monkeypatch.setattr(repro, "run", lambda *a, **k: {})
+    with pytest.raises(SystemExit) as exc:
+        repro.main(["--depths", "1"])
+    assert exc.value.code == 2  # argparse parser.error exit code
+
+
 @pytest.mark.slow
 @pytest.mark.requires_vst
 def test_main_drives_the_real_render_chain_end_to_end() -> None:
     """Real VST smoke test: depth-2 run must not raise SystemExit (regression for #489)."""
     # Seed both RNGs param_spec.sample() draws from so the loudness-gated patch
-    # search is deterministic and the test cannot flake on an unlucky draw.
+    # search is deterministic; restore prior state so the seed can't leak to other tests.
+    py_state, np_state = random.getstate(), np.random.get_state()
     random.seed(0)
     np.random.seed(0)
-    assert repro.main(["--depths", "2", "--no-control"]) is None
+    try:
+        assert repro.main(["--depths", "2", "--no-control"]) is None
+    finally:
+        random.setstate(py_state)
+        np.random.set_state(np_state)

--- a/tests/tools/test_repro_489_reuse_depth.py
+++ b/tests/tools/test_repro_489_reuse_depth.py
@@ -7,6 +7,8 @@ layer is stubbed. One ``@slow @requires_vst`` test drives the real render chain.
 
 from __future__ import annotations
 
+import random
+
 import numpy as np
 import pytest
 
@@ -72,6 +74,16 @@ def test_all_pairs_worst_mss_rejects_fewer_than_two_renders() -> None:
     """A single render has no pair to compare, so the reducer refuses it."""
     with pytest.raises(ValueError, match="at least 2"):
         repro.all_pairs_worst_mss([_const(0.1)], metric=lambda a, b: 0.0)
+
+
+def test_all_pairs_worst_mss_treats_non_finite_score_as_maximal_divergence() -> None:
+    """A NaN metric (the silent-junk symptom) is coerced to +inf, not skipped as clean."""
+    result = repro.all_pairs_worst_mss(
+        [_const(0.0), _const(0.0)], metric=lambda a, b: float("nan")
+    )
+    assert result.mss_max == float("inf")
+    assert result.worst_pair == (0, 1)
+    assert repro.classify(result.mss_max, reloaded_max=1.0) is repro.Verdict.BUG_PRESENT
 
 
 def test_integrated_loudness_rises_with_amplitude() -> None:
@@ -151,4 +163,8 @@ def test_main_passes_parsed_depths_through_to_run(monkeypatch: pytest.MonkeyPatc
 @pytest.mark.requires_vst
 def test_main_drives_the_real_render_chain_end_to_end() -> None:
     """Real VST smoke test: depth-2 run must not raise SystemExit (regression for #489)."""
+    # Seed both RNGs param_spec.sample() draws from so the loudness-gated patch
+    # search is deterministic and the test cannot flake on an unlucky draw.
+    random.seed(0)
+    np.random.seed(0)
     assert repro.main(["--depths", "2", "--no-control"]) is None


### PR DESCRIPTION
## What

Adds `synth_setter.tools.repro_489_reuse_depth` — a standalone reproducer for the #489 "every-other-render junk" bug that measures it **at the source**, bypassing the oracle/sweep harness that cannot surface it.

For each reuse depth N it renders one identical patch N times against a single cached `VST3Plugin` (the `plugin_reload_cadence="once"` path) and reports the **all-pairs worst-case** multi-scale spectral loss across those N renders — the exact signal that defined #489 in the PR #706 reproducer. A control arm re-renders the same patch reloading the plugin per call (the #713 workaround / current default). Per-depth verdict: `BUG_PRESENT` (reuse≫threshold, reload<threshold) / `INCONCLUSIVE` (both diverge → patch/phase) / `NO_REPRO`. `main` exits non-zero on any `BUG_PRESENT` so it can gate.

## Why

A sweep investigation could not reproduce the junk. Checking the W&B history (104 cadence sweeps / 370 runs) showed why the **sweeps are structurally unable** to surface it: they score target-vs-oracle-prediction *means* (`audio/mss_mean`, `shuffled_audio/mss_mean`), never two raw renders of one identical patch; the `shuffle` probe only ever fired at depth 10; and the deep runs (≤40) used `param_sample_cadence=sample`, where the loudness gate resamples junk away. The #489 fingerprint is the all-pairs *worst-case* between identical-patch renders — computed only in a test, never in the sweep. This tool fills that gap. Full analysis in #489.

## Result

Run [`sjiploz7`](https://wandb.ai/khaledtinubu-n-a/synth-setter/runs/sjiploz7) (surge_xt, surge-base):

| reuse depth | reuse-once worst MSS | reload control worst MSS | verdict |
|---|---|---|---|
| 12 | 1.251 | 1.052 | NO_REPRO |
| 40 | 1.658 | 1.390 | NO_REPRO |
| 80 | 2.034 | 1.748 | NO_REPRO |

The junk does **not** reproduce on current `main` even on the cached `once` path at depth 80 (original was mss≈21 at depth 12). This is the cached-instance arm with no per-render reload, so the result is stronger than "masked by #713's default" — the unconditional flush+reset in the current `render_params` appears to clear the stale state at the root. The tool lets this be re-checked on demand if that flush is ever removed for perf.

## Tests

- 15 fast unit tests: all-pairs reducer (worst-pair selection, pair enumeration via a counting metric, peak trace, `<2` guard), `integrated_loudness` amplitude monotonicity, parametrized `classify` (incl. `== threshold` boundary and `None`-control), and `main` exit-code paths.
- 1 `@slow @requires_vst` end-to-end test driving the real render chain.
- `make format` clean (ruff, ruff-format, pyright, pydoclint, interrogate, codespell).

Refs #489
