### PR TITLE
internal-fix(pipeline): scale subprocess timeouts by sample count

### DIFF
--- a/src/synth_setter/cli/eval.py
+++ b/src/synth_setter/cli/eval.py
@@ -17,6 +17,7 @@ from omegaconf import DictConfig, OmegaConf
 
 from synth_setter.pipeline import r2_io
 from synth_setter.pipeline.schemas.spec import _get_git_sha
+from synth_setter.pipeline.subprocess_stream import scaled_timeout
 from synth_setter.resources import as_file, vst_headless_wrapper
 from synth_setter.run_id import make_wandb_run_id
 from synth_setter.utils import (
@@ -36,7 +37,12 @@ from synth_setter.workspace import operator_workspace
 
 _PREDICT_VST_AUDIO_MODULE = "synth_setter.evaluation.predict_vst_audio"
 _COMPUTE_AUDIO_METRICS_MODULE = "synth_setter.evaluation.compute_audio_metrics"
-_SUBPROCESS_TIMEOUT_SECONDS = 600
+# Postprocessing subprocess timeouts scale with sample count so a larger eval
+# split can't spuriously time out; overhead covers fixed startup. See scaled_timeout.
+_RENDER_TIMEOUT_OVERHEAD_SECONDS = 300.0
+_RENDER_TIMEOUT_PER_SAMPLE_SECONDS = 60.0
+_METRICS_TIMEOUT_OVERHEAD_SECONDS = 180.0
+_METRICS_TIMEOUT_PER_SAMPLE_SECONDS = 30.0
 _AGGREGATED_METRICS_FILENAME = "aggregated_metrics.csv"
 _METRICS_FILENAME = "metrics.csv"
 _AGGREGATED_METRICS_SHUFFLED_FILENAME = "aggregated_metrics_shuffled.csv"
@@ -187,8 +193,8 @@ def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: D
     :raises ValueError: if ``evaluation.render_vst`` is enabled but ``cfg.render`` is
         unset, or the expected input directory for a stage is missing.
     :raises subprocess.CalledProcessError: propagated from a non-zero subprocess exit.
-    :raises subprocess.TimeoutExpired: propagated when a subprocess exceeds
-        :data:`_SUBPROCESS_TIMEOUT_SECONDS`.
+    :raises subprocess.TimeoutExpired: propagated when a subprocess exceeds its
+        sample-count-scaled budget (see :func:`scaled_timeout`).
     """
     output_dir = Path(cfg.paths.output_dir)
     predictions_dir = output_dir / "predictions"
@@ -239,11 +245,22 @@ def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: D
                     args += [flag, str(value)]
             if cfg.evaluation.rerender_target:
                 args.append("-t")
+            # Budget scales with the sample count predict_vst_audio will render:
+            # one pred-*.pt per batch, and VSTDataset drops the partial tail batch,
+            # so files * batch_size matches the rendered count.
+            n_render_samples = (
+                sum(1 for f in predictions_dir.glob("pred-*.pt") if f.is_file())
+                * cfg.datamodule.batch_size
+            )
             log.info(f"Rendering predicted audio: {args}")
             subprocess.run(  # noqa: S603
                 args,
                 check=True,
-                timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+                timeout=scaled_timeout(
+                    n_render_samples,
+                    overhead_seconds=_RENDER_TIMEOUT_OVERHEAD_SECONDS,
+                    per_sample_seconds=_RENDER_TIMEOUT_PER_SAMPLE_SECONDS,
+                ),
             )
 
     if cfg.evaluation.compute_metrics:
@@ -264,11 +281,22 @@ def _run_predict_postprocessing(cfg: DictConfig) -> dict[str, float]:  # noqa: D
             "-w",
             str(cfg.evaluation.num_workers),
         ]
+        # Upper-bounds the sample count compute_audio_metrics scores (it skips
+        # subdirs lacking both wavs); the surplus only loosens the budget.
+        n_metric_samples = sum(1 for d in audio_dir.glob("*") if d.is_dir())
+        # num_workers=0 is a valid config (Darwin runs in-process), i.e. one
+        # effective worker — clamp so it means that, not a scaled_timeout error.
+        metric_workers = max(cfg.evaluation.num_workers, 1)
         log.info(f"Computing audio metrics: {args}")
         subprocess.run(  # noqa: S603
             args,
             check=True,
-            timeout=_SUBPROCESS_TIMEOUT_SECONDS,
+            timeout=scaled_timeout(
+                n_metric_samples,
+                workers=metric_workers,
+                overhead_seconds=_METRICS_TIMEOUT_OVERHEAD_SECONDS,
+                per_sample_seconds=_METRICS_TIMEOUT_PER_SAMPLE_SECONDS,
+            ),
         )
         audio_metrics = _load_audio_metrics(metrics_dir)
         # Namespace every key (audio/* and shuffled_audio/*) per caller — e.g. one

--- a/src/synth_setter/cli/generate_dataset.py
+++ b/src/synth_setter/cli/generate_dataset.py
@@ -19,8 +19,9 @@ import time
 from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
 from contextlib import ExitStack
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
+import h5py
 import hydra
 import wandb
 from hydra.core.hydra_config import HydraConfig
@@ -54,6 +55,7 @@ from synth_setter.pipeline.spec_io import (
 # Imported under the module-local name tests already patch as the render /
 # rclone / eval subprocess seam (see tests/helpers/render_subprocess.py).
 from synth_setter.pipeline.subprocess_stream import check_call_streamed as _check_call_streamed
+from synth_setter.pipeline.subprocess_stream import scaled_timeout
 from synth_setter.resources import as_file, vst_headless_wrapper
 from synth_setter.utils import extras, log_wandb_provenance, pin_wandb_run_id, register_resolvers
 from synth_setter.utils.instantiators import close_loggers, instantiate_loggers
@@ -71,8 +73,10 @@ register_resolvers()
 # launcher's workspace (which may not exist on the worker filesystem).
 _WORKER_REPO_ROOT = "/home/build/synth-setter"
 
-# Smoke-shard-sized; longer eval runs belong on the dispatch path, not inline.
-_ORACLE_EVAL_TIMEOUT_SECONDS = 600
+# The inline eval (predict + re-render + metrics over a whole split) scales its
+# timeout with that split's sample count; per-sample covers all three. See scaled_timeout.
+_ORACLE_EVAL_TIMEOUT_OVERHEAD_SECONDS = 600.0
+_ORACLE_EVAL_TIMEOUT_PER_SAMPLE_SECONDS = 120.0
 
 # Finalized artifacts the eval datamodule opens; all must sit in dataset_root.
 _ORACLE_EVAL_REQUIRED_ARTIFACTS = ("train.h5", "val.h5", "test.h5", STATS_NPZ_FILENAME)
@@ -178,8 +182,20 @@ def _run_oracle_eval_subprocess(
     # (test split) leaves keys bare so existing sweeps/dashboards keep resolving.
     if metric_prefix:
         argv.append(f"+evaluation.metric_prefix={metric_prefix}")
+    # Budget scales with the split's sample count (predict + re-render + metrics
+    # all run over it); the finalized split exposes it as the audio row count.
+    # cast narrows h5py's Group|Dataset|Datatype union — "audio" is always a Dataset.
+    with h5py.File(predict_file, "r") as split_h5:
+        num_samples = int(cast(h5py.Dataset, split_h5["audio"]).shape[0])
     logger.info(f"oracle_eval_inline subprocess: {argv}")
-    _check_call_streamed(argv, timeout=_ORACLE_EVAL_TIMEOUT_SECONDS)
+    _check_call_streamed(
+        argv,
+        timeout=scaled_timeout(
+            num_samples,
+            overhead_seconds=_ORACLE_EVAL_TIMEOUT_OVERHEAD_SECONDS,
+            per_sample_seconds=_ORACLE_EVAL_TIMEOUT_PER_SAMPLE_SECONDS,
+        ),
+    )
 
 
 def _unsupported_cadence_reason(render_cfg: DictConfig) -> str | None:

--- a/src/synth_setter/pipeline/subprocess_stream.py
+++ b/src/synth_setter/pipeline/subprocess_stream.py
@@ -27,7 +27,7 @@ from typing import cast
 
 import structlog
 
-__all__ = ["check_call_streamed", "check_call_streamed_async"]
+__all__ = ["check_call_streamed", "check_call_streamed_async", "scaled_timeout"]
 
 _LOG = structlog.get_logger(__name__)
 
@@ -49,6 +49,47 @@ _CAPTURE_MAX_BYTES = 1 << 20
 # Exit-detection poll cadence, seconds. Negligible against children that run
 # seconds to hours; bounds added exit-detection latency to one tick.
 _EXIT_POLL_SECONDS = 0.05
+
+
+def scaled_timeout(
+    num_samples: int,
+    *,
+    workers: int = 1,
+    overhead_seconds: float,
+    per_sample_seconds: float,
+) -> float:
+    """Wall-clock timeout for a child whose runtime grows with ``num_samples``.
+
+    Cost is modelled as a fixed ``overhead_seconds`` (import, plugin/model load,
+    config compose — independent of dataset size) plus ``per_sample_seconds`` per
+    item, the per-item term divided across ``workers`` that process items
+    concurrently. Scaling the per-item term rather than fixing a flat ceiling
+    keeps a larger dataset from tripping a spurious ``TimeoutExpired``; the
+    constant term still fails a true startup hang fast at small ``num_samples``.
+    Any safety margin belongs folded into the two cost constants the caller
+    passes, so this stays the bare cost model.
+
+    :param num_samples: Item count the child will process; must be >= 0.
+    :param workers: Concurrent workers the child fans items across; the per-item
+        term is divided by this (ceil, so a partial final batch still counts).
+        Must be >= 1.
+    :param overhead_seconds: Fixed cost independent of ``num_samples``; must be >= 0.
+    :param per_sample_seconds: Marginal cost per item, margin included; must be >= 0.
+    :returns: ``overhead_seconds + per_sample_seconds * ceil(num_samples / workers)``.
+    :raises ValueError: if ``num_samples`` < 0, ``workers`` < 1, or either cost
+        is negative.
+    """
+    if num_samples < 0:
+        raise ValueError(f"num_samples must be >= 0, got {num_samples}")
+    if workers < 1:
+        raise ValueError(f"workers must be >= 1, got {workers}")
+    if overhead_seconds < 0:
+        raise ValueError(f"overhead_seconds must be >= 0, got {overhead_seconds}")
+    if per_sample_seconds < 0:
+        raise ValueError(f"per_sample_seconds must be >= 0, got {per_sample_seconds}")
+    # Integer ceil-division: exact for any size, unlike float math.ceil(a / b).
+    batches = -(-num_samples // workers)
+    return overhead_seconds + per_sample_seconds * batches
 
 
 async def _wait_exit(proc: asyncio.subprocess.Process) -> int:

--- a/tests/_vst.py
+++ b/tests/_vst.py
@@ -41,6 +41,7 @@ PLUGIN_PATH = default_plugin_path()
 # Probed once at import: a filesystem stat, no plugin load and no network hit.
 VST_AVAILABLE = Path(PLUGIN_PATH).exists()
 
-# Ceiling for any VST-driving subprocess a test spawns; generous because no
-# per-call tuning exists and a hung plugin load should fail, not wedge CI.
+# Flat ceiling for the single-shot VST load check — no per-sample work, so it
+# does not scale; dataset-building subprocesses instead use the sample-scaled
+# helper in tests/conftest.py.
 VST_SUBPROCESS_TIMEOUT_SECONDS = 600

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,11 +22,12 @@ from omegaconf import DictConfig, open_dict
 
 from synth_setter.data.vst import core, param_specs, preset_paths
 from synth_setter.pipeline.schemas.spec import DatasetSpec, RenderConfig
+from synth_setter.pipeline.subprocess_stream import scaled_timeout
 from synth_setter.resources import vst_headless_wrapper
 from synth_setter.utils.utils import register_resolvers
 from synth_setter.workspace import operator_workspace
 from tests._baseline_worktree import worktree_for_ref  # noqa: F401 — pytest fixture re-export
-from tests._vst import PLUGIN_PATH, VST_AVAILABLE, VST_SUBPROCESS_TIMEOUT_SECONDS
+from tests._vst import PLUGIN_PATH, VST_AVAILABLE
 from tests.data.vst._fake_plugin import FakeVST3Plugin
 from tests.pipeline.conftest import fake_r2_remote  # noqa: F401 — pytest fixture re-export
 
@@ -48,6 +49,21 @@ _SURGE_MEL_SHAPE = (2, 128, 401)
 _SURGE_SILENCE_PEAK_THRESHOLD = 1e-4
 
 NUM_FIXTURE_SAMPLES = 5
+
+
+def _scaled_vst_subprocess_timeout(num_samples: int = NUM_FIXTURE_SAMPLES) -> float:
+    """Wall-clock budget for a fixture-building VST subprocess, scaled by sample count.
+
+    A flat ceiling silently under-budgets the day ``NUM_FIXTURE_SAMPLES`` is
+    raised; scaling on it keeps the budget honest as the fixture grows. Overhead
+    covers fixed startup (plugin load, imports); the per-sample term is loose
+    render margin.
+
+    :param num_samples: Sample count the subprocess renders or reads.
+    :returns: Timeout in seconds for the subprocess.
+    """
+    return scaled_timeout(num_samples, overhead_seconds=300.0, per_sample_seconds=60.0)
+
 
 # Probed from the env var, no network hit — AGENTS.md's `rclone lsd r2:` is for
 # interactive verification, not the skip criterion. VST presence lives in tests._vst.
@@ -151,13 +167,14 @@ def _write_smoke_stats_npz(train_h5: Path) -> None:
         str(train_h5),
         "--mask-degenerate-bins",
     ]
+    timeout = _scaled_vst_subprocess_timeout()
     try:
         result = subprocess.run(  # noqa: S603
-            stats_args, text=True, check=False, timeout=VST_SUBPROCESS_TIMEOUT_SECONDS
+            stats_args, text=True, check=False, timeout=timeout
         )
     except subprocess.TimeoutExpired:
         pytest.fail(
-            f"get_dataset_stats timed out after {VST_SUBPROCESS_TIMEOUT_SECONDS}s\n"
+            f"get_dataset_stats timed out after {timeout}s\n"
             f"command: {stats_args}\n"
             f"(child stdout/stderr printed above; rerun with `pytest -s` if captured)",
             pytrace=False,
@@ -706,16 +723,17 @@ def _render_smoke_train_subprocess(output_path: Path, param_spec_name: str) -> N
     # forever. Output flows to pytest's normal capture (visible with `-s` or on failure);
     # we lose `result.stdout/stderr` on the failure branch but keep the exit code, which
     # is what the failure branch needs to fail loud. See #695.
+    timeout = _scaled_vst_subprocess_timeout()
     try:
         result = subprocess.run(  # noqa: S603
             generate_dataset_args,
             text=True,
             check=False,
-            timeout=VST_SUBPROCESS_TIMEOUT_SECONDS,
+            timeout=timeout,
         )
     except subprocess.TimeoutExpired:
         pytest.fail(
-            f"generate_vst_dataset timed out after {VST_SUBPROCESS_TIMEOUT_SECONDS}s\n"
+            f"generate_vst_dataset timed out after {timeout}s\n"
             f"command: {generate_dataset_args}\n"
             f"(child stdout/stderr printed above; rerun with `pytest -s` if captured)",
             pytrace=False,

--- a/tests/helpers/eval_fakes.py
+++ b/tests/helpers/eval_fakes.py
@@ -42,11 +42,15 @@ def fake_postprocessing_subprocess(
     :returns: Callable compatible with ``subprocess.run``.
     """
 
-    def _fake_run(args: list[str], **_kwargs: object) -> None:
+    def _fake_run(args: list[str], *, timeout: object = None, **_kwargs: object) -> None:
         is_render = any(PREDICT_VST_AUDIO_FRAGMENT in arg for arg in args)
         is_metrics = any(COMPUTE_AUDIO_METRICS_FRAGMENT in arg for arg in args)
         if not (is_render or is_metrics):
             return
+        # Both subprocess timeouts are now sample-count-scaled; assert a positive
+        # float reaches the call so a dropped/None timeout fails here too (exact
+        # values are pinned in tests/test_eval_postprocessing.py).
+        assert isinstance(timeout, float) and timeout > 0, timeout
 
         output_dir = Path(args[args.index("-m") + 3])
         output_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/pipeline/entrypoints/test_generate_dataset_unit.py
+++ b/tests/pipeline/entrypoints/test_generate_dataset_unit.py
@@ -66,6 +66,20 @@ from tests.helpers.subprocess_args import find_script_index
 
 VST_HEADLESS_WRAPPER = str(vst_headless_wrapper())
 
+
+def _write_audio_h5(path: Path, num_samples: int) -> None:
+    """Write a minimal HDF5 split exposing ``audio`` with ``num_samples`` rows.
+
+    ``_run_oracle_eval_subprocess`` reads this row count to scale the eval
+    timeout, so only the leading dimension is load-bearing here.
+
+    :param path: Destination ``.h5`` file.
+    :param num_samples: Row count the ``audio`` dataset is given.
+    """
+    with h5py.File(path, "w") as f:
+        f.create_dataset("audio", data=np.zeros((num_samples, 1), dtype=np.float32))
+
+
 # Reusable VST3 bundle with a real Contents/moduleinfo.json so
 # extract_renderer_version (called by generate) returns a deterministic version
 # without loading any .so via pedalboard. Version inside is "1.0.0-test" — the
@@ -1894,7 +1908,7 @@ class TestMainDispatchBranches:
 
         dataset_root = tmp_path / "data"
         dataset_root.mkdir()
-        for name in ("train.h5", "val.h5", "test.h5", "stats.npz"):
+        for name in ("train.h5", "val.h5", "stats.npz"):
             (dataset_root / name).touch()
         run_dir = tmp_path / "oracle_eval" / "some-run-id"
         render = spec.render.model_copy(
@@ -1905,6 +1919,8 @@ class TestMainDispatchBranches:
             }
         )
         predict_file = dataset_root / "test.h5"
