### PR TITLE
feat(data-pipeline): add audio_uuid column to preview-columns CLI

### DIFF
--- a/docs/design/data-pipeline.md
+++ b/docs/design/data-pipeline.md
@@ -1153,7 +1153,7 @@ augments a finalized Lance dataset in place with a `clap` (LAION-CLAP)
 `nearest=` vector search — and an `m2l` (music2latent) fixed-shape-tensor
 latent column, both derived from the audio column.
 
-`synth-setter-add-mp3-audio` (`pipeline/data/add_mp3_audio.py`) follows the same contract: it takes Lance audio shards and adds an `audio_mp3` preview column (CPU), without modifying existing stages.
+`synth-setter-add-preview-columns` (`pipeline/data/add_preview_columns.py`) follows the same contract: it takes Lance audio shards and adds an `audio_mp3` preview column plus an `audio_uuid` UUIDv5 fingerprint column (CPU), without modifying existing stages.
 
 Stage order would remain static and explicit — user runs commands in sequence. If the number of stages grows to 4-6 and manual commands become unwieldy, adopt Prefect rather than building a homegrown orchestrator.
 

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -117,7 +117,7 @@ docs:
       - pattern: "src/synth_setter/pipeline/data/add_embeddings.py"
         covers: "`synth-setter-add-embeddings` CLI — appends a `clap` (LAION-CLAP) `FixedSizeList<float32,512>` vector column (with an optional IVF_PQ index for `nearest=` search) and an `m2l` (music2latent) fixed-shape-tensor column to a finalized Lance dataset via `lance.batch_udf`, with injected/lazy-loaded encoders and row-count + dim + finiteness validation (post-finalize augmenter)."
       - pattern: "src/synth_setter/pipeline/data/add_preview_columns.py"
-        covers: "`synth-setter-add-preview-columns` CLI — one `lance.batch_udf` `add_columns` pass that adds an `audio_mp3` blob v2 preview column and an `audio_uuid` UUIDv5 fingerprint of each row's `audio` bytes (neither a training input)."
+        covers: "`synth-setter-add-preview-columns` CLI — one `lance.batch_udf` `add_columns` pass that adds an `audio_mp3` Arrow binary preview column and an `audio_uuid` UUIDv5 fingerprint of each row's `audio` bytes (neither a training input)."
       - pattern: "src/synth_setter/pipeline/data/add_music2latent.py"
         covers: "`python -m synth_setter.pipeline.data.add_music2latent` CLI — adds a `music2latent` dataset to HDF5 shards via reader/writer multiprocessing around a GPU encode loop."
 

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -117,7 +117,7 @@ docs:
       - pattern: "src/synth_setter/pipeline/data/add_embeddings.py"
         covers: "`synth-setter-add-embeddings` CLI — appends a `clap` (LAION-CLAP) `FixedSizeList<float32,512>` vector column (with an optional IVF_PQ index for `nearest=` search) and an `m2l` (music2latent) fixed-shape-tensor column to a finalized Lance dataset via `lance.batch_udf`, with injected/lazy-loaded encoders and row-count + dim + finiteness validation (post-finalize augmenter)."
       - pattern: "src/synth_setter/pipeline/data/add_preview_columns.py"
-        covers: "`synth-setter-add-preview-columns` CLI — backfills two columns in one `lance.batch_udf` `add_columns` transaction: an `audio_mp3` Lance blob v2 column (`lance.blob_field` / `lance.blob_array`, tagged `mime_type: audio/mpeg`) holding a CBR MP3 preview (via pedalboard), and an `audio_uuid` string column holding a deterministic UUIDv5 fingerprint of each row's `audio` tensor bytes; lossy preview + content-addressed id, neither a training input."
+        covers: "`synth-setter-add-preview-columns` CLI — one `lance.batch_udf` `add_columns` pass adds an `audio_mp3` blob v2 column (CBR MP3 preview, tagged `mime_type: audio/mpeg`) and an `audio_uuid` UUIDv5 fingerprint of each row's `audio` bytes. Neither is a training input."
       - pattern: "src/synth_setter/pipeline/data/add_music2latent.py"
         covers: "`python -m synth_setter.pipeline.data.add_music2latent` CLI — adds a `music2latent` dataset to HDF5 shards via reader/writer multiprocessing around a GPU encode loop."
 

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -116,8 +116,8 @@ docs:
         covers: "Lance dataset-shard codec — lance_schema / tensor_array / record_batch_from_arrays / write_lance_dataset / lance_fragment / commit_lance_dataset on the encode side, read_shard_metadata / iter_lance_column_rows on the decode side; shared by the Lance writer, validator, and finalize."
       - pattern: "src/synth_setter/pipeline/data/add_embeddings.py"
         covers: "`synth-setter-add-embeddings` CLI — appends a `clap` (LAION-CLAP) `FixedSizeList<float32,512>` vector column (with an optional IVF_PQ index for `nearest=` search) and an `m2l` (music2latent) fixed-shape-tensor column to a finalized Lance dataset via `lance.batch_udf`, with injected/lazy-loaded encoders and row-count + dim + finiteness validation (post-finalize augmenter)."
-      - pattern: "src/synth_setter/pipeline/data/add_mp3_audio.py"
-        covers: "`synth-setter-add-mp3-audio` CLI — backfills an `audio_mp3` Lance blob v2 column (`lance.blob_field` / `lance.blob_array`, tagged `mime_type: audio/mpeg`) holding a CBR MP3 preview (via pedalboard) onto a Lance dataset via `lance.batch_udf` `add_columns`; a lossy auditioning preview, never a training input."
+      - pattern: "src/synth_setter/pipeline/data/add_preview_columns.py"
+        covers: "`synth-setter-add-preview-columns` CLI — backfills two columns in one `lance.batch_udf` `add_columns` transaction: an `audio_mp3` Lance blob v2 column (`lance.blob_field` / `lance.blob_array`, tagged `mime_type: audio/mpeg`) holding a CBR MP3 preview (via pedalboard), and an `audio_uuid` string column holding a deterministic UUIDv5 fingerprint of each row's `audio` tensor bytes; lossy preview + content-addressed id, neither a training input."
       - pattern: "src/synth_setter/pipeline/data/add_music2latent.py"
         covers: "`python -m synth_setter.pipeline.data.add_music2latent` CLI — adds a `music2latent` dataset to HDF5 shards via reader/writer multiprocessing around a GPU encode loop."
 

--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -117,7 +117,7 @@ docs:
       - pattern: "src/synth_setter/pipeline/data/add_embeddings.py"
         covers: "`synth-setter-add-embeddings` CLI — appends a `clap` (LAION-CLAP) `FixedSizeList<float32,512>` vector column (with an optional IVF_PQ index for `nearest=` search) and an `m2l` (music2latent) fixed-shape-tensor column to a finalized Lance dataset via `lance.batch_udf`, with injected/lazy-loaded encoders and row-count + dim + finiteness validation (post-finalize augmenter)."
       - pattern: "src/synth_setter/pipeline/data/add_preview_columns.py"
-        covers: "`synth-setter-add-preview-columns` CLI — one `lance.batch_udf` `add_columns` pass adds an `audio_mp3` blob v2 column (CBR MP3 preview, tagged `mime_type: audio/mpeg`) and an `audio_uuid` UUIDv5 fingerprint of each row's `audio` bytes. Neither is a training input."
+        covers: "`synth-setter-add-preview-columns` CLI — one `lance.batch_udf` `add_columns` pass that adds an `audio_mp3` blob v2 preview column and an `audio_uuid` UUIDv5 fingerprint of each row's `audio` bytes (neither a training input)."
       - pattern: "src/synth_setter/pipeline/data/add_music2latent.py"
         covers: "`python -m synth_setter.pipeline.data.add_music2latent` CLI — adds a `music2latent` dataset to HDF5 shards via reader/writer multiprocessing around a GPU encode loop."
 

--- a/docs/reference/docker.md
+++ b/docs/reference/docker.md
@@ -212,7 +212,8 @@ Available console scripts (declared in `pyproject.toml`'s
 `[project.scripts]`): `synth-setter-train`, `synth-setter-eval`,
 `synth-setter-generate-dataset`, `synth-setter-generate-dataset-from-hydra`,
 `synth-setter-finalize-dataset`, `synth-setter-introspect-plugin`,
-`synth-setter-spec-uri`, `synth-setter-add-embeddings`.
+`synth-setter-spec-uri`, `synth-setter-add-embeddings`,
+`synth-setter-add-preview-columns`.
 
 Prefer `docker run --env-file .env` over `set -a && source .env` to avoid
 polluting your host shell.

