### PR TITLE
fix(monitoring): pass explicit batch_size to self.log in LightningModules

### DIFF
--- a/src/synth_setter/models/ksin_ff_module.py
+++ b/src/synth_setter/models/ksin_ff_module.py
@@ -60,9 +60,12 @@ class KSinFeedForwardModule(LightningModule):
 
     def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         loss, preds, targets, inputs = self.model_step(batch)
+        batch_size = inputs.shape[0]
 
         *_, synth_fn = batch
-        self.log("train/loss", loss, on_step=True, on_epoch=True, prog_bar=True)
+        self.log(
+            "train/loss", loss, on_step=True, on_epoch=True, prog_bar=True, batch_size=batch_size
+        )
 
         # return loss or backpropagation will fail
         return loss
@@ -72,21 +75,39 @@ class KSinFeedForwardModule(LightningModule):
 
     def validation_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         loss, preds, targets, inputs = self.model_step(batch)
+        batch_size = inputs.shape[0]
 
         # update and log metrics
         *_, synth_fn = batch
         self.val_lsd(preds, inputs, synth_fn)
         self.val_chamfer(preds, targets)
 
-        self.log("val/lsd", self.val_lsd, on_step=False, on_epoch=True, prog_bar=True)
-        self.log("val/chamfer", self.val_chamfer, on_step=False, on_epoch=True, prog_bar=True)
-        self.log("val/loss", loss, on_step=False, on_epoch=True, prog_bar=True)
+        self.log(
+            "val/lsd",
+            self.val_lsd,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            batch_size=batch_size,
+        )
+        self.log(
+            "val/chamfer",
+            self.val_chamfer,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            batch_size=batch_size,
+        )
+        self.log(
+            "val/loss", loss, on_step=False, on_epoch=True, prog_bar=True, batch_size=batch_size
+        )
 
     def on_validation_epoch_end(self):
         pass
 
     def test_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
         loss, preds, targets, inputs = self.model_step(batch)
+        batch_size = inputs.shape[0]
 
         *_, synth_fn = batch
         self.test_lsd(preds, inputs, synth_fn)
@@ -94,18 +115,42 @@ class KSinFeedForwardModule(LightningModule):
         self.test_lad(preds, targets)
 
         param_mse = (preds - targets).square().mean()
-        self.log("test/param_mse", param_mse, on_step=False, on_epoch=True, prog_bar=True)
+        self.log(
+            "test/param_mse",
+            param_mse,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            batch_size=batch_size,
+        )
 
-        self.log("test/lsd", self.test_lsd, on_step=False, on_epoch=True, prog_bar=True)
+        self.log(
+            "test/lsd",
+            self.test_lsd,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            batch_size=batch_size,
+        )
         self.log(
             "test/chamfer",
             self.test_chamfer,
             on_step=False,
             on_epoch=True,
             prog_bar=True,
+            batch_size=batch_size,
         )
-        self.log("test/loss", loss, on_step=False, on_epoch=True, prog_bar=True)
-        self.log("test/lad", self.test_lad, on_step=False, on_epoch=True, prog_bar=True)
+        self.log(
+            "test/loss", loss, on_step=False, on_epoch=True, prog_bar=True, batch_size=batch_size
+        )
+        self.log(
+            "test/lad",
+            self.test_lad,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            batch_size=batch_size,
+        )
 
     def on_test_epoch_end(self) -> None:
         # TODO: implement metrics

--- a/src/synth_setter/models/ksin_flow_matching_module.py
+++ b/src/synth_setter/models/ksin_flow_matching_module.py
@@ -389,7 +389,7 @@ class KSinFlowMatchingModule(LightningModule):
                 batch_size=batch_size,
             )
 
-        return loss + penalty
+        return loss if penalty is None else loss + penalty
 
     def on_train_epoch_end(self) -> None:
         pass

--- a/src/synth_setter/models/ksin_flow_matching_module.py
+++ b/src/synth_setter/models/ksin_flow_matching_module.py
@@ -97,6 +97,10 @@ class KSinFlowMatchingModule(LightningModule):
         self.encoder = encoder
         self.vector_field = vector_field
 