+        n_samples = 4
+        _write_audio_h5(predict_file, n_samples)
         gd._run_oracle_eval_subprocess(
             dataset_root,
             run_dir,
@@ -1915,9 +1931,10 @@ class TestMainDispatchBranches:
         )
 
         streamed_call_mock.assert_called_once()
-        # The timeout bound is the helper's only guard against an unbounded
-        # eval hang (#735); the hardcoded value catches a wrong constant too.
-        assert streamed_call_mock.call_args.kwargs["timeout"] == 600
+        # Hard-coded (not mirroring the module constants) so a wrong constant fails;
+        # the timeout bounds an otherwise-unbounded eval hang (#735) and now scales
+        # with the split: 600 overhead + 120/sample * 4 rows = 1080.
+        assert streamed_call_mock.call_args.kwargs["timeout"] == 1080.0
         called_argv = streamed_call_mock.call_args[0][0]
         assert "-m" in called_argv
         assert "synth_setter.cli.eval" in called_argv
@@ -1980,9 +1997,10 @@ class TestMainDispatchBranches:
 
         dataset_root = tmp_path / "data"
         dataset_root.mkdir()
-        for name in ("train.h5", "val.h5", "test.h5", "stats.npz"):
+        for name in ("val.h5", "test.h5", "stats.npz"):
             (dataset_root / name).touch()
         predict_file = dataset_root / "train.h5"
