### PR TITLE
refactor(training): extract pure prepare_batch from VSTDataset

### DIFF
--- a/src/synth_setter/data/surge_datamodule.py
+++ b/src/synth_setter/data/surge_datamodule.py
@@ -1,7 +1,7 @@
 import random
 from collections.abc import Iterator, Sequence
 from pathlib import Path
-from typing import ClassVar, Literal, Protocol
+from typing import ClassVar, Literal, NotRequired, Protocol, TypedDict
 
 import h5py
 import hdf5plugin  # noqa: F401  # side-effect import: registers HDF5 blosc filters for shard I/O
@@ -17,6 +17,89 @@ from synth_setter.pipeline import r2_io
 # Registry key whose spec width sizes fake-mode batches and seeds the
 # datamodule default when no ``param_spec_name`` is configured.
 _DEFAULT_PARAM_SPEC_NAME = "surge_xt"
+
+
+# DOC601/DOC603: pydoclint can't read sphinx ``:ivar:`` docs, so TypedDict keys
+# are documented in the docstring body instead.
+class RawBatch(TypedDict):  # noqa: DOC601, DOC603
+    """One batch of read shard columns, the input to :func:`prepare_batch`.
+
+    Shapes are ``(batch, ...)``: ``param_array`` is ``(batch, num_params)`` and
+    always present; ``mel_spec`` is ``(batch, channels, n_mels, n_frames)``,
+    ``music2latent`` is ``(batch, latent_dim, n_frames)``, ``audio`` is
+    ``(batch, channels, samples)``. Each optional key is ``None`` when its read
+    flag is off.
+    """
+
+    param_array: np.ndarray
+    mel_spec: NotRequired[np.ndarray | None]
+    music2latent: NotRequired[np.ndarray | None]
+    audio: NotRequired[np.ndarray | None]
+
+
+def prepare_batch(
+    raw: RawBatch,
+    *,
+    mean: np.ndarray | None,
+    std: np.ndarray | None,
+    rescale_params: bool,
+    ot: bool,
+    generator: torch.Generator,
+) -> dict[str, torch.Tensor | None]:
+    """Turn one batch of read columns into model-ready tensors.
+
+    The single owner of per-batch semantics: mel normalization, param rescale,
+    seeded noise, and optional Hungarian matching, in that order. Pure — it
+    reads only ``raw`` and the passed args and never writes back into them, so a
+    fixed ``generator`` seed makes the whole batch reproducible. The h5 and Lance
+    read paths both route here so batch contents stay format-independent.
+
+    :param raw: Read shard columns; see :class:`RawBatch` for keys and shapes.
+        ``param_array`` ``(batch, num_params)`` is required; a missing or
+        ``None`` optional modality drops to ``None`` in the output.
+    :param mean: Mel mean to subtract, broadcasting over the batch axis, or
+        ``None`` to skip normalization.
+    :param std: Mel std to divide by, broadcasting over the batch axis, or
+        ``None`` to skip normalization.
+    :param rescale_params: Whether to map params from ``[0, 1]`` to ``[-1, 1]``.
+    :param ot: Whether to Hungarian-match noise to params (and permute the
+        conditioning rows to follow).
+    :param generator: RNG for the noise draw; seed it to pin the batch.
+    :returns: ``{"mel_spec", "m2l", "params", "noise", "audio"}`` with
+        ``float32`` contiguous tensors, ``None`` for unread modalities; ``params``
+        and ``noise`` are ``(batch, num_params)``.
+    """
+    audio_raw = raw.get("audio")
+    audio = torch.from_numpy(audio_raw).to(dtype=torch.float32) if audio_raw is not None else None
+
+    mel_raw = raw.get("mel_spec")
+    if mel_raw is not None:
+        if mean is not None and std is not None:
+            mel_raw = (mel_raw - mean) / std
+        mel_spec = torch.from_numpy(mel_raw).to(dtype=torch.float32)
+    else:
+        mel_spec = None
+
+    m2l_raw = raw.get("music2latent")
+    m2l = torch.from_numpy(m2l_raw).to(dtype=torch.float32) if m2l_raw is not None else None
+
+    param_array = raw["param_array"]
+    if rescale_params:
+        param_array = param_array * 2 - 1
+    params = torch.from_numpy(param_array).to(dtype=torch.float32)
+    # empty_like(params) matches params' device/dtype/shape and normal_ accepts
+    # the generator (randn_like does not), so noise can't land on a foreign device.
+    noise = torch.empty_like(params).normal_(generator=generator)
+    if ot:
+        noise, params, mel_spec, audio = _hungarian_match(noise, params, mel_spec, audio)
+
+    return dict(
+        mel_spec=mel_spec.contiguous() if mel_spec is not None else None,
+        m2l=m2l.contiguous() if m2l is not None else None,
+        params=params.contiguous(),
+        noise=noise.contiguous(),
+        audio=audio.contiguous() if audio is not None else None,
+    )
 
 
 class ShardColumn(Protocol):
@@ -59,10 +142,8 @@ class ShardFile(Protocol):
         ...
 
 