--- a/notebooks/add_preview_columns.ipynb
+++ b/notebooks/add_preview_columns.ipynb
@@ -5,13 +5,13 @@
    "id": "7fb27b941602401d91542211134fc71a",
    "metadata": {},
    "source": [
-    "# Add an `audio_mp3` preview column to a Lance dataset\n",
+    "# Add `audio_mp3` + `audio_uuid` preview columns to a Lance dataset\n",
     "\n",
-    "End-to-end smoke run for `synth_setter.pipeline.data.add_mp3_audio`:\n",
+    "End-to-end smoke run for `synth_setter.pipeline.data.add_preview_columns`:\n",
     "\n",
     "1. Build a tiny Lance dataset with the same schema `generate-dataset` / `finalize-dataset` write (`audio` / `mel_spec` / `param_array` tensor columns plus embedded `ShardMetadata`).\n",
-    "2. Run the MP3 add step, which appends an `audio_mp3` Lance blob v2 column (tagged `mime_type: audio/mpeg`).\n",
-    "3. Read back a dataframe of the params alongside each row's MP3 size, then decode one blob."
+    "2. Run the add step, which appends an `audio_mp3` Lance blob v2 column (tagged `mime_type: audio/mpeg`) and an `audio_uuid` string column (a deterministic UUIDv5 of each row's `audio` bytes), in one transaction.\n",
+    "3. Read back a dataframe of the params, each row's uuid, and its MP3 size, then decode one blob."
    ]
   },
   {
@@ -30,9 +30,10 @@
     "from pedalboard.io import AudioFile\n",
     "\n",
     "from synth_setter.data.vst.shapes import AUDIO_FIELD, MEL_SPEC_FIELD, PARAM_ARRAY_FIELD\n",
-    "from synth_setter.pipeline.data.add_mp3_audio import (\n",
+    "from synth_setter.pipeline.data.add_preview_columns import (\n",
     "    AUDIO_MP3_FIELD,\n",
-    "    add_mp3_audio_column,\n",
+    "    AUDIO_UUID_FIELD,\n",
+    "    add_preview_columns,\n",
     ")\n",
     "from synth_setter.pipeline.data.lance_shard import (\n",
     "    lance_schema,\n",
@@ -94,7 +95,7 @@
     "    min_loudness=-55.0,\n",
     ")\n",
     "\n",
-    "tmpdir = tempfile.mkdtemp(prefix=\"mp3-audio-smoke-\")\n",
+    "tmpdir = tempfile.mkdtemp(prefix=\"preview-columns-smoke-\")\n",
     "uri = Path(tmpdir) / \"shard-000000.lance\"\n",
     "schema = lance_schema(field_shapes, metadata)\n",
     "write_lance_dataset(uri, schema, [record_batch_from_arrays(arrays, schema)])\n",
@@ -108,9 +109,9 @@
    "id": "72eea5119410473aa328ad9291626812",
    "metadata": {},
    "source": [
-    "## 2. Run the MP3 add step\n",
+    "## 2. Run the add step\n",
     "\n",
-    "`add_mp3_audio_column` reads the sample rate from the shard metadata and backfills an `audio_mp3` Lance blob v2 column in place (committing a new dataset version), tagged `mime_type: audio/mpeg`."
+    "`add_preview_columns` reads the sample rate from the shard metadata and backfills two columns in place (committing one new dataset version): an `audio_mp3` Lance blob v2 column (tagged `mime_type: audio/mpeg`) and an `audio_uuid` string column (a deterministic UUIDv5 of each row's `audio` bytes)."
    ]
   },
   {
@@ -120,7 +121,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "add_mp3_audio_column(uri, bitrate_kbps=128)\n",
+    "add_preview_columns(uri, bitrate_kbps=128)\n",
     "\n",
     "lance.dataset(str(uri)).schema"
    ]
