### PR TITLE
internal-fix(data-pipeline): store mp3 preview as binary

### DIFF
--- a/docs/doc-map.yaml
+++ b/docs/doc-map.yaml
@@ -117,7 +117,7 @@ docs:
       - pattern: "src/synth_setter/pipeline/data/add_embeddings.py"
         covers: "`synth-setter-add-embeddings` CLI — appends a `clap` (LAION-CLAP) `FixedSizeList<float32,512>` vector column (with an optional IVF_PQ index for `nearest=` search) and an `m2l` (music2latent) fixed-shape-tensor column to a finalized Lance dataset via `lance.batch_udf`, with injected/lazy-loaded encoders and row-count + dim + finiteness validation (post-finalize augmenter)."
       - pattern: "src/synth_setter/pipeline/data/add_preview_columns.py"
-        covers: "`synth-setter-add-preview-columns` CLI — one `lance.batch_udf` `add_columns` pass that adds an `audio_mp3` blob v2 preview column and an `audio_uuid` UUIDv5 fingerprint of each row's `audio` bytes (neither a training input)."
+        covers: "`synth-setter-add-preview-columns` CLI — one `lance.batch_udf` `add_columns` pass that adds an `audio_mp3` Arrow binary preview column and an `audio_uuid` UUIDv5 fingerprint of each row's `audio` bytes (neither a training input)."
       - pattern: "src/synth_setter/pipeline/data/add_music2latent.py"
         covers: "`python -m synth_setter.pipeline.data.add_music2latent` CLI — adds a `music2latent` dataset to HDF5 shards via reader/writer multiprocessing around a GPU encode loop."
 

--- a/notebooks/add_preview_columns.ipynb
+++ b/notebooks/add_preview_columns.ipynb
@@ -10,8 +10,8 @@
     "End-to-end smoke run for `synth_setter.pipeline.data.add_preview_columns`:\n",
     "\n",
     "1. Build a tiny Lance dataset with the same schema `generate-dataset` / `finalize-dataset` write (`audio` / `mel_spec` / `param_array` tensor columns plus embedded `ShardMetadata`).\n",
