### PR TITLE
internal-feat(train): log resolved Hydra cfg at DEBUG

### DIFF
--- a/src/synth_setter/cli/train.py
+++ b/src/synth_setter/cli/train.py
@@ -190,6 +190,12 @@ def train(cfg: DictConfig) -> tuple[dict[str, Any], dict[str, Any]]:
     if cfg.get("seed"):
         L.seed_everything(cfg.seed, workers=True)
 
+    try:
+        _cfg_yaml = OmegaConf.to_yaml(cfg, resolve=True)
+    except Exception:  # noqa: BLE001 — resolution failures must not abort training
+        _cfg_yaml = OmegaConf.to_yaml(cfg)
+    log.debug("Resolved Hydra config:\n%s", _cfg_yaml)
+
     log.info(f"Instantiating datamodule <{cfg.datamodule._target_}>")
     datamodule: LightningDataModule = hydra.utils.instantiate(cfg.datamodule)
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -11,6 +11,7 @@ import os
 from collections.abc import Callable
 from contextlib import nullcontext
 from pathlib import Path
+from unittest.mock import ANY, patch
 
 import numpy as np
 import pandas as pd
@@ -76,6 +77,30 @@ def test_train_fast_dev_run_tiny_model_tiny_data(cfg_train: DictConfig) -> None:
     with open_dict(cfg_train):
         cfg_train.trainer.fast_dev_run = True
     train(cfg_train)
+
+
+def test_train_debug_logs_resolved_cfg_before_datamodule(cfg_train: DictConfig) -> None:
+    """Train() emits the fully-resolved Hydra config via log.debug before any object is instantiated.
+
+    :param cfg_train: A DictConfig containing a valid training configuration.
+    """
+    HydraConfig().set_config(cfg_train)
+    with open_dict(cfg_train):
+        cfg_train.trainer.fast_dev_run = True
+
+    fake_yaml = "model:\n  _target_: fake\n"
+
+    with (
+        patch("synth_setter.cli.train.OmegaConf.to_yaml", return_value=fake_yaml) as mock_yaml,
+        patch("synth_setter.cli.train.log.debug") as mock_debug,
+    ):
+        train(cfg_train)
+
+    mock_yaml.assert_called_once_with(ANY, resolve=True)
+    assert mock_debug.call_count >= 1, "log.debug was never called in train()"
+    first_call = mock_debug.call_args_list[0]
+    assert "Resolved Hydra config" in first_call.args[0]
+    assert first_call.args[1] == fake_yaml
 
 
 @pytest.mark.gpu


### PR DESCRIPTION
## Why

Developers debugging training failures or unexpected behavior have no way to inspect the fully-resolved Hydra config without manually inserting `print(OmegaConf.to_yaml(cfg))` and re-running. Running with `log_cli_level=DEBUG` should be enough to see the full composed config — all overrides applied, all `${...}` interpolations expanded — without touching the source.

Closes #33

## What changed

- In `train()`, inserted `log.debug("Resolved Hydra config:\n%s", _cfg_yaml)` immediately after `L.seed_everything` and before the first `log.info` / object instantiation
- Resolution is attempted with `resolve=True` first; a bare `except Exception` (matching the `# noqa: BLE001` pattern already in `_log_model_artifact`) falls back to `resolve=False` when test-fixture configs contain unresolvable internal Hydra keys — so a resolution failure never aborts training
- Added `test_train_debug_logs_resolved_cfg_before_datamodule` in `tests/test_train.py`: patches `OmegaConf.to_yaml` and `log.debug` in the train module, asserts `to_yaml` is called with `resolve=True`, and verifies `log.debug` receives `"Resolved Hydra config"` as its format string

## Test plan

- Confirmed the debug call appears **after** `seed_everything` and **before** `Instantiating datamodule` in the log when running with `log_cli_level=DEBUG` — the position matters so the full config (including any seed-dependent state) is captured before any object is built
- Confirmed normal runs (without debug logging) produce no extra output — `log.debug` is silent unless debug logging is explicitly enabled
- Deliberately did not test with GPU or multirun: the change is rank-zero-only (via `RankedLogger`) and purely additive, so DDP and multirun paths are unaffected

## Out of scope

Logging the resolved config at other lifecycle points (eval, predict) — not requested by the issue.

---

- [x] One logical change; any breaking changes are called out above.