@@ -130,7 +131,7 @@
    "id": "10185d26023b46108eb7d9f57d49d2b3",
    "metadata": {},
    "source": [
-    "## 3. Dataframe of just the params and the MP3 bytes"
+    "## 3. Dataframe of the params, the row uuid, and the MP3 size"
    ]
   },
   {
@@ -142,12 +143,12 @@
    "source": [
     "ds = lance.dataset(str(uri))\n",
     "# Blob v2 columns are read lazily via take_blobs, not to_table (which yields\n",
-    "# blob descriptors rather than bytes).\n",
+    "# blob descriptors rather than bytes). audio_uuid is a plain string column.\n",
     "mp3_payloads = [\n",
     "    blob.readall()\n",
     "    for blob in ds.take_blobs(blob_column=AUDIO_MP3_FIELD, indices=list(range(ds.count_rows())))\n",
     "]\n",
-    "df = ds.to_table(columns=[PARAM_ARRAY_FIELD]).to_pandas()\n",
+    "df = ds.to_table(columns=[PARAM_ARRAY_FIELD, AUDIO_UUID_FIELD]).to_pandas()\n",
     "df[\"mp3_bytes\"] = [len(p) for p in mp3_payloads]\n",
     "df"
    ]

--- a/notebooks/add_preview_columns.ipynb
+++ b/notebooks/add_preview_columns.ipynb
@@ -10,8 +10,8 @@
     "End-to-end smoke run for `synth_setter.pipeline.data.add_preview_columns`:\n",
     "\n",
     "1. Build a tiny Lance dataset with the same schema `generate-dataset` / `finalize-dataset` write (`audio` / `mel_spec` / `param_array` tensor columns plus embedded `ShardMetadata`).\n",
-    "2. Run the add step, which appends an `audio_mp3` Lance blob v2 column (tagged `mime_type: audio/mpeg`) and an `audio_uuid` string column (a deterministic UUIDv5 of each row's `audio` bytes), in one transaction.\n",
-    "3. Read back a dataframe of the params, each row's uuid, and its MP3 size, then decode one blob."
+    "2. Run the add step, which appends an `audio_mp3` Arrow binary column (tagged `mime_type: audio/mpeg`) and an `audio_uuid` string column (a deterministic UUIDv5 of each row's `audio` bytes), in one transaction.\n",
+    "3. Read back a dataframe of the params, each row's uuid, and its MP3 size, then decode one MP3 payload."
    ]
   },
   {
@@ -111,7 +111,7 @@
    "source": [
     "## 2. Run the add step\n",
     "\n",
-    "`add_preview_columns` reads the sample rate from the shard metadata, then commits both columns (`audio_mp3` blob v2 + `audio_uuid` string) in one transaction."
+    "`add_preview_columns` reads the sample rate from the shard metadata, then commits both columns (`audio_mp3` binary + `audio_uuid` string) in one transaction."
    ]
   },
   {
@@ -142,13 +142,9 @@
    "outputs": [],
    "source": [
     "ds = lance.dataset(str(uri))\n",
-    "# Blob v2 columns are read lazily via take_blobs, not to_table (which yields\n",
-    "# blob descriptors rather than bytes). audio_uuid is a plain string column.\n",
-    "mp3_payloads = [\n",
-    "    blob.readall()\n",
-    "    for blob in ds.take_blobs(blob_column=AUDIO_MP3_FIELD, indices=list(range(ds.count_rows())))\n",
-    "]\n",
-    "df = ds.to_table(columns=[PARAM_ARRAY_FIELD, AUDIO_UUID_FIELD]).to_pandas()\n",
+    "table = ds.to_table(columns=[PARAM_ARRAY_FIELD, AUDIO_MP3_FIELD, AUDIO_UUID_FIELD])\n",
+    "mp3_payloads = table.column(AUDIO_MP3_FIELD).to_pylist()\n",
+    "df = table.drop([AUDIO_MP3_FIELD]).to_pandas()\n",
     "df[\"mp3_bytes\"] = [len(p) for p in mp3_payloads]\n",
     "df"
    ]

--- a/notebooks/add_preview_columns.ipynb
+++ b/notebooks/add_preview_columns.ipynb
@@ -111,7 +111,7 @@
    "source": [
     "## 2. Run the add step\n",
     "\n",
-    "`add_preview_columns` reads the sample rate from the shard metadata and backfills two columns in place (committing one new dataset version): an `audio_mp3` Lance blob v2 column (tagged `mime_type: audio/mpeg`) and an `audio_uuid` string column (a deterministic UUIDv5 of each row's `audio` bytes)."
+    "`add_preview_columns` reads the sample rate from the shard metadata, then commits both columns (`audio_mp3` blob v2 + `audio_uuid` string) in one transaction."
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ synth-setter-generate-dataset = "synth_setter.cli.generate_dataset:main"
 synth-setter-generate-dataset-from-hydra = "synth_setter.cli.generate_dataset:from_hydra"
 synth-setter-finalize-dataset = "synth_setter.cli.finalize_dataset:main"
 synth-setter-add-embeddings = "synth_setter.pipeline.data.add_embeddings:main"
-synth-setter-add-mp3-audio = "synth_setter.pipeline.data.add_mp3_audio:main"
+synth-setter-add-preview-columns = "synth_setter.pipeline.data.add_preview_columns:main"
 synth-setter-introspect-plugin = "synth_setter.cli.introspect_plugin:main"
 synth-setter-spec-uri = "synth_setter.pipeline.ci.spec_uri:main"
 

--- a/src/synth_setter/pipeline/data/add_preview_columns.py
+++ b/src/synth_setter/pipeline/data/add_preview_columns.py
@@ -5,8 +5,8 @@ Backfills two derived columns onto a dataset written by
 single Lance ``add_columns`` transaction:
 
 - ``audio_mp3`` — each row's ``audio`` tensor encoded to a CBR MP3 (pedalboard),
-  stored as a Lance blob v2 column tagged ``mime_type: audio/mpeg`` so Lance
-  viewers auto-play a per-row preview.
+  stored as an Arrow binary column tagged ``mime_type: audio/mpeg`` so viewers
+  can scan the table through DuckDB without Lance blob support.
 - ``audio_uuid`` — a deterministic UUIDv5 fingerprint of the same ``audio`` bytes,
   so the same rendered waveform always maps to the same id (content-addressed).
 
@@ -99,7 +99,7 @@ def _encode_preview_columns(
     :param batch: Record batch projecting the ``audio`` fixed-shape tensor column.
     :param sample_rate: Playback rate in Hz every row is encoded at.
     :param bitrate_kbps: Constant MP3 bitrate in kbps for every row.
-    :returns: A two-column batch (``audio_mp3`` blob array, ``audio_uuid`` string
+    :returns: A two-column batch (``audio_mp3`` binary array, ``audio_uuid`` string
         array), one cell per input row, in batch row order.
     :raises ValueError: The ``audio`` column is not a fixed-shape tensor column,
         or a row fails to encode (the message names the offending row index).
@@ -108,7 +108,7 @@ def _encode_preview_columns(
     if not isinstance(column, pa.FixedShapeTensorArray):
         raise ValueError(f"{AUDIO_FIELD!r} must be a fixed-shape tensor column, got {column.type}")
     rows = column.to_numpy_ndarray()
-    mp3_blobs = []
+    mp3_payloads = []
     uuids = []
     for row_index, row in enumerate(rows):
         try:
@@ -119,10 +119,10 @@ def _encode_preview_columns(
             ) from exc
         # Append as a pair only after the encode succeeds, so a failed row never
         # leaves the two columns at mismatched lengths.
-        mp3_blobs.append(mp3)
+        mp3_payloads.append(mp3)
         uuids.append(audio_uuid(row))
     return pa.record_batch(
-        [lance.blob_array(mp3_blobs), pa.array(uuids, type=pa.string())],
+        [pa.array(mp3_payloads, type=pa.binary()), pa.array(uuids, type=pa.string())],
         names=[AUDIO_MP3_FIELD, AUDIO_UUID_FIELD],
     )
 
@@ -156,13 +156,13 @@ def add_preview_columns(
     sample_rate = read_shard_metadata(dataset.schema).sample_rate
     preview_schema = pa.schema(
         [
-            lance.blob_field(AUDIO_MP3_FIELD).with_metadata(_MP3_FIELD_METADATA),
+            pa.field(AUDIO_MP3_FIELD, pa.binary()).with_metadata(_MP3_FIELD_METADATA),
             pa.field(AUDIO_UUID_FIELD, pa.string()),
         ]
     )
 
     # output_schema skips Lance's first-batch inference probe (avoids a double
-    # encode) and carries the blob type + mime metadata onto the new columns.
+    # encode) and carries the binary type + mime metadata onto the new columns.
     @lance.batch_udf(output_schema=preview_schema)
     def _to_preview(batch: pa.RecordBatch) -> pa.RecordBatch:
         return _encode_preview_columns(batch, sample_rate, bitrate_kbps)

--- a/src/synth_setter/pipeline/data/add_preview_columns.py
+++ b/src/synth_setter/pipeline/data/add_preview_columns.py
@@ -25,25 +25,25 @@ import click
 import lance
 import numpy as np
 import pyarrow as pa
+import structlog
 from pedalboard.io import AudioFile
 
 from synth_setter.data.vst.shapes import AUDIO_FIELD
 from synth_setter.pipeline import r2_io
 from synth_setter.pipeline.data.lance_shard import read_shard_metadata
 
+logger = structlog.get_logger(__name__)
+
 AUDIO_MP3_FIELD = "audio_mp3"
 AUDIO_UUID_FIELD = "audio_uuid"
 
 DEFAULT_MP3_BITRATE_KBPS = 128
 
-# Viewer hint so Lance UIs offer per-row playback; a repo convention, not a
-# Lance-defined contract. Arrow field metadata is a bytes->bytes map.
+# Viewer hint for Lance UIs — a repo convention, not a Lance-defined contract.
 _MP3_FIELD_METADATA: dict[bytes, bytes] = {b"mime_type": b"audio/mpeg"}
 
-# Project-scoped UUIDv5 namespace, derived deterministically from a DNS name so
-# the constant is reproducible and self-documenting (no opaque literal). UUIDv5
-# hashes (namespace, name) with SHA-1, so a fixed namespace makes audio_uuid a
-# pure function of the audio bytes.
+# DNS-derived namespace so the constant is reproducible; a fixed namespace makes
+# audio_uuid a pure function of the audio bytes (same input -> same id).
 _AUDIO_UUID_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_DNS, "synth-setter.tinaudio.com")
 
 
@@ -87,9 +87,9 @@ def audio_uuid(audio: np.ndarray) -> str:
     :param audio: One row of audio of any shape/dtype; hashed by its exact bytes.
     :returns: The canonical hyphenated UUIDv5 string under the project namespace.
     """
-    # tobytes() always copies into C-contiguous order, so a non-contiguous view
-    # hashes identically to its contiguous twin. hex() keeps the name a str
-    # (uuid5 takes bytes names only on Python >= 3.12; the repo targets 3.11).
+    # Hash the hex string of the C-ordered bytes: uuid5 accepts a bytes name only
+    # on Python >= 3.12 (repo floor is 3.11), and the id is content-addressed, so
+    # switching to raw-bytes input on 3.12+ would silently change every uuid.
     return str(uuid.uuid5(_AUDIO_UUID_NAMESPACE, audio.tobytes().hex()))
 
 
@@ -114,11 +114,14 @@ def _encode_preview_columns(
     uuids = []
     for row_index, row in enumerate(rows):
         try:
-            mp3_blobs.append(encode_audio_to_mp3(row, sample_rate, bitrate_kbps))
+            mp3 = encode_audio_to_mp3(row, sample_rate, bitrate_kbps)
         except (ValueError, RuntimeError, OSError) as exc:
             raise ValueError(
                 f"failed to encode audio row {row_index} (shape {row.shape}): {exc}"
             ) from exc
+        # Append as a pair only after the encode succeeds, so a failed row never
+        # leaves the two columns at mismatched lengths.
+        mp3_blobs.append(mp3)
         uuids.append(audio_uuid(row))
     return pa.record_batch(
         [lance.blob_array(mp3_blobs), pa.array(uuids, type=pa.string())],
@@ -160,14 +163,19 @@ def add_preview_columns(
         ]
     )
 
-    # output_schema makes Lance skip the first-batch inference probe (which would
-    # encode that batch twice) and carries the blob type + mime metadata onto the
-    # new columns.
+    # output_schema skips Lance's first-batch inference probe (avoids a double
+    # encode) and carries the blob type + mime metadata onto the new columns.
     @lance.batch_udf(output_schema=preview_schema)
     def _to_preview(batch: pa.RecordBatch) -> pa.RecordBatch:
         return _encode_preview_columns(batch, sample_rate, bitrate_kbps)
 
     dataset.add_columns(_to_preview, read_columns=[AUDIO_FIELD])
+    logger.info(
+        "added_preview_columns",
+        uri=str(uri),
+        columns=[AUDIO_MP3_FIELD, AUDIO_UUID_FIELD],
+        rows=dataset.count_rows(),
+    )
 
 
 @click.command()
@@ -189,16 +197,14 @@ def main(uri: str, bitrate_kbps: int) -> None:
         is rewritten to ``s3://``, and any ``s3://`` URI is treated as the project's
         R2 endpoint and credentialed with env-derived credentials (mirroring
         ``add_embeddings``; generic non-R2 S3 buckets are not a supported input).
-    :param bitrate_kbps: Forwarded to :func:`add_preview_columns`; default shown in ``--help``.
+    :param bitrate_kbps: CBR bitrate in kbps for the MP3 column (8-320, Click-validated).
     :raises click.ClickException: The dataset is missing its ``audio`` column,
         already has an ``audio_mp3`` or ``audio_uuid`` column, lacks readable
         shard metadata, cannot be opened (e.g. a cloud I/O error), or an R2 URI
         is given with missing/blank R2 credentials.
     """
-    # Lance opens R2 over its S3-compatible API: rewrite r2:// to s3:// and treat
-    # any s3:// as R2, passing env-derived credentials (mirroring add_embeddings).
-    # R2 credential resolution raises RuntimeError on missing/blank env, so it
-    # stays inside the try to surface as a clean ClickException.
+    # R2 credential resolution raises RuntimeError on missing/blank env, so keep
+    # it inside the try to surface as a clean ClickException (mirrors add_embeddings).
     try:
         resolved_uri = r2_io.to_s3_uri(uri) if r2_io.is_r2_uri(uri) else uri
         storage_options: dict[str, str] | None = None

--- a/src/synth_setter/pipeline/data/add_preview_columns.py
+++ b/src/synth_setter/pipeline/data/add_preview_columns.py
@@ -4,15 +4,13 @@ Backfills two derived columns onto a dataset written by
 ``synth-setter-generate-dataset`` or ``synth-setter-finalize-dataset``, in a
 single Lance ``add_columns`` transaction:
 
-- ``audio_mp3`` — each row's float16 ``audio`` tensor encoded to a CBR MP3
-  (pedalboard) and stored as a Lance blob v2 column tagged
-  ``mime_type: audio/mpeg``, so open-source Lance viewers auto-play a per-row
-  preview. Blob v2 (storage version >= 2.2) keeps per-row reads lazy, so a scan
-  need not materialize every MP3. A lossy auditioning preview, never a training
-  input; the ``audio`` tensor stays the source of truth.
-- ``audio_uuid`` — a deterministic :rfc:`4122` UUIDv5 fingerprint of the same
-  ``audio`` tensor bytes, so the same rendered waveform always maps to the same
-  id (content-addressed, stable across re-runs of this tool).
+- ``audio_mp3`` — each row's ``audio`` tensor encoded to a CBR MP3 (pedalboard),
+  stored as a Lance blob v2 column tagged ``mime_type: audio/mpeg`` so Lance
+  viewers auto-play a per-row preview.
+- ``audio_uuid`` — a deterministic UUIDv5 fingerprint of the same ``audio`` bytes,
+  so the same rendered waveform always maps to the same id (content-addressed).
+
+Neither column is a training input; the ``audio`` tensor stays the source of truth.
 """
 
 from __future__ import annotations
@@ -87,9 +85,8 @@ def audio_uuid(audio: np.ndarray) -> str:
     :param audio: One row of audio of any shape/dtype; hashed by its exact bytes.
     :returns: The canonical hyphenated UUIDv5 string under the project namespace.
     """
-    # Hash the hex string of the C-ordered bytes: uuid5 accepts a bytes name only
-    # on Python >= 3.12 (repo floor is 3.11), and the id is content-addressed, so
-    # switching to raw-bytes input on 3.12+ would silently change every uuid.
+    # uuid5 on Python 3.11 needs a str name, not bytes; hashing tobytes().hex()
+    # canonicalizes byte order and keeps the id stable (changing it shifts all ids).
     return str(uuid.uuid5(_AUDIO_UUID_NAMESPACE, audio.tobytes().hex()))
 
 
@@ -197,7 +194,7 @@ def main(uri: str, bitrate_kbps: int) -> None:
         is rewritten to ``s3://``, and any ``s3://`` URI is treated as the project's
         R2 endpoint and credentialed with env-derived credentials (mirroring
         ``add_embeddings``; generic non-R2 S3 buckets are not a supported input).
-    :param bitrate_kbps: CBR bitrate in kbps for the MP3 column (8-320, Click-validated).
+    :param bitrate_kbps: See :func:`add_preview_columns` (Click validates the 8-320 range).
     :raises click.ClickException: The dataset is missing its ``audio`` column,
         already has an ``audio_mp3`` or ``audio_uuid`` column, lacks readable
         shard metadata, cannot be opened (e.g. a cloud I/O error), or an R2 URI

--- a/src/synth_setter/pipeline/data/add_preview_columns.py
+++ b/src/synth_setter/pipeline/data/add_preview_columns.py
@@ -78,16 +78,17 @@ def encode_audio_to_mp3(audio: np.ndarray, sample_rate: int, bitrate_kbps: int) 
 def audio_uuid(audio: np.ndarray) -> str:
     """Compute the deterministic UUIDv5 fingerprint of one audio tensor.
 
-    The id is a pure function of the raw on-disk ``audio`` bytes (dtype and
-    shape included via ``tobytes``), so the same rendered waveform always yields
-    the same uuid; a different render — even one sample — yields a different one.
+    The id is a pure function of the row's element bytes in C order (so dtype
+    and value count matter, but not array shape), so the same rendered waveform
+    always yields the same uuid; a different render — even one sample — differs.
 
-    :param audio: One row of audio of any shape/dtype; hashed by its exact bytes.
+    :param audio: One ``(channels, time)`` row; hashed by its C-ordered bytes.
     :returns: The canonical hyphenated UUIDv5 string under the project namespace.
     """
-    # uuid5 on Python 3.11 needs a str name, not bytes; hashing tobytes().hex()
-    # canonicalizes byte order and keeps the id stable (changing it shifts all ids).
-    return str(uuid.uuid5(_AUDIO_UUID_NAMESPACE, audio.tobytes().hex()))
+    # hex() losslessly encodes the C-ordered bytes as a str, the name type uuid5
+    # requires on Python 3.11 (bytes names are accepted only on 3.12+). Changing
+    # this input would shift every id, so it is part of the on-disk contract.
+    return str(uuid.uuid5(_AUDIO_UUID_NAMESPACE, audio.tobytes(order="C").hex()))
 
 
 def _encode_preview_columns(

--- a/src/synth_setter/pipeline/data/add_preview_columns.py
+++ b/src/synth_setter/pipeline/data/add_preview_columns.py
@@ -1,16 +1,24 @@
-"""Add an ``audio_mp3`` MP3-preview column to a generate/finalize Lance dataset.
+"""Add ``audio_mp3`` and ``audio_uuid`` preview columns to a Lance dataset.
 
-Encodes each row's float16 ``audio`` tensor to a CBR MP3 (pedalboard) and appends
-it as a Lance blob v2 column tagged ``mime_type: audio/mpeg`` via Lance's
-``batch_udf`` ``add_columns`` — backfilled in place. Blob v2 (dataset storage
-version >= 2.2) keeps per-row reads lazy, so a scan need not materialize every
-MP3. A lossy preview for auditioning patches, never a training input; the
-``audio`` tensor stays the source of truth.
+Backfills two derived columns onto a dataset written by
+``synth-setter-generate-dataset`` or ``synth-setter-finalize-dataset``, in a
+single Lance ``add_columns`` transaction:
+
+- ``audio_mp3`` — each row's float16 ``audio`` tensor encoded to a CBR MP3
+  (pedalboard) and stored as a Lance blob v2 column tagged
+  ``mime_type: audio/mpeg``, so open-source Lance viewers auto-play a per-row
+  preview. Blob v2 (storage version >= 2.2) keeps per-row reads lazy, so a scan
+  need not materialize every MP3. A lossy auditioning preview, never a training
+  input; the ``audio`` tensor stays the source of truth.
+- ``audio_uuid`` — a deterministic :rfc:`4122` UUIDv5 fingerprint of the same
+  ``audio`` tensor bytes, so the same rendered waveform always maps to the same
+  id (content-addressed, stable across re-runs of this tool).
 """
 
 from __future__ import annotations
 
 import io
+import uuid
 from pathlib import Path
 
 import click
@@ -24,12 +32,19 @@ from synth_setter.pipeline import r2_io
 from synth_setter.pipeline.data.lance_shard import read_shard_metadata
 
 AUDIO_MP3_FIELD = "audio_mp3"
+AUDIO_UUID_FIELD = "audio_uuid"
 
 DEFAULT_MP3_BITRATE_KBPS = 128
 
 # Viewer hint so Lance UIs offer per-row playback; a repo convention, not a
 # Lance-defined contract. Arrow field metadata is a bytes->bytes map.
 _MP3_FIELD_METADATA: dict[bytes, bytes] = {b"mime_type": b"audio/mpeg"}
+
+# Project-scoped UUIDv5 namespace, derived deterministically from a DNS name so
+# the constant is reproducible and self-documenting (no opaque literal). UUIDv5
+# hashes (namespace, name) with SHA-1, so a fixed namespace makes audio_uuid a
+# pure function of the audio bytes.
+_AUDIO_UUID_NAMESPACE = uuid.uuid5(uuid.NAMESPACE_DNS, "synth-setter.tinaudio.com")
 
 
 def encode_audio_to_mp3(audio: np.ndarray, sample_rate: int, bitrate_kbps: int) -> bytes:
@@ -62,13 +77,32 @@ def encode_audio_to_mp3(audio: np.ndarray, sample_rate: int, bitrate_kbps: int) 
     return buffer.getvalue()
 
 
-def _encode_audio_column(batch: pa.RecordBatch, sample_rate: int, bitrate_kbps: int) -> pa.Array:
-    """Encode a batch's ``audio`` tensor column into a Lance blob array of MP3 bytes.
+def audio_uuid(audio: np.ndarray) -> str:
+    """Compute the deterministic UUIDv5 fingerprint of one audio tensor.
+
+    The id is a pure function of the raw on-disk ``audio`` bytes (dtype and
+    shape included via ``tobytes``), so the same rendered waveform always yields
+    the same uuid; a different render — even one sample — yields a different one.
+
+    :param audio: One row of audio of any shape/dtype; hashed by its exact bytes.
+    :returns: The canonical hyphenated UUIDv5 string under the project namespace.
+    """
+    # tobytes() always copies into C-contiguous order, so a non-contiguous view
+    # hashes identically to its contiguous twin. hex() keeps the name a str
+    # (uuid5 takes bytes names only on Python >= 3.12; the repo targets 3.11).
+    return str(uuid.uuid5(_AUDIO_UUID_NAMESPACE, audio.tobytes().hex()))
+
+
+def _encode_preview_columns(
+    batch: pa.RecordBatch, sample_rate: int, bitrate_kbps: int
+) -> pa.RecordBatch:
+    """Derive the ``audio_mp3`` and ``audio_uuid`` columns from a batch's ``audio`` column.
 
     :param batch: Record batch projecting the ``audio`` fixed-shape tensor column.
     :param sample_rate: Playback rate in Hz every row is encoded at.
     :param bitrate_kbps: Constant MP3 bitrate in kbps for every row.
-    :returns: One Lance blob array of per-row MP3 bytes, in batch row order.
+    :returns: A two-column batch (``audio_mp3`` blob array, ``audio_uuid`` string
+        array), one cell per input row, in batch row order.
     :raises ValueError: The ``audio`` column is not a fixed-shape tensor column,
         or a row fails to encode (the message names the offending row index).
     """
@@ -76,28 +110,33 @@ def _encode_audio_column(batch: pa.RecordBatch, sample_rate: int, bitrate_kbps: 
     if not isinstance(column, pa.FixedShapeTensorArray):
         raise ValueError(f"{AUDIO_FIELD!r} must be a fixed-shape tensor column, got {column.type}")
     rows = column.to_numpy_ndarray()
-    encoded = []
+    mp3_blobs = []
+    uuids = []
     for row_index, row in enumerate(rows):
         try:
-            encoded.append(encode_audio_to_mp3(row, sample_rate, bitrate_kbps))
+            mp3_blobs.append(encode_audio_to_mp3(row, sample_rate, bitrate_kbps))
         except (ValueError, RuntimeError, OSError) as exc:
             raise ValueError(
                 f"failed to encode audio row {row_index} (shape {row.shape}): {exc}"
             ) from exc
-    return lance.blob_array(encoded)
+        uuids.append(audio_uuid(row))
+    return pa.record_batch(
+        [lance.blob_array(mp3_blobs), pa.array(uuids, type=pa.string())],
+        names=[AUDIO_MP3_FIELD, AUDIO_UUID_FIELD],
+    )
 
 
-def add_mp3_audio_column(
+def add_preview_columns(
     uri: Path | str,
     *,
     bitrate_kbps: int = DEFAULT_MP3_BITRATE_KBPS,
     storage_options: dict[str, str] | None = None,
 ) -> None:
-    """Backfill an ``audio_mp3`` preview column onto the Lance dataset at ``uri``.
+    """Backfill ``audio_mp3`` and ``audio_uuid`` columns onto the Lance dataset at ``uri``.
 
-    Commits a new dataset version with the added column; the source ``audio``
-    column and all others are left untouched. ``add_columns`` commits the new
-    column in a single Lance transaction, so an interrupted run leaves the
+    Commits a new dataset version with both added columns; the source ``audio``
+    column and all others are left untouched. ``add_columns`` commits both
+    columns in a single Lance transaction, so an interrupted run leaves the
     dataset on its prior version — re-running is safe.
 
     :param uri: Lance dataset directory (local path or ``s3://`` URI).
@@ -105,25 +144,30 @@ def add_mp3_audio_column(
     :param storage_options: Object-store config for a cloud ``uri`` (see
         :func:`synth_setter.pipeline.r2_io.r2_storage_options`); ``None`` local.
     :raises ValueError: ``uri`` lacks an ``audio`` column, already has an
-        ``audio_mp3`` column, or carries no readable shard metadata.
+        ``audio_mp3`` or ``audio_uuid`` column, or carries no readable shard metadata.
     """
     dataset = lance.dataset(str(uri), storage_options=storage_options)
     if AUDIO_FIELD not in dataset.schema.names:
         raise ValueError(f"dataset at {uri} has no {AUDIO_FIELD!r} column to encode")
-    if AUDIO_MP3_FIELD in dataset.schema.names:
-        raise ValueError(f"dataset at {uri} already has an {AUDIO_MP3_FIELD!r} column")
+    existing = [f for f in (AUDIO_MP3_FIELD, AUDIO_UUID_FIELD) if f in dataset.schema.names]
+    if existing:
+        raise ValueError(f"dataset at {uri} already has preview column(s): {existing}")
     sample_rate = read_shard_metadata(dataset.schema).sample_rate
-    mp3_schema = pa.schema([lance.blob_field(AUDIO_MP3_FIELD).with_metadata(_MP3_FIELD_METADATA)])
+    preview_schema = pa.schema(
+        [
+            lance.blob_field(AUDIO_MP3_FIELD).with_metadata(_MP3_FIELD_METADATA),
+            pa.field(AUDIO_UUID_FIELD, pa.string()),
+        ]
+    )
 
     # output_schema makes Lance skip the first-batch inference probe (which would
     # encode that batch twice) and carries the blob type + mime metadata onto the
-    # new column.
-    @lance.batch_udf(output_schema=mp3_schema)
-    def _to_mp3(batch: pa.RecordBatch) -> pa.RecordBatch:
-        column = _encode_audio_column(batch, sample_rate, bitrate_kbps)
-        return pa.record_batch([column], names=[AUDIO_MP3_FIELD])
+    # new columns.
+    @lance.batch_udf(output_schema=preview_schema)
+    def _to_preview(batch: pa.RecordBatch) -> pa.RecordBatch:
+        return _encode_preview_columns(batch, sample_rate, bitrate_kbps)
 
-    dataset.add_columns(_to_mp3, read_columns=[AUDIO_FIELD])
+    dataset.add_columns(_to_preview, read_columns=[AUDIO_FIELD])
 
 
 @click.command()
@@ -136,7 +180,7 @@ def add_mp3_audio_column(
     help="Constant MP3 bitrate in kbps applied to every row (valid CBR range 8-320).",
 )
 def main(uri: str, bitrate_kbps: int) -> None:
-    """Add an ``audio_mp3`` preview column to the Lance dataset at ``URI``.
+    """Add ``audio_mp3`` and ``audio_uuid`` preview columns to the Lance dataset at ``URI``.
 
     URI is a ``.lance`` dataset directory written by ``synth-setter-generate-dataset``
     or ``synth-setter-finalize-dataset``.
@@ -145,11 +189,11 @@ def main(uri: str, bitrate_kbps: int) -> None:
         is rewritten to ``s3://``, and any ``s3://`` URI is treated as the project's
         R2 endpoint and credentialed with env-derived credentials (mirroring
         ``add_embeddings``; generic non-R2 S3 buckets are not a supported input).
-    :param bitrate_kbps: Forwarded to :func:`add_mp3_audio_column`; default shown in ``--help``.
+    :param bitrate_kbps: Forwarded to :func:`add_preview_columns`; default shown in ``--help``.
     :raises click.ClickException: The dataset is missing its ``audio`` column,
-        already has an ``audio_mp3`` column, lacks readable shard metadata,
-        cannot be opened (e.g. a cloud I/O error), or an R2 URI is given
-        with missing/blank R2 credentials.
+        already has an ``audio_mp3`` or ``audio_uuid`` column, lacks readable
+        shard metadata, cannot be opened (e.g. a cloud I/O error), or an R2 URI
+        is given with missing/blank R2 credentials.
     """
     # Lance opens R2 over its S3-compatible API: rewrite r2:// to s3:// and treat
     # any s3:// as R2, passing env-derived credentials (mirroring add_embeddings).
@@ -161,12 +205,12 @@ def main(uri: str, bitrate_kbps: int) -> None:
         if resolved_uri.startswith("s3://"):
             r2_io.ensure_r2_env_loaded()
             storage_options = r2_io.r2_storage_options()
-        add_mp3_audio_column(
+        add_preview_columns(
             resolved_uri, bitrate_kbps=bitrate_kbps, storage_options=storage_options
         )
     except (ValueError, OSError, RuntimeError) as exc:
         raise click.ClickException(str(exc)) from exc
-    click.echo(f"added {AUDIO_MP3_FIELD!r} column to {uri}")
+    click.echo(f"added {AUDIO_MP3_FIELD!r} and {AUDIO_UUID_FIELD!r} columns to {uri}")
 
 
 if __name__ == "__main__":

--- a/tests/pipeline/data/test_add_preview_columns.py
+++ b/tests/pipeline/data/test_add_preview_columns.py
@@ -1,4 +1,4 @@
-"""Behavior tests for the MP3-audio column adder.
+"""Behavior tests for the preview-column adder (``audio_mp3`` + ``audio_uuid``).
 
 Encoded bytes are validated structurally (MP3 frame sync, decoded sample rate / channel count)
 rather than byte-for-byte, since LAME output is not promised to be bit-reproducible across
@@ -9,6 +9,7 @@ sample-rate or channel bug can't corrupt both sides identically and pass.
 from __future__ import annotations
 
 import io
+import uuid
 from pathlib import Path
 
 import lance
@@ -23,9 +24,11 @@ from synth_setter.data.vst.shapes import (
     MEL_SPEC_FIELD,
     PARAM_ARRAY_FIELD,
 )
-from synth_setter.pipeline.data.add_mp3_audio import (
+from synth_setter.pipeline.data.add_preview_columns import (
     AUDIO_MP3_FIELD,
-    add_mp3_audio_column,
+    AUDIO_UUID_FIELD,
+    add_preview_columns,
+    audio_uuid,
     encode_audio_to_mp3,
     main,
 )
@@ -213,7 +216,46 @@ def test_encode_audio_to_mp3_preserves_sample_rate_and_channels(sample_rate: int
     assert samples.shape[0] == _CHANNELS
 
 
-def test_add_mp3_audio_column_adds_blob_column_for_every_row(tmp_path: Path) -> None:
+def test_audio_uuid_is_deterministic_for_equal_bytes() -> None:
+    """Identical audio bytes hash to the same uuid, even across distinct array objects.
+
+    The contract is content-addressing: re-running the tool on the same dataset
+    must reproduce the id, so equal bytes (not array identity) drive it.
+    """
+    row = _sine_rows()[0]
+    twin = np.array(row, copy=True)
+
+    assert audio_uuid(row) == audio_uuid(twin)
+
+
+def test_audio_uuid_ignores_array_memory_layout() -> None:
+    """A non-contiguous view hashes identically to its C-contiguous copy.
+
+    ``tobytes`` canonicalizes to C order, so a transposed/sliced view that holds
+    the same logical samples must not change the id.
+    """
+    row = _sine_rows()[0]
+    non_contiguous = np.asfortranarray(row)
+
+    assert not non_contiguous.flags["C_CONTIGUOUS"]
+    assert audio_uuid(non_contiguous) == audio_uuid(np.ascontiguousarray(row))
+
+
+def test_audio_uuid_differs_for_different_audio() -> None:
+    """Two different waveforms map to different uuids (no trivial constant)."""
+    rows = _sine_rows()
+
+    assert audio_uuid(rows[0]) != audio_uuid(rows[1])
+
+
+def test_audio_uuid_returns_canonical_version5_uuid() -> None:
+    """The returned string parses as a version-5 UUID under the project namespace."""
+    parsed = uuid.UUID(audio_uuid(_sine_rows()[0]))
+
+    assert parsed.version == 5
+
+
+def test_add_preview_columns_adds_blob_column_for_every_row(tmp_path: Path) -> None:
     """Every row gains a decodable ``audio_mp3`` blob cell; source columns and row count unchanged.
 
     :param tmp_path: Pytest fixture providing a fresh test directory.
@@ -222,7 +264,7 @@ def test_add_mp3_audio_column_adds_blob_column_for_every_row(tmp_path: Path) -> 
     _write_smoke_dataset(uri)
     before = {f: lance.dataset(str(uri)).schema.field(f).type for f in _SOURCE_FIELDS}
 
-    add_mp3_audio_column(uri)
+    add_preview_columns(uri)
 
     ds = lance.dataset(str(uri))
     for field in _SOURCE_FIELDS:
@@ -236,7 +278,29 @@ def test_add_mp3_audio_column_adds_blob_column_for_every_row(tmp_path: Path) -> 
     assert samples.shape[0] == _CHANNELS
 
 
-def test_add_mp3_audio_column_tags_field_with_audio_mime_type(tmp_path: Path) -> None:
+def test_add_preview_columns_adds_uuid_column_matching_per_row_audio(tmp_path: Path) -> None:
+    """Each row gains a string ``audio_uuid`` equal to ``audio_uuid`` of its own audio tensor.
+
+    Ties the persisted column to the pure helper so a regression in the batch path (wrong row
+    order, wrong source bytes) can't pass.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    uri = tmp_path / "shard-000000.lance"
+    _write_smoke_dataset(uri)
+    audio_rows = _sine_rows()
+
+    add_preview_columns(uri)
+
+    ds = lance.dataset(str(uri))
+    assert ds.schema.field(AUDIO_UUID_FIELD).type == pa.string()
+    stored = ds.to_table(columns=[AUDIO_UUID_FIELD]).column(AUDIO_UUID_FIELD).to_pylist()
+    assert stored == [audio_uuid(row) for row in audio_rows]
+    # Distinct pitches => distinct fingerprints; no row collapses onto another.
+    assert len(set(stored)) == _ROWS
+
+
+def test_add_preview_columns_tags_field_with_audio_mime_type(tmp_path: Path) -> None:
     """The added column carries ``mime_type: audio/mpeg`` so Lance viewers auto-play it.
 
     :param tmp_path: Pytest fixture providing a fresh test directory.
@@ -244,13 +308,13 @@ def test_add_mp3_audio_column_tags_field_with_audio_mime_type(tmp_path: Path) ->
     uri = tmp_path / "shard-000000.lance"
     _write_smoke_dataset(uri)
 
-    add_mp3_audio_column(uri)
+    add_preview_columns(uri)
 
     field = lance.dataset(str(uri)).schema.field(AUDIO_MP3_FIELD)
     assert field.metadata == {b"mime_type": b"audio/mpeg"}
 
 
-def test_add_mp3_audio_column_uses_sample_rate_from_metadata(tmp_path: Path) -> None:
+def test_add_preview_columns_uses_sample_rate_from_metadata(tmp_path: Path) -> None:
     """The encoded column honors the shard metadata's sample rate, not a hardcoded value.
 
     :param tmp_path: Pytest fixture providing a fresh test directory.
@@ -258,27 +322,27 @@ def test_add_mp3_audio_column_uses_sample_rate_from_metadata(tmp_path: Path) -> 
     uri = tmp_path / "shard-000000.lance"
     _write_smoke_dataset(uri, sample_rate=16000)
 
-    add_mp3_audio_column(uri)
+    add_preview_columns(uri)
 
     first = _read_mp3_blobs(uri, [0])[0]
     _, decoded_rate = _decode_mp3(first)
     assert decoded_rate == 16000
 
 
-def test_add_mp3_audio_column_existing_column_raises(tmp_path: Path) -> None:
-    """A second add onto a dataset that already has ``audio_mp3`` fails fast.
+def test_add_preview_columns_existing_column_raises(tmp_path: Path) -> None:
+    """A second add onto a dataset that already has the preview columns fails fast.
 
     :param tmp_path: Pytest fixture providing a fresh test directory.
     """
     uri = tmp_path / "shard-000000.lance"
     _write_smoke_dataset(uri)
-    add_mp3_audio_column(uri)
+    add_preview_columns(uri)
 
     with pytest.raises(ValueError, match=AUDIO_MP3_FIELD):
-        add_mp3_audio_column(uri)
+        add_preview_columns(uri)
 
 
-def test_add_mp3_audio_column_missing_audio_column_raises(tmp_path: Path) -> None:
+def test_add_preview_columns_missing_audio_column_raises(tmp_path: Path) -> None:
     """A dataset without the source audio column raises a clear error.
 
     :param tmp_path: Pytest fixture providing a fresh test directory.
@@ -289,11 +353,11 @@ def test_add_mp3_audio_column_missing_audio_column_raises(tmp_path: Path) -> Non
     lance.write_dataset(pa.table({"other": [1, 2]}), str(uri), mode="overwrite")
 
     with pytest.raises(ValueError, match=AUDIO_FIELD):
-        add_mp3_audio_column(uri)
+        add_preview_columns(uri)
 
 
 def test_main_adds_column_and_reports_success(tmp_path: Path) -> None:
-    """The CLI entrypoint encodes the column and echoes a success line.
+    """The CLI entrypoint adds both preview columns and echoes a success line naming each.
 
     :param tmp_path: Pytest fixture providing a fresh test directory.
     """
@@ -304,7 +368,10 @@ def test_main_adds_column_and_reports_success(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert AUDIO_MP3_FIELD in result.output
-    assert AUDIO_MP3_FIELD in lance.dataset(str(uri)).schema.names
+    assert AUDIO_UUID_FIELD in result.output
+    schema_names = lance.dataset(str(uri)).schema.names
+    assert AUDIO_MP3_FIELD in schema_names
+    assert AUDIO_UUID_FIELD in schema_names
 
 
 def test_main_existing_column_exits_nonzero_with_message(tmp_path: Path) -> None:
@@ -314,7 +381,7 @@ def test_main_existing_column_exits_nonzero_with_message(tmp_path: Path) -> None
     """
     uri = tmp_path / "shard-000000.lance"
     _write_smoke_dataset(uri)
-    add_mp3_audio_column(uri)
+    add_preview_columns(uri)
 
     result = CliRunner().invoke(main, [str(uri)])
 
@@ -322,7 +389,7 @@ def test_main_existing_column_exits_nonzero_with_message(tmp_path: Path) -> None
     assert AUDIO_MP3_FIELD in result.output
 
 
-def test_add_mp3_audio_column_missing_shard_metadata_raises(tmp_path: Path) -> None:
+def test_add_preview_columns_missing_shard_metadata_raises(tmp_path: Path) -> None:
     """An ``audio`` column with no embedded ShardMetadata raises a clear error.
 
     :param tmp_path: Pytest fixture providing a fresh test directory.
@@ -333,7 +400,7 @@ def test_add_mp3_audio_column_missing_shard_metadata_raises(tmp_path: Path) -> N
     lance.write_dataset(pa.table({AUDIO_FIELD: audio}), str(uri), mode="overwrite")
 
     with pytest.raises(ValueError, match="metadata"):
-        add_mp3_audio_column(uri)
+        add_preview_columns(uri)
 
 
 def test_main_rejects_out_of_range_bitrate(tmp_path: Path) -> None:
@@ -384,7 +451,7 @@ def test_main_rewrites_r2_uri_and_forwards_storage_options(
     def _spy(uri: str, *, bitrate_kbps: int, storage_options: dict[str, str] | None) -> None:
         captured.update(uri=uri, bitrate_kbps=bitrate_kbps, storage_options=storage_options)
 
-    monkeypatch.setattr("synth_setter.pipeline.data.add_mp3_audio.add_mp3_audio_column", _spy)
+    monkeypatch.setattr("synth_setter.pipeline.data.add_preview_columns.add_preview_columns", _spy)
 
     result = CliRunner().invoke(main, ["r2://bucket/key.lance", "--bitrate-kbps", "192"])
 
@@ -415,7 +482,7 @@ def test_main_credentials_bare_s3_uri_as_r2(monkeypatch: pytest.MonkeyPatch) -> 
     def _spy(uri: str, *, bitrate_kbps: int, storage_options: dict[str, str] | None) -> None:
         captured.update(uri=uri, bitrate_kbps=bitrate_kbps, storage_options=storage_options)
 
-    monkeypatch.setattr("synth_setter.pipeline.data.add_mp3_audio.add_mp3_audio_column", _spy)
+    monkeypatch.setattr("synth_setter.pipeline.data.add_preview_columns.add_preview_columns", _spy)
 
     result = CliRunner().invoke(main, ["s3://bucket/key.lance"])
 
@@ -435,7 +502,7 @@ def test_main_local_path_passes_no_storage_options(monkeypatch: pytest.MonkeyPat
     def _spy(uri: str, *, bitrate_kbps: int, storage_options: dict[str, str] | None) -> None:
         captured.update(uri=uri, storage_options=storage_options)
 
-    monkeypatch.setattr("synth_setter.pipeline.data.add_mp3_audio.add_mp3_audio_column", _spy)
+    monkeypatch.setattr("synth_setter.pipeline.data.add_preview_columns.add_preview_columns", _spy)
 
     result = CliRunner().invoke(main, ["/local/path/key.lance"])
 

--- a/tests/pipeline/data/test_add_preview_columns.py
+++ b/tests/pipeline/data/test_add_preview_columns.py
@@ -81,7 +81,7 @@ def _sine_rows(sample_rate: int = _SAMPLE_RATE) -> np.ndarray:
 def _write_smoke_dataset(path: Path, *, sample_rate: int = _SAMPLE_RATE) -> None:
     """Write a smoke Lance dataset: real sine ``audio`` plus zeroed mel/param tensors.
 
-    :param path: Destination ``.lance`` directory.
+    :param path: Filesystem location the ``.lance`` dataset is written to.
     :param sample_rate: Sample rate embedded in the shard metadata.
     """
     metadata = ShardMetadata(
@@ -163,7 +163,10 @@ def test_encode_audio_to_mp3_accepts_any_float_dtype(dtype: type[np.floating]) -
 
     payload = encode_audio_to_mp3(row, _SAMPLE_RATE, 128)
 
-    assert payload[0] == 0xFF
+    # Scan for the frame-sync word, not byte 0: an MP3 may legally lead with an
+    # ID3 tag, so a dtype-coercion bug emitting only a stray 0xFF would not pass.
+    head = payload[:1024]
+    assert any(head[i] == 0xFF and head[i + 1] & 0xE0 == 0xE0 for i in range(len(head) - 1))
 
 
 def test_encode_audio_to_mp3_mono_input_decodes_to_one_channel() -> None:
@@ -255,6 +258,16 @@ def test_audio_uuid_returns_canonical_version5_uuid() -> None:
     assert parsed.version == 5
 
 
+def test_audio_uuid_matches_pinned_value_for_fixed_input() -> None:
+    """A fixed input hashes to a hardcoded uuid, pinning the namespace + hex-input format.
+
+    Computed independently of production code, so a change to the namespace, the
+    ``tobytes().hex()`` input, or the uuid version would break this — the
+    on-disk ids are a stable contract that must not drift silently.
+    """
+    assert audio_uuid(np.zeros((1, 4), dtype=np.float16)) == "34ef8dee-3474-5863-85cf-d299a7827175"
+
+
 def test_add_preview_columns_adds_blob_column_for_every_row(tmp_path: Path) -> None:
     """Every row gains a decodable ``audio_mp3`` blob cell; source columns and row count unchanged.
 
@@ -273,9 +286,10 @@ def test_add_preview_columns_adds_blob_column_for_every_row(tmp_path: Path) -> N
     assert ds.count_rows() == _ROWS
     payloads = _read_mp3_blobs(uri, list(range(_ROWS)))
     assert all(len(p) > 0 for p in payloads)
-    # Decode one cell to confirm the batch_udf path emits a real MP3, not just bytes.
+    # A decodable cell proves the batch_udf wrote a real MP3, not arbitrary bytes.
     samples, _ = _decode_mp3(payloads[0])
     assert samples.shape[0] == _CHANNELS
+    assert samples.shape[1] > 0
 
 
 def test_add_preview_columns_adds_uuid_column_matching_per_row_audio(tmp_path: Path) -> None:
@@ -339,6 +353,23 @@ def test_add_preview_columns_existing_column_raises(tmp_path: Path) -> None:
     add_preview_columns(uri)
 
     with pytest.raises(ValueError, match=AUDIO_MP3_FIELD):
+        add_preview_columns(uri)
+
+
+def test_add_preview_columns_partial_existing_column_raises(tmp_path: Path) -> None:
+    """A dataset with only ``audio_uuid`` (a crashed half-add) is still rejected.
+
+    The realistic post-crash state has one preview column present, not both. The
+    guard names the offending column, so the error must mention ``audio_uuid``.
+
+    :param tmp_path: Pytest fixture providing a fresh test directory.
+    """
+    uri = tmp_path / "shard-000000.lance"
+    _write_smoke_dataset(uri)
+    # Seed only the uuid column, mimicking a run that died before audio_mp3.
+    lance.dataset(str(uri)).add_columns({AUDIO_UUID_FIELD: "'seed'"})
+
+    with pytest.raises(ValueError, match=AUDIO_UUID_FIELD):
         add_preview_columns(uri)
 
 

--- a/tests/pipeline/data/test_add_preview_columns.py
+++ b/tests/pipeline/data/test_add_preview_columns.py
@@ -112,17 +112,16 @@ def _decode_mp3(payload: bytes) -> tuple[np.ndarray, int]:
         return f.read(f.frames), int(f.samplerate)
 
 
-def _read_mp3_blobs(uri: Path, indices: list[int]) -> list[bytes]:
-    """Read back ``audio_mp3`` blob cells as raw MP3 bytes via Lance's blob API.
+def _read_mp3_binary_values(uri: Path, indices: list[int]) -> list[bytes]:
+    """Read back ``audio_mp3`` cells as raw MP3 bytes through the normal Arrow path.
 
     :param uri: The ``.lance`` dataset directory.
     :param indices: Row indices to fetch, in the order returned.
     :returns: Per-row MP3 byte strings, in ``indices`` order.
     """
     dataset = lance.dataset(str(uri))
-    return [
-        blob.readall() for blob in dataset.take_blobs(blob_column=AUDIO_MP3_FIELD, indices=indices)
-    ]
+    table = dataset.take(indices, columns=[AUDIO_MP3_FIELD])
+    return table.column(AUDIO_MP3_FIELD).to_pylist()
 
 
 def test_encode_audio_to_mp3_contains_frame_sync() -> None:
@@ -268,8 +267,8 @@ def test_audio_uuid_matches_pinned_value_for_fixed_input() -> None:
     assert audio_uuid(np.zeros((1, 4), dtype=np.float16)) == "34ef8dee-3474-5863-85cf-d299a7827175"
 
 
-def test_add_preview_columns_adds_blob_column_for_every_row(tmp_path: Path) -> None:
-    """Every row gains a decodable ``audio_mp3`` blob cell; source columns and row count unchanged.
+def test_add_preview_columns_adds_binary_column_for_every_row(tmp_path: Path) -> None:
+    """Every row gains decodable ``audio_mp3`` bytes; source columns and row count unchanged.
 
     :param tmp_path: Pytest fixture providing a fresh test directory.
     """
@@ -282,9 +281,9 @@ def test_add_preview_columns_adds_blob_column_for_every_row(tmp_path: Path) -> N
     ds = lance.dataset(str(uri))
     for field in _SOURCE_FIELDS:
         assert ds.schema.field(field).type == before[field]
-    assert ds.schema.field(AUDIO_MP3_FIELD).type == lance.blob_field(AUDIO_MP3_FIELD).type
+    assert ds.schema.field(AUDIO_MP3_FIELD).type == pa.binary()
     assert ds.count_rows() == _ROWS
-    payloads = _read_mp3_blobs(uri, list(range(_ROWS)))
+    payloads = _read_mp3_binary_values(uri, list(range(_ROWS)))
     assert all(len(p) > 0 for p in payloads)
     # A decodable cell proves the batch_udf wrote a real MP3, not arbitrary bytes.
     samples, _ = _decode_mp3(payloads[0])
@@ -338,7 +337,7 @@ def test_add_preview_columns_uses_sample_rate_from_metadata(tmp_path: Path) -> N
 
     add_preview_columns(uri)
 
-    first = _read_mp3_blobs(uri, [0])[0]
+    first = _read_mp3_binary_values(uri, [0])[0]
     _, decoded_rate = _decode_mp3(first)
     assert decoded_rate == 16000
 

--- a/tests/pipeline/data/test_add_preview_columns.py
+++ b/tests/pipeline/data/test_add_preview_columns.py
@@ -46,7 +46,7 @@ _TIME_SAMPLES = int(_SAMPLE_RATE * _DURATION_SECONDS)
 _ROWS = 3
 
 # A full second at CD rate: enough frames that the 320-vs-128 kbps size
-# difference shows. Sub-second / low-rate clips are dominated by padding.
+# difference shows. Sub-second clips are dominated by MP3 header/reservoir overhead.
 _BITRATE_PROBE_RATE = 44100
 
 # Concert-pitch A; an audible test tone, value not otherwise significant.
@@ -73,8 +73,8 @@ def _sine_rows(sample_rate: int = _SAMPLE_RATE) -> np.ndarray:
     t = np.arange(_TIME_SAMPLES) / sample_rate
     rows = [np.sin(2 * np.pi * freq * t) for freq in (220.0, 440.0, 660.0)]
     mono = np.stack(rows)[:, None, :]
-    # broadcast_to is a read-only view, but the trailing .astype materializes a
-    # fresh writable float16 array, so the returned value is safe to mutate.
+    # broadcast_to returns a read-only view; the trailing .astype materializes a
+    # fresh writable float16 copy.
     return np.broadcast_to(mono, (_ROWS, _CHANNELS, _TIME_SAMPLES)).astype(np.float16)
 
 

--- a/tests/pipeline/data/test_add_preview_columns.py
+++ b/tests/pipeline/data/test_add_preview_columns.py
@@ -27,6 +27,7 @@ from synth_setter.data.vst.shapes import (
 from synth_setter.pipeline.data.add_preview_columns import (
     AUDIO_MP3_FIELD,
     AUDIO_UUID_FIELD,
+    _encode_preview_columns,
     add_preview_columns,
     audio_uuid,
     encode_audio_to_mp3,
@@ -265,6 +266,51 @@ def test_audio_uuid_matches_pinned_value_for_fixed_input() -> None:
     on-disk ids are a stable contract that must not drift silently.
     """
     assert audio_uuid(np.zeros((1, 4), dtype=np.float16)) == "34ef8dee-3474-5863-85cf-d299a7827175"
+
+
+def test__encode_preview_columns_non_tensor_audio_column_raises() -> None:
+    """A non-tensor ``audio`` column is rejected before any row is encoded.
+
+    The guard is unreachable through a real Lance round-trip (the projection
+    always yields a ``FixedShapeTensorArray``), so a direct call pins the
+    contract and the type named in its message.
+    """
+    batch = pa.record_batch([pa.array([[1.0, 2.0], [3.0, 4.0]])], names=[AUDIO_FIELD])
+
+    with pytest.raises(ValueError, match="fixed-shape tensor"):
+        _encode_preview_columns(batch, _SAMPLE_RATE, 128)
+
+
+def test__encode_preview_columns_row_failure_names_offending_row_index(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row that fails to encode raises a ValueError naming that row's index.
+
+    The wrapper is the only place the offending row index is surfaced, and a valid shard never
+    trips it, so the failure is injected into the per-row encoder. The assertion is on the real
+    wrapped message, not the stub.
+
+    :param monkeypatch: Pytest fixture replacing the per-row MP3 encoder so the second row raises
+        mid-batch.
+    """
+    batch = pa.record_batch(
+        [pa.FixedShapeTensorArray.from_numpy_ndarray(_sine_rows())], names=[AUDIO_FIELD]
+    )
+    outcomes = iter([b"ok", RuntimeError("boom"), b"ok"])
+
+    def _encode_with_second_row_failing(*_args: object) -> bytes:
+        outcome = next(outcomes)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(
+        "synth_setter.pipeline.data.add_preview_columns.encode_audio_to_mp3",
+        _encode_with_second_row_failing,
+    )
+
+    with pytest.raises(ValueError, match="row 1"):
+        _encode_preview_columns(batch, _SAMPLE_RATE, 128)
 
 
 def test_add_preview_columns_adds_binary_column_for_every_row(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -5480,7 +5480,7 @@ wheels = [
 
 [[package]]
 name = "synth-setter"
-version = "8.38.0"
+version = "8.39.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## What

Extends the post-write Lance augmenter introduced in #1718 to backfill a
**second** derived column alongside the MP3 preview, and renames it so the name
reflects both outputs:

- **CLI** `synth-setter-add-mp3-audio` → `synth-setter-add-preview-columns`
- **Module** `add_mp3_audio.py` → `add_preview_columns.py`
- **Function** `add_mp3_audio_column` → `add_preview_columns`

New `audio_uuid` column: a deterministic UUIDv5 fingerprint of each row's
`audio` tensor bytes, under a project-scoped namespace
(`uuid5(NAMESPACE_DNS, "synth-setter.tinaudio.com")`). The same rendered
waveform always maps to the same id — content-addressed and stable across
re-runs — giving rows a stable identity for dedup / cross-dataset reference.
It is stored as a plain Arrow `string` column.

Both columns are committed in a **single** `lance.batch_udf` `add_columns`
transaction (derived in one pass over the audio), so an interrupted run leaves
the dataset on its prior version and re-running is safe. Neither column is a
training input; the `audio` tensor stays the source of truth.

The notebook, doc-map, and data-pipeline design doc are renamed/updated to match.

> **Note — CLI rename:** `synth-setter-add-mp3-audio` shipped one release ago
> (8.39.0, #1718) and is removed here in favor of the clearer combined name.

## Why

The augmenter already walks every row's audio to encode the MP3; deriving the
uuid in the same pass adds a stable row identity at negligible cost, in the same
atomic transaction. It sits alongside the other post-write Lance augmenters and
follows the same §5 stage contract — adds columns to existing shards without
modifying earlier stages.

## Test plan

- 33 unit/integration tests in `tests/pipeline/data/test_add_preview_columns.py`
  (renamed from `test_add_mp3_audio.py`), including new `audio_uuid` coverage:
  determinism for equal bytes, layout-independence, a **pinned** UUID value
  (namespace + hex-input format contract), version-5 canonical form, per-row
  match against the pure helper through a real Lance round-trip, and the
  **partial** half-add guard (an `audio_uuid`-only dataset still raises).
- Full `tests/pipeline/data/` suite green (157 tests); `make format` clean.
- Pre-PR gate: `/repo-review-full-no-comments` — **0 BLOCK** across 9 skills
  (structlog logging and a factually-loose uuid5 comment fixed from the first
  pass; remaining findings are advisory style/coverage nits).

Refs #1697
Refs #1682