-    "2. Run the add step, which appends an `audio_mp3` Lance blob v2 column (tagged `mime_type: audio/mpeg`) and an `audio_uuid` string column (a deterministic UUIDv5 of each row's `audio` bytes), in one transaction.\n",
-    "3. Read back a dataframe of the params, each row's uuid, and its MP3 size, then decode one blob."
+    "2. Run the add step, which appends an `audio_mp3` Arrow binary column (tagged `mime_type: audio/mpeg`) and an `audio_uuid` string column (a deterministic UUIDv5 of each row's `audio` bytes), in one transaction.\n",
+    "3. Read back a dataframe of the params, each row's uuid, and its MP3 size, then decode one MP3 payload."
    ]
   },
   {
@@ -111,7 +111,7 @@
    "source": [
     "## 2. Run the add step\n",
     "\n",
-    "`add_preview_columns` reads the sample rate from the shard metadata, then commits both columns (`audio_mp3` blob v2 + `audio_uuid` string) in one transaction."
+    "`add_preview_columns` reads the sample rate from the shard metadata, then commits both columns (`audio_mp3` binary + `audio_uuid` string) in one transaction."
    ]
   },
   {
@@ -142,13 +142,9 @@
    "outputs": [],
    "source": [
     "ds = lance.dataset(str(uri))\n",
-    "# Blob v2 columns are read lazily via take_blobs, not to_table (which yields\n",
-    "# blob descriptors rather than bytes). audio_uuid is a plain string column.\n",
-    "mp3_payloads = [\n",
-    "    blob.readall()\n",
-    "    for blob in ds.take_blobs(blob_column=AUDIO_MP3_FIELD, indices=list(range(ds.count_rows())))\n",
-    "]\n",
-    "df = ds.to_table(columns=[PARAM_ARRAY_FIELD, AUDIO_UUID_FIELD]).to_pandas()\n",
+    "table = ds.to_table(columns=[PARAM_ARRAY_FIELD, AUDIO_MP3_FIELD, AUDIO_UUID_FIELD])\n",
+    "mp3_payloads = table.column(AUDIO_MP3_FIELD).to_pylist()\n",
+    "df = table.drop([AUDIO_MP3_FIELD]).to_pandas()\n",
     "df[\"mp3_bytes\"] = [len(p) for p in mp3_payloads]\n",
     "df"
    ]

--- a/src/synth_setter/pipeline/data/add_preview_columns.py
+++ b/src/synth_setter/pipeline/data/add_preview_columns.py
@@ -5,8 +5,8 @@ Backfills two derived columns onto a dataset written by
 single Lance ``add_columns`` transaction:
 
 - ``audio_mp3`` — each row's ``audio`` tensor encoded to a CBR MP3 (pedalboard),
-  stored as a Lance blob v2 column tagged ``mime_type: audio/mpeg`` so Lance
-  viewers auto-play a per-row preview.
+  stored as an Arrow binary column tagged ``mime_type: audio/mpeg`` so viewers
+  can scan the table through DuckDB without Lance blob support.
 - ``audio_uuid`` — a deterministic UUIDv5 fingerprint of the same ``audio`` bytes,
   so the same rendered waveform always maps to the same id (content-addressed).
 
@@ -99,7 +99,7 @@ def _encode_preview_columns(
     :param batch: Record batch projecting the ``audio`` fixed-shape tensor column.
     :param sample_rate: Playback rate in Hz every row is encoded at.
     :param bitrate_kbps: Constant MP3 bitrate in kbps for every row.
-    :returns: A two-column batch (``audio_mp3`` blob array, ``audio_uuid`` string
+    :returns: A two-column batch (``audio_mp3`` binary array, ``audio_uuid`` string
         array), one cell per input row, in batch row order.
     :raises ValueError: The ``audio`` column is not a fixed-shape tensor column,
         or a row fails to encode (the message names the offending row index).
@@ -108,7 +108,7 @@ def _encode_preview_columns(
     if not isinstance(column, pa.FixedShapeTensorArray):
         raise ValueError(f"{AUDIO_FIELD!r} must be a fixed-shape tensor column, got {column.type}")
     rows = column.to_numpy_ndarray()
-    mp3_blobs = []
+    mp3_payloads = []
     uuids = []
     for row_index, row in enumerate(rows):
         try:
@@ -119,10 +119,10 @@ def _encode_preview_columns(
             ) from exc
         # Append as a pair only after the encode succeeds, so a failed row never
         # leaves the two columns at mismatched lengths.
-        mp3_blobs.append(mp3)
+        mp3_payloads.append(mp3)
         uuids.append(audio_uuid(row))
     return pa.record_batch(
-        [lance.blob_array(mp3_blobs), pa.array(uuids, type=pa.string())],
+        [pa.array(mp3_payloads, type=pa.binary()), pa.array(uuids, type=pa.string())],
         names=[AUDIO_MP3_FIELD, AUDIO_UUID_FIELD],
     )
 
@@ -156,13 +156,13 @@ def add_preview_columns(
     sample_rate = read_shard_metadata(dataset.schema).sample_rate
     preview_schema = pa.schema(
         [
-            lance.blob_field(AUDIO_MP3_FIELD).with_metadata(_MP3_FIELD_METADATA),
+            pa.field(AUDIO_MP3_FIELD, pa.binary()).with_metadata(_MP3_FIELD_METADATA),
             pa.field(AUDIO_UUID_FIELD, pa.string()),
         ]
     )
 
     # output_schema skips Lance's first-batch inference probe (avoids a double
-    # encode) and carries the blob type + mime metadata onto the new columns.
+    # encode) and carries the binary type + mime metadata onto the new columns.
     @lance.batch_udf(output_schema=preview_schema)
     def _to_preview(batch: pa.RecordBatch) -> pa.RecordBatch:
         return _encode_preview_columns(batch, sample_rate, bitrate_kbps)

--- a/tests/pipeline/data/test_add_preview_columns.py
+++ b/tests/pipeline/data/test_add_preview_columns.py
@@ -112,17 +112,16 @@ def _decode_mp3(payload: bytes) -> tuple[np.ndarray, int]:
         return f.read(f.frames), int(f.samplerate)
 
 
-def _read_mp3_blobs(uri: Path, indices: list[int]) -> list[bytes]:
-    """Read back ``audio_mp3`` blob cells as raw MP3 bytes via Lance's blob API.
+def _read_mp3_binary_values(uri: Path, indices: list[int]) -> list[bytes]:
+    """Read back ``audio_mp3`` cells as raw MP3 bytes through the normal Arrow path.
 
     :param uri: The ``.lance`` dataset directory.
     :param indices: Row indices to fetch, in the order returned.
     :returns: Per-row MP3 byte strings, in ``indices`` order.
     """
     dataset = lance.dataset(str(uri))
-    return [
-        blob.readall() for blob in dataset.take_blobs(blob_column=AUDIO_MP3_FIELD, indices=indices)
-    ]
+    table = dataset.take(indices, columns=[AUDIO_MP3_FIELD])
+    return table.column(AUDIO_MP3_FIELD).to_pylist()
 
 
 def test_encode_audio_to_mp3_contains_frame_sync() -> None:
@@ -268,8 +267,8 @@ def test_audio_uuid_matches_pinned_value_for_fixed_input() -> None:
     assert audio_uuid(np.zeros((1, 4), dtype=np.float16)) == "34ef8dee-3474-5863-85cf-d299a7827175"
 
 
-def test_add_preview_columns_adds_blob_column_for_every_row(tmp_path: Path) -> None:
-    """Every row gains a decodable ``audio_mp3`` blob cell; source columns and row count unchanged.
+def test_add_preview_columns_adds_binary_column_for_every_row(tmp_path: Path) -> None:
+    """Every row gains decodable ``audio_mp3`` bytes; source columns and row count unchanged.
 
     :param tmp_path: Pytest fixture providing a fresh test directory.
     """
@@ -282,9 +281,9 @@ def test_add_preview_columns_adds_blob_column_for_every_row(tmp_path: Path) -> N
     ds = lance.dataset(str(uri))
     for field in _SOURCE_FIELDS:
         assert ds.schema.field(field).type == before[field]
-    assert ds.schema.field(AUDIO_MP3_FIELD).type == lance.blob_field(AUDIO_MP3_FIELD).type
+    assert ds.schema.field(AUDIO_MP3_FIELD).type == pa.binary()
     assert ds.count_rows() == _ROWS
-    payloads = _read_mp3_blobs(uri, list(range(_ROWS)))
+    payloads = _read_mp3_binary_values(uri, list(range(_ROWS)))
     assert all(len(p) > 0 for p in payloads)
     # A decodable cell proves the batch_udf wrote a real MP3, not arbitrary bytes.
     samples, _ = _decode_mp3(payloads[0])
@@ -338,7 +337,7 @@ def test_add_preview_columns_uses_sample_rate_from_metadata(tmp_path: Path) -> N
 
     add_preview_columns(uri)
 
-    first = _read_mp3_blobs(uri, [0])[0]
+    first = _read_mp3_binary_values(uri, [0])[0]
     _, decoded_rate = _decode_mp3(first)
     assert decoded_rate == 16000
 


### PR DESCRIPTION
## What Changed

- Store the `audio_mp3` preview as a normal Arrow `pa.binary()` column instead of Lance blob v2.
- Keep `mime_type: audio/mpeg` metadata and the existing `audio_uuid` preview column behavior.
- Update the preview notebook and doc map to use normal Arrow table reads for MP3 payloads.

## Why

DuckDB/SmooSense can scan normal binary columns when browsing the Lance table, but chokes on the Lance blob-v2 extension path used for `audio_mp3` previews.

## Validation

- `make format`
- `uv run pytest tests/pipeline/data/test_add_preview_columns.py -q`
- `make test-fast`

Refs #1682