+        _write_audio_h5(predict_file, 4)
         gd._run_oracle_eval_subprocess(
             dataset_root,
             tmp_path / "oracle_eval" / "train" / "some-run-id",
@@ -1996,6 +2014,45 @@ class TestMainDispatchBranches:
         called_argv = streamed_call_mock.call_args[0][0]
         # ``+`` appends the key: it is absent from eval.yaml's evaluation group.
         assert "+evaluation.metric_prefix=train/" in called_argv
+
+    def test_run_oracle_eval_subprocess_timeout_grows_with_split_sample_count(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        spec: DatasetSpec,
+    ) -> None:
+        """A larger predict split yields a strictly larger eval timeout.
+
+        Pins the scaling itself (not just one formula point): a flat ceiling
+        would return the same budget for both splits and fail this.
+
+        :param monkeypatch: Patches ``_check_call_streamed`` to capture the timeout.
+        :param tmp_path: Roots the two distinct dataset roots.
+        :param spec: Source of a valid ``RenderConfig``.
+        """
+        import synth_setter.cli.generate_dataset as gd
+
+        def _timeout_for_split(root: Path, num_samples: int) -> float:
+            root.mkdir()
+            for name in ("train.h5", "val.h5", "stats.npz"):
+                (root / name).touch()
+            predict_file = root / "test.h5"
+            _write_audio_h5(predict_file, num_samples)
+            mock = MagicMock()
+            monkeypatch.setattr(gd, "_check_call_streamed", mock)
+            gd._run_oracle_eval_subprocess(
+                root,
+                root / "run",
+                "some-run-id",
+                render=spec.render,
+                num_workers=1,
+                predict_file=predict_file,
+            )
+            return mock.call_args.kwargs["timeout"]
+
+        small = _timeout_for_split(tmp_path / "small", 4)
+        large = _timeout_for_split(tmp_path / "large", 40)
+        assert large > small
 
     def test_run_oracle_eval_subprocess_missing_local_artifacts_raises(
         self,

--- a/tests/pipeline/test_subprocess_stream.py
+++ b/tests/pipeline/test_subprocess_stream.py
@@ -38,6 +38,7 @@ from synth_setter.pipeline.subprocess_stream import (
     _READ_CHUNK_BYTES,
     check_call_streamed,
     check_call_streamed_async,
+    scaled_timeout,
 )
 
 # Hard wedge backstop for every SUT invocation: no test scenario legitimately
@@ -801,3 +802,56 @@ class TestSyncFacade:
             out = future.result(timeout=_BACKSTOP_SECONDS)
 
         assert b"FROM_THREAD" in out
+
+
+class TestScaledTimeout:
+    """``scaled_timeout`` converts a per-item cost model into a wall-clock bound.
+
+    Problem: a flat per-call ceiling that ignores dataset size trips a spurious
+    ``TimeoutExpired`` once the dataset outgrows it. The fix scales the per-item
+    term so growth is absorbed, while a fixed overhead term still fails a true
+    startup hang fast at small N.
+    """
+
+    def test_formula_single_worker_returns_overhead_plus_per_sample_times_n(self) -> None:
+        """Single worker: budget is overhead + per_sample * num_samples."""
+        assert scaled_timeout(10, overhead_seconds=5.0, per_sample_seconds=2.0) == 25.0
+
+    def test_workers_divide_per_sample_term_ceil_not_floor(self) -> None:
+        """Workers divide the per-sample term by batch count, rounded up."""
+        # A flooring bug would drop the partial final batch and under-budget.
+        assert scaled_timeout(10, workers=4, overhead_seconds=5.0, per_sample_seconds=2.0) == 11.0
+
+    def test_zero_samples_returns_overhead_only(self) -> None:
+        """An empty dataset still gets the fixed startup overhead."""
+        assert scaled_timeout(0, overhead_seconds=7.0, per_sample_seconds=2.0) == 7.0
+
+    def test_workers_exceeding_samples_collapses_per_sample_to_one_batch(self) -> None:
+        """More workers than samples still costs one batch of per-sample time."""
+        assert scaled_timeout(3, workers=8, overhead_seconds=5.0, per_sample_seconds=2.0) == 7.0
+
+    def test_growing_dataset_increases_budget_monotonically(self) -> None:
+        """A larger sample count yields a strictly larger budget."""
+        small = scaled_timeout(100, overhead_seconds=30.0, per_sample_seconds=1.0)
+        large = scaled_timeout(1000, overhead_seconds=30.0, per_sample_seconds=1.0)
+        assert large > small
+
+    def test_negative_samples_raises_value_error(self) -> None:
+        """A negative sample count is rejected."""
+        with pytest.raises(ValueError, match="num_samples"):
+            scaled_timeout(-1, overhead_seconds=5.0, per_sample_seconds=2.0)
+
+    def test_zero_workers_raises_value_error(self) -> None:
+        """A worker count below one is rejected (division guard)."""
+        with pytest.raises(ValueError, match="workers"):
+            scaled_timeout(10, workers=0, overhead_seconds=5.0, per_sample_seconds=2.0)
+
+    def test_negative_overhead_raises_value_error(self) -> None:
+        """A negative overhead constant is rejected."""
+        with pytest.raises(ValueError, match="overhead_seconds"):
+            scaled_timeout(10, overhead_seconds=-1.0, per_sample_seconds=2.0)
+
+    def test_negative_per_sample_raises_value_error(self) -> None:
+        """A negative per-sample constant is rejected."""
+        with pytest.raises(ValueError, match="per_sample_seconds"):
+            scaled_timeout(10, overhead_seconds=5.0, per_sample_seconds=-1.0)

--- a/tests/test_eval_postprocessing.py
+++ b/tests/test_eval_postprocessing.py
@@ -55,6 +55,7 @@ def _build_postprocess_cfg(
     shuffle_seed: int = 0,
     metric_prefix: str = "",
     render: dict[str, Any] | None = None,
+    batch_size: int = 1,
 ) -> DictConfig:
     """Build a minimal cfg accepted by ``_run_predict_postprocessing``.
 
@@ -68,6 +69,8 @@ def _build_postprocess_cfg(
     :param metric_prefix: Drives ``cfg.evaluation.metric_prefix``; prepended to
         every returned audio metric key.
     :param render: Drives ``cfg.render``; pass ``None`` to test the unset-render branch.
+    :param batch_size: Drives ``cfg.datamodule.batch_size``; the render timeout
+        scales with ``pred-*.pt`` count times this.
     :returns: Minimal :class:`DictConfig` shaped the way the helper reads it.
     """
     return OmegaConf.create(  # type: ignore[no-any-return]
@@ -81,6 +84,7 @@ def _build_postprocess_cfg(
                 "shuffle_seed": shuffle_seed,
                 "metric_prefix": metric_prefix,
             },
+            "datamodule": {"batch_size": batch_size},
             "render": render,
         }
     )
@@ -1080,3 +1084,100 @@ def test_postprocessing_logs_shuffle_permutation_table_when_subprocess_writes_cs
     table = permutation_payloads[0]["shuffle/permutation"]
     assert isinstance(table, wandb.Table)
     assert table.columns == ["dest_idx", "src_idx"]
+
+
+@pytest.fixture
+def captured_timeouts(monkeypatch: pytest.MonkeyPatch) -> dict[str, float]:
+    """Capture each postprocessing subprocess's ``timeout`` keyed by module.
+
+    Like :func:`captured_argv` but records the ``timeout`` kwarg so the
+    sample-count scaling can be asserted; still materializes the aggregated CSV
+    so the metrics branch's load step succeeds.
+
+    :param monkeypatch: Stubs ``subprocess.run``, ``as_file``, and
+        ``vst_headless_wrapper`` so no real subprocess or package data is touched.
+    :returns: ``{module: timeout}`` populated one entry per intercepted call.
+    """
+    timeouts: dict[str, float] = {}
+
+    def _fake_run(args: list[str], *, timeout: float, **_kwargs: Any) -> None:
+        # Self-diagnosing if a call path ever drops the kwarg, vs an opaque TypeError.
+        assert isinstance(timeout, float), timeout
+        module = (
+            _COMPUTE_AUDIO_METRICS_MODULE
+            if _COMPUTE_AUDIO_METRICS_MODULE in args
+            else _PREDICT_VST_AUDIO_MODULE
+        )
+        timeouts[module] = timeout
+        if _COMPUTE_AUDIO_METRICS_MODULE not in args:
+            return
+        metrics_dir = Path(args[args.index(_COMPUTE_AUDIO_METRICS_MODULE) + 2])
+        metrics_dir.mkdir(parents=True, exist_ok=True)
+        (metrics_dir / "aggregated_metrics.csv").write_text(_AGGREGATED_METRICS_CSV)
+
+    monkeypatch.setattr(eval_mod.subprocess, "run", _fake_run)
+
+    @contextmanager
+    def _fake_as_file(_traversable: Any) -> Any:
+        yield Path(_FAKE_WRAPPER)
+
+    monkeypatch.setattr(eval_mod, "as_file", _fake_as_file)
+    monkeypatch.setattr(eval_mod, "vst_headless_wrapper", lambda: object())
+    return timeouts
+
+
+def test_render_timeout_scales_with_prediction_sample_count(
+    monkeypatch: pytest.MonkeyPatch,
+    predictions_tree: Path,
+    captured_timeouts: dict[str, float],
+) -> None:
+    """Render timeout grows as overhead + per_sample * (pred files * batch_size).
+
+    A flat ceiling tripped a spurious TimeoutExpired once the split outgrew it;
+    scaling on the rendered sample count is the fix.
+
+    :param monkeypatch: Pins ``sys.platform`` to ``darwin`` (no wrapper prefix).
+    :param predictions_tree: ``tmp_path`` with ``predictions/`` + ``audio/``.
+    :param captured_timeouts: ``{module: timeout}`` populated by the fixture.
+    """
+    monkeypatch.setattr(eval_mod.sys, "platform", "darwin")
+    for i in range(3):
+        (predictions_tree / "predictions" / f"pred-{i}.pt").write_bytes(b"")
+    cfg = _build_postprocess_cfg(
+        predictions_tree,
+        compute_metrics=False,
+        rerender_target=False,
+        batch_size=4,
+        render={"param_spec_name": "surge/fake_oracle", "preset_path": "preset.fxp"},
+    )
+
+    _run_predict_postprocessing(cfg)
+
+    # Hard-coded (not mirroring the module constants) so a wrong constant fails:
+    # 300 overhead + 60/sample * (3 pred files * batch_size 4) = 1020.
+    assert captured_timeouts[_PREDICT_VST_AUDIO_MODULE] == 1020.0
+
+
+def test_metrics_timeout_scales_with_audio_subdir_count_over_workers(
+    monkeypatch: pytest.MonkeyPatch,
+    predictions_tree: Path,
+    captured_timeouts: dict[str, float],
+) -> None:
+    """Metrics timeout grows as overhead + per_sample * ceil(audio subdirs / workers).
+
+    :param monkeypatch: Pins ``sys.platform`` to ``darwin`` (no wrapper prefix).
+    :param predictions_tree: ``tmp_path`` with ``predictions/`` + ``audio/``.
+    :param captured_timeouts: ``{module: timeout}`` populated by the fixture.
+    """
+    monkeypatch.setattr(eval_mod.sys, "platform", "darwin")
+    for i in range(7):
+        (predictions_tree / "audio" / f"sample-{i}").mkdir()
+    cfg = _build_postprocess_cfg(
+        predictions_tree, render_vst=False, compute_metrics=True, num_workers=2
+    )
+
+    _run_predict_postprocessing(cfg)
+
+    # Hard-coded (not mirroring the module constants) so a wrong constant fails:
+    # 180 overhead + 30/sample * ceil(7 subdirs / 2 workers)=4 = 300.
+    assert captured_timeouts[_COMPUTE_AUDIO_METRICS_MODULE] == 300.0


### PR DESCRIPTION
## What

Replace the flat subprocess timeout ceilings with budgets that scale by the number of samples the child processes, so growing a dataset (or the test fixture) can no longer trip a spurious `TimeoutExpired`.

New helper `scaled_timeout(num_samples, *, workers, overhead_seconds, per_sample_seconds)` in `pipeline/subprocess_stream.py`:

```
overhead_seconds + per_sample_seconds * ceil(num_samples / workers)
```

The fixed `overhead` term still fails a true startup hang fast at small N; the per-sample term absorbs dataset growth; margins fold into the two constants each call site passes.

## Wired call sites (each derives the exact sample count locally)

| Site                                          | N source                                                                              | workers       |
| --------------------------------------------- | ------------------------------------------------------------------------------------- | ------------- |
| `eval.py` render                              | `pred-*.pt` count × `datamodule.batch_size` (VSTDataset drops the partial tail batch) | 1             |
| `eval.py` metrics                             | audio-subdir count                                                                    | `num_workers` |
| `generate_dataset.py` inline oracle eval      | predict split's `audio` rows                                                          | 1             |
| `tests/conftest.py` stats + generate fixtures | `NUM_FIXTURE_SAMPLES`                                                                 | 1             |

The single-shot VST **load check** (`tests/_vst.py`) keeps its flat ceiling — one plugin load, no per-sample work.

## Tests

- `scaled_timeout` unit-tested directly (formula, worker division/ceil, zero-sample floor, validation) — `tests/pipeline/test_subprocess_stream.py`.
- Render/metrics timeout scaling pinned with hard-coded expected values in `tests/test_eval_postprocessing.py`; the e2e fake in `tests/test_eval.py` now asserts a positive float timeout reaches the call.
- Oracle-eval timeout scaling pinned in `tests/pipeline/entrypoints/test_generate_dataset_unit.py` (exact value + a grows-with-N test).

All affected suites pass locally (CPU, serial). The pre-existing `test_logging_utils` xdist flake and a Lance `INTERNALERROR` reproduce on unmodified `main` under `-n auto` — not introduced here.

## Review note

Opened with `REVIEW_COMMENT_GATE=warn`: the pre-PR review cleared all `:block` findings, but the comment-hygiene pass remained non-convergent across rounds — it flagged `eval.main`'s **pre-existing** docstring (untouched here), reversed its own guidance on the hard-coded-value derivation comments, and asked to drop `:param:`/`:returns:` from a helper that pydoclint requires them on. The substantive findings were addressed.

Fixes #1748