+        # Cached in training_step so on_before_optimizer_step can log grad norms with an
+        # explicit batch_size; that hook receives no batch to infer it from.
+        self._batch_size: int | None = None
+
         self.val_lsd = LogSpectralDistance()
         self.val_chamfer = ChamferDistance(params_per_token)
         # self.val_lad = LinearAssignmentDistance()
@@ -369,10 +373,21 @@ class KSinFlowMatchingModule(LightningModule):
                 param.requires_grad = True
 
         loss, penalty = self._train_step(batch)
-        self.log("train/loss", loss, on_step=True, on_epoch=True, prog_bar=True)
+        batch_size = batch[0].shape[0]
+        self._batch_size = batch_size
+        self.log(
+            "train/loss", loss, on_step=True, on_epoch=True, prog_bar=True, batch_size=batch_size
+        )
 
         if penalty is not None:
-            self.log("train/penalty", penalty, on_step=True, on_epoch=True, prog_bar=True)
+            self.log(
+                "train/penalty",
+                penalty,
+                on_step=True,
+                on_epoch=True,
+                prog_bar=True,
+                batch_size=batch_size,
+            )
 
         return loss + penalty
 
@@ -426,14 +441,30 @@ class KSinFlowMatchingModule(LightningModule):
             self.hparams.validation_cfg_strength,
         )
 
+        batch_size = inputs.shape[0]
+
         *_, synth_fn = batch
         # update and log metrics
         self.val_lsd(preds, inputs, synth_fn)
         self.val_chamfer(preds, targets)
         # self.val_lad(preds, targets)
 
-        self.log("val/lsd", self.val_lsd, on_step=False, on_epoch=True, prog_bar=True)
-        self.log("val/chamfer", self.val_chamfer, on_step=False, on_epoch=True, prog_bar=True)
+        self.log(
+            "val/lsd",
+            self.val_lsd,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            batch_size=batch_size,
+        )
+        self.log(
+            "val/chamfer",
+            self.val_chamfer,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            batch_size=batch_size,
+        )
         # self.log("val/lad", self.val_lad, on_step=False, on_epoch=True, prog_bar=True)
 
     def on_validation_epoch_end(self):
@@ -444,21 +475,45 @@ class KSinFlowMatchingModule(LightningModule):
             batch, self.hparams.test_sample_steps, self.hparams.test_cfg_strength
         )
 
+        batch_size = inputs.shape[0]
+
         *_, synth_fn = batch
         self.test_lsd(preds, inputs, synth_fn)
         self.test_chamfer(preds, targets)
         self.test_lad(preds, targets)
         param_mse = (preds - targets).square().mean()
-        self.log("test/param_mse", param_mse, on_step=False, on_epoch=True, prog_bar=True)
-        self.log("test/lsd", self.test_lsd, on_step=False, on_epoch=True, prog_bar=True)
+        self.log(
+            "test/param_mse",
+            param_mse,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            batch_size=batch_size,
+        )
+        self.log(
+            "test/lsd",
+            self.test_lsd,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            batch_size=batch_size,
+        )
         self.log(
             "test/chamfer",
             self.test_chamfer,
             on_step=False,
             on_epoch=True,
             prog_bar=True,
+            batch_size=batch_size,
         )
-        self.log("test/lad", self.test_lad, on_step=False, on_epoch=True, prog_bar=True)
+        self.log(
+            "test/lad",
+            self.test_lad,
+            on_step=False,
+            on_epoch=True,
+            prog_bar=True,
+            batch_size=batch_size,
+        )
 
     def on_test_epoch_end(self) -> None:
         # TODO: implement metrics
@@ -478,8 +533,8 @@ class KSinFlowMatchingModule(LightningModule):
         encoder_norms = {f"encoder/{k}": v for k, v in encoder_norms.items()}
         vf_norms = {f"vector_field/{k}": v for k, v in vf_norms.items()}
 