-# DOC601/DOC603: pydoclint cannot see sphinx ``:ivar:`` class-attribute docs (the
-# underlying docstring_parser drops them from its attribute list), so a documented
-# class with class-level annotations is unavoidably flagged; mean/std/dataset_file are
-# described in the class docstring body instead.
+# DOC601/DOC603: pydoclint can't read sphinx ``:ivar:`` docs, so class-level
+# annotations are documented in the docstring body instead.
 class VSTDataset(torch.utils.data.Dataset):  # noqa: DOC601, DOC603
     """Batch-indexed dataset over one shard of VST renders (HDF5 by default).
 
@@ -71,7 +152,9 @@ class VSTDataset(torch.utils.data.Dataset):  # noqa: DOC601, DOC603
     ``ot`` is set). Fake mode synthesises
     random tensors of the configured width without opening any file. ``mean`` and ``std``
     hold the optional saved mel statistics applied during reads (``None`` when unloaded);
-    ``dataset_file`` is the open :class:`ShardFile` handle (``None`` in fake mode).
+    ``dataset_file`` is the open :class:`ShardFile` handle (``None`` in fake mode);
+    ``generator`` is the entropy-seeded RNG threaded into :func:`prepare_batch` for the
+    per-batch noise draw (seed it to pin a batch).
     Storage-format subclasses override ``_open`` to read non-HDF5 shards.
     """
 
@@ -111,6 +194,13 @@ class VSTDataset(torch.utils.data.Dataset):  # noqa: DOC601, DOC603
         self.batch_size = batch_size
         self.ot = ot
 
+        # A bare torch.Generator() has a fixed default seed, so .seed() is needed
+        # to actually randomize production noise across runs; tests call
+        # generator.manual_seed(...) to pin a batch. num_workers>0 forks share
+        # this state and draw correlated noise; per-worker re-seed is Phase 2.
+        self.generator = torch.Generator()
+        self.generator.seed()
+
         self.read_audio = read_audio
         self.read_mel = read_mel
         self.read_m2l = read_m2l
@@ -147,8 +237,6 @@ class VSTDataset(torch.utils.data.Dataset):  # noqa: DOC601, DOC603
         :param dataset_file: Shard path used to locate the sibling ``stats.npz``.
         :raises FileNotFoundError: If the expected ``stats.npz`` is missing.
         """
-        # for /path/to/train.h5 we would expect to find /path/to/stats.npz
-        # if not, we throw an error
         stats_file = VSTDataset.get_stats_file_path(dataset_file)
         if not stats_file.exists():
             raise FileNotFoundError(
@@ -179,10 +267,15 @@ class VSTDataset(torch.utils.data.Dataset):  # noqa: DOC601, DOC603
         if self.fake:
             return 10000
 
-        return self.dataset_file["audio"].shape[0] // self.batch_size
+        # param_array is the one always-present column; audio is optional on
+        # Lance shards, so counting rows off it would KeyError before any read.
+        return self.dataset_file["param_array"].shape[0] // self.batch_size
 
     def _get_fake_item(self) -> dict[str, torch.Tensor | None]:
         """Synthesise one random batch matching the configured feature flags.