-        self.log_dict(encoder_norms, on_step=True, on_epoch=True)
-        self.log_dict(vf_norms, on_step=True, on_epoch=True)
+        self.log_dict(encoder_norms, on_step=True, on_epoch=True, batch_size=self._batch_size)
+        self.log_dict(vf_norms, on_step=True, on_epoch=True, batch_size=self._batch_size)
 
     def configure_optimizers(self) -> dict[str, Any]:
         optimizer = self.hparams.optimizer(params=self.trainer.model.parameters())

--- a/src/synth_setter/models/surge_flowvae_module.py
+++ b/src/synth_setter/models/surge_flowvae_module.py
@@ -67,7 +67,7 @@ class VSTFlowVAEModule(LightningModule):
             self.hparams.beta_max - self.hparams.beta_start
         )
 
-    def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def training_step(self, batch: dict[str, torch.Tensor], batch_idx: int):
         losses, mel_spec, _, vae_out = self.model_step(batch)
         x_hat = vae_out.x_hat
         batch_size = mel_spec.shape[0]
@@ -94,7 +94,7 @@ class VSTFlowVAEModule(LightningModule):
     def on_train_epoch_end(self) -> None:
         pass
 
-    def validation_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def validation_step(self, batch: dict[str, torch.Tensor], batch_idx: int):
         losses, mel_spec, _, vae_out = self.model_step(batch)
         x_hat = vae_out.x_hat
         batch_size = mel_spec.shape[0]
@@ -110,7 +110,7 @@ class VSTFlowVAEModule(LightningModule):
     def on_validation_epoch_end(self):
         pass
 
-    def test_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def test_step(self, batch: dict[str, torch.Tensor], batch_idx: int):
         losses, mel_spec, *_ = self.model_step(batch)
         batch_size = mel_spec.shape[0]
         losses = {f"test/{k}": v for k, v in losses.items()}
@@ -119,7 +119,7 @@ class VSTFlowVAEModule(LightningModule):
     def on_test_epoch_end(self) -> None:
         pass
 
-    def predict_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
+    def predict_step(self, batch: dict[str, torch.Tensor], batch_idx: int):
         mel_spec = batch["mel_spec"]
         out = self.net(mel_spec)
 

--- a/src/synth_setter/models/surge_flowvae_module.py
+++ b/src/synth_setter/models/surge_flowvae_module.py
@@ -68,19 +68,26 @@ class VSTFlowVAEModule(LightningModule):
         )
 
     def training_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
-        losses, *_, vae_out = self.model_step(batch)
+        losses, mel_spec, _, vae_out = self.model_step(batch)
         x_hat = vae_out.x_hat
+        batch_size = mel_spec.shape[0]
 
-        self.log("train/param_mean", x_hat.mean(), on_step=True, on_epoch=True)
-        self.log("train/param_std", x_hat.std(), on_step=True, on_epoch=True)
+        self.log(
+            "train/param_mean", x_hat.mean(), on_step=True, on_epoch=True, batch_size=batch_size
+        )
+        self.log(
+            "train/param_std", x_hat.std(), on_step=True, on_epoch=True, batch_size=batch_size
+        )
 
         beta = self.get_beta()
         loss = losses["reconstruction_loss"] + beta * losses["latent_loss"] + losses["param_loss"]
 
         losses_to_log = {f"train/{k}": v for k, v in losses.items()}
-        self.log("train/loss", loss, on_step=True, on_epoch=True, prog_bar=True)
-        self.log_dict(losses_to_log, on_step=True, on_epoch=True)
-        self.log("train/beta", beta, on_step=True, prog_bar=True)
+        self.log(
+            "train/loss", loss, on_step=True, on_epoch=True, prog_bar=True, batch_size=batch_size
+        )
+        self.log_dict(losses_to_log, on_step=True, on_epoch=True, batch_size=batch_size)
+        self.log("train/beta", beta, on_step=True, prog_bar=True, batch_size=batch_size)
 
         return loss
 
@@ -88,22 +95,26 @@ class VSTFlowVAEModule(LightningModule):
         pass
 
     def validation_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
-        losses, *_, vae_out = self.model_step(batch)
+        losses, mel_spec, _, vae_out = self.model_step(batch)
         x_hat = vae_out.x_hat
+        batch_size = mel_spec.shape[0]
 
-        self.log("val/param_mean", x_hat.mean(), on_step=False, on_epoch=True)
-        self.log("val/param_std", x_hat.std(), on_step=False, on_epoch=True)
+        self.log(
+            "val/param_mean", x_hat.mean(), on_step=False, on_epoch=True, batch_size=batch_size
+        )
+        self.log("val/param_std", x_hat.std(), on_step=False, on_epoch=True, batch_size=batch_size)
 
         losses = {f"val/{k}": v for k, v in losses.items()}
-        self.log_dict(losses, on_step=False, on_epoch=True, prog_bar=True)
+        self.log_dict(losses, on_step=False, on_epoch=True, prog_bar=True, batch_size=batch_size)
 
     def on_validation_epoch_end(self):
         pass
 
     def test_step(self, batch: tuple[torch.Tensor, torch.Tensor], batch_idx: int):
-        losses, *_ = self.model_step(batch)
+        losses, mel_spec, *_ = self.model_step(batch)
+        batch_size = mel_spec.shape[0]
         losses = {f"test/{k}": v for k, v in losses.items()}
-        self.log_dict(losses, on_step=False, on_epoch=True, prog_bar=True)
+        self.log_dict(losses, on_step=False, on_epoch=True, prog_bar=True, batch_size=batch_size)
 
     def on_test_epoch_end(self) -> None:
         pass