+
+        Bypasses :func:`prepare_batch`: fake batches are already tensors and need
+        no normalization or OT, and their noise is intentionally unseeded.
 
         :returns: Mapping of feature names to random tensors (or ``None`` when unread).
         """
@@ -233,43 +326,36 @@ class VSTDataset(torch.utils.data.Dataset):  # noqa: DOC601, DOC603
         if self.fake:
             return self._get_fake_item()
 
-        if self.read_audio:
-            audio = self._index_dataset(self.dataset_file["audio"], idx)
-            audio = torch.from_numpy(audio).to(dtype=torch.float32)
-        else:
-            audio = None
-
-        if self.read_mel:
-            mel_spec = self._index_dataset(self.dataset_file["mel_spec"], idx)
-            if self.mean is not None and self.std is not None:
-                mel_spec = (mel_spec - self.mean) / self.std
-            mel_spec = torch.from_numpy(mel_spec).to(dtype=torch.float32)
-        else:
-            mel_spec = None
-
-        if self.read_m2l:
-            m2l = self._index_dataset(self.dataset_file["music2latent"], idx)
-            m2l = torch.from_numpy(m2l).to(dtype=torch.float32)
-        else:
-            m2l = None
-
-        param_array = self._index_dataset(self.dataset_file["param_array"], idx)
-        if self.rescale_params:
-            param_array = param_array * 2 - 1
-        param_array = torch.from_numpy(param_array).to(dtype=torch.float32)
-        noise = torch.randn_like(param_array)
-        if self.ot:
-            noise, param_array, mel_spec, audio = _hungarian_match(
-                noise, param_array, mel_spec, audio
-            )
-
-        return dict(
-            mel_spec=mel_spec.contiguous() if mel_spec is not None else None,
-            m2l=m2l.contiguous() if m2l is not None else None,
-            params=param_array.contiguous(),
-            noise=noise.contiguous(),
-            audio=audio.contiguous() if audio is not None else None,
+        # Every key is always present; an off read flag stores ``None`` rather
+        # than omitting the key, so prepare_batch never relies on key-absence.
+        raw: RawBatch = {
+            "param_array": self._index_dataset(self.dataset_file["param_array"], idx),
+            "audio": self._read_column("audio", idx, self.read_audio),
+            "mel_spec": self._read_column("mel_spec", idx, self.read_mel),
+            "music2latent": self._read_column("music2latent", idx, self.read_m2l),
+        }
+        return prepare_batch(
+            raw,
+            mean=self.mean,
+            std=self.std,
+            rescale_params=self.rescale_params,
+            ot=self.ot,
+            generator=self.generator,
         )
+
+    def _read_column(
+        self, name: str, idx: int | Sequence[int] | np.ndarray, read: bool
+    ) -> np.ndarray | None:
+        """Slice one optional shard column, or skip it when its read flag is off.
+
+        :param name: Column name within the shard.
+        :param idx: Batch index, or a ``(start, stop)`` pair, or a sequence of rows.
+        :param read: Whether this column's modality is enabled.
+        :returns: The selected rows, or ``None`` when ``read`` is false.
+        """
+        if not read:
+            return None
+        return self._index_dataset(self.dataset_file[name], idx)
 
 
 class WithinChunkShuffledSampler(torch.utils.data.Sampler):
@@ -319,7 +405,6 @@ class WithinChunkShuffledSampler(torch.utils.data.Sampler):
 
         indices = np.concatenate(indices, axis=0)
 
-        # shuffle by rows
         np.random.shuffle(indices)
 
         for row in indices:
@@ -534,12 +619,7 @@ class VSTDataModule(LightningDataModule):
             batch_size=None,
             num_workers=self.num_workers,
             pin_memory=self.pin_memory,
-            # sampler=WithinChunkShuffledSampler(
-            #     self.batch_size, len(self.train_dataset), 4
-            # ),
             sampler=ShiftedBatchSampler(self.batch_size, len(self.train_dataset)),
-            # sampler=ShuffledSampler(self.batch_size, len(self.train_dataset)),
-            # shuffle=True,
         )
 
     def val_dataloader(self) -> DataLoader:

--- a/tests/data/test_prepare_batch.py
+++ b/tests/data/test_prepare_batch.py
@@ -1,0 +1,415 @@
+"""Pinning tests for :func:`synth_setter.data.surge_datamodule.prepare_batch`.
+
+Each test compares against :func:`_reference_prepare_batch`, an independent
+golden that applies the batch math (mel norm, param rescale, seeded noise,
+Hungarian match) drawing noise from the global RNG via ``torch.manual_seed``. A
+seeded ``torch.Generator`` reproduces the seeded global RNG bit-for-bit on CPU
+(true for current PyTorch; the equivalence is the comparison's only cross-version
+assumption), so the golden and ``prepare_batch`` are directly comparable.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import cast
+
+import numpy as np
+import pytest
+import torch
+
+from synth_setter.data.ot import _hungarian_match
+from synth_setter.data.surge_datamodule import RawBatch, prepare_batch
+
+_NUM_PARAMS = 5
+_BATCH = 8
+_MEL_SHAPE = (_BATCH, 2, 4, 6)
+_AUDIO_SHAPE = (_BATCH, 2, 16)
+_M2L_SHAPE = (_BATCH, 3, 7)
+
+
+def _unwrap(maybe_tensor: torch.Tensor | None) -> torch.Tensor:
+    """Assert ``maybe_tensor`` is non-``None`` and narrow it for pyright.
+
+    :param maybe_tensor: The dict value to narrow.
+    :returns: The same tensor, typed as non-``None``.
+    """
+    assert maybe_tensor is not None
+    return maybe_tensor
+
+
+def _unwrap_array(maybe_array: np.ndarray | None) -> np.ndarray:
+    """Assert ``maybe_array`` is non-``None`` and narrow it for pyright.
+
+    :param maybe_array: The ``raw`` dict value to narrow.
+    :returns: The same array, typed as non-``None``.
+    """
+    assert maybe_array is not None
+    return maybe_array
+
+
+def _reference_prepare_batch(
+    raw: RawBatch,
+    *,
+    mean: np.ndarray | None,
+    std: np.ndarray | None,
+    rescale_params: bool,
+    ot: bool,
+    seed: int,
+) -> dict[str, torch.Tensor | None]:
+    """Apply the batch math independently of ``prepare_batch`` as the golden.
+
+    Draws noise from the global RNG seeded by ``seed``; a seeded
+    ``torch.Generator`` in ``prepare_batch`` reproduces this bit-for-bit on CPU.
+
+    :param raw: Read shard columns; see :class:`RawBatch`.
+    :param mean: Mel mean, or ``None`` to skip normalization.
+    :param std: Mel std, or ``None`` to skip normalization.
+    :param rescale_params: Whether to map params ``[0, 1] -> [-1, 1]``.
+    :param ot: Whether to Hungarian-match noise to params.
+    :param seed: Global-RNG seed for the noise draw.
+    :returns: ``{"mel_spec", "m2l", "params", "noise", "audio"}`` tensors.
+    """
+    audio_raw = raw.get("audio")
+    if audio_raw is not None:
+        audio = torch.from_numpy(audio_raw).to(dtype=torch.float32)
+    else:
+        audio = None
+
+    mel_raw = raw.get("mel_spec")
+    if mel_raw is not None:
+        mel_spec = mel_raw
+        if mean is not None and std is not None:
+            mel_spec = (mel_spec - mean) / std
+        mel_spec = torch.from_numpy(mel_spec).to(dtype=torch.float32)
+    else:
+        mel_spec = None
+
+    m2l_raw = raw.get("music2latent")
+    if m2l_raw is not None:
+        m2l = torch.from_numpy(m2l_raw).to(dtype=torch.float32)
+    else:
+        m2l = None
+
+    param_raw = _unwrap_array(raw["param_array"])
+    if rescale_params:
+        param_raw = param_raw * 2 - 1
+    param_array = torch.from_numpy(param_raw).to(dtype=torch.float32)
+    with torch.random.fork_rng():
+        torch.manual_seed(seed)
+        noise = torch.randn_like(param_array)
+    if ot:
+        noise, param_array, mel_spec, audio = _hungarian_match(noise, param_array, mel_spec, audio)
+
+    return dict(
+        mel_spec=mel_spec.contiguous() if mel_spec is not None else None,
+        m2l=m2l.contiguous() if m2l is not None else None,
+        params=param_array.contiguous(),
+        noise=noise.contiguous(),
+        audio=audio.contiguous() if audio is not None else None,
+    )
+
+
+def _make_raw(
+    *,
+    read_mel: bool = True,
+    read_m2l: bool = False,
+    read_audio: bool = False,
+    seed: int = 7,
+) -> RawBatch:
+    """Build a deterministic ``raw`` batch for the given read flags.
+
+    :param read_mel: Whether to include a ``mel_spec`` array.
+    :param read_m2l: Whether to include a ``music2latent`` array.
+    :param read_audio: Whether to include an ``audio`` array.
+    :param seed: Seed for the NumPy generator backing every array.
+    :returns: ``raw`` batch with ``param_array`` always present.
+    """
+    rng = np.random.default_rng(seed)
+    raw: RawBatch = {
+        "param_array": rng.random((_BATCH, _NUM_PARAMS)).astype(np.float32),
+    }
+    if read_mel:
+        raw["mel_spec"] = rng.standard_normal(_MEL_SHAPE).astype(np.float32)
+    if read_m2l:
+        raw["music2latent"] = rng.standard_normal(_M2L_SHAPE).astype(np.float32)
+    if read_audio:
+        raw["audio"] = rng.standard_normal(_AUDIO_SHAPE).astype(np.float32)
+    return raw
+
+
+def test_prepare_batch_is_pure_and_pinned() -> None:
+    """``prepare_batch`` reproduces the frozen pre-refactor golden bit-for-bit."""
+    seed = 0
+    raw = _make_raw(read_mel=True, read_audio=True, seed=3)
+    mean = np.zeros((2, 4, 6), dtype=np.float32)
+    std = np.full((2, 4, 6), 2.0, dtype=np.float32)
+
+    golden = _reference_prepare_batch(
+        raw, mean=mean, std=std, rescale_params=True, ot=True, seed=seed
+    )
+    out = prepare_batch(
+        raw,
+        mean=mean,
+        std=std,
+        rescale_params=True,
+        ot=True,
+        generator=torch.Generator().manual_seed(seed),
+    )
+
+    for key in ("mel_spec", "params", "noise", "audio"):
+        # atol=rtol=0: every step (affine mel norm, x*2-1, seeded noise, integer
+        # row permutation from Hungarian) is exact, so bit-equality must hold.
+        torch.testing.assert_close(out[key], golden[key], atol=0.0, rtol=0.0)
+        assert _unwrap(out[key]).is_contiguous()
+        assert _unwrap(out[key]).dtype == torch.float32
+    assert out["m2l"] is None
+
+
+@pytest.mark.parametrize("ot", [False, True])
+def test_prepare_batch_same_seed_yields_identical_output(ot: bool) -> None:
+    """Two calls with the same seed produce identical outputs (deterministic purity).
+
+    :param ot: Whether to exercise the Hungarian-match path; ``ot=False`` isolates
+        determinism from any per-call generator consumption inside the matcher.
+    """
+    raw = _make_raw(seed=11)
+    first = prepare_batch(
+        raw,
+        mean=None,
+        std=None,
+        rescale_params=True,
+        ot=ot,
+        generator=torch.Generator().manual_seed(42),
+    )
+    second = prepare_batch(
+        raw,
+        mean=None,
+        std=None,
+        rescale_params=True,
+        ot=ot,
+        generator=torch.Generator().manual_seed(42),
+    )
+    for key in ("params", "noise", "mel_spec"):
+        torch.testing.assert_close(first[key], second[key], atol=0.0, rtol=0.0)
+    # The unread slots must stay None across calls, not silently materialize.
+    assert first["audio"] is None and second["audio"] is None
+    assert first["m2l"] is None and second["m2l"] is None
+
+
+def test_prepare_batch_does_not_mutate_raw_inputs() -> None:
+    """``prepare_batch`` performs no in-place writes to the ``raw`` arrays."""
+    raw = _make_raw(read_mel=True, read_audio=True, seed=5)
+    snapshot = {
+        "param_array": _unwrap_array(raw["param_array"]).copy(),
+        "mel_spec": _unwrap_array(raw.get("mel_spec")).copy(),
+        "audio": _unwrap_array(raw.get("audio")).copy(),
+    }
+    prepare_batch(
+        raw,
+        mean=np.zeros((2, 4, 6), dtype=np.float32),
+        std=np.ones((2, 4, 6), dtype=np.float32),
+        rescale_params=True,
+        ot=True,
+        generator=torch.Generator().manual_seed(0),
+    )
+    np.testing.assert_array_equal(_unwrap_array(raw["param_array"]), snapshot["param_array"])
+    np.testing.assert_array_equal(_unwrap_array(raw.get("mel_spec")), snapshot["mel_spec"])
+    np.testing.assert_array_equal(_unwrap_array(raw.get("audio")), snapshot["audio"])
+
+
+@pytest.mark.parametrize(
+    ("read_mel", "read_m2l", "read_audio"),
+    [(True, False, False), (False, True, False), (True, False, True)],
+)
+def test_prepare_batch_modality_slots_match_read_flags(
+    read_mel: bool, read_m2l: bool, read_audio: bool
+) -> None:
+    """Each modality slot is non-``None`` exactly when its source array is present.
+
+    :param read_mel: Whether the ``mel_spec`` source array is present.
+    :param read_m2l: Whether the ``music2latent`` source array is present.
+    :param read_audio: Whether the ``audio`` source array is present.
+    """
+    raw = _make_raw(read_mel=read_mel, read_m2l=read_m2l, read_audio=read_audio)
+    out = prepare_batch(
+        raw,
+        mean=None,
+        std=None,
+        rescale_params=True,
+        ot=False,
+        generator=torch.Generator().manual_seed(0),
+    )
+    assert set(out.keys()) == {"mel_spec", "m2l", "params", "noise", "audio"}
+    assert (out["mel_spec"] is not None) == read_mel
+    assert (out["m2l"] is not None) == read_m2l
+    assert (out["audio"] is not None) == read_audio
+    assert _unwrap(out["params"]).shape == (_BATCH, _NUM_PARAMS)
+    assert _unwrap(out["noise"]).shape == (_BATCH, _NUM_PARAMS)
+
+
+def test_prepare_batch_normalizes_mel_only_when_mean_and_std_set() -> None:
+    """Mel normalization applies iff both ``mean`` and ``std`` are provided."""
+    raw = _make_raw(read_mel=True)
+    raw["mel_spec"] = np.full(_MEL_SHAPE, 3.0, dtype=np.float32)
+
+    normalized = _unwrap(
+        prepare_batch(
+            raw,
+            mean=np.full((2, 4, 6), 1.0, dtype=np.float32),
+            std=np.full((2, 4, 6), 2.0, dtype=np.float32),
+            rescale_params=False,
+            ot=False,
+            generator=torch.Generator().manual_seed(0),
+        )["mel_spec"]
+    )
+    assert torch.allclose(normalized, torch.full_like(normalized, (3.0 - 1.0) / 2.0))
+
+    untouched = _unwrap(
+        prepare_batch(
+            raw,
+            mean=None,
+            std=None,
+            rescale_params=False,
+            ot=False,
+            generator=torch.Generator().manual_seed(0),
+        )["mel_spec"]
+    )
+    assert torch.allclose(untouched, torch.full_like(untouched, 3.0))
+
+
+def test_prepare_batch_rescale_toggle() -> None:
+    """``rescale_params`` maps params ``[0, 1] -> [-1, 1]`` exactly as ``x * 2 - 1``."""
+    raw = _make_raw(read_mel=False)
+    raw_params = torch.from_numpy(_unwrap_array(raw["param_array"])).to(dtype=torch.float32)
+
+    not_rescaled = _unwrap(
+        prepare_batch(
+            raw,
+            mean=None,
+            std=None,
+            rescale_params=False,
+            ot=False,
+            generator=torch.Generator().manual_seed(0),
+        )["params"]
+    )
+    assert not_rescaled.min() >= 0.0
+    assert not_rescaled.max() <= 1.0
+    torch.testing.assert_close(not_rescaled, raw_params, atol=0.0, rtol=0.0)
+
+    rescaled = _unwrap(
+        prepare_batch(
+            raw,
+            mean=None,
+            std=None,
+            rescale_params=True,
+            ot=False,
+            generator=torch.Generator().manual_seed(0),
+        )["params"]
+    )
+    assert rescaled.min() >= -1.0
+    assert rescaled.max() <= 1.0
+    torch.testing.assert_close(rescaled, raw_params * 2 - 1, atol=0.0, rtol=0.0)
+
+
+def test_prepare_batch_ot_true_matches_reference_hungarian() -> None:
+    """``ot=True`` pairs noise/params exactly as the reference ``_hungarian_match``."""
+    seed = 0
+    raw = _make_raw(read_mel=True, read_audio=True)
+    golden = _reference_prepare_batch(
+        raw, mean=None, std=None, rescale_params=True, ot=True, seed=seed
+    )
+    out = prepare_batch(
+        raw,
+        mean=None,
+        std=None,
+        rescale_params=True,
+        ot=True,
+        generator=torch.Generator().manual_seed(seed),
+    )
+    for key in ("noise", "params", "mel_spec", "audio"):
+        torch.testing.assert_close(out[key], golden[key], atol=0.0, rtol=0.0)
+
+
+def test_prepare_batch_ot_false_passes_through_unpermuted() -> None:
+    """``ot=False`` leaves every modality in its read order (no Hungarian permutation)."""
+    seed = 0
+    raw = _make_raw(read_mel=True, read_audio=True)
+    out = prepare_batch(
+        raw,
+        mean=None,
+        std=None,
+        rescale_params=True,
+        ot=False,
+        generator=torch.Generator().manual_seed(seed),
+    )
+    expected_params = torch.from_numpy(_unwrap_array(raw["param_array"]) * 2 - 1).to(
+        dtype=torch.float32
+    )
+    expected_mel = torch.from_numpy(_unwrap_array(raw.get("mel_spec"))).to(dtype=torch.float32)
+    expected_audio = torch.from_numpy(_unwrap_array(raw.get("audio"))).to(dtype=torch.float32)
+    torch.testing.assert_close(out["params"], expected_params, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(out["mel_spec"], expected_mel, atol=0.0, rtol=0.0)
+    torch.testing.assert_close(out["audio"], expected_audio, atol=0.0, rtol=0.0)
+    expected_noise = torch.randn(
+        expected_params.shape, generator=torch.Generator().manual_seed(seed)
+    )
+    torch.testing.assert_close(out["noise"], expected_noise, atol=0.0, rtol=0.0)
+
+
+def test_prepare_batch_missing_param_array_raises_key_error() -> None:
+    """``param_array`` is required; an absent key surfaces a ``KeyError``, not noise."""
+    # cast: deliberately omit the required key to pin the missing-column contract.
+    raw = cast(RawBatch, {"mel_spec": np.zeros(_MEL_SHAPE, dtype=np.float32)})
+    with pytest.raises(KeyError, match="param_array"):
+        prepare_batch(
+            raw,
+            mean=None,
+            std=None,
+            rescale_params=False,
+            ot=False,
+            generator=torch.Generator().manual_seed(0),
+        )
+
+
+def test_prepare_batch_ot_pairs_minimize_total_noise_to_param_distance() -> None:
+    """OT pairing minimizes summed noise-param L2 — an independent optimality check.
+
+    Hardcoded, reference-free: any valid permutation's total cost must be >= the
+    cost ``prepare_batch`` produces, so a mis-paired extraction is caught without
+    trusting ``_reference_prepare_batch``.
+    """
+
+    # 5! = 120 permutations keeps this brute force fast (8! would be 40320); the
+    # pairing is batch-size-independent, so a small batch still exercises it.
+    n_small = 5
+    rng = np.random.default_rng(7)
+    raw: RawBatch = {"param_array": rng.random((n_small, _NUM_PARAMS)).astype(np.float32)}
+    out = prepare_batch(
+        raw,
+        mean=None,
+        std=None,
+        rescale_params=True,
+        ot=True,
+        generator=torch.Generator().manual_seed(0),
+    )
+    noise = _unwrap(out["noise"])
+    params = _unwrap(out["params"])
+    chosen_cost = torch.linalg.vector_norm(noise - params, dim=1).sum().item()
+    for perm in itertools.permutations(range(n_small)):
+        cost = torch.linalg.vector_norm(noise[list(perm)] - params, dim=1).sum().item()
+        assert chosen_cost <= cost + 1e-5
+
+
+def test_prepare_batch_mean_none_alias_branch_does_not_mutate_raw() -> None:
+    """The ``mean=None`` mel path aliases the input array without writing back to it."""
+    raw = _make_raw(read_mel=True)
+    snapshot = _unwrap_array(raw.get("mel_spec")).copy()
+    prepare_batch(
+        raw,
+        mean=None,
+        std=None,
+        rescale_params=True,
+        ot=True,
+        generator=torch.Generator().manual_seed(0),
+    )
+    np.testing.assert_array_equal(_unwrap_array(raw.get("mel_spec")), snapshot)

--- a/tests/data/test_surge_datamodule.py
+++ b/tests/data/test_surge_datamodule.py
@@ -37,6 +37,7 @@ import pytest
 import torch
 
 from synth_setter.data import surge_datamodule
+from synth_setter.data.ot import _hungarian_match
 from synth_setter.data.surge_datamodule import (
     ShiftedBatchSampler,
     ShuffledSampler,
@@ -104,19 +105,10 @@ def _set_up_module(**kwargs: object) -> Iterator[VSTDataModule]:
 
 
 def _unwrap(maybe_tensor: torch.Tensor | None) -> torch.Tensor:
-    """Assert ``maybe_tensor`` is non-None and return it as a ``torch.Tensor``.
-
-    The dataset's ``__getitem__`` returns a dict where every value is typed
-    ``Tensor | None`` (mel/audio/m2l really are optional depending on read
-    flags; params/noise are unconditionally populated but share the same
-    dict type). Tests that exercise the populated keys go through this
-    helper so pyright narrows the type once, instead of every test
-    inlining ``assert x is not None``.
+    """Assert ``maybe_tensor`` is non-None and narrow it for pyright.
 
     :param maybe_tensor: The dict value to narrow.
-
     :return: The same tensor, now typed as non-None.
-    :rtype: torch.Tensor
     """
     assert maybe_tensor is not None
     return maybe_tensor
@@ -225,11 +217,6 @@ def single_h5(tmp_path: Path) -> Path:
     return h5_path
 
 
-# --------------------------------------------------------------------------- #
-# VSTDataset — fake mode                                                      #
-# --------------------------------------------------------------------------- #
-
-
 class TestVSTDatasetFakeMode:
     """``fake=True`` skips HDF5 entirely and returns randomly-generated tensors."""
 
@@ -284,9 +271,8 @@ class TestVSTDatasetFakeMode:
 
     def test_fake_mode_rescale_params_maps_into_minus_one_to_one(self) -> None:
         """``rescale_params=True`` rescales ``torch.rand`` from [0, 1) into [-1, 1)."""
-        # read_mel=False + read_audio=False skips the ~190 MB mel/audio
-        # allocations that fake mode would otherwise build at batch_size=128;
-        # this test only inspects params.
+        # batch_size=128 with mel/audio enabled allocates ~190 MB; disable both
+        # since this test only inspects params.
         dataset = VSTDataset(
             "ignored",
             batch_size=128,
@@ -298,9 +284,8 @@ class TestVSTDatasetFakeMode:
         params = _unwrap(dataset[0]["params"])
         assert params.min().item() >= -1.0
         assert params.max().item() < 1.0
-        # With 128*num_params samples from rand()*2 - 1 we will reach into
-        # [-1, 0) and [0, 1) with vanishing probability of staying on one side —
-        # pin the rescaling behavior, not just the bounds.
+        # 128*num_params samples make staying on one side vanishingly unlikely;
+        # assert both to pin the rescaling, not just the bounds.
         assert params.min().item() < 0.0
         assert params.max().item() > 0.0
 
@@ -343,11 +328,6 @@ class TestVSTDatasetFakeMode:
         assert _unwrap(item["noise"]).shape == (2, 92)
 
 
-# --------------------------------------------------------------------------- #
-# VSTDataset — real HDF5 mode                                                 #
-# --------------------------------------------------------------------------- #
-
-
 class TestVSTDatasetH5Mode:
     """HDF5-backed path: indexing, type conversion, OT routing, normalization."""
 
@@ -357,6 +337,18 @@ class TestVSTDatasetH5Mode:
         :param single_h5: Fixture-provided single-shard HDF5 path.
         """
         dataset = VSTDataset(single_h5, batch_size=3, ot=False)
+        assert len(dataset) == 8 // 3
+
+    def test_len_counts_param_array_rows_without_audio_column(self, tmp_path: Path) -> None:
+        """``__len__`` counts rows off ``param_array`` so an audio-less shard still works.
+
+        :param tmp_path: Pytest fixture providing a fresh test directory.
+        """
+        h5_path = tmp_path / "train.h5"
+        _write_h5_shard(h5_path, num_rows=8)
+        with h5py.File(h5_path, "a") as f:
+            del f["audio"]
+        dataset = VSTDataset(h5_path, batch_size=3, ot=False, use_saved_mean_and_variance=False)
         assert len(dataset) == 8 // 3
 
     def test_getitem_int_returns_batch_size_slice(self, single_h5: Path) -> None:
@@ -588,9 +580,8 @@ class TestVSTDatasetH5Mode:
         mock_match.assert_called_once()
         positional = mock_match.call_args.args
         assert len(positional) == 4
-        # Positional contract: (noise, params, mel_spec, audio). Pin each slot's
-        # shape so a regression that swaps positions is caught — bare arity does
-        # not distinguish `(noise, params, audio, mel_spec)` from the correct order.
+        # Pin per-slot shapes: bare arity can't distinguish a swapped
+        # (mel_spec, audio) order from the (noise, params, mel_spec, audio) contract.
         noise, params, mel_spec, audio = positional
         assert isinstance(noise, torch.Tensor) and noise.shape == (2, _NUM_PARAMS)
         assert isinstance(params, torch.Tensor) and params.shape == (2, _NUM_PARAMS)
@@ -649,9 +640,93 @@ class TestVSTDatasetH5Mode:
         assert set(item.keys()) == set(_ALL_TENSOR_KEYS)
 
 
-# --------------------------------------------------------------------------- #
-# WithinChunkShuffledSampler                                                  #
-# --------------------------------------------------------------------------- #
+def _reference_getitem(
+    dataset: VSTDataset, idx: int, *, seed: int
+) -> dict[str, torch.Tensor | None]:
+    """Apply the batch math against the same shard independently of ``__getitem__``.
+
+    Seeds the global RNG before the noise draw; a seeded ``VSTDataset.generator``
+    reproduces this bit-for-bit, so a match proves the delegation is a no-op.
+
+    :param dataset: Open HDF5-backed dataset to read columns from.
+    :param idx: Batch index to read.
+    :param seed: Global-RNG seed for the noise draw.
+    :raises ValueError: If ``dataset`` has no open shard handle.
+    :returns: The batch dict ``__getitem__`` is expected to return.
+    """
+    shard = dataset.dataset_file
+    if shard is None:
+        raise ValueError("dataset has no open shard handle")
+    if dataset.read_audio:
+        audio = dataset._index_dataset(shard["audio"], idx)
+        audio = torch.from_numpy(audio).to(dtype=torch.float32)
+    else:
+        audio = None
+
+    if dataset.read_mel:
+        mel_spec = dataset._index_dataset(shard["mel_spec"], idx)
+        if dataset.mean is not None and dataset.std is not None:
+            mel_spec = (mel_spec - dataset.mean) / dataset.std
+        mel_spec = torch.from_numpy(mel_spec).to(dtype=torch.float32)
+    else:
+        mel_spec = None
+
+    if dataset.read_m2l:
+        m2l = dataset._index_dataset(shard["music2latent"], idx)
+        m2l = torch.from_numpy(m2l).to(dtype=torch.float32)
+    else:
+        m2l = None
+
+    param_array = dataset._index_dataset(shard["param_array"], idx)
+    if dataset.rescale_params:
+        param_array = param_array * 2 - 1
+    param_array = torch.from_numpy(param_array).to(dtype=torch.float32)
+    with torch.random.fork_rng():
+        torch.manual_seed(seed)
+        noise = torch.randn_like(param_array)
+    if dataset.ot:
+        noise, param_array, mel_spec, audio = _hungarian_match(noise, param_array, mel_spec, audio)
+
+    return dict(
+        mel_spec=mel_spec.contiguous() if mel_spec is not None else None,
+        m2l=m2l.contiguous() if m2l is not None else None,
+        params=param_array.contiguous(),
+        noise=noise.contiguous(),
+        audio=audio.contiguous() if audio is not None else None,
+    )
+
+
+class TestGetitemNoOpAfterExtraction:
+    """The post-extraction ``__getitem__`` matches the independent golden."""
+
+    @pytest.mark.parametrize("idx", [0, 1])
+    def test_getitem_unchanged_after_extraction(self, single_h5: Path, idx: int) -> None:
+        """Seeding ``dataset.generator`` reproduces the golden at each batch index.
+
+        :param single_h5: Fixture-provided single-shard HDF5 path.
+        :param idx: Batch index to read; covers more than the first batch so an
+            off-by-one in the ``_read_column`` slicing would surface.
+        """
+        seed = 0
+        dataset = VSTDataset(
+            single_h5,
+            batch_size=4,
+            ot=True,
+            use_saved_mean_and_variance=True,
+            read_audio=True,
+            read_mel=True,
+            read_m2l=True,
+        )
+        golden = _reference_getitem(dataset, idx, seed=seed)
+        dataset.generator.manual_seed(seed)
+        out = dataset[idx]
+        for key in _ALL_TENSOR_KEYS:
+            if golden[key] is None:
+                assert out[key] is None, key
+                continue
+            # atol=rtol=0: the extraction is a pure structural move, so output
+            # must be bit-identical under the matched seed.
+            torch.testing.assert_close(out[key], golden[key], atol=0.0, rtol=0.0)
 
 
 class TestWithinChunkShuffledSampler:
@@ -711,11 +786,6 @@ class TestWithinChunkShuffledSampler:
         assert len(rows) == 5
 
 
-# --------------------------------------------------------------------------- #
-# ShuffledSampler                                                             #
-# --------------------------------------------------------------------------- #
-
-
 class TestShuffledSampler:
     """Global random permutation sampler — no locality guarantees."""
 
@@ -744,11 +814,6 @@ class TestShuffledSampler:
         sampler = ShuffledSampler(batch_size=batch_size, num_batches=num_batches)
         flat = [int(idx) for row in sampler for idx in row]
         assert sorted(flat) == list(range(batch_size * num_batches))
-
-
-# --------------------------------------------------------------------------- #
-# ShiftedBatchSampler                                                         #
-# --------------------------------------------------------------------------- #
 
 
 class TestShiftedBatchSampler:
@@ -787,9 +852,8 @@ class TestShiftedBatchSampler:
 
     def test_offset_can_vary_across_epochs(self) -> None:
         """A fresh ``iter()`` redraws the offset — over many epochs we see >1 distinct value."""
-        # Seed Python's random + numpy so the test is deterministic but still
-        # exercises the redraw. Save/restore the global states so other tests
-        # in the same pytest-xdist worker don't see a leaked seed.
+        # Seed global RNGs for determinism; save/restore so xdist workers don't
+        # see a leaked state.
         py_state = random.getstate()
         np_state = np.random.get_state()
         try:
@@ -814,11 +878,6 @@ class TestShiftedBatchSampler:
             for start, _ in ShiftedBatchSampler(batch_size=batch_size, num_batches=num_batches)
         )
         assert pair_indices == list(range(num_batches - 1))
-
-
-# --------------------------------------------------------------------------- #
-# VSTDataModule                                                               #
-# --------------------------------------------------------------------------- #
 
 
 class TestVSTDataModule:


### PR DESCRIPTION
## Why

Phase 1 of the Lance-native dataloader epic (#1738). Before any storage/sampling
changes, isolate the one thing in the migration that affects batch *semantics* —
the per-batch math — into a pure function and pin it with goldens, so every later
phase is plumbing that provably cannot change what a batch contains.

## What changed

- Extracts the per-batch math (mel normalization, param rescale `[0,1]→[-1,1]`,
  seeded noise, optional Hungarian/OT matching, `.contiguous()`, `None`
  passthrough) out of `VSTDataset.__getitem__` into a pure module-level
  `prepare_batch(raw, *, mean, std, rescale_params, ot, generator)`.
- Adds a `RawBatch` TypedDict for the read-column input contract.
- Threads an explicit `torch.Generator` through the noise draw so the batch is
  pinnable; `__getitem__` now assembles the raw column dict and delegates.
- **Incidental bug fix:** `__len__` counted rows off `dataset_file["audio"]`,
  which is optional on Lance shards and would `KeyError` before any read; it now
  counts off the always-present `param_array`.
- Samplers, `batch_size=None`, fake mode, and `repeat_first_batch` are untouched.

## Reviewer note — RNG seeding surface

The noise draw moves from a global `torch.randn_like` (governed by Lightning
`seed_everything`) to a per-dataset, entropy-seeded `torch.Generator`. The golden
tests pin the per-batch math bit-for-bit under matched seeds, so batch
*semantics* are unchanged — but the production *default* seeding surface changes
(noise is no longer governed by the global seed, and forked workers currently
share the generator and draw correlated noise). Per-worker re-seeding via
`worker_init_fn` is explicitly Phase 2 scope (#1740, Task 2.2), where the
seeding/DDP surface is finalized. Flagging here for reviewer awareness.

## Test plan

`tests/data/test_prepare_batch.py` (new) + new tests in
`tests/data/test_surge_datamodule.py`. 90 passed (serial, `-m "not slow"`):

- **Pinning/golden** — `prepare_batch` output matches a frozen reference of the
  pre-refactor body bit-for-bit under a fixed `torch.Generator` seed; outputs are
  `float32` + `.contiguous()`.
- **Purity** — same seed → identical output; `raw` inputs are not mutated.
- **Feature flags / rescale / OT** — modality slots match `read_*` flags; rescale
  toggle maps `[0,1]→[-1,1]`; `ot=True` pairing matches `_hungarian_match` and a
  reference-free brute-force OT-optimality check; `ot=False` passes through.
- **End-to-end no-op** — `test_getitem_unchanged_after_extraction` compares the
  post-refactor `__getitem__` to a pre-refactor golden, proving the rewire is a
  true no-op.

Closes #1739
Part of #1738