--- a/tests/models/test_ksin_ff_module.py
+++ b/tests/models/test_ksin_ff_module.py
@@ -452,6 +452,29 @@ def test_test_step_calls_lsd_chamfer_lad_and_logs_param_mse(  # noqa: DOC101,DOC
     assert torch.allclose(param_mse_call.args[1], expected_param_mse)
 
 
+def test_steps_log_metrics_with_explicit_batch_size(  # noqa: DOC101,DOC103
+    tiny_net: nn.Module,
+    opt_partial: Callable[..., torch.optim.Optimizer],
+    batch: tuple[torch.Tensor, torch.Tensor, Callable[[torch.Tensor], torch.Tensor]],
+    batch_size: int,
+) -> None:
+    """Train/val/test steps pass an explicit batch_size to every self.log call (#600)."""
+    module = _make_module(net=tiny_net, optimizer=opt_partial)
+    log_mock = _patch_metrics_and_log(module)["log"]
+
+    module.training_step(batch, 0)  # type: ignore[arg-type]
+    module.validation_step(batch, 0)  # type: ignore[arg-type]
+    module.test_step(batch, 0)  # type: ignore[arg-type]
+
+    assert log_mock.call_count > 0, "expected at least one self.log call across the steps"
+    for call in log_mock.call_args_list:
+        metric_name = call.args[0] if call.args else "<missing>"
+        assert call.kwargs.get("batch_size") == batch_size, (
+            f"self.log({metric_name!r}) passed batch_size="
+            f"{call.kwargs.get('batch_size')!r}, expected {batch_size}"
+        )
+
+
 def test_on_train_start_resets_val_metrics(  # noqa: DOC101,DOC103
     tiny_net: nn.Module,
     opt_partial: Callable[..., torch.optim.Optimizer],

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -97,7 +97,10 @@ def test_train_fast_dev_run_emits_no_batch_size_warning(cfg_train: DictConfig) -
         warnings.simplefilter("always")
         train(cfg_train)
 
-    batch_size_warnings = [str(w.message) for w in caught if "batch_size" in str(w.message)]
+    # Match Lightning's specific message, not any "batch_size" substring, so an unrelated
+    # warning that happens to mention batch size cannot trip this test.
+    warning_fragment = "Trying to infer the `batch_size` from an ambiguous collection"
+    batch_size_warnings = [str(w.message) for w in caught if warning_fragment in str(w.message)]
     assert not batch_size_warnings, (
         f"training emitted batch_size-inference warning(s): {batch_size_warnings}"
     )

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -8,6 +8,7 @@ that no private ``synth_setter.cli`` helper is imported here.
 """
 
 import os
+import warnings
 from collections.abc import Callable
 from contextlib import nullcontext
 from pathlib import Path
@@ -76,6 +77,30 @@ def test_train_fast_dev_run_tiny_model_tiny_data(cfg_train: DictConfig) -> None:
     with open_dict(cfg_train):
         cfg_train.trainer.fast_dev_run = True
     train(cfg_train)
+
+
+def test_train_fast_dev_run_emits_no_batch_size_warning(cfg_train: DictConfig) -> None:
+    """A `fast_dev_run` run emits no Lightning ambiguous-`batch_size` warning (#600).
+
+    Every ``self.log`` call in the LightningModules now passes an explicit ``batch_size``,
+    so Lightning never falls back to inferring it from the (tuple/dict) batch. Warnings are
+    captured directly here because the suite's ``filterwarnings = ["ignore::UserWarning"]``
+    would otherwise hide the ``PossibleUserWarning`` this test guards against.
+
+    :param cfg_train: A DictConfig containing a valid training configuration.
+    """
+    HydraConfig().set_config(cfg_train)
+    with open_dict(cfg_train):
+        cfg_train.trainer.fast_dev_run = True
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        train(cfg_train)
+
+    batch_size_warnings = [str(w.message) for w in caught if "batch_size" in str(w.message)]
+    assert not batch_size_warnings, (
+        f"training emitted batch_size-inference warning(s): {batch_size_warnings}"
+    )
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
## Why

PyTorch Lightning prints a `PossibleUserWarning` on every training run: "Trying to infer the `batch_size` from an ambiguous collection". The LightningModules call `self.log` / `self.log_dict` without an explicit `batch_size`, and the batch is a non-tensor collection (a tuple for the k-sinusoidal models, a dict for the Surge Flow-VAE), so Lightning cannot infer the size unambiguously. The guessed value is correct, but the warning is noise and leaves epoch-level reductions relying on a guess.

Closes #600

## What changed

- Source the batch size from the input tensor's leading dimension and pass `batch_size=` to every `self.log` / `self.log_dict` call in the `training_step` / `validation_step` / `test_step` of `ksin_ff_module`, `ksin_flow_matching_module`, and `surge_flowvae_module`.
- `surge_flowvae` unpacks `mel_spec` from `model_step` instead of re-indexing the batch, keeping the tuple-typed step signatures type-clean.
- `ksin_flow_matching` logs grad norms in `on_before_optimizer_step` (`on_epoch=True`), which has no batch; it reuses a batch size cached in `training_step` (`self._batch_size`).
- Added a unit test (every `self.log` in the ksin feed-forward steps passes `batch_size`) and an integration test (a `fast_dev_run` run emits no ambiguous-`batch_size` warning, captured directly since the suite ignores `UserWarning`).
- Also guard `KSinFlowMatchingModule.training_step` against a `None` penalty (`return loss + penalty` → `return loss if penalty is None else loss + penalty`), a latent `TypeError` flagged in review.

## Test plan

- Re-ran the reproduction `pytest tests/test_train.py::test_train_fast_dev_run_tiny_model_tiny_data -W always`: the `ambiguous collection` warning printed before this change and is gone after.
- New `test_train_fast_dev_run_emits_no_batch_size_warning` passes.
- `make test-fast` is green locally except `test_pinned_baselines_resolve`, a `@pytest.mark.network` baseline-fetch test that can't reach the network in my local environment (unrelated to this change).

## Out of scope

- The other Surge modules (`surge_ff_module.py`, `surge_flow_matching_module.py`, `surge_fake_oracle_module.py`) share the pattern but are outside this issue's named files — happy to follow up separately.

______________________________________________________________________

- [x] One logical change; any breaking changes are called out above.